### PR TITLE
Web Inspector: map WebAssembly byte offsets to original source with source maps

### DIFF
--- a/LayoutTests/http/tests/inspector/debugger/wasm/resources/named-module.py
+++ b/LayoutTests/http/tests/inspector/debugger/wasm/resources/named-module.py
@@ -1,12 +1,49 @@
 #!/usr/bin/env python3
 
 import base64
+import json
 import os
 import sys
 
 module = base64.b64decode(
     'AGFzbQEAAAABBwFgAn9/AX8DAgEABQMBAAEHEAIDYWRkAAAGbWVtb3J5AgAKCQEHACAAIAFqCwAaBG5hbWUAExJlbWJlZGRlZC1uYW1lLndhc20='
 )
+
+
+def encode_uleb128(value):
+    result = bytearray()
+    while True:
+        byte = value & 0x7f
+        value >>= 7
+        result.append(byte | (0x80 if value else 0))
+        if not value:
+            return result
+
+
+def append_string_custom_section(data, name, value):
+    name = name.encode()
+    value = value.encode()
+    payload = encode_uleb128(len(name)) + name + encode_uleb128(len(value)) + value
+    return data + b'\x00' + encode_uleb128(len(payload)) + payload
+
+
+if os.environ.get("QUERY_STRING", "") == "source-map":
+    source_map = {
+        "version": 3,
+        "file": "add.wasm",
+        "sources": ["add.wat"],
+        "sourcesContent": [
+            '(module\n'
+            '  (func (export "add") (param i32 i32) (result i32)\n'
+            '    local.get 0\n'
+            '    local.get 1\n'
+            '    i32.add))\n'
+        ],
+        "names": [],
+        "mappings": "iDAEA,EACA,EACA",
+    }
+    source_map_url = "data:application/json;base64," + base64.b64encode(json.dumps(source_map).encode()).decode()
+    module = append_string_custom_section(module, "sourceMappingURL", source_map_url)
 
 headers = b'Content-Type: application/wasm\r\n'
 if os.environ.get('QUERY_STRING') == 'memory-cache':

--- a/LayoutTests/http/tests/inspector/debugger/wasm/script-url-expected.txt
+++ b/LayoutTests/http/tests/inspector/debugger/wasm/script-url-expected.txt
@@ -43,6 +43,22 @@ PASS: The WebAssembly script should belong to the main frame.
 PASS: The associated Resource should belong to the main frame.
 PASS: The resource-backed WebAssembly script should not be an extra script.
 
+-- Running test case: WI.Script.URL.WebAssembly.StreamingSourceMap
+PASS: Should preserve the WebAssembly module's real URL.
+PASS: Should not expose the resource URL as a `sourceURL` directive.
+PASS: Should use the WebAssembly module's name section as the display name.
+PASS: Should associate the WebAssembly script with a Resource.
+PASS: Should associate the WebAssembly script with the resource for the module URL.
+PASS: The associated Resource should use the WebAssembly module's name section as its display name.
+PASS: The Resource should be associated with the WebAssembly script.
+PASS: The associated Resource should be treated as a script.
+PASS: The WebAssembly script should belong to the main frame.
+PASS: The associated Resource should belong to the main frame.
+PASS: The resource-backed WebAssembly script should not be an extra script.
+PASS: The WebAssembly script should own its source map.
+PASS: The associated Resource should expose the WebAssembly source map.
+PASS: The source map should retain the WebAssembly script as its generated source.
+
 -- Running test case: WI.Script.URL.WebAssembly.WorkerStreaming
 PASS: Should create a Worker target.
 PASS: The Worker's WebAssembly script should associate with a Resource.

--- a/LayoutTests/http/tests/inspector/debugger/wasm/script-url.html
+++ b/LayoutTests/http/tests/inspector/debugger/wasm/script-url.html
@@ -163,7 +163,14 @@ function test()
             functionName: "importWasmURL",
             query: "module-loader",
         },
-    ].forEach(function({name, description, functionName, query, redirect, scriptCount}) {
+        {
+            name: "StreamingSourceMap",
+            description: "A streamed WebAssembly module should keep its source map owned by the Script and exposed through the associated Resource.",
+            functionName: "instantiateWasmURL",
+            query: "source-map",
+            sourceMap: true,
+        },
+    ].forEach(function({name, description, functionName, query, redirect, scriptCount, sourceMap}) {
         suite.addTestCase({
             name: "WI.Script.URL.WebAssembly." + name,
             description,
@@ -190,6 +197,13 @@ function test()
                     let additionalScript = scripts[1];
                     InspectorTest.expectNull(additionalScript.resource, "Only one WebAssembly script should associate with a cloned Response's Resource.");
                     InspectorTest.expectTrue(WI.networkManager.mainFrame.extraScriptCollection.has(additionalScript), "The additional clone should remain visible as an extra script.");
+                }
+
+                if (sourceMap) {
+                    await retryUntil(() => script.sourceMaps.length);
+                    InspectorTest.expectEqual(script.sourceMaps.length, 1, "The WebAssembly script should own its source map.");
+                    InspectorTest.expectTrue(script.resource.sourceMaps.includes(script.sourceMaps[0]), "The associated Resource should expose the WebAssembly source map.");
+                    InspectorTest.expectEqual(script.sourceMaps[0].originalSourceCode, script, "The source map should retain the WebAssembly script as its generated source.");
                 }
 
                 if (name === "Streaming")

--- a/LayoutTests/inspector/debugger/wasm/resources/source-map.json
+++ b/LayoutTests/inspector/debugger/wasm/resources/source-map.json
@@ -1,0 +1,8 @@
+{
+    "version": 3,
+    "file": "add.wasm",
+    "sources": ["add.wat"],
+    "sourcesContent": ["(module\n  (func (export \"add\") (param i32 i32) (result i32)\n    local.get 0\n    local.get 1\n    i32.add))\n"],
+    "names": [],
+    "mappings": "iDAEA,EACA,EACA"
+}

--- a/LayoutTests/inspector/debugger/wasm/source-map-expected.txt
+++ b/LayoutTests/inspector/debugger/wasm/source-map-expected.txt
@@ -1,0 +1,34 @@
+Tests mapping WebAssembly module byte offsets to original source with source maps.
+
+
+== Running test suite: WI.Script.WebAssemblySourceMap
+-- Running test case: WI.Script.WebAssemblySourceMap.External
+PASS: The source map should be loaded.
+PASS: Original source locations should use the canonical WebAssembly line.
+PASS: Original source locations should preserve module byte offsets as columns.
+PASS: Canonical WebAssembly positions should map back to module byte offsets.
+PASS: The first parameter instruction should have an original location.
+PASS: Offset 49 should map to line 3.
+PASS: The original source should be add.wat.
+PASS: The add instruction should have an original location.
+PASS: Offset 53 should map to line 5.
+PASS: An instruction after a mapping should use the preceding mapping.
+PASS: Offset 54 should map to line 5.
+PASS: An uncovered module byte offset should remain in the generated source.
+
+-- Running test case: WI.Script.WebAssemblySourceMap.ContentLoad
+PASS: The location should use the canonical WebAssembly line.
+PASS: The location should preserve the module byte offset.
+PASS: The location should retain its original source.
+PASS: The location should retain its original line.
+PASS: Loading content should preserve the canonical WebAssembly line.
+PASS: Loading content should preserve the module byte offset.
+PASS: The canonical location should map to original source.
+PASS: Offset 53 should map to line 5.
+PASS: The original source should be add.wat.
+
+-- Running test case: WI.Script.WebAssemblySourceMap.Partial
+PASS: An instruction before the first mapping should remain in the generated source.
+PASS: A covered instruction should have an original location.
+PASS: Offset 53 should map to line 5.
+

--- a/LayoutTests/inspector/debugger/wasm/source-map.html
+++ b/LayoutTests/inspector/debugger/wasm/source-map.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function encodeULEB128(value)
+{
+    let bytes = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value)
+            byte |= 0x80;
+        bytes.push(byte);
+    } while (value);
+    return bytes;
+}
+
+function appendStringCustomSection(bytes, name, value)
+{
+    let encoder = new TextEncoder;
+    name = encoder.encode(name);
+    value = encoder.encode(value);
+    let payload = [...encodeULEB128(name.length), ...name, ...encodeULEB128(value.length), ...value];
+    return new Uint8Array([...bytes, 0, ...encodeULEB128(payload.length), ...payload]);
+}
+
+let wasmInstances = [];
+function instantiateWasmWithSourceMap(sourceMappingURL)
+{
+    let bytes = Uint8Array.from(atob("AGFzbQEAAAABBwFgAn9/AX8DAgEABQMBAAEHEAIDYWRkAAAGbWVtb3J5AgAKCQEHACAAIAFqCw=="), (character) => character.charCodeAt(0));
+    bytes = appendStringCustomSection(bytes, "sourceMappingURL", sourceMappingURL);
+    wasmInstances.push(new WebAssembly.Instance(new WebAssembly.Module(bytes)));
+}
+
+function test()
+{
+    async function createWasmScript(sourceMappingURL, shouldRequestContent = true)
+    {
+        let scriptPromise = Promise.withResolvers();
+        let listener = WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.ScriptAdded, (event) => {
+            let script = event.data.script;
+            if (script.sourceType !== WI.Script.SourceType.WebAssembly)
+                return;
+            WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.ScriptAdded, listener);
+            scriptPromise.resolve(script);
+        });
+
+        await InspectorTest.evaluateInPage(`instantiateWasmWithSourceMap(${JSON.stringify(sourceMappingURL)})`);
+        let script = await scriptPromise.promise;
+
+        if (!script.sourceMaps.length)
+            await script.awaitEvent(WI.SourceCode.Event.SourceMapAdded);
+        if (shouldRequestContent)
+            await script.requestContent();
+        return script;
+    }
+
+    let suite = InspectorTest.createAsyncSuite("WI.Script.WebAssemblySourceMap");
+
+    suite.addTestCase({
+        name: "WI.Script.WebAssemblySourceMap.External",
+        description: "A relative WebAssembly source map should resolve from the module URL and map module byte offsets to original source.",
+        async test() {
+            let script = await createWasmScript("resources/source-map.json");
+
+            InspectorTest.expectEqual(script.sourceMaps.length, 1, "The source map should be loaded.");
+
+            let sourceMapResource = script.sourceMaps[0].resources[0];
+            let originalLocations = [2, 3, 4].map((lineNumber) => sourceMapResource.createSourceCodeLocation(lineNumber, 0));
+            InspectorTest.expectTrue(originalLocations.every((location) => !location.lineNumber), "Original source locations should use the canonical WebAssembly line.");
+            InspectorTest.expectEqual(originalLocations.map((location) => location.columnNumber).join(", "), "49, 51, 53", "Original source locations should preserve module byte offsets as columns.");
+            InspectorTest.expectEqual(originalLocations.map((location) => script.bytecodeOffsetForPosition(location.lineNumber, location.columnNumber)).join(", "), "49, 51, 53", "Canonical WebAssembly positions should map back to module byte offsets.");
+
+            let firstParameter = script.createSourceCodeLocationForBytecodeOffset(49);
+            InspectorTest.expectTrue(firstParameter.hasMappedLocation(), "The first parameter instruction should have an original location.");
+            InspectorTest.expectEqual(firstParameter.displayLineNumber, 2, "Offset 49 should map to line 3.");
+            InspectorTest.expectEqual(firstParameter.displaySourceCode.displayName, "add.wat", "The original source should be add.wat.");
+
+            let add = script.createSourceCodeLocationForBytecodeOffset(53);
+            InspectorTest.expectTrue(add.hasMappedLocation(), "The add instruction should have an original location.");
+            InspectorTest.expectEqual(add.displayLineNumber, 4, "Offset 53 should map to line 5.");
+
+            let end = script.createSourceCodeLocationForBytecodeOffset(54);
+            InspectorTest.expectTrue(end.hasMappedLocation(), "An instruction after a mapping should use the preceding mapping.");
+            InspectorTest.expectEqual(end.displayLineNumber, 4, "Offset 54 should map to line 5.");
+
+            let moduleHeader = script.createSourceCodeLocation(0, 0);
+            InspectorTest.expectFalse(moduleHeader.hasMappedLocation(), "An uncovered module byte offset should remain in the generated source.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "WI.Script.WebAssemblySourceMap.ContentLoad",
+        description: "A source-mapped location should remain canonical when WebAssembly script content is loaded.",
+        async test() {
+            let script = await createWasmScript("resources/source-map.json?empty-content", false);
+            let sourceMapResource = script.sourceMaps[0].resources[0];
+            let add = sourceMapResource.createSourceCodeLocation(4, 0);
+
+            InspectorTest.expectEqual(add.lineNumber, 0, "The location should use the canonical WebAssembly line.");
+            InspectorTest.expectEqual(add.columnNumber, 53, "The location should preserve the module byte offset.");
+            InspectorTest.expectEqual(add.displaySourceCode, sourceMapResource, "The location should retain its original source.");
+            InspectorTest.expectEqual(add.displayLineNumber, 4, "The location should retain its original line.");
+
+            await script.requestContent();
+            InspectorTest.expectEqual(add.lineNumber, 0, "Loading content should preserve the canonical WebAssembly line.");
+            InspectorTest.expectEqual(add.columnNumber, 53, "Loading content should preserve the module byte offset.");
+            InspectorTest.expectTrue(add.hasMappedLocation(), "The canonical location should map to original source.");
+            InspectorTest.expectEqual(add.displayLineNumber, 4, "Offset 53 should map to line 5.");
+            InspectorTest.expectEqual(add.displaySourceCode.displayName, "add.wat", "The original source should be add.wat.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "WI.Script.WebAssemblySourceMap.Partial",
+        description: "A partial WebAssembly source map should leave uncovered module byte offsets in generated source.",
+        async test() {
+            let sourceMap = {
+                version: 3,
+                file: "add.wasm",
+                sources: ["add.wat"],
+                sourcesContent: ["(module\n  (func (export \"add\") (param i32 i32) (result i32)\n    local.get 0\n    local.get 1\n    i32.add))\n"],
+                names: [],
+                mappings: "qDAIA",
+            };
+            let sourceMappingURL = "data:application/json;base64," + btoa(JSON.stringify(sourceMap));
+            let script = await createWasmScript(sourceMappingURL);
+
+            let uncovered = script.createSourceCodeLocationForBytecodeOffset(49);
+            InspectorTest.expectFalse(uncovered.hasMappedLocation(), "An instruction before the first mapping should remain in the generated source.");
+
+            let covered = script.createSourceCodeLocationForBytecodeOffset(53);
+            InspectorTest.expectTrue(covered.hasMappedLocation(), "A covered instruction should have an original location.");
+            InspectorTest.expectEqual(covered.displayLineNumber, 4, "Offset 53 should map to line 5.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests mapping WebAssembly module byte offsets to original source with source maps.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/worker/debugger-getScriptSource-wasm-expected.txt
+++ b/LayoutTests/inspector/worker/debugger-getScriptSource-wasm-expected.txt
@@ -13,3 +13,9 @@ PASS: WebAssembly scripts should not expose source content.
 "inspector/worker/resources/<identifier>.wasm"
 PASS: WebAssembly scripts should not expose source content.
 
+-- Running test case: Worker.Debugger.WebAssembly.SourceMap
+"inspector/worker/resources/<identifier>.wasm"
+PASS: The add instruction should have an original location.
+PASS: Offset 53 should map to line 5.
+PASS: The original source should be add.wat.
+

--- a/LayoutTests/inspector/worker/debugger-getScriptSource-wasm.html
+++ b/LayoutTests/inspector/worker/debugger-getScriptSource-wasm.html
@@ -72,6 +72,28 @@ async function test()
         },
     });
 
+    suite.addTestCase({
+        name: "Worker.Debugger.WebAssembly.SourceMap",
+        description: "A WebAssembly module created in a Worker should map module byte offsets to original source.",
+        async test() {
+            let ignoredScripts = new Set(WI.debuggerManager.dataForTarget(workerTarget).scripts);
+            let [script] = await Promise.all([
+                awaitWasmScript(workerTarget, ignoredScripts),
+                InspectorTest.evaluateInPage("worker.postMessage('instantiate-source-map')"),
+            ]);
+            InspectorTest.assert(script.target === workerTarget, "Should belong to the Worker target.");
+            InspectorTest.assert(script.sourceType === WI.Script.SourceType.WebAssembly, "Should be WebAssembly.");
+            InspectorTest.log(JSON.stringify(sanitizeWasmURL(script.url)));
+
+            if (!script.sourceMaps.length)
+                await script.awaitEvent(WI.SourceCode.Event.SourceMapAdded);
+
+            let location = script.createSourceCodeLocationForBytecodeOffset(53);
+            InspectorTest.expectTrue(location.hasMappedLocation(), "The add instruction should have an original location.");
+            InspectorTest.expectEqual(location.displayLineNumber, 4, "Offset 53 should map to line 5.");
+            InspectorTest.expectEqual(location.displaySourceCode.displayName, "add.wat", "The original source should be add.wat.");
+        },
+    });
     suite.runTestCasesAndFinish();
 }
 </script>

--- a/LayoutTests/inspector/worker/resources/worker-debugger-wasm.js
+++ b/LayoutTests/inspector/worker/resources/worker-debugger-wasm.js
@@ -3,6 +3,28 @@ importScripts("../../../resources/wasm-builder.js", "../../debugger/wasm/resourc
 let wasmBytes = createAddWasmBytes();
 let wasmInstances = [];
 
+function encodeULEB128(value)
+{
+    let bytes = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value)
+            byte |= 0x80;
+        bytes.push(byte);
+    } while (value);
+    return bytes;
+}
+
+function appendStringCustomSection(bytes, name, value)
+{
+    let encoder = new TextEncoder;
+    name = encoder.encode(name);
+    value = encoder.encode(value);
+    let payload = [...encodeULEB128(name.length), ...name, ...encodeULEB128(value.length), ...value];
+    return new Uint8Array([...bytes, 0, ...encodeULEB128(payload.length), ...payload]);
+}
+
 function instantiateWasm(bytes)
 {
     let wasmModule = new WebAssembly.Module(bytes);
@@ -13,5 +35,7 @@ instantiateWasm(wasmBytes);
 addEventListener("message", ({data}) => {
     if (data === "instantiate")
         instantiateWasm(wasmBytes);
+    else if (data === "instantiate-source-map")
+        instantiateWasm(appendStringCustomSection(wasmBytes, "sourceMappingURL", "../../debugger/wasm/resources/source-map.json"));
 });
 postMessage("ready");

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -456,6 +456,7 @@ void Debugger::sourceParsed(JSGlobalObject* globalObject, JSWebAssemblyModule* m
     script.url = sourceProvider->sourceURL();
     script.displayName = Wasm::makeString(info->nameSection().moduleName);
     script.requestIdentifier = info->requestIdentifier;
+    script.sourceMappingURL = Wasm::makeString(info->sourceMappingURL);
     script.sourceProvider = WTF::move(sourceProvider);
     script.isContentScript = isContentScript(globalObject);
 

--- a/Source/WebInspectorUI/UserInterface/Models/Script.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Script.js
@@ -86,7 +86,7 @@ WI.Script = class Script extends WI.SourceCode
         if (sourceCode instanceof WI.Script)
             return sourceCode.sourceType === WI.Script.SourceType.WebAssembly;
 
-        return sourceCode instanceof WI.Resource && (sourceCode.mimeTypeComponents.type === "application/wasm" || sourceCode.scripts.some((script) => WI.Script.isWebAssembly(script)));
+        return sourceCode instanceof WI.Resource && (sourceCode.mimeTypeComponents.type === "application/wasm" || sourceCode.scripts.some((script) => script.sourceType === WI.Script.SourceType.WebAssembly));
     }
 
     // Public
@@ -262,6 +262,35 @@ WI.Script = class Script extends WI.SourceCode
         }
 
         return this._target.DebuggerAgent.getScriptSource(this._id);
+    }
+
+    createSourceCodeLocationForBytecodeOffset(bytecodeOffset)
+    {
+        return this.createSourceCodeLocation(0, bytecodeOffset);
+    }
+
+    createSourceMapSourceCodeLocation(lineNumber, columnNumber)
+    {
+        if (this._sourceType === WI.Script.SourceType.WebAssembly) {
+            console.assert(!lineNumber);
+            return this.createSourceCodeLocationForBytecodeOffset(columnNumber);
+        }
+
+        return super.createSourceMapSourceCodeLocation(lineNumber, columnNumber);
+    }
+
+    bytecodeOffsetForPosition(lineNumber, columnNumber)
+    {
+        console.assert(!lineNumber, lineNumber, columnNumber);
+        return columnNumber;
+    }
+
+    createSourceMapPosition(lineNumber, columnNumber)
+    {
+        if (this._sourceType === WI.Script.SourceType.WebAssembly)
+            return new WI.SourceCodePosition(0, this.bytecodeOffsetForPosition(lineNumber, columnNumber));
+
+        return super.createSourceMapPosition(lineNumber, columnNumber);
     }
 
     saveIdentityToCookie(cookie)

--- a/Source/WebInspectorUI/UserInterface/Models/SourceCode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceCode.js
@@ -201,6 +201,18 @@ WI.SourceCode = class SourceCode extends WI.Object
         return new WI.SourceCodeTextRange(this, textRange);
     }
 
+    createSourceMapSourceCodeLocation(lineNumber, columnNumber)
+    {
+        // Overridden by subclasses if needed.
+        return this.createSourceCodeLocation(lineNumber, columnNumber);
+    }
+
+    createSourceMapPosition(lineNumber, columnNumber)
+    {
+        // Overridden by subclasses if needed.
+        return new WI.SourceCodePosition(lineNumber, columnNumber);
+    }
+
     // Protected
 
     revisionContentDidChange(revision)

--- a/Source/WebInspectorUI/UserInterface/Models/SourceCodeLocation.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceCodeLocation.js
@@ -310,8 +310,9 @@ WI.SourceCodeLocation = class SourceCodeLocation extends WI.Object
         if (!this._sourceCode)
             return;
 
+        let sourceMapPosition = this._sourceCode.createSourceMapPosition(this._lineNumber, this._columnNumber);
         for (let sourceMap of this._sourceCode.sourceMaps) {
-            let originalPosition = sourceMap.findOriginalPosition(this._lineNumber, this._columnNumber);
+            let originalPosition = sourceMap.findOriginalPosition(sourceMapPosition.lineNumber, sourceMapPosition.columnNumber);
             if (originalPosition) {
                 [this._mappedResource, this._mappedLineNumber, this._mappedColumnNumber] = originalPosition;
                 break;

--- a/Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js
@@ -192,7 +192,7 @@ WI.SourceMapResource = class SourceMapResource extends WI.Resource
         }
 
         // Create the SourceCodeLocation and since we already know the the mapped location set it directly.
-        let location = originalSourceCode.createSourceCodeLocation(generatedLine, generatedColumn);
+        let location = originalSourceCode.createSourceMapSourceCodeLocation(generatedLine, generatedColumn);
         location._setMappedLocation(this, lineNumber, columnNumber);
         return location;
     }


### PR DESCRIPTION
#### 1a7f711d887ed01907e9f8d1d61710c543f967ac
<pre>
Web Inspector: map WebAssembly byte offsets to original source with source maps
<a href="https://bugs.webkit.org/show_bug.cgi?id=320621">https://bugs.webkit.org/show_bug.cgi?id=320621</a>

Reviewed by Yusuke Suzuki.

WebAssembly source maps use module byte offsets as generated columns on line `0`.
Preserve canonical `(0, byteOffset)` positions without requiring generated source content or a disassembly.

* Source/JavaScriptCore/debugger/Debugger.cpp:
(JSC::Debugger::sourceParsed):
Report the WebAssembly module&apos;s `sourceMappingURL` to Inspector.

* Source/WebInspectorUI/UserInterface/Models/Script.js:
(WI.Script.isWebAssembly):
Check known `WI.Script` instances directly by source type.
(WI.Script.prototype.createSourceCodeLocationForBytecodeOffset): Added.
(WI.Script.prototype.createSourceMapSourceCodeLocation): Added.
(WI.Script.prototype.bytecodeOffsetForPosition): Added.
(WI.Script.prototype.createSourceMapPosition): Added.
* Source/WebInspectorUI/UserInterface/Models/SourceCode.js:
(WI.SourceCode.prototype.createSourceMapSourceCodeLocation): Added.
(WI.SourceCode.prototype.createSourceMapPosition): Added.
Represent WebAssembly module byte offsets as canonical `(0, byteOffset)` source code positions and convert them to and from source map positions.

* Source/WebInspectorUI/UserInterface/Models/SourceCodeLocation.js:
(WI.SourceCodeLocation.prototype.resolveMappedLocation):
* Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js:
(WI.SourceMapResource.prototype.createSourceCodeLocation):
Convert raw locations to source map positions before resolving mappings, and convert generated source map positions back to raw locations.

* LayoutTests/http/tests/inspector/debugger/wasm/resources/named-module.py:
* LayoutTests/http/tests/inspector/debugger/wasm/script-url.html:
* LayoutTests/http/tests/inspector/debugger/wasm/script-url-expected.txt:
* LayoutTests/inspector/debugger/wasm/resources/source-map.json: Added.
* LayoutTests/inspector/debugger/wasm/source-map.html: Added.
* LayoutTests/inspector/debugger/wasm/source-map-expected.txt: Added.
* LayoutTests/inspector/worker/resources/worker-debugger-wasm.js:
* LayoutTests/inspector/worker/debugger-getScriptSource-wasm.html:
* LayoutTests/inspector/worker/debugger-getScriptSource-wasm-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318546@main">https://commits.webkit.org/318546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d463138cecb665d8d2ab0589609620180fb3bae4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187370 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141008 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138557 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96348 "3 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119020 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40744 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39106 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/989 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7799 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38799 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35832 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39032 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189798 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147675 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39854 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52048 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147461 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42174 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124263 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118727 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50556 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13776 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49952 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50192 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->