### PR TITLE
Media controls create their elements in the null namespace in SVG, MathML and XML documents

### DIFF
--- a/LayoutTests/media/modern-media-controls/media-controller/media-controller-mathml-document-expected.txt
+++ b/LayoutTests/media/modern-media-controls/media-controller/media-controller-mathml-document-expected.txt
@@ -1,0 +1,13 @@
+CONSOLE MESSAGE: Checking the media controls of a <video> element in a MathML document.
+CONSOLE MESSAGE: PASS: document.createElement("div").namespaceURI is null.
+CONSOLE MESSAGE: PASS: the first shadow root child is style.
+CONSOLE MESSAGE: PASS: the stylesheet namespace is http://www.w3.org/1999/xhtml.
+CONSOLE MESSAGE: PASS: the stylesheet is applied.
+CONSOLE MESSAGE: PASS: the controls container element is div.
+CONSOLE MESSAGE: PASS: the controls container namespace is http://www.w3.org/1999/xhtml.
+CONSOLE MESSAGE: PASS: the controls container is an HTMLElement.
+CONSOLE MESSAGE: PASS: typeof the controls container offsetWidth is number.
+CONSOLE MESSAGE: PASS: typeof the controls container offsetHeight is number.
+CONSOLE MESSAGE: PASS: the controls container has descendants.
+CONSOLE MESSAGE: PASS: the number of controls elements outside of the HTML namespace is 0.
+

--- a/LayoutTests/media/modern-media-controls/media-controller/media-controller-mathml-document.xml
+++ b/LayoutTests/media/modern-media-controls/media-controller/media-controller-mathml-document.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<math xmlns="http://www.w3.org/1998/Math/MathML">
+<mtext><video xmlns="http://www.w3.org/1999/xhtml" id="video" controls="controls" width="640" height="360"></video></mtext>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript"><![CDATA[
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const HTMLNamespace = "http://www.w3.org/1999/xhtml";
+
+function log(message)
+{
+    console.log(message);
+}
+
+function shouldBe(description, actual, expected)
+{
+    if (actual === expected)
+        log(`PASS: ${description} is ${expected}.`);
+    else
+        log(`FAIL: ${description} is ${actual}, expected ${expected}.`);
+}
+
+function shouldBeTrue(description, actual)
+{
+    log(`${actual === true ? "PASS" : "FAIL"}: ${description}.`);
+}
+
+requestAnimationFrame(() => requestAnimationFrame(() => {
+    log("Checking the media controls of a <video> element in a MathML document.");
+
+    // The document is not an HTML or XHTML document, so document.createElement() creates
+    // elements in the null namespace. The controls must not rely on it.
+    shouldBe("document.createElement(\"div\").namespaceURI", document.createElement("div").namespaceURI, null);
+
+    const shadowRoot = internals.shadowRoot(document.getElementById("video"));
+
+    const styleElement = shadowRoot.firstElementChild;
+    shouldBe("the first shadow root child", styleElement.localName, "style");
+    shouldBe("the stylesheet namespace", styleElement.namespaceURI, HTMLNamespace);
+    shouldBeTrue("the stylesheet is applied", styleElement.sheet !== null);
+
+    const container = shadowRoot.lastElementChild;
+    shouldBe("the controls container element", container.localName, "div");
+    shouldBe("the controls container namespace", container.namespaceURI, HTMLNamespace);
+    shouldBeTrue("the controls container is an HTMLElement", container instanceof HTMLElement);
+    shouldBe("typeof the controls container offsetWidth", typeof container.offsetWidth, "number");
+    shouldBe("typeof the controls container offsetHeight", typeof container.offsetHeight, "number");
+
+    const descendants = Array.from(container.querySelectorAll("*"));
+    shouldBeTrue("the controls container has descendants", descendants.length > 0);
+    shouldBe("the number of controls elements outside of the HTML namespace", descendants.filter(element => element.namespaceURI !== HTMLNamespace).length, 0);
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}));
+]]></script>
+</math>

--- a/LayoutTests/media/modern-media-controls/media-controller/media-controller-svg-document-expected.txt
+++ b/LayoutTests/media/modern-media-controls/media-controller/media-controller-svg-document-expected.txt
@@ -1,0 +1,13 @@
+CONSOLE MESSAGE: Checking the media controls of a <video> element in an SVG document.
+CONSOLE MESSAGE: PASS: document.createElement("div").namespaceURI is null.
+CONSOLE MESSAGE: PASS: the first shadow root child is style.
+CONSOLE MESSAGE: PASS: the stylesheet namespace is http://www.w3.org/1999/xhtml.
+CONSOLE MESSAGE: PASS: the stylesheet is applied.
+CONSOLE MESSAGE: PASS: the controls container element is div.
+CONSOLE MESSAGE: PASS: the controls container namespace is http://www.w3.org/1999/xhtml.
+CONSOLE MESSAGE: PASS: the controls container is an HTMLElement.
+CONSOLE MESSAGE: PASS: typeof the controls container offsetWidth is number.
+CONSOLE MESSAGE: PASS: typeof the controls container offsetHeight is number.
+CONSOLE MESSAGE: PASS: the controls container has descendants.
+CONSOLE MESSAGE: PASS: the number of controls elements outside of the HTML namespace is 0.
+

--- a/LayoutTests/media/modern-media-controls/media-controller/media-controller-svg-document.svg
+++ b/LayoutTests/media/modern-media-controls/media-controller/media-controller-svg-document.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600">
+<title>Media controls in an SVG document should be created in the HTML namespace.</title>
+<foreignObject x="0" y="0" width="640" height="360">
+    <video xmlns="http://www.w3.org/1999/xhtml" id="video" controls="controls" width="640" height="360"></video>
+</foreignObject>
+<script type="text/javascript"><![CDATA[
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const HTMLNamespace = "http://www.w3.org/1999/xhtml";
+
+function log(message)
+{
+    console.log(message);
+}
+
+function shouldBe(description, actual, expected)
+{
+    if (actual === expected)
+        log(`PASS: ${description} is ${expected}.`);
+    else
+        log(`FAIL: ${description} is ${actual}, expected ${expected}.`);
+}
+
+function shouldBeTrue(description, actual)
+{
+    log(`${actual === true ? "PASS" : "FAIL"}: ${description}.`);
+}
+
+requestAnimationFrame(() => requestAnimationFrame(() => {
+    log("Checking the media controls of a <video> element in an SVG document.");
+
+    // The document is not an HTML or XHTML document, so document.createElement() creates
+    // elements in the null namespace. The controls must not rely on it.
+    shouldBe("document.createElement(\"div\").namespaceURI", document.createElement("div").namespaceURI, null);
+
+    const shadowRoot = internals.shadowRoot(document.getElementById("video"));
+
+    const styleElement = shadowRoot.firstElementChild;
+    shouldBe("the first shadow root child", styleElement.localName, "style");
+    shouldBe("the stylesheet namespace", styleElement.namespaceURI, HTMLNamespace);
+    shouldBeTrue("the stylesheet is applied", styleElement.sheet !== null);
+
+    const container = shadowRoot.lastElementChild;
+    shouldBe("the controls container element", container.localName, "div");
+    shouldBe("the controls container namespace", container.namespaceURI, HTMLNamespace);
+    shouldBeTrue("the controls container is an HTMLElement", container instanceof HTMLElement);
+    shouldBe("typeof the controls container offsetWidth", typeof container.offsetWidth, "number");
+    shouldBe("typeof the controls container offsetHeight", typeof container.offsetHeight, "number");
+
+    const descendants = Array.from(container.querySelectorAll("*"));
+    shouldBeTrue("the controls container has descendants", descendants.length > 0);
+    shouldBe("the number of controls elements outside of the HTML namespace", descendants.filter(element => element.namespaceURI !== HTMLNamespace).length, 0);
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}));
+]]></script>
+</svg>

--- a/LayoutTests/media/modern-media-controls/media-controller/media-controller-xml-document-expected.txt
+++ b/LayoutTests/media/modern-media-controls/media-controller/media-controller-xml-document-expected.txt
@@ -1,0 +1,13 @@
+CONSOLE MESSAGE: Checking the media controls of a <video> element in an XML document.
+CONSOLE MESSAGE: PASS: document.createElement("div").namespaceURI is null.
+CONSOLE MESSAGE: PASS: the first shadow root child is style.
+CONSOLE MESSAGE: PASS: the stylesheet namespace is http://www.w3.org/1999/xhtml.
+CONSOLE MESSAGE: PASS: the stylesheet is applied.
+CONSOLE MESSAGE: PASS: the controls container element is div.
+CONSOLE MESSAGE: PASS: the controls container namespace is http://www.w3.org/1999/xhtml.
+CONSOLE MESSAGE: PASS: the controls container is an HTMLElement.
+CONSOLE MESSAGE: PASS: typeof the controls container offsetWidth is number.
+CONSOLE MESSAGE: PASS: typeof the controls container offsetHeight is number.
+CONSOLE MESSAGE: PASS: the controls container has descendants.
+CONSOLE MESSAGE: PASS: the number of controls elements outside of the HTML namespace is 0.
+

--- a/LayoutTests/media/modern-media-controls/media-controller/media-controller-xml-document.xml
+++ b/LayoutTests/media/modern-media-controls/media-controller/media-controller-xml-document.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test>
+<video xmlns="http://www.w3.org/1999/xhtml" id="video" controls="controls" width="640" height="360"></video>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript"><![CDATA[
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const HTMLNamespace = "http://www.w3.org/1999/xhtml";
+
+function log(message)
+{
+    console.log(message);
+}
+
+function shouldBe(description, actual, expected)
+{
+    if (actual === expected)
+        log(`PASS: ${description} is ${expected}.`);
+    else
+        log(`FAIL: ${description} is ${actual}, expected ${expected}.`);
+}
+
+function shouldBeTrue(description, actual)
+{
+    log(`${actual === true ? "PASS" : "FAIL"}: ${description}.`);
+}
+
+requestAnimationFrame(() => requestAnimationFrame(() => {
+    log("Checking the media controls of a <video> element in an XML document.");
+
+    // The document is not an HTML or XHTML document, so document.createElement() creates
+    // elements in the null namespace. The controls must not rely on it.
+    shouldBe("document.createElement(\"div\").namespaceURI", document.createElement("div").namespaceURI, null);
+
+    const shadowRoot = internals.shadowRoot(document.getElementById("video"));
+
+    const styleElement = shadowRoot.firstElementChild;
+    shouldBe("the first shadow root child", styleElement.localName, "style");
+    shouldBe("the stylesheet namespace", styleElement.namespaceURI, HTMLNamespace);
+    shouldBeTrue("the stylesheet is applied", styleElement.sheet !== null);
+
+    const container = shadowRoot.lastElementChild;
+    shouldBe("the controls container element", container.localName, "div");
+    shouldBe("the controls container namespace", container.namespaceURI, HTMLNamespace);
+    shouldBeTrue("the controls container is an HTMLElement", container instanceof HTMLElement);
+    shouldBe("typeof the controls container offsetWidth", typeof container.offsetWidth, "number");
+    shouldBe("typeof the controls container offsetHeight", typeof container.offsetHeight, "number");
+
+    const descendants = Array.from(container.querySelectorAll("*"));
+    shouldBeTrue("the controls container has descendants", descendants.length > 0);
+    shouldBe("the number of controls elements outside of the HTML namespace", descendants.filter(element => element.namespaceURI !== HTMLNamespace).length, 0);
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}));
+]]></script>
+</test>

--- a/Source/WebCore/Modules/modern-media-controls/controls/layout-node.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/layout-node.js
@@ -9,7 +9,7 @@ class LayoutNode
     {
 
         if (!stringOrElement)
-            this.element = document.createElement("div");
+            this.element = createHTMLElement("div");
         else if (stringOrElement instanceof Element)
             this.element = stringOrElement;
         else if (typeof stringOrElement === "string" || stringOrElement instanceof String)
@@ -363,9 +363,21 @@ function performScheduledLayout()
     nodesRequiringChildrenUpdate.clear();
 }
 
+// Always create the controls in the HTML namespace. The media element's document is not
+// necessarily an HTML or XHTML document: it may be an SVG (image/svg+xml), MathML or generic
+// XML document, in which case document.createElement() creates elements in the null namespace.
+// Those elements are not HTMLElements, so they have no style property and no offsetWidth or
+// offsetHeight, and a <style> element in the null namespace is not a stylesheet at all.
+function createHTMLElement(tagName)
+{
+    return document.createElementNS("http://www.w3.org/1999/xhtml", tagName);
+}
+
 function elementFromString(elementString)
 {
-    const element = document.createElement("div");
+    // The parsed fragment inherits the namespace of the element it is parsed in, so creating
+    // the container in the HTML namespace is enough for the whole subtree to be HTML elements.
+    const element = createHTMLElement("div");
     element.innerHTML = elementString;
     return element.firstElementChild;
 }

--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js
@@ -113,7 +113,7 @@ class MacOSInlineMediaControls extends InlineMediaControls
             return;
 
         if (this.mediaControlsHost?.isMediaControlsMacInlineSizeSpecsEnabled && !this.element.classList.contains('audio')) {
-            if (this.rightContainer?.element) {
+            if (this.rightContainer?.element?.style) {
                 this.rightContainer.element.style.removeProperty('left');
                 this.rightContainer._dirtyProperties.delete('x');
             }

--- a/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
@@ -52,7 +52,7 @@ class TimeControl extends LayoutItem
 
         this.activityIndicator = new LayoutNode(`<div class="activity-indicator"></div>`);
         for (let segmentClassName of ["n", "ne", "e", "se", "s", "sw", "w", "nw"])
-            this.activityIndicator.element.appendChild(document.createElement("div")).className = segmentClassName;
+            this.activityIndicator.element.appendChild(createHTMLElement("div")).className = segmentClassName;
 
         this._duration = 0;
         this._currentTime = 0;

--- a/Source/WebCore/Modules/modern-media-controls/main.js
+++ b/Source/WebCore/Modules/modern-media-controls/main.js
@@ -40,7 +40,7 @@ function createControls(shadowRoot, media, host)
 {
     if (host) {
         for (let styleSheet of host.shadowRootStyleSheets)
-            shadowRoot.appendChild(document.createElement("style")).textContent = styleSheet;
+            shadowRoot.appendChild(createHTMLElement("style")).textContent = styleSheet;
     }
 
     controller = new MediaController(shadowRoot, media, host);

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -83,7 +83,7 @@ class MediaController
 
         this.hasPlayed = !media.paused || !!media.played.length;
 
-        this.container = shadowRoot.appendChild(document.createElement("div"));
+        this.container = shadowRoot.appendChild(createHTMLElement("div"));
 
         this._updateControlsIfNeeded();
         this._usesLTRUserInterfaceLayoutDirection = false;
@@ -311,18 +311,18 @@ class MediaController
         if (this._statsContainer)
             return true;
 
-        this._statsContainer = this.container.appendChild(document.createElement("div"))
+        this._statsContainer = this.container.appendChild(createHTMLElement("div"))
         this._statsContainer.className = "stats-container";
 
-        let table = this._statsContainer.appendChild(document.createElement("table"));
+        let table = this._statsContainer.appendChild(createHTMLElement("table"));
 
         function createRow(label) {
-            let rowElement = table.appendChild(document.createElement("tr"));
+            let rowElement = table.appendChild(createHTMLElement("tr"));
 
-            let labelElement = rowElement.appendChild(document.createElement("th"));
+            let labelElement = rowElement.appendChild(createHTMLElement("th"));
             labelElement.textContent = label;
 
-            let valueElement = rowElement.appendChild(document.createElement("td"));
+            let valueElement = rowElement.appendChild(createHTMLElement("td"));
             return valueElement;
         }
         let sourceValueElement = createRow(UIString("Source"));
@@ -467,8 +467,8 @@ class MediaController
         // content box of its host (excluding borders). These properties are not affected
         // by CSS transforms, so they give the correct dimensions regardless of any
         // transform applied to the media element or its ancestors.
-        this.controls.width = Math.round(this.container.offsetWidth * this.controls.scaleFactor);
-        this.controls.height = Math.round(this.container.offsetHeight * this.controls.scaleFactor);
+        this.controls.width = Math.round((this.container.offsetWidth ?? 0) * this.controls.scaleFactor);
+        this.controls.height = Math.round((this.container.offsetHeight ?? 0) * this.controls.scaleFactor);
     }
 
     _updateTextTracksClassList()

--- a/Source/WebCore/Modules/modern-media-controls/media/placard-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/placard-support.js
@@ -119,7 +119,7 @@ class PlacardSupport extends MediaControllerSupport
 
 function escapeHTML(unsafeString)
 {
-    var div = document.createElement("div");
+    var div = createHTMLElement("div");
     div.textContent = unsafeString;
     return div.innerHTML;
 }


### PR DESCRIPTION
#### f2fd9e8eae77eb30f8fa28daf08a2904418d85c1
<pre>
Media controls create their elements in the null namespace in SVG, MathML and XML documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=307412">https://bugs.webkit.org/show_bug.cgi?id=307412</a>
<a href="https://rdar.apple.com/170528402">rdar://170528402</a>

Reviewed by NOBODY (OOPS!).

The modern media controls build their DOM with document.createElement(). That creates
elements in the HTML namespace only when the media element&apos;s document is an HTML or XHTML
document. In an SVG (image/svg+xml), MathML or generic XML document it creates elements in
the null namespace instead, which are plain Elements rather than HTMLElements: they have no
style property, no offsetWidth or offsetHeight, and a &lt;style&gt; element in the null namespace
is not a stylesheet at all, so the controls stylesheets were never applied either.

As a result, a &lt;video&gt; or &lt;audio&gt; element in such a document logged two TypeErrors while
laying out its controls, which also caused a harness failure in
svg/interact/scripted/tabindex-focus-flag.svg:

  TypeError: undefined is not an object
             (evaluating &apos;this.rightContainer.element.style.removeProperty&apos;)

This became visible in <a href="https://commits.webkit.org/315718@main">315718@main</a>: _updateControlsSize() previously derived the controls
size from getBoundingClientRect(), which returned an empty rect, so the width setter was a
no-op and never ran layout(). Reading the missing offsetWidth instead yields NaN, which is
not equal to the current width, so the setter now marks the node dirty and runs layout(),
reaching code that assumes element.style exists.

Add a createHTMLElement() helper that uses createElementNS() with the HTML namespace and
use it everywhere the controls create an element. Parsing a fragment with innerHTML inherits
the namespace of the element it is parsed in, so creating the container in the HTML
namespace is enough for elementFromString() to produce an HTML subtree.

Also make the two places that consume those elements resilient, so a stray non-HTML element
degrades instead of throwing: fall back to a zero size in _updateControlsSize(), and check
for element.style in MacOSInlineMediaControls.layout().

Tests: media/modern-media-controls/media-controller/media-controller-mathml-document.xml
 media/modern-media-controls/media-controller/media-controller-svg-document.svg
 media/modern-media-controls/media-controller/media-controller-xml-document.xml

* LayoutTests/media/modern-media-controls/media-controller/media-controller-mathml-document-expected.txt: Added.
* LayoutTests/media/modern-media-controls/media-controller/media-controller-mathml-document.xml: Added.
* LayoutTests/media/modern-media-controls/media-controller/media-controller-svg-document-expected.txt: Added.
* LayoutTests/media/modern-media-controls/media-controller/media-controller-svg-document.svg: Added.
* LayoutTests/media/modern-media-controls/media-controller/media-controller-xml-document-expected.txt: Added.
* LayoutTests/media/modern-media-controls/media-controller/media-controller-xml-document.xml: Added.
* Source/WebCore/Modules/modern-media-controls/controls/layout-node.js:
(LayoutNode):
(createHTMLElement):
(elementFromString):
* Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js:
(MacOSInlineMediaControls.prototype.layout):
* Source/WebCore/Modules/modern-media-controls/controls/time-control.js:
(TimeControl.):
* Source/WebCore/Modules/modern-media-controls/main.js:
(createControls):
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController):
(MediaController.prototype.setShowingStats.createRow):
(MediaController.prototype.setShowingStats):
(MediaController.prototype._updateControlsSize):
* Source/WebCore/Modules/modern-media-controls/media/placard-support.js:
(escapeHTML):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2fd9e8eae77eb30f8fa28daf08a2904418d85c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141006 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3748d4ba-e7b6-4ca2-a5cf-85f86467a00e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179622 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52989 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138555 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96346 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ca8e37b-e78b-41c7-b911-a497875f13c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119018 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02d23ce5-5a11-4f49-92d0-0d08415bfb89) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40743 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39107 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38798 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35830 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189796 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147673 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52046 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147459 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42175 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124261 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118725 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50554 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13775 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49950 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50012 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->