### PR TITLE
[JSC][Wasm] Speed up WebAssembly.Table construction

### DIFF
--- a/JSTests/microbenchmarks/wasm-table-create.js
+++ b/JSTests/microbenchmarks/wasm-table-create.js
@@ -1,0 +1,15 @@
+//@ $skipModes << :lockdown
+//@ requireOptions("--useExecutableAllocationFuzz=false")
+
+// Microbenchmark for WebAssembly.Table construction (bug 288529).
+const size = 100000;
+const iterations = 20;
+let sink = 0;
+for (let i = 0; i < iterations; ++i) {
+    const t1 = new WebAssembly.Table({ element: "externref", initial: size });
+    const t2 = new WebAssembly.Table({ element: "funcref", initial: size });
+    const t3 = new WebAssembly.Table({ element: "externref", initial: size }, {});
+    sink += t1.length + t2.length + t3.length;
+}
+if (sink !== iterations * size * 3)
+    throw new Error("bad sink " + sink);

--- a/JSTests/wasm/stress/table-create-fill.js
+++ b/JSTests/wasm/stress/table-create-fill.js
@@ -1,0 +1,155 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+function checkAll(table, expected, label) {
+    assert.eq(table.length, expected.length, label)
+    for (let i = 0; i < table.length; ++i) {
+        const v = table.get(i)
+        const msg = `${label}[${i}]`
+        if (expected[i] === null)
+            assert.eq(v, null, msg)
+        else if (expected[i] === undefined)
+            assert.eq(v, undefined, msg)
+        else
+            assert.eq(v, expected[i], msg)
+    }
+}
+
+const helperWat = `
+(module
+    (func (export "f") (result i32) (i32.const 42))
+)
+`
+
+const callIndirectWat = `
+(module
+    (type $sig (func (result i32)))
+    (import "env" "table" (table 4 funcref))
+    (func (export "call") (param i32) (result i32)
+        (call_indirect (type $sig) (local.get 0)))
+)
+`
+
+const callIndirectGrowableWat = `
+(module
+    (type $sig (func (result i32)))
+    (import "env" "table" (table 4 8 funcref))
+    (func (export "call") (param i32) (result i32)
+        (call_indirect (type $sig) (local.get 0)))
+)
+`
+
+async function testDefaultsAndNull() {
+    checkAll(new WebAssembly.Table({ element: "externref", initial: 4 }),
+        [undefined, undefined, undefined, undefined], "externref default")
+    checkAll(new WebAssembly.Table({ element: "externref", initial: 4 }, null),
+        [null, null, null, null], "externref null")
+    checkAll(new WebAssembly.Table({ element: "funcref", initial: 3 }),
+        [null, null, null], "funcref default")
+    checkAll(new WebAssembly.Table({ element: "funcref", initial: 3 }, null),
+        [null, null, null], "funcref null")
+}
+
+async function testExternrefObjectFill() {
+    const obj = { tag: "fill" }
+    const t = new WebAssembly.Table({ element: "externref", initial: 5 }, obj)
+    checkAll(t, [obj, obj, obj, obj, obj], "externref object")
+    assert.eq(t.get(0), t.get(4))
+
+    const size = 1000
+    const large = new WebAssembly.Table({ element: "externref", initial: size }, obj)
+    assert.eq(large.length, size)
+    assert.eq(large.get(0), obj)
+    assert.eq(large.get(size - 1), obj)
+    assert.eq(large.get(size >> 1), obj)
+}
+
+async function testFuncrefFillAndCallIndirect() {
+    const fn = (await instantiate(helperWat, {}, {})).exports.f
+
+    const growable = new WebAssembly.Table({ element: "funcref", initial: 4, maximum: 8 }, fn)
+    for (let i = 0; i < 4; ++i)
+        assert.eq(growable.get(i), fn)
+    assert.eq(growable.get(0)(), 42)
+
+    const fixed = new WebAssembly.Table({ element: "funcref", initial: 4, maximum: 4 }, fn)
+    for (let i = 0; i < 4; ++i)
+        assert.eq(fixed.get(i), fn)
+    assert.eq(fixed.get(1)(), 42)
+
+    const callGrowable = (await instantiate(callIndirectGrowableWat, {
+        env: { table: growable },
+    }, {})).exports.call
+    for (let i = 0; i < 4; ++i)
+        assert.eq(callGrowable(i), 42)
+
+    const callFixed = (await instantiate(callIndirectWat, {
+        env: { table: fixed },
+    }, {})).exports.call
+    for (let i = 0; i < 4; ++i)
+        assert.eq(callFixed(i), 42)
+}
+
+async function testFuncrefFillSurvivesGC() {
+    const n = 64
+    let growable
+    let fixed
+    let callFixed
+    let callGrowable
+    {
+        const fn = (await instantiate(helperWat, {}, {})).exports.f
+        growable = new WebAssembly.Table({ element: "funcref", initial: n, maximum: n * 2 }, fn)
+        fixed = new WebAssembly.Table({ element: "funcref", initial: n, maximum: n }, fn)
+        callGrowable = (await instantiate(`
+(module
+    (type $sig (func (result i32)))
+    (import "env" "table" (table ${n} ${n * 2} funcref))
+    (func (export "call") (param i32) (result i32)
+        (call_indirect (type $sig) (local.get 0)))
+)
+`, { env: { table: growable } }, {})).exports.call
+        callFixed = (await instantiate(`
+(module
+    (type $sig (func (result i32)))
+    (import "env" "table" (table ${n} ${n} funcref))
+    (func (export "call") (param i32) (result i32)
+        (call_indirect (type $sig) (local.get 0)))
+)
+`, { env: { table: fixed } }, {})).exports.call
+    }
+
+    fullGC()
+
+    for (let i = 0; i < n; ++i) {
+        assert.eq(typeof growable.get(i), "function")
+        assert.eq(growable.get(i)(), 42)
+        assert.eq(callGrowable(i), 42)
+        assert.eq(typeof fixed.get(i), "function")
+        assert.eq(fixed.get(i)(), 42)
+        assert.eq(callFixed(i), 42)
+    }
+}
+
+async function testExternrefFillSurvivesGC() {
+    const n = 100
+    let table
+    {
+        table = new WebAssembly.Table({ element: "externref", initial: n }, { tag: 0xbeef })
+    }
+    fullGC()
+    for (let i = 0; i < n; ++i) {
+        const v = table.get(i)
+        assert.eq(typeof v, "object")
+        assert.eq(v.tag, 0xbeef)
+    }
+}
+
+async function test() {
+    await testDefaultsAndNull()
+    await testExternrefObjectFill()
+    await testFuncrefFillAndCallIndirect()
+    await testFuncrefFillSurvivesGC()
+    await testExternrefFillSurvivesGC()
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -213,6 +213,16 @@ void Table::set(uint32_t index, JSValue value)
     });
 }
 
+void Table::fill(VM& vm, JSValue value)
+{
+    ASSERT(m_owner);
+    Locker locker { m_owner->cellLock() };
+    Integrity::auditCell<Integrity::AuditLevel::Full>(vm, value);
+    visitDerived([&](auto& table) {
+        table.fill(vm, value);
+    });
+}
+
 JSValue Table::get(uint32_t index)
 {
     ASSERT(index < length());
@@ -274,6 +284,14 @@ void ExternOrAnyRefTable::clear(uint32_t index)
 void ExternOrAnyRefTable::set(uint32_t index, JSValue value)
 {
     m_jsValues.get()[index].set(m_owner->vm(), m_owner, value);
+}
+
+void ExternOrAnyRefTable::fill(VM& vm, JSValue value)
+{
+    auto* slots = m_jsValues.get();
+    for (uint32_t i = 0; i < length(); ++i)
+        slots[i].setWithoutWriteBarrier(value);
+    vm.writeBarrier(m_owner, value);
 }
 
 FuncRefTable::FuncRefTable(VM& vm, uint32_t initial, std::optional<uint64_t> maximum, Type wasmType, Wasm::AddressType addressType)
@@ -390,6 +408,29 @@ void FuncRefTable::set(uint32_t index, JSValue value)
         clear(index);
     else
         setFunction(index, uncheckedDowncast<WebAssemblyFunctionBase>(value));
+}
+
+void FuncRefTable::fill(VM& vm, JSValue value)
+{
+    auto* functions = m_importableFunctions.get();
+    auto* wrappers = m_wrappers.get();
+    if (value.isNull()) {
+        for (uint32_t i = 0; i < length(); ++i) {
+            functions[i] = FuncRefTable::Function { };
+            ASSERT(functions[i].isEmpty());
+            wrappers[i].clear();
+        }
+        return;
+    }
+
+    auto* function = uncheckedDowncast<WebAssemblyFunctionBase>(value);
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(isSubtype(function->type(), wasmType()));
+    auto importable = function->importableFunction();
+    for (uint32_t i = 0; i < length(); ++i) {
+        functions[i] = importable;
+        wrappers[i].setWithoutWriteBarrier(function);
+    }
+    vm.writeBarrier(m_owner, function);
 }
 
 void FuncRefTable::registerInstance(JSWebAssemblyInstance& instance)

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -85,6 +85,7 @@ public:
 
     void clear(uint32_t);
     void set(uint32_t, JSValue);
+    void fill(VM&, JSValue);
     JSValue get(uint32_t);
 
     std::optional<uint32_t> grow(uint64_t delta, JSValue defaultValue);
@@ -123,6 +124,7 @@ public:
 
     void clear(uint32_t);
     void set(uint32_t, JSValue);
+    void fill(VM&, JSValue);
     JSValue get(uint32_t index) const { return m_jsValues.get()[index].get(); }
 
 private:
@@ -164,6 +166,7 @@ public:
 
     void clear(uint32_t);
     void set(uint32_t, JSValue);
+    void fill(VM&, JSValue);
     WebAssemblyFunctionBase* get(uint32_t index);
 
     void registerInstance(JSWebAssemblyInstance&);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
@@ -140,13 +140,9 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyTable, (JSGlobalObject* globalObj
         : callFrame->uncheckedArgument(1);
     if (jsWebAssemblyTable->table()->isFuncrefTable() && !defaultValue.isNull() && !isWebAssemblyHostFunction(defaultValue))
         return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.constructor expects the second argument to be null or an instance of WebAssembly.Function"_s);
-    for (uint32_t tableIndex = 0; tableIndex < initial; ++tableIndex) {
-        if (jsWebAssemblyTable->table()->isFuncrefTable() && !defaultValue.isNull())
-            jsWebAssemblyTable->set(tableIndex, defaultValue);
-        if (jsWebAssemblyTable->table()->isExternrefTable())
-            jsWebAssemblyTable->set(tableIndex, defaultValue);
-        RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-    }
+
+    if (!defaultValue.isNull())
+        jsWebAssemblyTable->table()->fill(vm, defaultValue);
 
     RELEASE_AND_RETURN(throwScope, JSValue::encode(jsWebAssemblyTable));
 }


### PR DESCRIPTION
#### 1803d6109d98baae1f4a4b9ad02b83546f25837e
<pre>
[JSC][Wasm] Speed up WebAssembly.Table construction
<a href="https://bugs.webkit.org/show_bug.cgi?id=288529">https://bugs.webkit.org/show_bug.cgi?id=288529</a>

Reviewed by Yusuke Suzuki.

Table construction filled every live slot through JSWebAssemblyTable::set,
which did a full integrity audit and write barrier per index. For null fill
values the slots already start empty/null, so the loop was pure overhead.
For non-null fills (including the externref JS default of undefined), convert
to a single bulk fill with one audit and one write barrier.

On Release arm64, creating an 1e6-element externref table with a non-null
value drops from ~14ms to ~0.4ms; default/null creates are similarly faster.

* Source/JavaScriptCore/wasm/WasmTable.h:
* Source/JavaScriptCore/wasm/WasmTable.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp:
* JSTests/wasm/stress/table-create-fill.js: Added.
* JSTests/microbenchmarks/wasm-table-create.js: Added.

Canonical link: <a href="https://commits.webkit.org/318365@main">https://commits.webkit.org/318365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68201897e7fe2e551591c188acb3530a8aabbfc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187302 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51344 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138504 "4 flakes 2 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118968 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40683 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39046 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/937 "") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7736 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151090 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38736 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35768 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38968 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189733 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51302 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147616 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51984 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35364 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147404 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27009 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42115 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124199 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118612 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50492 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13713 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49888 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->