### PR TITLE
feDropShadow ignores stdDeviation Y update when X changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-fedropshadow-stddeviation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-fedropshadow-stddeviation-expected.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<title>Filter Effects: mutating feDropShadow stdDeviation updates both x and y components (reference)</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#feDropShadowElement">
+<svg width="300" height="200">
+  <filter id="shadow" filterUnits="userSpaceOnUse" x="0" y="0" width="300" height="200">
+    <feDropShadow id="drop" dx="120" dy="0" stdDeviation="20 20" flood-color="black" flood-opacity="1"/>
+  </filter>
+  <rect x="20" y="80" width="40" height="40" fill="green" filter="url(#shadow)"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-fedropshadow-stddeviation-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-fedropshadow-stddeviation-ref.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<title>Filter Effects: mutating feDropShadow stdDeviation updates both x and y components (reference)</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#feDropShadowElement">
+<svg width="300" height="200">
+  <filter id="shadow" filterUnits="userSpaceOnUse" x="0" y="0" width="300" height="200">
+    <feDropShadow id="drop" dx="120" dy="0" stdDeviation="20 20" flood-color="black" flood-opacity="1"/>
+  </filter>
+  <rect x="20" y="80" width="40" height="40" fill="green" filter="url(#shadow)"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-fedropshadow-stddeviation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-fedropshadow-stddeviation.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html class="reftest-wait">
+<title>Filter Effects: mutating feDropShadow stdDeviation updates both x and y components</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#feDropShadowElement">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#element-attrdef-fedropshadow-stddeviation">
+<link rel="match" href="svg-mutation-fedropshadow-stddeviation-ref.html">
+<meta name="assert" content="Changing the stdDeviation attribute of an already-built feDropShadow must update both the x and y standard-deviation of the effect, not just x.">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+<svg width="300" height="200">
+  <filter id="shadow" filterUnits="userSpaceOnUse" x="0" y="0" width="300" height="200">
+    <feDropShadow id="drop" dx="120" dy="0" stdDeviation="2 2" flood-color="black" flood-opacity="1"/>
+  </filter>
+  <rect x="20" y="80" width="40" height="40" fill="green" filter="url(#shadow)"/>
+</svg>
+<script>
+  waitForAtLeastOneFrame().then(() => {
+    document.getElementById("drop").setAttribute("stdDeviation", "20 20");
+    takeScreenshot();
+  });
+</script>

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -120,8 +120,11 @@ bool SVGFEDropShadowElement::setFilterEffectAttribute(FilterEffect& filterEffect
 {
     auto& effect = downcast<FEDropShadow>(filterEffect);
     switch (attrName.nodeName()) {
-    case AttributeNames::stdDeviationAttr:
-        return effect.setStdDeviationX(stdDeviationX()) || effect.setStdDeviationY(stdDeviationY());
+    case AttributeNames::stdDeviationAttr: {
+        bool stdDeviationXChanged = effect.setStdDeviationX(stdDeviationX());
+        bool stdDeviationYChanged = effect.setStdDeviationY(stdDeviationY());
+        return stdDeviationXChanged || stdDeviationYChanged;
+    }
     case AttributeNames::dxAttr:
         return effect.setDx(dx());
     case AttributeNames::dyAttr:


### PR DESCRIPTION
#### 9636543604b585aaebbfc937370f05d0eace4574
<pre>
feDropShadow ignores stdDeviation Y update when X changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=320636">https://bugs.webkit.org/show_bug.cgi?id=320636</a>

Reviewed by Darin Adler.

SVGFEDropShadowElement::setFilterEffectAttribute() updated the drop-shadow&apos;s
standard deviation with:
```
      return effect.setStdDeviationX(stdDeviationX()) || effect.setStdDeviationY(stdDeviationY());
```
FEDropShadow::setStdDeviationX() returns true when the x deviation actually
changes, so the || short-circuits and setStdDeviationY() is never called. When
the stdDeviation attribute of an already-built feDropShadow is changed (via
setAttribute or SMIL) such that its x component changes, the y component of the
effect is left stale and the shadow is repainted with the wrong vertical blur.

Evaluate both setters into separate booleans before combining them, matching
the pattern already used by SVGFEGaussianBlurElement.

Test: imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-fedropshadow-stddeviation.html

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-fedropshadow-stddeviation-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-fedropshadow-stddeviation-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-fedropshadow-stddeviation.html: Added.
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::setFilterEffectAttribute):

Canonical link: <a href="https://commits.webkit.org/318281@main">https://commits.webkit.org/318281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f15328c2793ce23504ac75b7c719e3eb560ea78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51805 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187477 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51514 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180823 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/42170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119097 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40833 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/38881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35938 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/44396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189906 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/158917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39686 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52154 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147544 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/42256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50662 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/13860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50058 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->