### PR TITLE
toRelatedAcuteAngle in GeometryUtilities.cpp doesn't handle an angle greater than 270 degrees

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-sides-fourth-quadrant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-sides-fourth-quadrant-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Motion Path: ray() 'sides' size with a fourth-quadrant angle</title>
+    <style>
+      #container {
+        width: 400px;
+        height: 400px;
+      }
+      #target {
+        position: relative;
+        left: 200px;
+        top: 160px;
+        width: 40px;
+        height: 40px;
+        background-color: green;
+        transform-origin: 0px 0px;
+        /* ray(315deg sides) from (200,160) hits the top edge: length = 160 / cos(45deg).
+           With offset-rotate:0 this is a pure translation of length * (sin315, -cos315) = (-160, -160). */
+        transform: translate(-160px, -160px);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container"><div id="target"></div></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-sides-fourth-quadrant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-sides-fourth-quadrant-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Motion Path: ray() 'sides' size with a fourth-quadrant angle</title>
+    <style>
+      #container {
+        width: 400px;
+        height: 400px;
+      }
+      #target {
+        position: relative;
+        left: 200px;
+        top: 160px;
+        width: 40px;
+        height: 40px;
+        background-color: green;
+        transform-origin: 0px 0px;
+        /* ray(315deg sides) from (200,160) hits the top edge: length = 160 / cos(45deg).
+           With offset-rotate:0 this is a pure translation of length * (sin315, -cos315) = (-160, -160). */
+        transform: translate(-160px, -160px);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container"><div id="target"></div></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-sides-fourth-quadrant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-sides-fourth-quadrant.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Motion Path: ray() 'sides' size with a fourth-quadrant angle</title>
+    <link rel="author" title="Chris Dumez" href="mailto:cdumez@apple.com">
+    <link rel="help" href="https://drafts.fxtf.org/motion-1/#ray-function">
+    <link rel="match" href="offset-path-ray-sides-fourth-quadrant-ref.html">
+    <meta name="assert" content="ray(315deg sides) from (200,160) in a 400x400 containing block resolves its length against the top edge (160 / cos(45deg)), translating the box by (-160,-160). Angles in the (270deg, 360deg) range must fold down to an acute angle from the vertical axis.">
+    <style>
+      #container {
+        width: 400px;
+        height: 400px;
+      }
+      #target {
+        position: relative;
+        left: 200px;
+        top: 160px;
+        width: 40px;
+        height: 40px;
+        background-color: green;
+        transform-origin: 0px 0px;
+        offset-path: ray(315deg sides);
+        offset-distance: 100%;
+        offset-rotate: 0deg;
+        offset-position: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container"><div id="target"></div></div>
+  </body>
+</html>

--- a/Source/WebCore/platform/graphics/GeometryUtilities.cpp
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.cpp
@@ -278,20 +278,17 @@ RotatedRect rotatedBoundingRectWithMinimumAngleOfRotation(const FloatQuad& quad,
 
 float toPositiveAngle(float angle)
 {
-    angle = fmod(angle, 360);
+    angle = std::fmod(angle, 360.0f);
     while (angle < 0)
-        angle += 360.0;
+        angle += 360.0f;
     return angle;
 }
 
 // Compute acute angle from vertical axis
-float toRelatedAcuteAngle(float angle)
+SUPPRESS_NODELETE float toRelatedAcuteAngle(float angle)
 {
-    angle = toPositiveAngle(angle);
-    if (angle < 90)
-        return angle;
-    // FIXME: webkit.org/b/298890 toRelatedAcuteAngle in GeometryUtilities.cpp doesn't handle an angle greater than 270 degrees
-    return std::abs(180 - angle);
+    angle = std::fmod(toPositiveAngle(angle), 180.0f);
+    return std::min(angle, 180.0f - angle);
 }
 
 RectEdges<double> distanceOfPointToSidesOfRect(const FloatRect& box, const FloatPoint& position)


### PR DESCRIPTION
#### 3c1f378072db455b9d588cd5bc8cac5106d08e80
<pre>
toRelatedAcuteAngle in GeometryUtilities.cpp doesn&apos;t handle an angle greater than 270 degrees
<a href="https://bugs.webkit.org/show_bug.cgi?id=298890">https://bugs.webkit.org/show_bug.cgi?id=298890</a>
<a href="https://rdar.apple.com/161114695">rdar://161114695</a>

Reviewed by Darin Adler.

toRelatedAcuteAngle() is meant to return the acute angle from the vertical
axis, but it only handled angles up to 270 degrees:
```
      angle = toPositiveAngle(angle);
      if (angle &lt; 90)
          return angle;
      return std::abs(180 - angle);
```
For an angle in the fourth quadrant it returned the obtuse supplement instead
of an acute angle (e.g. 300 -&gt; 120, 315 -&gt; 135, 350 -&gt; 170). This fed wrong
values into intersectionSide() and lengthOfRayIntersectionWithBoundingBox(),
so an offset-path ray() with a &apos;sides&apos; size and a fourth-quadrant angle picked
the wrong box side and produced an incorrect (sometimes negative) ray length,
placing the element in the wrong position.

Fold the angle into [0, 90] for every quadrant by reducing it modulo 180 and
taking the smaller of the angle and its supplement. This matches the previous
behavior for angles in [0, 270] and fixes the (270, 360) range.

Test: imported/w3c/web-platform-tests/css/motion/offset-path-ray-sides-fourth-quadrant.html

* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-sides-fourth-quadrant-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-sides-fourth-quadrant-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-sides-fourth-quadrant.html: Added.
* Source/WebCore/platform/graphics/GeometryUtilities.cpp:
(WebCore::toRelatedAcuteAngle):
(WebCore::toPositiveAngle):

Canonical link: <a href="https://commits.webkit.org/318279@main">https://commits.webkit.org/318279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fb342d3f96a06d5d5b6933d2c81275a97512747

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187467 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51504 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9efc585d-0eb7-45b5-bd47-bcb4f20c7a32) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42157 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119091 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151225 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/38869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35928 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/44386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189896 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158905 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39685 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52144 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147535 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42246 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50652 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/13848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50048 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->