### PR TITLE
[GFC] Make sure there is at least one row when ImplicitGrid is created.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -83,6 +83,12 @@ GridDimensions GridLayout::calculateInitialImplicitGridDimensions(const Unplaced
     for (const auto& item : unplacedGridItems.definiteRowPositionedItems)
         updateGridBounds(item);
 
+    // The implicit grid always starts with at least one row. Grid coverage guarantees at least one
+    // in-flow grid item, and every item occupies at least one row, so placement would end up
+    // creating this row regardless. Starting with it means the grid matrix is never empty, which
+    // lets the column count always be read from the matrix itself.
+    maximumRowIndex = std::max<size_t>(maximumRowIndex, 1);
+
     return {
         maximumColumnIndex,
         maximumRowIndex

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
@@ -44,7 +44,6 @@ namespace Layout {
 
 ImplicitGrid::ImplicitGrid(size_t totalColumnsCount, size_t totalRowsCount)
     : m_gridMatrix(Vector<Vector<GridCell>>(FillWith { }, totalRowsCount, Vector<GridCell>(totalColumnsCount)))
-    , m_initialColumnsCount(totalColumnsCount)
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -43,7 +43,7 @@ public:
     ImplicitGrid(size_t totalColumnsCount, size_t totalRowsCount);
 
     size_t rowsCount() const { return m_gridMatrix.size(); }
-    size_t columnsCount() const { return rowsCount() ? m_gridMatrix[0].size() : m_initialColumnsCount; }
+    size_t columnsCount() const { return m_gridMatrix[0].size(); }
 
     void insertUnplacedGridItem(const UnplacedGridItem&);
     void insertDefiniteRowItem(const UnplacedGridItem&, GridAutoFlowOptions);
@@ -67,10 +67,6 @@ private:
     void placeAutoPositionedItemWithAutoColumnAndRow(const UnplacedGridItem&, GridAutoFlowOptions);
 
     GridMatrix m_gridMatrix;
-
-    // Track column count. This is needed when the initial grid has 0 rows and the column
-    // count would otherwise be lost.
-    size_t m_initialColumnsCount { 0 };
 
     // Per-row cursors for sparse packing in Step 2 (definite row items only).
     RowCursors m_rowCursors;


### PR DESCRIPTION
#### 8c3c4867e491626b96a310a141826deb83854fc7
<pre>
[GFC] Make sure there is at least one row when ImplicitGrid is created.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320581">https://bugs.webkit.org/show_bug.cgi?id=320581</a>
<a href="https://rdar.apple.com/problem/183558439">rdar://problem/183558439</a>

Reviewed by Alan Baradlay.

When an ImplicitGrid is created we first compute the dimensions of the
grid by looping over the placement of the grid items. This is then
passed into the constructor and the grid keeps track of the initial
number of implicit columns as a member.

This member is only used in one place: the public API on ImplicitGrid to
determine how many rows the grid has. This structure ended up resulting
in a crash when attempting to enable more content to run GFC due to
callers using rowsCount() and columnsCount(). Instead, what we can do is
just make sure there is at least one row when we calculate the implicit
grid dimensions.

Canonical link: <a href="https://commits.webkit.org/318221@main">https://commits.webkit.org/318221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49428a962af982abfe3062a0cc4073a4bf04d6a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187184 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/539e6a89-f986-475f-a01a-d20b702fc9a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138406 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9df60e2f-a46b-4334-aa44-0e5c120da0f7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41908 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159156 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118871 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/566cfbd3-9da0-4885-bc52-9ededfe5e92d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40569 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38945 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7652 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38652 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35651 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189613 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51185 "Built successfully") | | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147513 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; 31 flakes 2 failures; Uploaded test results; 1 flakes; Passed layout tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39643 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51867 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147297 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42008 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124082 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118495 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50375 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13629 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49771 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50011 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49833 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->