### PR TITLE
REGRESSION(318004@main): All ModelProcess LayoutTests are failing in Debug

### DIFF
--- a/Source/WebKit/Scripts/generate-derived-log-sources.py
+++ b/Source/WebKit/Scripts/generate-derived-log-sources.py
@@ -11,7 +11,7 @@ def generate_messages_file(log_messages, log_messages_receiver_input_file, strea
     with open(log_messages_receiver_input_file, 'w') as file:
         file.write("#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)\n")
         file.write("[\n")
-        file.write("    DispatchedFrom=WebContent,\n")
+        file.write("    DispatchedFrom=WebContent|Model,\n")
         file.write("    DispatchedTo=UI,\n")
         file.write("    ExceptionForEnabledBy\n")
         file.write("]\n")

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1796,18 +1796,28 @@ def generate_header_includes_from_conditions(header_conditions):
     return result
 
 
+PROCESS_NAME_PREDICATES = {
+    "UI": "!isInAuxiliaryProcess()",
+    "Networking": "isInNetworkProcess()",
+    "GPU": "isInGPUProcess()",
+    "WebContent": "isInWebProcess()",
+    "Model": "isInModelProcess()",
+}
+
+
 def generate_dispatched_for_x(dispatched_x, spacing='    '):
-    if dispatched_x == "WebContent":
-        return ['%sASSERT(isInWebProcess());\n' % spacing]
-    elif dispatched_x == "Networking":
-        return ['%sASSERT(isInNetworkProcess());\n' % spacing]
-    elif dispatched_x == "GPU":
-        return ['%sASSERT(isInGPUProcess());\n' % spacing]
-    elif dispatched_x == "UI":
-        return ['%sASSERT(!isInAuxiliaryProcess());\n' % spacing]
-    elif dispatched_x == "Model":
-        return ['%sASSERT(isInModelProcess());\n' % spacing]
-    return []
+    if not dispatched_x:
+        return []
+    predicates = [PROCESS_NAME_PREDICATES[name] for name in dispatched_x.split('|') if name in PROCESS_NAME_PREDICATES]
+    if not predicates:
+        return []
+    return ['%sASSERT(%s);\n' % (spacing, ' || '.join(predicates))]
+
+
+def process_name_enumerator(dispatched_x):
+    if not dispatched_x or '|' in dispatched_x:
+        return "Unknown"
+    return dispatched_x
 
 
 def generate_enabled_by_for_receiver(receiver, messages):
@@ -2293,11 +2303,11 @@ def generate_message_names_implementation(receivers):
                 result.append(', %s' % value)
             result.append(', %s' % ("true" if enumerator.messages[0].is_async_reply else "false"))
             if enumerator.messages[0].is_async_reply:
-                result.append(', ProcessName::%s' % (enumerator.receiver.receiver_dispatched_to or "Unknown"))
-                result.append(', ProcessName::%s' % (enumerator.receiver.receiver_dispatched_from or "Unknown"))
+                result.append(', ProcessName::%s' % process_name_enumerator(enumerator.receiver.receiver_dispatched_to))
+                result.append(', ProcessName::%s' % process_name_enumerator(enumerator.receiver.receiver_dispatched_from))
             else:
-                result.append(', ProcessName::%s' % (enumerator.receiver.receiver_dispatched_from or "Unknown"))
-                result.append(', ProcessName::%s' % (enumerator.receiver.receiver_dispatched_to or "Unknown"))
+                result.append(', ProcessName::%s' % process_name_enumerator(enumerator.receiver.receiver_dispatched_from))
+                result.append(', ProcessName::%s' % process_name_enumerator(enumerator.receiver.receiver_dispatched_to))
             result.append(' },\n')
         if condition:
             result.append('#endif\n')

--- a/Source/WebKit/Scripts/webkit/messages_unittest.py
+++ b/Source/WebKit/Scripts/webkit/messages_unittest.py
@@ -51,6 +51,7 @@ _test_receiver_names = [
     'TestWithImageData',
     'TestWithLegacyReceiver',
     'TestWithMultiLineExtendedAttributes',
+    'TestWithMultipleDispatchedFrom',
     'TestWithoutAttributes',
     'TestWithoutUsingIPCConnection',
     'TestWithSemaphore',

--- a/Source/WebKit/Scripts/webkit/parser.py
+++ b/Source/WebKit/Scripts/webkit/parser.py
@@ -286,9 +286,11 @@ def parse_enabled_by_string(enabled_by_string):
 
 
 def parse_process_name_string(value):
-    if value in ["UI", "Networking", "GPU", "WebContent", "Model"]:
-        return value
-    raise Exception('ERROR: Invalid Process Name found')
+    names = [name.strip() for name in value.split('|')]
+    for name in names:
+        if name not in ["UI", "Networking", "GPU", "WebContent", "Model"]:
+            raise Exception('ERROR: Invalid Process Name found')
+    return '|'.join(names)
 
 
 def parse_coalescing_keys(coalescing_keys_string, parameter_names):

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -157,6 +157,8 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
 #endif
     case MessageName::TestWithMultiLineExtendedAttributes_AlwaysEnabled:
         return jsValueForDecodedMessage<MessageName::TestWithMultiLineExtendedAttributes_AlwaysEnabled>(globalObject, decoder);
+    case MessageName::TestWithMultipleDispatchedFrom_AlwaysEnabled:
+        return jsValueForDecodedMessage<MessageName::TestWithMultipleDispatchedFrom_AlwaysEnabled>(globalObject, decoder);
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithoutAttributes_LoadURL:
         return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadURL>(globalObject, decoder);
@@ -843,6 +845,10 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
 #endif
 #endif
     case MessageName::TestWithMultiLineExtendedAttributes_AlwaysEnabled:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s },
+        };
+    case MessageName::TestWithMultipleDispatchedFrom_AlwaysEnabled:
         return Vector<ArgumentDescription> {
             { "url"_s, "String"_s },
         };

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -91,6 +91,7 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithLegacyReceiver_TouchEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
     MessageDescription { "TestWithMultiLineExtendedAttributes_AlwaysEnabled"_s, ReceiverName::TestWithMultiLineExtendedAttributes, false, false, false, ProcessName::GPU, ProcessName::WebContent },
+    MessageDescription { "TestWithMultipleDispatchedFrom_AlwaysEnabled"_s, ReceiverName::TestWithMultipleDispatchedFrom, false, false, false, ProcessName::Unknown, ProcessName::UI },
     MessageDescription { "TestWithSemaphore_ReceiveSemaphore"_s, ReceiverName::TestWithSemaphore, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSemaphore_ReceiveSemaphoreReply"_s, ReceiverName::TestWithSemaphore, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSemaphore_SendSemaphore"_s, ReceiverName::TestWithSemaphore, false, false, false, ProcessName::Unknown, ProcessName::Unknown },

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -52,26 +52,27 @@ enum class ReceiverName : uint8_t {
     , TestWithImageData = 8
     , TestWithLegacyReceiver = 9
     , TestWithMultiLineExtendedAttributes = 10
-    , TestWithSemaphore = 11
-    , TestWithSpanOfConst = 12
-    , TestWithStream = 13
-    , TestWithStreamBatched = 14
-    , TestWithStreamBuffer = 15
-    , TestWithStreamServerConnectionHandle = 16
-    , TestWithStreamSwift = 17
-    , TestWithSuperclass = 18
-    , TestWithSuperclassAndWantsAsyncDispatch = 19
-    , TestWithSuperclassAndWantsDispatch = 20
-    , TestWithSwift = 21
-    , TestWithSwiftConditionally = 22
-    , TestWithValidator = 23
-    , TestWithWantsAsyncDispatch = 24
-    , TestWithWantsDispatch = 25
-    , TestWithWantsDispatchNoSyncMessages = 26
-    , TestWithoutAttributes = 27
-    , TestWithoutUsingIPCConnection = 28
-    , IPC = 29
-    , Invalid = 30
+    , TestWithMultipleDispatchedFrom = 11
+    , TestWithSemaphore = 12
+    , TestWithSpanOfConst = 13
+    , TestWithStream = 14
+    , TestWithStreamBatched = 15
+    , TestWithStreamBuffer = 16
+    , TestWithStreamServerConnectionHandle = 17
+    , TestWithStreamSwift = 18
+    , TestWithSuperclass = 19
+    , TestWithSuperclassAndWantsAsyncDispatch = 20
+    , TestWithSuperclassAndWantsDispatch = 21
+    , TestWithSwift = 22
+    , TestWithSwiftConditionally = 23
+    , TestWithValidator = 24
+    , TestWithWantsAsyncDispatch = 25
+    , TestWithWantsDispatch = 26
+    , TestWithWantsDispatchNoSyncMessages = 27
+    , TestWithoutAttributes = 28
+    , TestWithoutUsingIPCConnection = 29
+    , IPC = 30
+    , Invalid = 31
 };
 
 enum class MessageName : uint16_t {
@@ -138,6 +139,7 @@ enum class MessageName : uint16_t {
     TestWithLegacyReceiver_TouchEvent,
 #endif
     TestWithMultiLineExtendedAttributes_AlwaysEnabled,
+    TestWithMultipleDispatchedFrom_AlwaysEnabled,
     TestWithSemaphore_ReceiveSemaphore,
     TestWithSemaphore_ReceiveSemaphoreReply,
     TestWithSemaphore_SendSemaphore,

--- a/Source/WebKit/Scripts/webkit/tests/TestWithMultipleDispatchedFrom.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithMultipleDispatchedFrom.messages.in
@@ -1,0 +1,30 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+[
+    ExceptionForEnabledBy,
+    DispatchedFrom=WebContent|Model,
+    DispatchedTo=UI
+]
+messages -> TestWithMultipleDispatchedFrom {
+    AlwaysEnabled(String url)
+}

--- a/Source/WebKit/Scripts/webkit/tests/TestWithMultipleDispatchedFromMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithMultipleDispatchedFromMessageReceiver.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestWithMultipleDispatchedFrom.h"
+
+#include "ArgumentCoders.h" // NOLINT
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestWithMultipleDispatchedFromMessages.h" // NOLINT
+#include <wtf/text/WTFString.h> // NOLINT
+
+#if ENABLE(IPC_TESTING_API)
+#include "JSIPCBinding.h"
+#endif
+
+namespace WebKit {
+
+void TestWithMultipleDispatchedFrom::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+{
+    if (decoder.messageName() == Messages::TestWithMultipleDispatchedFrom::AlwaysEnabled::name()) {
+        IPC::handleMessage<Messages::TestWithMultipleDispatchedFrom::AlwaysEnabled>(connection, decoder, this, &TestWithMultipleDispatchedFrom::alwaysEnabled);
+        return;
+    }
+    UNUSED_PARAM(connection);
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
+}
+
+} // namespace WebKit
+
+#if ENABLE(IPC_TESTING_API)
+
+namespace IPC {
+
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithMultipleDispatchedFrom_AlwaysEnabled>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithMultipleDispatchedFrom::AlwaysEnabled::Arguments>(globalObject, decoder);
+}
+
+}
+
+#endif
+

--- a/Source/WebKit/Scripts/webkit/tests/TestWithMultipleDispatchedFromMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithMultipleDispatchedFromMessages.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoders.h"
+#include "Connection.h"
+#include "MessageNames.h"
+#include <wtf/Forward.h>
+#include <wtf/RuntimeApplicationChecks.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/text/WTFString.h>
+
+
+namespace Messages {
+namespace TestWithMultipleDispatchedFrom {
+
+static inline IPC::ReceiverName messageReceiverName()
+{
+#if ASSERT_ENABLED
+    static std::once_flag onceFlag;
+    std::call_once(
+        onceFlag,
+        [&] {
+            ASSERT(!isInAuxiliaryProcess());
+        }
+    );
+#endif
+    return IPC::ReceiverName::TestWithMultipleDispatchedFrom;
+}
+
+class AlwaysEnabled {
+public:
+    using Arguments = std::tuple<String>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithMultipleDispatchedFrom_AlwaysEnabled; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr bool deferSendingIfSuspended = false;
+
+    explicit AlwaysEnabled(const String& url)
+        : m_url(url)
+    {
+        ASSERT(isInWebProcess() || isInModelProcess());
+    }
+
+    template<typename Encoder>
+    void encode(Encoder& encoder)
+    {
+        encoder << m_url;
+    }
+
+private:
+    const String& m_url;
+};
+
+} // namespace TestWithMultipleDispatchedFrom
+} // namespace Messages


### PR DESCRIPTION
#### 31b41abf4cbfec8ac7dd14484782de0025820a39
<pre>
REGRESSION(318004@main): All ModelProcess LayoutTests are failing in Debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=320567">https://bugs.webkit.org/show_bug.cgi?id=320567</a>
<a href="https://rdar.apple.com/183551686">rdar://183551686</a>

Reviewed by Per Arne Vollan.

LogStream is annotated DispatchedFrom=WebContent, so its generated message
constructor asserts isInWebProcess(). Now that the Model process forwards
os_log through the same relay, that fires on every message and all
ModelProcess layout tests fail in Debug.

Let DispatchedFrom list several processes separated by &apos;|&apos; (attributes are
comma-separated), asserting any of them, and annotate LogStream
DispatchedFrom=WebContent|Model. Single-process receivers are unaffected;
MessageDescription holds one ProcessName per direction, so multiple is
described as Unknown.

* Source/WebKit/Scripts/generate-derived-log-sources.py:
(generate_messages_file):
* Source/WebKit/Scripts/webkit/messages.py:
(generate_dispatched_for_x):
(process_name_enumerator):
(generate_message_names_implementation):
* Source/WebKit/Scripts/webkit/messages_unittest.py:
* Source/WebKit/Scripts/webkit/parser.py:
(parse_process_name_string):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::jsValueForArguments):
(IPC::messageArgumentDescriptions):
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/TestWithMultipleDispatchedFrom.messages.in: Added.
* Source/WebKit/Scripts/webkit/tests/TestWithMultipleDispatchedFromMessageReceiver.cpp: Added.
(WebKit::TestWithMultipleDispatchedFrom::didReceiveMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithMultipleDispatchedFrom_AlwaysEnabled&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithMultipleDispatchedFromMessages.h: Added.
(Messages::TestWithMultipleDispatchedFrom::messageReceiverName):
(Messages::TestWithMultipleDispatchedFrom::AlwaysEnabled::name):
(Messages::TestWithMultipleDispatchedFrom::AlwaysEnabled::AlwaysEnabled):
(Messages::TestWithMultipleDispatchedFrom::AlwaysEnabled::encode):

Canonical link: <a href="https://commits.webkit.org/318224@main">https://commits.webkit.org/318224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5edc2b066d26d61211e052dd02ead9a3e8f12147

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187235 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c87ba7c8-07ed-4177-9966-e643b05e4535) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138454 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e91a3e2-24bc-40ad-a4f4-3b11956f1069) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118918 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8d481db-52c2-4157-ae73-216ac7fd25ce) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176954 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40614 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38989 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38686 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35702 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43354 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43224 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189664 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51236 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147550 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39647 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51918 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147340 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42057 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124133 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118546 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50426 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13663 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49822 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50062 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49884 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->