### PR TITLE
[YARR] Do not filter the contents of a negative lookahead in `optimizeBOL`

### DIFF
--- a/JSTests/stress/regexp-negative-assertion-with-bol-is-not-dropped.js
+++ b/JSTests/stress/regexp-negative-assertion-with-bol-is-not-dropped.js
@@ -1,0 +1,47 @@
+// A negative assertion whose content can only match at the start of the input fails there and
+// succeeds everywhere else, so the once-through/loop split in optimizeBOL() must not drop it from
+// the loop alternative. See copyTerm() in YarrPattern.cpp. The bug is in Yarr's pattern analysis,
+// so it reproduces in every tier; the loop only makes sure the JIT tiers agree.
+
+function shouldBe(actual, expected, context) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected + " for " + context);
+}
+
+function check(re, string, expectedTest, expectedMatch, expectedIndex) {
+    const context = re + " against " + JSON.stringify(string);
+    shouldBe(re.test(string), expectedTest, context);
+    const result = re.exec(string);
+    if (expectedMatch === null) {
+        shouldBe(result, null, context);
+        return;
+    }
+    shouldBe(result[0], expectedMatch, context);
+    shouldBe(result.index, expectedIndex, context);
+}
+
+function step() {
+    check(/^a|(?!^)b/, "b", false, null);
+    check(/^a|(?!^)b/, "xb", true, "b", 1);
+    check(/^a|(?!^)b/, "ab", true, "a", 0);
+    check(/(?!^)b|^a/, "b", false, null);
+    check(/(?!^)b|^a/, "xb", true, "b", 1);
+    shouldBe("ab".replace(/^x|(?!^)a/, "Z"), "ab", "replace at 0");
+    shouldBe("ba".replace(/^x|(?!^)a/, "Z"), "bZ", "replace at 1");
+
+    check(/^x|(?!^|zz)b/, "b", false, null);
+    check(/^x|(?!^|zz)b/, "cb", true, "b", 1);
+    check(/^x|(?!zz|^)b/, "b", false, null);
+    check(/^x|(?!(?:^))b/, "b", false, null);
+    check(/^x|(?!(?=^)|zz)b/, "b", false, null);
+
+    check(/(?!(?=^)b)b/, "b", false, null);
+    check(/(?!(?=^)b)b/, "xb", true, "b", 1);
+    check(/(?!(?=^)b)c/, "bc", true, "c", 1);
+
+    check(/^a|(?!\b^)b/, "b", false, null);
+    check(/^a|(?!\b^)b/, " b", true, "b", 1);
+}
+
+for (var i = 0; i < testLoopCount; ++i)
+    step();

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1762,7 +1762,7 @@ public:
         if ((term.type != PatternTerm::Type::ParenthesesSubpattern) && (term.type != PatternTerm::Type::ParentheticalAssertion))
             return PatternTerm(term);
         
-        if (auto* newDisjunction = copyDisjunction(term.parentheses.disjunction, filterStartsWithBOL)) {
+        if (auto* newDisjunction = copyDisjunction(term.parentheses.disjunction, filterStartsWithBOL && !term.invert())) {
             PatternTerm termCopy = term;
             termCopy.parentheses.disjunction = newDisjunction;
             m_pattern.m_hasCopiedParenSubexpressions = true;


### PR DESCRIPTION
#### 46a4b17efbe9a1b9fe05a4ca8b6452650b001b51
<pre>
[YARR] Do not filter the contents of a negative lookahead in `optimizeBOL`
<a href="https://bugs.webkit.org/show_bug.cgi?id=320611">https://bugs.webkit.org/show_bug.cgi?id=320611</a>

Reviewed by Yusuke Suzuki.

    /^a|(?!^)b/.exec(&quot;b&quot;) // [&quot;b&quot;], should be null

optimizeBOL()&apos;s loop copy drops subterms that can only match at the start of
the input, since the onceThrough copy already covers position 0. Inside a
negative lookahead this flips: (?!^) fails at the start of the input and
succeeds everywhere else, so after 317981@main filtered out its content the
whole term was dropped and the loop copy /b/ falsely matched at position 0.
copyTerm() now copies the contents of an inverted assertion unfiltered.

Test: JSTests/stress/regexp-negative-assertion-with-bol-is-not-dropped.js

* JSTests/stress/regexp-negative-assertion-with-bol-is-not-dropped.js: Added.
(shouldBe):
(check):
(step):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::copyTerm):

Canonical link: <a href="https://commits.webkit.org/318234@main">https://commits.webkit.org/318234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b30f7b0b674cd8190394cedfef0487f582e5a05f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187273 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138483 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118947 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40654 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39021 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/916 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7716 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38716 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35739 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38939 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43391 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189703 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51273 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147588 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39652 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51955 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147378 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42089 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124170 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118583 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50463 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13693 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49859 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50099 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49921 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->