### PR TITLE
Drop cached SequesteredMalloc arena granules on memory-pressure notification

### DIFF
--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -32,6 +32,8 @@
 #include <wtf/Atomics.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/PageBlock.h>
+#include <wtf/SequesteredImmortalHeap.h>
+#include <wtf/SequesteredMalloc.h>
 
 #if OS(WINDOWS)
 #include <windows.h>
@@ -606,6 +608,10 @@ void releaseFastMallocFreeMemoryForThisThread()
 void releaseFastMallocFreeMemory()
 {
     bmalloc::api::scavenge();
+#if USE(PROTECTED_JIT)
+    if (isSequesteredArenaMallocEnabled())
+        SequesteredImmortalHeap::instance().reclaimIdleGranulesOnce();
+#endif
 }
 
 FastMallocStatistics fastMallocStatistics()

--- a/Source/WTF/wtf/SequesteredAllocator.h
+++ b/Source/WTF/wtf/SequesteredAllocator.h
@@ -144,7 +144,9 @@ private:
                 }
                 m_allocHead = 0;
                 m_allocBound = 0;
-                return WTF::move(m_granules);
+                GranuleList all { m_granules };
+                m_granules.clear();
+                return all;
             }
 
             GranuleList tail { m_granules.splitAt(1) };
@@ -301,7 +303,7 @@ public:
 
     void* malloc(size_t bytes)
     {
-        ASSERT(m_alive);
+        ASSERT(isAliveOnOwningThread());
         auto retval = m_genericSmallArena.allocate(bytes);
         registerSuccessfulAllocation(retval, bytes);
         return retval;
@@ -309,7 +311,7 @@ public:
 
     void* alignedMalloc(size_t alignment, size_t bytes)
     {
-        ASSERT(m_alive);
+        ASSERT(isAliveOnOwningThread());
         auto retval = m_genericSmallArena.alignedAllocate(alignment, bytes);
         registerSuccessfulAllocation(retval, bytes);
         return retval;
@@ -318,7 +320,7 @@ public:
     void* zeroedMalloc(size_t bytes)
     {
         WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        ASSERT(m_alive);
+        ASSERT(isAliveOnOwningThread());
         auto retval = m_genericSmallArena.allocate(bytes);
         std::memset(retval, 0, bytes);
         registerSuccessfulAllocation(retval, bytes);
@@ -328,7 +330,7 @@ public:
 
     void* tryMalloc(size_t bytes)
     {
-        ASSERT(m_alive);
+        ASSERT(isAliveOnOwningThread());
         auto retval = m_genericSmallArena.tryAllocate(bytes);
         if (retval) [[likely]]
             registerSuccessfulAllocation(retval, bytes);
@@ -337,7 +339,7 @@ public:
 
     void* tryAlignedMalloc(size_t alignment, size_t bytes)
     {
-        ASSERT(m_alive);
+        ASSERT(isAliveOnOwningThread());
         auto retval = m_genericSmallArena.tryAlignedAllocate(alignment, bytes);
         if (retval) [[likely]]
             registerSuccessfulAllocation(retval, bytes);
@@ -347,7 +349,7 @@ public:
     void* tryZeroedMalloc(size_t bytes)
     {
         WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        ASSERT(m_alive);
+        ASSERT(isAliveOnOwningThread());
         auto retval = m_genericSmallArena.tryAllocate(bytes);
         if (retval) [[likely]] {
             std::memset(retval, 0, bytes);
@@ -359,7 +361,7 @@ public:
 
     void free(void* p)
     {
-        ASSERT(m_alive);
+        ASSERT(isAliveOnOwningThread());
         ASSERT(m_liveAllocations > 0);
 
         registerSuccessfulFree(p);
@@ -369,7 +371,7 @@ public:
 
     void* realloc(void* p, size_t newSize)
     {
-        ASSERT(m_alive);
+        ASSERT(isAliveOnOwningThread());
         ASSERT(m_liveAllocations > 0);
 
         void* newP = m_genericSmallArena.allocate(newSize);
@@ -380,7 +382,7 @@ public:
 
     void* tryRealloc(void* p, size_t newSize)
     {
-        ASSERT(m_alive);
+        ASSERT(isAliveOnOwningThread());
 
         void* newP = m_genericSmallArena.tryAllocate(newSize);
         if (!newP)
@@ -396,19 +398,23 @@ public:
     }
 
     // Since this is thread-local, we assume beginArenaLifetime and
-    // endArenaLifetime cannot race
-    void beginArenaLifetime()
+    // endArenaLifetime cannot race with each other. The lock acquisition
+    // is only necessary to synchronize with the scavenger.
+    void beginArenaLifetime() WTF_EXCLUDES_LOCK(m_arenaLock)
     {
-        ASSERT(!m_alive);
-        m_alive = true;
+        ASSERT(!isAliveOnOwningThread());
+        {
+            Locker locker { m_arenaLock };
+            m_alive = true;
+        }
         m_liveAllocations = 0;
         dataLogLnIf(verbose, "Allocator ", id(), " in thread ", currentThreadID(),
             ": starting lifetime");
     }
 
-    void endArenaLifetime()
+    void endArenaLifetime() WTF_EXCLUDES_LOCK(m_arenaLock)
     {
-        ASSERT(m_alive);
+        ASSERT(isAliveOnOwningThread());
         if constexpr (trackAllocationDebugInfo) {
             if (m_liveAllocations > 0) {
                 logLiveAllocationDebugInfos();
@@ -416,10 +422,19 @@ public:
             }
         } else
             RELEASE_ASSERT(!m_liveAllocations);
-        m_alive = false;
 
-        m_decommitQueue.concatenate(m_genericSmallArena.reset(Arena::TopGranulePolicy::Retain));
-        if constexpr (!eagerlyDecommit)
+        // Under memory pressure, stop caching the top granule so this thread's
+        // footprint drops without waiting for the scavenger to reach it.
+        auto policy = SequesteredImmortalHeap::instance().shouldReduceRetention()
+            ? Arena::TopGranulePolicy::DoNotRetain
+            : Arena::TopGranulePolicy::Retain;
+
+        {
+            Locker locker { m_arenaLock };
+            m_alive = false;
+            resetArenaAndQueueGranules(policy);
+        }
+        if constexpr (eagerlyDecommit)
             m_decommitQueue.decommit();
 
         dataLogLnIf(verbose, "Allocator ", id(), " in thread ",
@@ -429,9 +444,29 @@ public:
             m_totalAllocatedBytes = 0;
     }
 
+    // Used by the scavenger to reclaim cached granules from idle compiler
+    // threads. Holds m_arenaLock to ensure the thread doesn't begin executing
+    // while its granule is being stolen.
+    void reclaimRetainedGranuleIfIdle() WTF_EXCLUDES_LOCK(m_arenaLock)
+    {
+        Locker locker { m_arenaLock };
+        if (m_alive)
+            return;
+        resetArenaAndQueueGranules(Arena::TopGranulePolicy::DoNotRetain);
+    }
+
+    // Entry point for the scavenger's per-slot pass: optionally reclaim this
+    // thread's cached granule, then decommit everything queued.
+    void scavenge(bool reclaimIdleGranule) WTF_EXCLUDES_LOCK(m_arenaLock)
+    {
+        if (reclaimIdleGranule)
+            reclaimRetainedGranuleIfIdle();
+        m_decommitQueue.decommit();
+    }
+
     bool inArenaLifetime()
     {
-        return m_alive;
+        return isAliveOnOwningThread();
     }
 
     int id()
@@ -507,6 +542,19 @@ private:
 
     void logLiveAllocationDebugInfos();
 
+    void resetArenaAndQueueGranules(Arena::TopGranulePolicy policy) WTF_REQUIRES_LOCK(m_arenaLock)
+    {
+        m_decommitQueue.concatenate(m_genericSmallArena.reset(policy));
+    }
+
+    // The owning thread is the only writer of m_alive, so it may read the flag
+    // without taking m_arenaLock; the lock only exists so that the scavenger
+    // never observes m_alive while the arena's granules are in flux.
+    bool isAliveOnOwningThread() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+    {
+        return m_alive;
+    }
+
     static SequesteredArenaAllocator& allocatorForArena(Arena& arena)
     {
         // This is legal since the existence of a valid Arena& implies the presence
@@ -554,7 +602,11 @@ private:
 
     ConcurrentDecommitQueue m_decommitQueue { };
     size_t m_liveAllocations { 0 };
-    bool m_alive { false };
+    // Guards m_alive and the arena's granule state against the scavenger. Only
+    // held briefly at arena-lifetime boundaries and during idle reclamation, so
+    // the per-allocation fast path stays lock-free.
+    Lock m_arenaLock;
+    bool m_alive WTF_GUARDED_BY_LOCK(m_arenaLock) { false };
 
     // m_genericSmallArena must be the first Arena member of this class
     // in order for debugIndexOfArena to work

--- a/Source/WTF/wtf/SequesteredImmortalHeap.cpp
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.cpp
@@ -28,6 +28,8 @@
 #if USE(PROTECTED_JIT)
 
 #include <bmalloc/pas_scavenger.h>
+#include <wtf/MemoryPressureHandler.h>
+#include <wtf/SequesteredAllocator.h>
 
 namespace WTF {
 
@@ -177,18 +179,36 @@ void SequesteredImmortalHeap::installScavenger()
 #endif
 }
 
+bool SequesteredImmortalHeap::shouldReduceRetention() const
+{
+    return MemoryPressureHandler::singleton().isUnderMemoryPressure();
+}
+
 bool SequesteredImmortalHeap::scavengeImpl(void* /*userdata*/)
 {
     dataLogLnIf(verbose, "SequesteredImmortalHeap: scavenging");
-    {
-        Locker listLocker { m_scavengerLock };
-        auto bound = m_slotManager.allocatedCount();
-        for (size_t i = 0; i < bound; i++) {
-            auto& queue = *reinterpret_cast<ConcurrentDecommitQueue*>(&m_slotManager[i]);
-            queue.decommit();
-        }
-    }
+    // Only steal idle threads' cached granules when we are actually trying to
+    // shed memory; otherwise leave them cached for compilation speed.
+    reclaimIdleSlots(shouldReduceRetention());
     return false;
+}
+
+void SequesteredImmortalHeap::reclaimIdleSlots(bool reclaimIdleGranules)
+{
+    Locker listLocker { m_scavengerLock };
+    auto bound = m_slotManager.allocatedCount();
+    for (size_t i = 0; i < bound; i++) {
+        // Every installed slot is a SequesteredArenaAllocator (its
+        // ConcurrentDecommitQueue sits at offset 0), so this reinterpret is
+        // valid; see SequesteredArenaAllocator::getCurrentAllocator.
+        auto& allocator = *reinterpret_cast<SequesteredArenaAllocator*>(&m_slotManager[i]);
+        allocator.scavenge(reclaimIdleGranules);
+    }
+}
+
+void SequesteredImmortalHeap::reclaimIdleGranulesOnce()
+{
+    reclaimIdleSlots(true);
 }
 
 SequesteredStackAllocator::Result SequesteredStackAllocator::allocate(size_t stackSize, size_t guardSize)

--- a/Source/WTF/wtf/SequesteredImmortalHeap.h
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.h
@@ -454,7 +454,7 @@ public:
     WTF_EXPORT_PRIVATE static SequesteredImmortalHeap& instance();
 
     template <typename T> requires (sizeof(T) <= slotSize)
-    T* allocateAndInstall()
+    T* allocateAndInstall() WTF_EXCLUDES_LOCK(m_scavengerLock)
     {
         T* slot = nullptr;
         size_t slotIndex = 0;
@@ -491,7 +491,9 @@ public:
         return getUnchecked();
     }
 
-    int computeSlotIndex(void* slotPtr)
+    // Slots and slot pages are never freed or moved once installed, so walking
+    // them to recover a slot's index does not need m_scavengerLock.
+    int computeSlotIndex(void* slotPtr) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     {
         return m_slotManager.computeSlotIndex(slotPtr);
     }
@@ -501,6 +503,13 @@ public:
         auto& sih = instance();
         return sih.scavengeImpl(userdata);
     }
+
+    // Reclaim the granule cached by every idle thread and decommit all queued
+    // granules right now, rather than waiting for the next scavenger tick.
+    WTF_EXPORT_PRIVATE void reclaimIdleGranulesOnce() WTF_EXCLUDES_LOCK(m_scavengerLock);
+
+    // If true, then SIH dependents should not cache any unnecessary memory.
+    WTF_EXPORT_PRIVATE bool shouldReduceRetention() const;
 
 private:
     SequesteredImmortalHeap()
@@ -521,16 +530,20 @@ private:
     }
 
     WTF_EXPORT_PRIVATE void installScavenger();
-    WTF_EXPORT_PRIVATE bool scavengeImpl(void* userdata);
+    WTF_EXPORT_PRIVATE bool scavengeImpl(void* userdata) WTF_EXCLUDES_LOCK(m_scavengerLock);
+
+    // Walks every slot under m_scavengerLock, optionally reclaiming the granule
+    // cached by each idle thread, then decommitting each slot's queued granules.
+    WTF_EXPORT_PRIVATE void reclaimIdleSlots(bool reclaimIdleGranules) WTF_EXCLUDES_LOCK(m_scavengerLock);
 
     static void* getUnchecked()
     {
         return _pthread_getspecific_direct(key);
     }
 
-    Lock m_scavengerLock { };
+    Lock m_scavengerLock;
     SequesteredImmortalAllocator m_immortalAllocator { };
-    SlotManager m_slotManager { };
+    SlotManager m_slotManager WTF_GUARDED_BY_LOCK(m_scavengerLock) { };
     SequesteredStackAllocator m_stackAllocator { };
     SequesteredGranuleProvider m_granuleProvider { };
 };


### PR DESCRIPTION
#### bb345ab09ac5b38035ec69ee7f96396adae11e7e
<pre>
Drop cached SequesteredMalloc arena granules on memory-pressure notification
<a href="https://bugs.webkit.org/show_bug.cgi?id=320593">https://bugs.webkit.org/show_bug.cgi?id=320593</a>
<a href="https://rdar.apple.com/181858046">rdar://181858046</a>

Reviewed by Keith Miller.

By default, each compiler thread caches a single granule to minimize the
latency of their next compiler job. This means the memory is never
decommitted, which adds persistent memory pressure even through
subsequent memory-pressure notifications.
This patch makes two changes:
  - Before caching a granule, each compiler thread checks whether the
    system is currently under memory pressure; if so, it doesn&apos;t cache
  - When memory pressure is encountered, we iterate all arenas and drop
    the first granule of all idle compiler threads
The latter condition requires a new lock to avoid a thread starting up
while the scavenger (or etc.) is midway through removing their granule.
This is worthwhile because the alternative would be waiting until the
compiler thread runs again, which could be some time due to the
sometimes-bursty nature of compilation jobs.

No new tests since this is an implementation detail.

* Source/WTF/wtf/FastMalloc.cpp:
(WTF::releaseFastMallocFreeMemory):
* Source/WTF/wtf/SequesteredAllocator.h:
* Source/WTF/wtf/SequesteredImmortalHeap.cpp:
(WTF::SequesteredImmortalHeap::shouldReduceRetention const):
(WTF::SequesteredImmortalHeap::scavengeImpl):
(WTF::SequesteredImmortalHeap::reclaimIdleSlots):
(WTF::SequesteredImmortalHeap::reclaimIdleGranulesOnce):
* Source/WTF/wtf/SequesteredImmortalHeap.h:

Canonical link: <a href="https://commits.webkit.org/318840@main">https://commits.webkit.org/318840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57a3d09def73e01ea04a471f80f703dd2f3d80ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179480 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189312 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143789 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b884020-8d98-40cd-a28c-969c153a7dd5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139962 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c6663c2-90db-4aa6-97d6-68d48f9348ef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120414 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2eaeca53-6659-4641-b936-1bfbc2a91f46) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42251 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40570 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2384 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9193 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152652 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40214 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/766 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40755 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191533 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53089 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149226 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40019 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53770 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148970 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43639 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126042 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120937 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52287 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15203 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51672 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51733 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->