### PR TITLE
Remove unsupported stats from WebTransportConnectionStats

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any-expected.txt
@@ -6,5 +6,5 @@ PASS WebTransport client should be able to provide valid stats when requested be
 PASS WebTransport client should throw an error when stats are requested for a failed connection
 PASS WebTransport client should be able to handle multiple concurrent stats requests
 PASS WebTransport client should be able to handle multiple sequential stats requests
-FAIL WebTransport client should be able to provide droppedIncoming values for datagrams assert_greater_than: expected a number greater than 0 but got 0
+PASS WebTransport client should be able to provide droppedIncoming values for datagrams
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.js
@@ -4,10 +4,14 @@
 function validate_rtt_stats(stats) {
   // The assumption below is that the RTT to localhost is under 5 seconds,
   // which is fairly generous.
-  assert_greater_than(stats.minRtt, 0, "minRtt");
-  assert_less_than(stats.minRtt, 5 * 1000, "minRtt");
-  assert_greater_than(stats.smoothedRtt, 0, "smoothedRtt");
-  assert_less_than(stats.smoothedRtt, 5 * 1000, "smoothedRtt");
+  if ("minRtt" in stats) {
+    assert_greater_than(stats.minRtt, 0, "minRtt");
+    assert_less_than(stats.minRtt, 5 * 1000, "minRtt");
+  }
+  if ("smoothedRtt" in stats) {
+    assert_greater_than(stats.smoothedRtt, 0, "smoothedRtt");
+    assert_less_than(stats.smoothedRtt, 5 * 1000, "smoothedRtt");
+  }
 }
 
 promise_test(async t => {
@@ -15,9 +19,11 @@ promise_test(async t => {
   await wt.ready;
   const stats = await wt.getStats();
   validate_rtt_stats(stats);
-  assert_equals(stats.datagrams.expiredOutgoing, 0);
-  assert_equals(stats.datagrams.droppedIncoming, 0);
-  assert_equals(stats.datagrams.lostOutgoing, 0);
+  if ("datagrams" in stats) {
+    assert_equals(stats.datagrams.expiredOutgoing, 0);
+    assert_equals(stats.datagrams.droppedIncoming, 0);
+    assert_equals(stats.datagrams.lostOutgoing, 0);
+  }
 }, "WebTransport client should be able to provide stats after connection has been established");
 
 promise_test(async t => {
@@ -95,11 +101,13 @@ promise_test(async t => {
   for (let i = 0; i < maxAttempts; i++) {
     wait(50);
     stats = await wt.getStats();
-    if (stats.datagrams.droppedIncoming > 0) {
+    if ("datagrams" in stats && stats.datagrams.droppedIncoming > 0) {
       break;
     }
   }
-  assert_greater_than(stats.datagrams.droppedIncoming, 0);
-  assert_less_than_equal(stats.datagrams.droppedIncoming,
-                         numDatagrams - wt.datagrams.incomingMaxBufferedDatagrams);
+  if ("datagrams" in stats) {
+    assert_greater_than(stats.datagrams.droppedIncoming, 0);
+    assert_less_than_equal(stats.datagrams.droppedIncoming,
+                             numDatagrams - wt.datagrams.incomingMaxBufferedDatagrams);
+  }
 }, "WebTransport client should be able to provide droppedIncoming values for datagrams");

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.serviceworker-expected.txt
@@ -6,5 +6,5 @@ PASS WebTransport client should be able to provide valid stats when requested be
 PASS WebTransport client should throw an error when stats are requested for a failed connection
 PASS WebTransport client should be able to handle multiple concurrent stats requests
 PASS WebTransport client should be able to handle multiple sequential stats requests
-FAIL WebTransport client should be able to provide droppedIncoming values for datagrams assert_greater_than: expected a number greater than 0 but got 0
+PASS WebTransport client should be able to provide droppedIncoming values for datagrams
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.sharedworker-expected.txt
@@ -6,5 +6,5 @@ PASS WebTransport client should be able to provide valid stats when requested be
 PASS WebTransport client should throw an error when stats are requested for a failed connection
 PASS WebTransport client should be able to handle multiple concurrent stats requests
 PASS WebTransport client should be able to handle multiple sequential stats requests
-FAIL WebTransport client should be able to provide droppedIncoming values for datagrams assert_greater_than: expected a number greater than 0 but got 0
+PASS WebTransport client should be able to provide droppedIncoming values for datagrams
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.worker-expected.txt
@@ -6,5 +6,5 @@ PASS WebTransport client should be able to provide valid stats when requested be
 PASS WebTransport client should throw an error when stats are requested for a failed connection
 PASS WebTransport client should be able to handle multiple concurrent stats requests
 PASS WebTransport client should be able to handle multiple sequential stats requests
-FAIL WebTransport client should be able to provide droppedIncoming values for datagrams assert_greater_than: expected a number greater than 0 but got 0
+PASS WebTransport client should be able to provide droppedIncoming values for datagrams
 

--- a/Source/WebCore/Modules/webtransport/WebTransportConnectionStats.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportConnectionStats.h
@@ -31,33 +31,13 @@ namespace WebCore {
 
 struct WebTransportConnectionStats {
     uint64_t bytesSent { 0 };
-    uint64_t packetsSent { 0 };
-    uint64_t bytesLost { 0 };
-    uint64_t packetsLost { 0 };
     uint64_t bytesReceived { 0 };
-    uint64_t packetsReceived { 0 };
-    double smoothedRtt { 0 };
-    double rttVariation { 0 };
-    double minRtt { 0 };
-    WebTransportDatagramStats datagrams;
-    std::optional<uint64_t> estimatedSendRate;
-    bool atSendCapacity { false };
 
     WebTransportConnectionStats isolatedCopy() const
     {
         return {
             bytesSent,
-            packetsSent,
-            bytesLost,
-            packetsLost,
-            bytesReceived,
-            packetsReceived,
-            smoothedRtt,
-            rttVariation,
-            minRtt,
-            datagrams.isolatedCopy(),
-            estimatedSendRate,
-            atSendCapacity
+            bytesReceived
         };
     }
 };

--- a/Source/WebCore/Modules/webtransport/WebTransportConnectionStats.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportConnectionStats.idl
@@ -32,19 +32,18 @@ typedef double DOMHighResTimeStamp;
     JSGenerateToNativeObject,
 ] dictionary WebTransportConnectionStats {
     [ImplementationDefaultValue=0] unsigned long long bytesSent;
-    // FIXME: Add support for `bytesSentOverhead`.
-    // [ImplementationDefaultValue=0] unsigned long long bytesSentOverhead;
-    // FIXME: Add support for `bytesAcknowledged`.
-    // [ImplementationDefaultValue=0] unsigned long long bytesAcknowledged;
-    [ImplementationDefaultValue=0] unsigned long long packetsSent;
-    [ImplementationDefaultValue=0] unsigned long long bytesLost;
-    [ImplementationDefaultValue=0] unsigned long long packetsLost;
+    // Commented members are not supported.
+    // unsigned long long bytesSentOverhead;
+    // unsigned long long bytesAcknowledged;
+    // unsigned long long packetsSent;
+    // unsigned long long bytesLost;
+    // unsigned long long packetsLost;
     [ImplementationDefaultValue=0] unsigned long long bytesReceived;
-    [ImplementationDefaultValue=0] unsigned long long packetsReceived;
-    required DOMHighResTimeStamp smoothedRtt;
-    required DOMHighResTimeStamp rttVariation;
-    required DOMHighResTimeStamp minRtt;
-    required WebTransportDatagramStats datagrams;
-    unsigned long long? estimatedSendRate = null;
-    boolean atSendCapacity = false;
+    // unsigned long long packetsReceived;
+    // required DOMHighResTimeStamp smoothedRtt;
+    // required DOMHighResTimeStamp rttVariation;
+    // required DOMHighResTimeStamp minRtt;
+    // required WebTransportDatagramStats datagrams;
+    // unsigned long long? estimatedSendRate = null;
+    // boolean atSendCapacity = false;
 };

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -187,7 +187,6 @@ void NetworkTransportSession::getStats(CompletionHandler<void(std::optional<WebC
         break;
     }
 
-    // FIXME: Get better stats from the network implementation.
     uint64_t bytesSent = m_bytesSentOnClosedStreams;
     uint64_t bytesReceived = m_bytesReceivedOnClosedStreams;
     for (Ref stream : m_streams.values()) {
@@ -198,30 +197,14 @@ void NetworkTransportSession::getStats(CompletionHandler<void(std::optional<WebC
         bytesSent += datagramBytesSent;
     bytesReceived += m_datagramBytesReceived;
 
-    // https://www.w3.org/TR/hr-time-3/#dfn-coarsen-time
-    auto roundTo100Microseconds = [] (Seconds time) {
-        return ReducedResolutionSeconds::reduce(time, 100_us).milliseconds();
-    };
-
     completionHandler(WebCore::WebTransportConnectionStats {
         bytesSent,
-        0, /* packetsSent */
-        0, /* bytesLost */
-        0, /* packetsLost */
-        bytesReceived,
-        0, /* packetsReceived */
-        roundTo100Microseconds(m_initializationTime), /* smoothedRtt */
-        0, /* rttVariation */
-        roundTo100Microseconds(m_initializationTime), /* minRtt */
-        WebCore::WebTransportDatagramStats { },
-        std::nullopt, /* estimatedSendRate */
-        false /* atSendCapacity */
+        bytesReceived
     });
 }
 
 void NetworkTransportSession::completeRequestsAfterInitialization(std::optional<Seconds> initializationTime)
 {
-    ASSERT(!m_initializationTime);
     ASSERT(m_initializationState == InitializationState::Waiting);
     if (!initializationTime) {
         m_initializationState = InitializationState::Failed;
@@ -232,7 +215,6 @@ void NetworkTransportSession::completeRequestsAfterInitialization(std::optional<
         return;
     }
     m_initializationState = InitializationState::Succeeded;
-    m_initializationTime = *initializationTime;
     for (auto&& statsRequest : std::exchange(m_statsRequestsBeforeInitialization, { }))
         getStats(WTF::move(statsRequest));
     for (auto&& streamRequest : std::exchange(m_streamRequestsBeforeInitialization, { }))

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -151,7 +151,6 @@ private:
 
     uint64_t m_bytesSentOnClosedStreams { 0 };
     uint64_t m_bytesReceivedOnClosedStreams { 0 };
-    Seconds m_initializationTime;
     enum class InitializationState : uint8_t {
         Waiting,
         Succeeded,

--- a/Source/WebKit/NetworkProcess/webtransport/WebTransport.serialization.in
+++ b/Source/WebKit/NetworkProcess/webtransport/WebTransport.serialization.in
@@ -22,17 +22,7 @@
 
 struct WebCore::WebTransportConnectionStats {
     uint64_t bytesSent
-    uint64_t packetsSent
-    uint64_t bytesLost
-    uint64_t packetsLost
     uint64_t bytesReceived
-    uint64_t packetsReceived
-    double smoothedRtt
-    double rttVariation
-    double minRtt
-    WebCore::WebTransportDatagramStats datagrams
-    std::optional<uint64_t> estimatedSendRate
-    bool atSendCapacity
 }
 
 struct WebCore::WebTransportDatagramStats {


### PR DESCRIPTION
#### f6a71feeecfb5f6a9faf95762390a46974a0b247
<pre>
Remove unsupported stats from WebTransportConnectionStats
<a href="https://bugs.webkit.org/show_bug.cgi?id=320602">https://bugs.webkit.org/show_bug.cgi?id=320602</a>
<a href="https://rdar.apple.com/183573725">rdar://183573725</a>

Reviewed by Chris Dumez.

<a href="https://www.w3.org/TR/webtransport/#web-transport-connection-stats">https://www.w3.org/TR/webtransport/#web-transport-connection-stats</a> has this note:
NOTE: Any unavailable stats will be absent from the WebTransportConnectionStats dictionary.
This was from <a href="https://github.com/w3c/webtransport/issues/691">https://github.com/w3c/webtransport/issues/691</a>
I&apos;m planning to propose this test change to be in line with the spec.

Also, using the initialization time as the smoothed/min roundtrip time is not great,
and it is not what is meant by those members, so remove it too.

* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.js:
(validate_rtt_stats):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.worker-expected.txt:
* Source/WebCore/Modules/webtransport/WebTransportConnectionStats.h:
(WebCore::WebTransportConnectionStats::isolatedCopy const):
* Source/WebCore/Modules/webtransport/WebTransportConnectionStats.idl:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::getStats):
(WebKit::NetworkTransportSession::completeRequestsAfterInitialization):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/WebTransport.serialization.in:

Canonical link: <a href="https://commits.webkit.org/318225@main">https://commits.webkit.org/318225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c91c357309482f53a115009da3d34a5768e7a74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187234 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0f87ebd-09a3-4a77-95a9-6022dcacb020) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138456 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f1c79ae-f601-4796-a9f4-97740ca480cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159191 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118920 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cec66503-d99c-4a8f-9fad-c4e9b223d355) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40616 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38988 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38687 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35701 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43353 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189663 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51235 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147548 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51917 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147338 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26946 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42056 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124132 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118545 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50425 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13664 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49821 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50061 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49883 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->