### PR TITLE
[CoordinatedGraphics] Some CoordinatedPlatformLayer pending changes are never reset

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -332,12 +332,7 @@ void CoordinatedPlatformLayer::setTransformedVisibleRect(IntRect&& transformedVi
 void CoordinatedPlatformLayer::setScrollingNodeID(std::optional<ScrollingNodeID> nodeID)
 {
     assertIsHeld(m_lock);
-    if (m_scrollingNodeID == nodeID)
-        return;
-
     m_scrollingNodeID = nodeID;
-    m_pendingChanges.add(Change::ScrollingNode);
-    notifyCompositionRequired();
 }
 
 const Markable<ScrollingNodeID>& CoordinatedPlatformLayer::scrollingNodeID() const
@@ -350,12 +345,7 @@ const Markable<ScrollingNodeID>& CoordinatedPlatformLayer::scrollingNodeID() con
 void CoordinatedPlatformLayer::setDrawsContent(bool drawsContent)
 {
     assertIsHeld(m_lock);
-    if (m_drawsContent == drawsContent)
-        return;
-
     m_drawsContent = drawsContent;
-    m_pendingChanges.add(Change::DrawsContent);
-    notifyCompositionRequired();
 }
 
 void CoordinatedPlatformLayer::setMasksToBounds(bool masksToBounds)
@@ -1363,6 +1353,7 @@ void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet
             auto clipPath = *m_clipPath.path.platformPath();
             clipPath.setFillType(m_clipPath.windRule == WindRule::EvenOdd ? SkPathFillType::kEvenOdd : SkPathFillType::kWinding);
             layer.setClipPath(WTF::move(clipPath));
+            m_pendingChanges.remove(Change::ClipPath);
         }
 
         if (m_pendingChanges.contains(Change::Filters)) {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -261,7 +261,6 @@ private:
         Damage,
 #endif
         DebugIndicators,
-        DrawsContent,
         Filters,
         Mask,
         MasksToBounds,
@@ -269,9 +268,6 @@ private:
         Position,
         Preserves3D,
         Replica,
-#if ENABLE(SCROLLING_THREAD)
-        ScrollingNode,
-#endif
         Size,
         Transform,
     };


### PR DESCRIPTION
#### 59e7807aea6b444a6d280e4fa8126a8e3e07ff6f
<pre>
[CoordinatedGraphics] Some CoordinatedPlatformLayer pending changes are never reset
<a href="https://bugs.webkit.org/show_bug.cgi?id=320654">https://bugs.webkit.org/show_bug.cgi?id=320654</a>

Reviewed by Nikolas Zimmermann.

DrawsContent, ClipPath and ScrollingNode are never removed from
m_pendingChanges. DrawsContent and ScrollingNode are not really needed
because those values are not passed to the compositing layer.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setScrollingNodeID):
(WebCore::CoordinatedPlatformLayer::setDrawsContent):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:

Canonical link: <a href="https://commits.webkit.org/318312@main">https://commits.webkit.org/318312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/439569f3db660484ae5255b163d0264b1a3d0f00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187556 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53177 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51593 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42245 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119170 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40908 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151313 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38950 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36017 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44476 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43501 "Build is in progress. Recent messages:") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189985 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51551 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147838 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52233 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147619 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26980 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42329 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118941 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50741 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13930 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50137 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50377 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->