### PR TITLE
Enable WebAssembly Memory64 feature flag

### DIFF
--- a/JSTests/wasm/js-api/memory64-js-api.js
+++ b/JSTests/wasm/js-api/memory64-js-api.js
@@ -1,5 +1,4 @@
 //@ requireOptions("--useWasmJSTypes=true")
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import * as assert from '../assert.js';
 
 const pageSize = 64 * 1024;

--- a/JSTests/wasm/js-api/table64-js-api.js
+++ b/JSTests/wasm/js-api/table64-js-api.js
@@ -1,5 +1,4 @@
 //@ requireOptions("--useWasmJSTypes=true")
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import * as assert from "../assert.js";
 
 {

--- a/JSTests/wasm/stress/memory64-atomic-notify-out-of-bounds.js
+++ b/JSTests/wasm/stress/memory64-atomic-notify-out-of-bounds.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/memory64-atomic-wait-out-of-bounds.js
+++ b/JSTests/wasm/stress/memory64-atomic-wait-out-of-bounds.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/memory64-atomics.js
+++ b/JSTests/wasm/stress/memory64-atomics.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/memory64-bulk-memory.js
+++ b/JSTests/wasm/stress/memory64-bulk-memory.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/memory64-grow-and-size.js
+++ b/JSTests/wasm/stress/memory64-grow-and-size.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/memory64-load-and-store.js
+++ b/JSTests/wasm/stress/memory64-load-and-store.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/memory64-overflow.js
+++ b/JSTests/wasm/stress/memory64-overflow.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("--useWasmMemory64=1")
 
 let assert;
 import('../assert.js').then((m) => { assert = m; }, $vm.crash);
@@ -62,35 +61,35 @@ const { testLoad, testStore, constantLoad, constantStore, offsetStore, offsetLoa
 function testOverflow() {
   assert.throws(() => testLoad(0xffffffffffffffffn),
       WebAssembly.RuntimeError,
-      "Out of bounds memory access (evaluating 'testLoad(0xffffffffffffffffn)')");
+      "Out of bounds memory access");
 
   assert.throws(() => testStore(0xffffffffffffffffn),
         WebAssembly.RuntimeError,
-      "Out of bounds memory access (evaluating 'testStore(0xffffffffffffffffn)')");
+      "Out of bounds memory access");
 
   assert.throws(() => testLoad(0xfffffffffffffffen),
       WebAssembly.RuntimeError,
-      "Out of bounds memory access (evaluating 'testLoad(0xfffffffffffffffen)')");
+      "Out of bounds memory access");
 
   assert.throws(() => testStore(0xfffffffffffffffen),
         WebAssembly.RuntimeError,
-      "Out of bounds memory access (evaluating 'testStore(0xfffffffffffffffen)')");
+      "Out of bounds memory access");
 
   assert.throws(() => constantLoad(),
         WebAssembly.RuntimeError,
-        "Out of bounds memory access (evaluating 'constantLoad()')");
+        "Out of bounds memory access");
 
   assert.throws(() => constantStore(),
         WebAssembly.RuntimeError,
-        "Out of bounds memory access (evaluating 'constantStore()')");
+        "Out of bounds memory access");
 
   assert.throws(() => offsetStore(),
         WebAssembly.RuntimeError,
-        "Out of bounds memory access (evaluating 'offsetStore()')");
+        "Out of bounds memory access");
 
     assert.throws(() => offsetLoad(),
         WebAssembly.RuntimeError,
-        "Out of bounds memory access (evaluating 'offsetLoad()')");
+        "Out of bounds memory access");
 }
 
 for (let i = 0; i < wasmTestLoopCount; i++)

--- a/JSTests/wasm/stress/memory64-write-to-address-over-4-gigs.js
+++ b/JSTests/wasm/stress/memory64-write-to-address-over-4-gigs.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-bulk.js
+++ b/JSTests/wasm/stress/table64-bulk.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-call-indirect.js
+++ b/JSTests/wasm/stress/table64-call-indirect.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-get-and-set.js
+++ b/JSTests/wasm/stress/table64-get-and-set.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-grow-and-size.js
+++ b/JSTests/wasm/stress/table64-grow-and-size.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-initial-truncation.js
+++ b/JSTests/wasm/stress/table64-initial-truncation.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0")
 import * as assert from "../assert.js";
 
 function leb128(value) {

--- a/JSTests/wasm/stress/table64-overflow.js
+++ b/JSTests/wasm/stress/table64-overflow.js
@@ -1,5 +1,4 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table64.wast.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmMemory64=1")
 (function table64_wast_js() {
 
 // table64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_copy64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_copy64.wast.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmMemory64=1")
 (function table_copy64_wast_js() {
 
 // table_copy64.wast:6

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_fill64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_fill64.wast.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmMemory64=1")
 (function table_fill64_wast_js() {
 
 // table_fill64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_get64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_get64.wast.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmMemory64=1")
 (function table_get64_wast_js() {
 
 // table_get64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_grow64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_grow64.wast.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmMemory64=1")
 (function table_grow64_wast_js() {
 
 // table_grow64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_init64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_init64.wast.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmMemory64=1")
 (function table_init64_wast_js() {
 
 // table_init64.wast:6

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_set64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_set64.wast.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmMemory64=1")
 (function table_set64_wast_js() {
 
 // table_set64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_size64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_size64.wast.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmMemory64=1")
 (function table_size64_wast_js() {
 
 // table_size64.wast:1

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -9797,7 +9797,7 @@ WasmJSTypesEnabled:
 
 WasmMemory64Enabled:
   type: bool
-  status: testable
+  status: stable
   category: javascript
   humanReadableName: "WebAssembly Memory64"
   humanReadableDescription: "Allow the Memory64 proposal for WebAssembly. This feature is currently only supported in the IPInt tier."
@@ -9806,7 +9806,7 @@ WasmMemory64Enabled:
   sharedPreferenceForWebProcess: true
   defaultValue:
     WebKit:
-      default: false
+      default: true
 
 WasmMemoryToBufferAPIsEnabled:
   type: bool


### PR DESCRIPTION
#### 0d0080ea539d2c07b06d92edb5705cbcc24fe3cc
<pre>
Enable WebAssembly Memory64 feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=320570">https://bugs.webkit.org/show_bug.cgi?id=320570</a>
<a href="https://rdar.apple.com/183543404">rdar://183543404</a>

Reviewed by Keith Miller.

After this patch, useWasmMemory64 flag is on by default.

* JSTests/wasm/js-api/memory64-js-api.js:
* JSTests/wasm/js-api/table64-js-api.js:
* JSTests/wasm/stress/memory64-atomic-notify-out-of-bounds.js:
* JSTests/wasm/stress/memory64-atomic-wait-out-of-bounds.js:
* JSTests/wasm/stress/memory64-atomics.js:
* JSTests/wasm/stress/memory64-bulk-memory.js:
* JSTests/wasm/stress/memory64-grow-and-size.js:
* JSTests/wasm/stress/memory64-load-and-store.js:
* JSTests/wasm/stress/memory64-overflow.js:
(testOverflow):
* JSTests/wasm/stress/memory64-write-to-address-over-4-gigs.js:
* JSTests/wasm/stress/table64-bulk.js:
* JSTests/wasm/stress/table64-call-indirect.js:
* JSTests/wasm/stress/table64-get-and-set.js:
* JSTests/wasm/stress/table64-grow-and-size.js:
* JSTests/wasm/stress/table64-initial-truncation.js:
* JSTests/wasm/stress/table64-overflow.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_copy64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_fill64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_get64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_grow64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_init64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_set64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_size64.wast.js:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/318257@main">https://commits.webkit.org/318257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85ea8d939b2a70f71293cc58546035163df2341c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187147 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5455da1-2b21-424a-9acd-9e1ec0043a65) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138377 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a6cb749-a751-46ed-9199-25d593047307) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118842 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40542 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38915 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/811 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7630 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38628 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35614 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38814 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189575 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51148 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147470 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39671 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51830 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147265 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41987 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124045 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118457 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50338 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13607 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49734 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49974 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49796 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->