### PR TITLE
Widen find16/find32 SIMD threshold; speed up ASCII case-conversion prefix copy

### DIFF
--- a/JSTests/microbenchmarks/string-case-conversion-prefix-copy.js
+++ b/JSTests/microbenchmarks/string-case-conversion-prefix-copy.js
@@ -1,0 +1,26 @@
+function testLower(string) {
+    return string.toLowerCase();
+}
+noInline(testLower);
+
+function testUpper(string) {
+    return string.toUpperCase();
+}
+noInline(testUpper);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+const prefixLengths = [64, 256, 1024, 4096, 16384];
+
+const lowerInputs = prefixLengths.map(len => makeString("a".repeat(len) + "Z"));
+const upperInputs = prefixLengths.map(len => makeString("A".repeat(len) + "z"));
+
+for (let i = 0; i < 1e4; ++i) {
+    for (const s of lowerInputs)
+        testLower(s);
+    for (const s of upperInputs)
+        testUpper(s);
+}

--- a/JSTests/microbenchmarks/typed-array-indexof-uint16-uint32-boundary.js
+++ b/JSTests/microbenchmarks/typed-array-indexof-uint16-uint32-boundary.js
@@ -1,0 +1,36 @@
+function testU16(array, target) {
+    return array.indexOf(target);
+}
+noInline(testU16);
+
+function testU32(array, target) {
+    return array.indexOf(target);
+}
+noInline(testU32);
+
+const lengths = [4, 8, 16, 32, 64, 128];
+
+function makeU16(len) {
+    const array = new Uint16Array(len);
+    for (let i = 0; i < len; ++i)
+        array[i] = 0x1000 + (i % 100);
+    return array;
+}
+
+function makeU32(len) {
+    const array = new Uint32Array(len);
+    for (let i = 0; i < len; ++i)
+        array[i] = 0x1000 + (i % 100);
+    return array;
+}
+
+const arrays16 = lengths.map(makeU16);
+const arrays32 = lengths.map(makeU32);
+const missingTarget = 0xBEEF;
+
+for (let i = 0; i < 1e5; ++i) {
+    for (const array of arrays16)
+        testU16(array, missingTarget);
+    for (const array of arrays32)
+        testU32(array, missingTarget);
+}

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -64,8 +64,8 @@ ALWAYS_INLINE AtomString AtomString::convertASCIICase() const
         return *this;
 SlowPath:
         std::array<Latin1Character, localBufferSize> localBuffer;
-        for (unsigned i = 0; i < failingIndex; ++i)
-            localBuffer[i] = characters[i];
+        std::span<Latin1Character> localSpan { localBuffer };
+        StringImpl::copyCharacters(localSpan, characters.first(failingIndex));
         for (unsigned i = failingIndex; i < length; ++i)
             localBuffer[i] = type == CaseConvertType::Lower ? toASCIILower(characters[i]) : toASCIIUpper(characters[i]);
         return std::span<const Latin1Character> { localBuffer }.first(length);

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -649,9 +649,8 @@ SUPPRESS_NODELETE ALWAYS_INLINE const UnsignedType* NODELETE findImpl(const Unsi
         return current == character;
     };
 
-    constexpr size_t threshold = 32;
     auto* end = pointer + length;
-    auto* cursor = SIMD::find<UnsignedType, threshold>(std::span { pointer, end }, vectorMatch, scalarMatch);
+    auto* cursor = SIMD::find(std::span { pointer, end }, vectorMatch, scalarMatch);
     if (cursor == end)
         return nullptr;
     return cursor;

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -430,11 +430,13 @@ Ref<StringImpl> StringImpl::convertToLowercaseWithoutLocaleStartingAtFailingInde
     auto newImpl = createUninitializedInternalNonEmpty(m_length, data8);
 
     auto span = span8();
+    copyCharacters(data8, span.first(failingIndex));
+#if ASSERT_ENABLED
     for (unsigned i = 0; i < failingIndex; ++i) {
         ASSERT(isASCII(span[i]));
         ASSERT(!isASCIIUpper(span[i]));
-        data8[i] = span[i];
     }
+#endif
 
     for (unsigned i = failingIndex; i < span.size(); ++i) {
         Latin1Character character = span[i];
@@ -479,11 +481,13 @@ Ref<StringImpl> StringImpl::convertToUppercaseWithoutLocaleStartingAtFailingInde
     auto newImpl = createUninitialized(m_length, destination);
 
     auto span = span8();
+    copyCharacters(destination, span.first(failingIndex));
+#if ASSERT_ENABLED
     for (unsigned i = 0; i < failingIndex; ++i) {
         ASSERT(isASCII(span[i]));
         ASSERT(!isASCIILower(span[i]));
-        destination[i] = span[i];
     }
+#endif
 
     // Do a faster loop for the case where all the characters are ASCII.
     unsigned ored = 0;

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -930,11 +930,7 @@ inline bool StringImpl::containsOnlyLatin1() const
 {
     if (is8Bit())
         return true;
-    auto characters = span16();
-    char16_t mergedCharacterBits = 0;
-    for (auto character : characters)
-        mergedCharacterBits |= character;
-    return isLatin1(mergedCharacterBits);
+    return charactersAreAllLatin1(span16());
 }
 
 template<bool isSpecialCharacter(char16_t), typename CharacterType, std::size_t Extent> inline bool containsOnly(std::span<const CharacterType, Extent> characters)

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -224,6 +224,42 @@ TEST(WTF_StringCommon, EqualIgnoringASCIICase)
     // EXPECT_TRUE(WTF::equalIgnoringASCIICase(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
+template<typename UnsignedType, typename FindFunction>
+static void testFindBoundaryLengths(FindFunction findFunction)
+{
+    // Boundary lengths around the new intermediate SIMD tier find16()/find32() gained for
+    // the [stride, threshold) gap (stride 8 for uint16_t / 4 for uint32_t on 128-bit SIMD;
+    // threshold is 32). Place the target character at every position for each length.
+    for (size_t length : { 1, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64 }) {
+        Vector<UnsignedType> buffer(length, [](size_t i) {
+            return static_cast<UnsignedType>(0x1000 + (i % 100));
+        });
+
+        EXPECT_EQ(findFunction(buffer.span().data(), static_cast<UnsignedType>(0xBEEF), length), nullptr) << "length=" << length;
+
+        for (size_t position = 0; position < length; ++position) {
+            auto withTarget = buffer;
+            withTarget[position] = 0xBEEF;
+            EXPECT_EQ(findFunction(withTarget.span().data(), static_cast<UnsignedType>(0xBEEF), length), withTarget.span().data() + position)
+                << "length=" << length << " position=" << position;
+        }
+    }
+}
+
+TEST(WTF_StringCommon, Find16BoundaryLengths)
+{
+    testFindBoundaryLengths<uint16_t>([](const uint16_t* pointer, uint16_t character, size_t length) {
+        return WTF::find16(pointer, character, length);
+    });
+}
+
+TEST(WTF_StringCommon, Find32BoundaryLengths)
+{
+    testFindBoundaryLengths<uint32_t>([](const uint32_t* pointer, uint32_t character, size_t length) {
+        return WTF::find32(pointer, character, length);
+    });
+}
+
 TEST(WTF_StringCommon, StartsWith)
 {
     EXPECT_TRUE(WTF::startsWith(u8"Water🍉Melon"_span, "Water"_s));

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -102,6 +102,31 @@ TEST(WTF, StringImplReplaceWithLiteral)
     ASSERT_TRUE(equal(testStringImpl.get(), "r555sum555"_s));
 }
 
+TEST(WTF, StringImplContainsOnlyLatin1)
+{
+    ASSERT_TRUE(StringImpl::create("abc"_s)->containsOnlyLatin1());
+    ASSERT_TRUE(StringImpl::create(""_span)->containsOnlyLatin1());
+
+    // 8-bit strings are Latin1 by construction, regardless of content (unchanged branch).
+    Latin1Character eightBitChars[] = { 0xFF, 0x00, 0x80 };
+    auto eightBit = StringImpl::create(std::span<const Latin1Character> { eightBitChars });
+    ASSERT_TRUE(eightBit->is8Bit());
+    ASSERT_TRUE(eightBit->containsOnlyLatin1());
+
+    // Explicitly char16_t-backed (so always 16-bit, regardless of String's own up/downconvert
+    // heuristics), with every code point still <= 0xFF: containsOnlyLatin1 must be true.
+    char16_t allLatin1Chars[] = { 'a', 'b', 0x00E9 /* é */, 0xFF, 'c' };
+    auto allLatin1Sixteen = StringImpl::create(std::span<const char16_t> { allLatin1Chars });
+    ASSERT_FALSE(allLatin1Sixteen->is8Bit());
+    ASSERT_TRUE(allLatin1Sixteen->containsOnlyLatin1());
+
+    // Same, but with one genuine non-Latin1 code point (> 0xFF).
+    char16_t nonLatin1Chars[] = { 'a', 'b', 0x00E9 /* é */, 0x65E5 /* 日 */, 'c' };
+    auto nonLatin1 = StringImpl::create(std::span<const char16_t> { nonLatin1Chars });
+    ASSERT_FALSE(nonLatin1->is8Bit());
+    ASSERT_FALSE(nonLatin1->containsOnlyLatin1());
+}
+
 TEST(WTF, StringImplEqualIgnoringASCIICaseBasic)
 {
     auto a = StringImpl::create("aBcDeFG"_s);


### PR DESCRIPTION
#### a288a8ec809b7ae932104ad4c4b78272214d80bd
<pre>
Widen find16/find32 SIMD threshold; speed up ASCII case-conversion prefix copy
<a href="https://bugs.webkit.org/show_bug.cgi?id=320578">https://bugs.webkit.org/show_bug.cgi?id=320578</a>
<a href="https://rdar.apple.com/183555635">rdar://183555635</a>

Reviewed by Yusuke Suzuki.

This patch makes the following changes:
- find16()/find32(): drop the 32-element override so SIMD::find()&apos;s own
smaller threshold applies, closing a scalar gap below it.
- StringImpl/AtomString case-conversion: bulk-copy the already-correct
prefix instead of a byte-at-a-time loop.
- containsOnlyLatin1(): delegate to the existing SIMD-accelerated
charactersAreAllLatin1().

                                                     ToT                     Patched

typed-array-indexof-uint16-uint32-boundary.     17.2571+-0.1205     ^     15.9118+-0.1062        ^ definitely 1.0845x faster
string-case-conversion-prefix-copy              365.4766+-1.4266     ^    250.2327+-0.8555        ^ definitely 1.4605x faster

Tests: JSTests/microbenchmarks/string-case-conversion-prefix-copy.js
       JSTests/microbenchmarks/typed-array-indexof-uint16-uint32-boundary.js
       Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
       Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp

Canonical link: <a href="https://commits.webkit.org/318252@main">https://commits.webkit.org/318252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f4f9ce9a183299d2acbb29ea5999669400168c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187179 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6020f9f-1414-4ecf-b07a-a4c671a53a8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138425 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6701dbc2-e1c4-46de-98ae-76d0e1d7bbe6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118889 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd07c7e2-1c06-4c81-a169-98d33539c69e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40573 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38942 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/858 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7646 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38646 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35646 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38846 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43298 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43177 "Found 1 new test failure: http/tests/workers/service/service-worker-download-task-uaf.https.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189607 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51180 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147507 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51862 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147299 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26953 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42011 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124077 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118490 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50370 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13623 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49766 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50006 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49828 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->