### PR TITLE
[Site Isolation] Cross-site iframe does not render after same-site top-level navigation

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -769,4 +769,14 @@ bool BackForwardCache::hasCachedPageExpired(BackForwardFrameItemIdentifier ident
     return (*cachedPage)->hasExpired();
 }
 
+void BackForwardCache::setDetachedRootFramesForFrameItem(BackForwardFrameItemIdentifier identifier, HashSet<WeakRef<LocalFrame>>&& frames)
+{
+    auto it = m_cachedPageMap.find(identifier);
+    if (it == m_cachedPageMap.end())
+        return;
+
+    if (auto* cachedPage = std::get_if<UniqueRef<CachedPage>>(&it->value))
+        (*cachedPage)->setDetachedRootFrames(WTF::move(frames));
+}
+
 } // namespace WebCore

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -29,9 +29,11 @@
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/HistoryItem.h>
 #include <wtf/Forward.h>
+#include <wtf/HashSet.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -81,6 +83,8 @@ public:
 
     WEBCORE_EXPORT bool NODELETE isInBackForwardCache(BackForwardFrameItemIdentifier) const;
     bool hasCachedPageExpired(BackForwardFrameItemIdentifier) const;
+
+    WEBCORE_EXPORT void setDetachedRootFramesForFrameItem(BackForwardFrameItemIdentifier, HashSet<WeakRef<LocalFrame>>&&);
 
 private:
     BackForwardCache();

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -28,6 +28,7 @@
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/CachedFrame.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/HashSet.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
@@ -37,6 +38,7 @@ namespace WebCore {
 class BackForwardController;
 class Document;
 class DocumentLoader;
+class LocalFrame;
 class Page;
 class RegistrableDomain;
 
@@ -72,6 +74,9 @@ public:
     void setItemID(BackForwardItemIdentifier itemID) { m_itemID = itemID; }
     std::optional<BackForwardItemIdentifier> itemID() const { return m_itemID; }
 
+    void setDetachedRootFrames(HashSet<WeakRef<LocalFrame>>&& frames) { m_detachedRootFrames = WTF::move(frames); }
+    HashSet<WeakRef<LocalFrame>> takeDetachedRootFrames() { return std::exchange(m_detachedRootFrames, { }); }
+
 private:
     void restoreNavigationAPIHistoryItems(LocalFrame&, BackForwardController*);
 
@@ -79,6 +84,7 @@ private:
     MonotonicTime m_expirationTime;
     std::unique_ptr<CachedFrame> m_cachedMainFrame;
     std::optional<BackForwardItemIdentifier> m_itemID;
+    HashSet<WeakRef<LocalFrame>> m_detachedRootFrames;
 #if ENABLE(VIDEO)
     bool m_needsCaptionPreferencesChanged { false };
 #endif

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -160,7 +160,10 @@ void Frame::detachFromPage()
 {
     if (isRootFrame()) {
         if (RefPtr page = m_page.get()) {
-            page->removeRootFrame(downcast<LocalFrame>(*this));
+            // WebPage::suspendWithFrameItem may have already removed this frame from
+            // Page::rootFrames(), so there is no need to remove it again.
+            if (page->rootFrames().contains(downcast<LocalFrame>(*this)))
+                page->removeRootFrame(downcast<LocalFrame>(*this));
             if (RefPtr scrollingCoordinator = page->scrollingCoordinator())
                 scrollingCoordinator->rootFrameWasRemoved(frameID());
         }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9018,8 +9018,8 @@ void WebPage::setIsSuspended(bool suspended, CompletionHandler<void(std::optiona
 
 void WebPage::suspendWithFrameItem(BackForwardFrameItemIdentifier identifier, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (m_isSuspended)
-        return completionHandler(BackForwardCache::singleton().isInBackForwardCache(identifier));
+    if (BackForwardCache::singleton().isInBackForwardCache(identifier))
+        return completionHandler(true);
 
     RefPtr page = corePage();
     if (!page) {
@@ -9027,7 +9027,6 @@ void WebPage::suspendWithFrameItem(BackForwardFrameItemIdentifier identifier, Co
         return completionHandler(false);
     }
 
-    freezeLayerTree(LayerTreeFreezeReason::PageSuspended);
     unfreezeLayerTree(LayerTreeFreezeReason::BackgroundApplication);
     flushDeferredDidReceiveMouseEvent();
 
@@ -9036,6 +9035,16 @@ void WebPage::suspendWithFrameItem(BackForwardFrameItemIdentifier identifier, Co
         return completionHandler(false);
     }
 
+    // Detach the current root frames instead of freezing the whole page, so a same-site navigation
+    // later reusing this WebPage for a new root frame doesn't get frozen too.
+    HashSet<WeakRef<WebCore::LocalFrame>> detachedFrames;
+    for (auto& weakFrame : copyToVector(page->rootFrames())) {
+        Ref frame = weakFrame.get();
+        detachedFrames.add(weakFrame);
+        page->removeRootFrame(frame);
+    }
+    BackForwardCache::singleton().setDetachedRootFramesForFrameItem(identifier, WTF::move(detachedFrames));
+
     m_isSuspended = true;
     WEBPAGE_RELEASE_LOG(ProcessSwapping, "suspendWithFrameItem: Successfully cached page");
     completionHandler(true);
@@ -9043,7 +9052,7 @@ void WebPage::suspendWithFrameItem(BackForwardFrameItemIdentifier identifier, Co
 
 void WebPage::restoreWithFrameItem(BackForwardFrameItemIdentifier identifier, std::optional<std::pair<URL, SecurityOriginData>>&& mainFrameURLAndOrigin, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (!m_isSuspended)
+    if (!BackForwardCache::singleton().isInBackForwardCache(identifier))
         return completionHandler(true);
 
     RefPtr page = corePage();
@@ -9055,6 +9064,7 @@ void WebPage::restoreWithFrameItem(BackForwardFrameItemIdentifier identifier, st
     auto cachedPage = BackForwardCache::singleton().take(identifier, page);
     if (!cachedPage) {
         WEBPAGE_RELEASE_LOG_ERROR(ProcessSwapping, "restoreWithFrameItem: take failed, cache entry missing or expired");
+        m_isSuspended = false;
         return completionHandler(false);
     }
 
@@ -9065,8 +9075,15 @@ void WebPage::restoreWithFrameItem(BackForwardFrameItemIdentifier identifier, st
         page->setMainFrameURLAndOrigin(mainFrameURLAndOrigin->first, mainFrameURLAndOrigin->second.securityOrigin());
 
     m_isSuspended = false;
-    unfreezeLayerTree(LayerTreeFreezeReason::PageSuspended);
+    auto restoredFrames = cachedPage->takeDetachedRootFrames();
     detachResidualSubframesForBackForwardCacheRestore(*page);
+
+    // Resume rendering for the frames detached in suspendWithFrameItem.
+    for (auto& weakFrame : restoredFrames) {
+        Ref frame = weakFrame.get();
+        page->addRootFrame(frame);
+    }
+
     cachedPage->restore(*page);
     completionHandler(true);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -524,6 +524,23 @@ static pid_t findFramePID(NSSet<_WKFrameTreeNode *> *set, FrameType local)
     return 0;
 }
 
+static void startCountingAnimationFrames(TestWKWebView *webView, WKFrameInfo *frame)
+{
+    [webView objectByEvaluatingJavaScript:@"window.__rafCount = 0; (function tick() { window.__rafCount++; requestAnimationFrame(tick); })();" inFrame:frame];
+}
+
+static long long animationFrameCount(TestWKWebView *webView, WKFrameInfo *frame)
+{
+    return [[webView objectByEvaluatingJavaScript:@"window.__rafCount" inFrame:frame] longLongValue];
+}
+
+static void expectAnimationFrameCountToIncrease(TestWKWebView *webView, WKFrameInfo *frame)
+{
+    auto initialCount = animationFrameCount(webView, frame);
+    TestWebKitAPI::Util::runFor(0.5_s);
+    EXPECT_GT(animationFrameCount(webView, frame), initialCount);
+}
+
 TEST(SiteIsolation, LoadingCallbacksAndPostMessage)
 {
     auto exampleHTML = "<script>"
@@ -11076,6 +11093,160 @@ TEST(SiteIsolation, ProvisionalSubframeCommitAfterMainFrameSwapDoesNotCrash)
     Util::runFor(0.5_s);
 
     EXPECT_WK_STREQ(@"https://c.com/c", [webView URL].absoluteString);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheSameSiteReusedIframeNotFrozen)
+{
+    HTTPServer server({
+        { "/a1"_s, { "<iframe src='https://b.com/frame1'></iframe>"_s } },
+        { "/a2"_s, { "<iframe src='https://b.com/frame2'></iframe>"_s } },
+        { "/frame1"_s, { "frame1"_s } },
+        { "/frame2"_s, { "frame2"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a1"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+
+    pid_t iframePID1 = findFramePID(frameTrees(webView.get()).get(), FrameType::Remote);
+    EXPECT_NE(iframePID1, 0);
+
+    // frame1 renders normally before ever being cached.
+    startCountingAnimationFrames(webView.get(), [webView firstChildFrame]);
+    expectAnimationFrameCountToIncrease(webView.get(), [webView firstChildFrame]);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a2"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+
+    // frame2's rendering must not have been frozen by frame1's earlier caching.
+    startCountingAnimationFrames(webView.get(), [webView firstChildFrame]);
+    expectAnimationFrameCountToIncrease(webView.get(), [webView firstChildFrame]);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheRestoreRerendersReattachedIframe)
+{
+    HTTPServer server({
+        { "/a1"_s, { "<iframe src='https://b.com/frame1'></iframe>"_s } },
+        { "/a2"_s, { "<iframe src='https://b.com/frame2'></iframe>"_s } },
+        { "/frame1"_s, { "frame1"_s } },
+        { "/frame2"_s, { "frame2"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a1"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+    [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_a1 = true"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a2"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_WK_STREQ(@"https://a.com/a1", [webView URL].absoluteString);
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_a1 ? true : false"] boolValue]);
+
+    Vector<ExpectedFrameTree> expectedAfterGoBack = {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    };
+    while (!frameTreesMatch(frameTrees(webView.get()).get(), Vector<ExpectedFrameTree> { expectedAfterGoBack }))
+        TestWebKitAPI::Util::spinRunLoop();
+    checkFrameTreesInProcesses(webView.get(), WTF::move(expectedAfterGoBack));
+
+    // Verify rendering is resumed.
+    startCountingAnimationFrames(webView.get(), [webView firstChildFrame]);
+    expectAnimationFrameCountToIncrease(webView.get(), [webView firstChildFrame]);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheRepeatedSameSiteSuspendCachesEachEntry)
+{
+    HTTPServer server({
+        { "/a1"_s, { "<iframe src='https://b.com/frame1'></iframe>"_s } },
+        { "/a2"_s, { "<iframe src='https://b.com/frame2'></iframe>"_s } },
+        { "/a3"_s, { "<iframe src='https://b.com/frame3'></iframe>"_s } },
+        { "/frame1"_s, { "frame1"_s } },
+        { "/frame2"_s, { "frame2"_s } },
+        { "/frame3"_s, { "frame3"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a1"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+    pid_t iframePID1 = findFramePID(frameTrees(webView.get()).get(), FrameType::Remote);
+    EXPECT_NE(iframePID1, 0);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a2"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+    [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_a2 = true" inFrame:[webView firstChildFrame]];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a3"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+
+    // frame3 must render normally regardless of how many times this WebPage was suspended before.
+    startCountingAnimationFrames(webView.get(), [webView firstChildFrame]);
+    expectAnimationFrameCountToIncrease(webView.get(), [webView firstChildFrame]);
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ(@"https://a.com/a2", [webView URL].absoluteString);
+
+    Vector<ExpectedFrameTree> expectedAfterGoBack = {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    };
+    while (!frameTreesMatch(frameTrees(webView.get()).get(), Vector<ExpectedFrameTree> { expectedAfterGoBack }))
+        TestWebKitAPI::Util::spinRunLoop();
+    checkFrameTreesInProcesses(webView.get(), WTF::move(expectedAfterGoBack));
+
+    // Confirm page is restored from cache.
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_a2 ? true : false" inFrame:[webView firstChildFrame]] boolValue]);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheSameSiteEvictionDoesNotCrashIframe)
+{
+    HTTPServer server({
+        { "/a1"_s, { "<iframe src='https://b.com/frame1'></iframe>"_s } },
+        { "/a2"_s, { "<iframe src='https://b.com/frame2'></iframe>"_s } },
+        { "/frame1"_s, { "frame1"_s } },
+        { "/frame2"_s, { "frame2"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a1"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+    [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_a1 = true" inFrame:[webView firstChildFrame]];
+
+    pid_t iframePID = findFramePID(frameTrees(webView.get()).get(), FrameType::Remote);
+    EXPECT_NE(iframePID, 0);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a2"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+
+    [webView _clearBackForwardCache];
+
+    startCountingAnimationFrames(webView.get(), [webView firstChildFrame]);
+    // Verify process does not crash after processing ClearCachedPage message.
+    EXPECT_TRUE(processStillRunning(iframePID));
+    expectAnimationFrameCountToIncrease(webView.get(), [webView firstChildFrame]);
+
+    // Confirm the entry was actually evicted and page is loaded from network.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ(@"https://a.com/a1", [webView URL].absoluteString);
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_a1 ? true : false" inFrame:[webView firstChildFrame]] boolValue]);
 }
 
 TEST(SiteIsolation, MultiProcessBFCacheSameSiteNavAfterRestore)


### PR DESCRIPTION
#### 3c248d1e5f942b73d0dc1f9cd46fb3c36e03fe56
<pre>
[Site Isolation] Cross-site iframe does not render after same-site top-level navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=320633">https://bugs.webkit.org/show_bug.cgi?id=320633</a>
<a href="https://rdar.apple.com/182905055">rdar://182905055</a>

Reviewed by Alex Christensen.

The subscribe widget iframe on bbc.com&apos;s /subscribe page (piano.io) never loaded when reached by clicking a same-site
link from bbc.com&apos;s home page, even though it worked fine when /subscribe was loaded directly.

The cause is that same-site top-level navigation (no process swap for the main frame, e.g. bbc.com -&gt; bbc.com/subscribe)
can reuse the same WebPage/process for a cross-site iframe present on both the old and new page. Caching the old page
into BackForwardCache broadcasts SuspendWithFrameItem to that shared iframe process, and the previous code responded by
calling freezeLayerTree() on the whole WebPage. Since the new page&apos;s own iframe is added to that same, now-frozen
WebPage moments later, it inherited the freeze before ever rendering a single frame and stayed permanently blank.

Fixed by having suspendWithFrameItem only detach the specific root frame(s) being cached from Page::rootFrames() -- pure
compositing bookkeeping; the frame stays alive via its RemoteFrame parent&apos;s ownership in the FrameTree -- instead of
freezing the whole DrawingArea. The detached frames are recorded on BackForwardCache&apos;s own CachedPage entry for that
identifier (BackForwardCache::setDetachedRootFramesForFrameItem / CachedPage::detachedRootFrames), and
restoreWithFrameItem reattaches them via Page::addRootFrame() on restore.

Testing this case surfaced two more, related bugs in the same code:
- Suspending the same, reused WebPage more than once before any restore (e.g.a.com/page1 -&gt; page2 -&gt; page3, each with
its own same-site iframe) silently skipped caching every suspend after the first, because suspendWithFrameItem guarded
on a single WebPage-wide &quot;already suspended&quot; bool instead of tracking each cached identifier separately. Fixed by keying
the detached-root-frame bookkeeping -- and the guard itself -- per identifier instead of per WebPage.

- Evicting a cache entry without ever restoring it (e.g. via prune() or _clearBackForwardCache) could remove the same
root frame a second time: the normal teardown (CachedFrame::destroy() -&gt; Frame::detachFromPage() -&gt;
Page::removeRootFrame()) doesn&apos;t know the frame was already detached from Page::rootFrames() by suspendWithFrameItem,
and tripped an assertion. Frame::detachFromPage() now only calls Page::removeRootFrame() if the frame is still actually
registered as a root frame.

Added regression tests for all three issues above.
Tests: SiteIsolation.MultiProcessBFCacheSameSiteReusedIframeNotFrozen
       SiteIsolation.MultiProcessBFCacheRestoreRerendersReattachedIframe
       SiteIsolation.MultiProcessBFCacheRepeatedSameSiteSuspendCachesEachEntry
       SiteIsolation.MultiProcessBFCacheSameSiteEvictionDoesNotCrashIframe

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::setDetachedRootFramesForFrameItem):
* Source/WebCore/history/BackForwardCache.h:
* Source/WebCore/history/CachedPage.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::detachFromPage):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::suspendWithFrameItem):
(WebKit::WebPage::restoreWithFrameItem):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::startCountingAnimationFrames):
(TestWebKitAPI::animationFrameCount):
(TestWebKitAPI::expectAnimationFrameCountToIncrease):
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheSameSiteReusedIframeNotFrozen)):
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheRestoreRerendersReattachedIframe)):
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheRepeatedSameSiteSuspendCachesEachEntry)):
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheSameSiteEvictionDoesNotCrashIframe)):

Canonical link: <a href="https://commits.webkit.org/318319@main">https://commits.webkit.org/318319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87ed6fc8d7fa73e6660a815b76443c440cafe0cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187507 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e24740f-b374-4b91-a6c8-87951170e151) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138662 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b4d7d61-7d44-405e-a368-328adc75781d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119125 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f81a69db-56dc-4720-a3f7-daa6d7f7365c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40857 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39218 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38904 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35968 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44426 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189936 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51502 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147791 "3 flakes") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39707 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52184 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147572 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42279 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124436 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118867 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50692 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13884 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50088 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50328 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50150 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->