### PR TITLE
[XHR] Final response charset is recomputed for every received data chunk

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/overridemimetype-chunked-response.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/overridemimetype-chunked-response.window-expected.txt
@@ -1,0 +1,6 @@
+
+PASS overrideMimeType() charset is used for every chunk of a chunked response
+PASS overrideMimeType() charset overrides the response charset for every chunk of a chunked response
+PASS Response charset is used for every chunk of a chunked response when overrideMimeType() has no charset
+PASS Response charset is used for every chunk of a chunked response
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/overridemimetype-chunked-response.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/overridemimetype-chunked-response.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/overridemimetype-chunked-response.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/overridemimetype-chunked-response.window.js
@@ -1,0 +1,53 @@
+// The response is delivered one byte-sequence at a time, with multi-byte
+// characters split across chunk boundaries, so the final encoding has to be
+// resolved once and then kept for the whole body.
+function chunkedURL(type, chunks) {
+  return "resources/content-in-chunks.py?type=" + encodeURIComponent(type) +
+      chunks.map(chunk => "&chunk=" + chunk).join("");
+}
+
+// "テスト" (83 65 83 58 83 67) in Shift_JIS, with the second and third
+// characters' bytes split across chunk boundaries.
+const shiftJISChunks = ["8365", "83", "5883", "67"];
+
+async_test(t => {
+  const client = new XMLHttpRequest();
+  client.onload = t.step_func_done(() => {
+    assert_equals(client.responseText, "テスト");
+  });
+  client.open("GET", chunkedURL("text/plain", shiftJISChunks));
+  client.overrideMimeType("text/plain;charset=Shift_JIS");
+  client.send();
+}, "overrideMimeType() charset is used for every chunk of a chunked response");
+
+async_test(t => {
+  const client = new XMLHttpRequest();
+  client.onload = t.step_func_done(() => {
+    assert_equals(client.responseText, "テスト");
+  });
+  client.open("GET", chunkedURL("text/plain;charset=UTF-8", shiftJISChunks));
+  client.overrideMimeType("text/plain;charset=Shift_JIS");
+  client.send();
+}, "overrideMimeType() charset overrides the response charset for every chunk of a chunked response");
+
+async_test(t => {
+  const client = new XMLHttpRequest();
+  client.onload = t.step_func_done(() => {
+    // The override has no charset of its own, so the response charset has to
+    // survive for the whole body.
+    assert_equals(client.responseText, "テスト");
+  });
+  client.open("GET", chunkedURL("text/plain;charset=Shift_JIS", shiftJISChunks));
+  client.overrideMimeType("text/xml");
+  client.send();
+}, "Response charset is used for every chunk of a chunked response when overrideMimeType() has no charset");
+
+async_test(t => {
+  const client = new XMLHttpRequest();
+  client.onload = t.step_func_done(() => {
+    assert_equals(client.responseText, "aéb");
+  });
+  // "é" in UTF-8, split across a chunk boundary.
+  client.open("GET", chunkedURL("text/plain;charset=UTF-8", ["61C3", "A962"]));
+  client.send();
+}, "Response charset is used for every chunk of a chunked response");

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/resources/content-in-chunks.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/resources/content-in-chunks.py
@@ -1,0 +1,21 @@
+import time
+
+
+def main(request, response):
+    """Streams each hex-encoded `chunk` parameter as its own chunk of a chunked
+    response, pausing `ms` milliseconds in between so that consumers observe one
+    network callback per chunk. `type` sets the Content-Type header."""
+    content_type = request.GET.first(b"type", b"text/plain")
+    delay = float(request.GET.first(b"ms", b"100")) / 1E3
+    chunks = [bytes.fromhex(chunk.decode(u"ascii")) for chunk in request.GET.get_list(b"chunk")]
+
+    response.headers.set(b"Content-Type", content_type)
+    response.headers.set(b"Transfer-Encoding", b"chunked")
+    response.write_status_headers()
+
+    for chunk in chunks:
+        time.sleep(delay)
+        response.writer.write(b"%x\r\n" % len(chunk))
+        response.writer.write(chunk)
+        response.writer.write(b"\r\n")
+    response.writer.write(b"0\r\n\r\n")

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -747,7 +747,6 @@ void XMLHttpRequest::clearResponse()
 void XMLHttpRequest::clearResponseBuffers()
 {
     m_responseBuilder.clear();
-    m_responseEncoding = String();
     m_createdDocument = false;
     {
         Locker locker { m_gcLock };
@@ -971,7 +970,6 @@ void XMLHttpRequest::didFinishLoading(ScriptExecutionContextIdentifier, std::opt
 
     m_sendFlag = false;
     changeState(DONE);
-    m_responseEncoding = String();
     m_decoder = nullptr;
 
     m_timeoutTimer.stop();
@@ -1023,11 +1021,14 @@ static inline bool NODELETE shouldDecodeResponse(XMLHttpRequest::ResponseType ty
 // https://xhr.spec.whatwg.org/#final-charset
 PAL::TextEncoding XMLHttpRequest::finalResponseCharset() const
 {
-    StringView label = m_responseEncoding;
+    // The charset of the response MIME type, if any, is overridden by the charset of the override MIME type.
+    StringView label = m_response.textEncodingName();
 
-    StringView overrideResponseCharset = extractCharsetFromMediaType(label);
-    if (!overrideResponseCharset.isEmpty())
-        label = overrideResponseCharset;
+    if (!m_mimeTypeOverride.isEmpty()) {
+        StringView overrideResponseCharset = extractCharsetFromMediaType(m_mimeTypeOverride);
+        if (!overrideResponseCharset.isEmpty())
+            label = overrideResponseCharset;
+    }
 
     return PAL::TextEncoding(label);
 }
@@ -1077,11 +1078,6 @@ void XMLHttpRequest::didReceiveData(const SharedBuffer& buffer)
 
     if (readyState() < HEADERS_RECEIVED)
         changeState(HEADERS_RECEIVED);
-
-    if (!m_mimeTypeOverride.isEmpty())
-        m_responseEncoding = extractCharsetFromMediaType(m_mimeTypeOverride).toString();
-    if (m_responseEncoding.isEmpty())
-        m_responseEncoding = m_response.textEncodingName();
 
     bool useDecoder = shouldDecodeResponse(responseType());
 

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -236,8 +236,6 @@ private:
     };
     std::optional<LoadingActivity> m_loadingActivity;
 
-    String m_responseEncoding;
-
     ResourceResponse m_response;
 
     RefPtr<TextResourceDecoder> m_decoder;


### PR DESCRIPTION
#### 3524e0b12a24b4427183d7789b4ca9f9436b783b
<pre>
[XHR] Final response charset is recomputed for every received data chunk
<a href="https://bugs.webkit.org/show_bug.cgi?id=320579">https://bugs.webkit.org/show_bug.cgi?id=320579</a>
<a href="https://rdar.apple.com/183557495">rdar://183557495</a>

Reviewed by Chris Dumez.

didReceiveData() resolved the final response charset into m_responseEncoding on
every chunk, costing a media type parse and a String allocation per network
callback. It was only read by finalResponseCharset() feeding createDecoder(),
which runs once per load, and neither input can change in between:
overrideMimeType() and the responseType setter throw once the state reaches
LOADING.

Resolve the charset directly from the two inputs in finalResponseCharset(), per
&lt;<a href="https://xhr.spec.whatwg.org/#final-charset">https://xhr.spec.whatwg.org/#final-charset</a>&gt;, and remove m_responseEncoding.
This also drops a second extractCharsetFromMediaType() call that could never
match, since its input was that same parser&apos;s output. No behavior change.

Add coverage for a charset spanning chunk boundaries; the existing
overrideMimeType() tests all use single-chunk responses.

Test: imported/w3c/web-platform-tests/xhr/overridemimetype-chunked-response.window.html

* LayoutTests/imported/w3c/web-platform-tests/xhr/overridemimetype-chunked-response.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/overridemimetype-chunked-response.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/overridemimetype-chunked-response.window.js: Added.
(chunkedURL):
(async_test.t.client.onload.t.step_func_done):
* LayoutTests/imported/w3c/web-platform-tests/xhr/resources/content-in-chunks.py: Added.
(main):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::clearResponseBuffers):
(WebCore::XMLHttpRequest::didFinishLoading):
(WebCore::XMLHttpRequest::finalResponseCharset const):
(WebCore::XMLHttpRequest::didReceiveData):
* Source/WebCore/xml/XMLHttpRequest.h:

Canonical link: <a href="https://commits.webkit.org/318297@main">https://commits.webkit.org/318297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32f0e829fe9ee0bceb6ff5fa1a9837503371766d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187183 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b6bd516-bc0f-4ec2-9e08-27b9539acc0a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138404 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8bf5a41f-87cf-4170-a452-770aff4a1e74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41910 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159149 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; 1 api test failed or timed out; 1 api test failed or timed out; 1 api test failed or timed out; Passed API tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118869 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46e214c0-0854-4aa0-849f-e3e1412279e1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40571 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38944 "Passed tests") | | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150978 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; 1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38645 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35650 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189612 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147503 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39695 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51866 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147295 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42007 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124081 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118494 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50374 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13622 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49770 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50010 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49832 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->