### PR TITLE
-[_WKFullscreenDelegate _webView:didFullscreenImageWithQuickLook:] never seems to be hit

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -251,6 +251,13 @@ Awaitable<bool> WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& conn
     m_fullscreenState = FullscreenState::EnteringFullscreen;
     page->fullscreenClient().willEnterFullscreen(page.get());
 
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+    if (CheckedPtr client = m_client; client && client->isUsingQuickLook()) {
+        didEnterFullScreen([] (bool) { });
+        co_return true;
+    }
+#endif
+
     auto needsPresentationUpdate = co_await AwaitableFromCompletionHandler<NeedsPresentationUpdate> { [this, protectedThis = Ref { *this }, frameID] (auto completionHandler) {
         enterFullScreenForOwnerElementsInOtherProcesses(frameID, WTF::move(completionHandler));
     } };

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -66,6 +66,7 @@ public:
     virtual bool isFullScreen() = 0;
     virtual void enterFullScreen(WebCore::FloatSize mediaDimensions, CompletionHandler<void(bool)>&&) = 0;
 #if ENABLE(QUICKLOOK_FULLSCREEN)
+    virtual bool isUsingQuickLook() const { return false; }
     virtual void updateImageSource() = 0;
 #endif
     virtual void exitFullScreen(CompletionHandler<void()>&&) = 0;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -259,6 +259,7 @@ private:
     bool isFullScreen() override;
     void enterFullScreen(WebCore::FloatSize mediaDimensions, CompletionHandler<void(bool)>&&) override;
 #if ENABLE(QUICKLOOK_FULLSCREEN)
+    bool isUsingQuickLook() const override;
     void updateImageSource() override;
 #endif
     void exitFullScreen(CompletionHandler<void()>&&) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -936,6 +936,11 @@ void PageClientImpl::enterFullScreen(FloatSize mediaDimensions, CompletionHandle
 }
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
+bool PageClientImpl::isUsingQuickLook() const
+{
+    return [webView() fullScreenWindowController].isUsingQuickLook;
+}
+
 void PageClientImpl::updateImageSource()
 {
     [[webView() fullScreenWindowController] updateImageSource];

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -571,6 +571,7 @@
 				WebKit/WebPage/WebPageTests.swift,
 				WebKit/WebPage/WebPageTransferableTests.swift,
 				WebKit/WKWebView/CodingTests.swift,
+				WebKit/WKWebView/ios/QuickLookFullscreen.mm,
 				WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift,
 			);
 			target = 8DD76F960486AA7600D96B5E /* TestWebKitAPI */;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/QuickLookFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/QuickLookFullscreen.mm
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import "InstanceMethodSwizzler.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/_WKFullscreenDelegate.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/RunLoop.h>
+
+static void swizzledPresentViewController(UIViewController *, SEL, UIViewController *, BOOL, dispatch_block_t completion)
+{
+    RunLoop::mainSingleton().dispatch([completion = makeBlockPtr(completion)] {
+        if (completion)
+            completion();
+    });
+}
+
+static void swizzledPresentWindow(id, SEL, dispatch_block_t completion)
+{
+    RunLoop::mainSingleton().dispatch([completion = makeBlockPtr(completion)] {
+        if (completion)
+            completion();
+    });
+}
+
+static void swizzledDismissWindow(id, SEL, dispatch_block_t completion)
+{
+    RunLoop::mainSingleton().dispatch([completion = makeBlockPtr(completion)] {
+        if (completion)
+            completion();
+    });
+}
+
+@interface QuickLookFullscreenDelegate : NSObject <_WKFullscreenDelegate>
+@end
+
+@implementation QuickLookFullscreenDelegate {
+    bool _didFullscreenImageWithQuickLook;
+}
+
+- (void)_webView:(WKWebView *)webView didFullscreenImageWithQuickLook:(CGSize)imageDimensions
+{
+    _didFullscreenImageWithQuickLook = true;
+}
+
+- (void)waitForDidFullscreenImageWithQuickLook
+{
+    TestWebKitAPI::Util::run(&_didFullscreenImageWithQuickLook);
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+static RetainPtr<NSString> spatialImageHTML()
+{
+    RetainPtr data = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"spatial" withExtension:@"heic"]];
+    RetainPtr base64 = [data base64EncodedStringWithOptions:0];
+    return adoptNS([[NSString alloc] initWithFormat:@"<img id='image' src='data:image/heic;base64,%@'>", base64.get()]);
+}
+
+TEST(QuickLookFullscreen, DidFullscreenImageWithQuickLook)
+{
+    if (![NSBundle.mainBundle.bundleIdentifier isEqualToString:@"org.webkit.TestWebKitAPI"])
+        return;
+
+    InstanceMethodSwizzler presentViewControllerSwizzler {
+        UIViewController.class,
+        @selector(presentViewController:animated:completion:),
+        reinterpret_cast<IMP>(swizzledPresentViewController)
+    };
+
+    Class previewWindowControllerClass = NSClassFromString(@"WKPreviewWindowController");
+    ASSERT_NE(previewWindowControllerClass, nullptr);
+
+    InstanceMethodSwizzler presentWindowSwizzler {
+        previewWindowControllerClass,
+        NSSelectorFromString(@"presentWindowWithCompletionHandler:"),
+        reinterpret_cast<IMP>(swizzledPresentWindow)
+    };
+
+    InstanceMethodSwizzler dismissWindowSwizzler {
+        previewWindowControllerClass,
+        NSSelectorFromString(@"dismissWindowWithCompletionHandler:"),
+        reinterpret_cast<IMP>(swizzledDismissWindow)
+    };
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration preferences].elementFullscreenEnabled = YES;
+
+    RetainPtr delegate = adoptNS([[QuickLookFullscreenDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration.get()]);
+    [webView _setFullscreenDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:spatialImageHTML().get()];
+    [webView waitForNextPresentationUpdate];
+
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"document.getElementById('image').requestFullscreen()"];
+
+    [delegate waitForDidFullscreenImageWithQuickLook];
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(QUICKLOOK_FULLSCREEN)


### PR DESCRIPTION
#### 693db686ef37e0a8f2052dbabe4595812570d41b
<pre>
-[_WKFullscreenDelegate _webView:didFullscreenImageWithQuickLook:] never seems to be hit
<a href="https://bugs.webkit.org/show_bug.cgi?id=320580">https://bugs.webkit.org/show_bug.cgi?id=320580</a>
<a href="https://rdar.apple.com/179784977">rdar://179784977</a>

Reviewed by NOBODY (OOPS!).

QuickLook fullscreen never notified the fullscreen client that it had entered fullscreen, so
_WKFullscreenDelegate&apos;s -_webView:didFullscreenImageWithQuickLook: never fired and its telemetry
was not recorded.

The QuickLook path presents its own preview window from -[WKFullScreenWindowController
_enterFullScreen:windowScene:completionHandler:] and does not go through the standard enter-fullscreen
animation that reports back to didEnterFullScreen(), so the client was never told entry had
completed.

Report it from the enter flow instead. WebFullScreenManagerProxyClient gains an isUsingQuickLook()
query, implemented in PageClientImpl off the window controller&apos;s state. The enterFullScreen coroutine,
right after willEnterFullscreen(), calls didEnterFullScreen() directly for the QuickLook case. This
keys off the UI process&apos;s QuickLook decision rather than the web process&apos;s, since the two diverge on
the com.apple.surfboard.chrome-customization entitlement.

Adds an API test that enters QuickLook fullscreen on a spatial image and asserts the delegate fires.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
(WebKit::WebFullScreenManagerProxyClient::isUsingQuickLook const):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::isUsingQuickLook const):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/QuickLookFullscreen.mm: Added.
(swizzledPresentViewController):
(swizzledPresentWindow):
(swizzledDismissWindow):
(-[QuickLookFullscreenDelegate _webView:didFullscreenImageWithQuickLook:]):
(-[QuickLookFullscreenDelegate waitForDidFullscreenImageWithQuickLook]):
(TestWebKitAPI::spatialImageHTML):
(TestWebKitAPI::TEST(QuickLookFullscreen, DidFullscreenImageWithQuickLook)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/693db686ef37e0a8f2052dbabe4595812570d41b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141094 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138620 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96359 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119083 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40812 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39176 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151217 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38863 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35918 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39118 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189886 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51452 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147741 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52134 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147527 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42250 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124386 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118817 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50642 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13842 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50038 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50278 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50100 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->