### PR TITLE
WGSL textureDimensions(t, level) codegen clamps mip level one past the last valid LOD

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1683,7 +1683,7 @@ static void emitTextureDimensions(FunctionDefinitionWriter* writer, AST::CallExp
         if (vector && call.arguments().size() > 1) {
             writer->stringBuilder().append("min("_s);
             writer->visit(call.arguments()[0]);
-            writer->stringBuilder().append(".get_num_mip_levels(), uint("_s);
+            writer->stringBuilder().append(".get_num_mip_levels() - 1, uint("_s);
             writer->visit(call.arguments()[1]);
             writer->stringBuilder().append(')');
             writer->stringBuilder().append(')');


### PR DESCRIPTION
#### 4ed1e2966ece9c19e07e22ce81a735d83d21ef69
<pre>
WGSL textureDimensions(t, level) codegen clamps mip level one past the last valid LOD
<a href="https://bugs.webkit.org/show_bug.cgi?id=320615">https://bugs.webkit.org/show_bug.cgi?id=320615</a>

Reviewed by Mike Wyrzykowski.

The vector-returning textureDimensions(t, level) overload emits Metal code that
clamps the caller-supplied mip level with min(t.get_num_mip_levels(), uint(level)),
then calls get_width/get_height/get_depth(&lt;that value&gt;). get_num_mip_levels()
returns the mip level count, so the valid LOD range is [0, count - 1]. A shader
passing level == count clamps to count -- still one past the last valid LOD -- and
queries get_width(count), an out-of-range LOD access whose result is
Metal-implementation-defined.

The level argument is arbitrary shader-controlled input, and nothing else clamps
it: the bounds-check pass (BoundsCheck.cpp) only rewrites index-access
expressions and variables, never texture-builtin arguments, so this min() is the
sole bounds protection for the builtin -- and it is off by one. The same file&apos;s
index-access bounds check clamps with min(index, size - 1) (BoundsCheck.cpp), i.e.
subtracts one from the count to get the last valid index; this fix applies the
same idiom to the mip level.

Clamp against get_num_mip_levels() - 1 instead. A texture always has at least one
mip level, so the subtraction cannot underflow, and valid levels (already
&lt;= count - 1) are unaffected.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitTextureDimensions):

Canonical link: <a href="https://commits.webkit.org/318273@main">https://commits.webkit.org/318273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f075d70666e34063e6fe8fef302d7539fe324cfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187287 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b3664b3-dcd6-4517-b6a8-93aac0eb3177) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138490 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66602e07-b1b0-43f9-930b-8f1722a1cf4f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42002 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159226 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118954 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4da75f06-a9d8-4525-847b-f20a6d61b6f4) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40663 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002.html imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39030 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38722 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35753 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189717 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51287 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147596 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39680 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51969 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147386 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42098 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124184 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118597 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50477 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13699 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49873 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50113 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49935 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->