### PR TITLE
[Site Isolation] Embedded YouTube videos on yahoo.com fail to render

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/offset-iframe-cross-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/offset-iframe-cross-origin-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Fully-visible target in an offset iframe is intersecting
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/offset-iframe-cross-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/offset-iframe-cross-origin.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: implicit root observer in a cross-origin iframe reports intersecting when the iframe has a nonzero layout offset</title>
+<link rel="author" title="Andy Estes" href="mailto:aestes@apple.com">
+
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/intersection-observer-test-utils.js"></script>
+<script src="./resources/offset-iframe.js"></script>
+
+<style>
+  #spacer {
+    height: 400px;
+  }
+  #iframe {
+    display: block;
+    width: 200px;
+    height: 200px;
+  }
+</style>
+
+<div id="spacer"></div>
+<iframe id="iframe"></iframe>
+
+<script>
+  runOffsetIframeTest(`${get_host_info().HTTP_NOTSAMESITE_ORIGIN}/intersection-observer/resources/offset-iframe-subframe.html`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/offset-iframe-same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/offset-iframe-same-origin-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Fully-visible target in an offset iframe is intersecting
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/offset-iframe-same-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/offset-iframe-same-origin.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: implicit root observer in a same-origin iframe reports intersecting when the iframe has a nonzero layout offset</title>
+<link rel="author" title="Andy Estes" href="mailto:aestes@apple.com">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/intersection-observer-test-utils.js"></script>
+<script src="./resources/offset-iframe.js"></script>
+
+<style>
+  #spacer {
+    height: 400px;
+  }
+  #iframe {
+    display: block;
+    width: 200px;
+    height: 200px;
+  }
+</style>
+
+<div id="spacer"></div>
+<iframe id="iframe"></iframe>
+
+<script>
+  runOffsetIframeTest("resources/offset-iframe-subframe.html");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/offset-iframe-subframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/offset-iframe-subframe.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #target {
+    height: 100px;
+    width: 100px;
+    background-color: green;
+  }
+</style>
+
+<div id="target"></div>
+
+<script>
+  let lastEntry = null;
+  let observer = new IntersectionObserver((entries) => {
+    lastEntry = entries[entries.length - 1];
+  });
+
+  window.addEventListener("message", (event) => {
+    if (event.data === "observe") {
+      observer.observe(document.getElementById("target"));
+      window.top.postMessage("observing", "*");
+    } else {
+      window.top.postMessage({ isIntersecting: lastEntry && lastEntry.isIntersecting }, "*");
+    }
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/offset-iframe.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/offset-iframe.js
@@ -1,0 +1,25 @@
+function runOffsetIframeTest(iframeSrc)
+{
+    async_test(function(t) {
+        const iframe = document.getElementById("iframe");
+
+        window.addEventListener("message", t.step_func(function(event) {
+            if (event.data === "observing") {
+                waitForNotification(t, function() {
+                    iframe.contentWindow.postMessage("report", "*");
+                });
+                return;
+            }
+            assert_true(event.data.isIntersecting);
+            t.done();
+        }));
+
+        iframe.onload = t.step_func(function() {
+            waitForNotification(t, function() {
+                iframe.contentWindow.postMessage("observe", "*");
+            });
+        });
+
+        iframe.src = iframeSrc;
+    }, "Fully-visible target in an offset iframe is intersecting");
+}

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2130,7 +2130,7 @@ std::optional<LayoutRect> LocalFrameView::visibleRectOfChild(const Frame& child)
     ASSERT(childOwnerRenderer->frame().frameID() == m_frame->frameID());
 
     auto rects = childOwnerRenderer->computeVisibleRectsInContainer(
-        { childOwnerRenderer->borderBoxRectInContainer() },
+        { childOwnerRenderer->borderBoxRect() },
         &childOwnerRenderer->view(),
         {
             .hasPositionFixedDescendant = false,


### PR DESCRIPTION
#### 00dd50aa571465067bb054efe20518947ed6a9a5
<pre>
[Site Isolation] Embedded YouTube videos on yahoo.com fail to render
<a href="https://bugs.webkit.org/show_bug.cgi?id=320588">https://bugs.webkit.org/show_bug.cgi?id=320588</a>
<a href="https://rdar.apple.com/177423546">rdar://177423546</a>

Reviewed by Kiet Ho.

As of 311380@main we gate accelerated video rendering on the video element intersecting the
viewport (by using an IntersectionObserver). If the observer never reports the video as
intersecting, a video layer is never attached and decoded frames are dropped, so the video plays
audio but shows no frames.

For a video in a cross-origin iframe with Site Isolation enabled, the observer computes
intersection from geometry sent over by the parent frame&apos;s process. That geometry was wrong on some
yahoo.com pages, so the video was reported as never intersecting even while fully within the
viewport.

The process that contains the iframe computes the frame&apos;s visible rect in
LocalFrameView::visibleRectOfChild by passing the iframe&apos;s rect to computeVisibleRectsInContainer.
That function expects a rect in the iframe&apos;s own coordinate space, but we were passing it a rect in
its container&apos;s coordinate space. This resulted in the iframe&apos;s offset position being applied
twice, resulting in an IntersectionObserver believing that elements within the iframe were too far
down to intersect the viewport.

Resolved this by passing borderBoxRect() (i.e. a rect in the element&apos;s own coordinate space) to
computeVisibleRectsInContainer, matching other call sites.

Tests: imported/w3c/web-platform-tests/intersection-observer/offset-iframe-cross-origin.html
       imported/w3c/web-platform-tests/intersection-observer/offset-iframe-same-origin.html

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/offset-iframe-cross-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/offset-iframe-cross-origin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/offset-iframe-same-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/offset-iframe-same-origin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/offset-iframe-subframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/offset-iframe.js: Added.
(runOffsetIframeTest.):
(runOffsetIframeTest):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::visibleRectOfChild const):

Canonical link: <a href="https://commits.webkit.org/318254@main">https://commits.webkit.org/318254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5fac09ca1e40bce3db492c00d521d0865bfe11f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187324 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/032d9132-55ce-48f0-8f54-d65950b987cb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138518 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29e1a6df-af50-4275-a444-4505705007f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118982 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32eac60c-cc41-42a1-abec-e8dc9e5d1dd4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40703 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39065 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38757 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35788 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189753 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147633 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39669 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52004 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35385 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Passed layout tests; 344 new passes 15 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147419 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42133 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124219 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118646 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50512 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13734 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49908 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50148 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49970 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->