### PR TITLE
FileReader.abort() is silently ignored on a reused reader after a prior read completes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_abort.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_abort.any-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Aborting before read
 PASS Aborting after read
+PASS Aborting a reused reader after a previous read completed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_abort.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_abort.any.js
@@ -36,3 +36,32 @@
               assert_equals(readerAbort.readyState, readerAbort.DONE);
             });
       }, "Aborting after read");
+
+    promise_test(t => {
+        var reader = new FileReader();
+
+        var eventWatcher = new EventWatcher(t, reader,
+            ['abort', 'loadstart', 'loadend', 'error', 'load']);
+
+        // First read: run to completion so the reader reaches the DONE state.
+        reader.readAsText(new Blob(["first read"]));
+        return eventWatcher.wait_for('loadstart')
+          .then(() => eventWatcher.wait_for('load'))
+          .then(() => eventWatcher.wait_for('loadend'))
+          .then(() => {
+              assert_equals(reader.readyState, reader.DONE);
+
+              // Reuse the same reader for a second read and abort it while it is
+              // still LOADING. 'abort' and 'loadend' are dispatched synchronously,
+              // so call wait_for before calling abort.
+              reader.readAsText(new Blob(["second read"]));
+              assert_equals(reader.readyState, reader.LOADING);
+              var nextEvent = eventWatcher.wait_for(['abort', 'loadend']);
+              reader.abort();
+              return nextEvent;
+            })
+          .then(() => {
+              assert_equals(reader.result, null);
+              assert_equals(reader.readyState, reader.DONE);
+            });
+      }, "Aborting a reused reader after a previous read completed");

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_abort.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_abort.any.worker-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Aborting before read
 PASS Aborting after read
+PASS Aborting a reused reader after a previous read completed
 

--- a/Source/WebCore/fileapi/FileReader.cpp
+++ b/Source/WebCore/fileapi/FileReader.cpp
@@ -129,6 +129,7 @@ ExceptionOr<void> FileReader::readInternal(Blob& blob, FileReaderLoader::ReadTyp
     m_blob = blob;
     m_readType = type;
     m_state = LOADING;
+    m_finishedLoading = false;
     m_error = nullptr;
 
     Ref loader = FileReaderLoader::create(m_readType, static_cast<FileReaderLoaderClient*>(this));


### PR DESCRIPTION
#### 40bdd4bde9f5fb62c2d3b7e0c5377caf5f34e488
<pre>
FileReader.abort() is silently ignored on a reused reader after a prior read completes
<a href="https://bugs.webkit.org/show_bug.cgi?id=320623">https://bugs.webkit.org/show_bug.cgi?id=320623</a>

Reviewed by Darin Adler.

FileReader::abort() early-returns when m_finishedLoading is true. That flag is
set inside the didFinishLoading task and was intended (230152@main) only to
preserve behavior when abort() is called re-entrantly from within the last
onprogress event. However, m_finishedLoading was never reset when a new read
started, so once any read completed the flag stayed true for the lifetime of the
FileReader.

As a result, reusing a FileReader (which is allowed by the spec once readyState
is no longer LOADING) left abort() permanently disabled: a subsequent read that
is genuinely in progress could not be aborted, and instead of firing
abort/loadend it ran to completion and delivered load and a result.

Reset m_finishedLoading = false in readInternal() when starting a new read, so
the guard is once again scoped to the intended last-onprogress-event window.

No new tests, updated imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_abort.any.js.

* LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_abort.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_abort.any.js:
(promise_test.t.return.eventWatcher.wait_for.string_appeared_here.then.eventWatcher.wait_for.string_appeared_here.then.eventWatcher.wait_for.string_appeared_here.then):
(promise_test.t.then):
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_abort.any.worker-expected.txt:
* Source/WebCore/fileapi/FileReader.cpp:
(WebCore::FileReader::readInternal):

Canonical link: <a href="https://commits.webkit.org/318288@main">https://commits.webkit.org/318288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eafa47ff82eab81d47d58058da68f2f40a93f8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51636 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45430 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187303 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34200a4e-46f6-4c7d-a367-a7d2f98549a4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138505 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159242 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118969 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/209f3841-d36e-44f1-bb1c-7aa096bc01aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40684 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39047 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38738 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35769 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189734 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51303 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147617 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39691 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51985 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147405 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42116 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124200 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118616 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50493 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13715 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49889 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50129 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49951 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->