### PR TITLE
Out-of-bounds read in WebM MIME sniffer at the 0x42 0x82 DocType check

### DIFF
--- a/Source/WebCore/platform/graphics/MIMESniffer.cpp
+++ b/Source/WebCore/platform/graphics/MIMESniffer.cpp
@@ -140,7 +140,7 @@ static bool NODELETE hasSignatureForWebM(std::span<const uint8_t> sequence)
     //   6. While iter is less than length and iter is less than 38, continuously loop through these steps:
     while (iter < length && iter < 38) {
         //  1. If the two bytes from sequence[iter] to sequence[iter + 1] are equal to 0x42 0x82,
-        if (sequence[iter] == 0x42 && sequence[iter + 1] == 0x82) {
+        if (iter + 1 < length && sequence[iter] == 0x42 && sequence[iter + 1] == 0x82) {
             //  1. Increment iter by 2.
             iter += 2;
             //  2. If iter is greater or equal than length, abort these steps.

--- a/Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp
@@ -63,6 +63,12 @@ TEST(MIMESniffer, WebMSnifferDoesNotReadPastEnd)
     // read in MIMESniffer.cpp under ASan / libc++ hardened mode.
     constexpr std::array<const uint8_t, 7> truncatedWebM = { 0x1A, 0x45, 0xDF, 0xA3, 0x42, 0x82, 0x80 };
     MIMESniffer::getMIMETypeFromContent(std::span { truncatedWebM });
+
+    // EBML magic (4 bytes) followed by a lone 0x42 as the last byte. The loop
+    // guard only ensures iter < length, so the 0x42 0x82 two-byte compare reads
+    // sequence[iter + 1] one byte past the end when iter == length - 1.
+    constexpr std::array<const uint8_t, 5> truncatedWebMAtMagicByte = { 0x1A, 0x45, 0xDF, 0xA3, 0x42 };
+    MIMESniffer::getMIMETypeFromContent(std::span { truncatedWebMAtMagicByte });
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### ef325e63cb21634b26ba345fb7783f4938db6173
<pre>
Out-of-bounds read in WebM MIME sniffer at the 0x42 0x82 DocType check
<a href="https://bugs.webkit.org/show_bug.cgi?id=320634">https://bugs.webkit.org/show_bug.cgi?id=320634</a>

Reviewed by Youenn Fablet.

314498@main guarded the inner skip-NUL loop in hasSignatureForWebM(),
but a second unguarded iter + 1 read remains at the top of the loop:
```
    while (iter &lt; length &amp;&amp; iter &lt; 38) {
        if (sequence[iter] == 0x42 &amp;&amp; sequence[iter + 1] == 0x82) {
```
The loop guard only guarantees iter &lt; length, not iter + 1 &lt; length. When
iter == length - 1 and sequence[iter] == 0x42, the short-circuit &amp;&amp; goes on
to evaluate sequence[iter + 1], reading one byte past the end of the span.
This is reachable before the skip-NUL path 314498@main fixed: a 5-byte
input of EBML magic + a trailing 0x42 (0x1A 0x45 0xDF 0xA3 0x42) enters the
loop at iter == 4 == length - 1 and reads sequence[5]. getMIMETypeFromContent()
is called on attacker-controlled response bytes via MediaResourceSniffer with
a span sized to the exact number of received bytes, so this is a remotely
reachable crash. WebKit builds with hardened libc++, so std::span&apos;s bounds
check turns it into a safe abort on every build.

Guard the two-byte compare with iter + 1 &lt; length so the bounds check
short-circuits the dereference, matching the guarded reads later in the
function, and extend the regression test with the truncated 5-byte input.

Test: MIMESniffer.WebMSnifferDoesNotReadPastEnd

* Source/WebCore/platform/graphics/MIMESniffer.cpp:
(WebCore::MIMESniffer::hasSignatureForWebM):
* Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp:
(TestWebKitAPI::TEST(MIMESniffer, WebMSnifferDoesNotReadPastEnd)):

Canonical link: <a href="https://commits.webkit.org/318243@main">https://commits.webkit.org/318243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ef0867e7b25a34344cd30900a4def122a409bb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187321 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7bbc3905-653c-4c1c-9968-15da9581eab4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138515 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f44490bb-59a9-45c6-b21b-79ecca7e6cb8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118979 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f78db709-e0a9-41d2-bb01-5a8642718f12) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40700 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39063 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38755 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35786 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43438 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43298 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189751 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51320 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147631 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39661 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52002 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147417 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; run-api-tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42132 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124217 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118644 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50510 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13732 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49906 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50146 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49968 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->