### PR TITLE
Avoid recomputing anonymousWrappers on removal of out-of-flow elements.

### DIFF
--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -946,6 +946,8 @@ void RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers(RenderObject& rendere
     };
     collapseAndDestroyAnonymousSiblings();
 
+    bool destroyRootWasInFlow = destroyRoot->isInFlow();
+
     // FIXME: Do not try to collapse/cleanup the anonymous wrappers inside destroy (see webkit.org/b/186746).
     WeakPtr destroyRootParent = destroyRoot->parent();
     if (&rendererToDestroy != destroyRoot.get()) {
@@ -963,7 +965,11 @@ void RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers(RenderObject& rendere
         return;
 
     auto anonymousDestroyRoot = SetForScope { m_anonymousDestroyRoot, destroyRootParent };
-    removeAnonymousWrappersForInlineChildrenIfNeeded(*destroyRootParent);
+
+    // Removing an out-of-flow positioned or floating child cannot change
+    // whether the parent's in-flow children need their anonymous block wrappers
+    if (destroyRootWasInFlow)
+        removeAnonymousWrappersForInlineChildrenIfNeeded(*destroyRootParent);
 
     // Anonymous parent might have become empty, try to delete it too.
     if (isAnonymousAndSafeToDelete(*destroyRootParent) && !destroyRootParent->firstChild())


### PR DESCRIPTION
#### f9b6c5cc59a1fd15e99f995cdf2a7cc40f881adc
<pre>
Avoid recomputing anonymousWrappers on removal of out-of-flow elements.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320616">https://bugs.webkit.org/show_bug.cgi?id=320616</a>
<a href="https://rdar.apple.com/183586571">rdar://183586571</a>

Reviewed by NOBODY (OOPS!).

Re-land of <a href="https://commits.webkit.org/318113@main">318113@main</a>, which was reverted because it regression Motion Mark 1.3
Leaves by 19.5%.

Since out-of-flow/floating boxes don&apos;t participate in the inline/block
determination that creates anonymous wrappers, removing an out-of-flow
positioned or floating child cannot change whether the parent&apos;s in-flow children
need their anonymous wrappers.

When removing many absolutely-positioned children from a large container,
removeAnonymousWrappersForInlineChildrenIfNeeded() scans all of the parent&apos;s
children, so skipping it for out-of-flow removals avoids O(n) work per removed
child.

* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9b6c5cc59a1fd15e99f995cdf2a7cc40f881adc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187291 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140933 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ab510fb-0c98-42ec-a513-cd110ff518a7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138491 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96335 "4 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2a4c572-dc9d-4125-ab31-2108902d37e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159228 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118955 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d928a8c-216a-4dd2-b7dd-b1ac140c7b74) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40668 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39037 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38724 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35757 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189721 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51291 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147602 "34 flakes 2 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51973 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147390 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42100 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124188 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 27120 issues") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118601 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50481 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13701 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49877 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50117 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49939 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->