### PR TITLE
[JSC] `EnumeratorNextUpdateIndexAndMode` should require the original array structure before using `InBoundsSaneChain`

### DIFF
--- a/JSTests/stress/for-in-enumerator-hole-with-inherited-index-custom-prototype.js
+++ b/JSTests/stress/for-in-enumerator-hole-with-inherited-index-custom-prototype.js
@@ -1,0 +1,37 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function mutate(array, proto, key, doMutate) {
+    if (doMutate && key === "1") {
+        delete array[3];
+        proto[3] = "inherited";
+    }
+}
+noInline(mutate);
+
+function test(array, proto, doMutate) {
+    var keys = [];
+    for (var key in array) {
+        keys.push(key);
+        mutate(array, proto, key, doMutate);
+    }
+    return keys.join(",");
+}
+noInline(test);
+
+function makeArray() {
+    var proto = {};
+    var array = [1, 2, 3, 4, 5];
+    Object.setPrototypeOf(array, proto);
+    return [array, proto];
+}
+
+for (var i = 0; i < testLoopCount; i++) {
+    var [array, proto] = makeArray();
+    shouldBe(test(array, proto, false), "0,1,2,3,4");
+}
+
+var [array, proto] = makeArray();
+shouldBe(test(array, proto, true), "0,1,2,3,4");

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3058,7 +3058,7 @@ private:
                 blessArrayOperation(base, index, storageEdge);
 
                 ArrayMode arrayMode = node->arrayMode();
-                if (arrayMode.benefitsFromOriginalArray())
+                if (arrayMode.isJSArrayWithOriginalStructure() && arrayMode.benefitsFromOriginalArray())
                     setSaneChainIfPossible(node, arrayMode.speculation() == Array::InBounds ? Array::InBoundsSaneChain : Array::OutOfBoundsSaneChain);
             }
 


### PR DESCRIPTION
#### 1566615170ec213c8f5c9188609d7b03fe245118
<pre>
[JSC] `EnumeratorNextUpdateIndexAndMode` should require the original array structure before using `InBoundsSaneChain`
<a href="https://bugs.webkit.org/show_bug.cgi?id=320620">https://bugs.webkit.org/show_bug.cgi?id=320620</a>

Reviewed by Yusuke Suzuki and Keith Miller.

The sane-chain speculation for the indexed enumerator mode was guarded
only by benefitsFromOriginalArray(), which checks the indexing type but
not the array class. As a result an array with a custom prototype got
InBoundsSaneChain and DFG/FTL skipped hole checks against the prototype,
diverging from LLInt/baseline. Check isJSArrayWithOriginalStructure()
first, like every other sane-chain site in fixup does.

Test: JSTests/stress/for-in-enumerator-hole-with-inherited-index-custom-prototype.js

* JSTests/stress/for-in-enumerator-hole-with-inherited-index-custom-prototype.js: Added.
(shouldBe):
(mutate):
(test):
(makeArray):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):

Canonical link: <a href="https://commits.webkit.org/318293@main">https://commits.webkit.org/318293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e06c1aaa06d99980df32638f2fc5a5be3371b55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187297 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138496 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118960 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40677 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39039 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/929 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7728 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38728 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35763 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38963 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189728 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51297 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147611 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39694 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51979 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147399 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42109 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124194 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118607 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50487 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13705 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49883 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49945 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->