### PR TITLE
[css-inline] Preserve fractional central baselines for atomic inlines

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-flex-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-flex-002-expected.txt
@@ -17,9 +17,7 @@ PASS .target > * 15
 PASS .target > * 16
 PASS .target > * 17
 PASS .target > * 18
-FAIL .target > * 19 assert_equals:
-<div data-offset-x="33"><span></span></div>
-offsetLeft expected 33 but got 32
+PASS .target > * 19
 PASS .target > * 20
 PASS .target > * 21
 PASS .target > * 22
@@ -27,9 +25,7 @@ PASS .target > * 23
 PASS .target > * 24
 PASS .target > * 25
 PASS .target > * 26
-FAIL .target > * 27 assert_equals:
-<div data-offset-x="38"><span></span></div>
-offsetLeft expected 38 but got 37
+PASS .target > * 27
 PASS .target > * 28
 PASS .target > * 29
 PASS .target > * 30
@@ -39,9 +35,7 @@ PASS .target > * 33
 PASS .target > * 34
 PASS .target > * 35
 PASS .target > * 36
-FAIL .target > * 37 assert_equals:
-<div data-offset-x="63"><span></span></div>
-offsetLeft expected 63 but got 62
+PASS .target > * 37
 PASS .target > * 38
 PASS .target > * 39
 PASS .target > * 40
@@ -49,9 +43,7 @@ PASS .target > * 41
 PASS .target > * 42
 PASS .target > * 43
 PASS .target > * 44
-FAIL .target > * 45 assert_equals:
-<div data-offset-x="43"><span></span></div>
-offsetLeft expected 43 but got 42
+PASS .target > * 45
 PASS .target > * 46
 PASS .target > * 47
 PASS .target > * 48

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-002-expected.txt
@@ -1,20 +1,14 @@
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-x="48"><span></span></div>
-offsetLeft expected 48 but got 47
+PASS .target > * 3
 PASS .target > * 4
 PASS .target > * 5
 PASS .target > * 6
-FAIL .target > * 7 assert_equals:
-<div data-offset-x="33"><span></span></div>
-offsetLeft expected 33 but got 32
+PASS .target > * 7
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10
-FAIL .target > * 11 assert_equals:
-<div data-offset-x="53"><span></span></div>
-offsetLeft expected 53 but got 52
+PASS .target > * 11
 PASS .target > * 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-003-expected.txt
@@ -1,20 +1,14 @@
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-x="93"><span></span></div>
-offsetLeft expected 93 but got 92
+PASS .target > * 3
 PASS .target > * 4
 PASS .target > * 5
 PASS .target > * 6
-FAIL .target > * 7 assert_equals:
-<div data-offset-x="108"><span></span></div>
-offsetLeft expected 108 but got 107
+PASS .target > * 7
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10
-FAIL .target > * 11 assert_equals:
-<div data-offset-x="88"><span></span></div>
-offsetLeft expected 88 but got 87
+PASS .target > * 11
 PASS .target > * 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-002-expected.txt
@@ -17,9 +17,7 @@ PASS .target > * 15
 PASS .target > * 16
 PASS .target > * 17
 PASS .target > * 18
-FAIL .target > * 19 assert_equals:
-<div data-offset-x="33"><span></span></div>
-offsetLeft expected 33 but got 32
+PASS .target > * 19
 PASS .target > * 20
 PASS .target > * 21
 PASS .target > * 22
@@ -27,9 +25,7 @@ PASS .target > * 23
 PASS .target > * 24
 PASS .target > * 25
 PASS .target > * 26
-FAIL .target > * 27 assert_equals:
-<div data-offset-x="38"><span></span></div>
-offsetLeft expected 38 but got 37
+PASS .target > * 27
 PASS .target > * 28
 PASS .target > * 29
 PASS .target > * 30
@@ -39,9 +35,7 @@ PASS .target > * 33
 PASS .target > * 34
 PASS .target > * 35
 PASS .target > * 36
-FAIL .target > * 37 assert_equals:
-<div data-offset-x="63"><span></span></div>
-offsetLeft expected 63 but got 62
+PASS .target > * 37
 PASS .target > * 38
 PASS .target > * 39
 PASS .target > * 40
@@ -49,9 +43,7 @@ PASS .target > * 41
 PASS .target > * 42
 PASS .target > * 43
 PASS .target > * 44
-FAIL .target > * 45 assert_equals:
-<div data-offset-x="43"><span></span></div>
-offsetLeft expected 43 but got 42
+PASS .target > * 45
 PASS .target > * 46
 PASS .target > * 47
 PASS .target > * 48

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-002-expected.txt
@@ -1,20 +1,14 @@
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-x="48"><span></span></div>
-offsetLeft expected 48 but got 47
+PASS .target > * 3
 PASS .target > * 4
 PASS .target > * 5
 PASS .target > * 6
-FAIL .target > * 7 assert_equals:
-<div data-offset-x="33"><span></span></div>
-offsetLeft expected 33 but got 32
+PASS .target > * 7
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10
-FAIL .target > * 11 assert_equals:
-<div data-offset-x="53"><span></span></div>
-offsetLeft expected 53 but got 52
+PASS .target > * 11
 PASS .target > * 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-003-expected.txt
@@ -1,20 +1,14 @@
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-x="93"><span></span></div>
-offsetLeft expected 93 but got 92
+PASS .target > * 3
 PASS .target > * 4
 PASS .target > * 5
 PASS .target > * 6
-FAIL .target > * 7 assert_equals:
-<div data-offset-x="108"><span></span></div>
-offsetLeft expected 108 but got 107
+PASS .target > * 7
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10
-FAIL .target > * 11 assert_equals:
-<div data-offset-x="88"><span></span></div>
-offsetLeft expected 88 but got 87
+PASS .target > * 11
 PASS .target > * 12
 

--- a/LayoutTests/platform/glib/fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed-expected.txt
+++ b/LayoutTests/platform/glib/fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed-expected.txt
@@ -47,17 +47,17 @@ layer at (8,419) size 74x310 clip at (9,420) size 72x308 scrollHeight 718
     RenderBR {BR} at (55,696) size 18x1
 layer at (8,790) size 27x310 clip at (9,791) size 25x308 scrollHeight 747
   RenderBlock {DIV} at (0,782) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x181
-      text run at (5,1) width 182: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (5,1) size 17x181
+      text run at (5,1) width 181: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,182) size 25x25
-    RenderText {#text} at (5,207) size 18x542
+    RenderText {#text} at (5,207) size 17x542
       text run at (5,207) width 542: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1161) size 27x310 clip at (9,1162) size 25x308 scrollHeight 743
   RenderBlock {DIV} at (0,1152) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x271
-      text run at (5,1) width 272: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (5,1) size 17x271
+      text run at (5,1) width 271: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,272) size 25x25
-    RenderText {#text} at (5,297) size 18x448
+    RenderText {#text} at (5,297) size 17x448
       text run at (5,297) width 448: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1532) size 20x310 clip at (9,1533) size 18x308 scrollY 410 scrollHeight 718
   RenderBlock {DIV} at (0,1523) size 20x311 [border: (1px solid #000000)]
@@ -79,15 +79,15 @@ layer at (8,1902) size 74x310 clip at (9,1903) size 72x308 scrollY 410 scrollHei
     RenderBR {BR} at (55,-387) size 18x1
 layer at (8,2273) size 27x310 clip at (9,2274) size 25x308 scrollY 439 scrollHeight 747
   RenderBlock {DIV} at (0,2265) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,128) size 18x181
-      text run at (5,128) width 182 RTL: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (5,128) size 17x181
+      text run at (5,128) width 181 RTL: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,103) size 25x25
-    RenderText {#text} at (5,-439) size 18x542
+    RenderText {#text} at (5,-439) size 17x542
       text run at (5,-438) width 542 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,2644) size 27x310 clip at (9,2645) size 25x308 scrollY 435 scrollHeight 743
   RenderBlock {DIV} at (0,2635) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,38) size 18x271
-      text run at (5,38) width 272 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (5,38) size 17x271
+      text run at (5,38) width 271 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,13) size 25x25
-    RenderText {#text} at (5,-435) size 18x448
+    RenderText {#text} at (5,-435) size 17x448
       text run at (5,-434) width 448 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."

--- a/LayoutTests/platform/glib/fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed-expected.txt
+++ b/LayoutTests/platform/glib/fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed-expected.txt
@@ -47,17 +47,17 @@ layer at (8,419) size 74x310 clip at (9,420) size 72x308 scrollHeight 718
     RenderBR {BR} at (55,696) size 18x1
 layer at (8,790) size 27x310 clip at (9,791) size 25x308 scrollHeight 747
   RenderBlock {DIV} at (0,782) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x181
-      text run at (5,1) width 182: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (5,1) size 17x181
+      text run at (5,1) width 181: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,182) size 25x25
-    RenderText {#text} at (5,207) size 18x542
+    RenderText {#text} at (5,207) size 17x542
       text run at (5,207) width 542: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1161) size 27x310 clip at (9,1162) size 25x308 scrollHeight 743
   RenderBlock {DIV} at (0,1152) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x271
-      text run at (5,1) width 272: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (5,1) size 17x271
+      text run at (5,1) width 271: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,272) size 25x25
-    RenderText {#text} at (5,297) size 18x448
+    RenderText {#text} at (5,297) size 17x448
       text run at (5,297) width 448: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1532) size 20x310 clip at (9,1533) size 18x308 scrollY 410 scrollHeight 718
   RenderBlock {DIV} at (0,1523) size 20x311 [border: (1px solid #000000)]
@@ -79,15 +79,15 @@ layer at (8,1902) size 74x310 clip at (9,1903) size 72x308 scrollY 410 scrollHei
     RenderBR {BR} at (55,-387) size 18x1
 layer at (8,2273) size 27x310 clip at (9,2274) size 25x308 scrollY 439 scrollHeight 747
   RenderBlock {DIV} at (0,2265) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,128) size 18x181
-      text run at (5,128) width 182 RTL: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (5,128) size 17x181
+      text run at (5,128) width 181 RTL: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,103) size 25x25
-    RenderText {#text} at (5,-439) size 18x542
+    RenderText {#text} at (5,-439) size 17x542
       text run at (5,-438) width 542 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,2644) size 27x310 clip at (9,2645) size 25x308 scrollY 435 scrollHeight 743
   RenderBlock {DIV} at (0,2635) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,38) size 18x271
-      text run at (5,38) width 272 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (5,38) size 17x271
+      text run at (5,38) width 271 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,13) size 25x25
-    RenderText {#text} at (5,-435) size 18x448
+    RenderText {#text} at (5,-435) size 17x448
       text run at (5,-434) width 448 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."

--- a/LayoutTests/platform/glib/fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed-expected.txt
+++ b/LayoutTests/platform/glib/fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed-expected.txt
@@ -47,17 +47,17 @@ layer at (8,419) size 74x310 clip at (9,420) size 72x308 scrollHeight 718
     RenderBR {BR} at (55,696) size 18x1
 layer at (8,790) size 27x310 clip at (9,791) size 25x308 scrollHeight 747
   RenderBlock {DIV} at (0,782) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x181
-      text run at (5,1) width 182: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (5,1) size 17x181
+      text run at (5,1) width 181: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,182) size 25x25
-    RenderText {#text} at (5,207) size 18x542
+    RenderText {#text} at (5,207) size 17x542
       text run at (5,207) width 542: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1161) size 27x310 clip at (9,1162) size 25x308 scrollHeight 743
   RenderBlock {DIV} at (0,1152) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x271
-      text run at (5,1) width 272: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (5,1) size 17x271
+      text run at (5,1) width 271: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,272) size 25x25
-    RenderText {#text} at (5,297) size 18x448
+    RenderText {#text} at (5,297) size 17x448
       text run at (5,297) width 448: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1532) size 20x310 clip at (9,1533) size 18x308 scrollY 410 scrollHeight 718
   RenderBlock {DIV} at (0,1523) size 20x311 [border: (1px solid #000000)]
@@ -79,15 +79,15 @@ layer at (8,1902) size 74x310 clip at (9,1903) size 72x308 scrollY 410 scrollHei
     RenderBR {BR} at (55,-387) size 18x1
 layer at (8,2273) size 27x310 clip at (9,2274) size 25x308 scrollY 439 scrollHeight 747
   RenderBlock {DIV} at (0,2265) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,128) size 18x181
-      text run at (5,128) width 182 RTL: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (5,128) size 17x181
+      text run at (5,128) width 181 RTL: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,103) size 25x25
-    RenderText {#text} at (5,-439) size 18x542
+    RenderText {#text} at (5,-439) size 17x542
       text run at (5,-438) width 542 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,2644) size 27x310 clip at (9,2645) size 25x308 scrollY 435 scrollHeight 743
   RenderBlock {DIV} at (0,2635) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,38) size 18x271
-      text run at (5,38) width 272 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (5,38) size 17x271
+      text run at (5,38) width 271 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,13) size 25x25
-    RenderText {#text} at (5,-435) size 18x448
+    RenderText {#text} at (5,-435) size 17x448
       text run at (5,-434) width 448 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."

--- a/LayoutTests/platform/glib/fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed-expected.txt
+++ b/LayoutTests/platform/glib/fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed-expected.txt
@@ -47,17 +47,17 @@ layer at (8,419) size 74x310 clip at (9,420) size 72x308 scrollHeight 718
     RenderBR {BR} at (55,696) size 18x1
 layer at (8,790) size 27x310 clip at (9,791) size 25x308 scrollHeight 747
   RenderBlock {DIV} at (0,782) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x181
-      text run at (5,1) width 182: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (5,1) size 17x181
+      text run at (5,1) width 181: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,182) size 25x25
-    RenderText {#text} at (5,207) size 18x542
+    RenderText {#text} at (5,207) size 17x542
       text run at (5,207) width 542: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1161) size 27x310 clip at (9,1162) size 25x308 scrollHeight 743
   RenderBlock {DIV} at (0,1152) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x271
-      text run at (5,1) width 272: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (5,1) size 17x271
+      text run at (5,1) width 271: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,272) size 25x25
-    RenderText {#text} at (5,297) size 18x448
+    RenderText {#text} at (5,297) size 17x448
       text run at (5,297) width 448: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1532) size 20x310 clip at (9,1533) size 18x308 scrollY 410 scrollHeight 718
   RenderBlock {DIV} at (0,1523) size 20x311 [border: (1px solid #000000)]
@@ -79,15 +79,15 @@ layer at (8,1902) size 74x310 clip at (9,1903) size 72x308 scrollY 410 scrollHei
     RenderBR {BR} at (55,-387) size 18x1
 layer at (8,2273) size 27x310 clip at (9,2274) size 25x308 scrollY 439 scrollHeight 747
   RenderBlock {DIV} at (0,2265) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,128) size 18x181
-      text run at (5,128) width 182 RTL: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (5,128) size 17x181
+      text run at (5,128) width 181 RTL: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,103) size 25x25
-    RenderText {#text} at (5,-439) size 18x542
+    RenderText {#text} at (5,-439) size 17x542
       text run at (5,-438) width 542 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,2644) size 27x310 clip at (9,2645) size 25x308 scrollY 435 scrollHeight 743
   RenderBlock {DIV} at (0,2635) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,38) size 18x271
-      text run at (5,38) width 272 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (5,38) size 17x271
+      text run at (5,38) width 271 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,13) size 25x25
-    RenderText {#text} at (5,-435) size 18x448
+    RenderText {#text} at (5,-435) size 17x448
       text run at (5,-434) width 448 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."

--- a/LayoutTests/platform/ios/fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed-expected.txt
@@ -47,18 +47,18 @@ layer at (8,419) size 74x310 clip at (9,420) size 72x308 scrollHeight 737
     RenderBR {BR} at (55,714) size 18x1
 layer at (8,790) size 27x310 clip at (9,791) size 25x308 scrollHeight 766
   RenderBlock {DIV} at (0,782) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x186
-      text run at (5,1) width 186: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,1) size 19x186
+      text run at (4,1) width 187: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,186) size 25x26
-    RenderText {#text} at (5,211) size 18x556
-      text run at (5,211) width 556: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,211) size 19x556
+      text run at (4,211) width 556: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1161) size 27x310 clip at (9,1162) size 25x308 scrollHeight 762
   RenderBlock {DIV} at (0,1152) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x278
-      text run at (5,1) width 278: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,1) size 19x278
+      text run at (4,1) width 279: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,278) size 25x26
-    RenderText {#text} at (5,303) size 18x460
-      text run at (5,303) width 460: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,303) size 19x460
+      text run at (4,303) width 460: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1532) size 20x310 clip at (9,1533) size 18x308 scrollY 430 scrollHeight 738
   RenderBlock {DIV} at (0,1523) size 20x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,-429) size 18x738
@@ -79,15 +79,15 @@ layer at (8,1902) size 74x310 clip at (9,1903) size 72x308 scrollY 430 scrollHei
     RenderBR {BR} at (55,-406) size 18x1
 layer at (8,2273) size 27x310 clip at (9,2274) size 25x308 scrollY 459 scrollHeight 767
   RenderBlock {DIV} at (0,2265) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,123) size 18x186
-      text run at (5,123) width 186 RTL: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,123) size 19x186
+      text run at (4,123) width 187 RTL: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,98) size 25x26
-    RenderText {#text} at (5,-458) size 18x557
-      text run at (5,-457) width 557 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-458) size 19x557
+      text run at (4,-457) width 557 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,2644) size 27x310 clip at (9,2645) size 25x308 scrollY 455 scrollHeight 763
   RenderBlock {DIV} at (0,2635) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,31) size 18x278
-      text run at (5,31) width 278 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,31) size 19x278
+      text run at (4,31) width 279 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,6) size 25x26
-    RenderText {#text} at (5,-454) size 18x461
-      text run at (5,-453) width 461 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-454) size 19x461
+      text run at (4,-453) width 461 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."

--- a/LayoutTests/platform/ios/fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed-expected.txt
@@ -47,18 +47,18 @@ layer at (8,419) size 74x310 clip at (9,420) size 72x308 scrollHeight 737
     RenderBR {BR} at (55,714) size 18x1
 layer at (8,790) size 27x310 clip at (9,791) size 25x308 scrollHeight 766
   RenderBlock {DIV} at (0,782) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x186
-      text run at (5,1) width 186: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,1) size 19x186
+      text run at (4,1) width 187: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,186) size 25x26
-    RenderText {#text} at (5,211) size 18x556
-      text run at (5,211) width 556: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,211) size 19x556
+      text run at (4,211) width 556: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1161) size 27x310 clip at (9,1162) size 25x308 scrollHeight 762
   RenderBlock {DIV} at (0,1152) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x278
-      text run at (5,1) width 278: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,1) size 19x278
+      text run at (4,1) width 279: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,278) size 25x26
-    RenderText {#text} at (5,303) size 18x460
-      text run at (5,303) width 460: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,303) size 19x460
+      text run at (4,303) width 460: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1532) size 20x310 clip at (9,1533) size 18x308 scrollY 430 scrollHeight 738
   RenderBlock {DIV} at (0,1523) size 20x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,-429) size 18x738
@@ -79,15 +79,15 @@ layer at (8,1902) size 74x310 clip at (9,1903) size 72x308 scrollY 430 scrollHei
     RenderBR {BR} at (55,-406) size 18x1
 layer at (8,2273) size 27x310 clip at (9,2274) size 25x308 scrollY 459 scrollHeight 767
   RenderBlock {DIV} at (0,2265) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,123) size 18x186
-      text run at (5,123) width 186 RTL: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,123) size 19x186
+      text run at (4,123) width 187 RTL: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,98) size 25x26
-    RenderText {#text} at (5,-458) size 18x557
-      text run at (5,-457) width 557 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-458) size 19x557
+      text run at (4,-457) width 557 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,2644) size 27x310 clip at (9,2645) size 25x308 scrollY 455 scrollHeight 763
   RenderBlock {DIV} at (0,2635) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,31) size 18x278
-      text run at (5,31) width 278 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,31) size 19x278
+      text run at (4,31) width 279 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,6) size 25x26
-    RenderText {#text} at (5,-454) size 18x461
-      text run at (5,-453) width 461 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-454) size 19x461
+      text run at (4,-453) width 461 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."

--- a/LayoutTests/platform/ios/fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed-expected.txt
@@ -47,18 +47,18 @@ layer at (8,419) size 74x310 clip at (9,420) size 72x308 scrollHeight 737
     RenderBR {BR} at (55,714) size 18x1
 layer at (8,790) size 27x310 clip at (9,791) size 25x308 scrollHeight 766
   RenderBlock {DIV} at (0,782) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x186
-      text run at (5,1) width 186: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,1) size 19x186
+      text run at (4,1) width 187: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,186) size 25x26
-    RenderText {#text} at (5,211) size 18x556
-      text run at (5,211) width 556: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,211) size 19x556
+      text run at (4,211) width 556: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1161) size 27x310 clip at (9,1162) size 25x308 scrollHeight 762
   RenderBlock {DIV} at (0,1152) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x278
-      text run at (5,1) width 278: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,1) size 19x278
+      text run at (4,1) width 279: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,278) size 25x26
-    RenderText {#text} at (5,303) size 18x460
-      text run at (5,303) width 460: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,303) size 19x460
+      text run at (4,303) width 460: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1532) size 20x310 clip at (9,1533) size 18x308 scrollY 430 scrollHeight 738
   RenderBlock {DIV} at (0,1523) size 20x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,-429) size 18x738
@@ -79,15 +79,15 @@ layer at (8,1902) size 74x310 clip at (9,1903) size 72x308 scrollY 430 scrollHei
     RenderBR {BR} at (55,-406) size 18x1
 layer at (8,2273) size 27x310 clip at (9,2274) size 25x308 scrollY 459 scrollHeight 767
   RenderBlock {DIV} at (0,2265) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,123) size 18x186
-      text run at (5,123) width 186 RTL: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,123) size 19x186
+      text run at (4,123) width 187 RTL: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,98) size 25x26
-    RenderText {#text} at (5,-458) size 18x557
-      text run at (5,-457) width 557 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-458) size 19x557
+      text run at (4,-457) width 557 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,2644) size 27x310 clip at (9,2645) size 25x308 scrollY 455 scrollHeight 763
   RenderBlock {DIV} at (0,2635) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,31) size 18x278
-      text run at (5,31) width 278 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,31) size 19x278
+      text run at (4,31) width 279 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,6) size 25x26
-    RenderText {#text} at (5,-454) size 18x461
-      text run at (5,-453) width 461 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-454) size 19x461
+      text run at (4,-453) width 461 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."

--- a/LayoutTests/platform/mac/fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed-expected.txt
@@ -47,18 +47,18 @@ layer at (8,419) size 74x310 clip at (9,420) size 72x308 scrollHeight 737
     RenderBR {BR} at (55,714) size 18x1
 layer at (8,790) size 27x310 clip at (9,791) size 25x308 scrollHeight 766
   RenderBlock {DIV} at (0,782) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x186
-      text run at (5,1) width 186: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,1) size 19x186
+      text run at (4,1) width 187: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,186) size 25x26
-    RenderText {#text} at (5,211) size 18x556
-      text run at (5,211) width 555: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,211) size 19x556
+      text run at (4,211) width 556: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1161) size 27x310 clip at (9,1162) size 25x308 scrollHeight 762
   RenderBlock {DIV} at (0,1152) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x278
-      text run at (5,1) width 278: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,1) size 19x278
+      text run at (4,1) width 279: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,278) size 25x26
-    RenderText {#text} at (5,303) size 18x460
-      text run at (5,303) width 459: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,303) size 19x460
+      text run at (4,303) width 460: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1532) size 20x310 clip at (9,1533) size 18x308 scrollY 430 scrollHeight 738
   RenderBlock {DIV} at (0,1523) size 20x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,-429) size 18x738
@@ -79,15 +79,15 @@ layer at (8,1902) size 74x310 clip at (9,1903) size 72x308 scrollY 430 scrollHei
     RenderBR {BR} at (55,-406) size 18x1
 layer at (8,2273) size 27x310 clip at (9,2274) size 25x308 scrollY 459 scrollHeight 767
   RenderBlock {DIV} at (0,2265) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,123) size 18x186
-      text run at (5,123) width 186 RTL: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,123) size 19x186
+      text run at (4,123) width 187 RTL: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,98) size 25x26
-    RenderText {#text} at (5,-458) size 18x557
-      text run at (5,-457) width 556 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-458) size 19x557
+      text run at (4,-457) width 557 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,2644) size 27x310 clip at (9,2645) size 25x308 scrollY 455 scrollHeight 763
   RenderBlock {DIV} at (0,2635) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,31) size 18x278
-      text run at (5,31) width 278 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,31) size 19x278
+      text run at (4,31) width 279 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,6) size 25x26
-    RenderText {#text} at (5,-454) size 18x461
-      text run at (5,-453) width 460 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-454) size 19x461
+      text run at (4,-453) width 461 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."

--- a/LayoutTests/platform/mac/fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed-expected.txt
@@ -47,18 +47,18 @@ layer at (8,419) size 74x310 clip at (9,420) size 72x308 scrollHeight 737
     RenderBR {BR} at (55,714) size 18x1
 layer at (8,790) size 27x310 clip at (9,791) size 25x308 scrollHeight 766
   RenderBlock {DIV} at (0,782) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x186
-      text run at (5,1) width 186: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,1) size 19x186
+      text run at (4,1) width 187: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,186) size 25x26
-    RenderText {#text} at (5,211) size 18x556
-      text run at (5,211) width 555: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,211) size 19x556
+      text run at (4,211) width 556: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1161) size 27x310 clip at (9,1162) size 25x308 scrollHeight 762
   RenderBlock {DIV} at (0,1152) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x278
-      text run at (5,1) width 278: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,1) size 19x278
+      text run at (4,1) width 279: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,278) size 25x26
-    RenderText {#text} at (5,303) size 18x460
-      text run at (5,303) width 459: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,303) size 19x460
+      text run at (4,303) width 460: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1532) size 20x310 clip at (9,1533) size 18x308 scrollY 430 scrollHeight 738
   RenderBlock {DIV} at (0,1523) size 20x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,-429) size 18x738
@@ -79,15 +79,15 @@ layer at (8,1902) size 74x310 clip at (9,1903) size 72x308 scrollY 430 scrollHei
     RenderBR {BR} at (55,-406) size 18x1
 layer at (8,2273) size 27x310 clip at (9,2274) size 25x308 scrollY 459 scrollHeight 767
   RenderBlock {DIV} at (0,2265) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,123) size 18x186
-      text run at (5,123) width 186 RTL: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,123) size 19x186
+      text run at (4,123) width 187 RTL: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,98) size 25x26
-    RenderText {#text} at (5,-458) size 18x557
-      text run at (5,-457) width 556 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-458) size 19x557
+      text run at (4,-457) width 557 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,2644) size 27x310 clip at (9,2645) size 25x308 scrollY 455 scrollHeight 763
   RenderBlock {DIV} at (0,2635) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,31) size 18x278
-      text run at (5,31) width 278 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,31) size 19x278
+      text run at (4,31) width 279 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,6) size 25x26
-    RenderText {#text} at (5,-454) size 18x461
-      text run at (5,-453) width 460 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-454) size 19x461
+      text run at (4,-453) width 461 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."

--- a/LayoutTests/platform/mac/fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed-expected.txt
@@ -47,18 +47,18 @@ layer at (8,419) size 74x310 clip at (9,420) size 72x308 scrollHeight 737
     RenderBR {BR} at (55,714) size 18x1
 layer at (8,790) size 27x310 clip at (9,791) size 25x308 scrollHeight 766
   RenderBlock {DIV} at (0,782) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x186
-      text run at (5,1) width 186: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,1) size 19x186
+      text run at (4,1) width 187: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,186) size 25x26
-    RenderText {#text} at (5,211) size 18x556
-      text run at (5,211) width 555: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,211) size 19x556
+      text run at (4,211) width 556: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1161) size 27x310 clip at (9,1162) size 25x308 scrollHeight 762
   RenderBlock {DIV} at (0,1152) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x278
-      text run at (5,1) width 278: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,1) size 19x278
+      text run at (4,1) width 279: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,278) size 25x26
-    RenderText {#text} at (5,303) size 18x460
-      text run at (5,303) width 459: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,303) size 19x460
+      text run at (4,303) width 460: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1532) size 20x310 clip at (9,1533) size 18x308 scrollY 430 scrollHeight 738
   RenderBlock {DIV} at (0,1523) size 20x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,-429) size 18x738
@@ -79,15 +79,15 @@ layer at (8,1902) size 74x310 clip at (9,1903) size 72x308 scrollY 430 scrollHei
     RenderBR {BR} at (55,-406) size 18x1
 layer at (8,2273) size 27x310 clip at (9,2274) size 25x308 scrollY 459 scrollHeight 767
   RenderBlock {DIV} at (0,2265) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,123) size 18x186
-      text run at (5,123) width 186 RTL: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,123) size 19x186
+      text run at (4,123) width 187 RTL: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,98) size 25x26
-    RenderText {#text} at (5,-458) size 18x557
-      text run at (5,-457) width 556 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-458) size 19x557
+      text run at (4,-457) width 557 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,2644) size 27x310 clip at (9,2645) size 25x308 scrollY 455 scrollHeight 763
   RenderBlock {DIV} at (0,2635) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,31) size 18x278
-      text run at (5,31) width 278 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,31) size 19x278
+      text run at (4,31) width 279 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,6) size 25x26
-    RenderText {#text} at (5,-454) size 18x461
-      text run at (5,-453) width 460 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-454) size 19x461
+      text run at (4,-453) width 461 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."

--- a/LayoutTests/platform/mac/fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed-expected.txt
@@ -47,18 +47,18 @@ layer at (8,419) size 74x310 clip at (9,420) size 72x308 scrollHeight 737
     RenderBR {BR} at (55,714) size 18x1
 layer at (8,790) size 27x310 clip at (9,791) size 25x308 scrollHeight 766
   RenderBlock {DIV} at (0,782) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x186
-      text run at (5,1) width 186: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,1) size 19x186
+      text run at (4,1) width 187: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,186) size 25x26
-    RenderText {#text} at (5,211) size 18x556
-      text run at (5,211) width 555: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,211) size 19x556
+      text run at (4,211) width 556: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1161) size 27x310 clip at (9,1162) size 25x308 scrollHeight 762
   RenderBlock {DIV} at (0,1152) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,1) size 18x278
-      text run at (5,1) width 278: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,1) size 19x278
+      text run at (4,1) width 279: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,278) size 25x26
-    RenderText {#text} at (5,303) size 18x460
-      text run at (5,303) width 459: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,303) size 19x460
+      text run at (4,303) width 460: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,1532) size 20x310 clip at (9,1533) size 18x308 scrollY 430 scrollHeight 738
   RenderBlock {DIV} at (0,1523) size 20x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,-429) size 18x738
@@ -79,15 +79,15 @@ layer at (8,1902) size 74x310 clip at (9,1903) size 72x308 scrollY 430 scrollHei
     RenderBR {BR} at (55,-406) size 18x1
 layer at (8,2273) size 27x310 clip at (9,2274) size 25x308 scrollY 459 scrollHeight 767
   RenderBlock {DIV} at (0,2265) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,123) size 18x186
-      text run at (5,123) width 186 RTL: "Lorem ipsum dolor sit amet, "
+    RenderText {#text} at (4,123) size 19x186
+      text run at (4,123) width 187 RTL: "Lorem ipsum dolor sit amet, "
     RenderImage {IMG} at (1,98) size 25x26
-    RenderText {#text} at (5,-458) size 18x557
-      text run at (5,-457) width 556 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-458) size 19x557
+      text run at (4,-457) width 557 RTL: " consectetur adipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
 layer at (8,2644) size 27x310 clip at (9,2645) size 25x308 scrollY 455 scrollHeight 763
   RenderBlock {DIV} at (0,2635) size 27x311 [border: (1px solid #000000)]
-    RenderText {#text} at (5,31) size 18x278
-      text run at (5,31) width 278 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
+    RenderText {#text} at (4,31) size 19x278
+      text run at (4,31) width 279 RTL: "Lorem ipsum dolor sit amet, consectetur ad"
     RenderImage {IMG} at (1,6) size 25x26
-    RenderText {#text} at (5,-454) size 18x461
-      text run at (5,-453) width 460 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."
+    RenderText {#text} at (4,-454) size 19x461
+      text run at (4,-453) width 461 RTL: "ipiscing elit. Vivamus vitae eros non libero faucibus sagittis sed ut eros."

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -712,7 +712,7 @@ void LineBoxBuilder::adjustIdeographicBaselineIfApplicable(LineBox& lineBox)
             setVerticalPropertiesForInlineLevelBox(lineBox, inlineLevelBox);
         else if (inlineLevelBox.isAtomicInlineBox()) {
             auto inlineLevelBoxHeight = inlineLevelBox.logicalHeight();
-            InlineLayoutUnit ideographicBaseline = roundToInt(inlineLevelBoxHeight / 2);
+            InlineLayoutUnit ideographicBaseline = inlineLevelBoxHeight / 2;
             // Move the baseline position but keep the same logical height.
             inlineLevelBox.setAscentAndDescent({ ideographicBaseline, inlineLevelBoxHeight - ideographicBaseline });
             inlineLevelBox.setLayoutBounds({ ideographicBaseline, inlineLevelBoxHeight - ideographicBaseline });


### PR DESCRIPTION
#### f692b8e75f587db273ca9a8a67806e2931a68559
<pre>
[css-inline] Preserve fractional central baselines for atomic inlines
<a href="https://bugs.webkit.org/show_bug.cgi?id=320613">https://bugs.webkit.org/show_bug.cgi?id=320613</a>
<a href="https://rdar.apple.com/183584888">rdar://183584888</a>

Reviewed by Alan Baradlay.

CSS requires an atomic inline&apos;s synthesized central baseline to be halfway between its line-over and
line-under margin edges. Rounding that midpoint for odd-sized boxes loses the fractional component
and causes one-pixel baseline alignment errors in flex and grid layouts.

Preserve the fractional midpoint without changing the box&apos;s logical height.

<a href="https://drafts.csswg.org/css-inline-3/#baseline-synthesis-box">https://drafts.csswg.org/css-inline-3/#baseline-synthesis-box</a>
<a href="https://www.w3.org/TR/css-writing-modes-3/#replaced-baselines">https://www.w3.org/TR/css-writing-modes-3/#replaced-baselines</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-flex-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-003-expected.txt:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
(WebCore::Layout::LineBoxBuilder::adjustIdeographicBaselineIfApplicable):

Canonical link: <a href="https://commits.webkit.org/318268@main">https://commits.webkit.org/318268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b48fadf541a024f92bf5489f06c451e4a0dd4716

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187328 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38099789-f9c8-40ed-be0e-8b4cccb41dbc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138520 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/abeafe22-756a-4de3-8612-b74f828eb6d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118984 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/edfcca3f-68ff-4b28-9332-a0deec32fb07) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40704 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39067 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151110 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38760 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35791 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189756 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51325 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147634 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52007 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147420 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26961 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42136 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124222 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118653 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50515 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13737 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49911 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50151 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49973 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->