### PR TITLE
[Site Isolation] PDF HUD of cross-origin <iframe src=pdf> gets displaced by main frame scroll offset

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -265,6 +265,7 @@ public:
     virtual void zoomIn() = 0;
     virtual void zoomOut() = 0;
     void save(CompletionHandler<void(const String&, const URL&, std::span<const uint8_t>)>&&);
+    void updateHUDLocation();
 #endif
 
     void openWithPreview(CompletionHandler<void(const String&, std::optional<FrameInfoData>&&, std::span<const uint8_t>)>&&);
@@ -451,7 +452,6 @@ protected:
     virtual void incrementalLoadingDidFinish() { }
 
 #if ENABLE(PDF_HUD)
-    void updateHUDLocation();
     WebCore::IntRect frameForHUDInRootViewCoordinates() const;
     bool NODELETE hudEnabled() const;
     bool shouldShowHUD() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1418,28 +1418,42 @@ void WebPage::frameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameID, 
         return;
 
     RefPtr coreFrame = frame->coreFrame();
-    if (coreFrame) {
-        coreFrame->updateFrameTreeSyncData(data);
+    if (!coreFrame)
+        return;
 
-        switch (static_cast<FrameTreeSyncDataType>(data.value.index())) {
-        case FrameTreeSyncDataType::FrameRect:
-            frame->updateFrameRectFromRemote(coreFrame->frameTreeSyncData().frameRect);
-            break;
+    coreFrame->updateFrameTreeSyncData(data);
+    auto dataType = static_cast<FrameTreeSyncDataType>(data.value.index());
 
-        case FrameTreeSyncDataType::FrameScrollPosition:
-            if (RefPtr view = coreFrame->virtualView())
-                view->scrollTo(coreFrame->frameTreeSyncData().frameScrollPosition);
+    switch (dataType) {
+    case FrameTreeSyncDataType::FrameRect:
+        frame->updateFrameRectFromRemote(coreFrame->frameTreeSyncData().frameRect);
+        break;
 
-            break;
+    case FrameTreeSyncDataType::FrameScrollPosition:
+        if (RefPtr view = coreFrame->virtualView())
+            view->scrollTo(coreFrame->frameTreeSyncData().frameScrollPosition);
+        break;
 
-        case FrameTreeSyncDataType::ChildrenFrameLayoutInfo:
-            updateExposedRectFromParent(*coreFrame);
-            break;
+    case FrameTreeSyncDataType::ChildrenFrameLayoutInfo:
+        updateExposedRectFromParent(*coreFrame);
+        break;
 
-        default:
-            break;
-        }
+    default:
+        break;
     }
+
+#if ENABLE(PDF_HUD)
+    switch (dataType) {
+    case FrameTreeSyncDataType::FrameRect:
+    case FrameTreeSyncDataType::FrameScrollPosition:
+    case FrameTreeSyncDataType::FrameLayoutViewportRect:
+    case FrameTreeSyncDataType::ChildrenFrameLayoutInfo:
+        updatePDFHUDLocationsAfterRemoteFrameGeometryChange();
+        break;
+    default:
+        break;
+    }
+#endif
 }
 
 void WebPage::allFrameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameID, Ref<WebCore::FrameTreeSyncData>&& data)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -663,6 +663,7 @@ public:
     void updatePDFHUDLocation(PDFPluginBase&, const WebCore::IntRect&);
     void removePDFHUD(PDFPluginBase&);
     void showPDFHUD(PDFPluginBase&);
+    void updatePDFHUDLocationsAfterRemoteFrameGeometryChange();
 #endif
 
 #if ENABLE(PDF_PAGE_NUMBER_INDICATOR)

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -1145,6 +1145,18 @@ void WebPage::showPDFHUD(PDFPluginBase& plugin)
         send(Messages::WebPageProxy::ShowPDFHUD(plugin.identifier()));
 }
 
+void WebPage::updatePDFHUDLocationsAfterRemoteFrameGeometryChange()
+{
+    // A remote parent's geometry changes but a cross-origin <iframe> plugin's
+    // local root view transform stays unchanged, so we ask the plugin to re-report
+    // its HUD location to the UI process, which runs the main frame conversion
+    // with newer geometry.
+    for (WeakPtr weakPlugin : m_pdfPlugInsWithHUD.values()) {
+        if (RefPtr plugin = weakPlugin.get())
+            plugin->updateHUDLocation();
+    }
+}
+
 #endif // ENABLE(PDF_PLUGIN)
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -785,6 +785,53 @@ public:
         return { };
     }
 
+    String scrollableMainHTML() const
+    {
+        // Same embedded PDF, but tall enough that the main frame actually scrolls.
+        return makeString(mainHTML(), "<div style='height:2000px'></div>"_s);
+    }
+
+    void SetUp() override
+    {
+        server = makeUnique<HTTPServer>(std::initializer_list<std::pair<String, HTTPResponse>> {
+            { "/main"_s, HTTPResponse { { { "Content-Type"_s, "text/html"_s } }, mainHTML() } },
+            { "/test.pdf"_s, HTTPResponse { { { "Content-Type"_s, "application/pdf"_s } }, testPDFData() } },
+        }, HTTPServer::Protocol::HttpsProxy);
+
+        configuration = server->httpsProxyConfiguration();
+        for (_WKFeature *feature in [WKPreferences _features]) {
+            NSString *key = feature.key;
+            if ([key isEqualToString:@"UnifiedPDFEnabled"] || [key isEqualToString:@"PDFPluginHUDEnabled"])
+                [[configuration preferences] _setEnabled:YES forFeature:feature];
+            else if ([key isEqualToString:@"SiteIsolationEnabled"])
+                [[configuration preferences] _setEnabled:siteIsolationEnabled() forFeature:feature];
+            else if ([key isEqualToString:@"SiteIsolationSharedProcessEnabled"])
+                [[configuration preferences] _setEnabled:siteIsolationSharedProcessEnabled() forFeature:feature];
+        }
+
+        navigationDelegate = adoptNS([TestNavigationDelegate new]);
+        [navigationDelegate allowAnyTLSCertificate];
+        webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+        [webView _setWindowOcclusionDetectionEnabled:NO];
+        [[webView window] makeKeyAndOrderFront:nil];
+        [[webView window] orderFrontRegardless];
+        [webView setNavigationDelegate:navigationDelegate];
+    }
+
+    RetainPtr<NSView> loadAndWaitForHUD()
+    {
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+        [navigationDelegate waitForDidFinishNavigation];
+        TestWebKitAPI::Util::waitFor([this] {
+            return [webView _pdfHUDs].count;
+        });
+        RetainPtr<NSView> hud = [webView _pdfHUDs].anyObject;
+        TestWebKitAPI::Util::waitFor([hud] {
+            return !NSEqualPoints([hud frame].origin, NSZeroPoint);
+        });
+        return hud;
+    }
+
     static std::string testNameGenerator(testing::TestParamInfo<EmbeddedPDFHUDSiteIsolationParams> info)
     {
         std::string element = [embedElement = std::get<0>(info.param)] {
@@ -804,47 +851,39 @@ public:
             + "_SiteIsolation" + (std::get<2>(info.param) ? "Enabled" : "Disabled")
             + "_SiteIsolationSharedProcess" + (std::get<3>(info.param) ? "Enabled" : "Disabled");
     }
+
+    std::unique_ptr<HTTPServer> server;
+    RetainPtr<WKWebViewConfiguration> configuration;
+    RetainPtr<TestNavigationDelegate> navigationDelegate;
+    RetainPtr<TestWKWebView> webView;
 };
 
 TEST_P(EmbeddedPDFHUDSiteIsolation, HUDMatchesOffset)
 {
-    HTTPServer server { {
-        { "/main"_s, HTTPResponse { { { "Content-Type"_s, "text/html"_s } }, mainHTML() } },
-        { "/test.pdf"_s, HTTPResponse { { { "Content-Type"_s, "application/pdf"_s } }, testPDFData() } },
-    }, HTTPServer::Protocol::HttpsProxy };
+    RetainPtr hud = loadAndWaitForHUD();
+    checkFrame([hud frame], 10, 28, 300, 150);
+}
 
-    RetainPtr configuration = server.httpsProxyConfiguration();
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        NSString *key = feature.key;
-        if ([key isEqualToString:@"UnifiedPDFEnabled"] || [key isEqualToString:@"PDFPluginHUDEnabled"])
-            [[configuration preferences] _setEnabled:YES forFeature:feature];
-        else if ([key isEqualToString:@"SiteIsolationEnabled"])
-            [[configuration preferences] _setEnabled:siteIsolationEnabled() forFeature:feature];
-        else if ([key isEqualToString:@"SiteIsolationSharedProcessEnabled"])
-            [[configuration preferences] _setEnabled:siteIsolationSharedProcessEnabled() forFeature:feature];
-    }
+TEST_P(EmbeddedPDFHUDSiteIsolation, HUDTracksMainFrameScroll)
+{
+    server->setResponse("/main"_s, HTTPResponse { { { "Content-Type"_s, "text/html"_s } }, scrollableMainHTML() });
 
-    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
-    [navigationDelegate allowAnyTLSCertificate];
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
-    [webView _setWindowOcclusionDetectionEnabled:NO];
-    [[webView window] makeKeyAndOrderFront:nil];
-    [[webView window] orderFrontRegardless];
-    [webView setNavigationDelegate:navigationDelegate];
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
-    [navigationDelegate waitForDidFinishNavigation];
-
-    TestWebKitAPI::Util::waitFor([webView] {
-        return [webView _pdfHUDs].count;
-    });
-
-    RetainPtr<NSView> hud = [webView _pdfHUDs].anyObject;
-
-    TestWebKitAPI::Util::waitFor([hud] {
-        return !NSEqualPoints([hud frame].origin, NSZeroPoint);
-    });
+    RetainPtr hud = loadAndWaitForHUD();
 
     checkFrame([hud frame], 10, 28, 300, 150);
+
+    bool scrolled = TestWebKitAPI::Util::waitFor([this] {
+        [webView objectByEvaluatingJavaScript:@"window.scrollTo(0, 20)"];
+        return [[webView objectByEvaluatingJavaScript:@"window.scrollY"] integerValue] == 20;
+    });
+    EXPECT_TRUE(scrolled);
+
+    TestWebKitAPI::Util::waitFor([this] {
+        [webView waitForNextPresentationUpdate];
+        RetainPtr<NSView> currentHUD = [webView _pdfHUDs].anyObject;
+        return currentHUD && [currentHUD frame].origin.y < 10;
+    });
+    checkFrame([webView _pdfHUDs].anyObject.frame, 10, 8, 300, 150, 1);
 }
 
 INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFHUDSiteIsolation, testing::Combine(testing::Values(PDFEmbedElement::IFrame, PDFEmbedElement::Embed, PDFEmbedElement::Object), testing::Bool(), testing::Bool(), testing::Bool()), &EmbeddedPDFHUDSiteIsolation::testNameGenerator);


### PR DESCRIPTION
#### 9a90b5af0558a9b1bfa2f6500cfc1efcf51bd703
<pre>
[Site Isolation] PDF HUD of cross-origin &lt;iframe src=pdf&gt; gets displaced by main frame scroll offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=320592">https://bugs.webkit.org/show_bug.cgi?id=320592</a>
<a href="https://rdar.apple.com/183356213">rdar://183356213</a>

Reviewed by Richard Robinson.

With site isolation enabled, if a remote parent&apos;s geometry changes (say,
the frame scroll position), that does not actually modify the
cross-origin &lt;iframe&gt; plugin&apos;s local root view transform. As such, we
need to ask the plugin to re-report its HUD location to the UI process,
which runs the main frame conversion with newer geometry. Otherwise,
when the top-level page scrolls the HUD stays where it was first placed
and drifts out of the iframe.

We hook up this &quot;ask the plugin&quot; part by keying off frame tree sync data
and calling WebPage::updatePDFHUDLocationsAfterRemoteFrameGeometryChange,
which enumerates through the tracked PDF plugins and asks them to
produce HUD location updates.

Test: TestWebKitAPI.UnifiedPDF/EmbeddedPDFHUDSiteIsolation.HUDTracksMainFrameScroll

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::frameTreeSyncDataChangedInAnotherProcess):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::updatePDFHUDLocationsAfterRemoteFrameGeometryChange):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::scrollableMainHTML const):
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::loadAndWaitForHUD):
(TestWebKitAPI::TEST_P):

We hoist the shared test setup into SetUp() (the gtest sanctioned test
class initializer), which makes the main test logic easier to read.

Canonical link: <a href="https://commits.webkit.org/318330@main">https://commits.webkit.org/318330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20dda6bd1dbfd6a6697ef58930a6d2ed9f6296f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187551 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1248c0df-a957-4ec1-9ebd-ef5d965866c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138702 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/181f5d90-182d-4961-b88e-1eaf865a211c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119165 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07809bb8-4451-44ad-9fae-c4222fc9bdeb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40904 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39261 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38945 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36012 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189980 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51546 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147832 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52228 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147613 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26995 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42324 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124481 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118930 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50736 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13925 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50132 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50372 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50194 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->