### PR TITLE
[GFC] Key track sizing space distribution by grid track index

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -387,13 +387,13 @@ static void sizeTracksToFitNonSpanningItems(const ResolveIntrinsicTrackSizesCont
 }
 
 // Used for space distribution.
-static Vector<size_t> indexesForUnfrozenAffectedTracks(const TrackIndexes& affectedTracks, const WTF::Range<size_t>& itemSpan,
+static Vector<size_t> indexesForUnfrozenAffectedTracks(const Vector<size_t>& spannedAffectedTracks,
     const UnsizedTracks& unsizedTracks, const Vector<LayoutUnit>& itemIncurredIncreases)
 {
     Vector<size_t> indexes;
-    for (auto [affectedIndex, trackIndex] : WTF::indexedRange(affectedTracks)) {
-        if (itemSpan.contains(trackIndex) && unsizedTracks[trackIndex].baseSize + itemIncurredIncreases[affectedIndex] < unsizedTracks[trackIndex].growthLimit)
-            indexes.append(affectedIndex);
+    for (auto trackIndex : spannedAffectedTracks) {
+        if (unsizedTracks[trackIndex].baseSize + itemIncurredIncreases[trackIndex] < unsizedTracks[trackIndex].growthLimit)
+            indexes.append(trackIndex);
     }
     return indexes;
 }
@@ -404,18 +404,28 @@ static void distributeExtraSpaceToBaseSizes(UnsizedTracks& unsizedTracks, const 
 {
     ASSERT(accommodatedItemsIndexes.size() == sizeContributions.size());
 
-    // 1. Maintain separately for each affected track a planned increase, initially set to 0.
-    Vector<LayoutUnit> plannedIncreases(affectedTracksIndexes.size());
+    // 1. Maintain separately for each affected track a planned increase, initially set to 0. The
+    // vector is keyed by track index (sized to all tracks); non-affected slots stay unused.
+    // Note that tracks beyond affectedTrackIndexes may be resized in step 2.3,
+    // where space is distributed to non-affected tracks.
+    Vector<LayoutUnit> plannedIncreases(unsizedTracks.size());
 
     // 2. For each accommodated item...
     for (auto [contributionIndex, gridItemIndex] : WTF::indexedRange(accommodatedItemsIndexes)) {
-        // ...considering only tracks the item spans:
+        // considering only tracks the item spans:
         auto itemSpan = gridItemSpanList[gridItemIndex];
 
         ASSERT(itemSpan.distance() == 1);
 
+        // Gather the affected tracks the item spans; they receive space up to their limits.
+        Vector<size_t> spannedAffectedTracks;
+        for (size_t trackIndex = itemSpan.begin(); trackIndex < itemSpan.end(); ++trackIndex) {
+            if (affectedTracksIndexes.contains(trackIndex))
+                spannedAffectedTracks.append(trackIndex);
+        }
+
         // 2.1. Find the space to distribute: the item's size contribution minus the base sizes of
-        //      every track it spans, floored at zero.
+        // every track it spans, floored at zero.
         LayoutUnit spannedBaseSizes;
         for (size_t trackIndex = itemSpan.begin(); trackIndex < itemSpan.end(); ++trackIndex)
             spannedBaseSizes += unsizedTracks[trackIndex].baseSize;
@@ -423,49 +433,48 @@ static void distributeExtraSpaceToBaseSizes(UnsizedTracks& unsizedTracks, const 
         if (!spaceToDistribute)
             continue;
 
-        // 2.2. Distribute space up to limits: find the item-incurred increase for each affected
-        //      track...
-        Vector<LayoutUnit> itemIncurredIncreases(affectedTracksIndexes.size());
-        auto unfrozenIndexes = indexesForUnfrozenAffectedTracks(affectedTracksIndexes, itemSpan, unsizedTracks, itemIncurredIncreases);
-        while (!unfrozenIndexes.isEmpty() && spaceToDistribute) {
+        // 2.2. Distribute space up to limits: find the item-incurred increase for each affected track...
+        Vector<LayoutUnit> itemIncurredIncreases(unsizedTracks.size());
+        auto unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(spannedAffectedTracks, unsizedTracks, itemIncurredIncreases);
+        while (!unfrozenTrackIndexes.isEmpty() && spaceToDistribute) {
 
             // ...by distributing the space equally among the affected tracks the item spans,
             //  freezing a track once its base size plus that increase reaches its growth limit.
-            auto tracksRemainingForDistributionCount = unfrozenIndexes.size();
-            for (auto affectedIndex : unfrozenIndexes) {
-                auto& track = unsizedTracks[affectedTracksIndexes[affectedIndex]];
-                auto spaceRemainingUntilGrowthLimit = track.growthLimit - (track.baseSize + itemIncurredIncreases[affectedIndex]);
+            auto tracksRemainingForDistributionCount = unfrozenTrackIndexes.size();
+            for (auto trackIndex : unfrozenTrackIndexes) {
+                auto& track = unsizedTracks[trackIndex];
+                auto spaceRemainingUntilGrowthLimit = track.growthLimit - (track.baseSize + itemIncurredIncreases[trackIndex]);
                 auto spaceDistributed = std::min(spaceToDistribute / tracksRemainingForDistributionCount, spaceRemainingUntilGrowthLimit);
-                itemIncurredIncreases[affectedIndex] += spaceDistributed;
+                itemIncurredIncreases[trackIndex] += spaceDistributed;
                 spaceToDistribute -= spaceDistributed;
                 --tracksRemainingForDistributionCount;
             }
-            unfrozenIndexes = indexesForUnfrozenAffectedTracks(affectedTracksIndexes, itemSpan, unsizedTracks, itemIncurredIncreases);
+            unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(spannedAffectedTracks, unsizedTracks, itemIncurredIncreases);
         }
 
         // 2.3. Distribute space to non-affected tracks: if extra space remains and the item spans
-        //      both affected and non-affected tracks, distribute it into the non-affected tracks.
+        // both affected and non-affected tracks, distribute it into the non-affected tracks.
         auto distributeSpaceToNonAffectedTracks = [] {
             notImplemented();
         };
         UNUSED_VARIABLE(distributeSpaceToNonAffectedTracks);
 
         // 2.4. Distribute space beyond limits: if extra space still remains, unfreeze and continue
-        //      distributing it to the item-incurred increases.
+        // distributing it to the item-incurred increases.
         auto distributeSpaceBeyondLimits = [] {
             notImplemented();
         };
         UNUSED_VARIABLE(distributeSpaceBeyondLimits);
 
         // 2.5. For each affected track, if its item-incurred increase is larger than its planned
-        //      increase, set the planned increase to that value.
-        for (auto [affectedIndex, trackIndex] : WTF::indexedRange(affectedTracksIndexes))
-            plannedIncreases[affectedIndex] = std::max(plannedIncreases[affectedIndex], itemIncurredIncreases[affectedIndex]);
+        // increase, set the planned increase to that value.
+        for (auto trackIndex : spannedAffectedTracks)
+            plannedIncreases[trackIndex] = std::max(plannedIncreases[trackIndex], itemIncurredIncreases[trackIndex]);
     }
 
     // 3. Update the affected tracks' base sizes by adding in the planned increase.
-    for (auto [affectedTrackIndex, trackIndex] : WTF::indexedRange(affectedTracksIndexes))
-        unsizedTracks[trackIndex].baseSize += plannedIncreases[affectedTrackIndex];
+    for (auto trackIndex : affectedTracksIndexes)
+        unsizedTracks[trackIndex].baseSize += plannedIncreases[trackIndex];
 }
 
 template<typename MinTrackSizingFunctionPredicate>


### PR DESCRIPTION
#### 40a9bf41957160d34f7f8b77353a64703fabc067
<pre>
[GFC] Key track sizing space distribution by grid track index
<a href="https://bugs.webkit.org/show_bug.cgi?id=320585">https://bugs.webkit.org/show_bug.cgi?id=320585</a>
&lt;<a href="https://rdar.apple.com/183561463">rdar://183561463</a>&gt;

Reviewed by Sammy Gill.

Re-keys distributeExtraSpaceToBaseSizes()&apos;s planned-increase to all tracks instead
of the list of affectedTrackIndexes.

This is required by step 2.3, which distributes space into the non-affected
tracks an item spans. In order to support this, we need to share one track-index
across distributeExtraSpaceToBaseSizes().

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::indexesForUnfrozenAffectedTracks):
(WebCore::Layout::distributeExtraSpaceToBaseSizes):

Canonical link: <a href="https://commits.webkit.org/318197@main">https://commits.webkit.org/318197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d55144b413b1b3662eddefc2f161e9deffdce087

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187195 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8e7a6dd7-33b6-4da3-bf4e-bb9aa340d569) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52821 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51238 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138415 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5ba67bd-0cda-4947-86a5-7d15c1c1987a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41917 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118880 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40578 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150985 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38655 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35662 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43314 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189624 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51196 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147515 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39624 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51878 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147306 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42021 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124093 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118506 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50386 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13632 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49782 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50022 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49844 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->