### PR TITLE
[Cleanup] Factor length unit conversion into standalone functions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/viewport-units-extreme-scale-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/viewport-units-extreme-scale-expected.txt
@@ -2,6 +2,6 @@
 
 PASS 100vw computes to 640px
 PASS 100vh computes to 480px
-FAIL calc((1vw - 6.3999px) * 10000000) computes to 1000px assert_equals: expected "1000px" but got "1000.953125px"
-FAIL calc((100vh - 479px) * 60000) computes to 60000px assert_equals: expected "60000px" but got "60001.140625px"
+PASS calc((1vw - 6.3999px) * 10000000) computes to 1000px
+PASS calc((100vh - 479px) * 60000) computes to 60000px
 

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -57,7 +57,6 @@ bindings/js/ScriptModuleLoader.cpp
 contentextensions/ContentExtensionsBackend.cpp
 css/CSSStyleProperties.cpp
 css/CSSStyleSheet.cpp
-css/CSSToLengthConversionData.cpp
 css/SelectorCheckerTestFunctions.h
 css/StyleAttributeMutationScope.h
 dom/Attr.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -57,6 +57,7 @@ style/StyleInvalidationFunctions.h
 style/UserAgentStyle.cpp
 style/computed/StyleComputedStyleBase+SettersInlines.h
 style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
+style/values/primitives/StyleLengthResolution.cpp
 svg/SVGUseElement.cpp
 testing/Internals.cpp
 testing/LegacyMockCDM.cpp

--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -112,48 +112,10 @@ const FontCascade& CSSToLengthConversionData::fontCascadeForFontUnits() const
     return style()->fontCascade();
 }
 
-FloatSize CSSToLengthConversionData::defaultViewportFactor() const
+void CSSToLengthConversionData::setUsesViewportUnits() const
 {
     if (m_styleBuilderState)
         m_styleBuilderState->setUsesViewportUnits();
-
-    if (!m_renderView)
-        return { };
-
-    return m_renderView->sizeForCSSDefaultViewportUnits() / 100.0;
-}
-
-FloatSize CSSToLengthConversionData::smallViewportFactor() const
-{
-    if (m_styleBuilderState)
-        m_styleBuilderState->setUsesViewportUnits();
-
-    if (!m_renderView)
-        return { };
-
-    return m_renderView->sizeForCSSSmallViewportUnits() / 100.0;
-}
-
-FloatSize CSSToLengthConversionData::largeViewportFactor() const
-{
-    if (m_styleBuilderState)
-        m_styleBuilderState->setUsesViewportUnits();
-
-    if (!m_renderView)
-        return { };
-
-    return m_renderView->sizeForCSSLargeViewportUnits() / 100.0;
-}
-
-FloatSize CSSToLengthConversionData::dynamicViewportFactor() const
-{
-    if (m_styleBuilderState)
-        m_styleBuilderState->setUsesViewportUnits();
-
-    if (!m_renderView)
-        return { };
-
-    return m_renderView->sizeForCSSDynamicViewportUnits() / 100.0;
 }
 
 void CSSToLengthConversionData::setUsesContainerUnits() const

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -75,11 +75,6 @@ public:
 
     const FontCascade& NODELETE fontCascadeForFontUnits() const;
 
-    FloatSize defaultViewportFactor() const;
-    FloatSize smallViewportFactor() const;
-    FloatSize largeViewportFactor() const;
-    FloatSize dynamicViewportFactor() const;
-
     CSSToLengthConversionData copyForFontSize() const
     {
         CSSToLengthConversionData copy(*this);
@@ -94,6 +89,7 @@ public:
         return copy;
     }
 
+    void NODELETE setUsesViewportUnits() const;
     void NODELETE setUsesContainerUnits() const;
 
     Style::BuilderState* styleBuilderState() const { return m_styleBuilderState.get(); }

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -174,7 +174,7 @@ std::optional<CanonicalDimension> canonicalize(NonCanonicalDimension root, const
 
     auto tryMakeCanonical = [&](double value, CSS::LengthUnit lengthUnit) -> std::optional<CanonicalDimension> {
         if (conversionData)
-            return CanonicalDimension { .value = Style::computeCanonicalNonCalcLengthDouble(value, lengthUnit, *conversionData), .dimension = CanonicalDimension::Dimension::Length };
+            return CanonicalDimension { .value = Style::resolveLength(value, lengthUnit, *conversionData), .dimension = CanonicalDimension::Dimension::Length };
         return { };
     };
 

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -287,7 +287,7 @@ double Value::computeLengthPx(const CSSToLengthConversionData& conversionData, c
         .conversionData = conversionData,
         .symbolTable = symbolTable
     };
-    return clampToPermittedRange(Style::computeNonCalcLengthDouble(evaluateDouble(m_tree, options).value_or(0), CSS::LengthUnit::Px, conversionData));
+    return clampToPermittedRange(Style::resolveLength(evaluateDouble(m_tree, options).value_or(0), CSS::LengthUnit::Px, conversionData));
 }
 
 Ref<Style::Calculation::Value> Value::createCalculationValue(const CSSToLengthConversionData& conversionData) const

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -73,7 +73,7 @@ std::optional<float> SizesAttributeParser::effectiveSizeDefaultValue()
     auto conversionData = this->conversionData();
     if (!conversionData)
         return std::nullopt;
-    auto result = CSS::clampToRange<CSS::Nonnegative, float>(Style::computeNonCalcLengthDouble(100.0, CSS::LengthUnit::Vw, *conversionData));
+    auto result = CSS::clampToRange<CSS::Nonnegative, float>(Style::resolveLength(100.0, CSS::LengthUnit::Vw, *conversionData));
     if (!result)
         return std::nullopt;
     return result;
@@ -145,7 +145,7 @@ std::optional<float> SizesAttributeParser::parseDimension(CSSParserTokenRange to
     auto value = token.numericValue();
 
     auto resolve = [&] -> std::optional<float> {
-        auto result = CSS::clampToRange<CSS::All, float>(Style::computeNonCalcLengthDouble(value, *unit, *conversionData));
+        auto result = CSS::clampToRange<CSS::All, float>(Style::resolveLength(value, *unit, *conversionData));
         if (result < 0)
             return std::nullopt;
         return result;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3287,7 +3287,7 @@ void CanvasRenderingContext2DBase::setLetterSpacing(const String& letterSpacing)
         return;
 
     CheckedRef fontCascade = fontProxy()->fontCascade();
-    double pixels = Style::computeNonCalcLengthDouble(rawLength->value, rawLength->unit, CSSPropertyLetterSpacing, fontCascade, nullptr);
+    double pixels = Style::resolveLength(rawLength->value, rawLength->unit, CSSPropertyLetterSpacing, fontCascade, nullptr);
 
     modifiableState().letterSpacing = CSS::serializationForCSS(CSS::defaultSerializationContext(), *rawLength);
     modifiableState().font.setLetterSpacing(pixels);
@@ -3315,7 +3315,7 @@ void CanvasRenderingContext2DBase::setWordSpacing(const String& wordSpacing)
         return;
 
     CheckedRef fontCascade = fontProxy()->fontCascade();
-    double pixels = Style::computeNonCalcLengthDouble(rawLength->value, rawLength->unit, CSSPropertyWordSpacing, fontCascade, nullptr);
+    double pixels = Style::resolveLength(rawLength->value, rawLength->unit, CSSPropertyWordSpacing, fontCascade, nullptr);
 
     modifiableState().wordSpacing = CSS::serializationForCSS(CSS::defaultSerializationContext(), *rawLength);
     modifiableState().font.setWordSpacing(pixels);

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -275,7 +275,7 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
 
                             RefPtr document = dynamicDowncast<Document>(context);
                             return {
-                                .size = static_cast<float>(Style::computeNonCalcLengthDouble(lengthPercentage.value, lengthUnit, CSSPropertyFontSize, fontCascade, document ? document->renderView() : nullptr)),
+                                .size = static_cast<float>(Style::resolveLength(lengthPercentage.value, lengthUnit, CSSPropertyFontSize, fontCascade, document ? document->renderView() : nullptr)),
                                 .keyword = CSSValueInvalid
                             };
                         }

--- a/Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp
@@ -335,7 +335,7 @@ Child toStyle(const CSSCalc::CanonicalDimension& root, const ToStyleConversionOp
 
     switch (root.dimension) {
     case CSSCalc::CanonicalDimension::Dimension::Length:
-        return dimension(Style::computeNonCalcLengthDouble(root.value, CSS::LengthUnit::Px, *options.evaluation.conversionData));
+        return dimension(resolveLength(root.value, CSS::LengthUnit::Px, *options.evaluation.conversionData));
 
     case CSSCalc::CanonicalDimension::Dimension::Angle:
     case CSSCalc::CanonicalDimension::Dimension::Time:

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -48,21 +48,216 @@
 namespace WebCore {
 namespace Style {
 
-static double NODELETE adjustValueForPageZoom(double dimension, const CSSToLengthConversionData& conversionData)
+// MARK: - Page Zoom
+
+static double NODELETE unapplyPageZoom(double dimension, const RenderView* renderView)
 {
-    auto* renderView = conversionData.renderView();
     if (!renderView)
         return dimension;
-
     return dimension / renderView->pageZoomFactor();
 }
 
-static double NODELETE lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis logicalAxis, const FloatSize& size, const Style::ComputedStyle* style)
+static double NODELETE unapplyPageZoom(double dimension, const CSSToLengthConversionData& conversionData)
 {
-    if (!style)
-        return 0;
+    return unapplyPageZoom(dimension, conversionData.renderView());
+}
 
-    switch (mapAxisLogicalToPhysical(style->writingMode(), logicalAxis)) {
+// MARK: - Text Zoom
+
+static double applyTextZoom(double value, const CSSToLengthConversionData& conversionData)
+{
+    if (CheckedPtr builderState = conversionData.styleBuilderState())
+        return value * builderState->zoomWithTextZoomFactor();
+    return value;
+}
+
+static double applyTextZoomIf(bool condition, double value, const CSSToLengthConversionData& conversionData)
+{
+    return condition ? applyTextZoom(value, conversionData) : value;
+}
+
+// MARK: - Font Metric Zoom
+
+// Raw font metrics include the usedZoomFactor and must be normalized.
+static double unzoomFontMetric(double metric, const FontDescription& fontDescription)
+{
+    if (auto usedZoomFactor = fontDescription.usedZoomFactor(); usedZoomFactor > 0)
+        return metric / usedZoomFactor;
+    return metric;
+}
+
+
+// MARK: - "font dependent" and "root font dependent" resolution functions
+
+// Resolve the "em", "rem" and "quirky-em" units.
+// https://drafts.csswg.org/css-values-4/#em
+// https://drafts.csswg.org/css-values-4/#rem
+static double resolveEm(CSSPropertyID propertyToCompute, const FontCascade& fontCascadeForUnit)
+{
+    auto& fontDescription = fontCascadeForUnit.fontDescription();
+
+    // FIXME: Should probably use specifiedSize for every property.
+    if (propertyToCompute == CSSPropertyFontSize)
+        return fontDescription.specifiedSize();
+
+    return fontDescription.unzoomedComputedSize();
+}
+
+// Resolve the "ex" and "rex" units.
+// https://drafts.csswg.org/css-values-4/#ex
+// https://drafts.csswg.org/css-values-4/#rex
+static double resolveEx(CSSPropertyID propertyToCompute, const FontCascade& fontCascadeForUnit)
+{
+    auto& fontDescription = fontCascadeForUnit.fontDescription();
+    auto& fontMetrics = fontCascadeForUnit.metricsOfPrimaryFont();
+    if (fontMetrics.xHeight())
+        return unzoomFontMetric(fontMetrics.xHeight().value(), fontDescription);
+
+    // FIXME: Should probably use specifiedSize for every property.
+    if (propertyToCompute == CSSPropertyFontSize)
+        return fontDescription.specifiedSize() / 2.0;
+
+    return fontDescription.unzoomedComputedSize() / 2.0;
+}
+
+// Resolve the "cap" and "rcap" units.
+// https://drafts.csswg.org/css-values-4/#cap
+// https://drafts.csswg.org/css-values-4/#rcap
+static double resolveCap(CSSPropertyID, const FontCascade& fontCascadeForUnit)
+{
+    auto& fontDescription = fontCascadeForUnit.fontDescription();
+    auto& fontMetrics = fontCascadeForUnit.metricsOfPrimaryFont();
+    if (fontMetrics.capHeight())
+        return unzoomFontMetric(fontMetrics.capHeight().value(), fontDescription);
+    return unzoomFontMetric(fontMetrics.intAscent(), fontDescription);
+}
+
+// Resolve the "ch" and "rch" units.
+// https://drafts.csswg.org/css-values-4/#ch
+// https://drafts.csswg.org/css-values-4/#rch
+static double resolveCh(CSSPropertyID, const FontCascade& fontCascadeForUnit)
+{
+    return unzoomFontMetric(fontCascadeForUnit.zeroWidth(), fontCascadeForUnit.fontDescription());
+}
+
+// Resolve the "ic" and "ric" units.
+// https://drafts.csswg.org/css-values-4/#ic
+// https://drafts.csswg.org/css-values-4/#ric
+static double resolveIc(CSSPropertyID, const FontCascade& fontCascadeForUnit)
+{
+    auto& fontDescription = fontCascadeForUnit.fontDescription();
+    auto ideogramWidth = fontCascadeForUnit.metricsOfPrimaryFont().ideogramWidth();
+    if (!ideogramWidth)
+        return fontDescription.unzoomedComputedSize();
+    return unzoomFontMetric(ideogramWidth.value(), fontDescription);
+}
+
+// Resolve the "lh" unit.
+// https://drafts.csswg.org/css-values-4/#lh
+static double resolveLh(const CSSToLengthConversionData& conversionData)
+{
+    if (conversionData.computingLineHeight() || conversionData.computingFontSize()) {
+        // Try to get the parent's computed line-height, or fall back to the initial line-height of this element's font spacing.
+        if (auto* parentStyle = conversionData.parentStyle()) {
+            return evaluate<float>(
+                parentStyle->lineHeight(),
+                LineHeightEvaluationContext {
+                    parentStyle->computedFontSize(),
+                    parentStyle->metricsOfPrimaryFont().lineSpacing()
+                },
+                parentStyle->usedZoomForLength()
+            );
+        }
+        return conversionData.fontCascadeForFontUnits().metricsOfPrimaryFont().intLineSpacing();
+    }
+
+    auto* style = conversionData.style();
+    return evaluate<float>(
+        style->lineHeight(),
+        LineHeightEvaluationContext {
+            style->fontDescription().unzoomedComputedSize(),
+            style->metricsOfPrimaryFont().lineSpacing()
+        },
+        ZoomFactor::none()
+    );
+}
+
+// Resolve the "rlh" unit.
+// FIXME: Share this implementation with resolveLh (as we do with other root relative units), passing in the root style.
+// https://drafts.csswg.org/css-values-4/#rlh
+static double resolveRlh(const CSSToLengthConversionData& conversionData)
+{
+    auto* rootStyle = conversionData.rootStyle();
+    if (!rootStyle)
+        return 1.0;
+
+    if (conversionData.computingLineHeight() || conversionData.computingFontSize()) {
+        return evaluate<float>(
+            rootStyle->specifiedLineHeight(),
+            LineHeightEvaluationContext {
+                rootStyle->computedFontSize(),
+                rootStyle->metricsOfPrimaryFont().lineSpacing()
+            },
+            rootStyle->usedZoomForLength()
+        );
+    }
+
+    return evaluate<float>(
+        rootStyle->lineHeight(),
+        LineHeightEvaluationContext {
+            rootStyle->fontDescription().unzoomedComputedSize(),
+            rootStyle->metricsOfPrimaryFont().lineSpacing()
+        },
+        ZoomFactor::none()
+    );
+}
+
+// MARK: - "viewport-percentage" resolution functions
+
+enum class ViewportType : uint8_t {
+    Default,
+    Small,
+    Large,
+    Dynamic,
+};
+
+enum class ViewportPhysicalDimension : uint8_t {
+    Height,
+    Width,
+    Max,
+    Min,
+};
+
+template<ViewportType type>
+static FloatSize resolveViewportType(const RenderView& renderView)
+{
+    if constexpr (type == ViewportType::Default)
+        return renderView.sizeForCSSDefaultViewportUnits();
+    else if constexpr (type == ViewportType::Small)
+        return renderView.sizeForCSSSmallViewportUnits();
+    else if constexpr (type == ViewportType::Large)
+        return renderView.sizeForCSSLargeViewportUnits();
+    else if constexpr (type == ViewportType::Dynamic)
+        return renderView.sizeForCSSDynamicViewportUnits();
+}
+
+template<ViewportPhysicalDimension axis>
+static double resolveViewportPercentagePhysicalAxis(const FloatSize& size)
+{
+    if constexpr (axis == ViewportPhysicalDimension::Height)
+        return size.height();
+    else if constexpr (axis == ViewportPhysicalDimension::Width)
+        return size.width();
+    else if constexpr (axis == ViewportPhysicalDimension::Max)
+        return size.maxDimension();
+    else if constexpr (axis == ViewportPhysicalDimension::Min)
+        return size.minDimension();
+}
+
+template<LogicalBoxAxis axis>
+static double NODELETE resolveViewportPercentageLogicalAxis(const FloatSize& size, const ComputedStyle& style)
+{
+    switch (mapAxisLogicalToPhysical(style.writingMode(), axis)) {
     case BoxAxis::Horizontal:
         return size.width();
     case BoxAxis::Vertical:
@@ -72,24 +267,100 @@ static double NODELETE lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static double NODELETE lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis logicalAxis, const FloatSize& size, const RenderView& renderView)
+template<LogicalBoxAxis axis>
+static double NODELETE resolveViewportPercentageLogicalAxis(const FloatSize& size, const Style::ComputedStyle* style)
+{
+    if (!style)
+        return 0;
+    return resolveViewportPercentageLogicalAxis<axis>(size, *style);
+}
+
+template<LogicalBoxAxis axis>
+static double NODELETE resolveViewportPercentageLogicalAxis(const FloatSize& size, const RenderView& renderView)
 {
     auto* rootElement = renderView.document().documentElement();
     if (!rootElement)
         return 0;
-
-    return lengthOfViewportPhysicalAxisForLogicalAxis(logicalAxis, size, rootElement->renderStyle());
+    return resolveViewportPercentageLogicalAxis<axis>(size, rootElement->renderStyle());
 }
 
-// Raw font metrics include the usedZoomFactor and must be normalized.
-static double unzoomFontMetricIfNeeded(double metric, const FontDescription& fontDescription)
+template<LogicalBoxAxis axis>
+static double resolveViewportPercentageLogicalAxis(const FloatSize& size, const RenderView& renderView, const ComputedStyle* style)
 {
-    if (auto usedZoomFactor = fontDescription.usedZoomFactor(); usedZoomFactor > 0)
-        return metric / usedZoomFactor;
-    return metric;
+    if (style)
+        return resolveViewportPercentageLogicalAxis<axis>(size, *style) / renderView.pageZoomFactor();
+    return resolveViewportPercentageLogicalAxis<axis>(size, renderView) / renderView.pageZoomFactor();
 }
 
-double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, CSSPropertyID propertyToCompute, const FontCascade& fontCascadeForUnit, const RenderView* renderView)
+template<ViewportType type, ViewportPhysicalDimension axis>
+static double resolveViewportPercentageUnit(const RenderView& renderView)
+{
+    return resolveViewportPercentagePhysicalAxis<axis>(resolveViewportType<type>(renderView)) / 100.0;
+}
+
+template<ViewportType type, LogicalBoxAxis axis>
+static double resolveViewportPercentageUnit(const RenderView& renderView, const ComputedStyle* style)
+{
+    return resolveViewportPercentageLogicalAxis<axis>(resolveViewportType<type>(renderView), renderView, style) / 100.0;
+}
+
+template<ViewportType type, ViewportPhysicalDimension axis>
+static double resolveViewportPercentageUnit(const RenderView* renderView)
+{
+    if (!renderView) {
+        if constexpr (axis == ViewportPhysicalDimension::Max || axis == ViewportPhysicalDimension::Min)
+            return 1;
+        else
+            return 0;
+    }
+    return resolveViewportPercentageUnit<type, axis>(*renderView) / renderView->pageZoomFactor();
+}
+
+template<ViewportType type, LogicalBoxAxis axis>
+static double resolveViewportPercentageUnit(const RenderView* renderView, const ComputedStyle* style)
+{
+    if (!renderView)
+        return 0;
+    return resolveViewportPercentageUnit<type, axis>(*renderView, style) / renderView->pageZoomFactor();
+}
+
+// MARK: - "container-percentage" resolution functions
+
+static std::optional<double> resolveContainerUnit(const CSSToLengthConversionData& conversionData, CQ::Axis physicalAxis)
+{
+    ASSERT(physicalAxis == CQ::Axis::Width || physicalAxis == CQ::Axis::Height);
+
+    conversionData.setUsesContainerUnits();
+
+    RefPtr element = conversionData.elementForContainerUnitResolution();
+    if (!element)
+        return { };
+
+    auto mode = !conversionData.style()->pseudoElementType()
+        ? Style::ContainerQueryEvaluator::SelectionMode::Element
+        : Style::ContainerQueryEvaluator::SelectionMode::PseudoElement;
+
+    // "The query container for each axis is the nearest ancestor container that accepts container size queries on that axis."
+    while ((element = Style::ContainerQueryEvaluator::selectContainer(CQ::ContainerRequirements { physicalAxis }, nullString(), *element, mode))) {
+        auto* containerRenderer = dynamicDowncast<RenderBox>(element->renderer());
+        if (containerRenderer && containerRenderer->hasEligibleContainmentForSizeQuery()) {
+            auto widthOrHeight = physicalAxis == CQ::Axis::Width ? containerRenderer->contentBoxWidth() : containerRenderer->contentBoxHeight();
+            auto adjustedWidthOrHeight = widthOrHeight.toDouble();
+
+            if (!conversionData.computingFontSize())
+                adjustedWidthOrHeight = unapplyPageZoom(adjustedWidthOrHeight, conversionData);
+
+            return adjustedWidthOrHeight / 100;
+        }
+        // For pseudo-elements the element itself can be the container. Avoid looping forever.
+        mode = Style::ContainerQueryEvaluator::SelectionMode::Element;
+    }
+    return { };
+}
+
+// MARK: - Length Resolution
+
+double resolveLength(double value, CSS::LengthUnit lengthUnit, CSSPropertyID propertyToCompute, const FontCascade& fontCascadeForUnit, const RenderView* renderView)
 {
     using enum CSS::LengthUnit;
 
@@ -97,106 +368,90 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, CSSP
     case Px:
         return value;
     case Cm:
-        return CSS::pixelsPerCm * value;
+        return value * CSS::pixelsPerCm;
     case Mm:
-        return CSS::pixelsPerMm * value;
+        return value * CSS::pixelsPerMm;
     case Q:
-        return CSS::pixelsPerQ * value;
+        return value * CSS::pixelsPerQ;
     case In:
-        return CSS::pixelsPerInch * value;
+        return value * CSS::pixelsPerInch;
     case Pt:
-        return CSS::pixelsPerPt * value;
+        return value * CSS::pixelsPerPt;
     case Pc:
-        return CSS::pixelsPerPc * value;
+        return value * CSS::pixelsPerPc;
 
     // MARK: "font dependent" and "root font dependent" resolution
 
     case Em:
     case QuirkyEm:
-    case Rem: {
-        auto& fontDescription = fontCascadeForUnit.fontDescription();
-        return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() :  fontDescription.unzoomedComputedSize()) * value;
-    }
+    case Rem:
+        return value * resolveEm(propertyToCompute, fontCascadeForUnit);
     case Ex:
-    case Rex: {
-        auto& fontDescription = fontCascadeForUnit.fontDescription();
-        auto& fontMetrics = fontCascadeForUnit.metricsOfPrimaryFont();
-        if (fontMetrics.xHeight())
-            return unzoomFontMetricIfNeeded(fontMetrics.xHeight().value(), fontDescription) * value;
-        return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() : fontDescription.unzoomedComputedSize()) / 2.0 * value;
-    }
+    case Rex:
+        return value * resolveEx(propertyToCompute, fontCascadeForUnit);
     case Cap:
-    case Rcap: {
-        auto& fontDescription = fontCascadeForUnit.fontDescription();
-        auto& fontMetrics = fontCascadeForUnit.metricsOfPrimaryFont();
-        if (fontMetrics.capHeight())
-            return unzoomFontMetricIfNeeded(fontMetrics.capHeight().value(), fontDescription) * value;
-        return unzoomFontMetricIfNeeded(fontMetrics.intAscent(), fontDescription) * value;
-    }
+    case Rcap:
+        return value * resolveCap(propertyToCompute, fontCascadeForUnit);
     case Ch:
-    case Rch: {
-        auto& fontDescription = fontCascadeForUnit.fontDescription();
-        return unzoomFontMetricIfNeeded(fontCascadeForUnit.zeroWidth(), fontDescription) * value;
-    }
+    case Rch:
+        return value * resolveCh(propertyToCompute, fontCascadeForUnit);
     case Ic:
-    case Ric: {
-        auto& fontDescription = fontCascadeForUnit.fontDescription();
-        auto ideogramWidth = fontCascadeForUnit.metricsOfPrimaryFont().ideogramWidth();
-        if (!ideogramWidth)
-            return fontDescription.unzoomedComputedSize() * value;
-        return unzoomFontMetricIfNeeded(ideogramWidth.value(), fontDescription) * value;
-    }
+    case Ric:
+        return value * resolveIc(propertyToCompute, fontCascadeForUnit);
 
     // MARK: "viewport percentage" resolution
 
     case Vh:
-        return renderView ? renderView->sizeForCSSDefaultViewportUnits().height() / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Default, ViewportPhysicalDimension::Height>(renderView);
     case Vw:
-        return renderView ? renderView->sizeForCSSDefaultViewportUnits().width() / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Default, ViewportPhysicalDimension::Width>(renderView);
     case Vmax:
-        return renderView ? renderView->sizeForCSSDefaultViewportUnits().maxDimension() / 100.0 * value : value;
+        return value * resolveViewportPercentageUnit<ViewportType::Default, ViewportPhysicalDimension::Max>(renderView);
     case Vmin:
-        return renderView ? renderView->sizeForCSSDefaultViewportUnits().minDimension() / 100.0 * value : value;
+        return value * resolveViewportPercentageUnit<ViewportType::Default, ViewportPhysicalDimension::Min>(renderView);
     case Vb:
-        return renderView ? lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Block, renderView->sizeForCSSDefaultViewportUnits(), *renderView) / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Default, LogicalBoxAxis::Block>(renderView, nullptr);
     case Vi:
-        return renderView ? lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Inline, renderView->sizeForCSSDefaultViewportUnits(), *renderView) / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Default, LogicalBoxAxis::Inline>(renderView, nullptr);
+
     case Svh:
-        return renderView ? renderView->sizeForCSSSmallViewportUnits().height() / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Small, ViewportPhysicalDimension::Height>(renderView);
     case Svw:
-        return renderView ? renderView->sizeForCSSSmallViewportUnits().width() / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Small, ViewportPhysicalDimension::Width>(renderView);
     case Svmax:
-        return renderView ? renderView->sizeForCSSSmallViewportUnits().maxDimension() / 100.0 * value : value;
+        return value * resolveViewportPercentageUnit<ViewportType::Small, ViewportPhysicalDimension::Max>(renderView);
     case Svmin:
-        return renderView ? renderView->sizeForCSSSmallViewportUnits().minDimension() / 100.0 * value : value;
+        return value * resolveViewportPercentageUnit<ViewportType::Small, ViewportPhysicalDimension::Min>(renderView);
     case Svb:
-        return renderView ? lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Block, renderView->sizeForCSSSmallViewportUnits(), *renderView) / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Small, LogicalBoxAxis::Block>(renderView, nullptr);
     case Svi:
-        return renderView ? lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Inline, renderView->sizeForCSSSmallViewportUnits(), *renderView) / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Small, LogicalBoxAxis::Inline>(renderView, nullptr);
+
     case Lvh:
-        return renderView ? renderView->sizeForCSSLargeViewportUnits().height() / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Large, ViewportPhysicalDimension::Height>(renderView);
     case Lvw:
-        return renderView ? renderView->sizeForCSSLargeViewportUnits().width() / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Large, ViewportPhysicalDimension::Width>(renderView);
     case Lvmax:
-        return renderView ? renderView->sizeForCSSLargeViewportUnits().maxDimension() / 100.0 * value : value;
+        return value * resolveViewportPercentageUnit<ViewportType::Large, ViewportPhysicalDimension::Max>(renderView);
     case Lvmin:
-        return renderView ? renderView->sizeForCSSLargeViewportUnits().minDimension() / 100.0 * value : value;
+        return value * resolveViewportPercentageUnit<ViewportType::Large, ViewportPhysicalDimension::Min>(renderView);
     case Lvb:
-        return renderView ? lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Block, renderView->sizeForCSSLargeViewportUnits(), *renderView) / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Large, LogicalBoxAxis::Block>(renderView, nullptr);
     case Lvi:
-        return renderView ? lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Inline, renderView->sizeForCSSLargeViewportUnits(), *renderView) / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Large, LogicalBoxAxis::Inline>(renderView, nullptr);
+
     case Dvh:
-        return renderView ? renderView->sizeForCSSDynamicViewportUnits().height() / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, ViewportPhysicalDimension::Height>(renderView);
     case Dvw:
-        return renderView ? renderView->sizeForCSSDynamicViewportUnits().width() / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, ViewportPhysicalDimension::Width>(renderView);
     case Dvmax:
-        return renderView ? renderView->sizeForCSSDynamicViewportUnits().maxDimension() / 100.0 * value : value;
+        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, ViewportPhysicalDimension::Max>(renderView);
     case Dvmin:
-        return renderView ? renderView->sizeForCSSDynamicViewportUnits().minDimension() / 100.0 * value : value;
+        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, ViewportPhysicalDimension::Min>(renderView);
     case Dvb:
-        return renderView ? lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Block, renderView->sizeForCSSDynamicViewportUnits(), *renderView) / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, LogicalBoxAxis::Block>(renderView, nullptr);
     case Dvi:
-        return renderView ? lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Inline, renderView->sizeForCSSDynamicViewportUnits(), *renderView) / 100.0 * value : 0;
+        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, LogicalBoxAxis::Inline>(renderView, nullptr);
 
     case Lh:
     case Rlh:
@@ -213,242 +468,177 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, CSSP
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static double applyTextZoom(double value, const CSSToLengthConversionData& conversionData)
-{
-    if (CheckedPtr builderState = conversionData.styleBuilderState())
-        return value * builderState->zoomWithTextZoomFactor();
-    return value;
-}
-
-double computeCanonicalNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, const CSSToLengthConversionData& conversionData)
-{
-    return computeNonCalcLengthDouble(value, lengthUnit, conversionData);
-}
-
-double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, const CSSToLengthConversionData& conversionData)
+double resolveLength(double value, CSS::LengthUnit lengthUnit, const CSSToLengthConversionData& conversionData)
 {
     using enum CSS::LengthUnit;
 
-    auto resolveContainerUnit = [&](CQ::Axis physicalAxis) -> std::optional<double> {
-        ASSERT(physicalAxis == CQ::Axis::Width || physicalAxis == CQ::Axis::Height);
-
-        conversionData.setUsesContainerUnits();
-
-        RefPtr element = conversionData.elementForContainerUnitResolution();
-        if (!element)
-            return { };
-
-        auto mode = !conversionData.style()->pseudoElementType()
-            ? Style::ContainerQueryEvaluator::SelectionMode::Element
-            : Style::ContainerQueryEvaluator::SelectionMode::PseudoElement;
-
-        // "The query container for each axis is the nearest ancestor container that accepts container size queries on that axis."
-        while ((element = Style::ContainerQueryEvaluator::selectContainer(CQ::ContainerRequirements { physicalAxis }, nullString(), *element, mode))) {
-            auto* containerRenderer = dynamicDowncast<RenderBox>(element->renderer());
-            if (containerRenderer && containerRenderer->hasEligibleContainmentForSizeQuery()) {
-                auto widthOrHeight = physicalAxis == CQ::Axis::Width ? containerRenderer->contentBoxWidth() : containerRenderer->contentBoxHeight();
-                auto adjustedWidthOrHeight = widthOrHeight.toDouble();
-
-                if (!conversionData.computingFontSize())
-                    adjustedWidthOrHeight = adjustValueForPageZoom(adjustedWidthOrHeight, conversionData);
-
-                return adjustedWidthOrHeight * value / 100;
-            }
-            // For pseudo-elements the element itself can be the container. Avoid looping forever.
-            mode = Style::ContainerQueryEvaluator::SelectionMode::Element;
-        }
-        return { };
-    };
-
     switch (lengthUnit) {
     case Px:
-        break;
+        return value * applyTextZoomIf(conversionData.computingLineHeight(), 1.0, conversionData);
     case Cm:
-        value = CSS::pixelsPerCm * value;
-        break;
+        return value * applyTextZoomIf(conversionData.computingLineHeight(), CSS::pixelsPerCm, conversionData);
     case Mm:
-        value = CSS::pixelsPerMm * value;
-        break;
+        return value * applyTextZoomIf(conversionData.computingLineHeight(), CSS::pixelsPerMm, conversionData);
     case Q:
-        value = CSS::pixelsPerQ * value;
-        break;
+        return value * applyTextZoomIf(conversionData.computingLineHeight(), CSS::pixelsPerQ, conversionData);
     case In:
-        value = CSS::pixelsPerInch * value;
-        break;
+        return value * applyTextZoomIf(conversionData.computingLineHeight(), CSS::pixelsPerInch, conversionData);
     case Pt:
-        value = CSS::pixelsPerPt * value;
-        break;
+        return value * applyTextZoomIf(conversionData.computingLineHeight(), CSS::pixelsPerPt, conversionData);
     case Pc:
-        value = CSS::pixelsPerPc * value;
-        break;
+        return value * applyTextZoomIf(conversionData.computingLineHeight(), CSS::pixelsPerPc, conversionData);
 
     // MARK: "font dependent" resolution
 
     case Em:
     case QuirkyEm:
+        return value * applyTextZoom(resolveEm(conversionData.propertyToCompute(), conversionData.fontCascadeForFontUnits()), conversionData);
     case Ex:
+        return value * applyTextZoom(resolveEx(conversionData.propertyToCompute(), conversionData.fontCascadeForFontUnits()), conversionData);
     case Cap:
+        return value * applyTextZoom(resolveCap(conversionData.propertyToCompute(), conversionData.fontCascadeForFontUnits()), conversionData);
+
     case Ch:
+        return value * applyTextZoom(resolveCh(conversionData.propertyToCompute(), conversionData.fontCascadeForFontUnits()), conversionData);
     case Ic:
-        value = computeNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), conversionData.fontCascadeForFontUnits(), nullptr);
-        value = applyTextZoom(value, conversionData);
-        break;
+        return value * applyTextZoom(resolveIc(conversionData.propertyToCompute(), conversionData.fontCascadeForFontUnits()), conversionData);
 
     case Lh:
-        if (conversionData.computingLineHeight() || conversionData.computingFontSize()) {
-            // Try to get the parent's computed line-height, or fall back to the initial line-height of this element's font spacing.
-            value *= conversionData.parentStyle() ? conversionData.parentStyle()->computedLineHeight() : conversionData.fontCascadeForFontUnits().metricsOfPrimaryFont().intLineSpacing();
-        } else {
-            auto* style = conversionData.style();
-            auto computedFontSize = style->fontDescription().unzoomedComputedSize();
-            Style::LineHeightEvaluationContext context { computedFontSize, style->metricsOfPrimaryFont().lineSpacing() };
-            value *= Style::evaluate<float>(style->lineHeight(), context, Style::ZoomFactor { 1.0f });
-        }
-        break;
+        return value * applyTextZoomIf(conversionData.computingLineHeight(), resolveLh(conversionData), conversionData);
 
     // MARK: "root font dependent" resolution
 
-    case Rcap:
-    case Rch:
     case Rem:
+        return value * applyTextZoom(resolveEm(conversionData.propertyToCompute(), conversionData.rootStyle() ? conversionData.rootStyle()->fontCascade() : conversionData.fontCascadeForFontUnits()), conversionData);
+    case Rcap:
+        return value * applyTextZoom(resolveCap(conversionData.propertyToCompute(), conversionData.rootStyle() ? conversionData.rootStyle()->fontCascade() : conversionData.fontCascadeForFontUnits()), conversionData);
+    case Rch:
+        return value * applyTextZoom(resolveCh(conversionData.propertyToCompute(), conversionData.rootStyle() ? conversionData.rootStyle()->fontCascade() : conversionData.fontCascadeForFontUnits()), conversionData);
     case Rex:
+        return value * applyTextZoom(resolveEx(conversionData.propertyToCompute(), conversionData.rootStyle() ? conversionData.rootStyle()->fontCascade() : conversionData.fontCascadeForFontUnits()), conversionData);
     case Ric:
-        value = computeNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), conversionData.rootStyle() ? conversionData.rootStyle()->fontCascade() : conversionData.fontCascadeForFontUnits(), nullptr);
-        value = applyTextZoom(value, conversionData);
-        break;
+        return value * applyTextZoom(resolveIc(conversionData.propertyToCompute(), conversionData.rootStyle() ? conversionData.rootStyle()->fontCascade() : conversionData.fontCascadeForFontUnits()), conversionData);
 
     case Rlh:
-        if (auto* rootStyle = conversionData.rootStyle()) {
-            if (conversionData.computingLineHeight() || conversionData.computingFontSize())
-                value *= Style::evaluate<float>(rootStyle->specifiedLineHeight(), Style::LineHeightEvaluationContext { rootStyle->computedFontSize(), rootStyle->metricsOfPrimaryFont().lineSpacing() }, rootStyle->usedZoomForLength());
-            else {
-                auto computedFontSize = rootStyle->fontDescription().unzoomedComputedSize();
-                Style::LineHeightEvaluationContext context { computedFontSize, rootStyle->metricsOfPrimaryFont().lineSpacing() };
-                value *= Style::evaluate<float>(rootStyle->lineHeight(), context, Style::ZoomFactor { 1.0f });
-            }
-        }
-        break;
+        return value * applyTextZoomIf(conversionData.computingLineHeight(), resolveRlh(conversionData), conversionData);
 
     // MARK: "viewport-percentage" resolution
 
     case Vh:
-        return value * adjustValueForPageZoom(conversionData.defaultViewportFactor().height(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Default, ViewportPhysicalDimension::Height>(conversionData.renderView());
     case Vw:
-        return value * adjustValueForPageZoom(conversionData.defaultViewportFactor().width(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Default, ViewportPhysicalDimension::Width>(conversionData.renderView());
     case Vmax:
-        return value * adjustValueForPageZoom(conversionData.defaultViewportFactor().maxDimension(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Default, ViewportPhysicalDimension::Max>(conversionData.renderView());
     case Vmin:
-        return value * adjustValueForPageZoom(conversionData.defaultViewportFactor().minDimension(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Default, ViewportPhysicalDimension::Min>(conversionData.renderView());
     case Vb:
-        return value * adjustValueForPageZoom(lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Block, conversionData.defaultViewportFactor(), conversionData.style()), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Default, LogicalBoxAxis::Block>(conversionData.renderView(), conversionData.style());
     case Vi:
-        return value * adjustValueForPageZoom(lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Inline, conversionData.defaultViewportFactor(), conversionData.style()), conversionData);
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Default, LogicalBoxAxis::Inline>(conversionData.renderView(), conversionData.style());
 
     case Svh:
-        return value * adjustValueForPageZoom(conversionData.smallViewportFactor().height(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Small, ViewportPhysicalDimension::Height>(conversionData.renderView());
     case Svw:
-        return value * adjustValueForPageZoom(conversionData.smallViewportFactor().width(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Small, ViewportPhysicalDimension::Width>(conversionData.renderView());
     case Svmax:
-        return value * adjustValueForPageZoom(conversionData.smallViewportFactor().maxDimension(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Small, ViewportPhysicalDimension::Max>(conversionData.renderView());
     case Svmin:
-        return value * adjustValueForPageZoom(conversionData.smallViewportFactor().minDimension(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Small, ViewportPhysicalDimension::Min>(conversionData.renderView());
     case Svb:
-        return value * adjustValueForPageZoom(lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Block, conversionData.smallViewportFactor(), conversionData.style()), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Small, LogicalBoxAxis::Block>(conversionData.renderView(), conversionData.style());
     case Svi:
-        return value * adjustValueForPageZoom(lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Inline, conversionData.smallViewportFactor(), conversionData.style()), conversionData);
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Small, LogicalBoxAxis::Inline>(conversionData.renderView(), conversionData.style());
 
     case Lvh:
-        return value * adjustValueForPageZoom(conversionData.largeViewportFactor().height(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Large, ViewportPhysicalDimension::Height>(conversionData.renderView());
     case Lvw:
-        return value * adjustValueForPageZoom(conversionData.largeViewportFactor().width(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Large, ViewportPhysicalDimension::Width>(conversionData.renderView());
     case Lvmax:
-        return value * adjustValueForPageZoom(conversionData.largeViewportFactor().maxDimension(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Large, ViewportPhysicalDimension::Max>(conversionData.renderView());
     case Lvmin:
-        return value * adjustValueForPageZoom(conversionData.largeViewportFactor().minDimension(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Large, ViewportPhysicalDimension::Min>(conversionData.renderView());
     case Lvb:
-        return value * adjustValueForPageZoom(lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Block, conversionData.largeViewportFactor(), conversionData.style()), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Large, LogicalBoxAxis::Block>(conversionData.renderView(), conversionData.style());
     case Lvi:
-        return value * adjustValueForPageZoom(lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Inline, conversionData.largeViewportFactor(), conversionData.style()), conversionData);
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Large, LogicalBoxAxis::Inline>(conversionData.renderView(), conversionData.style());
 
     case Dvh:
-        return value * adjustValueForPageZoom(conversionData.dynamicViewportFactor().height(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, ViewportPhysicalDimension::Height>(conversionData.renderView());
     case Dvw:
-        return value * adjustValueForPageZoom(conversionData.dynamicViewportFactor().width(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, ViewportPhysicalDimension::Width>(conversionData.renderView());
     case Dvmax:
-        return value * adjustValueForPageZoom(conversionData.dynamicViewportFactor().maxDimension(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, ViewportPhysicalDimension::Max>(conversionData.renderView());
     case Dvmin:
-        return value * adjustValueForPageZoom(conversionData.dynamicViewportFactor().minDimension(), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, ViewportPhysicalDimension::Min>(conversionData.renderView());
     case Dvb:
-        return value * adjustValueForPageZoom(lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Block, conversionData.dynamicViewportFactor(), conversionData.style()), conversionData);
-
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, LogicalBoxAxis::Block>(conversionData.renderView(), conversionData.style());
     case Dvi:
-        return value * adjustValueForPageZoom(lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Inline, conversionData.dynamicViewportFactor(), conversionData.style()), conversionData);
+        conversionData.setUsesViewportUnits();
+        return value * resolveViewportPercentageUnit<ViewportType::Dynamic, LogicalBoxAxis::Inline>(conversionData.renderView(), conversionData.style());
 
     // MARK: "container-percentage" resolution
 
-    case Cqw: {
-        if (auto resolvedValue = resolveContainerUnit(CQ::Axis::Width))
-            return *resolvedValue;
-        return computeNonCalcLengthDouble(value, Svw, conversionData);
-    }
+    case Cqw:
+        if (auto resolvedValue = resolveContainerUnit(conversionData, CQ::Axis::Width))
+            return value * *resolvedValue;
+        return resolveLength(value, Svw, conversionData);
 
-    case Cqh: {
-        if (auto resolvedValue = resolveContainerUnit(CQ::Axis::Height))
-            return *resolvedValue;
-        return computeNonCalcLengthDouble(value, Svh, conversionData);
-    }
+    case Cqh:
+        if (auto resolvedValue = resolveContainerUnit(conversionData, CQ::Axis::Height))
+            return value * *resolvedValue;
+        return resolveLength(value, Svh, conversionData);
 
-    case Cqi: {
-        if (auto resolvedValue = resolveContainerUnit(conversionData.style()->writingMode().isHorizontal() ? CQ::Axis::Width : CQ::Axis::Height))
-            return *resolvedValue;
-        return computeNonCalcLengthDouble(value, Svi, conversionData);
-    }
+    case Cqi:
+        if (auto resolvedValue = resolveContainerUnit(conversionData, conversionData.style()->writingMode().isHorizontal() ? CQ::Axis::Width : CQ::Axis::Height))
+            return value * *resolvedValue;
+        return resolveLength(value, Svi, conversionData);
 
-    case Cqb: {
-        if (auto resolvedValue = resolveContainerUnit(conversionData.style()->writingMode().isHorizontal() ? CQ::Axis::Height : CQ::Axis::Width))
-            return *resolvedValue;
-        return computeNonCalcLengthDouble(value, Svb, conversionData);
-    }
+    case Cqb:
+        if (auto resolvedValue = resolveContainerUnit(conversionData, conversionData.style()->writingMode().isHorizontal() ? CQ::Axis::Height : CQ::Axis::Width))
+            return value * *resolvedValue;
+        return resolveLength(value, Svb, conversionData);
 
     case Cqmax:
         if (value < 0)
-            return std::min(computeNonCalcLengthDouble(value, Cqb, conversionData), computeNonCalcLengthDouble(value, Cqi, conversionData));
-        return std::max(computeNonCalcLengthDouble(value, Cqb, conversionData), computeNonCalcLengthDouble(value, Cqi, conversionData));
+            return std::min(resolveLength(value, Cqb, conversionData), resolveLength(value, Cqi, conversionData));
+        return std::max(resolveLength(value, Cqb, conversionData), resolveLength(value, Cqi, conversionData));
 
     case Cqmin:
         if (value < 0)
-            return std::max(computeNonCalcLengthDouble(value, Cqb, conversionData), computeNonCalcLengthDouble(value, Cqi, conversionData));
-        return std::min(computeNonCalcLengthDouble(value, Cqb, conversionData), computeNonCalcLengthDouble(value, Cqi, conversionData));
+            return std::max(resolveLength(value, Cqb, conversionData), resolveLength(value, Cqi, conversionData));
+        return std::min(resolveLength(value, Cqb, conversionData), resolveLength(value, Cqi, conversionData));
     }
 
-    if (conversionData.computingLineHeight() && !isFontOrRootFontRelativeLength(lengthUnit))
-        return applyTextZoom(value, conversionData);
-
-    return value;
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 bool equalForLengthResolution(const Style::ComputedStyle& styleA, const Style::ComputedStyle& styleB)
 {
-    // These properties affect results of `computeNonCalcLengthDouble` above.
+    // These properties affect results of `resolveLength` above.
 
     if (styleA.fontDescription().computedSize() != styleB.fontDescription().computedSize())
         return false;
@@ -465,6 +655,8 @@ bool equalForLengthResolution(const Style::ComputedStyle& styleA, const Style::C
 
     return true;
 }
+
+// MARK: - em-to-px utility functions
 
 double emToPxDouble(double value, const CSSToLengthConversionData& conversionData)
 {

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.h
@@ -44,23 +44,19 @@ namespace Style {
 
 class ComputedStyle;
 
-// FIXME: These functions have odd names and invariants and could use improvements.
-
-// NOTE: `computeNonCalcLengthDouble` has the following restrictions:
+// NOTE: The `resolveLength` overload that doesn't take `CSSToLengthConversionData` has the following restrictions:
 //
 // It can never be called with the following LengthUnits:
 //    Lh, Rlh, Cqw, Cqh, Cqi, Cqb, Cqmin, Cqmax (line height, and container-percentage units)
 //
-// If `fontCascadeForUnit` is nullptr, it additionally cannot be called with the following LengthUnits:
-//    Em, QuirkyEm, Ex, Cap, Ch, Ic, Rca, Rc, Re, Re, Ri (font and root font dependent units)
-//
 // If `RenderView` is nullptr, the following LengthUnits will all cause a return value of zero:
-//    Vw, Vh, Vmin, Vmax, Vb, Vi, Svw, Svh, Svmin, Svmax, Svb, Svi, Lvw, Lvh, Lvmin, Lvmax, Lvb, Lvi, Dvw, Dvh, Dvmin, Dvmax, Dvb, Dvi (viewport-percentage units)
-double computeNonCalcLengthDouble(double value, CSS::LengthUnit, CSSPropertyID, const FontCascade& fontCascadeForUnit, const RenderView*);
-double computeNonCalcLengthDouble(double value, CSS::LengthUnit, const CSSToLengthConversionData&);
-double computeCanonicalNonCalcLengthDouble(double value, CSS::LengthUnit, const CSSToLengthConversionData&);
+//    Vw, Vh, Vb, Vi, Svw, Svh, Svb, Svi, Lvw, Lvh, Lvb, Lvi, Dvw, Dvh, Dvb, Dvi (width/height/block/inline viewport-percentage units)
+// and the following LengthUnits will all cause a return value of `value`:
+//    Vmin, Vmax, Svmin, Svmax, Lvmin, Lvmax, Dvmin, Dvmax (min/max viewport-percentage units)
+double resolveLength(double value, CSS::LengthUnit, CSSPropertyID, const FontCascade& fontCascadeForUnit, const RenderView*);
+double resolveLength(double value, CSS::LengthUnit, const CSSToLengthConversionData&);
 
-// True if `computeNonCalcLengthDouble` would produce identical results when resolved against both these styles.
+// True if `resolveLength` would produce identical results when resolved against both these styles.
 bool equalForLengthResolution(const Style::ComputedStyle&, const Style::ComputedStyle&);
 
 // Utilities for common conversions.

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
@@ -37,12 +37,12 @@ namespace Style {
 
 double canonicalizeLength(double value, CSS::LengthUnit unit, NoConversionDataRequiredToken)
 {
-    return computeNonCalcLengthDouble(value, unit, { });
+    return resolveLength(value, unit, { });
 }
 
 double canonicalizeLength(double value, CSS::LengthUnit unit, const CSSToLengthConversionData& conversionData)
 {
-    return computeNonCalcLengthDouble(value, unit, conversionData);
+    return resolveLength(value, unit, conversionData);
 }
 
 } // namespace Style

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -187,7 +187,7 @@ float SVGLengthContext::valueForLength(const Style::StrokeWidth& size, Style::Zo
 float SVGLengthContext::computeNonCalcLength(float inputValue, CSS::LengthUnit unit) const
 {
     if (!conversionToCanonicalUnitRequiresConversionData(unit))
-        return clampTo<float>(Style::computeNonCalcLengthDouble(inputValue, unit, { }));
+        return clampTo<float>(Style::resolveLength(inputValue, unit, { }));
 
 
     auto conversionData = cssConversionData();
@@ -199,7 +199,7 @@ float SVGLengthContext::computeNonCalcLength(float inputValue, CSS::LengthUnit u
         return 0.0f;
     }
 
-    return clampTo<float>(Style::computeNonCalcLengthDouble(inputValue, unit, *conversionData));
+    return clampTo<float>(Style::resolveLength(inputValue, unit, *conversionData));
 }
 
 ExceptionOr<float> SVGLengthContext::resolveValueToUserUnits(float value, const CSS::LengthPercentageUnit& targetUnit, SVGLengthMode lengthMode) const
@@ -213,7 +213,7 @@ ExceptionOr<float> SVGLengthContext::resolveValueToUserUnits(float value, const 
     }
 
     case CSS::LengthPercentageUnit::Ex:
-        // FIXME: Legacy quirk. Using the computeNonCalcLengthDouble conversion here causes test failures
+        // FIXME: Legacy quirk. Using the resolveLength conversion here causes test failures
         // (e.g. coords-units-03-b.svg drifting from 150 > ~139). Needs deeper investigation before unifying.
         return convertValueFromEXSToUserUnits(value);
 


### PR DESCRIPTION
#### e3276268feac295db37cc2f3c842bb81a87bdff5
<pre>
[Cleanup] Factor length unit conversion into standalone functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=320566">https://bugs.webkit.org/show_bug.cgi?id=320566</a>

Reviewed by Darin Adler.

Does a little cleanup in StyleLengthResolution.h/cpp

- Factors relative unit conversions into standalone functions
  with links to their spec definitions.
- Renames Style::computeNonCalcLengthDouble to Style::resolveLength
- Removes unnecessary alias Style::computeCanonicalNonCalcLengthDouble,
  callers can call Style::resolveLength now.
- Updates comment for Style::resolveLength to account for required
  FontCascade argument and more accurately describe the viewport-percentage
  unit results.
- Makes all arguments to Style::resolveLength required.
- Removes viewport factor getters from  CSSToLengthConversionData as these
  were only used by Style::resolveLength.
- Exposes setUsesViewportUnits along side setUsesContainerUnits for use by
  Style::resolveLength now that the viewport factor getters are not used.
- Uses a consistent style of &quot;return value * ...&quot; for each unit, removing
  all uses of break from the switch statements. The fact that some units
  returned early and some didn&apos;t was a source of confusion.

The newly passing test cases are due to the viewport-percentage unit calculations
now staying in `double` precision the entire time. Previously, some of the math was
done on `float` values.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/viewport-units-extreme-scale-expected.txt:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/css/CSSToLengthConversionData.cpp:
* Source/WebCore/css/CSSToLengthConversionData.h:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
* Source/WebCore/css/parser/SizesAttributeParser.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
* Source/WebCore/style/values/primitives/StyleLengthResolution.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp:
* Source/WebCore/svg/SVGLengthContext.cpp:

Canonical link: <a href="https://commits.webkit.org/318317@main">https://commits.webkit.org/318317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75cdc67360d20df363407436de22805213669f1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187517 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179770 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138675 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119138 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40871 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39229 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151276 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38915 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35978 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189946 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51512 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147803 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39705 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52194 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147584 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42292 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124446 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118880 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50702 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13895 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50098 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50338 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50160 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->