### PR TITLE
requestPictureInPicture() does not consume the user activation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-consumes-user-activation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-consumes-user-activation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS request Picture-in-Picture consumes the user activation, denying a fullscreen request from the same activation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-consumes-user-activation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-consumes-user-activation.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<title>Test that request Picture-in-Picture consumes the user activation</title>
+<script src="/common/media.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/picture-in-picture-helpers.js"></script>
+<body></body>
+<script>
+// Runs `action` synchronously from a click event handler, so that the requests
+// below are made while the user activation is live, as a page would make them.
+async function runFromClickHandler(t, action) {
+  const button = document.createElement('button');
+  button.textContent = 'This test requires user interaction. Please click here.';
+  document.body.appendChild(button);
+  t.add_cleanup(() => button.remove());
+
+  const result = new Promise(resolve => {
+    button.addEventListener('click', () => { resolve(action()); }, { once: true });
+  });
+  await test_driver.click(button);
+  return result;
+}
+
+promise_test(async t => {
+  const video = await loadVideo();
+  document.body.appendChild(video);
+  t.add_cleanup(async () => {
+    if (document.fullscreenElement)
+      await document.exitFullscreen();
+    if (document.pictureInPictureElement)
+      await document.exitPictureInPicture();
+    video.remove();
+  });
+
+  // https://w3c.github.io/picture-in-picture/#dom-htmlvideoelement-requestpictureinpicture
+  // requestPictureInPicture() consumes the user activation, so a fullscreen
+  // request made from the same activation must be denied.
+  //
+  // Each outcome is captured with handlers attached synchronously: the requests
+  // settle while the click is still being dispatched, so awaiting them later
+  // would report an unhandled rejection. Awaiting the outcomes rather than the
+  // requests themselves also keeps a wrongly granted fullscreen request from
+  // timing out the test: in that case the Picture-in-Picture request, whose
+  // presentation mode change is superseded by fullscreen, never settles.
+  const settled = promise => promise.then(() => 'fulfilled', error => error);
+  const outcomes = await runFromClickHandler(t, () => ({
+    // play() is only here to mirror how a page enters Picture-in-Picture from a
+    // click; its result is not what is under test.
+    play: settled(video.play()),
+    pictureInPicture: settled(video.requestPictureInPicture()),
+    fullscreen: settled(video.requestFullscreen()),
+  }));
+
+  const fullscreenOutcome = await outcomes.fullscreen;
+  assert_true(fullscreenOutcome instanceof TypeError,
+      'requestFullscreen() should be denied with a TypeError: requestPictureInPicture() ' +
+      `consumed the user activation (got ${fullscreenOutcome})`);
+  assert_equals(document.fullscreenElement, null, 'there should be no fullscreen element');
+
+  assert_equals(await outcomes.pictureInPicture, 'fulfilled', 'requestPictureInPicture()');
+  assert_equals(document.pictureInPictureElement, video,
+      'video should be the Picture-in-Picture element');
+}, 'request Picture-in-Picture consumes the user activation, denying a fullscreen request from the same activation');
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1301,6 +1301,7 @@ imported/w3c/web-platform-tests/picture-in-picture/picture-in-picture-window.htm
 imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-exits-existing.html [ Skip ]
 imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-twice.html [ Skip ]
 imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture.html [ Skip ]
+imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-consumes-user-activation.html [ Skip ]
 
 scrollbars/scrolling-backward-by-page-accounting-bottom-fixed-elements-on-keyboard-spacebar.html [ Skip ]
 scrollbars/scrolling-backward-by-page-on-keyboard-spacebar.html [ Skip ]

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
@@ -42,6 +42,7 @@
 #include "PictureInPictureWindow.h"
 #include "UserGestureIndicator.h"
 #include "VideoTrackList.h"
+#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -120,6 +121,12 @@ void HTMLVideoElementPictureInPicture::requestPictureInPicture(HTMLVideoElement&
         promise->reject(ExceptionCode::NotAllowedError, "The request is not triggered by a user activation."_s);
         return;
     }
+
+    // Consumed on exit rather than here because MediaElementSession::fullscreenPermitted(), reached through webkitSetPresentationMode() below, accepts this transient activation as the user gesture.
+    auto consumeUserActivation = makeScopeExit([&] {
+        if (userActivationRequired)
+            window->consumeTransientActivation();
+    });
 
     Ref videoElementPictureInPicture = HTMLVideoElementPictureInPicture::from(videoElement);
     if (protect(videoElement)->document().pictureInPictureElement() == &videoElement) {


### PR DESCRIPTION
#### 51385a5dc8bf092dee60e0a7cdc96c9ebf1fa942
<pre>
requestPictureInPicture() does not consume the user activation
<a href="https://bugs.webkit.org/show_bug.cgi?id=320114">https://bugs.webkit.org/show_bug.cgi?id=320114</a>
<a href="https://rdar.apple.com/183621577">rdar://183621577</a>

Reviewed by Jean-Yves Avenard.

requestPictureInPicture() is specified to consume the transient activation right after
checking for it [1]. WebKit only did the check, so a page could enter both
Picture-in-Picture and fullscreen from a single click by requesting Picture-in-Picture
first, since requestFullscreen() does consume it.

Consume it from a scope exit rather than where the specification does.
MediaElementSession::fullscreenPermitted(), reached through webkitSetPresentationMode(),
is gated on Document::processingUserGestureForMedia(), which falls back to the transient
activation when no user gesture token is on the stack — the usual case, since the request
comes from an asynchronous continuation of a click. Consuming any earlier makes
HTMLVideoElement::setPresentationMode() return early, leaving the promise unsettled. No
script can run in between, so the ordering is not observable.

Gating on userActivationRequired keeps a re-request for the element already in
Picture-in-Picture from consuming, as specified.

[1] <a href="https://w3c.github.io/picture-in-picture/#dom-htmlvideoelement-requestpictureinpicture">https://w3c.github.io/picture-in-picture/#dom-htmlvideoelement-requestpictureinpicture</a>

Test: imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-consumes-user-activation.html

* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-consumes-user-activation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-consumes-user-activation.html: Added.
* LayoutTests/platform/ios/TestExpectations: Add Platform Specific Expectation
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp:
(WebCore::HTMLVideoElementPictureInPicture::requestPictureInPicture):

Canonical link: <a href="https://commits.webkit.org/318673@main">https://commits.webkit.org/318673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36dfa29967f7b6df1f1c78595314f810c9155aa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52983 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46778 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188873 "Failed to checkout and rebase branch from PR 70525") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52693 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/188873 "Failed to checkout and rebase branch from PR 70525") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182001 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/188873 "Failed to checkout and rebase branch from PR 70525") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/188873 "Failed to checkout and rebase branch from PR 70525") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/191093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52653 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/159891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/191093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53333 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/191093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27165 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/43285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51851 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/14856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51236 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51477 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51297 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->