### PR TITLE
Support stream upload back pressure in case of service worker reading the upload data

### DIFF
--- a/LayoutTests/http/wpt/service-workers/upload-stream-backpressure-worker.js
+++ b/LayoutTests/http/wpt/service-workers/upload-stream-backpressure-worker.js
@@ -1,12 +1,22 @@
-let waitingToRead = null;
+let waitingToStart = null;
+let waitingToContinue = null;
 
 addEventListener("fetch", (event) => {
     const url = new URL(event.request.url);
+    const releaseStep = url.searchParams.get("release");
 
-    if (url.searchParams.get("release") === "1") {
-        if (waitingToRead) {
-            waitingToRead.resolve();
-            waitingToRead = null;
+    if (releaseStep === "1") {
+        if (waitingToStart) {
+            waitingToStart.resolve();
+            waitingToStart = null;
+        }
+        event.respondWith(new Response("released"));
+        return;
+    }
+    if (releaseStep === "2") {
+        if (waitingToContinue) {
+            waitingToContinue.resolve();
+            waitingToContinue = null;
         }
         event.respondWith(new Response("released"));
         return;
@@ -16,10 +26,23 @@ addEventListener("fetch", (event) => {
         return;
 
     event.respondWith((async () => {
-        await new Promise((resolve) => { waitingToRead = { resolve }; });
+        await new Promise((resolve) => { waitingToStart = { resolve }; });
 
         const reader = event.request.body.getReader();
         let total = 0;
+
+        // Consume a bounded number of chunks then pause to prove that backpressure
+        // re-engages once the service worker stops reading.
+        const CHUNKS_BEFORE_PAUSE = 4;
+        for (let i = 0; i < CHUNKS_BEFORE_PAUSE; ++i) {
+            const { value, done } = await reader.read();
+            if (done)
+                return new Response(String(total), { headers: { "Content-Type": "text/plain" } });
+            total += value.byteLength;
+        }
+
+        await new Promise((resolve) => { waitingToContinue = { resolve }; });
+
         while (true) {
             const { value, done } = await reader.read();
             if (done)

--- a/LayoutTests/http/wpt/service-workers/upload-stream-backpressure.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/upload-stream-backpressure.https-expected.txt
@@ -1,6 +1,6 @@
 
 
 PASS Setup: register service worker
-PASS Backpressure pauses the ReadableStream pull() and resumes once the service worker consumes the body
+PASS Backpressure pauses the ReadableStream pull() and re-engages when the service worker stops reading
 PASS Cleanup: unregister service worker
 

--- a/LayoutTests/http/wpt/service-workers/upload-stream-backpressure.https.html
+++ b/LayoutTests/http/wpt/service-workers/upload-stream-backpressure.https.html
@@ -9,7 +9,8 @@
 <script>
 const scope = "resources";
 const endpoint = "resources/backpressure-endpoint";
-const releaseUrl = "resources/backpressure-endpoint?release=1";
+const releaseUrl1 = "resources/backpressure-endpoint?release=1";
+const releaseUrl2 = "resources/backpressure-endpoint?release=2";
 const CHUNK_SIZE = 16 * 1024;   // 16 KB per pull
 const MAX_TOTAL   = 4 * 1024 * 1024; // 4 MB safety cap
 let activeWorker;
@@ -42,6 +43,22 @@ function makeCountedStream(counters) {
     });
 }
 
+async function waitForPullCountToStabilize(counters, { hits = 4, pollMs = 50, timeoutMs = 5000 } = {}) {
+    const deadline = performance.now() + timeoutMs;
+    let stableHits = 0;
+    let lastCount = counters.pullCount;
+    while (stableHits < hits && performance.now() < deadline) {
+        await new Promise(r => step_timeout(r, pollMs));
+        if (counters.pullCount === lastCount)
+            stableHits++;
+        else {
+            stableHits = 0;
+            lastCount = counters.pullCount;
+        }
+    }
+    return stableHits === hits;
+}
+
 promise_test(async () => {
     const registration = await navigator.serviceWorker.register("upload-stream-backpressure-worker.js", { scope });
     activeWorker = registration.active || registration.installing;
@@ -71,49 +88,51 @@ promise_test(async () => {
         await new Promise(r => step_timeout(r, 25));
     assert_greater_than(counters.pullCount, 0, "pull() must fire at least once");
 
-    // Phase 1b: wait for pull() to stabilize — i.e., the same count observed
-    // twice in a row across a short window. That's the signal that backpressure
-    // has kicked in and the ReadableStream is no longer being pulled.
-    const STABILITY_POLL_MS = 50;
-    const STABILITY_HITS_REQUIRED = 4; // ~200ms of no-change
-    const stabilizeDeadline = performance.now() + 5000;
-    let stableHits = 0;
-    let lastCount = counters.pullCount;
-    while (stableHits < STABILITY_HITS_REQUIRED && performance.now() < stabilizeDeadline) {
-        await new Promise(r => step_timeout(r, STABILITY_POLL_MS));
-        if (counters.pullCount === lastCount)
-            stableHits++;
-        else {
-            stableHits = 0;
-            lastCount = counters.pullCount;
-        }
-    }
-    assert_equals(stableHits, STABILITY_HITS_REQUIRED,
-        `pull() count never stabilized (last=${lastCount}, current=${counters.pullCount})`);
+    // Phase 1b: pull() must stabilize before the SW starts consuming, proving
+    // that source-side backpressure engaged.
+    let stabilized = await waitForPullCountToStabilize(counters);
+    assert_true(stabilized, `pull() count never stabilized (current=${counters.pullCount})`);
 
-    const pullsAfterFill = counters.pullCount;
     const bytesAfterFill = counters.bytesEnqueued;
-
-    // The amount pulled before backpressure should be close to the sink threshold (64KB)
-    // + the loader in-flight allowance. Upper-bound guards against runaway pulls.
+    const pullsAfterFill = counters.pullCount;
     assert_less_than(bytesAfterFill, 2 * 1024 * 1024,
         `pulled bytes before backpressure must be bounded (${bytesAfterFill})`);
 
-    // Phase 2: tell the SW to release. pull() should resume once the network
-    // process starts forwarding to the SW.
-    await controlledFrame.contentWindow.fetch(releaseUrl);
+    // Phase 2: tell the SW to read a bounded number of chunks and then pause,
+    // exercising the NeedData → drain credit-refresh loop between source and
+    // network.
+    await controlledFrame.contentWindow.fetch(releaseUrl1);
 
+    // pull() must resume once the service worker starts reading.
     const resumeDeadline = performance.now() + 5000;
     while (counters.pullCount === pullsAfterFill && performance.now() < resumeDeadline)
         await new Promise(r => step_timeout(r, 25));
     assert_greater_than(counters.pullCount, pullsAfterFill,
         "pull() must resume once the service worker starts reading the body");
 
+    // Phase 2b: SW paused after reading a bounded number of chunks. Wait for
+    // pull() to stabilize again — this proves end-to-end backpressure
+    // re-engaged rather than the stream draining unbounded once SW opened the
+    // pipe.
+    stabilized = await waitForPullCountToStabilize(counters);
+    assert_true(stabilized, `pull() count never re-stabilized (current=${counters.pullCount})`);
+
+    const bytesAfterPartialRead = counters.bytesEnqueued;
+    assert_greater_than(bytesAfterPartialRead, bytesAfterFill,
+        "pull() must have made progress while SW was reading");
+    assert_less_than(bytesAfterPartialRead, MAX_TOTAL,
+        `stream must not be fully drained while SW is paused (${bytesAfterPartialRead})`);
+    assert_less_than(bytesAfterPartialRead, 1 * 1024 * 1024,
+        `backpressure must re-engage when SW pauses (${bytesAfterPartialRead})`);
+
+    // Phase 3: let the SW consume the rest.
+    await controlledFrame.contentWindow.fetch(releaseUrl2);
+
     const response = await responsePromise;
     assert_true(response.ok, "network response ok");
     const totalReceived = parseInt(await response.text(), 10);
     assert_equals(totalReceived, counters.bytesEnqueued, "server saw exactly the bytes the stream enqueued");
-}, "Backpressure pauses the ReadableStream pull() and resumes once the service worker consumes the body");
+}, "Backpressure pauses the ReadableStream pull() and re-engages when the service worker stops reading");
 
 promise_test(async () => {
     if (activeWorker) {

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -340,8 +340,11 @@ void FetchBodyConsumer::consumeFormDataAsStream(const FormData& formData, FetchB
     if (!context)
         return;
 
-    m_formDataConsumer = FormDataConsumer::create(formData, *context, [source = Ref { source }](auto&& result) {
-        auto protectedSource = source;
+    m_formDataConsumer = FormDataConsumer::create(formData, *context, [weakSource = WeakPtr { source }](auto&& result) {
+        RefPtr source = weakSource.get();
+        if (!source)
+            return false;
+
         if (result.hasException()) {
             source->error(result.releaseException());
             return false;
@@ -354,7 +357,10 @@ void FetchBodyConsumer::consumeFormDataAsStream(const FormData& formData, FetchB
         }
 
         return source->enqueue(ArrayBuffer::tryCreate(value));
-    });
+    }, FormDataConsumer::Mode::Pull);
+
+    source.setFormDataConsumer(*m_formDataConsumer);
+
     protect(m_formDataConsumer)->start();
 }
 

--- a/Source/WebCore/Modules/fetch/FetchBodySource.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.cpp
@@ -29,6 +29,7 @@
 #include "ContextDestructionObserverInlines.h"
 
 #include "FetchResponse.h"
+#include "FormDataConsumer.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
 #include "ReadableByteStreamController.h"
@@ -73,9 +74,18 @@ Ref<DOMPromise> FetchBodySource::pull(JSDOMGlobalObject& globalObject, ReadableB
     ASSERT_UNUSED(controller, &controller == m_byteController.get() || !m_byteController);
 
     auto [promise, deferred] = createPromiseAndWrapper(globalObject);
-    m_isPulling = true;
-    m_pullPromise = WTF::move(deferred);
+    if (RefPtr consumer = m_formDataConsumer)
+        consumer->resume(WTF::move(deferred));
+    else
+        m_pullPromise = WTF::move(deferred);
     return promise;
+}
+
+void FetchBodySource::setFormDataConsumer(Ref<FormDataConsumer>&& consumer)
+{
+    m_formDataConsumer = WTF::move(consumer);
+    if (RefPtr pullPromise = std::exchange(m_pullPromise, { }))
+        protect(m_formDataConsumer)->resume(WTF::move(pullPromise));
 }
 
 Ref<DOMPromise> FetchBodySource::cancel(JSDOMGlobalObject& globalObject, ReadableByteStreamController& controller, std::optional<JSC::JSValue>&&)
@@ -157,7 +167,11 @@ void FetchBodySource::error(const Exception& exception)
 
 bool FetchBodySource::isPulling() const
 {
-    return m_nonByteSource ? m_nonByteSource->isPulling() : m_isPulling;
+    if (m_nonByteSource)
+        return m_nonByteSource->isPulling();
+    if (m_formDataConsumer)
+        return m_formDataConsumer->hasPendingPull();
+    return !!m_pullPromise;
 }
 
 bool FetchBodySource::isCancelling() const
@@ -172,7 +186,6 @@ void FetchBodySource::resolvePullPromise()
         return;
     }
 
-    m_isPulling = false;
     if (auto pullPromise = std::exchange(m_pullPromise, { }))
         pullPromise->resolve();
 }

--- a/Source/WebCore/Modules/fetch/FetchBodySource.h
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.h
@@ -28,6 +28,7 @@
 
 #include "ReadableStreamSource.h"
 #include <WebCore/ActiveDOMObject.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace JSC {
 class ArrayBuffer;
@@ -38,9 +39,10 @@ namespace WebCore {
 class DOMPromise;
 class Exception;
 class FetchBodyOwner;
+class FormDataConsumer;
 class ReadableByteStreamController;
 
-class FetchBodySource final : public RefCounted<FetchBodySource> {
+class FetchBodySource final : public RefCountedAndCanMakeWeakPtr<FetchBodySource> {
 public:
     static std::pair<Ref<FetchBodySource>, Ref<RefCountedReadableStreamSource>> createNonByteSource(FetchBodyOwner&);
     static Ref<FetchBodySource> createByteSource(FetchBodyOwner&);
@@ -60,6 +62,8 @@ public:
     void setByteController(ReadableByteStreamController&);
     Ref<DOMPromise> pull(JSDOMGlobalObject&, ReadableByteStreamController&);
     Ref<DOMPromise> cancel(JSDOMGlobalObject&, ReadableByteStreamController&, std::optional<JSC::JSValue>&&);
+
+    void setFormDataConsumer(Ref<FormDataConsumer>&&);
 
 private:
     class NonByteSource;
@@ -98,12 +102,12 @@ private:
 
     WeakPtr<FetchBodyOwner> m_bodyOwner;
     bool m_isCancelling { false };
-    bool m_isPulling { false };
 
     const RefPtr<NonByteSource> m_nonByteSource;
 
     WeakPtr<ReadableByteStreamController> m_byteController;
     RefPtr<DeferredPromise> m_pullPromise;
+    RefPtr<FormDataConsumer> m_formDataConsumer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
@@ -29,9 +29,11 @@
 #include "BlobLoader.h"
 #include "ExceptionOr.h"
 #include "FormData.h"
+#include "JSDOMPromiseDeferred.h"
 #include "PendingStreamState.h"
 #include "SWContextManager.h"
 #include "SharedBuffer.h"
+#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WorkQueue.h>
 
@@ -39,11 +41,12 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FormDataConsumer);
 
-FormDataConsumer::FormDataConsumer(const FormData& formData, ScriptExecutionContext& context, Callback&& callback)
+FormDataConsumer::FormDataConsumer(const FormData& formData, ScriptExecutionContext& context, Callback&& callback, Mode mode)
     : m_formData(formData.copy())
     , m_context(&context)
     , m_callback(WTF::move(callback))
     , m_fileQueue(WorkQueue::create("FormDataConsumer file queue"_s))
+    , m_mode(mode)
 {
     // We explicitly copy pendingStreamState as FormData::copy does not, to limit the risk of trying to consume mulitple times the same pendingStreamState.
     if (RefPtr state = formData.pendingStreamState())
@@ -160,8 +163,6 @@ void FormDataConsumer::consumePendingStream(PendingStreamState& state)
                 connection->startPendingStreamUploadForwarding(state.get());
         });
     }
-
-    drainPendingStream();
 }
 
 void FormDataConsumer::drainPendingStream()
@@ -173,12 +174,25 @@ void FormDataConsumer::drainPendingStream()
     if (!state)
         return;
 
+    if (m_mode == Mode::Pull && !m_pendingPullPromise)
+        return;
+
     auto result = state->takeAvailableChunks();
 
     if (!result) {
         didFail(Exception { ExceptionCode::NetworkError, "Stream upload failed"_s });
         return;
     }
+
+    if (result->first.isEmpty() && !result->second) {
+        // We do not have data, let's wait for data availability notification.
+        return;
+    }
+
+    auto scope = makeScopeExit([promise = std::exchange(m_pendingPullPromise, { })] {
+        if (promise)
+            promise->resolve();
+    });
 
     for (auto chunk : result->first) {
         if (m_callback) {
@@ -197,6 +211,13 @@ void FormDataConsumer::drainPendingStream()
 
     if (auto callback = std::exchange(m_callback, nullptr))
         callback(std::span<const uint8_t> { });
+}
+
+void FormDataConsumer::resume(RefPtr<DeferredPromise>&& promise)
+{
+    ASSERT(m_mode == Mode::Pull);
+    m_pendingPullPromise = WTF::move(promise);
+    drainPendingStream();
 }
 
 void FormDataConsumer::consume(std::span<const uint8_t> content)

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.h
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.h
@@ -36,6 +36,7 @@
 namespace WebCore {
 
 class BlobLoader;
+class DeferredPromise;
 class Exception;
 class FormData;
 class PendingStreamState;
@@ -45,17 +46,21 @@ template<typename> class ExceptionOr;
 class FormDataConsumer : public RefCountedAndCanMakeWeakPtr<FormDataConsumer> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(FormDataConsumer, WEBCORE_EXPORT);
 public:
+    enum class Mode : bool { Greedy, Pull };
     using Callback = Function<bool(ExceptionOr<std::span<const uint8_t>>)>;
-    static Ref<FormDataConsumer> create(const FormData& formData, ScriptExecutionContext& context, Callback&& callback) { return adoptRef(*new FormDataConsumer(formData, context, WTF::move(callback))); }
+    static Ref<FormDataConsumer> create(const FormData& formData, ScriptExecutionContext& context, Callback&& callback, Mode mode = Mode::Greedy) { return adoptRef(*new FormDataConsumer(formData, context, WTF::move(callback), mode)); }
     WEBCORE_EXPORT ~FormDataConsumer();
 
     void start() { read(); }
     void cancel();
 
+    void resume(RefPtr<DeferredPromise>&&);
+    bool hasPendingPull() const { return !!m_pendingPullPromise; }
+
     bool hasPendingActivity() const { return !!m_blobLoader || m_isReadingFile || !!m_pendingStreamState; }
 
 private:
-    FormDataConsumer(const FormData&, ScriptExecutionContext&, Callback&&);
+    FormDataConsumer(const FormData&, ScriptExecutionContext&, Callback&&, Mode);
 
     void consumeData(const Vector<uint8_t>&);
     void consumeFile(const String&);
@@ -71,6 +76,7 @@ private:
     const Ref<FormData> m_formData;
     RefPtr<ScriptExecutionContext> m_context;
     Callback m_callback;
+    RefPtr<DeferredPromise> m_pendingPullPromise;
 
     size_t m_currentElementIndex { 0 };
     const Ref<WorkQueue> m_fileQueue;
@@ -78,6 +84,7 @@ private:
     RefPtr<PendingStreamState> m_pendingStreamState;
     bool m_isReadingFile { false };
     bool m_hasRequestedPendingStream { false };
+    const Mode m_mode;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -466,6 +466,17 @@ void WebSWServerToContextConnection::cancelPendingStreamUploadForwarding(WebCore
         fetch->cancelPendingStreamUpload();
 }
 
+void WebSWServerToContextConnection::pendingStreamUploadNeedData(WebCore::FetchIdentifier fetchIdentifier)
+{
+    RefPtr fetch = m_ongoingFetches.get(fetchIdentifier);
+    if (!fetch)
+        return;
+    RefPtr loader = fetch->loader();
+    if (!loader)
+        return;
+    loader->connectionToWebProcess().connection().send(Messages::WebResourceLoader::ServiceWorkerPendingStreamForwardingNeedData { }, loader->coreIdentifier());
+}
+
 void WebSWServerToContextConnection::didReceiveFetchTaskMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     MESSAGE_CHECK(ObjectIdentifier<FetchIdentifierType>::isValidIdentifier(decoder.destinationID()));

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -140,6 +140,7 @@ private:
     void startPendingStreamUploadForwarding(WebCore::FetchIdentifier);
     void pendingStreamDataAvailable(WebCore::FetchIdentifier);
     void cancelPendingStreamUploadForwarding(WebCore::FetchIdentifier);
+    void pendingStreamUploadNeedData(WebCore::FetchIdentifier);
 
     void connectionClosed();
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
@@ -50,4 +50,5 @@ messages -> WebSWServerToContextConnection {
 
     [EnabledBy=ServiceWorkersEnabled] StartPendingStreamUploadForwarding(WebCore::FetchIdentifier fetchIdentifier)
     [EnabledBy=ServiceWorkersEnabled] CancelPendingStreamUploadForwarding(WebCore::FetchIdentifier fetchIdentifier)
+    [EnabledBy=ServiceWorkersEnabled] PendingStreamUploadNeedData(WebCore::FetchIdentifier fetchIdentifier)
 }

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -106,10 +106,8 @@ static constexpr uint64_t kMaxInFlightBytes = 64 * 1024;
 
 void WebResourceLoader::drainPendingStreamIfPossible()
 {
-    if (!m_isServiceWorkerPendingStreamForwarding) {
-        if (m_pendingStreamBytesForwardedToNetworkProcess >= m_pendingStreamBytesSentByNetwork + kMaxInFlightBytes)
-            return;
-    }
+    if (m_pendingStreamBytesForwardedToNetworkProcess >= m_pendingStreamBytesSentByNetwork + kMaxInFlightBytes)
+        return;
 
     RefPtr state = m_pendingStreamState;
     if (!state)
@@ -137,8 +135,7 @@ void WebResourceLoader::drainPendingStreamIfPossible()
 
 void WebResourceLoader::serviceWorkerPendingStreamForwardingNeedData()
 {
-    // FIXME: We should implement backpressure for service worker stream uploads as well.
-    m_isServiceWorkerPendingStreamForwarding = true;
+    m_pendingStreamBytesSentByNetwork = m_pendingStreamBytesForwardedToNetworkProcess;
     drainPendingStreamIfPossible();
 }
 

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -126,7 +126,6 @@ private:
     RefPtr<WebCore::PendingStreamState> m_pendingStreamState;
     uint64_t m_pendingStreamBytesForwardedToNetworkProcess { 0 };
     uint64_t m_pendingStreamBytesSentByNetwork { 0 };
-    bool m_isServiceWorkerPendingStreamForwarding { false };
     size_t m_numBytesReceived { 0 };
     size_t m_bytesTransferredOverNetwork { 0 };
 

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -330,6 +330,9 @@ void WebSWContextManagerConnection::startFetch(SWServerConnectionIdentifier serv
     if (RefPtr body = request.httpBody(); body && body->isPendingStream()) {
         Ref pendingStreamState = WebCore::PendingStreamState::create();
         pendingStreamState->setServiceWorkerFetchIdentifier(fetchIdentifier);
+        pendingStreamState->setQueueDrainedHandler([connection = m_connectionToNetworkProcess, fetchIdentifier] {
+            connection->send(Messages::WebSWServerToContextConnection::PendingStreamUploadNeedData { fetchIdentifier }, 0);
+        });
         body->setPendingStreamState(WTF::move(pendingStreamState));
     }
     serviceWorkerThreadProxy->startFetch(serverConnectionIdentifier, fetchIdentifier, WTF::move(client), WTF::move(request), WTF::move(referrer), WTF::move(options), isServiceWorkerNavigationPreloadEnabled, WTF::move(clientIdentifier), WTF::move(resultingClientIdentifier));


### PR DESCRIPTION
#### 9baf1695f93dd8f0e7abb02a6b0f9076dcdd8323
<pre>
Support stream upload back pressure in case of service worker reading the upload data
<a href="https://rdar.apple.com/183529369">rdar://183529369</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320562">https://bugs.webkit.org/show_bug.cgi?id=320562</a>

Reviewed by Alex Christensen.

Before this PR, whenever the service worker was starting to read the upload body, we would send upload data as fast as possible to the service worker.
WebResourceLoader is now sending only a first burst of data (64ko) and waits for the service worker to acknowledge that it has received this data.
Service worker is registering a drained handler on the service worker stream upload.
Whenever the web page reads enough data to trigger the drained handler, the service worker will send IPC to network process,
that will forward the IPC to WebResourceLoader, which will send another burst of data (64ko) before waiting for a new message from service worker.

We need to tie the fetch body stream backpressure mechanism to the PendingStreamState backpressure.
To do so, we make FormDataConsumer wait for a signal from FetchBodySource to actually draing the PendingStreamState.
We introduce FormDataConsumer::resume, which takes the pull promise.
The pull promise gets resolved when some chunks are pushed in the fetch body stream.
Once the JS reads sufficient data, FetchBodySource::pull will be called again, which will resume FormDataConsumer.

Covered by updated test.

* LayoutTests/http/wpt/service-workers/upload-stream-backpressure-worker.js:
(event.event.respondWith.async await):
(event.event.respondWith):
(event.url.searchParams): Deleted.
* LayoutTests/http/wpt/service-workers/upload-stream-backpressure.https-expected.txt:
* LayoutTests/http/wpt/service-workers/upload-stream-backpressure.https.html:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::consumeFormDataAsStream):
* Source/WebCore/Modules/fetch/FetchBodySource.cpp:
(WebCore::FetchBodySource::pull):
(WebCore::FetchBodySource::setFormDataConsumer):
(WebCore::FetchBodySource::isPulling const):
(WebCore::FetchBodySource::resolvePullPromise):
* Source/WebCore/Modules/fetch/FetchBodySource.h:
* Source/WebCore/Modules/fetch/FormDataConsumer.cpp:
(WebCore::FormDataConsumer::consumePendingStream):
(WebCore::FormDataConsumer::drainPendingStream):
(WebCore::FormDataConsumer::resume):
* Source/WebCore/Modules/fetch/FormDataConsumer.h:
(WebCore::FormDataConsumer::hasPendingPull const):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::pendingStreamUploadNeedData):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in:
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::drainPendingStreamIfPossible):
(WebKit::WebResourceLoader::serviceWorkerPendingStreamForwardingNeedData):
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::startFetch):

Canonical link: <a href="https://commits.webkit.org/318346@main">https://commits.webkit.org/318346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18e92aaae352154a87ddfc88e83d9d0958e8698a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187377 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c0caa1d-cdd9-4fad-9a53-33efdfd0d6eb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138561 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f7d8aee-771f-4f62-94c6-a62c178abe44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42089 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159309 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119024 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ded0dbe0-293a-4522-9411-95ea795c1def) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40751 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39113 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38805 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35839 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39039 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189805 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147678 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39721 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52055 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147464 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42181 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124270 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118736 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50563 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13782 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49959 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50199 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50021 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->