### PR TITLE
[GFC] Items with content based size do not have a specified size suggestion

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -187,7 +187,24 @@ static std::optional<BorderBoxSize> inlineSpecifiedSizeSuggestion(const PlacedGr
     }
     if (preferredSize.isAuto())
         return { };
-    ASSERT_NOT_IMPLEMENTED_YET();
+
+    // https://drafts.csswg.org/css-sizing-3/#definite
+    // The intrinsic sizing keywords (min-content, max-content, fit-content, and the non-standard
+    // intrinsic/min-intrinsic) size the box from its contents, so the preferred size is not
+    // definite and there is no specified size suggestion.
+    if (preferredSize.isIntrinsic() || preferredSize.isIntrinsicKeyword() || preferredSize.isMinIntrinsic())
+        return { };
+
+    // stretch/-webkit-fill-available resolve to the stretch-fit size, which is only definite when
+    // the grid area size is known.
+    if (preferredSize.isStretch()) {
+        if (!containingBlockSize)
+            return { };
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return { };
+    }
+
+    ASSERT_NOT_REACHED();
     return { };
 }
 
@@ -220,7 +237,24 @@ static std::optional<BorderBoxSize> blockSpecifiedSizeSuggestion(const PlacedGri
     }
     if (preferredSize.isAuto())
         return { };
-    ASSERT_NOT_IMPLEMENTED_YET();
+
+    // https://drafts.csswg.org/css-sizing-3/#definite
+    // The intrinsic sizing keywords (min-content, max-content, fit-content, and the non-standard
+    // intrinsic/min-intrinsic) size the box from its contents, so the preferred size is not
+    // definite and there is no specified size suggestion.
+    if (preferredSize.isIntrinsic() || preferredSize.isIntrinsicKeyword() || preferredSize.isMinIntrinsic())
+        return { };
+
+    // stretch/-webkit-fill-available resolve to the stretch-fit size, which is only definite when
+    // the grid area size is known.
+    if (preferredSize.isStretch()) {
+        if (!containingBlockSize)
+            return { };
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return { };
+    }
+
+    ASSERT_NOT_REACHED();
     return { };
 }
 


### PR DESCRIPTION
#### 2d6f59ccf8235b27ed9a71e6684fb9b68a235fab
<pre>
[GFC] Items with content based size do not have a specified size suggestion
<a href="https://bugs.webkit.org/show_bug.cgi?id=320589">https://bugs.webkit.org/show_bug.cgi?id=320589</a>
<a href="https://rdar.apple.com/problem/183563686">rdar://problem/183563686</a>

Reviewed by Alan Baradlay.

The inline/block specified size suggestion functions only handled a
fixed, percentage/calc, or auto preferred size and hit
ASSERT_NOT_IMPLEMENTED_YET() for everything else. Style::PreferredSize
also has the intrinsic sizing keywords (min-content, max-content,
fit-content) along with the non-standard intrinsic/min-intrinsic
keywords, and stretch/-webkit-fill-available that needs to be taken into
consideration

<a href="https://www.w3.org/TR/css-grid-2/#specified-size-suggestion">https://www.w3.org/TR/css-grid-2/#specified-size-suggestion</a> says the
specified size suggestion only exists when the item&apos;s preferred size in
the relevant axis is definite. The intrinsic sizing keywords all size the
box from its contents, so they are not definite and there is no specified
size suggestion for them. Returning std::nullopt makes the caller
continue on to the transferred size suggestion or the content size
suggestion, which is what we want.

stretch/-webkit-fill-available resolve to the stretch-fit size, so like a
percentage they are only definite once the grid area size is known. When
it is not known (during track sizing) there is no specified size
suggestion. We defer to implementing the logic for the stretch fit size
in a follow up patch.

Canonical link: <a href="https://commits.webkit.org/318216@main">https://commits.webkit.org/318216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57155ae2663f94555fe5db84f2849fb5315f3efa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187217 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05efe9c3-f9de-4d92-aec9-5aeb326e64ce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138434 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/241c714e-d6e5-45c2-895c-86e11ed0f047) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118898 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d36d46db-811a-42e4-af85-b7e531fd0081) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40606 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151013 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38667 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35684 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43336 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189646 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51218 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147534 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39640 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51900 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147325 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42040 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124115 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118528 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50408 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13644 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49804 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50044 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49866 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->