### PR TITLE
[GFC] Extract the equal-distribution loop for track sizing space distribution

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -398,6 +398,28 @@ static Vector<size_t> indexesForUnfrozenAffectedTracks(const Vector<size_t>& spa
     return indexes;
 }
 
+// Find the item-incurred increase for each affected track by:
+// distributing the space equally among these tracks,
+// freezing a track’s item-incurred increase as its affected size + item-incurred increase
+// reaches its limit (and continuing to grow the unfrozen tracks as needed).
+static void distributeSpaceEquallyAmongTracks(LayoutUnit& space, const Vector<size_t>& trackIndexes,
+    const UnsizedTracks& unsizedTracks, Vector<LayoutUnit>& itemIncurredIncreases)
+{
+    auto unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(trackIndexes, unsizedTracks, itemIncurredIncreases);
+    while (!unfrozenTrackIndexes.isEmpty() && space > 0) {
+        auto tracksRemainingForDistributionCount = unfrozenTrackIndexes.size();
+        for (auto trackIndex : unfrozenTrackIndexes) {
+            auto& track = unsizedTracks[trackIndex];
+            auto spaceRemainingUntilGrowthLimit = track.growthLimit - (track.baseSize + itemIncurredIncreases[trackIndex]);
+            auto spaceDistributed = std::min(space / tracksRemainingForDistributionCount, spaceRemainingUntilGrowthLimit);
+            itemIncurredIncreases[trackIndex] += spaceDistributed;
+            space -= spaceDistributed;
+            --tracksRemainingForDistributionCount;
+        }
+        unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(trackIndexes, unsizedTracks, itemIncurredIncreases);
+    }
+}
+
 // https://drafts.csswg.org/css-grid-1/#extra-space
 static void distributeExtraSpaceToBaseSizes(UnsizedTracks& unsizedTracks, const GridItemIndexes& accommodatedItemsIndexes,
     const PlacedGridItemSpanList& gridItemSpanList, const Vector<LayoutUnit>& sizeContributions, const TrackIndexes& affectedTracksIndexes)
@@ -433,24 +455,9 @@ static void distributeExtraSpaceToBaseSizes(UnsizedTracks& unsizedTracks, const 
         if (!spaceToDistribute)
             continue;
 
-        // 2.2. Distribute space up to limits: find the item-incurred increase for each affected track...
+        // 2.2. Distribute space up to limits:
         Vector<LayoutUnit> itemIncurredIncreases(unsizedTracks.size());
-        auto unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(spannedAffectedTracks, unsizedTracks, itemIncurredIncreases);
-        while (!unfrozenTrackIndexes.isEmpty() && spaceToDistribute) {
-
-            // ...by distributing the space equally among the affected tracks the item spans,
-            //  freezing a track once its base size plus that increase reaches its growth limit.
-            auto tracksRemainingForDistributionCount = unfrozenTrackIndexes.size();
-            for (auto trackIndex : unfrozenTrackIndexes) {
-                auto& track = unsizedTracks[trackIndex];
-                auto spaceRemainingUntilGrowthLimit = track.growthLimit - (track.baseSize + itemIncurredIncreases[trackIndex]);
-                auto spaceDistributed = std::min(spaceToDistribute / tracksRemainingForDistributionCount, spaceRemainingUntilGrowthLimit);
-                itemIncurredIncreases[trackIndex] += spaceDistributed;
-                spaceToDistribute -= spaceDistributed;
-                --tracksRemainingForDistributionCount;
-            }
-            unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(spannedAffectedTracks, unsizedTracks, itemIncurredIncreases);
-        }
+        distributeSpaceEquallyAmongTracks(spaceToDistribute, spannedAffectedTracks, unsizedTracks, itemIncurredIncreases);
 
         // 2.3. Distribute space to non-affected tracks: if extra space remains and the item spans
         // both affected and non-affected tracks, distribute it into the non-affected tracks.


### PR DESCRIPTION
#### 728eb106c9041a94ca490f55ad68b744e3c854be
<pre>
[GFC] Extract the equal-distribution loop for track sizing space distribution
<a href="https://bugs.webkit.org/show_bug.cgi?id=320608">https://bugs.webkit.org/show_bug.cgi?id=320608</a>
&lt;<a href="https://rdar.apple.com/183579852">rdar://183579852</a>&gt;

Reviewed by Sammy Gill.

Extract the space distribution loop out of distributeExtraSpaceToBaseSizes (CSS
Grid §12.5.1, #extra-space) into a standalone distributeSpaceEquallyAmongTracks()

This will let us reuse this code in steps 2.3 and 2.4. This was extracted as a standalone
instead of an inline lambda to keep the body of distributeExtraSpaceToBaseSizes more compact
and readable.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::distributeSpaceEquallyAmongTracks):
(WebCore::Layout::distributeExtraSpaceToBaseSizes):

Canonical link: <a href="https://commits.webkit.org/318218@main">https://commits.webkit.org/318218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c9c48620171d7ed70a26a647df93cf1e0e53dd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187259 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/99a9ccbe-924f-469f-865d-4b45e707f268) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51302 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138465 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18a0e2e4-e1a7-4900-bc15-ceb5bb446977) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41977 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118929 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7bdd025-89eb-4c6a-aa56-8500f9a47474) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151045 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38703 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35726 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43378 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189690 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51260 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147573 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51942 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147363 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26944 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42074 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124157 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118570 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50450 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13680 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49846 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50086 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49908 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->