### PR TITLE
[GFC][Integration] Allow every non-baseline self-alignment value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-fit-content-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-fit-content-001-expected.txt
@@ -1,0 +1,19 @@
+
+PASS justify-self: stretch on an item with an automatic width uses the stretch-fit size
+PASS justify-self: start on an item with an automatic width uses the fit-content size
+PASS justify-self: center on an item with an automatic width uses the fit-content size
+PASS justify-self: end on an item with an automatic width uses the fit-content size
+PASS justify-self: center on an item with an automatic width clamps the fit-content size by the stretch-fit size
+PASS align-self: stretch on an item with an automatic height uses the stretch-fit size
+PASS align-self: start on an item with an automatic height uses the fit-content size
+PASS align-self: center on an item with an automatic height uses the fit-content size
+PASS align-self: end on an item with an automatic height uses the fit-content size
+XXXXX
+XXXXX
+XXXXX
+XXXXX
+XX XX
+XXXXX
+XXXXX
+XXXXX
+XXXXX

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-fit-content-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-fit-content-001.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-item-sizing">
+<link rel="help" href="https://www.w3.org/TR/css-sizing-3/#fit-content-size">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="A grid item with an automatic size whose self-alignment is not stretch (and does not behave as stretch) is sized to its fit-content size in that axis, rather than filling its grid area.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Ahem at 20px with a line-height of 1 makes every glyph a 20px by 20px box,
+     so "XXXXX" is 100px wide and one line tall. */
+  .grid { display: grid; font: 20px/1 Ahem; }
+  .wide-area   { grid-template: 100px / 200px; }
+  .narrow-area { grid-template: 100px / 60px; }
+
+  .item { background: green; }
+
+  /* Isolate the axis under test by giving the item a fixed size in the other axis. */
+  .automatic-width { width: auto; height: 40px; }
+  .automatic-height { width: 100px; height: auto; }
+</style>
+<body>
+<div id="log"></div>
+
+<!-- Inline axis. The grid area is 200px wide and the item's max-content size is
+     100px, so a stretched item is 200px wide and a fit-content sized item is
+     100px wide. -->
+<div class="grid wide-area"><div class="item automatic-width" id="stretch-inline" style="justify-self: stretch">XXXXX</div></div>
+<div class="grid wide-area"><div class="item automatic-width" id="start-inline"   style="justify-self: start">XXXXX</div></div>
+<div class="grid wide-area"><div class="item automatic-width" id="center-inline"  style="justify-self: center">XXXXX</div></div>
+<div class="grid wide-area"><div class="item automatic-width" id="end-inline"     style="justify-self: end">XXXXX</div></div>
+
+<!-- The fit-content size is clamped by the stretch-fit size, so an item in a
+     60px area whose min-content size is 40px and whose max-content size is
+     100px is 60px wide. -->
+<div class="grid narrow-area"><div class="item automatic-width" id="center-inline-clamped" style="justify-self: center">XX XX</div></div>
+
+<!-- Block axis. The grid area is 100px tall and the item's content is one 20px
+     line tall, so a stretched item is 100px tall and a fit-content sized item
+     is 20px tall. -->
+<div class="grid wide-area"><div class="item automatic-height" id="stretch-block" style="align-self: stretch">XXXXX</div></div>
+<div class="grid wide-area"><div class="item automatic-height" id="start-block"   style="align-self: start">XXXXX</div></div>
+<div class="grid wide-area"><div class="item automatic-height" id="center-block"  style="align-self: center">XXXXX</div></div>
+<div class="grid wide-area"><div class="item automatic-height" id="end-block"     style="align-self: end">XXXXX</div></div>
+
+<script>
+function itemMetrics(id) {
+    const item = document.getElementById(id);
+    const gridRect = item.parentElement.getBoundingClientRect();
+    const itemRect = item.getBoundingClientRect();
+    return {
+        width: itemRect.width,
+        height: itemRect.height,
+        left: itemRect.left - gridRect.left,
+        top: itemRect.top - gridRect.top,
+    };
+}
+
+test(() => {
+    const metrics = itemMetrics("stretch-inline");
+    assert_equals(metrics.width, 200, "used width");
+    assert_equals(metrics.left, 0, "offset from the grid container's left edge");
+}, "justify-self: stretch on an item with an automatic width uses the stretch-fit size");
+
+test(() => {
+    const metrics = itemMetrics("start-inline");
+    assert_equals(metrics.width, 100, "used width");
+    assert_equals(metrics.left, 0, "offset from the grid container's left edge");
+}, "justify-self: start on an item with an automatic width uses the fit-content size");
+
+test(() => {
+    const metrics = itemMetrics("center-inline");
+    assert_equals(metrics.width, 100, "used width");
+    assert_equals(metrics.left, 50, "offset from the grid container's left edge");
+}, "justify-self: center on an item with an automatic width uses the fit-content size");
+
+test(() => {
+    const metrics = itemMetrics("end-inline");
+    assert_equals(metrics.width, 100, "used width");
+    assert_equals(metrics.left, 100, "offset from the grid container's left edge");
+}, "justify-self: end on an item with an automatic width uses the fit-content size");
+
+test(() => {
+    assert_equals(itemMetrics("center-inline-clamped").width, 60, "used width");
+}, "justify-self: center on an item with an automatic width clamps the fit-content size by the stretch-fit size");
+
+test(() => {
+    const metrics = itemMetrics("stretch-block");
+    assert_equals(metrics.height, 100, "used height");
+    assert_equals(metrics.top, 0, "offset from the grid container's top edge");
+}, "align-self: stretch on an item with an automatic height uses the stretch-fit size");
+
+test(() => {
+    const metrics = itemMetrics("start-block");
+    assert_equals(metrics.height, 20, "used height");
+    assert_equals(metrics.top, 0, "offset from the grid container's top edge");
+}, "align-self: start on an item with an automatic height uses the fit-content size");
+
+test(() => {
+    const metrics = itemMetrics("center-block");
+    assert_equals(metrics.height, 20, "used height");
+    assert_equals(metrics.top, 40, "offset from the grid container's top edge");
+}, "align-self: center on an item with an automatic height uses the fit-content size");
+
+test(() => {
+    const metrics = itemMetrics("end-block");
+    assert_equals(metrics.height, 20, "used height");
+    assert_equals(metrics.top, 80, "offset from the grid container's top edge");
+}, "align-self: end on an item with an automatic height uses the fit-content size");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-positional-values-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-positional-values-001-expected.txt
@@ -1,0 +1,18 @@
+
+PASS justify-self: start places the item's margin box within its grid area
+PASS justify-self: center places the item's margin box within its grid area
+PASS justify-self: end places the item's margin box within its grid area
+PASS justify-self: self-start places the item's margin box within its grid area
+PASS justify-self: self-end places the item's margin box within its grid area
+PASS justify-self: flex-start places the item's margin box within its grid area
+PASS justify-self: flex-end places the item's margin box within its grid area
+PASS justify-self: left places the item's margin box within its grid area
+PASS justify-self: right places the item's margin box within its grid area
+PASS align-self: start places the item's margin box within its grid area
+PASS align-self: center places the item's margin box within its grid area
+PASS align-self: end places the item's margin box within its grid area
+PASS align-self: self-start places the item's margin box within its grid area
+PASS align-self: self-end places the item's margin box within its grid area
+PASS align-self: flex-start places the item's margin box within its grid area
+PASS align-self: flex-end places the item's margin box within its grid area
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-positional-values-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-positional-values-001.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#self-alignment">
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#alignment">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="Each positional self-alignment value places a grid item's margin box within its grid area, and not within the grid container.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  /* Every item is placed in the second track so that a start-aligned item is
+     offset from the grid container's start edge. An offset of 0 therefore
+     cannot be mistaken for correct alignment. */
+  .grid { display: grid; }
+  .three-columns { grid-template: 100px / 100px 100px 100px; }
+  .three-rows    { grid-template: 100px 100px 100px / 100px; }
+
+  .item { width: 40px; height: 40px; background: green; }
+
+  .column2 { grid-area: 1 / 2 / 2 / 3; }
+  .row2    { grid-area: 2 / 1 / 3 / 2; }
+</style>
+<body>
+<div id="log"></div>
+
+<!-- Inline axis. The second column's start edge is at 100px and leaves 60px of
+     free space around the 40px wide item. Both the grid container and the items
+     are horizontal-tb and ltr, so self-start/flex-start/left behave as start and
+     self-end/flex-end/right behave as end. -->
+<div class="grid three-columns"><div class="item column2" style="justify-self: start"      data-expected-left="100" data-expected-top="0"></div></div>
+<div class="grid three-columns"><div class="item column2" style="justify-self: center"     data-expected-left="130" data-expected-top="0"></div></div>
+<div class="grid three-columns"><div class="item column2" style="justify-self: end"        data-expected-left="160" data-expected-top="0"></div></div>
+<div class="grid three-columns"><div class="item column2" style="justify-self: self-start" data-expected-left="100" data-expected-top="0"></div></div>
+<div class="grid three-columns"><div class="item column2" style="justify-self: self-end"   data-expected-left="160" data-expected-top="0"></div></div>
+<div class="grid three-columns"><div class="item column2" style="justify-self: flex-start" data-expected-left="100" data-expected-top="0"></div></div>
+<div class="grid three-columns"><div class="item column2" style="justify-self: flex-end"   data-expected-left="160" data-expected-top="0"></div></div>
+<div class="grid three-columns"><div class="item column2" style="justify-self: left"       data-expected-left="100" data-expected-top="0"></div></div>
+<div class="grid three-columns"><div class="item column2" style="justify-self: right"      data-expected-left="160" data-expected-top="0"></div></div>
+
+<!-- Block axis. The second row's start edge is at 100px and leaves 60px of free
+     space around the 40px tall item. left and right are not valid values for
+     align-self. -->
+<div class="grid three-rows"><div class="item row2" style="align-self: start"      data-expected-left="0" data-expected-top="100"></div></div>
+<div class="grid three-rows"><div class="item row2" style="align-self: center"     data-expected-left="0" data-expected-top="130"></div></div>
+<div class="grid three-rows"><div class="item row2" style="align-self: end"        data-expected-left="0" data-expected-top="160"></div></div>
+<div class="grid three-rows"><div class="item row2" style="align-self: self-start" data-expected-left="0" data-expected-top="100"></div></div>
+<div class="grid three-rows"><div class="item row2" style="align-self: self-end"   data-expected-left="0" data-expected-top="160"></div></div>
+<div class="grid three-rows"><div class="item row2" style="align-self: flex-start" data-expected-left="0" data-expected-top="100"></div></div>
+<div class="grid three-rows"><div class="item row2" style="align-self: flex-end"   data-expected-left="0" data-expected-top="160"></div></div>
+
+<script>
+for (const item of document.querySelectorAll(".item")) {
+    test(() => {
+        const gridRect = item.parentElement.getBoundingClientRect();
+        const itemRect = item.getBoundingClientRect();
+        assert_equals(itemRect.left - gridRect.left, Number(item.dataset.expectedLeft), "offset from the grid container's left edge");
+        assert_equals(itemRect.top - gridRect.top, Number(item.dataset.expectedTop), "offset from the grid container's top edge");
+    }, `${item.getAttribute("style")} places the item's margin box within its grid area`);
+}
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-unsafe-overflow-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-unsafe-overflow-001-expected.txt
@@ -1,0 +1,12 @@
+
+PASS justify-self: center on an item wider than its grid area overflows the start edge
+PASS justify-self: end on an item wider than its grid area overflows the start edge
+PASS justify-self: unsafe center on an item wider than its grid area overflows the start edge
+PASS align-self: center on an item taller than its grid area overflows the start edge
+PASS align-self: end on an item taller than its grid area overflows the start edge
+PASS align-self: unsafe center on an item taller than its grid area overflows the start edge
+PASS justify-self: center on an item overflowing the second column overflows toward the first column
+PASS justify-self: end on an item overflowing the second column overflows toward the first column
+PASS align-self: center on an item overflowing the second row overflows toward the first row
+PASS align-self: end on an item overflowing the second row overflows toward the first row
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-unsafe-overflow-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-unsafe-overflow-001.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#overflow-values">
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#alignment">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="Unsafe alignment, which is the default overflow alignment, lets a grid item larger than its grid area overflow the area's start edge.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  /* Every item uses explicit grid-area placement (with explicit end lines). */
+  .grid { display: grid; }
+  .single        { grid-template: 50px / 50px; }
+  .three-columns { grid-template: 50px / 50px 50px 50px; }
+  .three-rows    { grid-template: 50px 50px 50px / 50px; }
+
+  .item { background: green; }
+  .wide { width: 100px; height: 50px; }
+  .tall { width: 50px; height: 100px; }
+
+  .cell    { grid-area: 1 / 1 / 2 / 2; }
+  .column2 { grid-area: 1 / 2 / 2 / 3; }
+  .row2    { grid-area: 2 / 1 / 3 / 2; }
+</style>
+<body>
+<div id="log"></div>
+
+<!-- An item larger than a single grid area: the free space is negative, so
+     unsafe alignment distributes it and the item overflows the area's start
+     edge. This is the companion of grid-self-alignment-safe-overflow.html,
+     where the same cases are clamped to the start edge instead. -->
+<div class="grid single"><div class="item wide cell" id="justify-center"        style="justify-self: center"></div></div>
+<div class="grid single"><div class="item wide cell" id="justify-end"           style="justify-self: end"></div></div>
+<div class="grid single"><div class="item wide cell" id="justify-unsafe-center" style="justify-self: unsafe center"></div></div>
+<div class="grid single"><div class="item tall cell" id="align-center"          style="align-self: center"></div></div>
+<div class="grid single"><div class="item tall cell" id="align-end"             style="align-self: end"></div></div>
+<div class="grid single"><div class="item tall cell" id="align-unsafe-center"   style="align-self: unsafe center"></div></div>
+
+<!-- An item placed in the second track, larger than that track: unsafe
+     alignment lets it overflow toward the first track. -->
+<div class="grid three-columns"><div class="item wide column2" id="justify-center-second-column" style="justify-self: center"></div></div>
+<div class="grid three-columns"><div class="item wide column2" id="justify-end-second-column"    style="justify-self: end"></div></div>
+<div class="grid three-rows"><div class="item tall row2" id="align-center-second-row" style="align-self: center"></div></div>
+<div class="grid three-rows"><div class="item tall row2" id="align-end-second-row"    style="align-self: end"></div></div>
+
+<script>
+function startEdgeOffset(id) {
+    const item = document.getElementById(id);
+    const gridRect = item.parentElement.getBoundingClientRect();
+    const itemRect = item.getBoundingClientRect();
+    return { left: itemRect.left - gridRect.left, top: itemRect.top - gridRect.top };
+}
+
+test(() => {
+    assert_equals(startEdgeOffset("justify-center").left, -25);
+}, "justify-self: center on an item wider than its grid area overflows the start edge");
+
+test(() => {
+    assert_equals(startEdgeOffset("justify-end").left, -50);
+}, "justify-self: end on an item wider than its grid area overflows the start edge");
+
+test(() => {
+    assert_equals(startEdgeOffset("justify-unsafe-center").left, -25);
+}, "justify-self: unsafe center on an item wider than its grid area overflows the start edge");
+
+test(() => {
+    assert_equals(startEdgeOffset("align-center").top, -25);
+}, "align-self: center on an item taller than its grid area overflows the start edge");
+
+test(() => {
+    assert_equals(startEdgeOffset("align-end").top, -50);
+}, "align-self: end on an item taller than its grid area overflows the start edge");
+
+test(() => {
+    assert_equals(startEdgeOffset("align-unsafe-center").top, -25);
+}, "align-self: unsafe center on an item taller than its grid area overflows the start edge");
+
+test(() => {
+    assert_equals(startEdgeOffset("justify-center-second-column").left, 25);
+}, "justify-self: center on an item overflowing the second column overflows toward the first column");
+
+test(() => {
+    assert_equals(startEdgeOffset("justify-end-second-column").left, 0);
+}, "justify-self: end on an item overflowing the second column overflows toward the first column");
+
+test(() => {
+    assert_equals(startEdgeOffset("align-center-second-row").top, 25);
+}, "align-self: center on an item overflowing the second row overflows toward the first row");
+
+test(() => {
+    assert_equals(startEdgeOffset("align-end-second-row").top, 0);
+}, "align-self: end on an item overflowing the second row overflows toward the first row");
+</script>
+</body>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -268,10 +268,14 @@ static bool gridItemHasValidWidth(const Style::PreferredSize& width)
     );
 }
 
-static bool canComputeAutomaticInlineSize(const RenderBox& gridItem, const StyleSelfAlignmentData& usedJustifySelf)
+// A grid item with an automatic size which is not stretched is sized to its fit-content size in
+// the axis. GFC does not implement the remaining cases from grid item sizing, where a replaced
+// item uses its natural size and an item with a preferred aspect ratio transfers its size through
+// that ratio.
+// https://drafts.csswg.org/css-grid-1/#grid-item-sizing
+static bool canComputeAutomaticSize(const RenderBox& gridItem)
 {
-    return (usedJustifySelf.position() == ItemPosition::Normal || usedJustifySelf.position() == ItemPosition::Stretch)
-        && !protect(gridItem.element())->isReplaced()
+    return !protect(gridItem.element())->isReplaced()
         && !gridItem.style().aspectRatio().hasRatio();
 }
 
@@ -288,13 +292,6 @@ static bool gridItemHasValidHeight(const Style::PreferredSize& height)
             return false;
         }
     );
-}
-
-static bool canComputeAutomaticBlockSize(const RenderBox& gridItem, const StyleSelfAlignmentData& usedAlignSelf)
-{
-    return (usedAlignSelf.position() == ItemPosition::Normal || usedAlignSelf.position() == ItemPosition::Stretch)
-        && !protect(gridItem.element())->isReplaced()
-        && !gridItem.style().aspectRatio().hasRatio();
 }
 
 static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& renderGrid, ReasonCollectionMode reasonCollectionMode)
@@ -486,28 +483,30 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
 
         auto usedJustifySelf = gridItemStyle->justifySelf().resolve(renderGridStyle.ptr());
 
-        if ((usedJustifySelf.position() != ItemPosition::Start && usedJustifySelf.position() != ItemPosition::Normal && usedJustifySelf.position() != ItemPosition::Stretch)
-            || usedJustifySelf.overflow() != OverflowAlignment::Default)
+        // Every non-baseline self-alignment value is handled by GridLayout's self alignment,
+        // including the safe overflow alignment. Baseline alignment additionally requires the
+        // track sizing algorithm to form baseline-sharing groups and to grow the tracks which
+        // those groups span, which GFC does not implement yet.
+        if (isBaselinePosition(usedJustifySelf.position()))
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasUnsupportedInlineAxisAlignment, reasons, reasonCollectionMode);
 
         auto& gridItemWidth = gridItemStyle->width();
         if (!gridItemHasValidWidth(gridItemWidth))
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasUnsupportedWidthValue, reasons, reasonCollectionMode);
 
-        if (gridItemWidth.isAuto() && !canComputeAutomaticInlineSize(gridItem, usedJustifySelf))
+        if (gridItemWidth.isAuto() && !canComputeAutomaticSize(gridItem))
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasUnsupportedAutomaticInlineSizing, reasons, reasonCollectionMode);
 
         auto usedAlignSelf = gridItemStyle->alignSelf().resolve(renderGridStyle.ptr());
 
-        if ((usedAlignSelf.position() != ItemPosition::Start && usedAlignSelf.position() != ItemPosition::Normal && usedAlignSelf.position() != ItemPosition::Stretch)
-            || usedAlignSelf.overflow() != OverflowAlignment::Default)
+        if (isBaselinePosition(usedAlignSelf.position()))
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasUnsupportedBlockAxisAlignment, reasons, reasonCollectionMode);
 
         auto& gridItemHeight = gridItemStyle->height();
         if (!gridItemHasValidHeight(gridItemHeight))
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasUnsupportedHeightValue, reasons, reasonCollectionMode);
 
-        if (gridItemHeight.isAuto() && !canComputeAutomaticBlockSize(gridItem, usedAlignSelf))
+        if (gridItemHeight.isAuto() && !canComputeAutomaticSize(gridItem))
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasUnsupportedAutomaticBlockSizing, reasons, reasonCollectionMode);
 
         auto& minWidth = gridItemStyle->minWidth();


### PR DESCRIPTION
#### e9d9335369a32827e394d49a82a1466f1b2ce18a
<pre>
[GFC][Integration] Allow every non-baseline self-alignment value
<a href="https://bugs.webkit.org/show_bug.cgi?id=320664">https://bugs.webkit.org/show_bug.cgi?id=320664</a>
<a href="https://rdar.apple.com/182725413">rdar://182725413</a>

Reviewed by Alan Baradlay.

Items which are baseline aligned have track sizing implications that we
do not have support for yet, but we should have the logic for every
other type of self alignment. Let&apos;s allow this type of content to run
through GFC.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-fit-content-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-fit-content-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-positional-values-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-positional-values-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-unsafe-overflow-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-unsafe-overflow-001.html: Added.
Some tests to help cover these cases since it did not seem like WPT had
any tests that covered what we currently support now.

Canonical link: <a href="https://commits.webkit.org/318345@main">https://commits.webkit.org/318345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf35a62a98b3323296e538cb24d053a779cdb5ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187389 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3a06249-8c59-4f50-bef6-80b539770de4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179643 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138571 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c31bab2e-a78e-46df-aac6-864618b1aec4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119034 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40762 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39125 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38809 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35851 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189817 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147692 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39720 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52067 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147477 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42189 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124301 "Found 14 new failures in UIProcess/API/Cocoa/WKBackForwardList.mm, wasm/WasmConstExprGenerator.cpp, UIProcess/mac/ViewGestureControllerMac.mm, UIProcess/WebPageProxy.cpp, Platform/IPC/HandleMessage.h, UIProcess/WebBackForwardList.cpp, UIProcess/API/C/WKBackForwardListRef.cpp, UIProcess/RemotePageProxy.cpp, UIProcess/ProvisionalPageProxy.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118748 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50575 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13786 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49971 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50211 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50033 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->