### PR TITLE
__builtin_trap instead of inline asm when running clang static analyzer

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,5 +1,1 @@
 dfg/DFGIntegerRangeOptimizationPhase.cpp
-jit/ScratchRegisterAllocator.cpp
-runtime/IndexingType.cpp
-runtime/JSObject.cpp
-yarr/YarrInterpreter.cpp

--- a/Source/WTF/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,4 +1,2 @@
 wtf/Assertions.cpp
-wtf/MetaAllocator.cpp
 wtf/StdLibExtras.h
-wtf/text/StringBuilder.cpp

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -326,7 +326,7 @@ WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 
 #endif // CPU(ARM_THUMB2)
 
-#if ASAN_ENABLED
+#if ASAN_ENABLED || defined(__clang_analyzer__)
 #define WTFBreakpointTrap()  __builtin_trap()
 #elif CPU(X86_64) || CPU(X86) || CPU(ARM64) || CPU(ARM_THUMB2)
 #define WTFBreakpointTrap()  __asm__ volatile (WTF_FATAL_CRASH_INST)


### PR DESCRIPTION
#### 5b84cf3719fa3c23a2cf8bac7a029738c723aebc
<pre>
__builtin_trap instead of inline asm when running clang static analyzer
<a href="https://bugs.webkit.org/show_bug.cgi?id=320577">https://bugs.webkit.org/show_bug.cgi?id=320577</a>

Reviewed by Geoffrey Garen.

Use __builtin_trap instead of inline asm when running safer C++ static analysis
since no-delete analysis gets confused with inline asm.

No new tests since there should be no behavior changes.

* Source/JavaScriptCore/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WTF/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WTF/wtf/Assertions.h:

Canonical link: <a href="https://commits.webkit.org/318284@main">https://commits.webkit.org/318284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d0f43241cd2c9aba3d35724a91334d91ecfb907

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187408 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27c81746-c05d-427a-a235-8fdaa52f062d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138588 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db9b0d0d-9e94-405f-9462-71d4f88dac72) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119051 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f476792-c474-431d-93bb-fff516957b8a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40779 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39142 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1020 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7838 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38838 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35870 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39070 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189838 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51404 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147706 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52086 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147492 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26965 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42216 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124338 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118767 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50594 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13817 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49990 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50230 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50052 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->