### PR TITLE
Package.is_cached() should use exact version matching

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -287,7 +287,7 @@ class Package(object):
             return False
         if not manifest.get('version'):
             return False
-        if self.version and Version(*manifest.get('version').split('.')) not in self.version:
+        if self.version and Version(*manifest.get('version').split('.')) != self.version:
             return False
         if not all(pkg.is_cached() for dep in self.implicit_deps for pkg in AutoInstall.packages[dep]):
             return False

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py
@@ -94,6 +94,37 @@ class ArchiveTest(unittest.TestCase):
             self.assertEqual(mock_urlopen.call_count, 4)
 
 
+class IsCachedTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_directory.cleanup)
+
+        self.directory_patch = patch.object(AutoInstall, 'directory', self.temp_directory.name)
+        self.manifest_patch = patch.object(AutoInstall, 'manifest', {})
+
+        self.directory_patch.start()
+        self.manifest_patch.start()
+
+        self.addCleanup(self.directory_patch.stop)
+        self.addCleanup(self.manifest_patch.stop)
+
+    def test_is_cached_rejects_loose_version_match(self):
+        package = Package('example', version=Version(1, 2, 3))
+        AutoInstall.manifest[package.name] = {
+            'index': AutoInstall.index,
+            'version': '1.2',
+        }
+        self.assertFalse(package.is_cached())
+
+    def test_is_cached_accepts_exact_version_match(self):
+        package = Package('example', version=Version(1, 2, 3))
+        AutoInstall.manifest[package.name] = {
+            'index': AutoInstall.index,
+            'version': '1.2.3',
+        }
+        self.assertTrue(package.is_cached())
+
+
 class MergeMoveTest(unittest.TestCase):
     # Package._merge_move is what lets multiple distributions contribute to a
     # shared namespace package (e.g. 'backports') without clobbering each other.


### PR DESCRIPTION
#### 82407cd47dd16a25b04dbc974c520566ef171480
<pre>
Package.is_cached() should use exact version matching
<a href="https://bugs.webkit.org/show_bug.cgi?id=320507">https://bugs.webkit.org/show_bug.cgi?id=320507</a>
<a href="https://rdar.apple.com/183470357">rdar://183470357</a>

Reviewed by Ryan Haddad.

259248@main fixed this bug in Package.archives(), switching from
Version&apos;s __contains__ prefix matching to an exact one, but left
Package.is_cached() comparing the cached manifest version with
__contains__. A manifest cached under a looser pin (or from before
259248@main) can therefore still read as up to date even though it
isn&apos;t an exact match. Switch is_cached() to the same exact-match
comparison, so such a manifest is correctly treated as stale and
reinstalled.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(Package.is_cached): Use != instead of not in for the version comparison.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py:
(IsCachedTest):
(IsCachedTest.setUp):
(IsCachedTest.test_is_cached_rejects_loose_version_match):
(IsCachedTest.test_is_cached_accepts_exact_version_match):

Canonical link: <a href="https://commits.webkit.org/320006@main">https://commits.webkit.org/320006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cad039e8f37b23ba8f299ead458013776f52c0ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57393 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193690 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b746f06-2eb4-41c4-91ed-521ea9af3c45) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57128 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/143201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12c094eb-973b-439f-9bc6-d3b1a56b741e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186424 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/51210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/123622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79998354-545c-447d-ae1e-2e7b41e28e11) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182798 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/51210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4865 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195629 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182873 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57063 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/51210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57767 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/51210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/152397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27837 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/46949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56275 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/51210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55646 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55885 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/55713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->