### PR TITLE
NumericConstraint::valueForDiscreteCapabilityValues() resolves min/max constraints to the wrong supported value

### DIFF
--- a/LayoutTests/fast/mediastream/apply-constraints-sample-rate-range-expected.txt
+++ b/LayoutTests/fast/mediastream/apply-constraints-sample-rate-range-expected.txt
@@ -1,0 +1,3 @@
+
+PASS applyConstraints with sample rate min/max range constraints on a microphone track
+

--- a/LayoutTests/fast/mediastream/apply-constraints-sample-rate-range.html
+++ b/LayoutTests/fast/mediastream/apply-constraints-sample-rate-range.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+// The mock microphone starts at 44100Hz and only supports the discrete sample rates
+// 8000, 16000, 32000, 44100, 48000 and 96000.
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+
+    const track = stream.getAudioTracks()[0];
+    assert_equals(track.getSettings().sampleRate, 44100, "initial sample rate");
+
+    await track.applyConstraints({ sampleRate: { min: 16000, max: 48000 } });
+    assert_equals(track.getSettings().sampleRate, 44100, "'min' and 'max' set, current value satisfies both and there is no 'ideal', so it should not change");
+
+    await track.applyConstraints({ sampleRate: { max: 32000 } });
+    assert_equals(track.getSettings().sampleRate, 32000, "'max' only set, current value exceeds it, so the largest supported value that satisfies it should be used");
+
+    await track.applyConstraints({ sampleRate: { min: 44100 } });
+    assert_equals(track.getSettings().sampleRate, 44100, "'min' only set, current value is below it, so the smallest supported value that satisfies it should be used");
+
+    await track.applyConstraints({ sampleRate: { max: 96000 } });
+    assert_equals(track.getSettings().sampleRate, 44100, "'max' only set, current value satisfies it and there is no 'ideal', so it should not change");
+
+    await track.applyConstraints({ sampleRate: { min: 48000, max: 96000 } });
+    assert_equals(track.getSettings().sampleRate, 48000, "'min' and 'max' set, current value is below 'min', so it should be clamped up to a supported value");
+
+    await track.applyConstraints({ sampleRate: { min: 8000, max: 32000 } });
+    assert_equals(track.getSettings().sampleRate, 32000, "'min' and 'max' set, current value is above 'max', so it should be clamped down to a supported value");
+
+    await track.applyConstraints({ sampleRate: { exact: 44100 } });
+    assert_equals(track.getSettings().sampleRate, 44100, "'exact' set to a supported value");
+}, "applyConstraints with sample rate min/max range constraints on a microphone track");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2825,6 +2825,12 @@ http/wpt/mediastream/webrtc-vp9-colorspace.html [ Failure ]
 
 webkit.org/b/314659 webrtc/getDisplayMedia-pc-resolution.html [ Pass Crash Failure ]
 
+# The GStreamer mock microphone exposes sampleRate as the continuous capability range [44100, 96000]
+# and does not override RealtimeMediaSource::discreteSampleRates(), so constraints below 44100 are
+# overconstrained here and the discrete supported values path this test covers is never taken. The
+# path itself is covered on every port by the MediaConstraintsTest API tests.
+webkit.org/b/320645 fast/mediastream/apply-constraints-sample-rate-range.html [ Skip ]
+
 # Regressions introduced by https://commits.webkit.org/263750@main
 fast/mediastream/apply-constraints-advanced.html [ Failure ]
 fast/mediastream/apply-constraints-video.html [ Failure ]

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -290,39 +290,66 @@ public:
 
     std::optional<ValueType> valueForDiscreteCapabilityValues(ValueType current, const Vector<ValueType>& discreteCapabilityValues) const
     {
-        std::optional<ValueType> value;
-        std::optional<ValueType> min;
-        std::optional<ValueType> max;
+        if (discreteCapabilityValues.isEmpty())
+            return { };
 
         if (m_exact) {
             ASSERT(discreteCapabilityValues.contains(m_exact.value()));
             return m_exact.value();
         }
 
-        if (m_min) {
-            auto index = discreteCapabilityValues.findIf([&](ValueType value) { return m_min.value() >= value; });
-            if (index != notFound) {
-                min = value = discreteCapabilityValues[index];
+        std::optional<ValueType> value;
+        std::optional<ValueType> min;
+        std::optional<ValueType> max;
 
-                // If there is no ideal, don't change if minimum is smaller than current.
-                if (!m_ideal && *value < current)
-                    value = current;
+        if (m_min) {
+            // The smallest supported value that satisfies the min constraint.
+            for (auto& discreteValue : discreteCapabilityValues) {
+                if (discreteValue >= m_min.value() && (!min || discreteValue < *min))
+                    min = discreteValue;
             }
+
+            // No supported value satisfies the constraint, leave the setting alone.
+            if (!min)
+                return { };
+
+            value = *min;
+
+            // If there is no ideal, don't change if minimum is smaller than current.
+            if (!m_ideal && *value < current)
+                value = current;
         }
 
-        if (m_max && m_max.value() >= discreteCapabilityValues[0]) {
+        if (m_max) {
+            // The largest supported value that satisfies the max constraint.
             for (auto& discreteValue : discreteCapabilityValues) {
-                if (m_max.value() <= discreteValue)
-                    max = value = discreteValue;
+                if (discreteValue <= m_max.value() && (!max || discreteValue > *max))
+                    max = discreteValue;
+            }
+
+            // No supported value satisfies the constraint, leave the setting alone.
+            if (!max)
+                return { };
+
+            if (m_min) {
+                ASSERT(value);
+                if (*value > *max)
+                    value = *max;
+            } else {
+                value = *max;
+
+                // If there is no ideal, don't change if maximum is larger than current, as long as current is a valid value for this capability.
+                if (!m_ideal && current < *value && discreteCapabilityValues.contains(current))
+                    value = current;
             }
         }
 
         if (m_ideal && discreteCapabilityValues.contains(m_ideal.value())) {
             value = m_ideal.value();
             if (max)
-                value = std::min(max.value(), *value);
+                value = std::min(*max, *value);
             if (min)
-                value = std::max(min.value(), *value);
+                value = std::max(*min, *value);
         }
 
         return value;

--- a/Tools/TestWebKitAPI/Tests/WebCore/MediaConstraintsTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MediaConstraintsTests.cpp
@@ -109,6 +109,138 @@ TEST(MediaConstraintsTest, ValueForCapabilityRangeMinMaxIdealIsUnaffected)
     EXPECT_EQ(constraint.valueForCapabilityRange(1280, 0, 4096), 1024);
 }
 
+// The discrete sample rates supported by CoreAudioCaptureSource, the only capability
+// that currently resolves through valueForDiscreteCapabilityValues().
+static Vector<int> discreteSampleRates()
+{
+    return { 8000, 16000, 32000, 44100, 48000, 96000 };
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesExact)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setExact(32000);
+
+    EXPECT_EQ(constraint.valueForDiscreteCapabilityValues(48000, discreteSampleRates()), 32000);
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMinOnlySelectsSmallestSupportedValue)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMin(32000);
+
+    // Current value doesn't satisfy min, so the smallest supported value that does is used.
+    EXPECT_EQ(constraint.valueForDiscreteCapabilityValues(8000, discreteSampleRates()), 32000);
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMinOnlyPreservesValidCurrent)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMin(16000);
+
+    EXPECT_EQ(constraint.valueForDiscreteCapabilityValues(48000, discreteSampleRates()), 48000);
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMaxOnlyClampsToLargestSupportedValue)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMax(44100);
+
+    // Current value doesn't satisfy max, so the largest supported value that does is used.
+    EXPECT_EQ(constraint.valueForDiscreteCapabilityValues(96000, discreteSampleRates()), 44100);
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMaxOnlyPreservesValidCurrent)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMax(48000);
+
+    // Current value already satisfies max and there is no ideal, so it should be
+    // left unchanged rather than jumping to the largest allowed value.
+    EXPECT_EQ(constraint.valueForDiscreteCapabilityValues(44100, discreteSampleRates()), 44100);
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMaxOnlyIgnoresUnsupportedCurrent)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMax(48000);
+
+    // Current value is not one of the supported values, so it is not a valid current
+    // value and must not be preserved.
+    EXPECT_EQ(constraint.valueForDiscreteCapabilityValues(22050, discreteSampleRates()), 48000);
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMinMaxPreservesValidCurrent)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMin(16000);
+    constraint.setMax(48000);
+
+    // Current value already satisfies [min, max] and there is no ideal, so it
+    // should be left unchanged rather than jumping to max.
+    EXPECT_EQ(constraint.valueForDiscreteCapabilityValues(44100, discreteSampleRates()), 44100);
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMinMaxClampsAboveMax)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMin(16000);
+    constraint.setMax(44100);
+
+    EXPECT_EQ(constraint.valueForDiscreteCapabilityValues(96000, discreteSampleRates()), 44100);
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMinMaxClampsBelowMin)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMin(32000);
+    constraint.setMax(48000);
+
+    EXPECT_EQ(constraint.valueForDiscreteCapabilityValues(8000, discreteSampleRates()), 32000);
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesIdealIsClampedToMax)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMin(16000);
+    constraint.setMax(44100);
+    constraint.setIdeal(96000);
+
+    EXPECT_EQ(constraint.valueForDiscreteCapabilityValues(32000, discreteSampleRates()), 44100);
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesIdealIsUsedWhenSupported)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setIdeal(32000);
+
+    EXPECT_EQ(constraint.valueForDiscreteCapabilityValues(48000, discreteSampleRates()), 32000);
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesUnsatisfiableMaxLeavesSettingAlone)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMax(4000);
+
+    EXPECT_FALSE(constraint.valueForDiscreteCapabilityValues(48000, discreteSampleRates()));
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesUnsatisfiableMinLeavesSettingAlone)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMin(192000);
+
+    EXPECT_FALSE(constraint.valueForDiscreteCapabilityValues(48000, discreteSampleRates()));
+}
+
+TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesEmptyCapabilityValuesLeavesSettingAlone)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMax(48000);
+
+    EXPECT_FALSE(constraint.valueForDiscreteCapabilityValues(48000, { }));
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(MEDIA_STREAM)


### PR DESCRIPTION
#### 5fc2d4865768b83e02b976790165be88d4d80c1c
<pre>
NumericConstraint::valueForDiscreteCapabilityValues() resolves min/max constraints to the wrong supported value
<a href="https://bugs.webkit.org/show_bug.cgi?id=320645">https://bugs.webkit.org/show_bug.cgi?id=320645</a>
<a href="https://rdar.apple.com/183623103">rdar://183623103</a>

Reviewed by NOBODY (OOPS!).

For a capability exposed as a list of discrete supported values rather than a
range, valueForDiscreteCapabilityValues() resolved min and max constraints
incorrectly:

- The max block iterated the whole list and kept the last value greater than or
  equal to the max constraint, i.e. the largest supported value, which is the
  opposite of a max bound: applyConstraints({sampleRate: {max: 44100}}) moved the
  sample rate to 96000 instead of 44100. It also overwrote the value computed by
  the min block, so a current value already inside [min, max] was discarded and
  forced to that bound, exactly as in <a href="https://commits.webkit.org/318046@main">318046@main</a>.
- The min block used findIf(m_min &gt;= value), which matches the first supported
  value less than or equal to the min constraint, i.e. the smallest supported
  value, again regardless of the constraint: applyConstraints({sampleRate:
  {min: 32000}}) with a current rate of 8000 resolved to 8000, violating the
  constraint it was asked to satisfy.
- The max block guarded on discreteCapabilityValues[0], which reads out of
  bounds when the capability list is empty.

Resolve min to the smallest supported value that satisfies it and max to the
largest supported value that satisfies it, leave the setting alone when no
supported value satisfies the constraint, and clamp rather than overwrite the
already-computed value when both min and max are set. As in <a href="https://commits.webkit.org/318046@main">318046@main</a>, a
current value is only preserved in the max-only case when it is itself a valid
value for the capability, which here means one of the supported values, so a
sentinel or out-of-list current value cannot be reported as the resolved
setting. Also return early for an empty capability list.

sampleRate is the only capability that resolves through this path today, via
CoreAudioCaptureSource::discreteSampleRates(). Because mock microphone capture
on Cocoa is served by CoreAudioCaptureSource::createForTesting(), the new
layout test covers it directly.

Tests: fast/mediastream/apply-constraints-sample-rate-range.html
 Tools/TestWebKitAPI/Tests/WebCore/MediaConstraintsTests.cpp

* LayoutTests/fast/mediastream/apply-constraints-sample-rate-range-expected.txt: Added.
* LayoutTests/fast/mediastream/apply-constraints-sample-rate-range.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::NumericConstraint::valueForDiscreteCapabilityValues const):
* Tools/TestWebKitAPI/Tests/WebCore/MediaConstraintsTests.cpp:
(TestWebKitAPI::discreteSampleRates):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesExact)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMinOnlySelectsSmallestSupportedValue)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMinOnlyPreservesValidCurrent)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMaxOnlyClampsToLargestSupportedValue)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMaxOnlyPreservesValidCurrent)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMaxOnlyIgnoresUnsupportedCurrent)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMinMaxPreservesValidCurrent)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMinMaxClampsAboveMax)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesMinMaxClampsBelowMin)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesIdealIsClampedToMax)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesIdealIsUsedWhenSupported)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesUnsatisfiableMaxLeavesSettingAlone)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesUnsatisfiableMinLeavesSettingAlone)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForDiscreteCapabilityValuesEmptyCapabilityValuesLeavesSettingAlone)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fc2d4865768b83e02b976790165be88d4d80c1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141542 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e534fa6c-cd28-4e16-944c-32269ad37b7f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138990 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96502 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ed50b1f-2b70-491d-8056-e9d902ad124b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119445 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8bdd5764-ee21-4af4-9925-4ba76da584d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41218 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39571 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionContext.CleanUpOldOriginDataAfterMigration (failure)") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151618 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39257 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36365 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190336 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148141 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52582 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147916 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42633 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124846 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119446 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51100 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14232 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50485 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50725 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50547 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->