### PR TITLE
[css-flexbox] Fix baseline fallback for abspos flex static positions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-001-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 1
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got 1
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-002-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 1
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got 1
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-003-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 1
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got 1
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-004-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 1
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got 1
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-005-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 2
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 2
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-006-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 2
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 2
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-007-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="5"></div></div>
-offsetLeft expected 10 but got 2
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetLeft expected -2 but got 2
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-008-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="5"></div></div>
-offsetLeft expected 10 but got 2
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetLeft expected -2 but got 2
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-001-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 1
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got 1
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-002-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 1
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got 1
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-003-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 10
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got -2
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-004-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 10
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got -2
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-001-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 10
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -27,9 +25,7 @@ PASS .container > div 15
 PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
-FAIL .container > div 19 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got -2
+PASS .container > div 19
 PASS .container > div 20
 PASS .container > div 21
 PASS .container > div 22

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-002-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 10
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -27,9 +25,7 @@ PASS .container > div 15
 PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
-FAIL .container > div 19 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got -2
+PASS .container > div 19
 PASS .container > div 20
 PASS .container > div 21
 PASS .container > div 22

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-003-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 1
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got 1
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-004-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 1
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got 1
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -289,6 +289,10 @@ LayoutUnit FlexLayout::staticCrossAxisPositionForPositionedFlexItem(const Render
     auto availableSpace = utils.availableAlignmentSpaceForFlexItem(FlexFormattingUtils::crossAxisContentExtent(flexBox()), flexItem, utils.crossAxisExtentForFlexItem(flexItem));
     auto safety = utils.overflowAlignmentForFlexItem(flexItem);
     auto align = FlexFormattingUtils::alignmentForFlexItem(flexItem);
+    if (align == ItemPosition::Baseline)
+        align = ItemPosition::FlexStart;
+    else if (align == ItemPosition::LastBaseline)
+        align = ItemPosition::FlexEnd;
     if (availableSpace < 0 && safety == OverflowAlignment::Safe)
         align = ItemPosition::FlexStart;
     return FlexFormattingUtils::alignmentOffset(availableSpace, align, { }, { }, FlexFormattingUtils::isWrapReverse(flexBox()));


### PR DESCRIPTION
#### fe7e650aae8e2c4485ed7a9e570d650983bc7384
<pre>
[css-flexbox] Fix baseline fallback for abspos flex static positions
<a href="https://bugs.webkit.org/show_bug.cgi?id=320612">https://bugs.webkit.org/show_bug.cgi?id=320612</a>
<a href="https://rdar.apple.com/183584550">rdar://183584550</a>

Reviewed by NOBODY (OOPS!).

Absolutely positioned flex children do not participate in flex layout. Resolve `baseline` and `last
baseline` to the cross-axis start and end edges before computing their static position. Without
baseline metrics, both otherwise incorrectly place the child at cross-start.

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-008-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-004-expected.txt:
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
(WebCore::LayoutIntegration::FlexLayout::staticCrossAxisPositionForPositionedFlexItem):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe7e650aae8e2c4485ed7a9e570d650983bc7384

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140919 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d59004a5-bbaf-4568-b6f7-cbb977021d43) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138482 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96332 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62cc5590-6afe-4526-bbda-3d04190931f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118946 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26f513c9-6245-4254-a38a-8dfe9ea1a846) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40658 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39022 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7731 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151065 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38731 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35743 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189707 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51277 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147598 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51959 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147388 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42106 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124174 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118587 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50467 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13708 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49863 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50103 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49925 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->