### PR TITLE
Reduce sizeof(SelectorFragment) by eliminating struct padding in the CSS JIT

### DIFF
--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -324,7 +324,7 @@ static bool NODELETE shouldDumpCSSJITDisassembly()
     return JSC::Options::dumpDisassembly() || JSC::Options::dumpCSSJITDisassembly();
 }
 
-enum class BacktrackingAction {
+enum class BacktrackingAction : uint8_t {
     NoBacktracking,
     JumpToDescendantEntryPoint,
     JumpToIndirectAdjacentEntryPoint,
@@ -347,7 +347,7 @@ struct BacktrackingFlag {
     };
 };
 
-enum class FragmentRelation {
+enum class FragmentRelation : uint8_t {
     Rightmost,
     Descendant,
     Child,
@@ -362,7 +362,7 @@ enum class FunctionType {
     CannotCompile
 };
 
-enum class FragmentPositionInRootFragments {
+enum class FragmentPositionInRootFragments : uint8_t {
     Rightmost,
     AdjacentToRightmost,
     Other
@@ -449,6 +449,22 @@ struct SelectorFragment {
     BacktrackingAction matchingTagNameBacktrackingAction = BacktrackingAction::NoBacktracking;
     BacktrackingAction matchingPostTagNameBacktrackingAction = BacktrackingAction::NoBacktracking;
     unsigned char backtrackingFlags = 0;
+
+    bool matchesHasScope { false };
+
+    // For quirks mode, follow this: http://quirks.spec.whatwg.org/#the-:active-and-:hover-quirk
+    // In quirks mode, a compound selector 'selector' that matches the following conditions must not match elements that would not also match the ':any-link' selector.
+    //
+    //    selector uses the ':active' or ':hover' pseudo-classes.
+    //    selector does not use a type selector.
+    //    selector does not use an attribute selector.
+    //    selector does not use an ID selector.
+    //    selector does not use a class selector.
+    //    selector does not use a pseudo-class selector other than ':active' and ':hover'.
+    //    selector does not use a pseudo-element selector.
+    //    selector is not part of an argument to a functional pseudo-class or pseudo-element.
+    bool onlyMatchesLinksInQuirksMode = true;
+
     unsigned tagNameMatchedBacktrackingStartHeightFromDescendant = invalidHeight;
     unsigned tagNameNotMatchedBacktrackingStartHeightFromDescendant = invalidHeight;
     unsigned heightFromDescendant = 0;
@@ -475,21 +491,6 @@ struct SelectorFragment {
     Vector<SelectorList> matchesFilters;
     Vector<Vector<SelectorFragment>> anyFilters;
     const CSSSelector* pseudoElementSelector = nullptr;
-
-    bool matchesHasScope { false };
-
-    // For quirks mode, follow this: http://quirks.spec.whatwg.org/#the-:active-and-:hover-quirk
-    // In quirks mode, a compound selector 'selector' that matches the following conditions must not match elements that would not also match the ':any-link' selector.
-    //
-    //    selector uses the ':active' or ':hover' pseudo-classes.
-    //    selector does not use a type selector.
-    //    selector does not use an attribute selector.
-    //    selector does not use an ID selector.
-    //    selector does not use a class selector.
-    //    selector does not use a pseudo-class selector other than ':active' and ':hover'.
-    //    selector does not use a pseudo-element selector.
-    //    selector is not part of an argument to a functional pseudo-class or pseudo-element.
-    bool onlyMatchesLinksInQuirksMode = true;
 };
 
 class SelectorFragmentList : public Vector<SelectorFragment, 4> {


### PR DESCRIPTION
#### 08d31de09e2b120d1bb2a2bb9abe97c6f3802c13
<pre>
Reduce sizeof(SelectorFragment) by eliminating struct padding in the CSS JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=320628">https://bugs.webkit.org/show_bug.cgi?id=320628</a>
<a href="https://rdar.apple.com/183591712">rdar://183591712</a>

Reviewed by Chris Dumez.

SelectorFragment had 12 bytes of padding holes on 64-bit: 3 bytes after
isRightmostOrAdjacent, 3 bytes after backtrackingFlags, and 6 bytes of tail
padding after the two trailing bools.

Give BacktrackingAction, FragmentRelation and FragmentPositionInRootFragments
an explicit uint8_t underlying type, and move matchesHasScope and
onlyMatchesLinksInQuirksMode up beside the other byte-sized members so all ten
of them pack contiguously into offsets 0-9. This moves the first pointer member
from offset 56 down to 40 and takes sizeof(SelectorFragment) from 528 to 504,
leaving only the 2 bytes of alignment padding before the first unsigned.

These three enums are used only within SelectorCompiler.cpp for bookkeeping
during compilation; none of them are encoded into the generated code, so
narrowing them has no effect on the emitted JIT code.

SelectorFragmentList is a Vector&lt;SelectorFragment, 4&gt;, so its inline (stack)
storage shrinks from 2144 to 2048 bytes. That saving compounds while compiling
nested functional pseudo-classes, where notFilters, matchesFilters and the
nthChildOf filter lists nest SelectorFragmentLists recursively. See the
existing FIXME about the inline capacity in this struct.

No change in behavior.

* Source/WebCore/cssjit/SelectorCompiler.cpp:

Canonical link: <a href="https://commits.webkit.org/318247@main">https://commits.webkit.org/318247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0079f2d3c41b9facdba5c75eda860f99d86a7c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187309 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/855a4abf-17e6-450a-8207-f41c8c20b46d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51351 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138549 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35c5d135-3c1c-4cea-834f-28f1037b1c47) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118975 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8f27451f-3486-459e-b868-4fa6079a2650) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40688 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39052 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38742 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35775 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189740 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51309 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147623 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39666 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51991 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147409 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42120 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124206 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118626 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50499 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13719 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49895 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50135 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->