### PR TITLE
[css-anchor-position] Refactor how position-anchor: none and normal work

### DIFF
--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -813,12 +813,14 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::findAnchorForAnchorFun
     }).iterator->value.get();
 
     auto scopedAnchorName = [&] {
-        if (anchorNameArgument)
-            return *anchorNameArgument;
-        return defaultAnchorName(style);
-    };
+        if (!anchorNameArgument)
+            return defaultAnchorName(style);
+        return anchorNameArgument;
+    }();
+    if (!scopedAnchorName)
+        return { };
 
-    auto resolvedAnchorName = ResolvedScopedName::createFromScopedName(protect(styleable.element), scopedAnchorName());
+    auto resolvedAnchorName = ResolvedScopedName::createFromScopedName(protect(styleable.element), *scopedAnchorName);
 
     // Collect anchor names that this element refers to in anchor() or anchor-size()
     bool isNewAnchorName = anchorPositionedState.anchorNames.add(resolvedAnchorName).isNewEntry;
@@ -1262,17 +1264,11 @@ static AnchorsForAnchorName collectAnchorsForAnchorName(const Document& document
     return anchorsForAnchorName;
 }
 
-static AnchorElements findAnchorsForAnchorPositionedElement(const Styleable& anchorPositioned, const Style::ComputedStyle& anchorPositionedStyle, const HashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName& anchorsForAnchorName)
+static AnchorElements findAnchorsForAnchorPositionedElement(const Styleable& anchorPositioned, const HashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName& anchorsForAnchorName)
 {
     AnchorElements anchorElements;
 
     for (auto& anchorName : anchorNames) {
-        auto isImplicitAnchorName = anchorName.name() == implicitAnchorElementName().name;
-        auto isDefaultAnchorNone = anchorPositionedStyle.positionAnchor().isNone()
-            || (anchorPositionedStyle.positionAnchor().isNormal() && anchorPositionedStyle.positionArea().isNone());
-        if (isImplicitAnchorName && isDefaultAnchorNone)
-            continue;
-
         auto anchor = findLastAcceptableAnchorWithName(anchorName, anchorPositioned, anchorsForAnchorName);
         anchorElements.add(anchorName, anchor);
     }
@@ -1301,7 +1297,7 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
         case AnchorPositionResolutionStage::FindAnchors: {
             if (renderer) {
                 // FIXME: Remove the redundant anchorElements member. The mappings are available in anchorPositionedToAnchorMap.
-                state->anchorElements = findAnchorsForAnchorPositionedElement(*anchorPositioned, renderer->style(), state->anchorNames, anchorsForAnchorName);
+                state->anchorElements = findAnchorsForAnchorPositionedElement(*anchorPositioned, state->anchorNames, anchorsForAnchorName);
                 if (isLayoutTimeAnchorPositioned(renderer->style()))
                     renderer->setNeedsLayout();
 
@@ -1413,12 +1409,14 @@ void AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPosi
     }).iterator->value.get();
 
     if (shouldResolveDefaultAnchor) {
-        // Always resolve the default anchor. Even if nothing is anchored to it we need it to compute the scroll compensation.
-        auto resolvedDefaultAnchor = ResolvedScopedName::createFromScopedName(element, defaultAnchorName(style));
-        if (state.anchorNames.add(resolvedDefaultAnchor).isNewEntry) {
-            // If anchor resolution has progressed past FindAnchors, and we pick up a new anchor name, set the
-            // stage back to FindAnchors. This restarts the resolution process to resolve newly added names.
-            state.stage = AnchorPositionResolutionStage::FindAnchors;
+        if (auto anchorName = defaultAnchorName(style)) {
+            // Always resolve the default anchor. Even if nothing is anchored to it we need it to compute the scroll compensation.
+            auto resolvedDefaultAnchor = ResolvedScopedName::createFromScopedName(element, *anchorName);
+            if (state.anchorNames.add(resolvedDefaultAnchor).isNewEntry) {
+                // If anchor resolution has progressed past FindAnchors, and we pick up a new anchor name, set the
+                // stage back to FindAnchors. This restarts the resolution process to resolve newly added names.
+                state.stage = AnchorPositionResolutionStage::FindAnchors;
+            }
         }
     }
 }
@@ -1755,10 +1753,18 @@ bool AnchorPositionEvaluator::isImplicitAnchor(const Style::ComputedStyle& style
     return isImplicitAnchorForPseudoElement(PseudoElementType::Before) || isImplicitAnchorForPseudoElement(PseudoElementType::After);
 }
 
-ScopedName AnchorPositionEvaluator::defaultAnchorName(const Style::ComputedStyle& style)
+std::optional<ScopedName> AnchorPositionEvaluator::defaultAnchorName(const Style::ComputedStyle& style)
 {
-    if (auto name = style.positionAnchor().tryName())
+    const auto& positionAnchor = style.positionAnchor();
+
+    bool doesNotHaveDefaultAnchor = positionAnchor.isNone() || (positionAnchor.isNormal() && style.positionArea().isNone());
+    if (doesNotHaveDefaultAnchor)
+        return std::nullopt;
+
+    if (auto name = positionAnchor.tryName())
         return *name;
+
+    ASSERT(positionAnchor.isAuto() || (positionAnchor.isNormal() && !style.positionArea().isNone()));
     return implicitAnchorElementName();
 }
 
@@ -1780,10 +1786,14 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::defaultAnchorForBox(co
     if (!anchors.allAnchorsPositioned)
         return nullptr;
 
-    auto anchorName = ResolvedScopedName::createFromScopedName(protect(styleable->element), defaultAnchorName(box.style()));
+    auto anchorName = defaultAnchorName(box.style());
+    if (!anchorName)
+        return nullptr;
+
+    auto resolvedAnchorName = ResolvedScopedName::createFromScopedName(protect(styleable->element), *anchorName);
 
     for (auto& anchor : anchors.anchors) {
-        if (anchorName == anchor.name)
+        if (resolvedAnchorName == anchor.name)
             return anchor.renderer.get();
     }
     return nullptr;

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -221,7 +221,11 @@ public:
     static bool overflowsInsetModifiedContainingBlock(const RenderBox& anchoredBox);
     static bool isDefaultAnchorInvisibleOrClippedByInterveningBoxes(const RenderBox& anchoredBox);
 
-    static ScopedName defaultAnchorName(const Style::ComputedStyle&);
+    // Given a style, determine the name of the default anchor. If it has a default anchor,
+    // return the name (either an explicit name, or the name of the implicit anchor).
+    // Otherwise, it doesn't have a default anchor, and returns std::nullopt.
+    static std::optional<ScopedName> defaultAnchorName(const Style::ComputedStyle&);
+
     static bool isAnchor(const Style::ComputedStyle&);
     static bool isImplicitAnchor(const Style::ComputedStyle&);
 


### PR DESCRIPTION
#### c2a26696cc420b4c9c925cdf6b1a2afa122dc9a8
<pre>
[css-anchor-position] Refactor how position-anchor: none and normal work
<a href="https://rdar.apple.com/183590606">rdar://183590606</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320625">https://bugs.webkit.org/show_bug.cgi?id=320625</a>

Reviewed by Antti Koivisto.

position-anchor: none makes an element not have a default anchor, while
position-anchor: normal gives it a default anchor (the implicit anchor)
if it uses position-area.

A natural place to implement this is AnchorPositionEvaluator::defaultAnchorName,
which determines the name of the default anchor name. Instead, the current code
doesn&apos;t touch defaultAnchorName at all - elements that should not have a default
anchor are still given the implicit anchor as the default anchor. Then, in
findAnchorForAnchorFunctionAndAttemptResolution, we reject resolving the implicit
anchor if the element shouldn&apos;t have a default anchor.

This patch moves the implementation to defaultAnchorName - it now returns std::nullopt
if the element doesn&apos;t have a default anchor. Its callers got fixed up to deal with
it returning std::nullopt.

Refactoring, tested by existing test suite.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):
(WebCore::Style::findAnchorsForAnchorPositionedElement):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPositionVisibility):
(WebCore::Style::AnchorPositionEvaluator::defaultAnchorName):
(WebCore::Style::AnchorPositionEvaluator::defaultAnchorForBox):
* Source/WebCore/style/AnchorPositionEvaluator.h:

Canonical link: <a href="https://commits.webkit.org/318823@main">https://commits.webkit.org/318823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bed27fa12f185e3f8e19de5d46bb2beb1a3f4072

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141042 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74714748-fd25-4c15-94a7-3ce1fac5dd5c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138581 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96353 "1 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119044 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c96879d1-a1fd-4e33-9fc8-c5001092252e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40776 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39134 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.MultiProcessBFCacheSameSiteWithCrossSiteIframeMultipleCycles (failure)") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151181 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38835 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189834 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51400 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147704 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40015 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52082 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147490 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42203 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124334 "Found 14 new failures in UIProcess/API/Cocoa/WKBackForwardList.mm, wasm/WasmConstExprGenerator.cpp, UIProcess/mac/ViewGestureControllerMac.mm, UIProcess/WebPageProxy.cpp, Platform/IPC/HandleMessage.h, UIProcess/WebBackForwardList.cpp, UIProcess/API/C/WKBackForwardListRef.cpp, UIProcess/RemotePageProxy.cpp, UIProcess/ProvisionalPageProxy.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118763 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50590 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13814 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49986 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50048 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->