### PR TITLE
Remove the style recalc and layout timers

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2757,7 +2757,8 @@ void Document::scheduleStyleRecalc()
 
     ASSERT(childNeedsStyleRecalc() || m_needsFullStyleRebuild);
 
-    m_styleRecalcTimer.startOneShot(0_s);
+    scheduleRenderingUpdate({ });
+//    m_styleRecalcTimer.startOneShot(0_s);
 
     InspectorInstrumentation::didScheduleStyleRecalculation(*this);
 }
@@ -10405,6 +10406,7 @@ void Document::intersectionObserversInitialUpdateTimerFired()
 
 void Document::scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedSteps)
 {
+    // Why is m_intersectionObserversInitialUpdateTimer special?
     if (m_intersectionObserversInitialUpdateTimer.isActive()) {
         m_intersectionObserversInitialUpdateTimer.stop();
         requestedSteps.add(RenderingUpdateStep::IntersectionObservations);

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -746,7 +746,9 @@ void LocalFrameViewLayoutContext::scheduleLayout()
     ASSERT(renderView());
     InspectorInstrumentation::didScheduleLayout(*renderView());
 
-    m_layoutTimer.startOneShot(0_s);
+    if (CheckedPtr view = renderView())
+        protect(view->page())->scheduleRenderingUpdate({ });
+//    m_layoutTimer.startOneShot(0_s);
 }
 
 void LocalFrameViewLayoutContext::unscheduleLayout()


### PR DESCRIPTION
#### a2f7be597c4f5ebe2db381d324605b52e1a66d8b
<pre>
Remove the style recalc and layout timers
<a href="https://bugs.webkit.org/show_bug.cgi?id=320675">https://bugs.webkit.org/show_bug.cgi?id=320675</a>
<a href="https://rdar.apple.com/183654816">rdar://183654816</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::scheduleStyleRecalc):
(WebCore::Document::scheduleRenderingUpdate):
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::scheduleLayout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2f7be597c4f5ebe2db381d324605b52e1a66d8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141052 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ac76a42-a1fa-4b54-98ed-1cba7ec0f02a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51452 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138607 "Found 24 new test failures: animations/change-keyframes.html fast/css/acid2-pixel.html fast/css/acid2.html fast/mediastream/mediaPlayer-visibility.html fast/repaint/iframe-avoid-redundant-repaint.html http/tests/misc/acid2-pixel.html http/tests/misc/acid2.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-010.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-011.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-012.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96352 "2 flakes 8 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b45c1f9-6609-47d3-a289-ba4d226bf2e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180761 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42177 "Found 6 new test failures: animations/change-keyframes.html fast/css/acid2-pixel.html fast/mediastream/mediaPlayer-visibility.html http/tests/misc/acid2-pixel.html http/tests/site-isolation/basic-iframe-render-output.html http/tests/site-isolation/fullscreen-resize-event.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159339 "Found 3 new API test failures: TestWebKitAPI.TextManipulation.StartTextManipulationDoesNotFindContentInNewMainFrame, TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting, TestWebKitAPI.WebKit.ResizeReversePaginatedWebView (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119070 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40840 "Found 19 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/transform-010.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-011.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-012.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-013.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-015.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-016.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-017.html imported/w3c/web-platform-tests/css/selectors/invalidation/has-invalidation-first-in-sibling-chain.html imported/w3c/web-platform-tests/css/selectors/invalidation/has-with-nth-child.html imported/w3c/web-platform-tests/css/selectors/invalidation/is-pseudo-containing-sibling-relationship-in-has.html ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39145 "Found 2 new API test failures: TestWebKitAPI.TextManipulation.StartTextManipulationDoesNotFindContentInNewMainFrame, TestWebKitAPI.WebKit.ResizeReversePaginatedWebView (failure)") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151245 "Found 2 new API test failures: TestWebKitAPI.TextManipulation.StartTextManipulationDoesNotFindContentInNewMainFrame, TestWebKitAPI.TextManipulation.CompleteTextManipulationShouldBatchItemCallback (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38834 "Too many flaky failures: accessibility/mac/tab-focus-post-notification.html, animations/change-keyframes.html, fast/css/acid2-pixel.html, fast/loader/submit-form-while-parsing-2.html, fast/mediastream/mediaPlayer-visibility.html, fast/scrolling/mac/scrollbars/overflow-in-iframe-overlay-scrollbar-hovered.html, http/tests/misc/acid2-pixel.html, http/tests/performance/performance-resource-timing-cross-origin-media.html, http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html, http/tests/site-isolation/fullscreen-resize-event.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35876 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44327 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43381 "Found 22 new test failures: accessibility/mac/tab-focus-post-notification.html animations/change-keyframes.html fast/mediastream/mediaPlayer-visibility.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-010.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-011.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-012.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-013.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-015.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-016.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-017.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189844 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51410 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147714 "Found 28 new test failures: fast/css/acid2-pixel.html fast/css/acid2.html fast/mediastream/mediaPlayer-visibility.html fast/repaint/iframe-avoid-redundant-repaint.html http/tests/misc/acid2-pixel.html http/tests/misc/acid2.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-010.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-011.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-012.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-013.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52092 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35463 "Found 28 new test failures: accessibility/mac/tab-focus-post-notification.html animations/change-keyframes.html fast/css/acid2-pixel.html fast/mediastream/mediaPlayer-visibility.html http/tests/misc/acid2-pixel.html http/tests/site-isolation/fullscreen-resize-event.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-010.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-011.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-012.html imported/w3c/web-platform-tests/css/css-anchor-position/transform-013.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147500 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42212 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124344 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118773 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50600 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13813 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49996 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50236 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50058 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->