### PR TITLE
Drop SVGAltGlyphElement::hasValidGlyphElements() as it is dead code

### DIFF
--- a/Source/WebCore/svg/SVGAltGlyphDefElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphDefElement.cpp
@@ -20,11 +20,8 @@
 #include "config.h"
 #include "SVGAltGlyphDefElement.h"
 
-#include "ElementChildIteratorInlines.h"
-#include "SVGAltGlyphItemElement.h"
-#include "SVGElementTypeHelpers.h"
-#include "SVGGlyphRefElement.h"
 #include "SVGNames.h"
+#include "SVGPropertyOwnerRegistry.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -40,84 +37,6 @@ inline SVGAltGlyphDefElement::SVGAltGlyphDefElement(const QualifiedName& tagName
 Ref<SVGAltGlyphDefElement> SVGAltGlyphDefElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new SVGAltGlyphDefElement(tagName, document));
-}
-
-bool SVGAltGlyphDefElement::hasValidGlyphElements(Vector<String>& glyphNames) const
-{
-    // Spec: http://www.w3.org/TR/SVG/text.html#AltGlyphDefElement
-    // An 'altGlyphDef' can contain either of the following:
-    //
-    // 1. In the simplest case, an 'altGlyphDef' contains one or more 'glyphRef' elements.
-    // Each 'glyphRef' element references a single glyph within a particular font.
-    // If all of the referenced glyphs are available, then these glyphs are rendered
-    // instead of the character(s) inside of the referencing 'altGlyph' element.
-    // If any of the referenced glyphs are unavailable, then the character(s) that are
-    // inside of the 'altGlyph' element are rendered as if there were not an 'altGlyph'
-    // element surrounding those characters.
-    //
-    // 2. In the more complex case, an 'altGlyphDef' contains one or more 'altGlyphItem' elements.
-    // Each 'altGlyphItem' represents a candidate set of substitute glyphs. Each 'altGlyphItem'
-    // contains one or more 'glyphRef' elements. Each 'glyphRef' element references a single
-    // glyph within a particular font. The first 'altGlyphItem' in which all referenced glyphs
-    // are available is chosen. The glyphs referenced from this 'altGlyphItem' are rendered
-    // instead of the character(s) that are inside of the referencing 'altGlyph' element.
-    // If none of the 'altGlyphItem' elements result in a successful match (i.e., none of the
-    // 'altGlyphItem' elements has all of its referenced glyphs available), then the character(s)
-    // that are inside of the 'altGlyph' element are rendered as if there were not an 'altGlyph'
-    // element surrounding those characters.
-    //
-    // The spec doesn't tell how to deal with the mixing of <glyphRef> and <altGlyItem>.
-    // However, we determine content model by the type of the first appearing element
-    // just like Opera 11 does. After the content model is determined we skip elements
-    // which don't comform to it. For example:
-    // a.    <altGlyphDef>
-    //         <glyphRef id="g1" />
-    //         <altGlyphItem id="i1"> ... </altGlyphItem>
-    //         <glyphRef id="g2" />
-    //       </altGlyphDef>
-    //
-    // b.    <altGlyphDef>
-    //         <altGlyphItem id="i1"> ... </altGlyphItem>
-    //         <altGlyphItem id="i2"> ... </altGlyphItem>
-    //         <glyphRef id="g1" />
-    //         <glyphRef id="g2" />
-    //       </altGlyphDef>
-    // For a), the content model is 1), so we will use "g1" and "g2" if they are all valid
-    // and "i1" is skipped.
-    // For b), the content model is 2), so we will use <glyphRef> elements contained in
-    // "i1" if they are valid and "g1" and "g2" are skipped.
-
-    // These 2 variables are used to determine content model.
-    bool fountFirstGlyphRef = false;
-    bool foundFirstAltGlyphItem = false;
-
-    for (Ref child : childrenOfType<SVGElement>(*this)) {
-        if (RefPtr glyphRef = dynamicDowncast<SVGGlyphRefElement>(child); glyphRef && !foundFirstAltGlyphItem) {
-            fountFirstGlyphRef = true;
-            String referredGlyphName;
-
-            if (glyphRef->hasValidGlyphElement(referredGlyphName))
-                glyphNames.append(referredGlyphName);
-            else {
-                // As the spec says "If any of the referenced glyphs are unavailable,
-                // then the character(s) that are inside of the 'altGlyph' element are
-                // rendered as if there were not an 'altGlyph' element surrounding
-                // those characters.".
-                glyphNames.clear();
-                return false;
-            }
-        } else if (!fountFirstGlyphRef) {
-            if (RefPtr altGlyphItem = dynamicDowncast<SVGAltGlyphItemElement>(WTF::move(child))) {
-                foundFirstAltGlyphItem = true;
-
-                // As the spec says "The first 'altGlyphItem' in which all referenced glyphs
-                // are available is chosen."
-                if (altGlyphItem->hasValidGlyphElements(glyphNames) && !glyphNames.isEmpty())
-                    return true;
-            }
-        }
-    }
-    return !glyphNames.isEmpty();
 }
 
 }

--- a/Source/WebCore/svg/SVGAltGlyphDefElement.h
+++ b/Source/WebCore/svg/SVGAltGlyphDefElement.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "SVGElement.h"
-#include <wtf/Forward.h>
 
 namespace WebCore {
 
@@ -29,8 +28,6 @@ class SVGAltGlyphDefElement final : public SVGElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAltGlyphDefElement);
 public:
     static Ref<SVGAltGlyphDefElement> create(const QualifiedName&, Document&);
-
-    bool hasValidGlyphElements(Vector<String>& glyphNames) const;
 
 private:
     SVGAltGlyphDefElement(const QualifiedName&, Document&);

--- a/Source/WebCore/svg/SVGAltGlyphElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphElement.cpp
@@ -24,12 +24,8 @@
 #include "SVGAltGlyphElement.h"
 
 #include "RenderSVGTSpan.h"
-#include "SVGAltGlyphDefElement.h"
 #include "SVGElementInlines.h"
-#include "SVGElementTypeHelpers.h"
-#include "SVGGlyphElement.h"
 #include "SVGNames.h"
-#include "XLinkNames.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -76,20 +72,6 @@ bool SVGAltGlyphElement::childShouldCreateRenderer(const Node& child) const
 RenderPtr<RenderElement> SVGAltGlyphElement::createElementRenderer(Style::ComputedStyle&& style, const RenderTreePosition&)
 {
     return createRenderer<RenderSVGTSpan>(*this, WTF::move(style));
-}
-
-bool SVGAltGlyphElement::hasValidGlyphElements(Vector<String>& glyphNames) const
-{
-    // No need to support altGlyph referencing another node inside a shadow tree.
-    auto target = targetElementFromIRIString(getAttribute(SVGNames::hrefAttr, XLinkNames::hrefAttr), protect(document()));
-
-    if (is<SVGGlyphElement>(target.element)) {
-        glyphNames.append(target.identifier);
-        return true;
-    }
-    
-    RefPtr altGlyphDefElement = downcast<SVGAltGlyphDefElement>(target.element.get());
-    return altGlyphDefElement && altGlyphDefElement->hasValidGlyphElements(glyphNames);
 }
 
 }

--- a/Source/WebCore/svg/SVGAltGlyphElement.h
+++ b/Source/WebCore/svg/SVGAltGlyphElement.h
@@ -27,8 +27,6 @@
 
 namespace WebCore {
 
-class SVGGlyphElement;
-
 class SVGAltGlyphElement final : public SVGTextPositioningElement, public SVGURIReference {
     WTF_MAKE_TZONE_ALLOCATED(SVGAltGlyphElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAltGlyphElement);
@@ -39,8 +37,6 @@ public:
     ExceptionOr<void> setGlyphRef(const AtomString&);
     const AtomString& NODELETE format() const;
     ExceptionOr<void> setFormat(const AtomString&);
-
-    bool hasValidGlyphElements(Vector<String>& glyphNames) const;
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGAltGlyphElement, SVGTextPositioningElement, SVGURIReference>;
 

--- a/Source/WebCore/svg/SVGAltGlyphItemElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphItemElement.cpp
@@ -21,10 +21,8 @@
 
 #include "SVGAltGlyphItemElement.h"
 
-#include "ElementChildIteratorInlines.h"
-#include "SVGElementTypeHelpers.h"
-#include "SVGGlyphRefElement.h"
 #include "SVGNames.h"
+#include "SVGPropertyOwnerRegistry.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -40,29 +38,6 @@ inline SVGAltGlyphItemElement::SVGAltGlyphItemElement(const QualifiedName& tagNa
 Ref<SVGAltGlyphItemElement> SVGAltGlyphItemElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new SVGAltGlyphItemElement(tagName, document));
-}
-
-bool SVGAltGlyphItemElement::hasValidGlyphElements(Vector<String>& glyphNames) const
-{
-    // Spec: http://www.w3.org/TR/SVG/text.html#AltGlyphItemElement
-    // The ‘altGlyphItem’ element defines a candidate set of possible glyph substitutions.
-    // The first ‘altGlyphItem’ element whose referenced glyphs are all available is chosen.
-    // Its glyphs are rendered instead of the character(s) that are inside of the referencing
-    // ‘altGlyph’ element.
-    //
-    // Here we fill glyphNames and return true only if all referenced glyphs are valid and
-    // there is at least one glyph.
-
-    for (Ref glyphRef : childrenOfType<SVGGlyphRefElement>(*this)) {
-        String referredGlyphName;
-        if (glyphRef->hasValidGlyphElement(referredGlyphName))
-            glyphNames.append(referredGlyphName);
-        else {
-            glyphNames.clear();
-            return false;
-        }
-    }
-    return !glyphNames.isEmpty();
 }
 
 }

--- a/Source/WebCore/svg/SVGAltGlyphItemElement.h
+++ b/Source/WebCore/svg/SVGAltGlyphItemElement.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "SVGElement.h"
-#include <wtf/Forward.h>
 
 namespace WebCore {
 
@@ -29,8 +28,6 @@ class SVGAltGlyphItemElement final : public SVGElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAltGlyphItemElement);
 public:
     static Ref<SVGAltGlyphItemElement> create(const QualifiedName&, Document&);
-
-    bool hasValidGlyphElements(Vector<String>& glyphNames) const;
 
 private:
     SVGAltGlyphItemElement(const QualifiedName&, Document&);

--- a/Source/WebCore/svg/SVGGlyphRefElement.cpp
+++ b/Source/WebCore/svg/SVGGlyphRefElement.cpp
@@ -22,11 +22,8 @@
 #include "SVGGlyphRefElement.h"
 
 #include "NodeName.h"
-#include "SVGElementTypeHelpers.h"
-#include "SVGGlyphElement.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
-#include "XLinkNames.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>
 
@@ -44,16 +41,6 @@ inline SVGGlyphRefElement::SVGGlyphRefElement(const QualifiedName& tagName, Docu
 Ref<SVGGlyphRefElement> SVGGlyphRefElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new SVGGlyphRefElement(tagName, document));
-}
-
-bool SVGGlyphRefElement::hasValidGlyphElement(String& glyphName) const
-{
-    // FIXME: We only support xlink:href so far.
-    // https://bugs.webkit.org/show_bug.cgi?id=64787
-    // No need to support glyphRef referencing another node inside a shadow tree.
-    auto target = targetElementFromIRIString(getAttribute(SVGNames::hrefAttr, XLinkNames::hrefAttr), protect(document()));
-    glyphName = target.identifier;
-    return is<SVGGlyphElement>(target.element);
 }
 
 static float parseFloat(const AtomString& value)

--- a/Source/WebCore/svg/SVGGlyphRefElement.h
+++ b/Source/WebCore/svg/SVGGlyphRefElement.h
@@ -32,8 +32,6 @@ class SVGGlyphRefElement final : public SVGElement, public SVGURIReference {
 public:
     static Ref<SVGGlyphRefElement> create(const QualifiedName&, Document&);
 
-    bool hasValidGlyphElement(String& glyphName) const;
-
     float x() const { return m_x; }
     void setX(float);
     float y() const { return m_y; }


### PR DESCRIPTION
#### 1db54fba037f5e76caabb29c3edfe40a3a24212c
<pre>
Drop SVGAltGlyphElement::hasValidGlyphElements() as it is dead code
<a href="https://bugs.webkit.org/show_bug.cgi?id=320637">https://bugs.webkit.org/show_bug.cgi?id=320637</a>

Reviewed by Darin Adler.

* Source/WebCore/svg/SVGAltGlyphDefElement.cpp:
(WebCore::SVGAltGlyphDefElement::hasValidGlyphElements const): Deleted.
* Source/WebCore/svg/SVGAltGlyphDefElement.h:
* Source/WebCore/svg/SVGAltGlyphElement.cpp:
(WebCore::SVGAltGlyphElement::hasValidGlyphElements const): Deleted.
* Source/WebCore/svg/SVGAltGlyphElement.h:
* Source/WebCore/svg/SVGAltGlyphItemElement.cpp:
(WebCore::SVGAltGlyphItemElement::hasValidGlyphElements const): Deleted.
* Source/WebCore/svg/SVGAltGlyphItemElement.h:
* Source/WebCore/svg/SVGGlyphRefElement.cpp:
(WebCore::SVGGlyphRefElement::hasValidGlyphElement const): Deleted.
* Source/WebCore/svg/SVGGlyphRefElement.h:

Canonical link: <a href="https://commits.webkit.org/318275@main">https://commits.webkit.org/318275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae6ed4082f50d06efe12dfea5e7e7cfd945eb195

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187359 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138546 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119010 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40734 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39095 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38787 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35821 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189787 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51355 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147664 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39683 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52037 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147450 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42162 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124252 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118708 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50545 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13764 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49941 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50181 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50003 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->