### PR TITLE
MediaSessionManagerInterface::sessionWillEndPlayback reorders a copy of the session set

### DIFF
--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -590,7 +590,7 @@ void MediaSessionManagerInterface::sessionWillEndPlayback(PlatformMediaSessionIn
     MEDIASESSIONMANAGERINTERFACE_RELEASE_LOG(SessionWillEndPlayback, pausingSession.logIdentifier());
 #endif
 
-    auto sessions = this->sessions();
+    auto& sessions = this->sessions();
     auto sessionCount = sessions.computeSize();
     if (sessionCount < 2)
         return;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -255,6 +255,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/PathTests.cpp
         Tests/WebCore/PixelBufferConversionTests.cpp
         Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
+        Tests/WebCore/PlatformMediaSessionManagerTests.cpp
         Tests/WebCore/PublicSuffix.cpp
         Tests/WebCore/RegionTests.cpp
         Tests/WebCore/RenderStyleChange.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -788,6 +788,7 @@
 				WebCore/PixelBufferConversionTests.cpp,
 				WebCore/PlatformCAAnimationKeyPath.cpp,
 				WebCore/PlatformDynamicRangeLimitTests.cpp,
+				WebCore/PlatformMediaSessionManagerTests.cpp,
 				WebCore/PODIntervalTree.cpp,
 				WebCore/PrivateClickMeasurement.cpp,
 				WebCore/PublicSuffix.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/PlatformMediaSessionManagerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PlatformMediaSessionManagerTests.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/PlatformMediaSession.h>
+#include <WebCore/PlatformMediaSessionManager.h>
+#include <wtf/Logger.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace TestWebKitAPI {
+using namespace WebCore;
+
+class TestMediaSessionManager final : public PlatformMediaSessionManager {
+public:
+    static Ref<TestMediaSessionManager> create() { return adoptRef(*new TestMediaSessionManager()); }
+
+    using PlatformMediaSessionManager::currentSession;
+
+private:
+    TestMediaSessionManager()
+        : PlatformMediaSessionManager(std::nullopt)
+    {
+    }
+};
+
+class TestMediaSessionClient final : public PlatformMediaSessionClient {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(TestMediaSessionClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TestMediaSessionClient);
+public:
+    explicit TestMediaSessionClient(MediaSessionManagerInterface& manager)
+        : m_manager(manager)
+    {
+    }
+
+    RefPtr<MediaSessionManagerInterface> sessionManager() const final { return m_manager.ptr(); }
+
+    PlatformMediaSessionMediaType mediaType() const final { return PlatformMediaSessionMediaType::Video; }
+    PlatformMediaSessionMediaType presentationType() const final { return PlatformMediaSessionMediaType::Video; }
+
+    void mayResumePlayback(bool) final { }
+    void suspendPlayback() final { }
+
+    bool canReceiveRemoteControlCommands() const final { return false; }
+    void didReceiveRemoteControlCommand(PlatformMediaSessionRemoteControlCommandType, const PlatformMediaSessionRemoteCommandArgument&) final { }
+    bool supportsSeeking() const final { return false; }
+
+    bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSessionInterruptionType) const final { return false; }
+
+    std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const final { return std::nullopt; }
+
+#if !RELEASE_LOG_DISABLED
+    const Logger& logger() const final { return m_logger.get(); }
+    uint64_t logIdentifier() const final { return 0; }
+#endif
+
+private:
+    Ref<MediaSessionManagerInterface> m_manager;
+#if !RELEASE_LOG_DISABLED
+    const Ref<Logger> m_logger { Logger::create(this) };
+#endif
+};
+
+TEST(PlatformMediaSessionManager, PausingFrontSessionDemotesItInCurrentSession)
+{
+    auto manager = TestMediaSessionManager::create();
+
+    auto clientA = makeUnique<TestMediaSessionClient>(manager.get());
+    auto clientB = makeUnique<TestMediaSessionClient>(manager.get());
+
+    auto sessionA = PlatformMediaSession::create(*clientA);
+    auto sessionB = PlatformMediaSession::create(*clientB);
+
+    // setActive(true) registers the session with the manager (appended), giving
+    // the order [A, B]. Both are playing.
+    sessionA->setActive(true);
+    sessionB->setActive(true);
+    sessionA->setState(PlatformMediaSession::State::Playing);
+    sessionB->setState(PlatformMediaSession::State::Playing);
+
+    EXPECT_EQ(manager->currentSession().get(), static_cast<PlatformMediaSessionInterface*>(sessionA.ptr()));
+
+    // A pauses. Since no other session is paused, A must be moved to the back,
+    // so B becomes the current session.
+    manager->sessionWillEndPlayback(sessionA.get(), DelayCallingUpdateNowPlaying::No);
+
+    // With the bug, the reorder hits a copy and currentSession() is still A.
+    EXPECT_EQ(manager->currentSession().get(), static_cast<PlatformMediaSessionInterface*>(sessionB.ptr()));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### d058de4fcb0ca270323b9bd0d7a066646928175f
<pre>
MediaSessionManagerInterface::sessionWillEndPlayback reorders a copy of the session set
<a href="https://bugs.webkit.org/show_bug.cgi?id=320629">https://bugs.webkit.org/show_bug.cgi?id=320629</a>

Reviewed by Eric Carlson.

sessionWillEndPlayback() intends to demote the just-paused session behind the
first already-paused session (or to the end of the list) so that the front of
m_sessions keeps pointing at a still-playing session. It did this via:
```
      auto sessions = this-&gt;sessions();
```
sessions() returns WeakListHashSet&lt;PlatformMediaSessionInterface&gt;&amp;, but the
missing reference means auto deduces a value and copies the set. The subsequent
remove()/insertBefore()/appendOrMoveToLast() calls therefore mutate a throwaway
copy, and the live m_sessions ordering is never updated. As a result
currentSession() (which returns m_sessions.first()) can keep returning the
session that just paused instead of the one that should take over, which in turn
feeds the wrong value into computeSupportsSeeking() and the now-playing / remote
command routing that depend on session order.

Fix it by taking a reference to the live set, and add an API test covering the
ordering after a pause.

Test: Tools/TestWebKitAPI/Tests/WebCore/PlatformMediaSessionManagerTests.cpp

* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::sessionWillEndPlayback):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/PlatformMediaSessionManagerTests.cpp: Added.
(TestWebKitAPI::TEST(PlatformMediaSessionManager, PausingFrontSessionDemotesItInCurrentSession)):

Canonical link: <a href="https://commits.webkit.org/318276@main">https://commits.webkit.org/318276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/531a24dd32ef8840003349f1f722c3115859fd6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187327 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18cdeba1-a0ad-4896-856d-5422263f0153) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138519 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb7c1b2f-0e21-493a-a562-8f301d2c1330) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118983 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b32864a-35fc-4dc5-8a63-d1091ce1f975) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40693 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39056 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38748 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35779 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189757 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51313 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147635 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39681 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51995 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35376 "Too many flaky failures: http/tests/media/media-element-frame-destroyed-crash.html, http/tests/misc/slow-preload-cancel.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/policy-does-not-affect-child.html, http/tests/security/mixedContent/redirect-https-to-http-image-secure-cookies-UpgradeMixedContent.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html, http/tests/websocket/tests/hybi/contentextensions/block-worker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147421 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42125 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124210 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118633 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50503 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13725 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49899 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50139 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49961 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->