### PR TITLE
[EWS] Parent build retries in AnalyzeLayoutTestsResults should only trigger the builder that made the request

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -2991,10 +2991,9 @@ class Trigger(trigger.Trigger):
                 'github.head.repo.full_name', 'github.number', 'github.title',
                 'repository', 'project', 'owners', 'classification', 'identifier',
             ]
-        if self.triggers:
-            property_names.append('triggers')
-
         properties_to_pass = {prop: properties.Property(prop) for prop in property_names}
+        if self.triggers:
+            properties_to_pass['triggers'] = self.triggers
         properties_to_pass['retry_count'] = properties.Property('retry_count', default=0)
         if not self.triggers:
             properties_to_pass['os_version_builder'] = properties.Property('os_version', default='')

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -32,6 +32,7 @@ import time
 from unittest import skip as skipTest
 from unittest.mock import call, create_autospec, patch
 
+from buildbot.process import properties
 from buildbot.process import remotetransfer
 from buildbot.process.results import SUCCESS, FAILURE, WARNINGS, SKIPPED, RETRY
 from buildbot.test.fake.fakebuild import FakeBuild
@@ -2993,6 +2994,23 @@ class TestAnalyzeLayoutTestsResults(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_outcome(result=SUCCESS, state_string=message)
         rc = self.run_step()
         self.expect_property('build_summary', message)
+        return rc
+
+    def test_retry_build_triggers_only_current_queue(self):
+        self.configureStep()
+        self.setProperty('buildername', 'iOS-13-Simulator-WK2-Tests-EWS')
+        self.setProperty('triggered_by', 'ios-13-sim-build-ews')
+        self.setProperty('scheduler', 'ios-13-sim-wk2-tests-ews')
+        self.setProperty('first_run_failures', ['test1'])
+        self.setProperty('second_run_failures', ['test1'])
+        self.setProperty('clean_tree_results_exceed_failure_limit', True)
+        self.setProperty('clean_tree_run_failures', [f'test{i}' for i in range(0, 30)])
+        next_steps = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
+        self.expect_outcome(result=SUCCESS, state_string='Unable to confirm if test failures are introduced by change, retrying build')
+        rc = self.run_step()
+        self.assertEqual(len(next_steps), 1)
+        self.assertEqual(next_steps[0].set_properties['triggers'], ['ios-13-sim-wk2-tests-ews'])
         return rc
 
     def test_clean_tree_has_lot_of_failures(self):
@@ -11825,6 +11843,18 @@ class TestTrigger(BuildStepMixinAdditions, unittest.TestCase):
         step = Trigger(schedulerNames=['test-scheduler'], triggers=['trigger1', 'trigger2'])
         props = step.propertiesToPassToTriggers()
         self.assertIn('triggers', props)
+
+    def test_triggers_property_passes_explicit_list(self):
+        step = Trigger(schedulerNames=['test-scheduler'], triggers=['tester-a'])
+        props = step.propertiesToPassToTriggers()
+        # Property overloads __eq__ to return a renderable, so assert the type before the value.
+        self.assertIsInstance(props['triggers'], list)
+        self.assertEqual(props['triggers'], ['tester-a'])
+
+    def test_triggers_property_is_not_a_renderable(self):
+        step = Trigger(schedulerNames=['test-scheduler'], triggers=['tester-a'])
+        props = step.propertiesToPassToTriggers()
+        self.assertNotIsInstance(props['triggers'], properties.Property)
 
     def test_ews_revision_excluded_when_include_revision_false(self):
         step = Trigger(schedulerNames=['test-scheduler'], include_revision=False)


### PR DESCRIPTION
#### ccea3d8723c964e5d3cef2ff2afacaf841bf93fb
<pre>
[EWS] Parent build retries in AnalyzeLayoutTestsResults should only trigger the builder that made the request
<a href="https://bugs.webkit.org/show_bug.cgi?id=320576">https://bugs.webkit.org/show_bug.cgi?id=320576</a>

Reviewed by Aakash Jain.

AnalyzeLayoutTestsResults.retry_build() already passes triggers=[scheduler] when re-triggering
its parent archive build, intending for that rebuild to only re-run the tester that asked for
the retry. That value never reached the new parent build, so every automatic retry fanned out
to the parent&apos;s full set of configured testers.

To fix this, pass the explicit list instead. ConfigureBuild already declines to overwrite a pre-set &apos;triggers&apos;
property, which is the same mechanism the force-retry-&lt;builder&gt; schedulers rely on, so no other
changes are needed.

* Tools/CISupport/ews-build/steps.py:
(Trigger.propertiesToPassToTriggers): Pass the explicit trigger list rather than a renderable
that reads the wrong build&apos;s property.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestAnalyzeLayoutTestsResults.test_retry_build_triggers_only_current_queue): Add unit test.
(TestTrigger.test_triggers_property_passes_explicit_list): Ditto.
(TestTrigger.test_triggers_property_is_not_a_renderable): Ditto.

Canonical link: <a href="https://commits.webkit.org/318261@main">https://commits.webkit.org/318261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/864fd34d74239207fa870c1957ac872b186739df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51507 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45301 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187173 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fd04585-169f-46d6-9477-3d81863307a4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51216 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138398 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0495d6a1-52ba-4b35-8bf1-d3b263f57598) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180525 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41900 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/45301 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/118863 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/99a81231-5581-4e8d-a560-925e942e11c8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40561 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38936 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/45301 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150968 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45301 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35640 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43171 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189601 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/176972 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51174 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/45301 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147495 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51856 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45301 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/147287 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26957 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/42001 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118483 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50364 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/45301 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49760 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50000 "Build was cancelled. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49822 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->