### PR TITLE
WGSL Token copy-assignment leaks the Identifier String's StringImpl on every token advance

### DIFF
--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -221,6 +221,9 @@ struct Token {
 
     Token& operator=(const Token& other)
     {
+        if (type == TokenType::Identifier)
+            ident.~String();
+
         type = other.type;
         span = other.span;
 


### PR DESCRIPTION
#### e02581f3b0d9122b97c7aef7454c3327a1dc553b
<pre>
WGSL Token copy-assignment leaks the Identifier String&apos;s StringImpl on every token advance
<a href="https://bugs.webkit.org/show_bug.cgi?id=320614">https://bugs.webkit.org/show_bug.cgi?id=320614</a>

Reviewed by Mike Wyrzykowski.

Token stores its identifier in a union member (String ident), so the String&apos;s
lifetime must be managed manually via the type discriminant. The move-assignment
operator and the destructor both destruct the existing String before overwriting
(if (type == TokenType::Identifier) ident.~String();), but the copy-assignment
operator omitted this: it overwrote type and then placement-constructed a fresh
String over the still-live one, leaking the previously held StringImpl reference.

Parser::consume() copy-assigns into m_current on every token advance
(m_current = m_tokens[++m_currentTokenIndex]), and identifiers are the most common
token in WGSL, so compiling attacker-supplied shader source leaked one StringImpl
per identifier consumed for the lifetime of the process -- a monotonic
memory-growth vector reachable from untrusted WGSL in the GPU process.

Destruct the existing Identifier String at the top of the copy-assignment
operator, mirroring the move-assignment operator and the destructor.

* Source/WebGPU/WGSL/Token.h:
(WGSL::Token::operator=):

Canonical link: <a href="https://commits.webkit.org/318274@main">https://commits.webkit.org/318274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b665413276e4f25f75bb72c10e6fc3c549bc7c1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187283 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08b4f060-4512-45ec-802e-61aba7367315) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138492 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c893ae14-4d4e-4b37-bc3e-58732eccb960) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118956 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a57b479-2ce2-4b61-88bf-ad1890edb657) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40657 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39026 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38719 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35749 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189713 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51283 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147592 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39679 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51965 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147382 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42094 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124180 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118593 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50473 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13696 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49869 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50109 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49931 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->