### PR TITLE
corner-shape: corners are mis-positioned/mis-shaped on outlines and box-shadow spread

### DIFF
--- a/Source/WebCore/platform/graphics/BezierUtilities.cpp
+++ b/Source/WebCore/platform/graphics/BezierUtilities.cpp
@@ -28,6 +28,7 @@
 #include "FloatPoint.h"
 #include "FloatRect.h"
 #include "GeometryUtilities.h"
+#include "Path.h"
 #include "RectEdges.h"
 #include <algorithm>
 #include <cmath>
@@ -110,19 +111,6 @@ Vector<double, 3> solveCubicForParametersInUnitInterval(double cubicCoefficient,
     for (int rootIndex = 0; rootIndex < 3; ++rootIndex)
         addRoot(magnitude * std::cos((angle - twoPi * rootIndex) / 3.0) - shift);
     return parametersInUnitInterval;
-}
-
-FloatPoint pointOnBezierAtParameter(const BezierSegment& curve, double parameter)
-{
-    double oneMinusParameter = 1.0 - parameter;
-    double weightStart = oneMinusParameter * oneMinusParameter * oneMinusParameter;
-    double weightControl1 = 3.0 * oneMinusParameter * oneMinusParameter * parameter;
-    double weightControl2 = 3.0 * oneMinusParameter * parameter * parameter;
-    double weightEnd = parameter * parameter * parameter;
-    return {
-        static_cast<float>(curve.start.x() * weightStart + curve.controlPoint1.x() * weightControl1 + curve.controlPoint2.x() * weightControl2 + curve.end.x() * weightEnd),
-        static_cast<float>(curve.start.y() * weightStart + curve.controlPoint1.y() * weightControl1 + curve.controlPoint2.y() * weightControl2 + curve.end.y() * weightEnd),
-    };
 }
 
 Vector<BezierIntersection> intersectBezierAndLine(const BezierSegment& curve, const FloatPoint& lineStart, const FloatPoint& lineEnd)
@@ -220,6 +208,21 @@ static bool boxesTouchOrOverlap(const FloatRect& first, const FloatRect& second)
 
 } // namespace
 
+// `parameter` is the Bézier curve parameter t in [0, 1] (the variable of the Bernstein basis
+// below, and of solveCubicForParametersInUnitInterval): t = 0 is curve.start, t = 1 is curve.end.
+FloatPoint pointOnBezierAtParameter(const BezierSegment& curve, double parameter)
+{
+    double oneMinusParameter = 1.0 - parameter;
+    double weightStart = oneMinusParameter * oneMinusParameter * oneMinusParameter;
+    double weightControl1 = 3.0 * oneMinusParameter * oneMinusParameter * parameter;
+    double weightControl2 = 3.0 * oneMinusParameter * parameter * parameter;
+    double weightEnd = parameter * parameter * parameter;
+    return {
+        static_cast<float>(curve.start.x() * weightStart + curve.controlPoint1.x() * weightControl1 + curve.controlPoint2.x() * weightControl2 + curve.end.x() * weightEnd),
+        static_cast<float>(curve.start.y() * weightStart + curve.controlPoint1.y() * weightControl1 + curve.controlPoint2.y() * weightControl2 + curve.end.y() * weightEnd),
+    };
+}
+
 Vector<BezierSegment> trimBezierToRect(const BezierSegment& curve, const FloatRect& rect)
 {
     // The curve stays within its control points' convex hull
@@ -250,6 +253,101 @@ Vector<BezierSegment> trimBezierToRect(const BezierSegment& curve, const FloatRe
         curves = clipped;
     }
     return curves;
+}
+
+// Resample a flattened polyline to `count` points spaced evenly along its arc length
+Vector<FloatPoint> resampleByArcLength(const Vector<FloatPoint>& polyline, unsigned count)
+{
+    Vector<float> cumulativeLength;
+    cumulativeLength.reserveInitialCapacity(polyline.size());
+    cumulativeLength.append(0.0f);
+    for (size_t pointIndex = 1; pointIndex < polyline.size(); ++pointIndex)
+        cumulativeLength.append(cumulativeLength[pointIndex - 1] + (polyline[pointIndex] - polyline[pointIndex - 1]).diagonalLength());
+    float totalLength = cumulativeLength.last();
+    if (totalLength <= 0.0f)
+        totalLength = 1.0f;
+    Vector<FloatPoint> resampled;
+    resampled.reserveInitialCapacity(count);
+    size_t segmentIndex = 0;
+    for (unsigned sample = 0; sample < count; ++sample) {
+        float targetLength = totalLength * sample / (count - 1);
+        while (segmentIndex + 2 < polyline.size() && cumulativeLength[segmentIndex + 1] < targetLength)
+            ++segmentIndex;
+        float segmentLength = cumulativeLength[segmentIndex + 1] - cumulativeLength[segmentIndex];
+        float fraction = segmentLength > 0.0f ? (targetLength - cumulativeLength[segmentIndex]) / segmentLength : 0.0f;
+        resampled.append(polyline[segmentIndex] + (polyline[segmentIndex + 1] - polyline[segmentIndex]).scaled(fraction));
+    }
+    return resampled;
+}
+
+// Cubic Hermite blend of two point-for-point corresponding curves. `interpolationFraction` runs
+// from 0 (return startPoints, moving with startVelocities) to 1 (return endPoints, moving with
+// endVelocities); the velocities are the endpoint tangents that make the blend smooth.
+//
+// For each point, with t = interpolationFraction, p0 = startPoints, v0 = startVelocities,
+// p1 = endPoints, v1 = endVelocities, the standard Hermite basis is:
+//     h00(t) =  2t^3 - 3t^2 + 1   (startPositionWeight)
+//     h10(t) =   t^3 - 2t^2 + t   (startVelocityWeight)
+//     h01(t) = -2t^3 + 3t^2       (endPositionWeight)
+//     h11(t) =   t^3 -  t^2       (endVelocityWeight)
+// and the blended point is:
+//     p(t) = h00(t)*p0 + h10(t)*v0 + h01(t)*p1 + h11(t)*v1
+Vector<FloatPoint> hermiteInterpolate(const Vector<FloatPoint>& startPoints, const Vector<FloatSize>& startVelocities, const Vector<FloatPoint>& endPoints, const Vector<FloatSize>& endVelocities, double interpolationFraction)
+{
+    double startPositionWeight = 2.0 * interpolationFraction * interpolationFraction * interpolationFraction - 3.0 * interpolationFraction * interpolationFraction + 1.0;
+    double startVelocityWeight = interpolationFraction * interpolationFraction * interpolationFraction - 2.0 * interpolationFraction * interpolationFraction + interpolationFraction;
+    double endPositionWeight = -2.0 * interpolationFraction * interpolationFraction * interpolationFraction + 3.0 * interpolationFraction * interpolationFraction;
+    double endVelocityWeight = interpolationFraction * interpolationFraction * interpolationFraction - interpolationFraction * interpolationFraction;
+    Vector<FloatPoint> blended;
+    blended.reserveInitialCapacity(startPoints.size());
+    for (size_t index = 0; index < startPoints.size(); ++index) {
+        blended.append({
+            float(startPositionWeight * startPoints[index].x() + startVelocityWeight * startVelocities[index].width() + endPositionWeight * endPoints[index].x() + endVelocityWeight * endVelocities[index].width()),
+            float(startPositionWeight * startPoints[index].y() + startVelocityWeight * startVelocities[index].height() + endPositionWeight * endPoints[index].y() + endVelocityWeight * endVelocities[index].height()),
+        });
+    }
+    return blended;
+}
+
+// Converts each Catmull-Rom span to a cubic Bézier: control points sit 1/6 of the neighbor-to-neighbor tangent out from each endpoint, giving one smooth curve through every knot
+void addCatmullRomBeziers(Path& path, const Vector<FloatPoint>& points, unsigned segmentCount, bool& started)
+{
+    if (points.size() < 2)
+        return;
+    unsigned knotCount = std::min<unsigned>(points.size(), segmentCount + 1);
+    auto knots = knotCount < points.size() ? resampleByArcLength(points, knotCount) : points;
+    if (knots.size() < 2)
+        return;
+
+    if (!started) {
+        path.moveTo(knots[0]);
+        started = true;
+    } else
+        path.addLineTo(knots[0]);
+
+    // End tangents taken from the dense curve so the fit leaves/arrives along its true direction
+    auto knotAt = [&](int index) {
+        return knots[std::clamp(index, 0, static_cast<int>(knots.size()) - 1)];
+    };
+    size_t tail = std::min<size_t>(3, points.size() - 1);
+    auto startTravel = (points[tail] - points[0]).normalized();
+    auto endTravel = (points[points.size() - 1] - points[points.size() - 1 - tail]).normalized();
+    unsigned lastSpan = knots.size() - 2;
+
+    for (unsigned spanIndex = 0; spanIndex + 1 < knots.size(); ++spanIndex) {
+        auto previous = knotAt(static_cast<int>(spanIndex) - 1);
+        auto current = knots[spanIndex];
+        auto next = knots[spanIndex + 1];
+        auto following = knotAt(static_cast<int>(spanIndex) + 2);
+        auto controlPoint1 = current + (next - previous).scaled(1.0f / 6.0f);
+        auto controlPoint2 = next - (following - current).scaled(1.0f / 6.0f);
+        float third = (next - current).diagonalLength() / 3.0f;
+        if (!spanIndex)
+            controlPoint1 = current + startTravel.scaled(third);
+        if (spanIndex == lastSpan)
+            controlPoint2 = next - endTravel.scaled(third);
+        path.addBezierCurveTo(controlPoint1, controlPoint2, next);
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/BezierUtilities.h
+++ b/Source/WebCore/platform/graphics/BezierUtilities.h
@@ -26,9 +26,12 @@
 
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FloatRect.h>
+#include <WebCore/FloatSize.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
+
+class Path;
 
 struct BezierSegment {
     FloatPoint start;
@@ -38,5 +41,13 @@ struct BezierSegment {
 };
 
 WEBCORE_EXPORT Vector<BezierSegment> trimBezierToRect(const BezierSegment& curve, const FloatRect&);
+// `parameter` is the Bézier curve parameter t in [0, 1]: 0 is the start point, 1 is the end point (not arc length).
+FloatPoint pointOnBezierAtParameter(const BezierSegment& curve, double parameter);
+Vector<FloatPoint> resampleByArcLength(const Vector<FloatPoint>& polyline, unsigned count);
+// `interpolationFraction` blends from the start curve (0) to the end curve (1); it is a shape-morph
+// fraction between two whole curves, not a position along a single curve.
+Vector<FloatPoint> hermiteInterpolate(const Vector<FloatPoint>& startPoints, const Vector<FloatSize>& startVelocities, const Vector<FloatPoint>& endPoints, const Vector<FloatSize>& endVelocities, double interpolationFraction);
+
+void addCatmullRomBeziers(Path&, const Vector<FloatPoint>& points, unsigned segmentCount, bool& started);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
@@ -212,21 +212,25 @@ static Corner buildRoundCorners(const Corner& original, double startInset, doubl
     return { innerStart, innerOuter, innerEnd, original.center, FloatSize(radiusX, radiusY), original.curvature, original.orientation };
 }
 
-static Corner adjustCornerForInset(const Corner& original, double startInset, double endInset)
+enum class ForceHullDirection : bool { No, Yes };
+
+static Corner adjustCornerForInset(const Corner& original, double startInset, double endInset, ForceHullDirection forceHullDirection = ForceHullDirection::No)
 {
     if (isEmpty(original) || (startInset == 0.0 && endInset == 0.0))
         return original;
 
-    if (isBevel(original)) {
-        auto [cutStart, cutEnd] = buildBevelCorners(original, startInset, endInset);
-        return { cutStart, original.outer, cutEnd, original.center, cornerRadii(original.center, original.outer), original.curvature, original.orientation };
+    if (forceHullDirection == ForceHullDirection::No) {
+        if (isBevel(original)) {
+            auto [cutStart, cutEnd] = buildBevelCorners(original, startInset, endInset);
+            return { cutStart, original.outer, cutEnd, original.center, cornerRadii(original.center, original.outer), original.curvature, original.orientation };
+        }
+
+        if (isScoop(original))
+            return buildScoopCorners(original, startInset, endInset);
+
+        if (isRound(original))
+            return buildRoundCorners(original, startInset, endInset);
     }
-
-    if (isScoop(original))
-        return buildScoopCorners(original, startInset, endInset);
-
-    if (isRound(original))
-        return buildRoundCorners(original, startInset, endInset);
 
     double strokeA = 0, strokeB = 0;
     if (isNotch(original)) {
@@ -343,6 +347,17 @@ static std::array<BezierSegment, 2> superellipseCornerBeziers(const Corner& corn
     return { firstHalf, secondHalf };
 }
 
+// Control point of the quadratic that approximates the corner, giving the curve's tangent at its endpoints
+static FloatPoint quadraticControlPoint(const Corner& corner)
+{
+    auto drawn = isConcave(corner) ? inverseCorner(corner) : corner;
+    if (drawn.curvature >= 1.0)
+        return drawn.outer;
+    auto handles = superellipseBezierHandles(drawn.curvature);
+    float normalizedControl = 2.0f * float(handles.halfCorner) - 0.5f;
+    return mapPointToCorner(drawn, FloatSize(normalizedControl, normalizedControl));
+}
+
 static void addCurvedCorner(Path& path, const Corner& corner)
 {
     if (isNotch(corner)) {
@@ -418,31 +433,167 @@ static void addTrimmedSuperellipseCorner(Path& path, const Corner& corner, const
     }
 }
 
-static void buildCorners(RectCorners<Corner>& corners, const RectCorners<CornerInput>& cornerRects)
+static void buildCorners(RectCorners<Corner>& corners, const RectCorners<CornerInput>& cornerRects, ForceHullDirection forceHullDirection = ForceHullDirection::No)
 {
     for (auto key : { BoxCorner::TopLeft, BoxCorner::TopRight, BoxCorner::BottomLeft, BoxCorner::BottomRight }) {
         auto& input = cornerRects[key];
         auto original = makeCorner(input);
-        auto corner = adjustCornerForInset(original, input.startInset, input.endInset);
+        auto corner = adjustCornerForInset(original, input.startInset, input.endInset, forceHullDirection);
         corners[key] = corner;
     }
+}
+
+using ContourEdge = std::pair<FloatPoint, FloatPoint>;
+
+// Flatten the drawn corner curve (start..end) into points, matching addCurvedCorner's geometry.
+static void sampleDrawnCorner(const Corner& corner, unsigned stepsPerHalf, Vector<FloatPoint>& out)
+{
+    if (isConcave(corner)) {
+        sampleDrawnCorner(inverseCorner(corner), stepsPerHalf, out);
+        return;
+    }
+    out.append(corner.start);
+    if (isBevel(corner)) {
+        out.append(corner.end);
+        return;
+    }
+    if (isSquare(corner)) {
+        out.append(corner.outer);
+        out.append(corner.end);
+        return;
+    }
+    for (auto& segment : superellipseCornerBeziers(corner)) {
+        for (unsigned step = 1; step <= stepsPerHalf; ++step)
+            out.append(pointOnBezierAtParameter(segment, double(step) / stepsPerHalf));
+    }
+}
+
+// The outset+miter curve for a single corner, flattened from its start miter to its end miter.
+static Vector<FloatPoint> cornerOutsetSamples(const CornerInput& input, double curvature, const ContourEdge& startEdge, const ContourEdge& endEdge, unsigned stepsPerHalf)
+{
+    CornerInput swapped = input;
+    swapped.curvature = curvature;
+    auto corner = adjustCornerForInset(makeCorner(swapped), input.startInset, input.endInset, ForceHullDirection::Yes);
+    auto controlPoint = quadraticControlPoint(corner);
+    auto miterStart = findIntersection(startEdge.first, startEdge.second, corner.start, controlPoint).value_or(corner.start);
+    auto miterEnd = findIntersection(endEdge.first, endEdge.second, corner.end, controlPoint).value_or(corner.end);
+    Vector<FloatPoint> points;
+    points.append(miterStart);
+    sampleDrawnCorner(corner, stepsPerHalf, points);
+    points.append(miterEnd);
+    return points;
+}
+
+// Cubic Hermite morph of the outset curve at s = -1, 0, +1 for a corner whose curvature is in (-1, 1).
+static void addMorphedOutsetCorner(Path& path, const CornerInput& input, const ContourEdge& startEdge, const ContourEdge& endEdge, float deviceScaleFactor, bool& started)
+{
+    constexpr double flatnessTolerance = 0.25; // device pixels
+    double radius = std::max(input.width, input.height) + std::max(std::abs(input.startInset), std::abs(input.endInset));
+    double scale = deviceScaleFactor > 0.0f ? deviceScaleFactor : 1.0;
+    double quarterArcChords = std::numbers::pi / 2.0 * std::sqrt(radius * scale / (8.0 * flatnessTolerance));
+    unsigned stepsPerHalf = std::max(2u, static_cast<unsigned>(std::clamp(std::ceil(quarterArcChords / 2.0), 4.0, 64.0)));
+    unsigned sampleCount = 2 * stepsPerHalf + 4;
+    constexpr double epsilon = 0.04; // curvature step for the endpoint-velocity finite differences
+    double curvature = input.curvature;
+
+    auto anchor = [&](double sampleCurvature) {
+        return resampleByArcLength(cornerOutsetSamples(input, sampleCurvature, startEdge, endEdge, stepsPerHalf), sampleCount);
+    };
+
+    auto velocity = [&](const Vector<FloatPoint>& ahead, const Vector<FloatPoint>& behind, double deltaCurvature) {
+        Vector<FloatSize> perPointVelocity(sampleCount);
+        for (unsigned index = 0; index < sampleCount; ++index)
+            perPointVelocity[index] = (ahead[index] - behind[index]).scaled(1.0f / deltaCurvature);
+        return perPointVelocity;
+    };
+
+    auto middleAnchor = anchor(0.0);
+    Vector<FloatPoint> startAnchor, endAnchor;
+    Vector<FloatSize> startVelocity, endVelocity;
+    // The morph brackets the curvature s into a sub-interval whose endpoints are anchor curves, then
+    // remaps s onto [0, 1] as hermiteInterpolate's blend fraction
+    double interpolationFraction;
+    if (curvature < 0.0) {
+        startAnchor = anchor(-1.0);
+        endAnchor = middleAnchor;
+        startVelocity = velocity(startAnchor, anchor(-1.0 - epsilon), epsilon); // dPosition/ds at s = -1 (from below)
+        endVelocity = velocity(anchor(epsilon), anchor(-epsilon), 2.0 * epsilon); // dPosition/ds at s = 0 (central)
+        interpolationFraction = curvature + 1.0; // s in [-1, 0] -> [0, 1]
+    } else {
+        startAnchor = middleAnchor;
+        endAnchor = anchor(1.0);
+        startVelocity = velocity(anchor(epsilon), anchor(-epsilon), 2.0 * epsilon); // dPosition/ds at s = 0 (central)
+        endVelocity = velocity(anchor(1.0 + epsilon), endAnchor, epsilon); // dPosition/ds at s = +1 (from above)
+        interpolationFraction = curvature; // s in [0, 1] -> [0, 1]
+    }
+
+    auto morphedCorner = hermiteInterpolate(startAnchor, startVelocity, endAnchor, endVelocity, interpolationFraction);
+
+    // Fixed count sized for the worst-case corner (up to ~R = 240) to stay within 0.25px of the true curve
+    // TODO: cache the built path then a Schneider fit could use fewer segments on large corners
+    constexpr unsigned bezierSegmentCount = 18;
+    addCatmullRomBeziers(path, morphedCorner, bezierSegmentCount, started);
 }
 
 } // namespace
 
 // https://drafts.csswg.org/css-borders-4/#contour-path
-void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, const FloatRect* innerTrimRect)
+void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, const FloatRect* targetRect, OutsetMiter outsetMiter, float deviceScaleFactor)
 {
     RectCorners<Corner> corners;
-    buildCorners(corners, cornerRects);
+    buildCorners(corners, cornerRects, outsetMiter == OutsetMiter::Yes ? ForceHullDirection::Yes : ForceHullDirection::No);
+
+    using Edge = std::pair<FloatPoint, FloatPoint>;
+    auto edges = targetRect ? targetRect->edges() : RectEdges<Edge> { };
+
+    auto edgesForCorner = [&](BoxCorner key) -> std::pair<Edge, Edge> {
+        switch (key) {
+        case BoxCorner::TopRight:
+            return { edges.top(), edges.right() };
+        case BoxCorner::BottomRight:
+            return { edges.right(), edges.bottom() };
+        case BoxCorner::BottomLeft:
+            return { edges.bottom(), edges.left() };
+        case BoxCorner::TopLeft:
+            return { edges.left(), edges.top() };
+        }
+        return { edges.top(), edges.right() };
+    };
+
+    auto miterToEdge = [](const FloatPoint& endpoint, const FloatPoint& tangentControl, const Edge& edge) {
+        return findIntersection(edge.first, edge.second, endpoint, tangentControl).value_or(endpoint);
+    };
 
     bool started = false;
     for (auto key : { BoxCorner::TopRight, BoxCorner::BottomRight, BoxCorner::BottomLeft, BoxCorner::TopLeft }) {
         const auto& corner = corners[key];
-        if (innerTrimRect && isSuperellipse(corner)) {
-            addTrimmedSuperellipseCorner(path, corner, *innerTrimRect, started);
+
+        if (outsetMiter == OutsetMiter::Yes) {
+            auto [startEdge, endEdge] = edgesForCorner(key);
+            double curvature = cornerRects[key].curvature;
+            if (targetRect && curvature > -1.0 && curvature < 1.0) {
+                addMorphedOutsetCorner(path, cornerRects[key], startEdge, endEdge, deviceScaleFactor, started);
+                continue;
+            }
+            auto controlPoint = quadraticControlPoint(corner);
+            auto miterStart = miterToEdge(corner.start, controlPoint, startEdge);
+            auto miterEnd = miterToEdge(corner.end, controlPoint, endEdge);
+            if (!started) {
+                path.moveTo(miterStart);
+                started = true;
+            } else
+                path.addLineTo(miterStart);
+            addCurvedCorner(path, corner);
+            path.addLineTo(miterEnd);
             continue;
         }
+
+        // Inset: carve the superellipse corner's curve to the target rect.
+        if (targetRect && isSuperellipse(corner)) {
+            addTrimmedSuperellipseCorner(path, corner, *targetRect, started);
+            continue;
+        }
+
         if (!started) {
             path.moveTo(corner.start);
             started = true;

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.h
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.h
@@ -42,8 +42,10 @@ struct CornerInput {
     BoxCorner orientation { BoxCorner::TopRight };
 };
 
+enum class OutsetMiter : bool { No, Yes };
+
 // https://drafts.csswg.org/css-borders-4/#contour-path
-void borderContourPath(Path&, const RectCorners<CornerInput>&, const FloatRect* innerTrimRect = nullptr);
+void borderContourPath(Path&, const RectCorners<CornerInput>&, const FloatRect* targetRect = nullptr, OutsetMiter = OutsetMiter::No, float deviceScaleFactor = 1.0f);
 
 // https://drafts.csswg.org/css-borders-4/#corner-shape-constrain-radii
 double oppositeCornerScaleFactor(const RectCorners<CornerInput>&);

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -113,7 +113,7 @@ BorderShape BorderShape::shapeForBorderRect(const Style::ComputedStyle& style, c
     return BorderShape { borderRect, usedBorderWidths };
 }
 
-BorderShape BorderShape::shapeForOffsetRect(const Style::ComputedStyle& style, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges)
+BorderShape BorderShape::shapeForOffsetRect(const Style::ComputedStyle& style, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges, ConstantThicknessOffset constantThickness)
 {
     auto usedEdgeWidths = applyClosedEdges(edgeWidths, closedEdges);
 
@@ -142,6 +142,7 @@ BorderShape BorderShape::shapeForOffsetRect(const Style::ComputedStyle& style, c
         if (!referenceRadii.areRenderableInRect(borderRect))
             referenceRadii.makeRenderableInRect(borderRect);
         shape.m_offsetReferenceRect = LayoutRoundedRect { borderRect, referenceRadii };
+        shape.m_constantThicknessOffset = constantThickness == ConstantThicknessOffset::Yes;
 
         return shape;
     }
@@ -179,6 +180,7 @@ BorderShape BorderShape::shapeWithBorderWidths(const RectEdges<LayoutUnit>& bord
 {
     auto shape = BorderShape(m_borderRect.rect(), borderWidths, m_borderRect.radii(), m_cornerCurvatures);
     shape.m_offsetReferenceRect = m_offsetReferenceRect;
+    shape.m_constantThicknessOffset = m_constantThicknessOffset;
     return shape;
 }
 
@@ -408,6 +410,43 @@ std::optional<FloatRoundedRect> BorderShape::snappedOffsetReferenceRect(float de
     return m_offsetReferenceRect->pixelSnappedRoundedRectForPainting(deviceScaleFactor);
 }
 
+static bool cornersHaveConvexSuperellipse(const RectCorners<float>& cornerCurvatures)
+{
+    auto isConvexSuperellipse = [](float curvature) {
+        return std::isfinite(curvature) && curvature > 1.0f;
+    };
+    return isConvexSuperellipse(cornerCurvatures.topLeft()) || isConvexSuperellipse(cornerCurvatures.topRight())
+        || isConvexSuperellipse(cornerCurvatures.bottomLeft()) || isConvexSuperellipse(cornerCurvatures.bottomRight());
+}
+
+// "Aligned-to-curve offset" generates the moved contour by offsetting the border-box corner curve at
+// constant distance (see addAlignedToCurveOffsetContour), not by scaling radii. Only needed for corners
+// whose shape can't be reproduced by scaling: finite superellipses with curvature < 1 and != 0.
+static bool cornersUseAlignedToCurveOffset(const RectCorners<float>& cornerCurvatures)
+{
+    auto usesAlignedOffset = [](float curvature) {
+        return std::isfinite(curvature) && curvature < 1.0f && curvature != 0.0f;
+    };
+    return usesAlignedOffset(cornerCurvatures.topLeft()) || usesAlignedOffset(cornerCurvatures.topRight())
+        || usesAlignedOffset(cornerCurvatures.bottomLeft()) || usesAlignedOffset(cornerCurvatures.bottomRight());
+}
+
+// Offset the border-box reference curve to targetRect at constant thickness: outset corners miter out to the edges along their tangent, inset corners trim to the rect.
+static void addAlignedToCurveOffsetContour(Path& path, const FloatRoundedRect& referenceSnapped, const RectCorners<float>& cornerCurvatures, const FloatRect& targetRect)
+{
+    auto referenceRect = referenceSnapped.rect();
+    double leftOffset = referenceRect.x() - targetRect.x();
+    double topOffset = referenceRect.y() - targetRect.y();
+    double rightOffset = targetRect.maxX() - referenceRect.maxX();
+    double bottomOffset = targetRect.maxY() - referenceRect.maxY();
+
+    RectCorners<CornerInput> referenceCorners;
+    buildCornerInputs(referenceSnapped, cornerCurvatures, -leftOffset, -topOffset, -rightOffset, -bottomOffset, referenceCorners);
+
+    auto outsetMiter = referenceRect.contains(targetRect) ? OutsetMiter::No : OutsetMiter::Yes;
+    borderContourPath(path, referenceCorners, &targetRect, outsetMiter);
+}
+
 static void addOuterCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const RectCorners<float>& cornerCurvatures, const std::optional<FloatRoundedRect>& offsetReferenceRect)
 {
     RectCorners<CornerInput> cornerRects;
@@ -419,6 +458,14 @@ static void addOuterCornerShapeToPath(Path& path, const FloatRoundedRect& outerS
 Path BorderShape::pathForOuterCornerShape(const FloatRoundedRect& outerSnapped, const std::optional<FloatRoundedRect>& snappedOffsetReference) const
 {
     Path path;
+    bool useAlignedToCurve = snappedOffsetReference
+        && (cornersUseAlignedToCurveOffset(m_cornerCurvatures)
+            || (m_constantThicknessOffset && cornersHaveConvexSuperellipse(m_cornerCurvatures)));
+    if (useAlignedToCurve) {
+        addAlignedToCurveOffsetContour(path, *snappedOffsetReference, m_cornerCurvatures, outerSnapped.rect());
+        if (!path.isEmpty())
+            return path;
+    }
     addOuterCornerShapeToPath(path, outerSnapped, m_cornerCurvatures, snappedOffsetReference);
     if (!path.isEmpty())
         return path;
@@ -444,6 +491,14 @@ static void addInnerCornerShapeToPath(Path& path, const FloatRoundedRect& outerS
 Path BorderShape::pathForInnerCornerShape(const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped, const std::optional<FloatRoundedRect>& snappedOffsetReference) const
 {
     Path path;
+    bool useAlignedToCurve = snappedOffsetReference
+        && (cornersUseAlignedToCurveOffset(m_cornerCurvatures)
+            || (m_constantThicknessOffset && cornersHaveConvexSuperellipse(m_cornerCurvatures)));
+    if (useAlignedToCurve) {
+        addAlignedToCurveOffsetContour(path, *snappedOffsetReference, m_cornerCurvatures, innerSnapped.rect());
+        if (!path.isEmpty())
+            return path;
+    }
     addInnerCornerShapeToPath(path, outerSnapped, innerSnapped, m_cornerCurvatures, snappedOffsetReference);
     if (path.isEmpty())
         return pathForInnerRoundedRect(innerSnapped);
@@ -614,6 +669,7 @@ void BorderShape::fillRectWithInnerHoleShape(GraphicsContext& context, const Lay
         Path path;
         path.addRect(outerSnapped);
         addInnerShapeToPath(path, deviceScaleFactor);
+        context.setFillRule(WindRule::EvenOdd);
         context.setFillColor(color);
         context.fillPath(path);
         return;

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -47,6 +47,9 @@ namespace Style {
 class ComputedStyle;
 }
 
+// Whether an offset shape keeps constant thickness along the curve (outline) vs. expanding as an area (box-shadow spread).
+enum class ConstantThicknessOffset : bool { No, Yes };
+
 // BorderShape is used to fill and clip to the shape formed by the border and padding boxes with border-radius.
 // In future, this may be a more complex shape than a rounded rect, so accessors that return rounded rects
 // are deprecated.
@@ -59,7 +62,7 @@ public:
     // Create a BorderShape suitable for rendering an outline or shadow. borderRect is provided to
     // allow for scaling the corner radii; radii expand outward or shrink inward based on the offset
     // between borderRect and offsetRect.
-    static BorderShape shapeForOffsetRect(const Style::ComputedStyle&, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges = { true });
+    static BorderShape shapeForOffsetRect(const Style::ComputedStyle&, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges = { true }, ConstantThicknessOffset constantThickness = ConstantThicknessOffset::No);
 
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths);
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const LayoutRoundedRectRadii&);
@@ -152,6 +155,7 @@ private:
     RectCorners<float> m_cornerCurvatures { 1.0f, 1.0f, 1.0f, 1.0f };
 
     std::optional<LayoutRoundedRect> m_offsetReferenceRect;
+    bool m_constantThicknessOffset { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -107,7 +107,7 @@ void OutlinePainter::paintOutline(const RenderElement& renderer, const LayoutRec
     auto closedEdges = RectEdges<bool> { true };
 
     auto outlineEdgeWidths = RectEdges<LayoutUnit> { outlineWidth };
-    auto outlineShape = BorderShape::shapeForOffsetRect(styleToUse.get(), paintRect, outerRect, outlineEdgeWidths, closedEdges);
+    auto outlineShape = BorderShape::shapeForOffsetRect(styleToUse.get(), paintRect, outerRect, outlineEdgeWidths, closedEdges, ConstantThicknessOffset::Yes);
 
     auto bleedAvoidance = BleedAvoidance::ShrinkBackground;
     auto appliedClipAlready = false;
@@ -314,7 +314,7 @@ void OutlinePainter::paintFocusRing(const RenderElement& renderer, const Vector<
         auto borderRect = focusRingRects[0];
         auto outlineRect = borderRect;
         outlineRect.inflate(LayoutUnit(outlineOffset));
-        auto outlineShape = BorderShape::shapeForOffsetRect(style.get(), borderRect, outlineRect, RectEdges<LayoutUnit> { }, RectEdges<bool> { true });
+        auto outlineShape = BorderShape::shapeForOffsetRect(style.get(), borderRect, outlineRect, RectEdges<LayoutUnit> { }, RectEdges<bool> { true }, ConstantThicknessOffset::Yes);
         auto path = outlineShape.pathForOuterShape(deviceScaleFactor);
         drawFocusRing(m_paintInfo.context(), path, style.get(), focusRingColor);
         return;


### PR DESCRIPTION
#### f0f0f788dff03626596509029957a1fd63411667
<pre>
corner-shape: corners are mis-positioned/mis-shaped on outlines and box-shadow spread
<a href="https://bugs.webkit.org/show_bug.cgi?id=320590">https://bugs.webkit.org/show_bug.cgi?id=320590</a>
<a href="https://rdar.apple.com/183564957">rdar://183564957</a>

Reviewed by Simon Fraser.

Non-round corner-shape corners don&apos;t follow their geometry when a decoration
is offset from the border box, outlines (with outline-offset) and box-shadow
spread. Scaling the corner radii on the moved rect only works for corners that
meet their edges tangentially, so shapes that don&apos;t (or have no radius to scale)come
out wrong across the board, not just the exact-shape corners.

Passes tests written in another commit

* Source/WebCore/platform/graphics/BezierUtilities.cpp:
(WebCore::pointOnBezierAtParameter):
(WebCore::resampleByArcLength):
(WebCore::hermiteInterpolate):
(WebCore::addCatmullRomBeziers):
* Source/WebCore/platform/graphics/BezierUtilities.h:
* Source/WebCore/platform/graphics/CornerShapeUtilities.cpp:
(WebCore::borderContourPath):
* Source/WebCore/platform/graphics/CornerShapeUtilities.h:
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::shapeForOffsetRect):
(WebCore::BorderShape::shapeWithBorderWidths const):
(WebCore::cornersHaveConvexSuperellipse):
(WebCore::cornersUseAlignedToCurveOffset):
(WebCore::addAlignedToCurveOffsetContour):
(WebCore::BorderShape::pathForOuterCornerShape const):
(WebCore::BorderShape::pathForInnerCornerShape const):
(WebCore::BorderShape::fillRectWithInnerHoleShape const):
* Source/WebCore/rendering/BorderShape.h:
(WebCore::BorderShape::shapeForOffsetRect):
* Source/WebCore/rendering/OutlinePainter.cpp:
(WebCore::OutlinePainter::paintOutline const):
(WebCore::OutlinePainter::paintFocusRing const):

Canonical link: <a href="https://commits.webkit.org/318287@main">https://commits.webkit.org/318287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b17e7698bb9310c19e2c1f17665afd1ba9bd985

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187418 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179672 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138595 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119058 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40787 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39148 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38837 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35880 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189848 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51414 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147716 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52096 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147502 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26967 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42214 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124348 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118777 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50604 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13816 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50000 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->