### PR TITLE
LibWebRTCAudioModule can use the audio transport after it is unregistered and destroyed

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
@@ -50,6 +50,7 @@ int32_t LibWebRTCAudioModule::RegisterAudioCallback(webrtc::AudioTransport* audi
 {
     RELEASE_LOG(WebRTC, "LibWebRTCAudioModule::RegisterAudioCallback %d", !!audioTransport);
 
+    Locker locker { m_audioTransportLock };
     m_audioTransport = audioTransport;
     return 0;
 }
@@ -130,15 +131,17 @@ void LibWebRTCAudioModule::pollAudioData()
 
 void LibWebRTCAudioModule::pollFromSource()
 {
-    auto* audioTransport = m_audioTransport.load();
-    if (!audioTransport)
+    ASSERT(m_queue->isCurrent());
+
+    Locker locker { m_audioTransportLock };
+    if (!m_audioTransport)
         return;
 
     for (unsigned i = 0; i < PollSamplesCount; i++) {
         int64_t elapsedTime = -1;
         int64_t ntpTime = -1;
         char data[LibWebRTCAudioFormat::sampleByteSize * channels * LibWebRTCAudioFormat::chunkSampleCount];
-        audioTransport->PullRenderData(LibWebRTCAudioFormat::sampleByteSize * 8, LibWebRTCAudioFormat::sampleRate, channels, LibWebRTCAudioFormat::chunkSampleCount, data, &elapsedTime, &ntpTime);
+        m_audioTransport->PullRenderData(LibWebRTCAudioFormat::sampleByteSize * 8, LibWebRTCAudioFormat::sampleRate, channels, LibWebRTCAudioFormat::chunkSampleCount, data, &elapsedTime, &ntpTime);
 #if PLATFORM(COCOA)
         if (m_isRenderingIncomingAudioCounter)
             m_incomingAudioMediaStreamTrackRendererUnit->newAudioChunkPushed(m_currentAudioSampleCount);

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
@@ -30,6 +30,7 @@
 #include <WebCore/LibWebRTCMacros.h>
 #include <WebCore/Timer.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/Lock.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Platform.h>
 #include <wtf/WorkQueue.h>
@@ -155,7 +156,8 @@ private:
 
     const Ref<WorkQueue> m_queue;
     std::atomic<bool> m_isPlaying { false };
-    std::atomic<webrtc::AudioTransport*> m_audioTransport { nullptr };
+    Lock m_audioTransportLock;
+    webrtc::AudioTransport* m_audioTransport WTF_GUARDED_BY_LOCK(m_audioTransportLock) { nullptr };
     MonotonicTime m_pollingTime;
     Timer m_logTimer;
     int m_timeSpent { 0 };


### PR DESCRIPTION
#### de6ac853eb8beed6c1a3f482e4a31d16894bfe93
<pre>
LibWebRTCAudioModule can use the audio transport after it is unregistered and destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=320641">https://bugs.webkit.org/show_bug.cgi?id=320641</a>
<a href="https://rdar.apple.com/183619537">rdar://183619537</a>

Reviewed by Youenn Fablet.

Completes 318047@main. Making m_audioTransport a
std::atomic&lt;webrtc::AudioTransport*&gt; made the pointer value race-free but
gave no ordering against the pointee&apos;s destruction. The transport is
AudioState::audio_transport_, a member of AudioState, so when
WebRtcVoiceEngine::Terminate() calls StopPlayout() then
RegisterAudioCallback(nullptr) and drops AudioState, a poll still inside
PullRenderData() is using freed memory. StopPlayout() only stores false
into m_isPlaying and returns; it does not wait for the polling chain.

Guard m_audioTransport with a lock that pollFromSource() holds across its
PullRenderData() calls. RegisterAudioCallback() takes that same lock, so it
cannot return while a poll is still using the transport it is replacing, and
its caller is then free to destroy that transport, as
WebRtcVoiceEngine::Terminate() does. That subsumes the atomic, which is no
longer needed, and WTF_GUARDED_BY_LOCK now machine-checks every access. The
barrier belongs here rather than in StopPlayout(), which libwebrtc reaches
from BaseChannel::UpdateMediaSendRecvState_w() under
RTC_DCHECK_DISALLOW_THREAD_BLOCKING_CALLS() on every renegotiation to
sendonly or inactive; RegisterAudioCallback() runs only at engine init and
terminate, where waiting for at most one in-flight poll is acceptable.

Keep m_isPlaying atomic: it is written on libwebrtc&apos;s worker thread, read
on the work queue, and read via Playing() from AudioState.

* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp:
(WebCore::LibWebRTCAudioModule::RegisterAudioCallback):
(WebCore::LibWebRTCAudioModule::pollFromSource):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h:

Canonical link: <a href="https://commits.webkit.org/318712@main">https://commits.webkit.org/318712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72d40630edda40f85510ec7f94acd4d37cd5a5f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188872 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9d94f3aa-337e-4ed9-ad3c-982b4c821da9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139619 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3fc60a37-d085-4ba8-ab3f-e6b3f0ea7d0f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120065 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37cd71f3-b26b-41b8-84af-14cb7afbe9d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41885 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40228 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152285 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39876 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/179 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191092 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52652 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148846 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39953 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53332 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36502 "Too many flaky failures: http/tests/media/media-play-stream-chunked-icy.html, http/tests/misc/script-500.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/do-not-block-top-level-navigation-redirect.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/image-blocked-alt-text.html, http/tests/security/mixedContent/redirect-https-to-http-iframe-in-main-frame.html, http/tests/site-isolation/iframe-and-window-open.html, http/tests/site-isolation/inspector/network/resource-timing-cross-origin-page-navigation.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148593 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43284 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125603 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120417 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51850 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14855 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51235 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51476 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51296 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->