### PR TITLE
[Memory64] Wasm table imports don't check that the address type matches

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js-expected.txt
@@ -136,37 +136,17 @@ PASS #134 Test that WebAssembly compilation succeeds (memory64-imports.wast:49)
 PASS #135 Test that WebAssembly instantiation fails (memory64-imports.wast:49)
 PASS #136 Test that a WebAssembly module is unlinkable
 PASS #137 Test that WebAssembly compilation succeeds (memory64-imports.wast:53)
-FAIL #138 Test that WebAssembly instantiation fails (memory64-imports.wast:53) assert_true: instance@async_index.js:219:29
-assert_unlinkable@async_index.js:423:11
-memory64_imports_wast_js@memory64-imports.wast.js:211:18
-global code@memory64-imports.wast.js:447:3 expected true got false
-FAIL #139 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@async_index.js:422:29
-memory64_imports_wast_js@memory64-imports.wast.js:211:18
-global code@memory64-imports.wast.js:447:3 expected true got false
+PASS #138 Test that WebAssembly instantiation fails (memory64-imports.wast:53)
+PASS #139 Test that a WebAssembly module is unlinkable
 PASS #140 Test that WebAssembly compilation succeeds (memory64-imports.wast:57)
-FAIL #141 Test that WebAssembly instantiation fails (memory64-imports.wast:57) assert_true: instance@async_index.js:219:29
-assert_unlinkable@async_index.js:423:11
-memory64_imports_wast_js@memory64-imports.wast.js:217:18
-global code@memory64-imports.wast.js:447:3 expected true got false
-FAIL #142 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@async_index.js:422:29
-memory64_imports_wast_js@memory64-imports.wast.js:217:18
-global code@memory64-imports.wast.js:447:3 expected true got false
+PASS #141 Test that WebAssembly instantiation fails (memory64-imports.wast:57)
+PASS #142 Test that a WebAssembly module is unlinkable
 PASS #143 Test that WebAssembly compilation succeeds (memory64-imports.wast:61)
-FAIL #144 Test that WebAssembly instantiation fails (memory64-imports.wast:61) assert_true: instance@async_index.js:219:29
-assert_unlinkable@async_index.js:423:11
-memory64_imports_wast_js@memory64-imports.wast.js:223:18
-global code@memory64-imports.wast.js:447:3 expected true got false
-FAIL #145 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@async_index.js:422:29
-memory64_imports_wast_js@memory64-imports.wast.js:223:18
-global code@memory64-imports.wast.js:447:3 expected true got false
+PASS #144 Test that WebAssembly instantiation fails (memory64-imports.wast:61)
+PASS #145 Test that a WebAssembly module is unlinkable
 PASS #146 Test that WebAssembly compilation succeeds (memory64-imports.wast:65)
-FAIL #147 Test that WebAssembly instantiation fails (memory64-imports.wast:65) assert_true: instance@async_index.js:219:29
-assert_unlinkable@async_index.js:423:11
-memory64_imports_wast_js@memory64-imports.wast.js:229:18
-global code@memory64-imports.wast.js:447:3 expected true got false
-FAIL #148 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@async_index.js:422:29
-memory64_imports_wast_js@memory64-imports.wast.js:229:18
-global code@memory64-imports.wast.js:447:3 expected true got false
+PASS #147 Test that WebAssembly instantiation fails (memory64-imports.wast:65)
+PASS #148 Test that a WebAssembly module is unlinkable
 PASS #149 Test that WebAssembly compilation succeeds (memory64-imports.wast:68)
 PASS #150 Test that WebAssembly instantiation succeeds (memory64-imports.wast:68)
 PASS #151 Test that WebAssembly compilation succeeds (memory64-imports.wast:69)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -457,6 +457,9 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
             if (!Wasm::isSubtype(actualType, expectedType) || !Wasm::isSubtype(expectedType, actualType))
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Table import"_s, "provided a 'type' that is wrong"_s)));
 
+            if (table->table()->addressType() != moduleInformation.tables[import.kindIndex].addressType())
+                return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Table import"_s, "provided an 'address' that is different from the module's declared 'address' import table attribute"_s)));
+
             // ii. Append v to tables.
             // iii. Append v.[[Table]] to imports.
             m_instance->setTable(vm, import.kindIndex, table);


### PR DESCRIPTION
#### 862994e2cc372c16a11440b96b4f5c34158431f2
<pre>
[Memory64] Wasm table imports don&apos;t check that the address type matches
<a href="https://bugs.webkit.org/show_bug.cgi?id=320672">https://bugs.webkit.org/show_bug.cgi?id=320672</a>
<a href="https://rdar.apple.com/183653434">rdar://183653434</a>

Reviewed by Keith Miller.

When linking a table import, we validated the element type, &apos;initial&apos;, and
&apos;maximum&apos;, but never compared the address type of the provided table against
the one declared by the importing module. As a result an i32 table could
satisfy a table64 import (and vice versa), instead of throwing a LinkError.

This fixes the 8 failing subtests in the imported WPT memory64-imports test
covering memory64-imports.wast:53, 57, 61 and 65.

* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js-expected.txt:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):

Canonical link: <a href="https://commits.webkit.org/318280@main">https://commits.webkit.org/318280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b447d02f3094c61635f690040c3071b9a4bb201

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187412 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac7484c2-0871-4aaa-9375-f037bb1b9ec3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138592 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9b1e413-28b8-4bce-918d-b910e3332b9d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119055 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2de5a6f4-d986-425a-a12b-e15c186e53a6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39143 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1024 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7832 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151187 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38832 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35874 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39074 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189842 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51408 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147712 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39687 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52090 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147498 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42206 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124342 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118771 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50598 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13811 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49994 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50234 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50056 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->