### PR TITLE
[YARR] Stop the chunked v-mode class set operation loop as soon as it can produce nothing more

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -890,6 +890,26 @@ private:
         size_t rhsMatchIndex = 0;
         size_t rhsRangeIndex = 0;
 
+        auto lhsHasMore = [&] {
+            return lhsMatchIndex < m_matches32.size() || lhsRangeIndex < m_ranges32.size();
+        };
+        auto rhsHasMore = [&] {
+            return rhsMatchIndex < rhsMatches32.size() || rhsRangeIndex < rhsRanges32.size();
+        };
+        auto canProduceMore = [&] {
+            switch (m_setOp) {
+            case CharacterClassSetOp::Default:
+            case CharacterClassSetOp::Union:
+                return lhsHasMore() || rhsHasMore();
+            case CharacterClassSetOp::Intersection:
+                return lhsHasMore() && rhsHasMore();
+            case CharacterClassSetOp::Subtraction:
+                return lhsHasMore();
+            }
+            RELEASE_ASSERT_NOT_REACHED();
+            return false;
+        };
+
         if (!m_matches32.isEmpty())
             chunkLo = std::min(chunkLo, m_matches32[0]);
 
@@ -902,16 +922,7 @@ private:
         if (!rhsRanges32.isEmpty())
             chunkLo = std::min(chunkLo, rhsRanges32[0].begin);
 
-        // If both the LHS and RHS are empty, bail out.
-        if (chunkLo == INT_MAX)
-            return;
-
-        while (lhsMatchIndex < m_matches32.size() || lhsRangeIndex < m_ranges32.size() || rhsMatchIndex < rhsMatches32.size() || rhsRangeIndex < rhsRanges32.size()) {
-            if (rhsMatchIndex >= rhsMatches32.size() && rhsRangeIndex > rhsRanges32.size() && m_setOp == CharacterClassSetOp::Intersection) {
-                // RHS is exhausted, we can short cut from here. Can't intersect anything more so bail out.
-                break;
-            }
-
+        while (canProduceMore()) {
             chunkHi = chunkLo + chunkSize - 1;
 
             for (; lhsMatchIndex < m_matches32.size(); ++lhsMatchIndex) {


### PR DESCRIPTION
#### a458a6c1f0a71390a7641f8fbb5a5485c6900a1e
<pre>
[YARR] Stop the chunked v-mode class set operation loop as soon as it can produce nothing more
<a href="https://bugs.webkit.org/show_bug.cgi?id=320619">https://bugs.webkit.org/show_bug.cgi?id=320619</a>

Reviewed by Yusuke Suzuki.

CharacterClassConstructor::nonLatin1OpSorted() computes v-mode class set
operations over the non-Latin-1 range by walking 0x100..0x10FFFF in
2048-codepoint chunks until every LHS/RHS index is consumed. It had an
early-exit for intersection with an exhausted RHS, but that compared
rhsRangeIndex with &apos;&gt;&apos; against rhsRanges32.size(), which can never be true,
so /[\p{Any}&amp;&amp;[a-c]]/v scanned all ~540 chunks even though the RHS has no
non-Latin-1 elements at all.

Replace the loop condition with an op-aware canProduceMore() predicate:
union continues while either side has input left, intersection while both
do, and subtraction while the LHS does. This subsumes the dead early-exit and
the empty-input bail-out, and additionally stops early when the LHS of an
intersection or a subtraction is exhausted. The resulting character sets are
unchanged.

Microbenchmark (500 constructions of new RegExp(&quot;(?:x&quot; + i + &quot;)?&quot; + pattern, &quot;v&quot;)):

    pattern                        baseline      patched

    [\p{Any}&amp;&amp;[a-c]]                1876.6 ms       2.9 ms
    [[a-c]&amp;&amp;\p{Any}]                1866.6 ms       2.3 ms
    [\p{L}&amp;&amp;\p{Any}]                2458.2 ms     981.7 ms
    [\p{Any}--[a-c]]                4862.2 ms    4932.5 ms
    [[\u{100}-\u{200}]--\p{Any}]    1774.9 ms       6.8 ms
    [\p{L}[0-9]]                     645.5 ms     696.4 ms

* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::nonLatin1OpSorted):

Canonical link: <a href="https://commits.webkit.org/318392@main">https://commits.webkit.org/318392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cb38a6fc1138aaed4893bdb91697828a20c5595

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187294 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138495 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118959 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40674 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39038 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/928 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7726 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38726 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35760 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38960 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189725 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51294 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147608 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39756 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51976 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147396 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42104 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124191 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118604 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50484 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13703 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49880 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50120 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->