### PR TITLE
REGRESSION(315609@main): Aborting many in-progress transactions of a suspended process can cause stack overflow

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -47,6 +47,7 @@
 #include <algorithm>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Scope.h>
+#include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -1515,7 +1516,7 @@ RefPtr<UniqueIDBDatabaseTransaction> UniqueIDBDatabase::takeNextRunnableTransact
     return currentTransaction;
 }
 
-void UniqueIDBDatabase::transactionCompleted(RefPtr<UniqueIDBDatabaseTransaction>&& transaction)
+void UniqueIDBDatabase::transactionCompleted(RefPtr<UniqueIDBDatabaseTransaction>&& transaction, ShouldStartRunnableWork shouldStartRunnableWork)
 {
     ASSERT(transaction);
     ASSERT(!m_inProgressTransactions.contains(transaction->info().identifier()));
@@ -1531,6 +1532,9 @@ void UniqueIDBDatabase::transactionCompleted(RefPtr<UniqueIDBDatabaseTransaction
 
     if (m_versionChangeTransaction == transaction)
         m_versionChangeTransaction = nullptr;
+
+    if (shouldStartRunnableWork == ShouldStartRunnableWork::No)
+        return;
 
     // Previously blocked operations might be runnable.
     handleDatabaseOperations();
@@ -1640,6 +1644,10 @@ void UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients()
     if (m_pendingTransactions.isEmpty() || m_inProgressTransactions.isEmpty())
         return;
 
+    SetForScope recursionScope(m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth, m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth + 1);
+    if (m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth > 5)
+        RELEASE_LOG_ERROR(IndexedDB, "UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients - recursion depth reaches %u", m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth);
+
     Vector<Ref<UniqueIDBDatabaseTransaction>> transactionsToAbort;
     for (auto& transaction : m_inProgressTransactions.values()) {
         RefPtr databaseConnection = transaction->databaseConnection();
@@ -1649,9 +1657,8 @@ void UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients()
             transactionsToAbort.append(transaction);
     }
 
+    bool abortedAnyTransaction = false;
     for (auto& transaction : transactionsToAbort) {
-        // transactionCompleted() below re-enters handleTransactions(), which may have already
-        // aborted this transaction in a nested pass.
         auto transactionIdentifier = transaction->info().identifier();
         auto takenTransaction = m_inProgressTransactions.take(transactionIdentifier);
         if (!takenTransaction)
@@ -1678,10 +1685,15 @@ void UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients()
             error = backingStore->abortTransaction(transactionIdentifier);
         transaction->setSuspensionAbortResult(error);
 
-        // Completing the transaction lets the next pending transaction begin. The transaction
-        // object stays in its connection's transaction map so a client that later resumes can
-        // still abort or commit it and learn about the suspension abort.
-        transactionCompleted(WTF::move(takenTransaction));
+        // The transaction object stays in its connection's transaction map so a client that
+        // later resumes can still abort or commit it and learn about the suspension abort.
+        transactionCompleted(WTF::move(takenTransaction), ShouldStartRunnableWork::No);
+        abortedAnyTransaction = true;
+    }
+
+    if (abortedAnyTransaction) {
+        handleDatabaseOperations();
+        handleTransactions();
     }
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -151,7 +151,9 @@ private:
     bool transactionBlocksPendingTransactions(UniqueIDBDatabaseTransaction&);
 
     void activateTransactionInBackingStore(UniqueIDBDatabaseTransaction&);
-    void transactionCompleted(RefPtr<UniqueIDBDatabaseTransaction>&&);
+
+    enum class ShouldStartRunnableWork : bool { No, Yes };
+    void transactionCompleted(RefPtr<UniqueIDBDatabaseTransaction>&&, ShouldStartRunnableWork = ShouldStartRunnableWork::Yes);
 
     void connectionClosedFromServer(UniqueIDBDatabaseConnection&);
     void deleteBackingStore();
@@ -187,6 +189,7 @@ private:
     // These sets help to decide which transactions can be started and which must be deferred.
     HashCountedSet<IDBObjectStoreIdentifier> m_objectStoreTransactionCounts;
     HashSet<IDBObjectStoreIdentifier> m_objectStoreWriteTransactions;
+    unsigned m_abortInProgressTransactionsBlockedOnSuspendedClientsRecursionDepth { 0 };
 };
 
 } // namespace IDBServer

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm
@@ -440,3 +440,98 @@ TEST(IndexedDB, UncontendedTransactionOfSuspendedProcessIsNotAborted)
     [firstWebView evaluateJavaScript:@"stopTransaction = true;" completionHandler:nil];
     EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"first transaction completed");
 }
+
+TEST(IndexedDB, AbortMultipleTransactionsOfSuspendedProcess)
+{
+    static NSString *firstClientString = @"<script> \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var storeCount = 10; \
+        var startedCount = 0; \
+        var abortedCount = 0; \
+        var request = indexedDB.open('ManySuspendedTransactionsDatabase'); \
+        request.onupgradeneeded = function(event) { \
+            var db = event.target.result; \
+            for (var i = 0; i < storeCount; i++) \
+                db.createObjectStore('Store' + i); \
+        }; \
+        request.onerror = function() { \
+            post('first database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var db = event.target.result; \
+            for (var i = 0; i < storeCount; i++) { \
+                (function(storeName) { \
+                    var transaction = db.transaction(storeName, 'readonly'); \
+                    transaction.onabort = function() { \
+                        abortedCount++; \
+                        if (abortedCount === storeCount) \
+                            post('all first transactions aborted'); \
+                    }; \
+                    var objectStore = transaction.objectStore(storeName); \
+                    var started = false; \
+                    function keepTransactionAlive() { \
+                        var getRequest = objectStore.get('TestKey'); \
+                        getRequest.onsuccess = function() { \
+                            if (!started) { \
+                                started = true; \
+                                if (++startedCount === storeCount) \
+                                    post('first transactions started'); \
+                            } \
+                            keepTransactionAlive(); \
+                        }; \
+                    } \
+                    keepTransactionAlive(); \
+                })('Store' + i); \
+            } \
+        }; \
+        </script>";
+
+    static NSString *secondClientString = @"<script> \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var storeCount = 10; \
+        var storeNames = []; \
+        for (var i = 0; i < storeCount; i++) \
+            storeNames.push('Store' + i); \
+        var request = indexedDB.open('ManySuspendedTransactionsDatabase'); \
+        request.onerror = function() { \
+            post('second database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var transaction = event.target.result.transaction(storeNames, 'readwrite'); \
+            transaction.oncomplete = function() { \
+                post('second transaction completed'); \
+            }; \
+            transaction.objectStore(storeNames[0]).put('OtherValue', 'OtherKey'); \
+        }; \
+        </script>";
+
+    readyToContinue = false;
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
+        readyToContinue = true;
+    }];
+    TestWebKitAPI::Util::run(&readyToContinue);
+
+    RetainPtr firstHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr firstConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [firstConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[firstConfiguration userContentController] addScriptMessageHandler:firstHandler.get() name:@"testHandler"];
+    RetainPtr firstWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:firstConfiguration.get()]);
+    [firstWebView loadHTMLString:firstClientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+    EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"first transactions started");
+
+    [firstWebView _setThrottleStateForTesting:0];
+
+    RetainPtr secondHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr secondConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [secondConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[secondConfiguration userContentController] addScriptMessageHandler:secondHandler.get() name:@"testHandler"];
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:secondConfiguration.get()]);
+    [secondWebView loadHTMLString:secondClientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+
+    EXPECT_WK_STREQ([secondHandler waitForMessage].body, @"second transaction completed");
+    EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"all first transactions aborted");
+}


### PR DESCRIPTION
#### 674b378249dd2ac78888412e09e5f7b727153783
<pre>
REGRESSION(315609@main): Aborting many in-progress transactions of a suspended process can cause stack overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=320598">https://bugs.webkit.org/show_bug.cgi?id=320598</a>
<a href="https://rdar.apple.com/182837687">rdar://182837687</a>

Reviewed by Chris Dumez.

Aborting one suspended-client transaction can recurse into aborting the next one, forming a chain like:
handleTransactions()
  -&gt; abortInProgressTransactionsBlockedOnSuspendedClients()
        -&gt; transactionCompleted()
          -&gt; handleTransactions()
                -&gt; abortInProgressTransactionsBlockedOnSuspendedClients()
                  -&gt; transactionCompleted()
                        -&gt; ...

Each transactionCompleted() call re-enters handleTransactions(), which re-enters
abortInProgressTransactionsBlockedOnSuspendedClients() to abort the next transaction, before the previous call has
returned. With enough blocked transactions from a suspended client, this chain gets deep enough to overflow the stack.

Break the chain: have the abort loop pass ShouldStartRunnableWork::No to transactionCompleted() so it only updates the
transaction bookkeeping and does not call back into handleTransactions(). Once every transaction in the batch has been
aborted, run handleDatabaseOperations()/handleTransactions() a single time, instead of once per aborted transaction.

API test: IndexedDB.AbortMultipleTransactionsOfSuspendedProcess

* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::transactionCompleted):
(WebCore::IDBServer::UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm:
(AbortMultipleTransactionsOfSuspendedProcess)):

Canonical link: <a href="https://commits.webkit.org/318222@main">https://commits.webkit.org/318222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67042a872efbf47b5959cac9571e5a81c16869b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187229 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3eefb647-0ca5-4748-a55c-c12e1c2943b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138447 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6bfda82d-800a-4710-a5e7-bab3d79a4c41) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159186 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118911 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef353028-8f9e-45ff-ac26-6bbb4ccf2a45) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40617 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38984 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38682 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35696 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43348 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189658 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51230 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147545 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39646 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51912 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147335 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42052 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124127 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118540 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50420 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13659 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49816 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50056 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49878 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->