### PR TITLE
m_isInvokingQueueDrainedHandler assertions are thread racy

### DIFF
--- a/Source/WebCore/platform/network/PendingStreamState.cpp
+++ b/Source/WebCore/platform/network/PendingStreamState.cpp
@@ -31,6 +31,7 @@
 #include <wtf/Locker.h>
 #include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/Threading.h>
 
 namespace WebCore {
 
@@ -82,9 +83,9 @@ Result PendingStreamState::invokeDrainedHandlerIfNeeded(NOESCAPE const std::func
     auto result = function(handler);
     if (handler) {
 #if ASSERT_ENABLED
-        m_isInvokingQueueDrainedHandler = true;
+        m_invokingQueueDrainedHandlerThreadUID = Thread::currentSingleton().uid();
         auto scope = makeScopeExit([&] {
-            m_isInvokingQueueDrainedHandler = false;
+            m_invokingQueueDrainedHandlerThreadUID = 0;
         });
 #endif
         handler->invoke();
@@ -92,11 +93,18 @@ Result PendingStreamState::invokeDrainedHandlerIfNeeded(NOESCAPE const std::func
     return result;
 }
 
+#if ASSERT_ENABLED
+bool PendingStreamState::isInvokingQueueDrainedHandlerInSameThread() const
+{
+    return m_invokingQueueDrainedHandlerThreadUID.load() == Thread::currentSingleton().uid();
+}
+#endif
+
 void PendingStreamState::appendData(Ref<SharedBuffer>&& buffer)
 {
     invokeHandlerIfNeeded([&] -> RefPtr<CallbackHandler> {
         Locker locker { m_lock };
-        ASSERT(!m_isInvokingQueueDrainedHandler);
+        ASSERT(!isInvokingQueueDrainedHandlerInSameThread());
         if (m_ended || m_errorCode)
             return nullptr;
         m_chunks.append(WTF::move(buffer));
@@ -108,7 +116,7 @@ void PendingStreamState::endStream()
 {
     invokeHandlerIfNeeded([&] -> RefPtr<CallbackHandler> {
         Locker locker { m_lock };
-        ASSERT(!m_isInvokingQueueDrainedHandler);
+        ASSERT(!isInvokingQueueDrainedHandlerInSameThread());
         if (m_ended || m_errorCode)
             return nullptr;
         m_ended = true;
@@ -120,7 +128,7 @@ void PendingStreamState::errorStream(int errorCode)
 {
     invokeHandlerIfNeeded([&] -> RefPtr<CallbackHandler> {
         Locker locker { m_lock };
-        ASSERT(!m_isInvokingQueueDrainedHandler);
+        ASSERT(!isInvokingQueueDrainedHandlerInSameThread());
         if (m_ended || m_errorCode)
             return nullptr;
         m_errorCode = errorCode ? errorCode : -1;
@@ -139,7 +147,7 @@ void PendingStreamState::setDataAvailableHandler(Function<void()>&& handler)
     invokeHandlerIfNeeded([&] -> RefPtr<CallbackHandler> {
         Locker locker { m_lock };
         ASSERT(!m_dataAvailableHandler);
-        ASSERT(!m_isInvokingQueueDrainedHandler);
+        ASSERT(!isInvokingQueueDrainedHandlerInSameThread());
         RELEASE_LOG_ERROR_IF(m_dataAvailableHandler, Network, "Trying to get upload stream data twice");
         m_dataAvailableHandler = CallbackHandler::create(WTF::move(handler));
         if (!m_chunks.isEmpty() || m_ended || m_errorCode)
@@ -177,7 +185,7 @@ PendingStreamState::ReadResult PendingStreamState::readInto(std::span<uint8_t> o
 {
     return invokeDrainedHandlerIfNeeded<ReadResult>([&](auto& drainedHandler) -> ReadResult {
         Locker locker { m_lock };
-        ASSERT(!m_isInvokingQueueDrainedHandler);
+        ASSERT(!isInvokingQueueDrainedHandlerInSameThread());
 
         if (m_errorCode)
             return makeUnexpected(m_errorCode);
@@ -208,7 +216,7 @@ PendingStreamState::TakeResult PendingStreamState::takeAvailableChunks()
     return invokeDrainedHandlerIfNeeded<TakeResult>([&](auto& drainedHandler) -> TakeResult {
         Locker locker { m_lock };
         ASSERT(!m_frontChunkOffset);
-        ASSERT(!m_isInvokingQueueDrainedHandler);
+        ASSERT(!isInvokingQueueDrainedHandlerInSameThread());
 
         if (m_errorCode)
             return makeUnexpected(m_errorCode);

--- a/Source/WebCore/platform/network/PendingStreamState.h
+++ b/Source/WebCore/platform/network/PendingStreamState.h
@@ -84,6 +84,10 @@ private:
     template<typename Result>
     Result invokeDrainedHandlerIfNeeded(NOESCAPE const std::function<Result(RefPtr<CallbackHandler>&)>&);
 
+#if ASSERT_ENABLED
+    bool isInvokingQueueDrainedHandlerInSameThread() const;
+#endif
+
     Lock m_lock;
     Deque<Ref<SharedBuffer>> m_chunks WTF_GUARDED_BY_LOCK(m_lock);
     size_t m_frontChunkOffset WTF_GUARDED_BY_LOCK(m_lock) { 0 };
@@ -95,7 +99,7 @@ private:
     HTTPVersionProbe m_httpVersionProbe WTF_GUARDED_BY_LOCK(m_lock);
     Markable<FetchIdentifier> m_serviceWorkerFetchIdentifier;
 #if ASSERT_ENABLED
-    std::atomic<bool> m_isInvokingQueueDrainedHandler { false };
+    std::atomic<uint32_t> m_invokingQueueDrainedHandlerThreadUID { 0 };
 #endif
 };
 


### PR DESCRIPTION
#### a044b48be8a5207680cd24678cf03910c7e7d1b6
<pre>
m_isInvokingQueueDrainedHandler assertions are thread racy
<a href="https://rdar.apple.com/183614090">rdar://183614090</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320640">https://bugs.webkit.org/show_bug.cgi?id=320640</a>

Reviewed by Chris Dumez.

The goal of m_isInvokingQueueDrainedHandler assertions is to ensure that, when we call the drained handler, we do not synchronously append new data within that handler.
But m_isInvokingQueueDrainedHandler assertions are too aggresive.
In particular, if the drained handler is being called on thread A and thread B tries to append data, we would assert although this is fine.

We change m_isInvokingQueueDrainedHandler from a bool to the thread id on which the drained handler is being called.
We replace the past m_isInvokingQueueDrainedHandler assertions by checking that we are not adding data on that specific thread when the drained handler is being called.

Covered by existing tests on debug builds.

* Source/WebCore/platform/network/PendingStreamState.cpp:
(WebCore::PendingStreamState::invokeDrainedHandlerIfNeeded):
(WebCore::PendingStreamState::isInvokingQueueDrainedHandlerInSameThread const):
(WebCore::PendingStreamState::appendData):
(WebCore::PendingStreamState::endStream):
(WebCore::PendingStreamState::errorStream):
(WebCore::PendingStreamState::setDataAvailableHandler):
(WebCore::PendingStreamState::readInto):
(WebCore::PendingStreamState::takeAvailableChunks):
* Source/WebCore/platform/network/PendingStreamState.h:

Canonical link: <a href="https://commits.webkit.org/318246@main">https://commits.webkit.org/318246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07b03d9fdadff0248153e3e0e25fdcd094c77830

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187350 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3782051e-e3d7-4a23-befb-c29183397624) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138538 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf526be2-5626-4866-8450-aad5e8d1cbb9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42062 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119002 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8855241a-15c6-4d07-882b-73e2b18aa31a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40724 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151130 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38778 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35812 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43464 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189778 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51346 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147656 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39664 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52028 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147442 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42155 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124243 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118691 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50536 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13755 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49932 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50172 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49994 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->