### PR TITLE
[GFC][Integration] Allow grid items in trailing implicit columns.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001-expected.txt
@@ -1,0 +1,6 @@
+
+PASS .grid 1
+PASS .grid 2
+PASS .grid 3
+PASS .grid 4
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Grid items placed into trailing implicit columns</title>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#auto-tracks">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#line-placement">
+<meta name="assert" content="A grid item whose definite column placement lands past the last explicit column line creates a trailing implicit column that is sized by grid-auto-columns.">
+<style>
+.grid {
+    display: grid;
+    position: relative;
+}
+.grid > div { background: green; }
+
+/* Single trailing implicit column via an explicit start / explicit end. */
+#explicit-end {
+    grid-template-columns: 50px;
+    grid-template-rows: 30px 30px;
+    grid-auto-columns: 100px;
+}
+
+/* Single-value grid-column (explicit start, auto end) resolving to a single-cell span. */
+#auto-end {
+    grid-template-columns: 60px;
+    grid-template-rows: 30px;
+    grid-auto-columns: 80px;
+}
+
+/* Multiple trailing implicit columns cycle through the grid-auto-columns track list. */
+#cycling {
+    grid-template-columns: 40px;
+    grid-template-rows: 30px 30px 30px;
+    grid-auto-columns: 20px 30px;
+}
+
+/* column-gap is applied at the boundary between the explicit and implicit columns. */
+#with-gap {
+    grid-template-columns: 50px;
+    grid-template-rows: 30px;
+    grid-auto-columns: 100px;
+    column-gap: 10px;
+}
+</style>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.grid')">
+<div id="log"></div>
+
+<div class="grid" id="explicit-end">
+    <div style="grid-column: 1 / 2; grid-row: 1 / 2;"
+        data-offset-x="0" data-offset-y="0" data-expected-width="50" data-expected-height="30"></div>
+    <div style="grid-column: 2 / 3; grid-row: 2 / 3;"
+        data-offset-x="50" data-offset-y="30" data-expected-width="100" data-expected-height="30"></div>
+</div>
+
+<div class="grid" id="auto-end">
+    <div style="grid-column: 2; grid-row: 1 / 2;"
+        data-offset-x="60" data-offset-y="0" data-expected-width="80" data-expected-height="30"></div>
+</div>
+
+<div class="grid" id="cycling">
+    <div style="grid-column: 2 / 3; grid-row: 1 / 2;"
+        data-offset-x="40" data-offset-y="0" data-expected-width="20" data-expected-height="30"></div>
+    <div style="grid-column: 3 / 4; grid-row: 2 / 3;"
+        data-offset-x="60" data-offset-y="30" data-expected-width="30" data-expected-height="30"></div>
+    <div style="grid-column: 4 / 5; grid-row: 3 / 4;"
+        data-offset-x="90" data-offset-y="60" data-expected-width="20" data-expected-height="30"></div>
+</div>
+
+<div class="grid" id="with-gap">
+    <div style="grid-column: 2 / 3; grid-row: 1 / 2;"
+        data-offset-x="60" data-offset-y="0" data-expected-width="100" data-expected-height="30"></div>
+</div>
+
+</body>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -87,7 +87,6 @@ enum class GridAvoidanceReason : uint8_t {
     GridItemColumnStartHasLineName,
     GridItemColumnStartHasNegativeLineNumber,
     GridItemColumnStartHasSpan,
-    GridItemHasColumnStartOutsideExplicitGrid,
     GridItemHasUnsupportedColumnEnd,
 
     GridNeedsImplicitColumnsForItemsLockedToRow,
@@ -114,7 +113,6 @@ static bool avoidanceReasonIsColumnPlacementRelated(GridAvoidanceReason gridAvoi
     case GridAvoidanceReason::GridItemColumnStartHasLineName:
     case GridAvoidanceReason::GridItemColumnStartHasNegativeLineNumber:
     case GridAvoidanceReason::GridItemColumnStartHasSpan:
-    case GridAvoidanceReason::GridItemHasColumnStartOutsideExplicitGrid:
     case GridAvoidanceReason::GridItemHasUnsupportedColumnEnd:
         return true;
     default:
@@ -153,14 +151,16 @@ static bool avoidanceReasonIsRowPlacementRelated(GridAvoidanceReason gridAvoidan
     }
 #endif
 
-static bool hasValidColumnEnd(const Style::GridPositionExplicit& explicitColumnStart, const Style::GridPosition columnEnd, size_t linesFromGridTemplateColumnsCount)
+static bool hasValidColumnEnd(const Style::GridPositionExplicit& explicitColumnStart, const Style::GridPosition columnEnd)
 {
     return WTF::switchOn(columnEnd,
         [](const CSS::Keyword::Auto&) {
-            return false;
+            // An auto end with an explicit start resolves to a single-column span at the start line
+            // (grid shorthand behavior), so trailing implicit columns are supported here.
+            return true;
         },
         [&](const Style::GridPositionExplicit&) {
-            if (!columnEnd.namedGridLine().value.isEmpty() || columnEnd.explicitPosition() < 0 || columnEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateColumnsCount))
+            if (!columnEnd.namedGridLine().value.isEmpty() || columnEnd.explicitPosition() < 0)
                 return false;
 
             // FIXME: Multi-span items are not yet supported in intrinsic sizing
@@ -551,9 +551,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
                     return GridAvoidanceReason::GridItemColumnStartHasLineName;
                 if (columnStartLineNumber < 0)
                     return GridAvoidanceReason::GridItemColumnStartHasNegativeLineNumber;
-                if (columnStartLineNumber > static_cast<int>(linesFromGridTemplateColumnsCount))
-                    return GridAvoidanceReason::GridItemHasColumnStartOutsideExplicitGrid;
-                if (!hasValidColumnEnd(explicitPosition, gridItemStyle->gridItemColumnEnd(), linesFromGridTemplateColumnsCount))
+                if (!hasValidColumnEnd(explicitPosition, gridItemStyle->gridItemColumnEnd()))
                     return GridAvoidanceReason::GridItemHasUnsupportedColumnEnd;
                 return { };
             },
@@ -590,7 +588,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
                 if (!hasValidRowEnd(explicitPosition, rowEnd, linesFromGridTemplateRowsCount))
                     return GridAvoidanceReason::GridItemHasUnsupportedRowEnd;
 
-                ASSERT(rowEnd.isExplicit());
+                ASSERT(rowEnd.isExplicit() || rowEnd.isAuto());
                 size_t rowIndex = rowStartLineNumber + 1;
                 auto rowsCount = explicitlyPlacedItemsInRowCount.size();
                 if (rowIndex > rowsCount)
@@ -829,9 +827,6 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
         break;
     case GridAvoidanceReason::GridItemColumnStartHasSpan:
         stream << "grid item column start has span";
-        break;
-    case GridAvoidanceReason::GridItemHasColumnStartOutsideExplicitGrid:
-        stream << "grid item has column start outside explicit grid";
         break;
     case GridAvoidanceReason::GridItemHasUnsupportedColumnEnd:
         stream << "grid item has unsupported column end";


### PR DESCRIPTION
#### 9941b43e5c2b41cedca985ec85e7873702b1ba04
<pre>
[GFC][Integration] Allow grid items in trailing implicit columns.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320665">https://bugs.webkit.org/show_bug.cgi?id=320665</a>
<a href="https://rdar.apple.com/problem/183644533">rdar://problem/183644533</a>

Reviewed by NOBODY (OOPS!).

This allows content when a grid item is has a column placement that is
outside any explicit columns. For example, grid-column: 4 / 5 should be
allowed if there are only two explicit columns.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001-expected.txt: Added.
Some extra test coverage since it did not seem like there were WPTs that
cover this case.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9941b43e5c2b41cedca985ec85e7873702b1ba04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187656 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141290 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9d0e9e60-b191-4edd-9814-212838adbcd0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51690 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138783 "Found 8 new test failures: fast/repaint/align-items-overflow-change.html fast/repaint/align-self-change.html fast/repaint/align-self-overflow-change.html fast/repaint/justify-items-change.html fast/repaint/justify-items-legacy-change.html fast/repaint/justify-items-overflow-change.html fast/repaint/justify-self-change.html fast/repaint/justify-self-overflow-change.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96395 "19 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab549409-f487-40af-92d8-40bea3ded4c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159533 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119239 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/87a8688f-ee7a-41ac-a940-d5a74587f808) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40993 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39345 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151393 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39031 "Found 8 new test failures: fast/repaint/align-items-overflow-change.html fast/repaint/align-self-change.html fast/repaint/align-self-overflow-change.html fast/repaint/justify-items-change.html fast/repaint/justify-items-legacy-change.html fast/repaint/justify-items-overflow-change.html fast/repaint/justify-self-change.html fast/repaint/justify-self-overflow-change.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36114 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44580 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43586 "Found 8 new test failures: fast/repaint/align-items-overflow-change.html fast/repaint/align-self-change.html fast/repaint/align-self-overflow-change.html fast/repaint/justify-items-change.html fast/repaint/justify-items-legacy-change.html fast/repaint/justify-items-overflow-change.html fast/repaint/justify-self-change.html fast/repaint/justify-self-overflow-change.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190083 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159059 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147925 "Found 8 new test failures: fast/repaint/align-items-overflow-change.html fast/repaint/align-self-change.html fast/repaint/align-self-overflow-change.html fast/repaint/justify-items-change.html fast/repaint/justify-items-legacy-change.html fast/repaint/justify-items-overflow-change.html fast/repaint/justify-self-change.html fast/repaint/justify-self-overflow-change.html (failure)") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39722 "Found 8 new test failures: fast/repaint/align-items-overflow-change.html fast/repaint/align-self-change.html fast/repaint/align-self-overflow-change.html fast/repaint/justify-items-change.html fast/repaint/justify-items-legacy-change.html fast/repaint/justify-items-overflow-change.html fast/repaint/justify-self-change.html fast/repaint/justify-self-overflow-change.html (failure)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52331 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35655 "Found 8 new test failures: fast/repaint/align-items-overflow-change.html fast/repaint/align-self-change.html fast/repaint/align-self-overflow-change.html fast/repaint/justify-items-change.html fast/repaint/justify-items-legacy-change.html fast/repaint/justify-items-overflow-change.html fast/repaint/justify-self-change.html fast/repaint/justify-self-overflow-change.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147701 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42408 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124594 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119064 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50849 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14003 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50234 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50474 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50296 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->