### PR TITLE
XMLHttpRequest.responseURL still returns the aborted request's URL after abort()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any-expected.txt
@@ -1,0 +1,7 @@
+
+PASS abort() during HEADERS_RECEIVED clears responseURL
+PASS abort() during LOADING clears responseURL
+PASS abort() during DONE clears responseURL (async)
+PASS abort() during DONE clears responseURL (sync)
+PASS responseURL reflects the new response after abort() and reuse
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.js
@@ -1,0 +1,91 @@
+// META: title=XMLHttpRequest: responseURL is the empty string after abort()
+
+// https://xhr.spec.whatwg.org/#the-abort()-method
+// abort() sets the response to a network error, both via the request error steps (step 2) and
+// when the state is already done (step 3). A network error's URL is null, so responseURL must
+// return the empty string, just like status is 0 and getAllResponseHeaders() is "".
+
+const url = "resources/well-formed.xml";
+
+function assertNetworkError(client) {
+  assert_equals(client.status, 0, "status");
+  assert_equals(client.statusText, "", "statusText");
+  assert_equals(client.getAllResponseHeaders(), "", "getAllResponseHeaders()");
+  assert_equals(client.responseURL, "", "responseURL");
+}
+
+async_test(test => {
+  const client = new XMLHttpRequest();
+  client.onreadystatechange = test.step_func(() => {
+    if (client.readyState !== 2)
+      return;
+    assert_equals(client.status, 200);
+    assert_not_equals(client.responseURL, "", "responseURL before abort()");
+    client.abort();
+    assertNetworkError(client);
+  });
+  client.onloadend = test.step_func_done(() => {
+    assertNetworkError(client);
+  });
+  client.open("GET", url);
+  client.send(null);
+}, "abort() during HEADERS_RECEIVED clears responseURL");
+
+async_test(test => {
+  const client = new XMLHttpRequest();
+  let aborted = false;
+  client.onreadystatechange = test.step_func(() => {
+    if (client.readyState !== 3 || aborted)
+      return;
+    aborted = true;
+    assert_equals(client.status, 200);
+    assert_not_equals(client.responseURL, "", "responseURL before abort()");
+    client.abort();
+    assertNetworkError(client);
+  });
+  client.onloadend = test.step_func_done(() => {
+    assert_true(aborted, "reached LOADING");
+    assertNetworkError(client);
+  });
+  client.open("GET", url);
+  client.send(null);
+}, "abort() during LOADING clears responseURL");
+
+async_test(test => {
+  const client = new XMLHttpRequest();
+  client.onload = test.step_func_done(() => {
+    assert_equals(client.readyState, 4);
+    assert_not_equals(client.responseURL, "", "responseURL before abort()");
+    client.abort();
+    assert_equals(client.readyState, 0);
+    assertNetworkError(client);
+  });
+  client.open("GET", url);
+  client.send(null);
+}, "abort() during DONE clears responseURL (async)");
+
+test(() => {
+  const client = new XMLHttpRequest();
+  client.open("GET", url, false);
+  client.send(null);
+  assert_equals(client.readyState, 4);
+  assert_not_equals(client.responseURL, "", "responseURL before abort()");
+  client.abort();
+  assert_equals(client.readyState, 0);
+  assertNetworkError(client);
+}, "abort() during DONE clears responseURL (sync)");
+
+async_test(test => {
+  const client = new XMLHttpRequest();
+  client.open("GET", url);
+  client.send(null);
+  client.abort();
+  assertNetworkError(client);
+  // A reused XMLHttpRequest must report the new response's URL, not the aborted one.
+  client.onload = test.step_func_done(() => {
+    assert_equals(client.status, 200);
+    assert_equals(client.responseURL, new URL(url + "?reused", location.href).href);
+  });
+  client.open("GET", url + "?reused");
+  client.send(null);
+}, "responseURL reflects the new response after abort() and reuse");

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.worker-expected.txt
@@ -1,0 +1,7 @@
+
+PASS abort() during HEADERS_RECEIVED clears responseURL
+PASS abort() during LOADING clears responseURL
+PASS abort() during DONE clears responseURL (async)
+PASS abort() during DONE clears responseURL (sync)
+PASS responseURL reflects the new response after abort() and reuse
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -696,7 +696,7 @@ void XMLHttpRequest::abort()
     if (!internalAbort())
         return;
 
-    clearResponseBuffers();
+    clearResponse();
 
     m_requestHeaders.clear();
     if ((readyState() == OPENED && m_sendFlag) || readyState() == HEADERS_RECEIVED || readyState() == LOADING) {


### PR DESCRIPTION
#### f8eec063afd9a4a16b29d2a0c800a1de7e1034a5
<pre>
XMLHttpRequest.responseURL still returns the aborted request&apos;s URL after abort()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320617">https://bugs.webkit.org/show_bug.cgi?id=320617</a>
<a href="https://rdar.apple.com/183587043">rdar://183587043</a>

Reviewed by Chris Dumez.

XMLHttpRequest::abort() only called clearResponseBuffers(), which clears the
response body, decoder and cached document but leaves m_response -- and
therefore the response URL, status, status message and header list -- intact.

status(), statusText(), getResponseHeader() and getAllResponseHeaders() all
happen to hide the stale response because they bail out early when m_error is
set, but responseURL() has no such guard and reads m_response.url() directly.
So after abort() we reported status 0, empty statusText and empty headers,
while responseURL kept handing back the URL of the request that was just
aborted, in all three abort states (HEADERS_RECEIVED, LOADING and DONE).

Per <a href="https://xhr.spec.whatwg.org/#the-abort()-method">https://xhr.spec.whatwg.org/#the-abort()-method</a>, both the request error
steps (step 2) and step 3 set the response to a network error, and a network
error&apos;s URL is null, so responseURL must return the empty string. Call
clearResponse() instead, which resets m_response as well as the buffers.

Firefox and Chrome both return the empty string here.

Tests: imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.html
       imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.worker.html

* LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.js: Added.
(assertNetworkError):
(async_test.test.client.onreadystatechange.test.step_func):
(async_test.test.client.onloadend.test.step_func_done):
(async_test.test.client.onload.test.step_func_done):
(test):
* LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/responseurl-after-abort.any.worker.html: Added.
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::abort):

Canonical link: <a href="https://commits.webkit.org/318241@main">https://commits.webkit.org/318241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34ae4638ccae5fd800805bb22af87197a6a52974

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187290 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/209018b1-38b6-41a0-8556-6ef6c8e3770c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138493 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f16b2f2-b428-4c1e-bbf5-e074f20fe3c3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118957 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f2ba3702-6188-419b-83fe-1ee3e0325d23) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40671 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39033 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38723 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35756 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43408 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43268 "Found 1 new test failure: http/tests/workers/service/service-worker-download-task-uaf.https.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189720 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147618 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39659 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51972 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147391 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42099 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124187 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118600 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50480 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13700 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49876 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50116 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49938 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->