### PR TITLE
[PDF] Don't show system actions in Recovery mode for the alternate PDF HUD view

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
@@ -28,15 +28,10 @@ public import Foundation
 import WebKit_Internal
 @_weakLinked @_spi(Private) import SwiftUI
 
-// FIXME: Add localizable strings support.
-// FIXME: Implement `WKAlternatePDFHUDView.show`.
-// FIXME: Figure out the final design.
-
-private let barVerticalOffset: CGFloat = 40
-
 private struct Controls: View {
     private static let autoHideDelay: Duration = .seconds(3)
 
+    let showSystemActions: Bool
     let action: (WKPDFHUDViewControlAction) -> Void
 
     @State
@@ -59,18 +54,20 @@ private struct Controls: View {
                 action(.zoomIn)
             }
 
-            Button {
-                action(.openInPreview)
-            } label: {
-                Label {
-                    Text("Open in Preview")
-                } icon: {
-                    Image(_internalSystemName: "preview")
+            if showSystemActions {
+                Button {
+                    action(.openInPreview)
+                } label: {
+                    Label {
+                        Text("Open in Preview")
+                    } icon: {
+                        Image(_internalSystemName: "preview")
+                    }
                 }
-            }
 
-            Button("Save PDF", systemImage: "arrow.down.circle") {
-                action(.savePDF)
+                Button("Save PDF", systemImage: "arrow.down.circle") {
+                    action(.savePDF)
+                }
             }
         }
         .labelStyle(.iconOnly)
@@ -93,6 +90,8 @@ private struct Controls: View {
 @objc
 @implementation
 extension WKAlternatePDFHUDView {
+    private static let barVerticalOffset: CGFloat = 40
+
     let frameIdentifier: UInt64
 
     init(
@@ -105,14 +104,14 @@ extension WKAlternatePDFHUDView {
 
         super.init(frame: frame)
 
-        let controls = Controls(action: actionHandler)
+        let controls = Controls(showSystemActions: !isInRecoveryOS(), action: actionHandler)
 
         let hostingView = NSHostingView(rootView: controls)
         hostingView.translatesAutoresizingMaskIntoConstraints = false
 
         addSubview(hostingView)
         hostingView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
-        hostingView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -barVerticalOffset).isActive = true
+        hostingView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Self.barVerticalOffset).isActive = true
     }
 
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -123,6 +122,7 @@ extension WKAlternatePDFHUDView {
     }
 
     func show() {
+        // FIXME: Implement `WKAlternatePDFHUDView.show`.
     }
 }
 

--- a/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift
@@ -51,7 +51,7 @@ private let autoHideDelay: TimeInterval = 3.0
 private let hoverInset: CGFloat = -16.0
 
 // FIXME: (rdar://164559261) understand/document/remove unsafety
-private func isInRecoveryOS() -> Bool {
+func isInRecoveryOS() -> Bool {
     unsafe os_variant_is_basesystem("WebKit")
 }
 


### PR DESCRIPTION
#### 46aeab80f4bcd0d83874adb1f6e4016411aea623
<pre>
[PDF] Don&apos;t show system actions in Recovery mode for the alternate PDF HUD view
<a href="https://bugs.webkit.org/show_bug.cgi?id=320631">https://bugs.webkit.org/show_bug.cgi?id=320631</a>
<a href="https://rdar.apple.com/183594766">rdar://183594766</a>

Reviewed by Abrar Rahman Protyasha.

Mimic the behavior of WKDefaultPDFHUDView.

* Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift:
(Controls.body):
(WKAlternatePDFHUDView.show):
* Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift:
(isInRecoveryOS):

Canonical link: <a href="https://commits.webkit.org/318265@main">https://commits.webkit.org/318265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbcd5736b033ae1ca6b806836a851b59e9369cfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45443 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187316 "") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e47c81ac-a0d5-4d15-892b-f8d75c292195) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51358 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/187316 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55946c88-e2e4-4f54-87f4-d776a4e5a2f7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159255 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/187316 "") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca92a20d-00d1-4b0a-8aa0-98aff1087fc3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40696 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39059 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/187316 "") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151103 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38751 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35782 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43434 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43294 "Found 1 new test failure: http/wpt/background-fetch/change-documents-in-progress-event.window.html (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189747 "") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51316 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/189747 "") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39674 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51998 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35379 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/189747 "") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42128 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124213 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118640 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50506 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13728 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49902 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50142 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49964 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->