### PR TITLE
[JSC] Extend StringSplitCache for RegExp

### DIFF
--- a/JSTests/stress/regexp-split-cache-regexp-statics.js
+++ b/JSTests/stress/regexp-split-cache-regexp-statics.js
@@ -1,0 +1,116 @@
+// The RegExp split cache skips the match loop on a hit, so it must replay the legacy RegExp
+// statics that the loop would have updated. A match can update those statics without producing
+// any element (a match at end of input, or a zero-length match at the current position), so the
+// replay cannot be inferred from the result length.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+function shouldBeArray(actual, expected) {
+    if (!Array.isArray(actual))
+        throw new Error(`bad value: expected an array but got ${actual}`);
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+function statics() {
+    return [RegExp.input, RegExp.lastMatch, RegExp.leftContext, RegExp.rightContext, RegExp.$1, RegExp.$2].join(" ");
+}
+
+// Overwrites every static with an unrelated match, so a missing replay is visible.
+function clobberStatics() {
+    /seed(s)/.test("hello seeds world");
+    shouldBe(RegExp.input, "hello seeds world");
+}
+
+function split(subject, regexp) {
+    clobberStatics();
+    const result = subject.split(regexp);
+    return { result, statics: statics() };
+}
+
+const cases = [
+    // Matches at end of input: records statics, pushes nothing.
+    { subject: "abc", regexp: /$/ },
+    // Zero-length match at position 0: records statics, pushes nothing.
+    { subject: "abc", regexp: /(?=abc)/ },
+    { subject: "abc", regexp: /^/ },
+    // Ordinary separators.
+    { subject: "abc", regexp: /b/ },
+    { subject: "abc", regexp: /b/y },
+    { subject: "a,b,c", regexp: /,/ },
+    // Capture groups that participate: the result stays cacheable and $1 must be replayed.
+    { subject: "abc", regexp: /(b)/ },
+    // A non-participating group yields undefined, which the atom-strings butterfly cannot hold, so
+    // the entry is cached with the generic contiguous structure instead.
+    { subject: "abc", regexp: /(x)|(b)/ },
+    // No match at all: nothing to replay, statics must stay clobbered.
+    { subject: "abc", regexp: /zzz/ },
+];
+
+function check(testCase) {
+    const observed = split(testCase.subject, testCase.regexp);
+    shouldBeArray(observed.result, testCase.reference.result);
+    if (observed.statics !== testCase.reference.statics)
+        throw new Error(`stale RegExp statics for ${testCase.subject}.split(${testCase.regexp}): expected ${JSON.stringify(testCase.reference.statics)} but got ${JSON.stringify(observed.statics)}`);
+}
+
+// One case at a time: the cache is keyed by the subject's hash, so interleaving several regexps
+// over one subject would evict each entry before it is ever read back.
+for (const testCase of cases) {
+    // The first split of a given (subject, regexp) pair in this process cannot be a cache hit, so
+    // it is the reference for the repeats that follow.
+    testCase.reference = split(testCase.subject, testCase.regexp);
+    for (let i = 0; i < 1e4; ++i)
+        check(testCase);
+
+    // Publishing again after the cache is dropped must behave the same way.
+    if (typeof gc === "function") {
+        gc();
+        for (let i = 0; i < 100; ++i)
+            check(testCase);
+    }
+}
+
+// Pin down the reference behavior itself, so a bug shared by both paths is still caught.
+shouldBeArray("abc".split(/$/), ["abc"]);
+shouldBe(RegExp.input, "abc");
+shouldBe(RegExp.lastMatch, "");
+shouldBe(RegExp.leftContext, "abc");
+shouldBe(RegExp.rightContext, "");
+
+shouldBeArray("abc".split(/(?=abc)/), ["abc"]);
+shouldBe(RegExp.input, "abc");
+shouldBe(RegExp.lastMatch, "");
+shouldBe(RegExp.leftContext, "");
+shouldBe(RegExp.rightContext, "abc");
+
+shouldBeArray("abc".split(/(b)/), ["a", "b", "c"]);
+shouldBe(RegExp.lastMatch, "b");
+shouldBe(RegExp.$1, "b");
+
+shouldBeArray("abc".split(/(x)|(b)/), ["a", undefined, "b", "c"]);
+shouldBe(RegExp.lastMatch, "b");
+shouldBe(RegExp.$1, "");
+shouldBe(RegExp.$2, "b");
+
+// Splitting never touches the receiver's lastIndex, cached or not.
+for (const regexp of [/b/, /b/g, /b/y]) {
+    regexp.lastIndex = 2;
+    for (let i = 0; i < 1e3; ++i) {
+        "abc".split(regexp);
+        shouldBe(regexp.lastIndex, 2);
+    }
+}
+
+// A cache hit hands back a copy-on-write array; writing to it must not corrupt later results.
+for (let i = 0; i < 1e3; ++i) {
+    const array = "a,b,c".split(/,/);
+    shouldBeArray(array, ["a", "b", "c"]);
+    array[1] = "mutated";
+    array.push("appended");
+}
+shouldBeArray("a,b,c".split(/,/), ["a", "b", "c"]);

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -6068,6 +6068,7 @@
 		E365F33924AA621200C991B2 /* IntlDisplayNamesConstructor.lut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlDisplayNamesConstructor.lut.h; sourceTree = "<group>"; };
 		E36706282A2705DB00CF892F /* StringSplitCacheInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringSplitCacheInlines.h; sourceTree = "<group>"; };
 		E36706292A2705DB00CF892F /* StringSplitCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringSplitCache.h; sourceTree = "<group>"; };
+		CACD83A32AC046EB9E482B34 /* StringSplitCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringSplitCache.cpp; sourceTree = "<group>"; };
 		E36965F02D76E96F005BCC77 /* MicrotaskQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MicrotaskQueue.h; sourceTree = "<group>"; };
 		E36965F12D76E96F005BCC77 /* MicrotaskQueue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MicrotaskQueue.cpp; sourceTree = "<group>"; };
 		E36A9C6B2E8F890A002D561C /* JSFunctionWithFields.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSFunctionWithFields.h; sourceTree = "<group>"; };
@@ -9531,6 +9532,7 @@
 				8C469C292D8EBC8A008C6403 /* StringReplaceCache.cpp */,
 				E35B36062A2E981E004EC264 /* StringReplaceCache.h */,
 				E35B36052A2E981E004EC264 /* StringReplaceCacheInlines.h */,
+				CACD83A32AC046EB9E482B34 /* StringSplitCache.cpp */,
 				E36706292A2705DB00CF892F /* StringSplitCache.h */,
 				E36706282A2705DB00CF892F /* StringSplitCacheInlines.h */,
 				BCDE3AB00E6C82CF001453A7 /* Structure.cpp */,

--- a/Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -42,7 +42,6 @@ runtime/JSGlobalObject.h
 runtime/JSGlobalObjectInlines.h
 runtime/PropertySlot.h
 runtime/StringReplaceCache.h
-runtime/StringSplitCache.h
 runtime/Structure.h
 runtime/VM.h
 runtime/WriteBarrier.h

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1082,6 +1082,7 @@ runtime/StringObject.cpp
 runtime/StringPrototype.cpp
 runtime/StringRecursionChecker.cpp
 runtime/StringReplaceCache.cpp
+runtime/StringSplitCache.cpp
 runtime/Structure.cpp
 runtime/StructureCache.cpp
 runtime/StructureChain.cpp

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -87,6 +87,7 @@
 #include "SpaceTimeMutatorScheduler.h"
 #include "StochasticSpaceTimeMutatorScheduler.h"
 #include "StopIfNecessaryTimer.h"
+#include "StringSplitCache.h"
 #include "StructureAlignedMemoryAllocator.h"
 #include "SubspaceInlines.h"
 #include "SuperSampler.h"
@@ -2368,7 +2369,8 @@ void Heap::finalize()
         vm().stringReplaceCache.clear();
     }
     vm().keyAtomStringCache.clear();
-    vm().stringSplitCache.clear();
+    if (auto* cache = vm().stringSplitCache())
+        cache->clear();
     vm().jsonAtomStringCache.clearJSStrings();
 
     m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope.removeAllMatching([&](const auto& iter) {

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -26,6 +26,7 @@
 #include "IntegrityInlines.h"
 #include "JSArray.h"
 #include "JSCJSValue.h"
+#include "JSCellButterfly.h"
 #include "JSGlobalObject.h"
 #include "JSRegExpStringIterator.h"
 #include "JSStringInlines.h"
@@ -37,6 +38,7 @@
 #include "RegExpObjectInlines.h"
 #include "RegExpPrototypeInlines.h"
 #include "StringRecursionChecker.h"
+#include "StringSplitCacheInlines.h"
 #include "YarrFlags.h"
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringCommon.h>
@@ -673,29 +675,30 @@ enum SplitControl {
 };
 
 template<typename ControlFunc, typename PushFunc>
-void genericSplit(
+MatchResult genericSplit(
     JSGlobalObject* globalObject, RegExp* regexp, JSString* inputString, StringView input, unsigned inputSize, unsigned& position,
     unsigned& matchPosition, bool regExpIsSticky, bool regExpIsUnicode,
     const ControlFunc& control, const PushFunc& push)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
+    MatchResult lastMatchResult;
 
     while (matchPosition < inputSize) {
         {
             auto result = control();
-            RETURN_IF_EXCEPTION(scope, void());
+            RETURN_IF_EXCEPTION(scope, { });
             if (result == AbortSplit)
-                return;
+                return lastMatchResult;
         }
-        
+
         int* ovector;
-        
+
         // a. Perform ? Set(splitter, "lastIndex", q, true).
         // b. Let z be ? RegExpExec(splitter, S).
         MatchResult result = globalObject->regExpGlobalData().performMatch(globalObject, regexp, inputString, input, matchPosition, &ovector);
         int mpos = result.start;
-        RETURN_IF_EXCEPTION(scope, void());
+        RETURN_IF_EXCEPTION(scope, { });
 
         // c. If z is null, let q be AdvanceStringIndex(S, q, unicodeMatching).
         if (mpos < 0) {
@@ -704,6 +707,7 @@ void genericSplit(
             matchPosition = advanceStringIndex(input, inputSize, matchPosition, regExpIsUnicode);
             continue;
         }
+        lastMatchResult = result;
         if (static_cast<unsigned>(mpos) >= inputSize) {
             // The spec redoes the RegExpExec starting at the next character of the input.
             // But in our case, mpos < 0 means that the native regexp already searched all permutations
@@ -733,9 +737,9 @@ void genericSplit(
         // 2. Perform ! CreateDataProperty(A, ! ToString(lengthA), T).
         {
             auto result = push(true, position, matchPosition - position);
-            RETURN_IF_EXCEPTION(scope, void());
+            RETURN_IF_EXCEPTION(scope, { });
             if (result == AbortSplit)
-                return;
+                return lastMatchResult;
         }
         
         // 5. Let p be e.
@@ -751,14 +755,110 @@ void genericSplit(
             int sub = ovector[i * 2];
             int subEnd = ovector[i * 2 + 1];
             auto result = push(sub >= 0 && subEnd >= sub, sub, subEnd - sub);
-            RETURN_IF_EXCEPTION(scope, void());
+            RETURN_IF_EXCEPTION(scope, { });
             if (result == AbortSplit)
-                return;
+                return lastMatchResult;
         }
         
         // 10. Let q be p.
         matchPosition = position;
     }
+
+    return lastMatchResult;
+}
+
+// A finished split is recorded in vm.stringSplitIndice as two entries per element, a start offset
+// in the input and a length. Keeping the result in this form until the very end means an element
+// that gets interned in vm.atomStringToJSStringMap never pays for a substring JSString on the way
+// there.
+// An element contributed by a capture group that did not participate is undefined rather than a
+// substring of the input, and is recorded with notFound as its start.
+static constexpr unsigned undefinedSplitSpanStart = static_cast<unsigned>(WTF::notFound);
+static_assert(JSString::MaxLength < undefinedSplitSpanStart, "notFound must not be a representable offset, or a real element would decode as undefined");
+
+static ALWAYS_INLINE void recordSplitSpan(Vector<unsigned>& spans, unsigned start, unsigned length)
+{
+    spans.append(start);
+    spans.append(length);
+}
+
+static ALWAYS_INLINE unsigned splitSpanCount(const Vector<unsigned>& spans)
+{
+    ASSERT(!(spans.size() % 2));
+    return spans.size() / 2;
+}
+
+static JSArray* createArrayFromSplitSpans(JSGlobalObject* globalObject, VM& vm, JSString* inputString, const Vector<unsigned>& spans)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    unsigned resultLength = splitSpanCount(spans);
+    JSArray* result = constructEmptyArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), resultLength);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    for (unsigned i = 0; i < resultLength; ++i) {
+        unsigned start = spans[i * 2];
+        unsigned length = spans[i * 2 + 1];
+        result->putDirectIndex(globalObject, i, start == undefinedSplitSpanStart ? jsUndefined() : jsSubstringOfResolved(vm, inputString, start, length));
+        RETURN_IF_EXCEPTION(scope, nullptr);
+    }
+    return result;
+}
+
+static NEVER_INLINE JSArray* tryAddToRegExpSplitCache(JSGlobalObject* globalObject, VM& vm, JSString* inputString, StringView input, RegExp* regexp, const Vector<unsigned>& spans, MatchResult lastMatch)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    unsigned resultLength = splitSpanCount(spans);
+    if (!resultLength || resultLength >= MIN_SPARSE_ARRAY_INDEX)
+        return nullptr;
+
+    auto subject = inputString->value(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    if (!subject->impl() || !subject->impl()->isAtom())
+        return nullptr;
+
+    constexpr unsigned atomStringsArrayLimit = 100;
+    bool makeAtomStringsArray = resultLength < atomStringsArrayLimit;
+    Structure* cellButterflyStructure = makeAtomStringsArray ? vm.cellButterflyOnlyAtomStringsStructure.get() : vm.cellButterflyStructure(CopyOnWriteArrayWithContiguous);
+    auto* newButterfly = JSCellButterfly::tryCreate(vm, cellButterflyStructure, resultLength);
+    if (!newButterfly)
+        return nullptr;
+
+    bool encounteredNonAtoms = false;
+    for (unsigned i = 0; i < resultLength; ++i) {
+        unsigned start = spans[i * 2];
+        unsigned length = spans[i * 2 + 1];
+        if (start == undefinedSplitSpanStart) {
+            encounteredNonAtoms = true;
+            newButterfly->setIndex(vm, i, jsUndefined());
+            continue;
+        }
+        JSString* string = nullptr;
+        const bool isPotentiallyIdentifier = length && isASCIIIdentifierStart(input.codeUnitAt(start));
+        if (makeAtomStringsArray && isPotentiallyIdentifier) {
+            auto subView = input.substring(start, length);
+            auto identifier = subView.is8Bit() ? Identifier::fromString(vm, subView.span8()) : Identifier::fromString(vm, subView.span16());
+
+            DeferGC defer(vm);
+            string = vm.atomStringToJSStringMap.ensureValue(identifier.impl(), [&] {
+                return jsString(vm, identifier.string());
+            });
+        } else {
+            string = jsSubstringOfResolved(vm, inputString, start, length);
+            encounteredNonAtoms = true;
+        }
+        newButterfly->setIndex(vm, i, string);
+    }
+
+    if (makeAtomStringsArray && encounteredNonAtoms) {
+        Structure* replacementStructure = vm.cellButterflyStructure(CopyOnWriteArrayWithContiguous);
+        newButterfly->setStructure(vm, replacementStructure);
+    }
+
+    vm.ensureStringSplitCache().setForRegExp(subject, regexp, newButterfly, lastMatch);
+    Structure* arrayStructure = globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous);
+    return JSArray::createWithButterfly(vm, nullptr, arrayStructure, newButterfly->toButterfly());
 }
 
 // Fast path used by RegExp.prototype[Symbol.split] and String.prototype.split when the
@@ -772,6 +872,27 @@ JSCell* regExpSplitFast(JSGlobalObject* globalObject, RegExpObject* regexpObject
 
     RegExp* regexp = regexpObject->regExp();
 
+    bool cacheable = limit == 0xFFFFFFFFu && !globalObject->isHavingABadTime();
+    if (cacheable) {
+        StringImpl* impl = inputString->tryGetValueImpl();
+        cacheable = impl && impl->isAtom();
+    }
+    if (cacheable) {
+        auto subject = inputString->value(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        MatchResult cachedLastMatch;
+        auto* cache = vm.stringSplitCache();
+        if (auto* immutableButterfly = cache ? cache->getForRegExp(subject, regexp, cachedLastMatch) : nullptr) {
+            // The skipped match loop would have updated the legacy RegExp statics
+            // (RegExp.$1, lastMatch, leftContext, ...) via performMatch. Replay its final
+            // match so those observable properties match the uncached path.
+            if (cachedLastMatch)
+                globalObject->regExpGlobalData().recordMatch(vm, globalObject, regexp, inputString, cachedLastMatch, false);
+            Structure* arrayStructure = globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous);
+            return JSArray::createWithButterfly(vm, nullptr, arrayStructure, immutableButterfly->toButterfly());
+        }
+    }
+
     auto input = inputString->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     ASSERT(!input->isNull());
@@ -783,7 +904,6 @@ JSCell* regExpSplitFast(JSGlobalObject* globalObject, RegExpObject* regexpObject
     // 11. Let array be ! ArrayCreate(0).
     // 12. Let lengthA be 0.
     // 13. If limit is undefined, let lim be 2**32 - 1; else let lim be ℝ(? ToUint32(limit)).
-    unsigned resultLength = 0;
     unsigned inputSize = input->length();
     unsigned position = 0;
 
@@ -869,40 +989,49 @@ JSCell* regExpSplitFast(JSGlobalObject* globalObject, RegExpObject* regexpObject
     bool regExpIsUnicode = regexp->eitherUnicode();
 
     unsigned maxSizeForDirectPath = 100000;
-    JSArray* result = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 1);
-    if (!result) [[unlikely]] {
-        throwOutOfMemoryError(globalObject, scope);
-        return { };
-    }
 
-    genericSplit(
+    auto& spans = vm.stringSplitIndice;
+    spans.shrink(0);
+    MatchResult lastMatchResult = genericSplit(
         globalObject, regexp, inputString, input, inputSize, position, matchPosition, regExpIsSticky, regExpIsUnicode,
         [&] () -> SplitControl {
-            if (resultLength >= maxSizeForDirectPath)
+            if (splitSpanCount(spans) >= maxSizeForDirectPath)
                 return AbortSplit;
             return ContinueSplit;
         },
         [&] (bool isDefined, unsigned start, unsigned length) -> SplitControl {
-            result->putDirectIndex(globalObject, resultLength++, isDefined ? jsSubstringOfResolved(vm, inputString, start, length) : jsUndefined());
-            RETURN_IF_EXCEPTION(scope, AbortSplit);
-            if (resultLength >= limit)
+            recordSplitSpan(spans, isDefined ? start : undefinedSplitSpanStart, length);
+            if (splitSpanCount(spans) >= limit)
                 return AbortSplit;
             return ContinueSplit;
         });
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (resultLength >= limit)
-        return result;
+    if (splitSpanCount(spans) >= limit)
+        RELEASE_AND_RETURN(scope, createArrayFromSplitSpans(globalObject, vm, inputString, spans));
 
-    if (resultLength < maxSizeForDirectPath) {
+    if (splitSpanCount(spans) < maxSizeForDirectPath) {
         // 20. Let substring be the substring of string from lastMatchEnd to size.
         // 21. Perform ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(lengthA)), substring).
-        scope.release();
-        result->putDirectIndex(globalObject, resultLength, jsSubstringOfResolved(vm, inputString, position, inputSize - position));
+        recordSplitSpan(spans, position, inputSize - position);
+
+        if (cacheable) {
+            JSArray* cached = tryAddToRegExpSplitCache(globalObject, vm, inputString, input, regexp, spans, lastMatchResult);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (cached)
+                return cached;
+        }
 
         // 22. Return array.
-        return result;
+        RELEASE_AND_RETURN(scope, createArrayFromSplitSpans(globalObject, vm, inputString, spans));
     }
+
+    // Absurdly large results are not cached, and recording every element up front would cost more
+    // scratch space than the dry run below needs to bound the total size. Materialize what the split
+    // produced so far and finish it directly into the array.
+    JSArray* result = createArrayFromSplitSpans(globalObject, vm, inputString, spans);
+    RETURN_IF_EXCEPTION(scope, { });
+    unsigned resultLength = splitSpanCount(spans);
 
     // Now do a dry run to see how big things get. Give up if they get absurd.
     unsigned savedPosition = position;
@@ -931,7 +1060,7 @@ JSCell* regExpSplitFast(JSGlobalObject* globalObject, RegExpObject* regexpObject
     // OK, we know that if we finish the split, we won't have to OOM.
     position = savedPosition;
     matchPosition = savedMatchPosition;
-    
+
     genericSplit(
         globalObject, regexp, inputString, input, inputSize, position, matchPosition, regExpIsSticky, regExpIsUnicode,
         [&] () -> SplitControl {

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1055,11 +1055,6 @@ static ALWAYS_INLINE bool splitStringByOneCharacterImpl(Indice& result, StringIm
     return false;
 }
 
-static bool NODELETE isASCIIIdentifierStart(char16_t ch)
-{
-    return isASCIIAlpha(ch) || ch == '_' || ch == '$';
-}
-
 JSCell* stringSplitFast(JSGlobalObject* globalObject, JSString* thisString, JSString* separatorString, unsigned limit)
 {
     VM& vm = globalObject->vm();
@@ -1078,7 +1073,8 @@ JSCell* stringSplitFast(JSGlobalObject* globalObject, JSString* thisString, JSSt
         RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
 
     if (limit == 0xFFFFFFFFu && !globalObject->isHavingABadTime()) [[likely]] {
-        if (auto* immutableButterfly = vm.stringSplitCache.get(input, separator)) {
+        auto* cache = vm.stringSplitCache();
+        if (auto* immutableButterfly = cache ? cache->getForString(input, separator) : nullptr) {
             Structure* arrayStructure = globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous);
             return JSArray::createWithButterfly(vm, nullptr, arrayStructure, immutableButterfly->toButterfly());
         }
@@ -1132,7 +1128,7 @@ JSCell* stringSplitFast(JSGlobalObject* globalObject, JSString* thisString, JSSt
                 Structure* replacementStructure = vm.cellButterflyStructure(CopyOnWriteArrayWithContiguous);
                 newButterfly->setStructure(vm, replacementStructure);
             }
-            vm.stringSplitCache.set(input, separator, newButterfly);
+            vm.ensureStringSplitCache().setForString(input, separator, newButterfly);
             Structure* arrayStructure = globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous);
             return JSArray::createWithButterfly(vm, nullptr, arrayStructure, newButterfly->toButterfly());
         }
@@ -1192,7 +1188,7 @@ JSCell* stringSplitFast(JSGlobalObject* globalObject, JSString* thisString, JSSt
                 }
                 newButterfly->setIndex(vm, i, string);
             }
-            vm.stringSplitCache.set(input, separator, newButterfly);
+            vm.ensureStringSplitCache().setForString(input, separator, newButterfly);
             Structure* arrayStructure = globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous);
             return JSArray::createWithButterfly(vm, nullptr, arrayStructure, newButterfly->toButterfly());
         }

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -1601,6 +1601,11 @@ ALWAYS_INLINE JSString* replace(VM& vm, JSGlobalObject* globalObject, JSValue th
     RELEASE_AND_RETURN(scope, replaceUsingStringSearch<replaceMode>(vm, globalObject, string, thisString, WTF::move(searchString), replaceValue));
 }
 
+ALWAYS_INLINE bool isASCIIIdentifierStart(char16_t ch)
+{
+    return isASCIIAlpha(ch) || ch == '_' || ch == '$';
+}
+
 ALWAYS_INLINE char32_t codePointAt(const String& string, unsigned position, unsigned length)
 {
     RELEASE_ASSERT(position < length);

--- a/Source/JavaScriptCore/runtime/StringSplitCache.cpp
+++ b/Source/JavaScriptCore/runtime/StringSplitCache.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StringSplitCache.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace JSC {
+
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StringSplitCache);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StringSplitCache);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/StringSplitCache.h
+++ b/Source/JavaScriptCore/runtime/StringSplitCache.h
@@ -26,8 +26,10 @@
 
 #pragma once
 
+#include <JavaScriptCore/MatchResult.h>
 #include <array>
 #include <wtf/DebugHeap.h>
+#include <wtf/HashFunctions.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -38,31 +40,52 @@ namespace JSC {
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER_AND_EXPORT(StringSplitCache, WTF_INTERNAL);
 
 class JSCellButterfly;
+class RegExp;
 
 class StringSplitCache {
     WTF_MAKE_TZONE_ALLOCATED(StringSplitCache);
     WTF_MAKE_NONCOPYABLE(StringSplitCache);
 public:
-    static constexpr unsigned cacheSize = 64;
-
     StringSplitCache() = default;
 
-    struct Entry {
+    struct StringEntry {
         RefPtr<AtomStringImpl> m_subject { nullptr };
         RefPtr<AtomStringImpl> m_separator { nullptr };
         JSCellButterfly* m_butterfly { nullptr };
     };
 
-    JSCellButterfly* get(const String& subject, const String& separator);
-    void set(const String& subject, const String& separator, JSCellButterfly*);
+    struct RegExpEntry {
+        RefPtr<AtomStringImpl> m_subject { nullptr };
+        RegExp* m_regExp { nullptr };
+        JSCellButterfly* m_butterfly { nullptr };
+        MatchResult m_lastMatch { };
+    };
+
+    JSCellButterfly* getForString(const String& subject, const String& separator);
+    void setForString(const String& subject, const String& separator, JSCellButterfly*);
+
+    JSCellButterfly* getForRegExp(const String& subject, RegExp*, MatchResult& lastMatch);
+    void setForRegExp(const String& subject, RegExp*, JSCellButterfly*, MatchResult lastMatch);
 
     void clear()
     {
-        m_entries.fill(Entry { });
+        m_stringEntries.fill(StringEntry { });
+        m_regExpEntries.fill(RegExpEntry { });
     }
 
 private:
-    std::array<Entry, cacheSize> m_entries { };
+    static constexpr unsigned stringCacheSize = 64;
+    static constexpr unsigned regExpCacheSize = 256;
+    static_assert(!(stringCacheSize & (stringCacheSize - 1)));
+    static_assert(!(regExpCacheSize & (regExpCacheSize - 1)));
+
+    size_t regExpEntryIndex(AtomStringImpl* subject, RegExp* regExp) const
+    {
+        return pairIntHash(subject->hash(), PtrHash<RegExp*>::hash(regExp)) & (m_regExpEntries.size() - 1);
+    }
+
+    std::array<StringEntry, stringCacheSize> m_stringEntries { };
+    std::array<RegExpEntry, regExpCacheSize> m_regExpEntries { };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/StringSplitCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/StringSplitCacheInlines.h
@@ -31,7 +31,7 @@
 
 namespace JSC {
 
-inline JSCellButterfly* StringSplitCache::get(const String& subject, const String& separator)
+inline JSCellButterfly* StringSplitCache::getForString(const String& subject, const String& separator)
 {
     AssertNoGC assertNoGC;
     if (!subject.impl() || !subject.impl()->isAtom())
@@ -41,21 +41,21 @@ inline JSCellButterfly* StringSplitCache::get(const String& subject, const Strin
 
     auto* subjectImpl = static_cast<AtomStringImpl*>(subject.impl());
     auto* separatorImpl = static_cast<AtomStringImpl*>(separator.impl());
-    unsigned index = subjectImpl->hash() & (cacheSize - 1);
+    size_t index = subjectImpl->hash() & (m_stringEntries.size() - 1);
     {
-        auto& entry = m_entries[index];
+        auto& entry = m_stringEntries[index];
         if (entry.m_subject == subjectImpl && entry.m_separator == separatorImpl)
             return entry.m_butterfly;
     }
     {
-        auto& entry = m_entries[(index + 1) & (cacheSize - 1)];
+        auto& entry = m_stringEntries[(index + 1) & (m_stringEntries.size() - 1)];
         if (entry.m_subject == subjectImpl && entry.m_separator == separatorImpl)
             return entry.m_butterfly;
     }
     return nullptr;
 }
 
-inline void StringSplitCache::set(const String& subject, const String& separator, JSCellButterfly* butterfly)
+inline void StringSplitCache::setForString(const String& subject, const String& separator, JSCellButterfly* butterfly)
 {
     AssertNoGC assertNoGC;
     if (!subject.impl() || !subject.impl()->isAtom())
@@ -65,15 +65,15 @@ inline void StringSplitCache::set(const String& subject, const String& separator
 
     auto* subjectImpl = static_cast<AtomStringImpl*>(subject.impl());
     auto* separatorImpl = static_cast<AtomStringImpl*>(separator.impl());
-    unsigned index = subjectImpl->hash() & (cacheSize - 1);
+    size_t index = subjectImpl->hash() & (m_stringEntries.size() - 1);
     {
-        auto& entry1 = m_entries[index];
+        auto& entry1 = m_stringEntries[index];
         if (!entry1.m_subject) {
             entry1.m_subject = subjectImpl;
             entry1.m_separator = separatorImpl;
             entry1.m_butterfly = butterfly;
         } else {
-            auto& entry2 = m_entries[(index + 1) & (cacheSize - 1)];
+            auto& entry2 = m_stringEntries[(index + 1) & (m_stringEntries.size() - 1)];
             if (!entry2.m_subject) {
                 entry2.m_subject = subjectImpl;
                 entry2.m_separator = separatorImpl;
@@ -87,6 +87,63 @@ inline void StringSplitCache::set(const String& subject, const String& separator
             }
         }
     }
+}
+
+inline JSCellButterfly* StringSplitCache::getForRegExp(const String& subject, RegExp* regExp, MatchResult& lastMatch)
+{
+    AssertNoGC assertNoGC;
+    if (!subject.impl() || !subject.impl()->isAtom())
+        return nullptr;
+    if (!regExp)
+        return nullptr;
+
+    auto* subjectImpl = static_cast<AtomStringImpl*>(subject.impl());
+    size_t index = regExpEntryIndex(subjectImpl, regExp);
+    {
+        auto& entry = m_regExpEntries[index];
+        if (entry.m_subject == subjectImpl && entry.m_regExp == regExp) {
+            lastMatch = entry.m_lastMatch;
+            return entry.m_butterfly;
+        }
+    }
+    {
+        auto& entry = m_regExpEntries[(index + 1) & (m_regExpEntries.size() - 1)];
+        if (entry.m_subject == subjectImpl && entry.m_regExp == regExp) {
+            lastMatch = entry.m_lastMatch;
+            return entry.m_butterfly;
+        }
+    }
+    return nullptr;
+}
+
+inline void StringSplitCache::setForRegExp(const String& subject, RegExp* regExp, JSCellButterfly* butterfly, MatchResult lastMatch)
+{
+    AssertNoGC assertNoGC;
+    if (!subject.impl() || !subject.impl()->isAtom())
+        return;
+    if (!regExp)
+        return;
+
+    auto* subjectImpl = static_cast<AtomStringImpl*>(subject.impl());
+    size_t index = regExpEntryIndex(subjectImpl, regExp);
+    auto store = [&](RegExpEntry& entry) {
+        entry.m_subject = subjectImpl;
+        entry.m_regExp = regExp;
+        entry.m_butterfly = butterfly;
+        entry.m_lastMatch = lastMatch;
+    };
+    auto& entry1 = m_regExpEntries[index];
+    if (!entry1.m_subject) {
+        store(entry1);
+        return;
+    }
+    auto& entry2 = m_regExpEntries[(index + 1) & (m_regExpEntries.size() - 1)];
+    if (!entry2.m_subject) {
+        store(entry2);
+        return;
+    }
+    entry2 = RegExpEntry { };
+    store(entry1);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -125,6 +125,7 @@
 #include "SideDataRepository.h"
 #include "SimpleTypedArrayController.h"
 #include "SourceProviderCache.h"
+#include "StringSplitCache.h"
 #include "StrongInlines.h"
 #include "StructureChainInlines.h"
 #include "StructureInlines.h"
@@ -289,6 +290,10 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
 
         m_megamorphicCache.initLater([](VM&, auto& ref) {
             ref.set(makeUniqueRef<MegamorphicCache>());
+        });
+
+        m_stringSplitCache.initLater([](VM&, auto& ref) {
+            ref.set(makeUniqueRef<StringSplitCache>());
         });
 
         m_shadowChicken.initLater([](VM&, auto& ref) {

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -46,7 +46,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <JavaScriptCore/NumericStrings.h>
 #include <JavaScriptCore/SmallStrings.h>
 #include <JavaScriptCore/StringReplaceCache.h>
-#include <JavaScriptCore/StringSplitCache.h>
 #include <JavaScriptCore/StrongForward.h>
 #include <JavaScriptCore/VMThreadContext.h>
 #include <JavaScriptCore/WeakGCMap.h>
@@ -150,6 +149,7 @@ class SourceProvider;
 class SourceProviderCache;
 enum class SourceTaintedOrigin : uint8_t;
 class StackFrame;
+class StringSplitCache;
 class Structure;
 class Symbol;
 class TypedArrayController;
@@ -623,7 +623,6 @@ public:
     Ref<AtomStringImpl> lastAtomizedIdentifierAtomStringImpl { *static_cast<AtomStringImpl*>(StringImpl::empty()) };
     JSONAtomStringCache jsonAtomStringCache;
     KeyAtomStringCache keyAtomStringCache;
-    StringSplitCache stringSplitCache;
     Vector<unsigned> stringSplitIndice;
     StringReplaceCache stringReplaceCache;
 
@@ -931,6 +930,10 @@ public:
     LazyUniqueRef<VM, MegamorphicCache> m_megamorphicCache;
     ALWAYS_INLINE MegamorphicCache* megamorphicCache() { return m_megamorphicCache.getIfExists(); }
     MegamorphicCache& ensureMegamorphicCache() { return m_megamorphicCache.get(*this); }
+
+    LazyUniqueRef<VM, StringSplitCache> m_stringSplitCache;
+    ALWAYS_INLINE StringSplitCache* stringSplitCache() { return m_stringSplitCache.getIfExists(); }
+    StringSplitCache& ensureStringSplitCache() { return m_stringSplitCache.get(*this); }
 
     const UniqueRef<MicrotaskCallCache> m_syncResumeCallCache;
     MicrotaskCallCache& syncResumeCallCache() { return m_syncResumeCallCache.get(); }


### PR DESCRIPTION
#### 73e4c589c1e6f099ef31cab839174494da20d909
<pre>
[JSC] Extend StringSplitCache for RegExp
<a href="https://bugs.webkit.org/show_bug.cgi?id=320591">https://bugs.webkit.org/show_bug.cgi?id=320591</a>
<a href="https://rdar.apple.com/183565424">rdar://183565424</a>

Reviewed by Yijia Huang.

This patch extends existing StringSplitCache to have RegExp splitting
version as it is also common in practice. We basically follow to the
same conditions used for string split caching. We record extracted range
into a Vector, and materialize it to JSCellButterfly when necessary.
One critical point is that because it is using RegExp for splitting, it
can have a side-effect of updating RegExp cache information (e.g.
RegExp.$1), to achieve that, we record MatchResult as well in the cache
for RegExp case.

Test: JSTests/stress/regexp-split-cache-regexp-statics.js

* JSTests/stress/regexp-split-cache-regexp-statics.js: Added.
(shouldBe):
(statics):
(clobberStatics):
(split):
(regexp):
(check):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::clearConcurrentRetainedDataIfPossible):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::genericSplit):
(JSC::recordSplitSpan):
(JSC::splitSpanCount):
(JSC::createArrayFromSplitSpans):
(JSC::tryAddToRegExpSplitCache):
(JSC::regExpSplitFast):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::stringSplitFast):
(JSC::isASCIIIdentifierStart): Deleted.
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::isASCIIIdentifierStart):
* Source/JavaScriptCore/runtime/StringSplitCache.cpp: Copied from Source/JavaScriptCore/runtime/StringSplitCache.h.
* Source/JavaScriptCore/runtime/StringSplitCache.h:
(JSC::StringSplitCache::clear):
(JSC::StringSplitCache::regExpEntryIndex const):
* Source/JavaScriptCore/runtime/StringSplitCacheInlines.h:
(JSC::StringSplitCache::getForString):
(JSC::StringSplitCache::setForString):
(JSC::StringSplitCache::getForRegExp):
(JSC::StringSplitCache::setForRegExp):
(JSC::StringSplitCache::get): Deleted.
(JSC::StringSplitCache::set): Deleted.
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::stringSplitCache):
(JSC::VM::ensureStringSplitCache):

Canonical link: <a href="https://commits.webkit.org/318212@main">https://commits.webkit.org/318212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03b0c170f3841ca1cc2927ba6793d6f184f73aaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177669 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/51607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f987341-f6a9-44a1-80d8-d549f3d5c66e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52899 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/187274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31dda25f-ca16-437d-b9be-20550774a850) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180625 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/40128f11-ffe9-4cfc-9193-0400f2de4e67) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/35740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/38940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/43392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/51316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/189704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/189704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/51956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/189704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26942 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/51956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50464 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->