### PR TITLE
[Site Isolation] RemoteDOMWindow::focus() should honor WindowFocusRestricted and the creator context check before raising the top window

### DIFF
--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -57,11 +57,13 @@
 #include "ScheduledAction.h"
 #include "Screen.h"
 #include "SecurityOrigin.h"
+#include "Settings.h"
 #include "Site.h"
 #include "StyleMedia.h"
 #include "VisualViewport.h"
 #include "WebCoreOpaqueRoot.h"
 #include "WebKitPoint.h"
+#include "WindowFocusAllowedIndicator.h"
 #include "WindowProxy.h"
 #include "dom/SandboxFlags.h"
 #include "page/RemoteFrame.h"
@@ -527,6 +529,22 @@ ExceptionOr<bool> DOMWindow::originAgentCluster() const
     if (!localThis)
         return Exception { ExceptionCode::SecurityError };
     return localThis->originAgentCluster();
+}
+
+bool DOMWindow::isWindowFocusAllowed(const LocalDOMWindow& incumbentWindow) const
+{
+    RefPtr frame = this->frame();
+    if (!frame)
+        return false;
+
+    RefPtr openerFrame = frame->opener();
+    if (openerFrame && openerFrame != frame && incumbentWindow.frame() == openerFrame) {
+        RefPtr page = openerFrame->page();
+        if (page && page->isVisibleAndActive())
+            return true;
+    }
+
+    return WindowFocusAllowedIndicator::windowFocusAllowed() || !frame->settings().windowFocusRestricted();
 }
 
 void DOMWindow::focus(LocalDOMWindow& incumbentWindow)

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -233,6 +233,7 @@ public:
     bool isInsecureScriptAccess(const LocalDOMWindow& activeWindow, const URL&);
 
 protected:
+    bool isWindowFocusAllowed(const LocalDOMWindow& incumbentWindow) const;
     bool passesSetLocationSecurityChecks(const LocalDOMWindow& activeWindow, const URL& completedURL, CanNavigateState& navigationState);
     explicit DOMWindow(GlobalWindowIdentifier&&, DOMWindowType);
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1104,15 +1104,7 @@ HTMLFrameOwnerElement* LocalDOMWindow::frameElement() const
 
 void LocalDOMWindow::focus(LocalDOMWindow& incumbentWindow)
 {
-    RefPtr frame = this->frame();
-    RefPtr openerFrame = frame ? frame->opener() : nullptr;
-    focus([&] {
-        if (!openerFrame || openerFrame == frame || incumbentWindow.frame() != openerFrame)
-            return false;
-
-        auto* page = openerFrame->page();
-        return page && page->isVisibleAndActive();
-    }());
+    focus(isWindowFocusAllowed(incumbentWindow));
 }
 
 void LocalDOMWindow::focus(bool allowFocus)

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -74,11 +74,16 @@ void RemoteDOMWindow::frameDetached()
     m_frame = nullptr;
 }
 
-void RemoteDOMWindow::focus(LocalDOMWindow&)
+void RemoteDOMWindow::focus(LocalDOMWindow& incumbentWindow)
 {
-    // FIXME(264713): Add security checks here equivalent to LocalDOMWindow::focus().
-    if (m_frame && m_frame->isMainFrame())
-        m_frame->client().focus();
+    RefPtr frame = this->frame();
+    if (!frame || !frame->isMainFrame())
+        return;
+
+    if (!isWindowFocusAllowed(incumbentWindow))
+        return;
+
+    frame->client().focus();
 }
 
 void RemoteDOMWindow::blur()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -11268,4 +11268,29 @@ TEST(SiteIsolation, WebsitePoliciesAppliedToCrossOriginSubframeDocumentLoader)
     EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:check inFrame:[webView firstChildFrame]], "available");
 }
 
+#if PLATFORM(MAC)
+TEST(SiteIsolation, CrossOriginSubframeCannotFocusTopWindow)
+{
+    auto mainframeHTML = "<iframe id='iframe' src='https://domain2.com/subframe'></iframe>"_s;
+    HTTPServer server({
+        { "/mainframe"_s, { mainframeHTML } },
+        { "/subframe"_s, { ""_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    __block bool focusCalled = false;
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    [uiDelegate setFocusWebView:^(WKWebView *) {
+        focusCalled = true;
+    }];
+    webView.get().UIDelegate = uiDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView objectByEvaluatingJavaScript:@"top.focus()" inFrame:[webView firstChildFrame]];
+    EXPECT_FALSE(focusCalled);
+}
+#endif
+
 }


### PR DESCRIPTION
#### 0e82a6fdf254f8b0bdba8eaaf7cb0a4c3c740272
<pre>
[Site Isolation] RemoteDOMWindow::focus() should honor WindowFocusRestricted and the creator context check before raising the top window
<a href="https://bugs.webkit.org/show_bug.cgi?id=320574">https://bugs.webkit.org/show_bug.cgi?id=320574</a>
<a href="https://rdar.apple.com/183550899">rdar://183550899</a>

Reviewed by NOBODY (OOPS!).

RemoteDOMWindow::focus() discarded the incumbent window argument and unconditionally called
client().focus() whenever the remote frame was the main frame. Under site isolation, a cross site
subframe&apos;s top is a RemoteDOMWindow, so top.focus() with no user gesture produced a null gesture
token, WebPageProxy::focusRemoteFrame skipped its consumed-gesture guard, and the top-level window
was focused, a call that LocalDOMWindow::focus() blocks.

Move the shared policy into DOMWindow::isWindowFocusAllowed(), which both
LocalDOMWindow::focus(LocalDOMWindow&amp;) and RemoteDOMWindow::focus() now consult.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::isWindowFocusAllowed const):
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::focus):
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::focus):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, CrossOriginSubframeCannotFocusTopWindow)):
</pre>