### PR TITLE
[GFC][Integration] RenderGrid needs grid items' areas after layout.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -183,7 +183,7 @@ static Style::GridTemplateList gridTemplateListWithPercentagesConvertedToAuto(co
     return Style::GridTemplateList { WTF::move(transformedList) };
 }
 
-UsedTrackSizes GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)
+GridLayoutResult GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)
 {
     auto unplacedGridItems = constructUnplacedGridItems();
     CheckedRef gridStyle = root().style();
@@ -224,12 +224,12 @@ UsedTrackSizes GridFormattingContext::layout(GridLayoutConstraints layoutConstra
             auto columnPosition = GridLayoutUtils::computeGridLinePosition(lineNumbersForGridArea.columnStartLine, usedTrackSizes.columnSizes, layoutState.usedColumnGap);
             auto rowPosition = GridLayoutUtils::computeGridLinePosition(lineNumbersForGridArea.rowStartLine, usedTrackSizes.rowSizes, layoutState.usedRowGap);
 
-            gridItemRect.borderBoxRect.moveBy({ columnPosition, rowPosition });
+            gridItemRect.borderBoxRect.moveBy(LayoutPoint { columnPosition, rowPosition });
         }
     };
     mapGridItemLocationsToGrid();
     setGridItemGeometries(gridItemRects);
-    return usedTrackSizes;
+    return { WTF::move(usedTrackSizes), WTF::move(gridItemRects) };
 }
 
 PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas& gridAreas) const

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "GridTypeAliases.h"
+#include "UsedTrackSizes.h"
 #include <WebCore/LayoutIntegrationUtils.h>
 #include <WebCore/LayoutState.h>
 #include <WebCore/StyleGapGutter.h>
@@ -45,7 +46,6 @@ class UnplacedGridItem;
 struct GridAreaLines;
 struct GridLayoutConstraints;
 struct UnplacedGridItems;
-struct UsedTrackSizes;
 
 enum class PackingStrategy : bool {
     Sparse,
@@ -60,6 +60,11 @@ enum class GridAutoFlowDirection : bool {
 struct GridAutoFlowOptions {
     PackingStrategy strategy;
     GridAutoFlowDirection direction;
+};
+
+struct GridLayoutResult {
+    UsedTrackSizes usedTrackSizes;
+    GridItemRects gridItemRects;
 };
 
 // https://drafts.csswg.org/css-grid-1/#grid-definition
@@ -86,7 +91,7 @@ public:
 
     GridFormattingContext(const ElementBox& gridBox, LayoutState&);
 
-    UsedTrackSizes layout(GridLayoutConstraints);
+    GridLayoutResult layout(GridLayoutConstraints);
 
     struct IntrinsicWidths {
         LayoutUnit minimum;

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -232,7 +232,7 @@ GridLayoutResult GridLayout::layout(UnplacedGridItems& unplacedGridItems, const 
 
     auto gridItemRects = computeGridItemRects(placedGridItems, inlineAxisPositions, blockAxisPositions, usedInlineSizes, usedBlockSizes, usedInlineMargins, usedBlockMargins);
 
-    return { usedTrackSizes, gridItemRects };
+    return { WTF::move(usedTrackSizes), WTF::move(gridItemRects) };
 }
 
 BorderBoxPositions GridLayout::performInlineAxisSelfAlignment(const PlacedGridItems& placedGridItems, const Vector<UsedMargins>& inlineMargins, const UsedInlineSizes& borderBoxSizes,

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -51,11 +51,6 @@ struct GridDimensions {
     size_t totalRows { 0 };
 };
 
-struct GridLayoutResult {
-    UsedTrackSizes usedTrackSizes;
-    GridItemRects gridItemRects;
-};
-
 enum class GridLayoutScope : bool {
     Full, // Run the whole grid sizing algorithm, lay out the grid items, and align them.
     ColumnSizingOnly // Run only the first step of the grid sizing algorithm (size the columns); skip row sizing, grid-item layout, and alignment.

--- a/Source/WebCore/layout/formattingContexts/grid/UsedTrackSizes.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UsedTrackSizes.h
@@ -25,6 +25,8 @@
 #pragma once
 
 #include "GridTypeAliases.h"
+#include "LayoutUnit.h"
+#include <wtf/Vector.h>
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -28,6 +28,7 @@
 
 #include "FormattingContextBoxIterator.h"
 #include "GridFormattingContext.h"
+#include "GridItemRect.h"
 #include "GridLayoutConstraints.h"
 #include "GridLayoutUtils.h"
 #include "LayoutIntegrationBoxGeometryUpdater.h"
@@ -171,11 +172,23 @@ void GridLayout::updateGridItemRenderers()
     }
 }
 
-void GridLayout::updateFormattingContextRootRenderer(const Layout::GridLayoutConstraints& layoutConstraints, const Layout::UsedTrackSizes& usedTrackSizes)
+void GridLayout::updateFormattingContextRootRenderer(const Layout::GridLayoutConstraints& layoutConstraints, const Layout::UsedTrackSizes& usedTrackSizes, const Layout::GridItemRects& gridItemRects)
 {
     CheckedRef renderGrid = gridBoxRenderer();
     auto& currentGrid = renderGrid->currentGrid();
+
+    // Render tree clients which consult the grid area of a grid item outside of layout (e.g.
+    // RenderGrid::isExtrinsicallySized) would otherwise read from an empty map.
+    for (auto& gridItemRect : gridItemRects) {
+        auto& lineNumbersForGridArea = gridItemRect.lineNumbersForGridArea;
+        auto gridArea = GridArea {
+            GridSpan::translatedDefiniteGridSpan(static_cast<unsigned>(lineNumbersForGridArea.rowStartLine), static_cast<unsigned>(lineNumbersForGridArea.rowEndLine)),
+            GridSpan::translatedDefiniteGridSpan(static_cast<unsigned>(lineNumbersForGridArea.columnStartLine), static_cast<unsigned>(lineNumbersForGridArea.columnEndLine))
+        };
+        currentGrid.setGridItemArea(downcast<RenderBox>(*protect(gridItemRect.layoutBox->rendererForIntegration())), gridArea);
+    }
     currentGrid.setNeedsItemsPlacement(false);
+
     OrderIteratorPopulator orderIteratorPopulator(currentGrid.orderIterator());
 
     if (layoutConstraints.blockAxis.scenario() != Layout::AxisConstraint::FreeSpaceScenario::Definite) {
@@ -209,9 +222,9 @@ std::pair<LayoutUnit, LayoutUnit> GridLayout::computeIntrinsicWidths()
 void GridLayout::layout()
 {
     auto gridLayoutConstraints = constraintsForGridContent(gridBox());
-    auto usedTrackSizes = Layout::GridFormattingContext { gridBox(), layoutState() }.layout(gridLayoutConstraints);
+    auto [ usedTrackSizes, gridItemRects ] = Layout::GridFormattingContext { gridBox(), layoutState() }.layout(gridLayoutConstraints);
     updateGridItemRenderers();
-    updateFormattingContextRootRenderer(gridLayoutConstraints, usedTrackSizes);
+    updateFormattingContextRootRenderer(gridLayoutConstraints, usedTrackSizes, gridItemRects);
     layoutOutOfFlowBoxes(usedTrackSizes);
 
     CheckedRef renderGrid = gridBoxRenderer();

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "GridTypeAliases.h"
 #include "LayoutState.h"
 #include <wtf/CheckedPtr.h>
 
@@ -53,9 +54,10 @@ public:
 
     void layout();
 
-    // A GFC layout marks the legacy grid as placed without populating it, since the GFC path does not
-    // rely on the legacy grid state. Reverts that stale state so a subsequent legacy (non-GFC) layout
-    // treats the grid as needing a fresh layout, for example re-placing items to rebuild its tracks.
+    // A GFC layout marks the legacy grid as placed and sets the grid area of each item, but
+    // leaves the rest of the legacy grid state (e.g. its grid matrix) untouched. Reverts that
+    // partial state so a subsequent legacy (non-GFC) layout treats the grid as needing a fresh
+    // layout, for example re-placing items to rebuild its tracks.
     static void invalidateFormattingContextRootRenderer(RenderGrid&);
 
     std::pair<LayoutUnit, LayoutUnit> computeIntrinsicWidths();
@@ -64,7 +66,7 @@ public:
 
 private:
     void updateGridItemRenderers();
-    void updateFormattingContextRootRenderer(const Layout::GridLayoutConstraints&, const Layout::UsedTrackSizes&);
+    void updateFormattingContextRootRenderer(const Layout::GridLayoutConstraints&, const Layout::UsedTrackSizes&, const Layout::GridItemRects&);
     void layoutOutOfFlowBoxes(const Layout::UsedTrackSizes&);
     void updateOverflow(RenderGrid&);
     void populateGridPositionsForOutOfFlowLayout(const Layout::UsedTrackSizes&);


### PR DESCRIPTION
#### d9d5b5e6ff86784a3bc8e05bea925d1fa7243774
<pre>
[GFC][Integration] RenderGrid needs grid items&apos; areas after layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320583">https://bugs.webkit.org/show_bug.cgi?id=320583</a>
<a href="https://rdar.apple.com/problem/183559501">rdar://problem/183559501</a>

Reviewed by Alan Baradlay.

After laying out a grid, the integration layer tells the legacy grid that its items
no longer need placement so that render tree clients which rely on that state (e.g.
RenderGrid::paintChildren) behave as if placement had run. It does not, however,
populate the legacy grid&apos;s item area map, which only legacy placement fills in.

Clients which consult the grid area of a grid item outside of layout therefore read
from an empty map. RenderGrid::isExtrinsicallySized, which RenderObject::markContainingBlocksForLayout
calls on every ancestor grid, does exactly that through
isPlacedWithinExtrinsicallySizedExplicitTracks: its needsItemsPlacement() guard passes
and Grid::gridItemArea asserts that the item is in the map.

We can have the integration layer write back the grid areas for each of
the grid items at the end of layout. This information is already
outputted to us by GridLayout as the part of the GridItemRects in
GridLayoutResult.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
Return the GridLayoutResult that we got from GridLayout. It was being
used above to do some mapping of the grid item rects so that the
locations are in the coordinate space of the grid&apos;s content box.

* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp:
Go through each item and take the line numbers for its grid area and map
them to &quot;translated definite spans,&quot; which is what is seems like
RenderGrid uses for the positions of the grid item after placement is
done.

Canonical link: <a href="https://commits.webkit.org/318248@main">https://commits.webkit.org/318248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/befb14495f8ca8973d823752b90482a6fd80b66d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187284 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64226a0a-9451-4f1b-bd5a-10e48c93d164) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138487 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c0a1192-8fe3-4a41-9807-781982a5e073) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41998 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159229 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118951 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47a25562-7586-413c-81b1-1538e53c7061) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40659 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39028 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38725 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35750 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189714 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51284 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147594 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39667 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51966 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147384 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42095 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124181 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118594 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50474 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13702 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49870 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50110 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49932 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->