### PR TITLE
XMLHttpRequest.getAllResponseHeaders() returns the previous response's headers when the object is reused

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/getallresponseheaders-after-reuse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/getallresponseheaders-after-reuse-expected.txt
@@ -1,0 +1,3 @@
+
+PASS getAllResponseHeaders() must not return the previous response's headers
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/getallresponseheaders-after-reuse.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/getallresponseheaders-after-reuse.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>XMLHttpRequest: getAllResponseHeaders() after reusing the object</title>
+<link rel="help" href="https://xhr.spec.whatwg.org/#the-getallresponseheaders()-method">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id="log"></div>
+<script>
+function load(client, url) {
+  return new Promise((resolve, reject) => {
+    client.onload = () => resolve(client.getAllResponseHeaders());
+    client.onerror = () => reject(new Error("unexpected error loading " + url));
+    client.open("GET", url);
+    client.send();
+  });
+}
+
+promise_test(async () => {
+  const client = new XMLHttpRequest();
+  assert_equals(await load(client, "resources/headers-basic.asis"),
+                "foo-test: 1, 2, 3\r\n", "first response");
+  assert_equals(await load(client, "resources/headers-www-authenticate.asis"),
+                "www-authenticate: 1, 2, 3, 4\r\n", "second response");
+}, "getAllResponseHeaders() must not return the previous response's headers");
+</script>

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -755,6 +755,7 @@ void XMLHttpRequest::clearResponseBuffers()
     }
     m_binaryResponseBuilder.reset();
     m_responseCacheIsValid = false;
+    m_allResponseHeaders = { };
 }
 
 void XMLHttpRequest::clearRequest()


### PR DESCRIPTION
#### eb7b1d25196e82c5d9f5410c8dd444c3b5d1a929
<pre>
XMLHttpRequest.getAllResponseHeaders() returns the previous response&apos;s headers when the object is reused
<a href="https://bugs.webkit.org/show_bug.cgi?id=320586">https://bugs.webkit.org/show_bug.cgi?id=320586</a>
<a href="https://rdar.apple.com/183561750">rdar://183561750</a>

Reviewed by Alexey Proskuryakov.

getAllResponseHeaders() lazily builds the sorted, serialized header block
and caches it in m_allResponseHeaders, but nothing ever invalidated that
cache. Reusing an XMLHttpRequest object -- calling open() and send() a
second time -- kept returning the first response&apos;s header block for the
rest of the object&apos;s lifetime, since the cache is only ever written and
never cleared.

Clear it in clearResponseBuffers(), next to m_responseCacheIsValid, so it
is dropped both when open() resets the response state via clearResponse()
and when the load is aborted.

Firefox and Chrome both return the new response&apos;s headers here.

The test reuses one XMLHttpRequest object across two .asis resources, whose
responses are byte-exact, so the second getAllResponseHeaders() result can be
compared with assert_equals().

* LayoutTests/imported/w3c/web-platform-tests/xhr/getallresponseheaders-after-reuse-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/getallresponseheaders-after-reuse.html: Added.
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::clearResponseBuffers):

Canonical link: <a href="https://commits.webkit.org/318217@main">https://commits.webkit.org/318217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eea5987f28202cf43a3cd7431cc74e3748376818

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187201 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/faf0ac0c-5dcf-4996-a04c-041fef97cccc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138418 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3bf68e71-ac76-490b-bb91-a89aac014ca4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118883 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ce0e538-ce87-4290-a986-c3b8a5424798) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40585 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38959 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38662 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35668 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189630 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147520 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39642 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51884 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147311 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42035 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124099 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118512 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50392 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13639 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49850 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->