### PR TITLE
[GTK][WPE] Fix thread safety issues caught by -Wthread-safety

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCVirtualMachine.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCVirtualMachine.cpp
@@ -115,7 +115,11 @@ static void jsc_virtual_machine_class_init(JSCVirtualMachineClass* klass)
 
 GRefPtr<JSCVirtualMachine> jscVirtualMachineGetOrCreate(JSContextGroupRef jsContextGroup)
 {
-    GRefPtr<JSCVirtualMachine> vm = wrapperMap().get(jsContextGroup);
+    GRefPtr<JSCVirtualMachine> vm;
+    {
+        Locker locker { wrapperCacheMutex };
+        vm = wrapperMap().get(jsContextGroup);
+    }
     if (!vm) {
         vm = adoptGRef(jsc_virtual_machine_new());
         jscVirtualMachineSetContextGroup(vm.get(), jsContextGroup);

--- a/Source/WTF/wtf/glib/ActivityObserver.h
+++ b/Source/WTF/wtf/glib/ActivityObserver.h
@@ -31,7 +31,7 @@ namespace WTF {
 class ActivityObserver : public ThreadSafeRefCounted<ActivityObserver> {
     WTF_MAKE_TZONE_ALLOCATED(ActivityObserver);
 public:
-    using Callback = Function<void()>;
+    using Callback = std::function<void()>;
 
     static Ref<ActivityObserver> create(Ref<RunLoop>&& runLoop, bool isRepeating, uint8_t order, OptionSet<RunLoop::Activity> activities, Callback&& callback)
     {
@@ -45,7 +45,10 @@ public:
 
     void start()
     {
-        ASSERT(m_callback);
+        if (ASSERT_ENABLED) {
+            Locker lock { m_callbackLock };
+            ASSERT(m_callback);
+        }
         if (auto runLoop = m_runLoop.get())
             runLoop->observeActivity(*this);
     }
@@ -69,13 +72,16 @@ public:
 
     void notify()
     {
+        Callback callback;
         {
             Locker lock { m_callbackLock };
             if (!m_callback)
                 return;
+
+            callback = m_callback;
         }
 
-        m_callback();
+        callback();
 
         if (!m_isRepeating)
             stop();

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
@@ -81,6 +81,7 @@ Ref<ScrollingTreeNode> ScrollingTreeCoordinated::createScrollingTreeNode(Scrolli
 
 void ScrollingTreeCoordinated::applyLayerPositionsInternal()
 {
+    assertIsHeld(m_treeLock);
     auto* rootScrollingNode = rootNode();
     if (!rootScrollingNode)
         return;
@@ -113,6 +114,7 @@ void ScrollingTreeCoordinated::didCompletePlatformRenderingUpdate()
 
 static bool traverseDescendantLayersAtPoint(const Ref<CoordinatedPlatformLayer>& parent, const FloatPoint& point, const Function<bool(const Ref<CoordinatedPlatformLayer>&, const FloatPoint&)>& function)
 {
+    assertIsHeld(parent->lock());
     for (auto& child : parent->children() | std::views::reverse) {
         Locker childLocker { child->lock() };
         FloatPoint transformedPoint(point);
@@ -150,6 +152,7 @@ RefPtr<ScrollingTreeNode> ScrollingTreeCoordinated::scrollingNodeForPoint(FloatP
 
     RefPtr<ScrollingTreeNode> result = rootScrollingNode;
     traverseDescendantLayersAtPoint(Ref { *rootContentsLayer }, point, [&](const Ref<CoordinatedPlatformLayer>& layer, const FloatPoint&) {
+        assertIsHeld(layer->lock());
         if (!layer->scrollingNodeID())
             return false;
         auto* scrollingNode = nodeForID(layer->scrollingNodeID());
@@ -190,6 +193,7 @@ OptionSet<EventListenerRegionType> ScrollingTreeCoordinated::eventListenerRegion
 
     OptionSet<EventListenerRegionType> result;
     traverseDescendantLayersAtPoint(rootContentsLayer, point, [&](const Ref<CoordinatedPlatformLayer>& layer, const FloatPoint& point) {
+        assertIsHeld(layer->lock());
         result = layer->eventRegion().eventListenerRegionTypesForPoint(roundedIntPoint(point));
         return true;
     });

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -330,8 +330,12 @@ void AudioDestinationGStreamer::notifyIsPlaying(bool isPlaying)
 
     GST_DEBUG("Is playing: %s", boolForPrinting(isPlaying));
     m_isPlaying = isPlaying;
-    if (m_callback)
-        m_callback->isPlayingDidChange();
+
+    {
+        Locker locker { m_callbackLock };
+        if (m_callback)
+            m_callback->isPlayingDidChange();
+    }
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -300,7 +300,10 @@ void TrackDataHolder::disconnect()
         m_stream.clear();
     }
 
-    m_tags.clear();
+    {
+        Locker locker { m_tagMutex };
+        m_tags.clear();
+    }
 
     m_notifier->cancelPendingNotifications();
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
@@ -218,8 +218,11 @@ VideoFrameMetadata webkitGstBufferGetVideoFrameMetadata(GstBuffer* buffer)
         return videoFrameMetadata;
 
     auto processingDuration = MediaTime::zeroTime();
-    for (auto& [startTime, stopTime] : meta->priv->processingTimes.values())
-        processingDuration += fromGstClockTime(GST_CLOCK_DIFF(startTime, stopTime));
+    {
+        Locker locker { meta->priv->lock };
+        for (auto& [startTime, stopTime] : meta->priv->processingTimes.values())
+            processingDuration += fromGstClockTime(GST_CLOCK_DIFF(startTime, stopTime));
+    }
 
     if (processingDuration != MediaTime::zeroTime())
         videoFrameMetadata.processingDuration = processingDuration.toDouble();
@@ -280,6 +283,7 @@ MediaTime webkitGstBufferGetProcessingTime(GstBuffer* buffer, GstElement* elemen
     if (!meta)
         return MediaTime::invalidTime();
 
+    Locker locker { meta->priv->lock };
     auto [startTime, stopTime] = meta->priv->processingTimes.get(element);
     return fromGstClockTime(GST_CLOCK_DIFF(startTime, stopTime));
 }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -159,8 +159,11 @@ MediaSourcePrivateGStreamer::AddStatus MediaSourcePrivateGStreamer::addSourceBuf
     if (!SourceBufferPrivateGStreamer::isContentTypeSupported(contentType))
         return MediaSourcePrivateGStreamer::AddStatus::NotSupported;
 
-    m_sourceBuffers.append(SourceBufferPrivateGStreamer::create(*this, contentType));
-    sourceBufferPrivate = m_sourceBuffers.last();
+    {
+        Locker locker { m_lock };
+        m_sourceBuffers.append(SourceBufferPrivateGStreamer::create(*this, contentType));
+        sourceBufferPrivate = m_sourceBuffers.last();
+    }
     sourceBufferPrivate->setMediaSourceDuration(duration());
     return MediaSourcePrivateGStreamer::AddStatus::Ok;
 }
@@ -244,10 +247,13 @@ void MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks()
         return;
     }
 
-    for (auto& sourceBuffer : m_sourceBuffers) {
-        if (!sourceBuffer->hasReceivedFirstInitializationSegment()) {
-            GST_DEBUG_OBJECT(player->pipeline(), "There are still SourceBuffers without an initialization segment, not starting source yet.");
-            return;
+    {
+        Locker locker { m_lock };
+        for (auto& sourceBuffer : m_sourceBuffers) {
+            if (!sourceBuffer->hasReceivedFirstInitializationSegment()) {
+                GST_DEBUG_OBJECT(player->pipeline(), "There are still SourceBuffers without an initialization segment, not starting source yet.");
+                return;
+            }
         }
     }
 
@@ -255,10 +261,13 @@ void MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks()
     m_hasAllTracks = true;
 
     Vector<RefPtr<MediaSourceTrackGStreamer>> tracks;
-    for (auto& privateSourceBuffer : m_sourceBuffers) {
-        auto sourceBuffer = downcast<SourceBufferPrivateGStreamer>(privateSourceBuffer);
-        for (auto& [_, track] : sourceBuffer->tracks())
-            tracks.append(track);
+    {
+        Locker locker { m_lock };
+        for (auto& privateSourceBuffer : m_sourceBuffers) {
+            auto sourceBuffer = downcast<SourceBufferPrivateGStreamer>(privateSourceBuffer);
+            for (auto& [_, track] : sourceBuffer->tracks())
+                tracks.append(track);
+        }
     }
     player->startSource(tracks);
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
@@ -71,7 +71,8 @@ public:
     void wait()
     {
         Locker locker { m_lock };
-        m_condition.wait(m_lock, [this]() WTF_REQUIRES_LOCK(m_lock) {
+        m_condition.wait(m_lock, [this]() {
+            assertIsHeld(m_lock);
             return !m_pendingCount;
         });
     }

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -116,7 +116,7 @@ Ref<BitmapTexture> BitmapTexturePool::createTextureForImage(EGLImage image, cons
 
 void BitmapTexturePool::scheduleReleaseUnusedTextures()
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_releaseUnusedTexturesTimer.isActive())
         return;
 
@@ -128,6 +128,7 @@ void BitmapTexturePool::releaseUnusedTexturesTimerFired()
     Locker locker { m_lock };
 
     auto hasTextures = [this] -> bool {
+        assertIsHeld(m_lock);
         if (!m_textures.isEmpty())
             return true;
 #if USE(GBM)
@@ -141,11 +142,13 @@ void BitmapTexturePool::releaseUnusedTexturesTimerFired()
         return;
 
     auto releaseTexturesIfNeeded = [&] {
+        assertIsHeld(m_lock);
         if (!m_textures.isEmpty()) {
             // Delete entries, which have been unused in releaseUnusedSecondsTolerance.
             MonotonicTime minUsedTime = MonotonicTime::now() - m_releaseUnusedSecondsTolerance;
 
             auto matchCount = m_textures.removeAllMatching([this, &minUsedTime](const Entry& entry) {
+                assertIsHeld(m_lock);
                 if (entry.canBeReleased(minUsedTime)) {
                     m_poolSizeInBytes -= entry.texture->sizeInBytes();
                     return true;
@@ -181,7 +184,7 @@ void BitmapTexturePool::releaseUnusedTexturesTimerFired()
 
 void BitmapTexturePool::enterLimitExceededModeIfNeeded()
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_onLimitExceededMode)
         return;
 
@@ -199,7 +202,7 @@ void BitmapTexturePool::enterLimitExceededModeIfNeeded()
 
 void BitmapTexturePool::exitLimitExceededModeIfNeeded()
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (!m_onLimitExceededMode)
         return;
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
@@ -99,6 +99,7 @@ Ref<CoordinatedBackingStoreProxy> CoordinatedBackingStoreProxy::create()
 
 OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStoreProxy::updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>& dirtyRegion, Damage& damage, CoordinatedPlatformLayer& layer)
 {
+    assertIsHeld(layer.lock());
     Vector<uint32_t> tilesToCreate;
     Vector<uint32_t> tilesToRemove;
     if (shouldCreateAndDestroyTiles)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -173,7 +173,7 @@ void CoordinatedPlatformLayer::notifyCompositionRequired()
 
 void CoordinatedPlatformLayer::setPosition(FloatPoint&& position)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     m_pendingState.position = WTF::move(position);
 }
 
@@ -185,7 +185,7 @@ void CoordinatedPlatformLayer::setPositionForScrolling(const FloatPoint& positio
 
 const FloatPoint& CoordinatedPlatformLayer::position() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return m_position;
 }
 
@@ -207,7 +207,7 @@ FloatPoint CoordinatedPlatformLayer::topLeftPositionForScrolling()
 
 void CoordinatedPlatformLayer::setBoundsOrigin(const FloatPoint& origin)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     m_pendingState.boundsOrigin = origin;
 }
 
@@ -219,13 +219,13 @@ void CoordinatedPlatformLayer::setBoundsOriginForScrolling(const FloatPoint& ori
 
 const FloatPoint& CoordinatedPlatformLayer::boundsOrigin() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return m_boundsOrigin;
 }
 
 void CoordinatedPlatformLayer::setAnchorPoint(FloatPoint3D&& point)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_anchorPoint == point)
         return;
 
@@ -236,13 +236,13 @@ void CoordinatedPlatformLayer::setAnchorPoint(FloatPoint3D&& point)
 
 const FloatPoint3D& CoordinatedPlatformLayer::anchorPoint() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return m_anchorPoint;
 }
 
 void CoordinatedPlatformLayer::setSize(FloatSize&& size)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_size == size)
         return;
 
@@ -253,19 +253,19 @@ void CoordinatedPlatformLayer::setSize(FloatSize&& size)
 
 const FloatSize& CoordinatedPlatformLayer::size() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return m_size;
 }
 
 FloatRect CoordinatedPlatformLayer::bounds() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return FloatRect({ }, m_size);
 }
 
 void CoordinatedPlatformLayer::setTransform(const TransformationMatrix& matrix)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_transform == matrix)
         return;
 
@@ -276,13 +276,13 @@ void CoordinatedPlatformLayer::setTransform(const TransformationMatrix& matrix)
 
 const TransformationMatrix& CoordinatedPlatformLayer::transform() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return m_transform;
 }
 
 void CoordinatedPlatformLayer::setChildrenTransform(const TransformationMatrix& matrix)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_childrenTransform == matrix)
         return;
 
@@ -293,7 +293,7 @@ void CoordinatedPlatformLayer::setChildrenTransform(const TransformationMatrix& 
 
 const TransformationMatrix& CoordinatedPlatformLayer::childrenTransform() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return m_childrenTransform;
 }
 
@@ -304,7 +304,7 @@ void CoordinatedPlatformLayer::didUpdateLayerTransform()
 
 void CoordinatedPlatformLayer::setVisibleRect(const FloatRect& visibleRect)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_visibleRect == visibleRect)
         return;
 
@@ -313,13 +313,13 @@ void CoordinatedPlatformLayer::setVisibleRect(const FloatRect& visibleRect)
 
 const FloatRect& CoordinatedPlatformLayer::visibleRect() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return m_visibleRect;
 }
 
 void CoordinatedPlatformLayer::setTransformedVisibleRect(IntRect&& transformedVisibleRect, IntRect&& transformedVisibleRectIncludingFuture)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_transformedVisibleRect == transformedVisibleRect && m_transformedVisibleRectIncludingFuture == transformedVisibleRectIncludingFuture)
         return;
 
@@ -331,7 +331,7 @@ void CoordinatedPlatformLayer::setTransformedVisibleRect(IntRect&& transformedVi
 #if ENABLE(SCROLLING_THREAD)
 void CoordinatedPlatformLayer::setScrollingNodeID(std::optional<ScrollingNodeID> nodeID)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_scrollingNodeID == nodeID)
         return;
 
@@ -342,14 +342,14 @@ void CoordinatedPlatformLayer::setScrollingNodeID(std::optional<ScrollingNodeID>
 
 const Markable<ScrollingNodeID>& CoordinatedPlatformLayer::scrollingNodeID() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return m_scrollingNodeID;
 }
 #endif
 
 void CoordinatedPlatformLayer::setDrawsContent(bool drawsContent)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_drawsContent == drawsContent)
         return;
 
@@ -360,7 +360,7 @@ void CoordinatedPlatformLayer::setDrawsContent(bool drawsContent)
 
 void CoordinatedPlatformLayer::setMasksToBounds(bool masksToBounds)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_masksToBounds == masksToBounds)
         return;
 
@@ -372,7 +372,7 @@ void CoordinatedPlatformLayer::setMasksToBounds(bool masksToBounds)
 
 void CoordinatedPlatformLayer::setPreserves3D(bool preserves3D)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_preserves3D == preserves3D)
         return;
 
@@ -383,7 +383,7 @@ void CoordinatedPlatformLayer::setPreserves3D(bool preserves3D)
 
 void CoordinatedPlatformLayer::setBackfaceVisibility(bool backfaceVisibility)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_backfaceVisibility == backfaceVisibility)
         return;
 
@@ -394,7 +394,7 @@ void CoordinatedPlatformLayer::setBackfaceVisibility(bool backfaceVisibility)
 
 void CoordinatedPlatformLayer::setOpacity(float opacity)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_opacity == opacity)
         return;
 
@@ -405,7 +405,7 @@ void CoordinatedPlatformLayer::setOpacity(float opacity)
 
 void CoordinatedPlatformLayer::setBlendMode(BlendMode blendMode)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_blendMode == blendMode)
         return;
 
@@ -417,7 +417,7 @@ void CoordinatedPlatformLayer::setBlendMode(BlendMode blendMode)
 
 void CoordinatedPlatformLayer::setContentsVisible(bool contentsVisible)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_contentsVisible == contentsVisible)
         return;
 
@@ -429,13 +429,13 @@ void CoordinatedPlatformLayer::setContentsVisible(bool contentsVisible)
 
 bool CoordinatedPlatformLayer::contentsVisible() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return m_contentsVisible;
 }
 
 void CoordinatedPlatformLayer::setContentsOpaque(bool contentsOpaque)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_contentsOpaque == contentsOpaque)
         return;
 
@@ -448,7 +448,7 @@ void CoordinatedPlatformLayer::setContentsOpaque(bool contentsOpaque)
 
 void CoordinatedPlatformLayer::setContentsRect(const FloatRect& contentsRect)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_contentsRect == contentsRect)
         return;
 
@@ -460,7 +460,7 @@ void CoordinatedPlatformLayer::setContentsRect(const FloatRect& contentsRect)
 
 void CoordinatedPlatformLayer::setContentsRectClipsDescendants(bool contentsRectClipsDescendants)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_contentsRectClipsDescendants == contentsRectClipsDescendants)
         return;
 
@@ -472,7 +472,7 @@ void CoordinatedPlatformLayer::setContentsRectClipsDescendants(bool contentsRect
 
 void CoordinatedPlatformLayer::setContentsClippingRect(const FloatRoundedRect& contentsClippingRect)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_contentsClippingRect == contentsClippingRect)
         return;
 
@@ -484,7 +484,7 @@ void CoordinatedPlatformLayer::setContentsClippingRect(const FloatRoundedRect& c
 
 void CoordinatedPlatformLayer::setContentsScale(float contentsScale)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_contentsScale == contentsScale)
         return;
 
@@ -495,13 +495,13 @@ void CoordinatedPlatformLayer::setContentsScale(float contentsScale)
 
 float CoordinatedPlatformLayer::contentsScale() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return m_contentsScale;
 }
 
 bool CoordinatedPlatformLayer::hasCommittedContentsBuffer() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
 #if USE(SKIA)
     if (m_skiaTarget)
         return !!m_skiaTarget->contentsBuffer();
@@ -512,7 +512,7 @@ bool CoordinatedPlatformLayer::hasCommittedContentsBuffer() const
 
 void CoordinatedPlatformLayer::setContentsBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&& buffer, std::optional<Damage>&& dirtyRegion, RequireComposition requireComposition)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (!buffer && !m_contentsBuffer.pending && !hasCommittedContentsBuffer())
         return;
 
@@ -558,7 +558,7 @@ void CoordinatedPlatformLayer::replaceCurrentContentsBufferWithCopy()
 
 void CoordinatedPlatformLayer::setContentsImage(NativeImage* image)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (image) {
         if (m_imageBackingStore.current && m_imageBackingStore.current->isSameNativeImage(*image))
             return;
@@ -577,7 +577,7 @@ void CoordinatedPlatformLayer::setContentsImage(NativeImage* image)
 
 void CoordinatedPlatformLayer::setContentsColor(const Color& color)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_contentsColor == color)
         return;
 
@@ -588,7 +588,7 @@ void CoordinatedPlatformLayer::setContentsColor(const Color& color)
 
 void CoordinatedPlatformLayer::setContentsTileSize(const FloatSize& contentsTileSize)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_contentsTileSize == contentsTileSize)
         return;
 
@@ -600,7 +600,7 @@ void CoordinatedPlatformLayer::setContentsTileSize(const FloatSize& contentsTile
 
 void CoordinatedPlatformLayer::setContentsTilePhase(const FloatSize& contentsTilePhase)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_contentsTilePhase == contentsTilePhase)
         return;
 
@@ -612,7 +612,7 @@ void CoordinatedPlatformLayer::setContentsTilePhase(const FloatSize& contentsTil
 
 void CoordinatedPlatformLayer::setDirtyRegion(Damage&& damage)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     auto dirtyRegion = damage.rects();
     if (m_dirtyRegion != dirtyRegion) {
         m_dirtyRegion = WTF::move(dirtyRegion);
@@ -627,6 +627,7 @@ void CoordinatedPlatformLayer::setDirtyRegion(Damage&& damage)
 #if ENABLE(DAMAGE_TRACKING)
 void CoordinatedPlatformLayer::addDamage(Damage&& damage)
 {
+    assertIsHeld(m_lock);
     if (!m_damage)
         m_damage = WTF::move(damage);
     else
@@ -638,6 +639,7 @@ void CoordinatedPlatformLayer::addDamage(Damage&& damage)
 void CoordinatedPlatformLayer::damageWholeLayer()
 {
 #if ENABLE(DAMAGE_TRACKING)
+    assertIsHeld(m_lock);
     // An empty Damage rejects everything added to it later, so it must never become the layer's damage.
     if (!m_damagePropagationEnabled || m_size.isEmpty())
         return;
@@ -648,7 +650,7 @@ void CoordinatedPlatformLayer::damageWholeLayer()
 
 void CoordinatedPlatformLayer::setFilters(const FilterOperations& filters)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_filters == filters)
         return;
 
@@ -660,7 +662,7 @@ void CoordinatedPlatformLayer::setFilters(const FilterOperations& filters)
 
 void CoordinatedPlatformLayer::setMask(CoordinatedPlatformLayer* mask)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_mask == mask)
         return;
 
@@ -672,7 +674,7 @@ void CoordinatedPlatformLayer::setMask(CoordinatedPlatformLayer* mask)
 
 void CoordinatedPlatformLayer::setReplica(CoordinatedPlatformLayer* replica)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_replica == replica)
         return;
 
@@ -684,7 +686,7 @@ void CoordinatedPlatformLayer::setReplica(CoordinatedPlatformLayer* replica)
 
 void CoordinatedPlatformLayer::setBackdrop(CoordinatedPlatformLayer* backdrop)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_backdrop == backdrop)
         return;
 
@@ -694,7 +696,7 @@ void CoordinatedPlatformLayer::setBackdrop(CoordinatedPlatformLayer* backdrop)
 
 void CoordinatedPlatformLayer::notifyBackdropFiltersChanged()
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     m_pendingChanges.add(Change::Backdrop);
     damageWholeLayer();
     notifyCompositionRequired();
@@ -702,7 +704,7 @@ void CoordinatedPlatformLayer::notifyBackdropFiltersChanged()
 
 void CoordinatedPlatformLayer::setBackdropRect(const FloatRoundedRect& backdropRect)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_backdropRect == backdropRect)
         return;
 
@@ -714,7 +716,7 @@ void CoordinatedPlatformLayer::setBackdropRect(const FloatRoundedRect& backdropR
 
 void CoordinatedPlatformLayer::setIsBackdropRoot(bool isBackdropRoot)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_isBackdropRoot == isBackdropRoot)
         return;
 
@@ -725,7 +727,7 @@ void CoordinatedPlatformLayer::setIsBackdropRoot(bool isBackdropRoot)
 
 void CoordinatedPlatformLayer::setAnimations(const TextureMapperAnimations& animations)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     m_animations = animations;
     m_pendingChanges.add(Change::Animations);
     notifyCompositionRequired();
@@ -733,7 +735,7 @@ void CoordinatedPlatformLayer::setAnimations(const TextureMapperAnimations& anim
 
 void CoordinatedPlatformLayer::setChildren(Vector<Ref<CoordinatedPlatformLayer>>&& children)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_children == children)
         return;
 
@@ -744,25 +746,25 @@ void CoordinatedPlatformLayer::setChildren(Vector<Ref<CoordinatedPlatformLayer>>
 
 const Vector<Ref<CoordinatedPlatformLayer>>& CoordinatedPlatformLayer::children() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return m_children;
 }
 
 void CoordinatedPlatformLayer::setEventRegion(const EventRegion& eventRegion)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     m_eventRegion = eventRegion;
 }
 
 const EventRegion& CoordinatedPlatformLayer::eventRegion() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     return m_eventRegion;
 }
 
 void CoordinatedPlatformLayer::setClipPath(const Path& path, WindRule windRule)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     m_clipPath.path = path;
     m_clipPath.windRule = windRule;
     m_pendingChanges.add(Change::ClipPath);
@@ -771,7 +773,7 @@ void CoordinatedPlatformLayer::setClipPath(const Path& path, WindRule windRule)
 
 void CoordinatedPlatformLayer::setDebugBorder(Color&& borderColor, float borderWidth)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (m_debugBorderColor == borderColor && m_debugBorderWidth == borderWidth)
         return;
 
@@ -783,7 +785,7 @@ void CoordinatedPlatformLayer::setDebugBorder(Color&& borderColor, float borderW
 
 void CoordinatedPlatformLayer::setShowRepaintCounter(bool showRepaintCounter)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if ((m_repaintCount != -1 && showRepaintCounter) || (m_repaintCount == -1 && !showRepaintCounter))
         return;
 
@@ -794,7 +796,7 @@ void CoordinatedPlatformLayer::setShowRepaintCounter(bool showRepaintCounter)
 
 bool CoordinatedPlatformLayer::needsBackingStore() const
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     if (!m_owner)
         return false;
 
@@ -846,7 +848,7 @@ void CoordinatedPlatformLayer::updateBackingStore()
 
 void CoordinatedPlatformLayer::updateContents(bool affectedByTransformAnimation)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
 
     if (needsBackingStore()) {
         if (!m_backingStoreProxy) {
@@ -933,7 +935,7 @@ void CoordinatedPlatformLayer::didPaintTile()
 
 Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::paint(const IntRect& dirtyRect)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     ASSERT(m_client);
     ASSERT(m_owner);
 #if USE(CAIRO)
@@ -960,7 +962,7 @@ sk_sp<GrContextThreadSafeProxy> CoordinatedPlatformLayer::threadSafeGrContext() 
 
 Ref<SkiaRecordingResult> CoordinatedPlatformLayer::record(const IntRect& recordRect, unsigned dirtyTilesCount)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     ASSERT(m_client);
     ASSERT(m_owner);
     return m_client->paintingEngine().record(*m_owner, recordRect, m_contentsOpaque, m_contentsScale, dirtyTilesCount);
@@ -968,7 +970,7 @@ Ref<SkiaRecordingResult> CoordinatedPlatformLayer::record(const IntRect& recordR
 
 Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::replay(Ref<SkiaRecordingResult>&& recording, const IntRect& tileRect, const IntRect& dirtyRect)
 {
-    ASSERT(m_lock.isHeld());
+    assertIsHeld(m_lock);
     ASSERT(m_client);
     ASSERT(m_owner);
     return m_client->paintingEngine().replay(*m_owner, WTF::move(recording), tileRect, dirtyRect);
@@ -1030,6 +1032,7 @@ void CoordinatedPlatformLayer::flushPositionChanges(const OptionSet<CompositionR
         return;
 
     auto applyPositionChanges = [this](auto& layer) {
+        assertIsHeld(m_lock);
         if (m_pendingChanges.contains(Change::Position)) {
             layer.setPosition(m_position);
             m_pendingChanges.remove(Change::Position);
@@ -1074,6 +1077,7 @@ void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<Composition
 
 void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<CompositionReason>& reasons, TextureMapperLayer& layer)
 {
+    assertIsHeld(m_lock);
     if (reasons.containsAny({ CompositionReason::RenderingUpdate, CompositionReason::AsyncScrolling })) {
         if (m_pendingChanges.contains(Change::ContentsRect)) {
             layer.setContentsRect(m_contentsRect);
@@ -1261,6 +1265,7 @@ void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<Com
 #if USE(SKIA)
 void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet<CompositionReason>& reasons, SkiaCompositingLayer& layer)
 {
+    assertIsHeld(m_lock);
     if (reasons.containsAny({ CompositionReason::RenderingUpdate, CompositionReason::AsyncScrolling })) {
         if (m_pendingChanges.contains(Change::ContentsRect)) {
             layer.setContentsRect(m_contentsRect);
@@ -1375,12 +1380,17 @@ void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet
             m_pendingChanges.remove(Change::Replica);
         }
 
-        if (m_pendingChanges.contains(Change::Backdrop) || (m_backdrop && m_backdrop->m_pendingChanges.contains(Change::Filters))) {
-            // FIXME: stop creating a layer for backdrop filters when switching to SkiaCompositingLayer.
-            layer.setBackdropFilters(m_backdrop ? m_backdrop->m_filters : FilterOperations());
+        // FIXME: stop creating a layer for backdrop filters when switching to SkiaCompositingLayer.
+        if (m_pendingChanges.contains(Change::Backdrop) && !m_backdrop) {
+            layer.setBackdropFilters(FilterOperations());
             m_pendingChanges.remove(Change::Backdrop);
-            if (m_backdrop)
+        } else if (m_backdrop) {
+            Locker locker { m_backdrop->lock() };
+            if (m_pendingChanges.contains(Change::Backdrop) || m_backdrop->m_pendingChanges.contains(Change::Filters)) {
+                layer.setBackdropFilters(m_backdrop->m_filters);
+                m_pendingChanges.remove(Change::Backdrop);
                 m_backdrop->m_pendingChanges.remove(Change::Filters);
+            }
         }
 
         if (m_pendingChanges.contains(Change::BackdropRect)) {
@@ -1449,6 +1459,7 @@ bool CoordinatedPlatformLayer::hasPendingBackingStoreTileUpdates() const
         return m_skiaTarget->hasPendingBackingStoreTileUpdates();
 #endif
 
+    Locker locker { m_lock };
     if (m_backingStore)
         return m_backingStore->hasPendingUpdates();
 
@@ -1466,6 +1477,7 @@ void CoordinatedPlatformLayer::processPendingBackingStoreTileUpdates()
     }
 #endif
 
+    Locker locker { m_lock };
     if (m_backingStore)
         m_backingStore->processPendingUpdates();
 }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -95,7 +95,7 @@ public:
     virtual ~CoordinatedPlatformLayer();
 
     PlatformLayerIdentifier id() const { return m_id; }
-    Lock& lock() LIFETIME_BOUND { return m_lock; }
+    Lock& lock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_lock) { return m_lock; }
 
     Client& client() const { ASSERT(m_client); return *m_client; }
     void invalidateClient();
@@ -115,84 +115,83 @@ public:
     void setDamageInGlobalCoordinateSpace(std::shared_ptr<Damage> damage) { m_damageInGlobalCoordinateSpace = WTF::move(damage); }
 #endif
 
-    void setPosition(FloatPoint&&);
+    void setPosition(FloatPoint&&) WTF_REQUIRES_LOCK(m_lock);
     void setPositionForScrolling(const FloatPoint&);
-    const FloatPoint& position() const;
+    const FloatPoint& position() const WTF_REQUIRES_LOCK(m_lock);
     void setTopLeftPositionForScrolling(const FloatPoint&);
     FloatPoint topLeftPositionForScrolling();
-    void setBoundsOrigin(const FloatPoint&);
+    void setBoundsOrigin(const FloatPoint&) WTF_REQUIRES_LOCK(m_lock);
     void setBoundsOriginForScrolling(const FloatPoint&);
-    const FloatPoint& boundsOrigin() const;
-    void setAnchorPoint(FloatPoint3D&&);
-    const FloatPoint3D& anchorPoint() const;
-    void setSize(FloatSize&&);
-    const FloatSize& size() const;
-    FloatRect bounds() const;
+    const FloatPoint& boundsOrigin() const WTF_REQUIRES_LOCK(m_lock);
+    void setAnchorPoint(FloatPoint3D&&) WTF_REQUIRES_LOCK(m_lock);
+    const FloatPoint3D& anchorPoint() const WTF_REQUIRES_LOCK(m_lock);
+    void setSize(FloatSize&&) WTF_REQUIRES_LOCK(m_lock);
+    const FloatSize& size() const WTF_REQUIRES_LOCK(m_lock);
+    FloatRect bounds() const WTF_REQUIRES_LOCK(m_lock);
 
-    void setTransform(const TransformationMatrix&);
-    const TransformationMatrix& transform() const;
-    void setChildrenTransform(const TransformationMatrix&);
-    const TransformationMatrix& childrenTransform() const;
+    void setTransform(const TransformationMatrix&) WTF_REQUIRES_LOCK(m_lock);
+    const TransformationMatrix& transform() const WTF_REQUIRES_LOCK(m_lock);
+    void setChildrenTransform(const TransformationMatrix&) WTF_REQUIRES_LOCK(m_lock);
+    const TransformationMatrix& childrenTransform() const WTF_REQUIRES_LOCK(m_lock);
     void didUpdateLayerTransform();
 
-    void setVisibleRect(const FloatRect&);
-    const FloatRect& visibleRect() const;
-    void setTransformedVisibleRect(IntRect&& visibleRect, IntRect&& visibleRectIncludingFuture);
+    void setVisibleRect(const FloatRect&) WTF_REQUIRES_LOCK(m_lock);
+    const FloatRect& visibleRect() const WTF_REQUIRES_LOCK(m_lock);
+    void setTransformedVisibleRect(IntRect&& visibleRect, IntRect&& visibleRectIncludingFuture) WTF_REQUIRES_LOCK(m_lock);
 
 #if ENABLE(SCROLLING_THREAD)
-    void setScrollingNodeID(std::optional<ScrollingNodeID>);
-    const Markable<ScrollingNodeID>& scrollingNodeID() const;
+    void setScrollingNodeID(std::optional<ScrollingNodeID>) WTF_REQUIRES_LOCK(m_lock);
+    const Markable<ScrollingNodeID>& scrollingNodeID() const WTF_REQUIRES_LOCK(m_lock);
 #endif
 
-    void setDrawsContent(bool);
-    void setMasksToBounds(bool);
-    void setPreserves3D(bool);
-    void setBackfaceVisibility(bool);
-    void setOpacity(float);
-    void setBlendMode(BlendMode);
+    void setDrawsContent(bool) WTF_REQUIRES_LOCK(m_lock);
+    void setMasksToBounds(bool) WTF_REQUIRES_LOCK(m_lock);
+    void setPreserves3D(bool) WTF_REQUIRES_LOCK(m_lock);
+    void setBackfaceVisibility(bool) WTF_REQUIRES_LOCK(m_lock);
+    void setOpacity(float) WTF_REQUIRES_LOCK(m_lock);
+    void setBlendMode(BlendMode) WTF_REQUIRES_LOCK(m_lock);
 
-    void setContentsVisible(bool);
-    bool contentsVisible() const;
-    void setContentsOpaque(bool);
-    void setContentsRect(const FloatRect&);
-    void setContentsRectClipsDescendants(bool);
-    void setContentsClippingRect(const FloatRoundedRect&);
-    void setContentsScale(float);
-    float contentsScale() const;
+    void setContentsVisible(bool) WTF_REQUIRES_LOCK(m_lock);
+    bool contentsVisible() const WTF_REQUIRES_LOCK(m_lock);
+    void setContentsOpaque(bool) WTF_REQUIRES_LOCK(m_lock);
+    void setContentsRect(const FloatRect&) WTF_REQUIRES_LOCK(m_lock);
+    void setContentsRectClipsDescendants(bool) WTF_REQUIRES_LOCK(m_lock);
+    void setContentsClippingRect(const FloatRoundedRect&) WTF_REQUIRES_LOCK(m_lock);
+    void setContentsScale(float) WTF_REQUIRES_LOCK(m_lock);
+    float contentsScale() const WTF_REQUIRES_LOCK(m_lock);
     enum class RequireComposition : bool { No, Yes };
-    void setContentsBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&, std::optional<Damage>&& = std::nullopt, RequireComposition = RequireComposition::Yes);
+    void setContentsBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&, std::optional<Damage>&& = std::nullopt, RequireComposition = RequireComposition::Yes) WTF_REQUIRES_LOCK(m_lock);
 #if ENABLE(VIDEO) && USE(GSTREAMER)
     void replaceCurrentContentsBufferWithCopy();
 #endif
-    void setContentsBufferNeedsDisplay();
-    void setContentsImage(NativeImage*);
-    void setContentsColor(const Color&);
-    void setContentsTileSize(const FloatSize&);
-    void setContentsTilePhase(const FloatSize&);
-    void setDirtyRegion(Damage&&);
+    void setContentsImage(NativeImage*) WTF_REQUIRES_LOCK(m_lock);
+    void setContentsColor(const Color&) WTF_REQUIRES_LOCK(m_lock);
+    void setContentsTileSize(const FloatSize&) WTF_REQUIRES_LOCK(m_lock);
+    void setContentsTilePhase(const FloatSize&) WTF_REQUIRES_LOCK(m_lock);
+    void setDirtyRegion(Damage&&) WTF_REQUIRES_LOCK(m_lock);
 
-    void setFilters(const FilterOperations&);
-    void setMask(CoordinatedPlatformLayer*);
-    void setReplica(CoordinatedPlatformLayer*);
-    void setBackdrop(CoordinatedPlatformLayer*);
-    void notifyBackdropFiltersChanged();
-    void setBackdropRect(const FloatRoundedRect&);
-    void setIsBackdropRoot(bool);
+    void setFilters(const FilterOperations&) WTF_REQUIRES_LOCK(m_lock);
+    void setMask(CoordinatedPlatformLayer*) WTF_REQUIRES_LOCK(m_lock);
+    void setReplica(CoordinatedPlatformLayer*) WTF_REQUIRES_LOCK(m_lock);
+    void setBackdrop(CoordinatedPlatformLayer*) WTF_REQUIRES_LOCK(m_lock);
+    void notifyBackdropFiltersChanged() WTF_REQUIRES_LOCK(m_lock);
+    void setBackdropRect(const FloatRoundedRect&) WTF_REQUIRES_LOCK(m_lock);
+    void setIsBackdropRoot(bool) WTF_REQUIRES_LOCK(m_lock);
 
-    void setAnimations(const TextureMapperAnimations&);
+    void setAnimations(const TextureMapperAnimations&) WTF_REQUIRES_LOCK(m_lock);
 
-    void setChildren(Vector<Ref<CoordinatedPlatformLayer>>&&);
-    const Vector<Ref<CoordinatedPlatformLayer>>& children() const;
+    void setChildren(Vector<Ref<CoordinatedPlatformLayer>>&&) WTF_REQUIRES_LOCK(m_lock);
+    const Vector<Ref<CoordinatedPlatformLayer>>& children() const WTF_REQUIRES_LOCK(m_lock);
 
-    void setEventRegion(const EventRegion&);
-    const EventRegion& eventRegion() const;
+    void setEventRegion(const EventRegion&) WTF_REQUIRES_LOCK(m_lock);
+    const EventRegion& eventRegion() const WTF_REQUIRES_LOCK(m_lock);
 
-    void setClipPath(const Path&, WindRule);
+    void setClipPath(const Path&, WindRule) WTF_REQUIRES_LOCK(m_lock);
 
-    void setDebugBorder(Color&&, float);
-    void setShowRepaintCounter(bool);
+    void setDebugBorder(Color&&, float) WTF_REQUIRES_LOCK(m_lock);
+    void setShowRepaintCounter(bool) WTF_REQUIRES_LOCK(m_lock);
 
-    void updateContents(bool affectedByTransformAnimation);
+    void updateContents(bool affectedByTransformAnimation) WTF_REQUIRES_LOCK(m_lock);
     void updateBackingStore();
 
     void flushPendingState();
@@ -207,10 +206,10 @@ public:
     RunLoop* compositingRunLoop() const;
     int maxTextureSize() const;
 
-    Ref<CoordinatedTileBuffer> paint(const IntRect&);
+    Ref<CoordinatedTileBuffer> paint(const IntRect&) WTF_REQUIRES_LOCK(m_lock);
 #if USE(SKIA)
-    Ref<SkiaRecordingResult> record(const IntRect&, unsigned dirtyTilesCount);
-    Ref<CoordinatedTileBuffer> replay(Ref<SkiaRecordingResult>&&, const IntRect&, const IntRect&);
+    Ref<SkiaRecordingResult> record(const IntRect&, unsigned dirtyTilesCount) WTF_REQUIRES_LOCK(m_lock);
+    Ref<CoordinatedTileBuffer> replay(Ref<SkiaRecordingResult>&&, const IntRect&, const IntRect&) WTF_REQUIRES_LOCK(m_lock);
 #endif
     void willPaintTile();
     void didPaintTile();
@@ -224,12 +223,12 @@ private:
     bool needsBackingStore() const;
     void purgeBackingStores();
 
-    bool hasCommittedContentsBuffer() const;
+    bool hasCommittedContentsBuffer() const WTF_REQUIRES_LOCK(m_lock);
 
 #if ENABLE(DAMAGE_TRACKING)
-    void addDamage(Damage&&);
+    void addDamage(Damage&&) WTF_REQUIRES_LOCK(m_lock);
 #endif
-    void damageWholeLayer();
+    void damageWholeLayer() WTF_REQUIRES_LOCK(m_lock);
 
     void flushCompositingStateOnTarget(const OptionSet<CompositionReason>&, TextureMapperLayer&);
 #if USE(SKIA)
@@ -295,7 +294,7 @@ private:
     std::shared_ptr<Damage> m_damageInGlobalCoordinateSpace;
 #endif
 
-    Lock m_lock;
+    mutable Lock m_lock;
     EnumSet<Change> m_pendingChanges WTF_GUARDED_BY_LOCK(m_lock);
     FloatPoint m_position WTF_GUARDED_BY_LOCK(m_lock);
     FloatPoint3D m_anchorPoint WTF_GUARDED_BY_LOCK(m_lock) { 0.5f, 0.5f, 0 };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp
@@ -75,9 +75,10 @@ void CoordinatedPlatformLayerBufferProxy::consumePendingBufferIfNeeded()
     if (!m_pendingBuffer)
         return;
 
-    if (m_layer)
+    if (m_layer) {
+        assertIsHeld(m_layer->lock());
         m_layer->setContentsBuffer(WTF::move(m_pendingBuffer));
-    else
+    } else
         m_pendingBuffer = nullptr;
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerContentsDisplayDelegateCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerContentsDisplayDelegateCoordinated.cpp
@@ -43,6 +43,7 @@ void GraphicsLayerContentsDisplayDelegateCoordinated::setDisplayBuffer(std::uniq
 
 bool GraphicsLayerContentsDisplayDelegateCoordinated::display(CoordinatedPlatformLayer& layer, std::optional<Damage>&& dirtyRegion)
 {
+    assertIsHeld(layer.lock());
     if (!m_displayBuffer)
         return false;
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -882,6 +882,7 @@ void GraphicsLayerCoordinated::computePixelAlignmentIfNeeded(float pageScaleFact
 
 void GraphicsLayerCoordinated::updateGeometry(float pageScaleFactor, const FloatPoint& positionRelativeToBase)
 {
+    assertIsHeld(m_platformLayer->lock());
     FloatPoint adjustedPosition;
     FloatPoint adjustedBoundsOrigin;
     FloatPoint3D adjustedAnchorPoint;
@@ -951,6 +952,7 @@ void GraphicsLayerCoordinated::clampToSizeIfRectIsInfinite(FloatRect& rect, cons
 
 void GraphicsLayerCoordinated::updateVisibleRect(const FloatRect& rect)
 {
+    assertIsHeld(m_platformLayer->lock());
     m_platformLayer->setVisibleRect(rect);
 
     IntRect visibleRect;
@@ -979,6 +981,7 @@ void GraphicsLayerCoordinated::updateVisibleRect(const FloatRect& rect)
 
 void GraphicsLayerCoordinated::updateBackdropFilters()
 {
+    assertIsHeld(m_platformLayer->lock());
     bool canHaveBackdropFilters = needsBackdrop();
     if (!canHaveBackdropFilters) {
         m_platformLayer->setBackdrop(nullptr);
@@ -1018,6 +1021,7 @@ void GraphicsLayerCoordinated::updateBackdropFilters()
 
 void GraphicsLayerCoordinated::updateBackdropFiltersRect()
 {
+    assertIsHeld(m_platformLayer->lock());
     if (!m_backdropLayer)
         return;
 
@@ -1032,6 +1036,8 @@ void GraphicsLayerCoordinated::updateBackdropFiltersRect()
 
 void GraphicsLayerCoordinated::updateAnimations()
 {
+    assertIsHeld(m_platformLayer->lock());
+
     m_animations.setTranslate(client().transformMatrixForProperty(AnimatedProperty::Translate));
     m_animations.setRotate(client().transformMatrixForProperty(AnimatedProperty::Rotate));
     m_animations.setScale(client().transformMatrixForProperty(AnimatedProperty::Scale));
@@ -1042,6 +1048,8 @@ void GraphicsLayerCoordinated::updateAnimations()
 
 void GraphicsLayerCoordinated::updateIndicators()
 {
+    assertIsHeld(m_platformLayer->lock());
+
     Color borderColor;
     float borderWidth = 0;
     if (m_showDebugBorder)

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -317,13 +317,13 @@ GStreamerElementHarness::Stream::Stream(GRefPtr<GstPad>&& pad, RefPtr<GStreamerE
 
     gst_pad_set_chain_function_full(m_targetPad.get(), reinterpret_cast<GstPadChainFunction>(+[](GstPad* pad, GstObject*, GstBuffer* buffer) -> GstFlowReturn {
         auto& stream = *reinterpret_cast<GStreamerElementHarness::Stream*>(pad->chaindata);
+        GRefPtr caps = stream.outputCaps();
         if (auto downstreamHarness = stream.downstreamHarness()) {
             if (!downstreamHarness->isStarted())
-                downstreamHarness->start(GRefPtr<GstCaps>(stream.outputCaps()));
+                downstreamHarness->start(WTF::move(caps));
             return downstreamHarness->pushBufferFull(adoptGRef(buffer));
         }
 
-        const auto& caps = stream.outputCaps();
         const GstSegment* segment = nullptr;
         if (GRefPtr segmentEvent = adoptGRef(gst_pad_get_sticky_event(stream.pad().get(), GST_EVENT_SEGMENT, 0)))
             gst_event_parse_segment(segmentEvent.get(), &segment);
@@ -364,8 +364,8 @@ GStreamerElementHarness::Stream::~Stream()
 
 GRefPtr<GstSample> GStreamerElementHarness::Stream::pullSample()
 {
-    GST_LOG_OBJECT(m_pad.get(), "%zu samples currently queued", m_sampleQueue.size());
     Locker locker { m_sampleQueueLock };
+    GST_LOG_OBJECT(m_pad.get(), "%zu samples currently queued", m_sampleQueue.size());
     if (m_sampleQueue.isEmpty())
         return nullptr;
     return m_sampleQueue.takeLast();
@@ -387,7 +387,7 @@ bool GStreamerElementHarness::Stream::sendEvent(GstEvent* event)
     return result;
 }
 
-const GRefPtr<GstCaps>& GStreamerElementHarness::Stream::outputCaps()
+GRefPtr<GstCaps> GStreamerElementHarness::Stream::outputCaps()
 {
     Locker locker { m_sinkEventQueueLock };
     if (m_outputCaps)

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -53,7 +53,7 @@ public:
 
         const GRefPtr<GstPad>& pad() const { return m_pad; }
         const GRefPtr<GstPad>& targetPad() const { return m_targetPad; }
-        const GRefPtr<GstCaps>& outputCaps();
+        GRefPtr<GstCaps> outputCaps();
 
         const RefPtr<GStreamerElementHarness> downstreamHarness() const { return m_downstreamHarness; }
 

--- a/Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp
@@ -235,4 +235,16 @@ PlatformImagePtr ScalableImageDecoder::createFrameImageAtIndex(size_t index, Sub
     return buffer->backingStore()->image();
 }
 
+size_t ScalableImageDecoder::frameCount() const
+{
+    Locker locker { m_lock };
+    return decodeIfNeededAndGetFrameCount();
 }
+
+void ScalableImageDecoder::clearFrameBufferCache(size_t index)
+{
+    Locker locker { m_lock };
+    clearDecodedPixelDataIfNeeded(index);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/image-decoders/ScalableImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/ScalableImageDecoder.h
@@ -122,17 +122,9 @@ public:
         return true;
     }
 
-    // Lazily-decodes enough of the image to get the frame count (if
-    // possible), without decoding the individual frames.
-    // FIXME: Right now that has to be done by each subclass; factor the
-    // decode call out and use it here.
-    size_t frameCount() const override { return 1; }
+    size_t frameCount() const override;
 
     RepetitionCount repetitionCount() const override { return RepetitionCountNone; }
-
-    // Decodes as much of the requested frame as possible, and returns an
-    // ScalableImageDecoder-owned pointer.
-    virtual ScalableImageDecoderFrame* frameBufferAtIndex(size_t) = 0;
 
     bool frameIsCompleteAtIndex(size_t) const override;
 
@@ -167,16 +159,28 @@ public:
 
     bool failed() const { return m_encodedDataStatus == EncodedDataStatus::Error; }
 
-    // Clears decoded pixel data from before the provided frame unless that
-    // data may be needed to decode future frames (e.g. due to GIF frame
-    // compositing).
-    void clearFrameBufferCache(size_t) override { }
+    void clearFrameBufferCache(size_t) override;
 
     // If the image has a cursor hot-spot, stores it in the argument
     // and returns true. Otherwise returns false.
     std::optional<IntPoint> hotSpot() const override { return std::nullopt; }
 
 protected:
+    // Decodes as much of the requested frame as possible, and returns an
+    // ScalableImageDecoder-owned pointer.
+    virtual ScalableImageDecoderFrame* frameBufferAtIndex(size_t) WTF_REQUIRES_LOCK(m_lock) = 0;
+
+    // Lazily-decodes enough of the image to get the frame count (if
+    // possible), without decoding the individual frames.
+    // FIXME: Right now that has to be done by each subclass; factor the
+    // decode call out and use it here.
+    virtual size_t decodeIfNeededAndGetFrameCount() const WTF_REQUIRES_LOCK(m_lock) { return 1; }
+
+    // Clears decoded pixel data from before the provided frame unless that
+    // data may be needed to decode future frames (e.g. due to GIF frame
+    // compositing).
+    virtual void clearDecodedPixelDataIfNeeded(size_t) WTF_REQUIRES_LOCK(m_lock) { }
+
     RefPtr<const SharedBuffer> m_data;
     Vector<ScalableImageDecoderFrame, 1> m_frameBufferCache WTF_GUARDED_BY_LOCK(m_lock);
     mutable Lock m_lock;

--- a/Source/WebCore/platform/image-decoders/avif/AVIFImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/avif/AVIFImageDecoder.cpp
@@ -50,6 +50,7 @@ RepetitionCount AVIFImageDecoder::repetitionCount() const
 
 size_t AVIFImageDecoder::findFirstRequiredFrameToDecode(size_t frameIndex)
 {
+    assertIsHeld(m_lock);
     // The first frame doesn't depend on any other.
     if (!frameIndex)
         return 0;
@@ -66,7 +67,8 @@ size_t AVIFImageDecoder::findFirstRequiredFrameToDecode(size_t frameIndex)
 
 ScalableImageDecoderFrame* AVIFImageDecoder::frameBufferAtIndex(size_t index)
 {
-    const size_t imageCount = frameCount();
+    assertIsHeld(m_lock);
+    const size_t imageCount = decodeIfNeededAndGetFrameCount();
     if (index >= imageCount)
         return nullptr;
 
@@ -93,6 +95,7 @@ bool AVIFImageDecoder::setFailed()
 
 bool AVIFImageDecoder::isComplete()
 {
+    assertIsHeld(m_lock);
     if (m_frameBufferCache.isEmpty())
         return false;
 
@@ -118,6 +121,7 @@ void AVIFImageDecoder::tryDecodeSize(bool allDataReceived)
 
 void AVIFImageDecoder::decode(size_t frameIndex, bool allDataReceived)
 {
+    assertIsHeld(m_lock);
     if (failed())
         return;
 

--- a/Source/WebCore/platform/image-decoders/avif/AVIFImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/avif/AVIFImageDecoder.h
@@ -44,7 +44,7 @@ public:
 
     // ScalableImageDecoder
     String filenameExtension() const final { return "avif"_s; }
-    size_t frameCount() const final { return m_frameCount; };
+    size_t decodeIfNeededAndGetFrameCount() const final { return m_frameCount; };
     RepetitionCount repetitionCount() const final;
     ScalableImageDecoderFrame* frameBufferAtIndex(size_t index) final WTF_REQUIRES_LOCK(m_lock);
     bool setFailed() final;

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageDecoder.cpp
@@ -58,6 +58,7 @@ void BMPImageDecoder::setData(const FragmentedSharedBuffer& data, bool allDataRe
 
 ScalableImageDecoderFrame* BMPImageDecoder::frameBufferAtIndex(size_t index)
 {
+    assertIsHeld(m_lock);
     if (index)
         return 0;
 
@@ -78,6 +79,7 @@ bool BMPImageDecoder::setFailed()
 
 void BMPImageDecoder::decode(bool onlySize, bool allDataReceived)
 {
+    assertIsHeld(m_lock);
     if (failed())
         return;
 
@@ -93,6 +95,7 @@ void BMPImageDecoder::decode(bool onlySize, bool allDataReceived)
 
 bool BMPImageDecoder::decodeHelper(bool onlySize)
 {
+    assertIsHeld(m_lock);
     size_t imgDataOffset = 0;
     if ((m_decodedOffset < sizeOfFileHeader) && !processFileHeader(&imgDataOffset))
         return false;

--- a/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp
@@ -57,8 +57,9 @@ bool GIFImageDecoder::setSize(const IntSize& size)
     return ScalableImageDecoder::setSize(size);
 }
 
-size_t GIFImageDecoder::frameCount() const
+size_t GIFImageDecoder::decodeIfNeededAndGetFrameCount() const
 {
+    assertIsHeld(m_lock);
     const_cast<GIFImageDecoder*>(this)->decode(std::numeric_limits<unsigned>::max(), GIFFrameCountQuery, isAllDataReceived());
     return m_frameBufferCache.size();
 }
@@ -98,6 +99,7 @@ RepetitionCount GIFImageDecoder::repetitionCount() const
 
 size_t GIFImageDecoder::findFirstRequiredFrameToDecode(size_t frameIndex)
 {
+    assertIsHeld(m_lock);
     // The first frame doesn't depend on any other.
     if (!frameIndex)
         return 0;
@@ -133,7 +135,8 @@ size_t GIFImageDecoder::findFirstRequiredFrameToDecode(size_t frameIndex)
 
 ScalableImageDecoderFrame* GIFImageDecoder::frameBufferAtIndex(size_t index)
 {
-    if (index >= frameCount())
+    assertIsHeld(m_lock);
+    if (index >= decodeIfNeededAndGetFrameCount())
         return 0;
 
     auto& frame = m_frameBufferCache[index];
@@ -151,8 +154,9 @@ bool GIFImageDecoder::setFailed()
     return ScalableImageDecoder::setFailed();
 }
 
-void GIFImageDecoder::clearFrameBufferCache(size_t clearBeforeFrame)
+void GIFImageDecoder::clearDecodedPixelDataIfNeeded(size_t clearBeforeFrame)
 {
+    assertIsHeld(m_lock);
     // In some cases, like if the decoder was destroyed while animating, we
     // can be asked to clear more frames than we currently have.
     if (m_frameBufferCache.isEmpty())
@@ -209,6 +213,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 bool GIFImageDecoder::haveDecodedRow(unsigned frameIndex, const Vector<unsigned char>& rowBuffer, size_t width, size_t rowNumber, unsigned repeatCount, bool writeTransparentPixels)
 {
+    assertIsHeld(m_lock);
     const GIFFrameContext* frameContext = m_reader->frameContext();
     // The pixel data and coordinates supplied to us are relative to the frame's
     // origin within the entire image size, i.e.
@@ -268,6 +273,7 @@ bool GIFImageDecoder::haveDecodedRow(unsigned frameIndex, const Vector<unsigned 
 
 bool GIFImageDecoder::frameComplete(unsigned frameIndex, unsigned frameDuration, ScalableImageDecoderFrame::DisposalMethod disposalMethod)
 {
+    assertIsHeld(m_lock);
     // Initialize the frame if necessary.  Some GIFs insert do-nothing frames,
     // in which case we never reach haveDecodedRow() before getting here.
     auto& buffer = m_frameBufferCache[frameIndex];
@@ -326,6 +332,7 @@ void GIFImageDecoder::gifComplete()
 
 void GIFImageDecoder::decode(unsigned haltAtFrame, GIFQuery query, bool allDataReceived)
 {
+    assertIsHeld(m_lock);
     if (failed())
         return;
 
@@ -363,6 +370,7 @@ void GIFImageDecoder::decode(unsigned haltAtFrame, GIFQuery query, bool allDataR
 
 bool GIFImageDecoder::initFrameBuffer(unsigned frameIndex)
 {
+    assertIsHeld(m_lock);
     // Initialize the frame rect in our buffer.
     const GIFFrameContext* frameContext = m_reader->frameContext();
     IntRect frameRect(frameContext->xOffset, frameContext->yOffset, frameContext->width, frameContext->height);

--- a/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.h
@@ -48,14 +48,14 @@ public:
     String filenameExtension() const final { return "gif"_s; }
     void setData(const FragmentedSharedBuffer& data, bool allDataReceived) final;
     bool setSize(const IntSize&) final;
-    size_t frameCount() const final;
+    size_t decodeIfNeededAndGetFrameCount() const final;
     RepetitionCount repetitionCount() const final;
     ScalableImageDecoderFrame* frameBufferAtIndex(size_t index) final;
     // CAUTION: setFailed() deletes |m_reader|. Be careful to avoid
     // accessing deleted memory, especially when calling this from inside
     // GIFImageReader!
     bool setFailed() final;
-    void clearFrameBufferCache(size_t clearBeforeFrame) final;
+    void clearDecodedPixelDataIfNeeded(size_t clearBeforeFrame) final;
 
     // Callbacks from the GIF reader.
     bool haveDecodedRow(unsigned frameIndex, const Vector<unsigned char>& rowBuffer, size_t width, size_t rowNumber, unsigned repeatCount, bool writeTransparentPixels);

--- a/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
@@ -86,16 +86,18 @@ bool ICOImageDecoder::setSize(const IntSize& size)
     return m_frameSize.isEmpty() ? ScalableImageDecoder::setSize(size) : ((size == m_frameSize) || setFailed());
 }
 
-size_t ICOImageDecoder::frameCount() const
+size_t ICOImageDecoder::decodeIfNeededAndGetFrameCount() const
 {
+    assertIsHeld(m_lock);
     const_cast<ICOImageDecoder*>(this)->decode(0, true, isAllDataReceived());
     return m_frameBufferCache.size();
 }
 
 ScalableImageDecoderFrame* ICOImageDecoder::frameBufferAtIndex(size_t index)
 {
+    assertIsHeld(m_lock);
     // Ensure |index| is valid.
-    if (index >= frameCount())
+    if (index >= decodeIfNeededAndGetFrameCount())
         return 0;
 
     auto* buffer = &m_frameBufferCache[index];
@@ -152,6 +154,7 @@ void ICOImageDecoder::setDataForPNGDecoderAtIndex(size_t index)
 
 void ICOImageDecoder::decode(size_t index, bool onlySize, bool allDataReceived)
 {
+    assertIsHeld(m_lock);
     if (failed())
         return;
 
@@ -186,6 +189,7 @@ bool ICOImageDecoder::decodeDirectory()
 
 bool ICOImageDecoder::decodeAtIndex(size_t index)
 {
+    assertIsHeld(m_lock);
     ASSERT_WITH_SECURITY_IMPLICATION(index < m_dirEntries.size());
     const IconDirectoryEntry& dirEntry = m_dirEntries[index];
     const ImageType imageType = imageTypeAtIndex(index);
@@ -195,7 +199,7 @@ bool ICOImageDecoder::decodeAtIndex(size_t index)
     if (imageType == BMP) {
         if (!m_bmpReaders[index]) {
             // We need to have already sized m_frameBufferCache before this, and
-            // we must not resize it again later (see caution in frameCount()).
+            // we must not resize it again later (see caution in decodeIfNeededAndGetFrameCount()).
             ASSERT(m_frameBufferCache.size() == m_dirEntries.size());
             m_bmpReaders[index] = makeUnique<BMPImageReader>(this, dirEntry.m_imageOffset, 0, true);
             m_bmpReaders[index]->setData(*m_data);
@@ -215,7 +219,8 @@ bool ICOImageDecoder::decodeAtIndex(size_t index)
     // in the directory.
     if (m_pngDecoders[index]->encodedDataStatus() >= EncodedDataStatus::SizeAvailable && (m_pngDecoders[index]->size() != dirEntry.m_size))
         return setFailed();
-    m_frameBufferCache[index] = *m_pngDecoders[index]->frameBufferAtIndex(0);
+
+    m_frameBufferCache[index] = *static_cast<PNGImageDecoder*>(m_pngDecoders[index].get())->firstFrameBuffer();
     return !m_pngDecoders[index]->failed() || setFailed();
 }
 

--- a/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.h
@@ -50,7 +50,7 @@ public:
     IntSize size() const final;
     IntSize frameSizeAtIndex(size_t, SubsamplingLevel) const final;
     bool setSize(const IntSize&) final;
-    size_t frameCount() const final;
+    size_t decodeIfNeededAndGetFrameCount() const final;
     ScalableImageDecoderFrame* frameBufferAtIndex(size_t) final;
     // CAUTION: setFailed() deletes all readers and decoders. Be careful to
     // avoid accessing deleted memory, especially when calling this from

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -568,6 +568,7 @@ JPEGImageDecoder::~JPEGImageDecoder()
 
 ScalableImageDecoderFrame* JPEGImageDecoder::frameBufferAtIndex(size_t index)
 {
+    assertIsHeld(m_lock);
     if (index)
         return 0;
 
@@ -653,6 +654,7 @@ bool JPEGImageDecoder::outputScanlines(ScalableImageDecoderFrame& buffer)
 
 bool JPEGImageDecoder::outputScanlines()
 {
+    assertIsHeld(m_lock);
     if (m_frameBufferCache.isEmpty())
         return false;
 
@@ -703,6 +705,7 @@ bool JPEGImageDecoder::outputScanlines()
 
 void JPEGImageDecoder::jpegComplete()
 {
+    assertIsHeld(m_lock);
     if (m_frameBufferCache.isEmpty())
         return;
 
@@ -715,6 +718,7 @@ void JPEGImageDecoder::jpegComplete()
 
 void JPEGImageDecoder::decode(bool onlySize, bool allDataReceived)
 {
+    assertIsHeld(m_lock);
     if (failed())
         return;
 

--- a/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
@@ -81,8 +81,9 @@ void JPEGXLImageDecoder::clear()
 #endif
 }
 
-size_t JPEGXLImageDecoder::frameCount() const
+size_t JPEGXLImageDecoder::decodeIfNeededAndGetFrameCount() const
 {
+    assertIsHeld(m_lock);
     if (!hasAnimation())
         return 1;
 
@@ -106,11 +107,12 @@ RepetitionCount JPEGXLImageDecoder::repetitionCount() const
 
 ScalableImageDecoderFrame* JPEGXLImageDecoder::frameBufferAtIndex(size_t index)
 {
+    assertIsHeld(m_lock);
     if (ScalableImageDecoder::encodedDataStatus() < EncodedDataStatus::SizeAvailable)
         return nullptr;
 
-    if (index >= frameCount())
-        index = frameCount() - 1;
+    if (index >= decodeIfNeededAndGetFrameCount())
+        index = decodeIfNeededAndGetFrameCount() - 1;
 
     if (m_frameBufferCache.isEmpty())
         m_frameBufferCache.grow(1);
@@ -121,8 +123,9 @@ ScalableImageDecoderFrame* JPEGXLImageDecoder::frameBufferAtIndex(size_t index)
     return &frame;
 }
 
-void JPEGXLImageDecoder::clearFrameBufferCache(size_t clearBeforeFrame)
+void JPEGXLImageDecoder::clearDecodedPixelDataIfNeeded(size_t clearBeforeFrame)
 {
+    assertIsHeld(m_lock);
     if (m_frameBufferCache.isEmpty())
         return;
 
@@ -227,6 +230,7 @@ void JPEGXLImageDecoder::updateFrameCount()
     if (failed())
         return;
 
+    assertIsHeld(m_lock);
     decode(Query::FrameCount, 0, isAllDataReceived());
 
     if (m_frameCount != m_frameBufferCache.size())
@@ -279,6 +283,7 @@ void JPEGXLImageDecoder::decode(Query query, size_t frameIndex, bool allDataRece
 
 JxlDecoderStatus JPEGXLImageDecoder::processInput(Query query)
 {
+    assertIsHeld(m_lock);
     while (true) {
         auto status = JxlDecoderProcessInput(m_decoder.get());
 
@@ -384,6 +389,7 @@ void JPEGXLImageDecoder::imageOutCallback(void* that, size_t x, size_t y, size_t
 
 void JPEGXLImageDecoder::imageOut(size_t x, size_t y, size_t numPixels, const uint8_t* pixels)
 {
+    assertIsHeld(m_lock);
     if (m_currentFrame >= m_frameBufferCache.size())
         return;
 

--- a/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.h
@@ -50,10 +50,10 @@ public:
 
     // ScalableImageDecoder
     String filenameExtension() const override { return "jxl"_s; }
-    size_t frameCount() const override WTF_REQUIRES_LOCK(m_lock);
+    size_t decodeIfNeededAndGetFrameCount() const override;
     RepetitionCount repetitionCount() const override;
-    ScalableImageDecoderFrame* frameBufferAtIndex(size_t index) override WTF_REQUIRES_LOCK(m_lock);
-    void clearFrameBufferCache(size_t clearBeforeFrame) override WTF_REQUIRES_LOCK(m_lock);
+    ScalableImageDecoderFrame* frameBufferAtIndex(size_t index) override;
+    void clearDecodedPixelDataIfNeeded(size_t clearBeforeFrame) override;
 
     bool setFailed() override;
 

--- a/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
@@ -252,11 +252,12 @@ RepetitionCount PNGImageDecoder::repetitionCount() const
 
 ScalableImageDecoderFrame* PNGImageDecoder::frameBufferAtIndex(size_t index)
 {
+    assertIsHeld(m_lock);
     if (ScalableImageDecoder::encodedDataStatus() < EncodedDataStatus::SizeAvailable)
         return nullptr;
 
-    if (index >= frameCount())
-        index = frameCount() - 1;
+    if (index >= decodeIfNeededAndGetFrameCount())
+        index = decodeIfNeededAndGetFrameCount() - 1;
 
     if (m_frameBufferCache.isEmpty())
         m_frameBufferCache.grow(1);
@@ -265,6 +266,12 @@ ScalableImageDecoderFrame* PNGImageDecoder::frameBufferAtIndex(size_t index)
     if (!frame.isComplete())
         decode(false, index, isAllDataReceived());
     return &frame;
+}
+
+ScalableImageDecoderFrame* PNGImageDecoder::firstFrameBuffer()
+{
+    Locker locker { m_lock };
+    return frameBufferAtIndex(0);
 }
 
 void PNGImageDecoder::clear()
@@ -430,11 +437,12 @@ void PNGImageDecoder::headerAvailable()
 
 void PNGImageDecoder::rowAvailable(unsigned char* rowBuffer, unsigned rowIndex, int)
 {
+    assertIsHeld(m_lock);
     if (m_frameBufferCache.isEmpty())
         return;
 
     // Initialize the framebuffer if needed.
-    if (m_currentFrame >= frameCount())
+    if (m_currentFrame >= decodeIfNeededAndGetFrameCount())
         return;
     auto& buffer = m_frameBufferCache[m_currentFrame];
     if (buffer.isInvalid()) {
@@ -543,6 +551,7 @@ void PNGImageDecoder::rowAvailable(unsigned char* rowBuffer, unsigned rowIndex, 
 
 void PNGImageDecoder::pngComplete()
 {
+    assertIsHeld(m_lock);
     if (m_isAnimated) {
         if (!processingFinish() && m_frameCount == m_currentFrame)
             return;
@@ -575,6 +584,7 @@ void PNGImageDecoder::decode(bool onlySize, unsigned haltAtFrame, bool allDataRe
 
 void PNGImageDecoder::readChunks(png_unknown_chunkp chunk)
 {
+    assertIsHeld(m_lock);
     if (chunk->size == 8 && spanHasPrefix(byteCast<char>(std::span { chunk->name }), "acTL"_span)) {
         if (m_hasInfo || m_isAnimated)
             return;
@@ -728,8 +738,9 @@ void PNGImageDecoder::init()
     m_sequenceNumber = 0;
 }
 
-void PNGImageDecoder::clearFrameBufferCache(size_t clearBeforeFrame)
+void PNGImageDecoder::clearDecodedPixelDataIfNeeded(size_t clearBeforeFrame)
 {
+    assertIsHeld(m_lock);
     if (m_frameBufferCache.isEmpty())
         return;
 
@@ -753,7 +764,8 @@ void PNGImageDecoder::clearFrameBufferCache(size_t clearBeforeFrame)
 
 void PNGImageDecoder::initFrameBuffer(size_t frameIndex)
 {
-    if (frameIndex >= frameCount())
+    assertIsHeld(m_lock);
+    if (frameIndex >= decodeIfNeededAndGetFrameCount())
         return;
 
     auto& buffer = m_frameBufferCache[frameIndex];
@@ -813,7 +825,8 @@ void PNGImageDecoder::initFrameBuffer(size_t frameIndex)
 
 void PNGImageDecoder::frameComplete()
 {
-    if (m_frameIsHidden || m_currentFrame >= frameCount())
+    assertIsHeld(m_lock);
+    if (m_frameIsHidden || m_currentFrame >= decodeIfNeededAndGetFrameCount())
         return;
 
     auto& buffer = m_frameBufferCache[m_currentFrame];

--- a/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.h
@@ -49,7 +49,7 @@ namespace WebCore {
 
         // ScalableImageDecoder
         String filenameExtension() const override { return "png"_s; }
-        size_t frameCount() const override { return m_frameCount; }
+        size_t decodeIfNeededAndGetFrameCount() const override { return m_frameCount; }
         RepetitionCount repetitionCount() const override;
         ScalableImageDecoderFrame* frameBufferAtIndex(size_t index) override;
         // CAUTION: setFailed() deletes |m_reader|.  Be careful to avoid
@@ -65,10 +65,11 @@ namespace WebCore {
         void frameHeader();
 
         void init();
-        void clearFrameBufferCache(size_t clearBeforeFrame) override;
+        void clearDecodedPixelDataIfNeeded(size_t clearBeforeFrame) override;
 
         bool isComplete() const
         {
+            assertIsHeld(m_lock);
             if (m_frameBufferCache.isEmpty())
                 return false;
 
@@ -82,8 +83,11 @@ namespace WebCore {
 
         bool isCompleteAtIndex(size_t index)
         {
+            assertIsHeld(m_lock);
             return (index < m_frameBufferCache.size() && m_frameBufferCache[index].isComplete());
         }
+
+        ScalableImageDecoderFrame* firstFrameBuffer();
 
     private:
         PNGImageDecoder(AlphaOption, GammaAndColorProfileOption);

--- a/Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.cpp
@@ -70,7 +70,8 @@ RepetitionCount WEBPImageDecoder::repetitionCount() const
 
 ScalableImageDecoderFrame* WEBPImageDecoder::frameBufferAtIndex(size_t index)
 {
-    if (index >= frameCount())
+    assertIsHeld(m_lock);
+    if (index >= decodeIfNeededAndGetFrameCount())
         return 0;
 
     // The size of m_frameBufferCache may be smaller than the index requested. This can happen
@@ -86,6 +87,7 @@ ScalableImageDecoderFrame* WEBPImageDecoder::frameBufferAtIndex(size_t index)
 
 size_t WEBPImageDecoder::findFirstRequiredFrameToDecode(size_t frameIndex, WebPDemuxer* demuxer)
 {
+    assertIsHeld(m_lock);
     // The first frame doesn't depend on any other.
     if (!frameIndex)
         return 0;
@@ -124,6 +126,7 @@ size_t WEBPImageDecoder::findFirstRequiredFrameToDecode(size_t frameIndex, WebPD
 
 void WEBPImageDecoder::decode(size_t frameIndex, bool allDataReceived)
 {
+    assertIsHeld(m_lock);
     if (failed())
         return;
 
@@ -157,6 +160,7 @@ void WEBPImageDecoder::decode(size_t frameIndex, bool allDataReceived)
 
 void WEBPImageDecoder::decodeFrame(size_t frameIndex, WebPDemuxer* demuxer)
 {
+    assertIsHeld(m_lock);
     if (failed())
         return;
 
@@ -219,7 +223,8 @@ void WEBPImageDecoder::decodeFrame(size_t frameIndex, WebPDemuxer* demuxer)
 
 bool WEBPImageDecoder::initFrameBuffer(size_t frameIndex, const WebPIterator* webpFrame)
 {
-    if (frameIndex >= frameCount())
+    assertIsHeld(m_lock);
+    if (frameIndex >= decodeIfNeededAndGetFrameCount())
         return false;
 
     auto& buffer = m_frameBufferCache[frameIndex];
@@ -258,6 +263,7 @@ bool WEBPImageDecoder::initFrameBuffer(size_t frameIndex, const WebPIterator* we
 
 void WEBPImageDecoder::applyPostProcessing(size_t frameIndex, WebPIDecoder* decoder, WebPDecBuffer& decoderBuffer, bool blend)
 {
+    assertIsHeld(m_lock);
     auto& buffer = m_frameBufferCache[frameIndex];
     int decodedWidth = 0;
     int decodedHeight = 0;
@@ -337,8 +343,9 @@ void WEBPImageDecoder::parseHeader()
     WebPDemuxDelete(demuxer);
 }
 
-void WEBPImageDecoder::clearFrameBufferCache(size_t clearBeforeFrame)
+void WEBPImageDecoder::clearDecodedPixelDataIfNeeded(size_t clearBeforeFrame)
 {
+    assertIsHeld(m_lock);
     if (m_frameBufferCache.isEmpty())
         return;
 

--- a/Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.h
@@ -48,8 +48,8 @@ public:
     void setData(const FragmentedSharedBuffer&, bool) final;
     ScalableImageDecoderFrame* frameBufferAtIndex(size_t index) override;
     RepetitionCount repetitionCount() const override;
-    size_t frameCount() const override { return m_frameCount; }
-    void clearFrameBufferCache(size_t) override;
+    size_t decodeIfNeededAndGetFrameCount() const override { return m_frameCount; }
+    void clearDecodedPixelDataIfNeeded(size_t) override;
 
 private:
     WEBPImageDecoder(AlphaOption, GammaAndColorProfileOption);

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -208,12 +208,14 @@ void MediaRecorderPrivateBackend::stopRecording(CompletionHandler<void()>&& comp
     gst_element_get_state(m_pipeline.get(), &state, nullptr, GST_CLOCK_TIME_NONE);
     if (state != GST_STATE_VOID_PENDING && state < GST_STATE_PLAYING) {
         GST_DEBUG_OBJECT(m_pipeline.get(), "Pipeline is not in playing state, not sending EOS event");
+        Locker lock(m_eosLock);
         m_eos = true;
         return;
     }
 
     if (!webkitMediaStreamSrcHasPrerolled(WEBKIT_MEDIA_STREAM_SRC(m_src.get()))) {
         GST_DEBUG_OBJECT(m_pipeline.get(), "Source element hasn't prerolled yet, no need to send EOS event");
+        Locker lock(m_eosLock);
         m_eos = true;
         return;
     }
@@ -225,12 +227,14 @@ void MediaRecorderPrivateBackend::stopRecording(CompletionHandler<void()>&& comp
     GST_DEBUG_OBJECT(m_pipeline.get(), "Emitting EOS event(s)");
     if (!gst_element_send_event(m_pipeline.get(), gst_event_new_eos())) {
         GST_WARNING_OBJECT(m_pipeline.get(), "EOS event wasn't handled");
+        Locker lock(m_eosLock);
         m_eos = true;
         return;
     }
 
     if (gst_app_sink_is_eos(GST_APP_SINK(m_sink.get()))) {
         GST_DEBUG_OBJECT(m_pipeline.get(), "Sink received EOS already");
+        Locker lock(m_eosLock);
         m_eos = true;
         return;
     }
@@ -241,8 +245,10 @@ void MediaRecorderPrivateBackend::stopRecording(CompletionHandler<void()>&& comp
     while (!isEOS) {
         Locker lock(m_eosLock);
         m_eosCondition.waitFor(m_eosLock, 200_ms, [weakThis = ThreadSafeWeakPtr { *this }]() -> bool {
-            if (auto protectedThis = weakThis.get())
+            if (auto protectedThis = weakThis.get()) {
+                assertIsHeld(protectedThis->m_eosLock);
                 return protectedThis->m_eos;
+            }
             return true;
         });
         isEOS = m_eos;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -108,7 +108,7 @@ void GStreamerVideoCapturer::tearDown(bool disconnectSignals)
         m_videoSrcMIMETypeFilter = nullptr;
 }
 
-void GStreamerVideoCapturer::setupPipeline()
+void GStreamerVideoCapturer::setupPipeline() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     GStreamerCapturer::setupPipeline();
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLGBM.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLGBM.cpp
@@ -64,6 +64,7 @@ void RemoteGraphicsContextGLGBM::prepareForDisplay(CompletionHandler<void(uint64
 
     UnixFileDescriptor fenceFD;
     m_context->prepareForDisplayWithFinishedSignal([this, &fenceFD] {
+        assertIsCurrent(workQueue());
         fenceFD = m_context->createExportedFence();
         if (!fenceFD)
             m_context->flush();

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorThreaded.cpp
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorThreaded.cpp
@@ -55,6 +55,7 @@ bool DisplayVBlankMonitorThreaded::startThreadIfNeeded()
             {
                 Locker locker { m_lock };
                 m_condition.wait(m_lock, [this]() -> bool {
+                    assertIsHeld(m_lock);
                     return m_state != State::Stop;
                 });
                 if (m_state == State::Invalid || m_state == State::Failed)
@@ -107,6 +108,7 @@ void DisplayVBlankMonitorThreaded::stop()
 void DisplayVBlankMonitorThreaded::invalidate()
 {
     if (!m_thread) {
+        Locker locker { m_lock };
         m_state = State::Invalid;
         return;
     }

--- a/Source/WebKit/UIProcess/wpe/DisplayVBlankMonitorWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/DisplayVBlankMonitorWPE.cpp
@@ -69,6 +69,7 @@ WPEScreenSyncObserver* DisplayVBlankMonitorWPE::observer() const
 
 void DisplayVBlankMonitorWPE::addCallbackIfNeeded()
 {
+    assertIsHeld(m_lock);
     if (m_callbackID)
         return;
 
@@ -83,6 +84,7 @@ void DisplayVBlankMonitorWPE::addCallbackIfNeeded()
 
 void DisplayVBlankMonitorWPE::removeCallbackIfNeeded()
 {
+    assertIsHeld(m_lock);
     if (!m_callbackID)
         return;
 

--- a/Source/WebKit/UIProcess/wpe/DisplayVBlankMonitorWPE.h
+++ b/Source/WebKit/UIProcess/wpe/DisplayVBlankMonitorWPE.h
@@ -50,8 +50,8 @@ private:
     bool isActive() final;
     void invalidate() final;
 
-    void addCallbackIfNeeded();
-    void removeCallbackIfNeeded();
+    void addCallbackIfNeeded() WTF_REQUIRES_LOCK(m_lock);
+    void removeCallbackIfNeeded() WTF_REQUIRES_LOCK(m_lock);
 
     mutable Lock m_lock;
     GRefPtr<WPEScreenSyncObserver> m_observer WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -763,8 +763,10 @@ std::unique_ptr<AcceleratedSurface::RenderTarget> AcceleratedSurface::SwapChain:
     switch (m_type) {
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
 #if USE(GBM) || OS(ANDROID)
-    case Type::EGLImage:
+    case Type::EGLImage: {
+        Locker locker { m_bufferFormatLock };
         return RenderTargetEGLImage::create(m_surface.get(), m_size, m_bufferFormat);
+    }
 #endif
     case Type::Texture:
         return RenderTargetTexture::create(m_surface.get(), m_size);
@@ -1034,6 +1036,7 @@ uint64_t AcceleratedSurface::window()
 bool AcceleratedSurface::isOpaque() const
 {
     ASSERT(RunLoop::isMain());
+    Locker locker { m_backgroundColorLock };
     return !m_backgroundColor || m_backgroundColor->isOpaque();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -425,7 +425,7 @@ private:
         Vector<std::unique_ptr<RenderTarget>, s_maximumBuffers> m_lockedTargets;
         bool m_initialTargetsCreated { false };
 #if (PLATFORM(GTK) || ENABLE(WPE_PLATFORM)) && (USE(GBM) || OS(ANDROID))
-        Lock m_bufferFormatLock;
+        mutable Lock m_bufferFormatLock;
         BufferFormat m_bufferFormat WTF_GUARDED_BY_LOCK(m_bufferFormatLock);
         bool m_bufferFormatChanged WTF_GUARDED_BY_LOCK(m_bufferFormatLock) { false };
 #endif
@@ -492,7 +492,7 @@ private:
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
     bool m_hardwareAccelerationEnabled { true };
 #endif
-    Lock m_backgroundColorLock;
+    mutable Lock m_backgroundColorLock;
     std::optional<WebCore::Color> m_backgroundColor WTF_GUARDED_BY_LOCK(m_backgroundColorLock);
     SwapChain m_swapChain;
     RenderTarget* m_target { nullptr };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -116,6 +116,7 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
         auto nativeSurfaceHandle = (GLNativeWindowType)m_surface->window();
         auto context = GLContext::create(PlatformDisplay::sharedDisplay(), nativeSurfaceHandle);
         if (!context || !context->makeContextCurrent()) {
+            Locker locker { m_state.lock };
             m_state.state = State::Invalidated;
             return;
         }
@@ -174,7 +175,7 @@ void ThreadedCompositor::invalidate()
 
 void ThreadedCompositor::startRenderTimer()
 {
-    ASSERT(m_state.lock.isHeld());
+    assertIsHeld(m_state.lock);
     ASSERT(!m_state.isRenderTimerActive);
     m_state.isRenderTimerActive = true;
     updateRenderTimer();
@@ -182,14 +183,14 @@ void ThreadedCompositor::startRenderTimer()
 
 void ThreadedCompositor::stopRenderTimer()
 {
-    ASSERT(m_state.lock.isHeld());
+    assertIsHeld(m_state.lock);
     m_state.isRenderTimerActive = false;
     updateRenderTimer();
 }
 
 void ThreadedCompositor::updateRenderTimer()
 {
-    ASSERT(m_state.lock.isHeld());
+    assertIsHeld(m_state.lock);
 
     // m_renderTimer is bound to the compositor thread's run loop (m_workQueue), so it must be started
     // and stopped there. The render timer's desired state is tracked synchronously under m_state.lock by
@@ -212,7 +213,7 @@ void ThreadedCompositor::updateRenderTimer()
 
 bool ThreadedCompositor::isOnlyRenderingUpdatePendingAndWaitingForTiles() const
 {
-    ASSERT(m_state.lock.isHeld());
+    assertIsHeld(m_state.lock);
     return m_state.reasons.containsOnly({ CompositionReason::RenderingUpdate }) && m_state.isWaitingForTiles;
 }
 
@@ -650,7 +651,7 @@ ASCIILiteral ThreadedCompositor::stateToString(ThreadedCompositor::State state)
 
 void ThreadedCompositor::scheduleUpdateLocked()
 {
-    ASSERT(m_state.lock.isHeld());
+    assertIsHeld(m_state.lock);
     WTFEmitSignpost(this, ScheduleComposition, "reasons: %s, state: %s, waiting for tiles: %s, render timer active: %s", reasonsToString(m_state.reasons).ascii().data(), stateToString(m_state.state).characters(), m_state.isWaitingForTiles ? "yes" : "no", m_state.isRenderTimerActive ? "yes" : "no");
 
     switch (m_state.state) {


### PR DESCRIPTION
#### a7ea27dd3bb648bfff86a210d1cd640f96f21d1c
<pre>
[GTK][WPE] Fix thread safety issues caught by -Wthread-safety
<a href="https://bugs.webkit.org/show_bug.cgi?id=320639">https://bugs.webkit.org/show_bug.cgi?id=320639</a>

Reviewed by Adrian Perez de Castro.

Most of them are false positives that just require proper annotations,
but there are quite a few real issues too.

* Source/JavaScriptCore/API/glib/JSCVirtualMachine.cpp:
(jscVirtualMachineGetOrCreate):
* Source/WTF/wtf/glib/ActivityObserver.h:
(WTF::ActivityObserver::start):
(WTF::ActivityObserver::notify):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp:
(WebCore::ScrollingTreeCoordinated::applyLayerPositionsInternal):
(WebCore::traverseDescendantLayersAtPoint):
(WebCore::ScrollingTreeCoordinated::scrollingNodeForPoint):
(WebCore::ScrollingTreeCoordinated::eventListenerRegionTypesForPoint const):
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::notifyIsPlaying):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackDataHolder::disconnect):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp:
(webkitGstBufferGetVideoFrameMetadata):
(webkitGstBufferGetProcessingTime):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::addSourceBuffer):
(WebCore::MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks):
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h:
(WebCore::AtlasUploadCondition::wait):
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp:
(WebCore::BitmapTexturePool::scheduleReleaseUnusedTextures):
(WebCore::BitmapTexturePool::releaseUnusedTexturesTimerFired):
(WebCore::BitmapTexturePool::enterLimitExceededModeIfNeeded):
(WebCore::BitmapTexturePool::exitLimitExceededModeIfNeeded):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
(WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setPosition):
(WebCore::CoordinatedPlatformLayer::position const):
(WebCore::CoordinatedPlatformLayer::setBoundsOrigin):
(WebCore::CoordinatedPlatformLayer::boundsOrigin const):
(WebCore::CoordinatedPlatformLayer::setAnchorPoint):
(WebCore::CoordinatedPlatformLayer::anchorPoint const):
(WebCore::CoordinatedPlatformLayer::setSize):
(WebCore::CoordinatedPlatformLayer::size const):
(WebCore::CoordinatedPlatformLayer::bounds const):
(WebCore::CoordinatedPlatformLayer::setTransform):
(WebCore::CoordinatedPlatformLayer::transform const):
(WebCore::CoordinatedPlatformLayer::setChildrenTransform):
(WebCore::CoordinatedPlatformLayer::childrenTransform const):
(WebCore::CoordinatedPlatformLayer::setVisibleRect):
(WebCore::CoordinatedPlatformLayer::visibleRect const):
(WebCore::CoordinatedPlatformLayer::setTransformedVisibleRect):
(WebCore::CoordinatedPlatformLayer::setScrollingNodeID):
(WebCore::CoordinatedPlatformLayer::scrollingNodeID const):
(WebCore::CoordinatedPlatformLayer::setDrawsContent):
(WebCore::CoordinatedPlatformLayer::setMasksToBounds):
(WebCore::CoordinatedPlatformLayer::setPreserves3D):
(WebCore::CoordinatedPlatformLayer::setBackfaceVisibility):
(WebCore::CoordinatedPlatformLayer::setOpacity):
(WebCore::CoordinatedPlatformLayer::setBlendMode):
(WebCore::CoordinatedPlatformLayer::setContentsVisible):
(WebCore::CoordinatedPlatformLayer::contentsVisible const):
(WebCore::CoordinatedPlatformLayer::setContentsOpaque):
(WebCore::CoordinatedPlatformLayer::setContentsRect):
(WebCore::CoordinatedPlatformLayer::setContentsRectClipsDescendants):
(WebCore::CoordinatedPlatformLayer::setContentsClippingRect):
(WebCore::CoordinatedPlatformLayer::setContentsScale):
(WebCore::CoordinatedPlatformLayer::contentsScale const):
(WebCore::CoordinatedPlatformLayer::hasCommittedContentsBuffer const):
(WebCore::CoordinatedPlatformLayer::setContentsBuffer):
(WebCore::CoordinatedPlatformLayer::setContentsImage):
(WebCore::CoordinatedPlatformLayer::setContentsColor):
(WebCore::CoordinatedPlatformLayer::setContentsTileSize):
(WebCore::CoordinatedPlatformLayer::setContentsTilePhase):
(WebCore::CoordinatedPlatformLayer::setDirtyRegion):
(WebCore::CoordinatedPlatformLayer::addDamage):
(WebCore::CoordinatedPlatformLayer::damageWholeLayer):
(WebCore::CoordinatedPlatformLayer::setFilters):
(WebCore::CoordinatedPlatformLayer::setMask):
(WebCore::CoordinatedPlatformLayer::setReplica):
(WebCore::CoordinatedPlatformLayer::setBackdrop):
(WebCore::CoordinatedPlatformLayer::notifyBackdropFiltersChanged):
(WebCore::CoordinatedPlatformLayer::setBackdropRect):
(WebCore::CoordinatedPlatformLayer::setIsBackdropRoot):
(WebCore::CoordinatedPlatformLayer::setAnimations):
(WebCore::CoordinatedPlatformLayer::setChildren):
(WebCore::CoordinatedPlatformLayer::children const):
(WebCore::CoordinatedPlatformLayer::setEventRegion):
(WebCore::CoordinatedPlatformLayer::eventRegion const):
(WebCore::CoordinatedPlatformLayer::setClipPath):
(WebCore::CoordinatedPlatformLayer::setDebugBorder):
(WebCore::CoordinatedPlatformLayer::setShowRepaintCounter):
(WebCore::CoordinatedPlatformLayer::needsBackingStore const):
(WebCore::CoordinatedPlatformLayer::updateContents):
(WebCore::CoordinatedPlatformLayer::paint):
(WebCore::CoordinatedPlatformLayer::record):
(WebCore::CoordinatedPlatformLayer::replay):
(WebCore::CoordinatedPlatformLayer::flushPositionChanges):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnTarget):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget):
(WebCore::CoordinatedPlatformLayer::hasPendingBackingStoreTileUpdates const):
(WebCore::CoordinatedPlatformLayer::processPendingBackingStoreTileUpdates):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
(WebCore::CoordinatedPlatformLayer::WTF_RETURNS_LOCK):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp:
(WebCore::CoordinatedPlatformLayerBufferProxy::consumePendingBufferIfNeeded):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerContentsDisplayDelegateCoordinated.cpp:
(WebCore::GraphicsLayerContentsDisplayDelegateCoordinated::display):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::updateGeometry):
(WebCore::GraphicsLayerCoordinated::updateVisibleRect):
(WebCore::GraphicsLayerCoordinated::updateBackdropFilters):
(WebCore::GraphicsLayerCoordinated::updateBackdropFiltersRect):
(WebCore::GraphicsLayerCoordinated::updateAnimations):
(WebCore::GraphicsLayerCoordinated::updateIndicators):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::Stream::Stream):
(WebCore::GStreamerElementHarness::Stream::pullSample):
(WebCore::GStreamerElementHarness::Stream::outputCaps):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.h:
* Source/WebCore/platform/image-decoders/avif/AVIFImageDecoder.cpp:
(WebCore::AVIFImageDecoder::findFirstRequiredFrameToDecode):
(WebCore::AVIFImageDecoder::frameBufferAtIndex):
(WebCore::AVIFImageDecoder::isComplete):
(WebCore::AVIFImageDecoder::decode):
* Source/WebCore/platform/image-decoders/bmp/BMPImageDecoder.cpp:
(WebCore::BMPImageDecoder::frameBufferAtIndex):
(WebCore::BMPImageDecoder::decode):
(WebCore::BMPImageDecoder::decodeHelper):
* Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp:
(WebCore::GIFImageDecoder::frameCount const):
(WebCore::GIFImageDecoder::findFirstRequiredFrameToDecode):
(WebCore::GIFImageDecoder::frameBufferAtIndex):
(WebCore::GIFImageDecoder::clearFrameBufferCache):
(WebCore::GIFImageDecoder::haveDecodedRow):
(WebCore::GIFImageDecoder::frameComplete):
(WebCore::GIFImageDecoder::decode):
(WebCore::GIFImageDecoder::initFrameBuffer):
(WebCore::GIFImageDecoder::decodeIfNeededAndGetFrameCount const):
(WebCore::GIFImageDecoder::clearDecodedPixelDataIfNeeded):
* Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp:
(WebCore::ICOImageDecoder::frameCount const):
(WebCore::ICOImageDecoder::frameBufferAtIndex):
(WebCore::ICOImageDecoder::decode):
(WebCore::ICOImageDecoder::decodeAtIndex):
(WebCore::ICOImageDecoder::decodeIfNeededAndGetFrameCount const):
* Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp:
(WebCore::JPEGImageDecoder::frameBufferAtIndex):
(WebCore::JPEGImageDecoder::outputScanlines):
(WebCore::JPEGImageDecoder::jpegComplete):
(WebCore::JPEGImageDecoder::decode):
* Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp:
(WebCore::JPEGXLImageDecoder::frameBufferAtIndex):
(WebCore::JPEGXLImageDecoder::clearFrameBufferCache):
(WebCore::JPEGXLImageDecoder::updateFrameCount):
(WebCore::JPEGXLImageDecoder::processInput):
(WebCore::JPEGXLImageDecoder::imageOut):
(WebCore::JPEGXLImageDecoder::decodeIfNeededAndGetFrameCount const):
(WebCore::JPEGXLImageDecoder::clearDecodedPixelDataIfNeeded):
(WebCore::JPEGXLImageDecoder::frameCount const): Deleted.
* Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp:
(WebCore::PNGImageDecoder::frameBufferAtIndex):
(WebCore::PNGImageDecoder::rowAvailable):
(WebCore::PNGImageDecoder::pngComplete):
(WebCore::PNGImageDecoder::readChunks):
(WebCore::PNGImageDecoder::clearFrameBufferCache):
(WebCore::PNGImageDecoder::initFrameBuffer):
(WebCore::PNGImageDecoder::frameComplete):
(WebCore::PNGImageDecoder::firstFrameBuffer):
(WebCore::PNGImageDecoder::clearDecodedPixelDataIfNeeded):
* Source/WebCore/platform/image-decoders/png/PNGImageDecoder.h:
* Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.cpp:
(WebCore::WEBPImageDecoder::frameBufferAtIndex):
(WebCore::WEBPImageDecoder::findFirstRequiredFrameToDecode):
(WebCore::WEBPImageDecoder::decode):
(WebCore::WEBPImageDecoder::decodeFrame):
(WebCore::WEBPImageDecoder::initFrameBuffer):
(WebCore::WEBPImageDecoder::applyPostProcessing):
(WebCore::WEBPImageDecoder::clearFrameBufferCache):
(WebCore::WEBPImageDecoder::clearDecodedPixelDataIfNeeded):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::stopRecording):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::setupPipeline): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLGBM.cpp:
(WebKit::RemoteGraphicsContextGLGBM::prepareForDisplay):
* Source/WebKit/UIProcess/glib/DisplayVBlankMonitorThreaded.cpp:
(WebKit::DisplayVBlankMonitorThreaded::startThreadIfNeeded):
(WebKit::DisplayVBlankMonitorThreaded::invalidate):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::SwapChain::createTarget const):
(WebKit::AcceleratedSurface::isOpaque const):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::m_renderTimer):
(WebKit::ThreadedCompositor::startRenderTimer):
(WebKit::ThreadedCompositor::stopRenderTimer):
(WebKit::ThreadedCompositor::updateRenderTimer):
(WebKit::ThreadedCompositor::isOnlyRenderingUpdatePendingAndWaitingForTiles const):
(WebKit::ThreadedCompositor::scheduleUpdateLocked):
* Source/WebKit/UIProcess/wpe/DisplayVBlankMonitorWPE.cpp:
(WebKit::DisplayVBlankMonitorWPE::addCallbackIfNeeded):
(WebKit::DisplayVBlankMonitorWPE::removeCallbackIfNeeded):
* Source/WebKit/UIProcess/wpe/DisplayVBlankMonitorWPE.h:
* Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp:
(WebCore::ScalableImageDecoder::frameCount const):
(WebCore::ScalableImageDecoder::clearFrameBufferCache):
* Source/WebCore/platform/image-decoders/ScalableImageDecoder.h:
(WebCore::ScalableImageDecoder::WTF_REQUIRES_LOCK):
* Source/WebCore/platform/image-decoders/avif/AVIFImageDecoder.h:
* Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.h:
* Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.h:
* Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.h:
* Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.h:

Canonical link: <a href="https://commits.webkit.org/318300@main">https://commits.webkit.org/318300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7b6feb31a39e702d582fa22741e5eb0f3a4591b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187373 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138559 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119022 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40747 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39109 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/991 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7802 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38802 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35835 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39035 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189801 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51369 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147677 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52051 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147463 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26974 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42178 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124266 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118732 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50559 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13779 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49955 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50195 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->