### PR TITLE
[WPE][GTK] use a separate expectations file for test262

### DIFF
--- a/JSTests/test262/expectations-linux.yaml
+++ b/JSTests/test262/expectations-linux.yaml
@@ -1,0 +1,223 @@
+---
+test/annexB/language/function-code/block-decl-func-skip-arguments.js:
+  default: 'Test262Error: Expected SameValue(«"function arguments() {}"», «"[object Arguments]"») to be true'
+test/built-ins/Function/internals/Construct/derived-return-val-realm.js:
+  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
+  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
+test/built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js:
+  default: 'Test262Error: Expected a ReferenceError but got a different error constructor with the same name'
+  strict mode: 'Test262Error: Expected a ReferenceError but got a different error constructor with the same name'
+test/built-ins/Function/prototype/arguments/prop-desc.js:
+  default: 'Test262Error: Function.prototype.arguments property getter/setter are the same function Expected SameValue(«function arguments() {'
+  strict mode: 'Test262Error: Function.prototype.arguments property getter/setter are the same function Expected SameValue(«function arguments() {'
+test/built-ins/Function/prototype/caller-arguments/accessor-properties.js:
+  default: 'Test262Error: Function.prototype.arguments and Function.prototype.caller accessor functions should match (%ThrowTypeError%) Expected SameValue(«function caller() {'
+  strict mode: 'Test262Error: Function.prototype.arguments and Function.prototype.caller accessor functions should match (%ThrowTypeError%) Expected SameValue(«function caller() {'
+test/built-ins/Function/prototype/caller/prop-desc.js:
+  default: 'Test262Error: Caller property getter/setter are the same function Expected SameValue(«function caller() {'
+  strict mode: 'Test262Error: Caller property getter/setter are the same function Expected SameValue(«function caller() {'
+test/built-ins/Function/prototype/toString/built-in-function-object.js:
+  default: 'Test262Error: Conforms to NativeFunction Syntax: "function $*() {\n    [native code]\n}" (%RegExp%.$*)'
+  strict mode: 'Test262Error: Conforms to NativeFunction Syntax: "function $*() {\n    [native code]\n}" (%RegExp%.$*)'
+test/built-ins/Proxy/apply/arguments-realm.js:
+  default: 'Test262Error: Expected SameValue(«function Array() {'
+  strict mode: 'Test262Error: Expected SameValue(«function Array() {'
+test/built-ins/Proxy/apply/null-handler-realm.js:
+  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
+  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
+test/built-ins/Proxy/apply/trap-is-not-callable-realm.js:
+  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
+  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
+test/built-ins/Proxy/construct/arguments-realm.js:
+  default: 'Test262Error: Expected SameValue(«function Array() {'
+  strict mode: 'Test262Error: Expected SameValue(«function Array() {'
+test/built-ins/Proxy/construct/trap-is-not-callable-realm.js:
+  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
+  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
+test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js:
+  default: 'Test262Error: Actual [20, 30, 40, 60] and expected [20, 20, 20, 60] should have the same contents.  (Testing with Float64Array and makePassthrough.)'
+  strict mode: 'Test262Error: Actual [20, 30, 40, 60] and expected [20, 20, 20, 60] should have the same contents.  (Testing with Float64Array and makePassthrough.)'
+test/built-ins/TypedArrayConstructors/ctors/object-arg/iterated-array-changed-by-tonumber.js:
+  default: 'Test262Error: Expected SameValue(«NaN», «2») to be true (Testing with Float64Array and makePassthrough.)'
+  strict mode: 'Test262Error: Expected SameValue(«NaN», «2») to be true (Testing with Float64Array and makePassthrough.)'
+test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage-empty.js:
+  default: 'SyntaxError: Uint8Array.prototype.setFromBase64 requires a valid base64 string'
+  strict mode: 'SyntaxError: Uint8Array.prototype.setFromBase64 requires a valid base64 string'
+test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage.js:
+  default: 'SyntaxError: Uint8Array.prototype.setFromBase64 requires a valid base64 string'
+  strict mode: 'SyntaxError: Uint8Array.prototype.setFromBase64 requires a valid base64 string'
+test/language/destructuring/binding/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js:
+  default: 'Test262Error: Actual [binding::source, binding::sourceKey, sourceKey, get source, binding::defaultValue, binding::varTarget] and expected [binding::source, binding::sourceKey, sourceKey, binding::varTarget, get source, binding::defaultValue] should have the same contents. '
+test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js:
+  default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«"param"», «undefined») to be true'
+test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js:
+  default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«"param"», «undefined») to be true'
+test/language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js:
+  default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«"param"», «undefined») to be true'
+test/language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign.js:
+  default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«"param"», «undefined») to be true'
+test/language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js:
+  default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«"param"», «undefined») to be true'
+test/language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign.js:
+  default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«"param"», «undefined») to be true'
+test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js:
+  default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«"param"», «undefined») to be true'
+test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js:
+  default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«"param"», «undefined») to be true'
+test/language/expressions/assignment/fn-name-lhs-cover.js:
+  default: 'Test262Error: name descriptor value should be ; name value should be '
+  strict mode: 'Test262Error: name descriptor value should be ; name value should be '
+test/language/expressions/call/tco-non-eval-function-dynamic.js:
+  default: 'RangeError: Maximum call stack size exceeded.'
+test/language/expressions/call/tco-non-eval-function.js:
+  default: 'RangeError: Maximum call stack size exceeded.'
+test/language/expressions/call/tco-non-eval-global.js:
+  default: 'RangeError: Maximum call stack size exceeded.'
+test/language/expressions/call/tco-non-eval-with.js:
+  default: 'RangeError: Maximum call stack size exceeded.'
+test/language/expressions/delete/super-property-uninitialized-this.js:
+  default: 'Test262Error: Expected a ReferenceError but got a Test262Error'
+  strict mode: 'Test262Error: Expected a ReferenceError but got a Test262Error'
+test/language/expressions/dynamic-import/import-attributes/2nd-param-with-type-text.js:
+  default: 'Test262:AsyncTestFailure:TypeError: Import attribute type "text" is not valid'
+  strict mode: 'Test262:AsyncTestFailure:TypeError: Import attribute type "text" is not valid'
+test/language/expressions/new/non-ctor-err-realm.js:
+  default: 'Test262Error: production including Arguments Expected a TypeError but got a different error constructor with the same name'
+  strict mode: 'Test262Error: production including Arguments Expected a TypeError but got a different error constructor with the same name'
+test/language/expressions/object/computed-property-name-topropertykey-before-value-evaluation.js:
+  default: 'Test262Error: Expected SameValue(«"bad"», «"ok"») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«"bad"», «"ok"») to be true'
+test/language/expressions/super/prop-expr-uninitialized-this-putvalue-compound-assign.js:
+  default: 'Test262Error: Expected a ReferenceError but got a Test262Error'
+  strict mode: 'Test262Error: Expected a ReferenceError but got a Test262Error'
+test/language/expressions/super/prop-expr-uninitialized-this-putvalue-increment.js:
+  default: 'Test262Error: Expected a ReferenceError but got a Test262Error'
+  strict mode: 'Test262Error: Expected a ReferenceError but got a Test262Error'
+test/language/expressions/super/prop-expr-uninitialized-this-putvalue.js:
+  default: 'Test262Error: Expected a ReferenceError but got a Test262Error'
+  strict mode: 'Test262Error: Expected a ReferenceError but got a Test262Error'
+test/language/expressions/yield/star-iterable.js:
+  default: 'Test262Error: First result `done` flag Expected SameValue(«false», «undefined») to be true'
+  strict mode: 'Test262Error: First result `done` flag Expected SameValue(«false», «undefined») to be true'
+test/language/expressions/yield/star-rhs-iter-nrml-res-done-no-value.js:
+  default: 'Test262Error: access count (first iteration) Expected SameValue(«1», «0») to be true'
+  strict mode: 'Test262Error: access count (first iteration) Expected SameValue(«1», «0») to be true'
+test/language/expressions/yield/star-rhs-iter-rtrn-res-done-no-value.js:
+  default: 'Test262Error: access count (second iteration) Expected SameValue(«1», «0») to be true'
+  strict mode: 'Test262Error: access count (second iteration) Expected SameValue(«1», «0») to be true'
+test/language/expressions/yield/star-rhs-iter-thrw-res-done-no-value.js:
+  default: 'Test262Error: access count (second iteration) Expected SameValue(«1», «0») to be true'
+  strict mode: 'Test262Error: access count (second iteration) Expected SameValue(«1», «0») to be true'
+test/language/identifier-resolution/assign-to-global-undefined.js:
+  strict mode: Expected uncaught exception with name 'ReferenceError' but none was thrown
+test/language/import/import-attributes/text-empty.js:
+  module: 'TypeError: Import attribute type "text" is not valid'
+test/language/import/import-attributes/text-javascript.js:
+  module: 'TypeError: Import attribute type "text" is not valid'
+test/language/import/import-attributes/text-self.js:
+  module: 'TypeError: Import attribute type "text" is not valid'
+test/language/import/import-attributes/text-string.js:
+  module: 'TypeError: Import attribute type "text" is not valid'
+test/language/import/import-attributes/text-via-namespace.js:
+  module: 'TypeError: Import attribute type "text" is not valid'
+test/language/statements/class/elements/private-class-field-on-nonextensible-objects.js:
+  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+test/language/statements/class/subclass/private-class-field-on-nonextensible-return-override.js:
+  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+test/language/statements/for-await-of/head-lhs-async.js:
+  default: "SyntaxError: Unexpected identifier 'of'"
+  strict mode: "SyntaxError: Unexpected identifier 'of'"
+test/language/statements/for-in/head-lhs-let.js:
+  default: "SyntaxError: Cannot use the keyword 'in' as a lexical variable name."
+test/language/statements/for-in/identifier-let-allowed-as-lefthandside-expression-not-strict.js:
+  default: "SyntaxError: Cannot use the keyword 'in' as a lexical variable name."
+test/language/statements/for/head-lhs-let.js:
+  default: "SyntaxError: Unexpected token ';'. Expected a parameter pattern or a ')' in parameter list."
+test/language/statements/with/get-binding-value-call-with-proxy-env.js:
+  default: 'Test262Error: Actual [has:Object, get:Symbol(Symbol.unscopables), get:Object] and expected [has:Object, get:Symbol(Symbol.unscopables), has:Object, get:Object] should have the same contents. '
+test/language/statements/with/get-binding-value-idref-with-proxy-env.js:
+  default: 'Test262Error: Actual [has:Object, get:Symbol(Symbol.unscopables), get:Object] and expected [has:Object, get:Symbol(Symbol.unscopables), has:Object, get:Object] should have the same contents. '
+test/language/statements/with/get-mutable-binding-binding-deleted-in-get-unscopables.js:
+  default: "ReferenceError: Can't find variable: binding"
+test/language/statements/with/set-mutable-binding-idref-compound-assign-with-proxy-env.js:
+  default: 'Test262Error: Actual [has:p, get:Symbol(Symbol.unscopables), get:p, has:p, set:p, getOwnPropertyDescriptor:p, defineProperty:p] and expected [has:p, get:Symbol(Symbol.unscopables), has:p, get:p, has:p, set:p, getOwnPropertyDescriptor:p, defineProperty:p] should have the same contents. '
+test/staging/sm/ArrayBuffer/slice-species.js:
+  default: 'Test262Error: Expected SameValue(«function ArrayBuffer() {'
+  strict mode: 'Test262Error: Expected SameValue(«function ArrayBuffer() {'
+test/staging/sm/Date/two-digit-years.js:
+  default: 'Test262Error: Expected SameValue(«NaN», «957164400000») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«NaN», «957164400000») to be true'
+test/staging/sm/Function/arguments-parameter-shadowing.js:
+  default: 'Test262Error: Expected SameValue(«true», «false») to be true'
+test/staging/sm/Function/function-name-assignment.js:
+  default: 'Test262Error: Expected SameValue(«"inParen"», «""») to be true'
+test/staging/sm/Function/function-toString-builtin-name.js:
+  default: 'Test262Error: Incorrect match for undefined Expected SameValue(«"fn"», «undefined») to be true'
+  strict mode: 'Test262Error: Incorrect match for undefined Expected SameValue(«"fn"», «undefined») to be true'
+test/staging/sm/PrivateName/modify-non-extensible.js:
+  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+test/staging/sm/Proxy/revoked-get-function-realm-typeerror.js:
+  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+test/staging/sm/RegExp/replace-sticky-lastIndex.js:
+  default: 'Test262Error: Expected SameValue(«"b"», «"a"») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«"b"», «"a"») to be true'
+test/staging/sm/RegExp/replace-sticky.js:
+  default: 'Test262Error: Expected SameValue(«"ABCDEabcdeabcdefghij"», «"abcdeABCDEabcdefghij"») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«"ABCDEabcdeabcdefghij"», «"abcdeABCDEabcdefghij"») to be true'
+test/staging/sm/RegExp/unicode-braced.js:
+  default: 'SyntaxError: Invalid regular expression: regular expression too large'
+  strict mode: 'SyntaxError: Invalid regular expression: regular expression too large'
+test/staging/sm/RegExp/unicode-class-braced.js:
+  default: 'SyntaxError: Invalid regular expression: regular expression too large'
+  strict mode: 'SyntaxError: Invalid regular expression: regular expression too large'
+test/staging/sm/TypedArray/slice-memcpy.js:
+  default: 'Test262Error: Actual [1, 2, 1, 2, 3, 4] and expected [1, 2, 1, 2, 1, 2] should have the same contents. '
+  strict mode: 'Test262Error: Actual [1, 2, 1, 2, 3, 4] and expected [1, 2, 1, 2, 1, 2] should have the same contents. '
+test/staging/sm/class/superPropOrdering.js:
+  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+test/staging/sm/eval/redeclared-arguments-in-param-expression-eval.js:
+  default: 'Test262Error: Expected SameValue(«true», «false») to be true'
+test/staging/sm/expressions/exponentiation-unparenthesised-unary.js:
+  default: 'Test262Error: AsyncFunction:await a ** 0 Expected a SyntaxError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: AsyncFunction:await a ** 0 Expected a SyntaxError to be thrown but no exception was thrown at all'
+test/staging/sm/expressions/object-literal-computed-property-evaluation.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «"abc"») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «"abc"») to be true'
+test/staging/sm/expressions/short-circuit-compound-assignment-anon-fns.js:
+  default: 'Test262Error: Expected SameValue(«"a"», «""») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«"a"», «""») to be true'
+test/staging/sm/extensions/function-caller-skips-eval-frames.js:
+  default: 'Test262Error: Expected SameValue(«null», «function nest() { return eval("innermost();"); }») to be true'
+test/staging/sm/extensions/new-cross-compartment.js:
+  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
+  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
+test/staging/sm/fields/await-identifier-module-2.js:
+  module: 'Test262: This statement should not be evaluated.'
+test/staging/sm/generators/delegating-yield-1.js:
+  default: 'Test262Error: Expected [Object {value: 1}, Object {value: 34, done: true}] to be structurally equal to [Object {value: 1, done: false}, Object {value: 34, done: true}]. '
+  strict mode: 'Test262Error: Expected [Object {value: 1}, Object {value: 34, done: true}] to be structurally equal to [Object {value: 1, done: false}, Object {value: 34, done: true}]. '
+test/staging/sm/generators/delegating-yield-3.js:
+  default: 'Test262Error: Expected SameValue(«true», «undefined») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«true», «undefined») to be true'
+test/staging/sm/generators/delegating-yield-5.js:
+  default: 'Test262Error: Expected [Object {value: 1}, Object {value: 34, done: true}] to be structurally equal to [Object {value: 1, done: false}, Object {value: 34, done: true}]. '
+  strict mode: 'Test262Error: Expected [Object {value: 1}, Object {value: 34, done: true}] to be structurally equal to [Object {value: 1, done: false}, Object {value: 34, done: true}]. '
+test/staging/sm/generators/delegating-yield-6.js:
+  default: 'Test262Error: Expected SameValue(«"indvndvndvndvndvndv"», «"indndndndndndv"») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«"indvndvndvndvndvndv"», «"indndndndndndv"») to be true'
+test/staging/sm/generators/delegating-yield-7.js:
+  default: 'Test262Error: Expected [Object {value: 1}, Object {value: 34, done: true}] to be structurally equal to [Object {value: 1, done: false}, Object {value: 34, done: true}]. '
+  strict mode: 'Test262Error: Expected [Object {value: 1}, Object {value: 34, done: true}] to be structurally equal to [Object {value: 1, done: false}, Object {value: 34, done: true}]. '
+test/staging/sm/lexical-environment/block-scoped-functions-annex-b-label.js:
+  default: "TypeError: f1 is not a function. (In 'f1()', 'f1' is undefined)"
+test/staging/sm/lexical-environment/block-scoped-functions-deprecated-redecl.js:
+  default: 'Test262Error: Expected SameValue(«3», «4») to be true'
+test/staging/sm/lexical-environment/for-loop.js:
+  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
+test/staging/sm/misc/future-reserved-words.js:
+  default: 'Test262Error: implements: function argument retroactively strict Expected a SyntaxError to be thrown but no exception was thrown at all'
+test/staging/sm/module/await-restricted-nested.js:
+  module: 'Test262: This statement should not be evaluated.'

--- a/Tools/Scripts/test262/Runner.pm
+++ b/Tools/Scripts/test262/Runner.pm
@@ -135,7 +135,8 @@ my $noProgress;
 
 my $test262Dir;
 my $webkitTest262Dir = abs_path("$Bin/../../../JSTests/test262");
-my $expectationsFile = abs_path("$webkitTest262Dir/expectations.yaml");
+my $expectationsFilename = $^O eq 'linux' ? "expectations-linux.yaml" : "expectations.yaml";
+my $expectationsFile = abs_path("$webkitTest262Dir/$expectationsFilename");
 my $configFile = abs_path("$webkitTest262Dir/config.yaml");
 
 my $resultsDir = $ENV{PWD} . "/test262-results";


### PR DESCRIPTION
#### f0dbc4c6b9d1bc9c9db77f9708d92d4ba0b4eb59
<pre>
[WPE][GTK] use a separate expectations file for test262
<a href="https://bugs.webkit.org/show_bug.cgi?id=320635">https://bugs.webkit.org/show_bug.cgi?id=320635</a>

Reviewed by Carlos Alberto Lopez Perez.

Runner.pm now resolves its default expectations file based on
platform: expectations-linux.yaml on Linux, expectations.yaml
everywhere else. This lets glib/wpe test262 results be tracked
separately from other ports without requiring --expectations on
every invocation.

Reuse expectations.yaml to create expectations-linux.yaml
so existing known failures carry over as the starting baseline.

* JSTests/test262/expectations-linux.yaml: Added.
* Tools/Scripts/test262/Runner.pm:

Canonical link: <a href="https://commits.webkit.org/318294@main">https://commits.webkit.org/318294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/518216e94e4861d67c17c5d724dff1ea18157410

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187337 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138524 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42049 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159324 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118988 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40711 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39074 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/957 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7766 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38766 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35799 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38999 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189765 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51333 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147642 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52015 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147428 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26970 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42142 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118662 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50523 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13743 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49919 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50159 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->