### PR TITLE
[JSC] Extend Array.from()'s Set fast path to cover set.keys()/.values()

### DIFF
--- a/JSTests/microbenchmarks/array-from-set-iterator.js
+++ b/JSTests/microbenchmarks/array-from-set-iterator.js
@@ -1,0 +1,16 @@
+class ObservableSet {
+    constructor(values) {
+        this._set = new Set(values);
+    }
+    keys() {
+        return this._set.keys();
+    }
+}
+
+const set = new ObservableSet();
+for (let i = 0; i < 64; ++i)
+    set._set.add(i);
+
+let total = 0;
+for (let i = 0; i < 1e4; ++i)
+    total += Array.from(set.keys()).length;

--- a/JSTests/stress/array-from-set-iterator-fast-path.js
+++ b/JSTests/stress/array-from-set-iterator-fast-path.js
@@ -1,0 +1,110 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+// Basic correctness: keys() and values() are the exact same function (aliased in the spec),
+// both produce a JSSetIterator with IterationKind::Values.
+{
+    let s = new Set([1, 2, 3]);
+    shouldBeArray(Array.from(s.values()), [1, 2, 3]);
+    shouldBeArray(Array.from(s.keys()), [1, 2, 3]);
+    shouldBeArray(Array.from(s[Symbol.iterator]()), [1, 2, 3]);
+}
+
+// entries() must not take this fast path -- it still yields [v, v] pairs correctly.
+{
+    let s = new Set(['a', 'b']);
+    let entries = Array.from(s.entries());
+    shouldBe(entries.length, 2);
+    shouldBeArray(entries[0], ['a', 'a']);
+    shouldBeArray(entries[1], ['b', 'b']);
+}
+
+// Partially-consumed iterator must resume from its real cursor, not restart from the beginning.
+{
+    let s = new Set([10, 20, 30, 40]);
+    let it = s.values();
+    it.next();
+    it.next();
+    shouldBeArray(Array.from(it), [30, 40]);
+}
+
+// Empty set iterator.
+{
+    let s = new Set();
+    shouldBeArray(Array.from(s.values()), []);
+}
+
+// Already-exhausted iterator should yield an empty array, not throw.
+{
+    let s = new Set([1]);
+    let it = s.values();
+    it.next();
+    it.next();
+    shouldBeArray(Array.from(it), []);
+}
+
+// Own "return" property on the iterator instance forces the slow path
+// (per getDirectOffset(returnKeyword) inside setIteratorProtocolIsFastAndNonObservable).
+{
+    let s = new Set([1, 2, 3]);
+    let it = s.values();
+    let called = false;
+    it.return = function () { called = true; return { done: true, value: undefined }; };
+    shouldBeArray(Array.from(it), [1, 2, 3]);
+    shouldBe(called, false);
+}
+
+// Overriding SetIteratorPrototype.next must be observed, i.e. the fast path must disengage.
+{
+    let s = new Set([1, 2, 3]);
+    let proto = Object.getPrototypeOf(s.values());
+    let calls = 0;
+    let origNext = proto.next;
+    proto.next = function () { calls++; return origNext.call(this); };
+    try {
+        shouldBeArray(Array.from(s.values()), [1, 2, 3]);
+        if (calls === 0)
+            throw new Error('overridden next() was never called -- fast path incorrectly bypassed observable override');
+    } finally {
+        proto.next = origNext;
+    }
+}
+
+// A Set subclass's own .values()/.keys() iterator still fast-paths correctly: the guard checks
+// the iterator's own prototype, not the underlying Set's prototype chain.
+{
+    class MySet extends Set { }
+    let s = new MySet([5, 6, 7]);
+    shouldBeArray(Array.from(s.values()), [5, 6, 7]);
+}
+
+// Mutating the underlying set between manual next() calls and Array.from of the remaining
+// iterator must not crash and must reflect the live storage.
+{
+    let s = new Set([1, 2]);
+    let it = s.values();
+    it.next();
+    s.add(3);
+    s.add(4);
+    shouldBeArray(Array.from(it), [2, 3, 4]);
+}
+
+// Mixed types exercise the contiguous (non-int32/non-double) storage path.
+{
+    let s = new Set(['x', { a: 1 }, [1, 2], null, undefined]);
+    shouldBe(Array.from(s.values()).length, 5);
+}
+
+// All-double-representable values exercise the hasDouble() storage path.
+{
+    let s = new Set([1.5, 2.5, 3.5]);
+    shouldBeArray(Array.from(s.values()), [1.5, 2.5, 3.5]);
+}

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
@@ -33,8 +33,10 @@
 #include "JSMapIterator.h"
 #include "JSSet.h"
 #include "JSSetInlines.h"
+#include "JSSetIterator.h"
 #include "MapIteratorPrototypeInlines.h"
 #include "ProxyObject.h"
+#include "SetIteratorPrototypeInlines.h"
 #include <wtf/text/MakeString.h>
 
 #include "VMInlines.h"
@@ -578,6 +580,115 @@ static JSArray* tryCreateArrayFromMapIterator(JSGlobalObject* globalObject, JSMa
     return JSArray::createWithButterfly(vm, nullptr, resultStructure, resultButterfly);
 }
 
+static JSArray* tryCreateArrayFromSetIterator(JSGlobalObject* globalObject, JSSetIterator* setIterator)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSSet* set = setIterator->iteratedObject();
+    if (!set) [[unlikely]]
+        return nullptr;
+
+    ASSERT(setIterator->kind() == IterationKind::Keys || setIterator->kind() == IterationKind::Values);
+
+    JSCell* storageCell = setIterator->tryGetStorage();
+    if (storageCell == vm.orderedHashTableSentinel())
+        RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
+    if (!storageCell) {
+        storageCell = set->storageOrSentinel(vm);
+        if (storageCell == vm.orderedHashTableSentinel())
+            RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
+    }
+
+    JSSet::Helper::Entry startEntry = setIterator->entry();
+    auto* storage = uncheckedDowncast<JSSet::Storage>(storageCell);
+
+    IndexingType indexingType = IsArray;
+    JSSet::Helper::Entry entry = startEntry;
+    unsigned length = 0;
+
+    while (true) {
+        JSCell* nextCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, *storage, entry);
+        if (nextCell == vm.orderedHashTableSentinel())
+            break;
+
+        auto* currentStorage = uncheckedDowncast<JSSet::Storage>(nextCell);
+        entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
+        JSValue entryValue = JSSet::Helper::getIterationEntryKey(*currentStorage);
+
+        indexingType = leastUpperBoundOfIndexingTypeAndValue(indexingType, entryValue);
+        ++length;
+        storage = currentStorage;
+    }
+
+    if (!length)
+        RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
+
+    Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(indexingType);
+    IndexingType resultIndexingType = resultStructure->indexingType();
+
+    if (hasAnyArrayStorage(resultIndexingType)) [[unlikely]]
+        return nullptr;
+
+    ASSERT(!globalObject->isHavingABadTime());
+
+    auto vectorLength = Butterfly::optimalContiguousVectorLength(resultStructure, length);
+    void* memory = vm.auxiliarySpace().allocate(
+        vm,
+        Butterfly::totalSize(0, 0, true, vectorLength * sizeof(EncodedJSValue)),
+        nullptr, AllocationFailureMode::ReturnNull);
+    if (!memory) [[unlikely]]
+        return nullptr;
+    auto* resultButterfly = Butterfly::fromBase(memory, 0, 0);
+    resultButterfly->setVectorLength(vectorLength);
+    resultButterfly->setPublicLength(length);
+
+    storageCell = setIterator->tryGetStorage();
+    if (!storageCell)
+        storageCell = set->storageOrSentinel(vm);
+    storage = uncheckedDowncast<JSSet::Storage>(storageCell);
+    entry = startEntry;
+    size_t i = 0;
+
+    if (hasDouble(resultIndexingType)) {
+        while (true) {
+            JSCell* nextCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, *storage, entry);
+            if (nextCell == vm.orderedHashTableSentinel())
+                break;
+
+            auto* currentStorage = uncheckedDowncast<JSSet::Storage>(nextCell);
+            entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
+            JSValue value = JSSet::Helper::getIterationEntryKey(*currentStorage);
+
+            ASSERT(value.isNumber());
+            resultButterfly->contiguousDouble().atUnsafe(i) = value.asNumber();
+            ++i;
+            storage = currentStorage;
+        }
+    } else if (hasInt32(resultIndexingType) || hasContiguous(resultIndexingType)) {
+        while (true) {
+            JSCell* nextCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, *storage, entry);
+            if (nextCell == vm.orderedHashTableSentinel())
+                break;
+
+            auto* currentStorage = uncheckedDowncast<JSSet::Storage>(nextCell);
+            entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
+            JSValue value = JSSet::Helper::getIterationEntryKey(*currentStorage);
+
+            resultButterfly->contiguous().atUnsafe(i).setWithoutWriteBarrier(value);
+            ++i;
+            storage = currentStorage;
+        }
+    } else
+        RELEASE_ASSERT_NOT_REACHED();
+
+    Butterfly::clearRange(resultIndexingType, resultButterfly, length, vectorLength);
+
+    setIterator->close(vm);
+
+    return JSArray::createWithButterfly(vm, nullptr, resultStructure, resultButterfly);
+}
+
 JSC_DEFINE_HOST_FUNCTION(arrayConstructorPrivateFromFastWithoutMapFn, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -638,6 +749,13 @@ JSC_DEFINE_HOST_FUNCTION(arrayConstructorPrivateFromFastWithoutMapFn, (JSGlobalO
         auto* mapIterator = uncheckedDowncast<JSMapIterator>(items.asCell());
         if (mapIterator->kind() != IterationKind::Entries && mapIteratorProtocolIsFastAndNonObservable(vm, mapIterator)) [[likely]] {
             result = tryCreateArrayFromMapIterator(globalObject, mapIterator);
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+    } else if (items && items.isCell() && items.asCell()->type() == JSSetIteratorType) {
+        // For `Array.from(set.keys())`, `Array.from(set.values())`
+        auto* setIterator = uncheckedDowncast<JSSetIterator>(items.asCell());
+        if (setIterator->kind() != IterationKind::Entries && setIteratorProtocolIsFastAndNonObservable(vm, setIterator)) [[likely]] {
+            result = tryCreateArrayFromSetIterator(globalObject, setIterator);
             RETURN_IF_EXCEPTION(scope, { });
         }
     }


### PR DESCRIPTION
#### cb1c48b3e95fb9670d91b400cc1111ea7b420dbe
<pre>
[JSC] Extend Array.from()&apos;s Set fast path to cover set.keys()/.values()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320575">https://bugs.webkit.org/show_bug.cgi?id=320575</a>
<a href="https://rdar.apple.com/183552376">rdar://183552376</a>

Reviewed by Yusuke Suzuki.

Array.from() already bypasses the generic iterator protocol for plain
Array.from(set) and Array.from(map.keys()/.values()), reading internal
hash-table storage directly. arrayConstructorPrivateFromFastWithoutMapFn
had a JSMapIteratorType case but no JSSetIteratorType case, so
Array.from(set.keys()) and Array.from(set.values()) never got the fast
path Map already had. Add tryCreateArrayFromSetIterator(), a mirror of
the existing tryCreateArrayFromMapIterator().

                                    ToT                     Patched

array-from-set-iterator        6.3581+-0.4507     ^      2.9109+-0.1796        ^ definitely 2.1842x faster

Tests: JSTests/microbenchmarks/array-from-set-iterator.js
       JSTests/stress/array-from-set-iterator-fast-path.js

Canonical link: <a href="https://commits.webkit.org/318251@main">https://commits.webkit.org/318251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a9458661703ee55bffa778107fcef270859e53a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187191 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51234 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138411 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118876 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40577 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38950 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/845 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7653 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38653 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35658 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38858 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189620 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51192 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147514 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51874 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35281 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147305 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26952 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42016 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124089 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118502 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50382 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13630 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49778 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50018 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49840 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->