### PR TITLE
[HTML-in-Canvas] Implement the IDL changes for HTML-in-Canvas

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1358,10 +1358,12 @@ set(WebCore_NON_SVG_IDL_FILES
     html/VoidCallback.idl
 
     html/canvas/CanvasDirection.idl
+    html/canvas/CanvasElementImage.idl
     html/canvas/CanvasFillRule.idl
     html/canvas/CanvasGradient.idl
     html/canvas/CanvasLineCap.idl
     html/canvas/CanvasLineJoin.idl
+    html/canvas/CanvasPaintEvent.idl
     html/canvas/CanvasPattern.idl
     html/canvas/CanvasRenderingContext2D.idl
     html/canvas/CanvasRenderingContext2DSettings.idl
@@ -1832,6 +1834,8 @@ list(APPEND WebCore_NON_SVG_IDL_FILES
     Modules/WebGPU/GPUComputePassTimestampWrites.idl
     Modules/WebGPU/GPUComputePipeline.idl
     Modules/WebGPU/GPUComputePipelineDescriptor.idl
+    Modules/WebGPU/GPUCopyElementImageDestination.idl
+    Modules/WebGPU/GPUCopyElementImageSource.idl
     Modules/WebGPU/GPUCullMode.idl
     Modules/WebGPU/GPUDepthStencilState.idl
     Modules/WebGPU/GPUDevice.idl
@@ -2095,6 +2099,7 @@ set(WebCore_SUPPLEMENTAL_IDL_FILES
     html/PopoverInvokerElement.idl
 
     html/canvas/CanvasCompositing.idl
+    html/canvas/CanvasDrawElementImage.idl
     html/canvas/CanvasDrawImage.idl
     html/canvas/CanvasDrawPath.idl
     html/canvas/CanvasFillStrokeStyles.idl
@@ -2470,6 +2475,7 @@ list(APPEND WebCore_IDL_FILES
     html/canvas/WebGLCompressedTextureS3TCsRGB.idl
     html/canvas/WebGLContextAttributes.idl
     html/canvas/WebGLContextEvent.idl
+    html/canvas/WebGLCopyElementImageConfig.idl
     html/canvas/WebGLDebugRendererInfo.idl
     html/canvas/WebGLDebugShaders.idl
     html/canvas/WebGLDepthTexture.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -99,6 +99,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/WebGPU/GPUComputePassTimestampWrites.idl \
     $(WebCore)/Modules/WebGPU/GPUComputePipeline.idl \
     $(WebCore)/Modules/WebGPU/GPUComputePipelineDescriptor.idl \
+	$(WebCore)/Modules/WebGPU/GPUCopyElementImageDestination.idl \
+	$(WebCore)/Modules/WebGPU/GPUCopyElementImageSource.idl \
     $(WebCore)/Modules/WebGPU/GPUCullMode.idl \
     $(WebCore)/Modules/WebGPU/GPUDebugCommandsMixin.idl \
     $(WebCore)/Modules/WebGPU/GPUDepthStencilState.idl \
@@ -1416,8 +1418,10 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/canvas/ANGLEInstancedArrays.idl \
     $(WebCore)/html/canvas/CanvasCompositing.idl \
     $(WebCore)/html/canvas/CanvasDirection.idl \
+	$(WebCore)/html/canvas/CanvasDrawElementImage.idl \
     $(WebCore)/html/canvas/CanvasDrawImage.idl \
     $(WebCore)/html/canvas/CanvasDrawPath.idl \
+	$(WebCore)/html/canvas/CanvasElementImage.idl \
     $(WebCore)/html/canvas/CanvasFillRule.idl \
     $(WebCore)/html/canvas/CanvasFillStrokeStyles.idl \
     $(WebCore)/html/canvas/CanvasFilters.idl \
@@ -1427,6 +1431,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/canvas/CanvasLayers.idl \
     $(WebCore)/html/canvas/CanvasLineCap.idl \
     $(WebCore)/html/canvas/CanvasLineJoin.idl \
+	$(WebCore)/html/canvas/CanvasPaintEvent.idl \
     $(WebCore)/html/canvas/CanvasPath.idl \
     $(WebCore)/html/canvas/CanvasPathDrawingStyles.idl \
     $(WebCore)/html/canvas/CanvasPattern.idl \
@@ -1495,6 +1500,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/canvas/WebGLCompressedTextureS3TCsRGB.idl \
     $(WebCore)/html/canvas/WebGLContextAttributes.idl \
     $(WebCore)/html/canvas/WebGLContextEvent.idl \
+	$(WebCore)/html/canvas/WebGLCopyElementImageConfig.idl \
     $(WebCore)/html/canvas/WebGLDebugRendererInfo.idl \
     $(WebCore)/html/canvas/WebGLDebugShaders.idl \
     $(WebCore)/html/canvas/WebGLDepthTexture.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1676,6 +1676,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/VideoFrameRequestCallback.h
     html/VoidCallback.h
 
+    html/canvas/CanvasElementImage.h
     html/canvas/PredefinedColorSpace.h
     html/canvas/WebGLAny.h
     html/canvas/WebGLBuffer.h

--- a/Source/WebCore/Modules/WebGPU/GPUCopyElementImageDestination.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCopyElementImageDestination.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GPUImageCopyTextureTagged.h"
+
+namespace WebCore {
+
+struct GPUCopyElementImageDestination {
+    GPUImageCopyTextureTagged destination;
+    std::optional<unsigned> width;
+    std::optional<unsigned> height;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/WebGPU/GPUCopyElementImageDestination.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCopyElementImageDestination.idl
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
+
+// https://github.com/WICG/html-in-canvas
+[
+    EnabledBySetting=HTMLInCanvasEnabled,
+] dictionary GPUCopyElementImageDestination {
+    required GPUImageCopyTextureTagged destination;
+    GPUIntegerCoordinate width;
+    GPUIntegerCoordinate height;
+};

--- a/Source/WebCore/Modules/WebGPU/GPUCopyElementImageSource.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCopyElementImageSource.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CanvasElementImage.h"
+
+namespace WebCore {
+
+struct GPUCopyElementImageSource {
+    CanvasElementImageSource source;
+    std::optional<float> sx;
+    std::optional<float> sy;
+    std::optional<float> swidth;
+    std::optional<float> sheight;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/WebGPU/GPUCopyElementImageSource.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCopyElementImageSource.idl
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+typedef (Element or CanvasElementImage) CanvasElementImageSource;
+
+// https://github.com/WICG/html-in-canvas
+[
+    EnabledBySetting=HTMLInCanvasEnabled,
+] dictionary GPUCopyElementImageSource {
+    required CanvasElementImageSource source;
+    float sx;
+    float sy;
+    float swidth;
+    float sheight;
+};

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1217,6 +1217,11 @@ ExceptionOr<void> GPUQueue::copyExternalImageToTexture(ScriptExecutionContext& c
     callbackScopeIsSafe = false;
 
     return { };
+}
+
+ExceptionOr<void> GPUQueue::copyElementImageToTexture(const GPUCopyElementImageSource&, const GPUCopyElementImageDestination&)
+{
+    return Exception { ExceptionCode::InvalidStateError };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,6 +47,8 @@ namespace WebCore {
 class GPUBuffer;
 class GPUDevice;
 struct GPUImageCopyExternalImage;
+struct GPUCopyElementImageDestination;
+struct GPUCopyElementImageSource;
 
 class GPUQueue : public RefCountedAndCanMakeWeakPtr<GPUQueue> {
 public:
@@ -81,6 +83,10 @@ public:
         const GPUImageCopyExternalImage& source,
         const GPUImageCopyTextureTagged& destination,
         const GPUExtent3D& copySize);
+
+    ExceptionOr<void> copyElementImageToTexture(
+        const GPUCopyElementImageSource&,
+        const GPUCopyElementImageDestination&);
 
     WebGPU::Queue& backing() { return m_backing; }
     const WebGPU::Queue& backing() const { return m_backing; }

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,6 +58,10 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
         GPUImageCopyExternalImage source,
         GPUImageCopyTextureTagged destination,
         GPUExtent3D copySize);
+        
+    [EnabledBySetting=HTMLInCanvasEnabled] undefined copyElementImageToTexture(
+        GPUCopyElementImageSource source,
+        GPUCopyElementImageDestination destination);
 };
 GPUQueue includes GPUObjectBase;
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1746,9 +1746,11 @@ html/ValidatedFormListedElement.cpp
 html/ValidationMessage.cpp @header:RenderStyleGetters @cost:5
 html/WeekInputType.cpp
 html/canvas/ANGLEInstancedArrays.cpp
+html/canvas/CanvasElementImage.cpp
 html/canvas/CanvasFilterContextSwitcher.cpp
 html/canvas/CanvasGradient.cpp
 html/canvas/CanvasLayerContextSwitcher.cpp
+html/canvas/CanvasPaintEvent.cpp
 html/canvas/CanvasPath.cpp
 html/canvas/CanvasPattern.cpp
 html/canvas/CanvasRenderingContext.cpp
@@ -4009,8 +4011,10 @@ JSCacheQueryOptions.cpp
 JSCanvasCaptureMediaStreamTrack.cpp
 JSCanvasCompositing.cpp
 JSCanvasDirection.cpp
+JSCanvasDrawElementImage.cpp
 JSCanvasDrawImage.cpp
 JSCanvasDrawPath.cpp
+JSCanvasElementImage.cpp
 JSCanvasFillRule.cpp
 JSCanvasFillStrokeStyles.cpp
 JSCanvasFilters.cpp
@@ -4019,6 +4023,7 @@ JSCanvasImageData.cpp
 JSCanvasImageSmoothing.cpp
 JSCanvasLineCap.cpp
 JSCanvasLineJoin.cpp
+JSCanvasPaintEvent.cpp
 JSCanvasPath.cpp
 JSCanvasPathDrawingStyles.cpp
 JSCanvasPattern.cpp
@@ -4309,6 +4314,8 @@ JSGPUComputePassEncoder.cpp
 JSGPUComputePassTimestampWrites.cpp
 JSGPUComputePipeline.cpp
 JSGPUComputePipelineDescriptor.cpp
+JSGPUCopyElementImageDestination.cpp
+JSGPUCopyElementImageSource.cpp
 JSGPUCullMode.cpp
 JSGPUDebugCommandsMixin.cpp
 JSGPUDepthStencilState.cpp
@@ -5250,6 +5257,7 @@ JSWebGLCompressedTextureS3TC.cpp
 JSWebGLCompressedTextureS3TCsRGB.cpp
 JSWebGLContextAttributes.cpp
 JSWebGLContextEvent.cpp
+JSWebGLCopyElementImageConfig.cpp
 JSWebGLDebugRendererInfo.cpp
 JSWebGLDebugShaders.cpp
 JSWebGLDepthTexture.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2985,6 +2985,7 @@
 		71EFCEDC202B38A900D7C411 /* AnimationEffect.h in Headers */ = {isa = PBXBuildFile; fileRef = 71EFCED7202B388D00D7C411 /* AnimationEffect.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		71F0B1DB2CCBEA660030E30B /* AcceleratedTimeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F0B1DA2CCBEA660030E30B /* AcceleratedTimeline.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		71FCB17027BAB3FE00E0631C /* FrameRateAligner.h in Headers */ = {isa = PBXBuildFile; fileRef = 71FCB16D27BAB3DF00E0631C /* FrameRateAligner.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		721292A3301BA12F009DA7C9 /* CanvasElementImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 7224293B301ABB3600856621 /* CanvasElementImage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72144333223EC8B000F12FF7 /* SVGProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 55EE5363223B2A2400FBA944 /* SVGProperty.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72144334223EC91600F12FF7 /* SVGPropertyOwner.h in Headers */ = {isa = PBXBuildFile; fileRef = 55EE5360223B2A2100FBA944 /* SVGPropertyOwner.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		721B3E9629679E38004F5FF6 /* InnerSpinButtonPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 721B3E9529679E38004F5FF6 /* InnerSpinButtonPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -14428,6 +14429,10 @@
 		7209C47E2931C86400633C0D /* TransparencyLayerContextSwitcher.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TransparencyLayerContextSwitcher.cpp; sourceTree = "<group>"; };
 		7209C47F2931C86400633C0D /* TransparencyLayerContextSwitcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TransparencyLayerContextSwitcher.h; sourceTree = "<group>"; };
 		7211B5D6276536820076FEF8 /* FilterResults.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilterResults.h; sourceTree = "<group>"; };
+		721292A1301AE64C009DA7C9 /* CanvasPaintEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CanvasPaintEvent.h; sourceTree = "<group>"; };
+		721292A2301AE64C009DA7C9 /* CanvasPaintEvent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasPaintEvent.cpp; sourceTree = "<group>"; };
+		721292A4301BAE1A009DA7C9 /* GPUCopyElementImageSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GPUCopyElementImageSource.h; sourceTree = "<group>"; };
+		721292A5301BAE31009DA7C9 /* GPUCopyElementImageDestination.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GPUCopyElementImageDestination.h; sourceTree = "<group>"; };
 		721443452240C8BA00F12FF7 /* SVGAnimatedValueProperty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGAnimatedValueProperty.h; sourceTree = "<group>"; };
 		721443462240CAD200F12FF7 /* SVGValueProperty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGValueProperty.h; sourceTree = "<group>"; };
 		7214B9B7274458FA003BE6DF /* FilterEffectVector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilterEffectVector.h; sourceTree = "<group>"; };
@@ -14440,6 +14445,15 @@
 		721B3EF22968F45D004F5FF6 /* MenuListButtonMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MenuListButtonMac.h; sourceTree = "<group>"; };
 		721B3EF32968F45E004F5FF6 /* MenuListButtonMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MenuListButtonMac.mm; sourceTree = "<group>"; };
 		721B3EF42968F47D004F5FF6 /* MenuListButtonPart.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuListButtonPart.h; sourceTree = "<group>"; };
+		72242937301AA86900856621 /* CanvasElementImage.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = CanvasElementImage.idl; sourceTree = "<group>"; };
+		72242938301AAC3E00856621 /* CanvasDrawElementImage.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = CanvasDrawElementImage.idl; sourceTree = "<group>"; };
+		72242939301AAF1F00856621 /* CanvasPaintEvent.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = CanvasPaintEvent.idl; sourceTree = "<group>"; };
+		7224293A301AB8B700856621 /* WebGLCopyElementImageConfig.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGLCopyElementImageConfig.idl; sourceTree = "<group>"; };
+		7224293B301ABB3600856621 /* CanvasElementImage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CanvasElementImage.h; sourceTree = "<group>"; };
+		7224293C301ABB3600856621 /* CanvasElementImage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasElementImage.cpp; sourceTree = "<group>"; };
+		7224293D301ACFD400856621 /* GPUCopyElementImageDestination.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = GPUCopyElementImageDestination.idl; sourceTree = "<group>"; };
+		7224293E301ACFD400856621 /* GPUCopyElementImageSource.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = GPUCopyElementImageSource.idl; sourceTree = "<group>"; };
+		72242943301ADA9800856621 /* WebGLCopyElementImageConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGLCopyElementImageConfig.h; sourceTree = "<group>"; };
 		7224ABCF2C0174EE00D85362 /* BitmapImageDescriptor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BitmapImageDescriptor.h; sourceTree = "<group>"; };
 		7225E8062A3E298C00947EBF /* RotationDirection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RotationDirection.cpp; sourceTree = "<group>"; };
 		722623BF29486B28006DCCF1 /* ControlFactory.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ControlFactory.cpp; sourceTree = "<group>"; };
@@ -25905,6 +25919,10 @@
 				1C66A7A32A4F784E0086DB6F /* GPUComputePipeline.idl */,
 				1C66A6F82A4F78160086DB6F /* GPUComputePipelineDescriptor.h */,
 				1C66A71A2A4F78200086DB6F /* GPUComputePipelineDescriptor.idl */,
+				721292A5301BAE31009DA7C9 /* GPUCopyElementImageDestination.h */,
+				7224293D301ACFD400856621 /* GPUCopyElementImageDestination.idl */,
+				721292A4301BAE1A009DA7C9 /* GPUCopyElementImageSource.h */,
+				7224293E301ACFD400856621 /* GPUCopyElementImageSource.idl */,
 				1C66A6DB2A4F780D0086DB6F /* GPUCullMode.h */,
 				1C66A73C2A4F782A0086DB6F /* GPUCullMode.idl */,
 				1C66A8152A4F78700086DB6F /* GPUDebugCommandsMixin.idl */,
@@ -28274,8 +28292,12 @@
 				7C193BAA1F5E0EB10088F3E6 /* CanvasCompositing.idl */,
 				7C193BB61F5E0EB90088F3E6 /* CanvasDirection.h */,
 				7C193BAC1F5E0EB20088F3E6 /* CanvasDirection.idl */,
+				72242938301AAC3E00856621 /* CanvasDrawElementImage.idl */,
 				7C193B9A1F5E0EA70088F3E6 /* CanvasDrawImage.idl */,
 				7C193BA61F5E0EAE0088F3E6 /* CanvasDrawPath.idl */,
+				7224293C301ABB3600856621 /* CanvasElementImage.cpp */,
+				7224293B301ABB3600856621 /* CanvasElementImage.h */,
+				72242937301AA86900856621 /* CanvasElementImage.idl */,
 				7C193BA11F5E0EAB0088F3E6 /* CanvasFillRule.h */,
 				7C193BA51F5E0EAE0088F3E6 /* CanvasFillRule.idl */,
 				7C193BA01F5E0EAA0088F3E6 /* CanvasFillStrokeStyles.idl */,
@@ -28294,6 +28316,9 @@
 				7C193BB11F5E0EB50088F3E6 /* CanvasLineCap.idl */,
 				7C193B9F1F5E0EAA0088F3E6 /* CanvasLineJoin.h */,
 				7C193B9C1F5E0EA80088F3E6 /* CanvasLineJoin.idl */,
+				721292A2301AE64C009DA7C9 /* CanvasPaintEvent.cpp */,
+				721292A1301AE64C009DA7C9 /* CanvasPaintEvent.h */,
+				72242939301AAF1F00856621 /* CanvasPaintEvent.idl */,
 				4671E0631D67A57B00C6B497 /* CanvasPath.cpp */,
 				4671E0641D67A57B00C6B497 /* CanvasPath.h */,
 				936B21F41DBBF8300052E117 /* CanvasPath.idl */,
@@ -28488,6 +28513,8 @@
 				93F6F1EA127F70B10055CB06 /* WebGLContextEvent.cpp */,
 				93F6F1EB127F70B10055CB06 /* WebGLContextEvent.h */,
 				93F6F1EC127F70B10055CB06 /* WebGLContextEvent.idl */,
+				72242943301ADA9800856621 /* WebGLCopyElementImageConfig.h */,
+				7224293A301AB8B700856621 /* WebGLCopyElementImageConfig.idl */,
 				A0EE0DF1144F825500F80B0D /* WebGLDebugRendererInfo.cpp */,
 				A0EE0DF2144F825500F80B0D /* WebGLDebugRendererInfo.h */,
 				A0EE0DF0144F824300F80B0D /* WebGLDebugRendererInfo.idl */,
@@ -44473,6 +44500,7 @@
 				313171561FB079E5008D91FC /* CanvasBase.h in Headers */,
 				415CDAF51E6B8F8B004F11EE /* CanvasCaptureMediaStreamTrack.h in Headers */,
 				7C193BBB1F5E0EED0088F3E6 /* CanvasDirection.h in Headers */,
+				721292A3301BA12F009DA7C9 /* CanvasElementImage.h in Headers */,
 				7C193BBC1F5E0EED0088F3E6 /* CanvasFillRule.h in Headers */,
 				49484FC2102CF23C00187DD3 /* CanvasGradient.h in Headers */,
 				7C193BBD1F5E0EED0088F3E6 /* CanvasLineCap.h in Headers */,

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -196,6 +196,7 @@ namespace WebCore {
     macro(DigitalCredential) \
     macro(DocumentTimeline) \
     macro(DynamicsCompressorNode) \
+    macro(ElementImage) \
     macro(ElementInternals) \
     macro(EncodedAudioChunk) \
     macro(EncodedVideoChunk) \
@@ -355,6 +356,7 @@ namespace WebCore {
     macro(OffscreenCanvasRenderingContext2D) \
     macro(Origin) \
     macro(OscillatorNode) \
+    macro(PaintEvent) \
     macro(PaintRenderingContext2D) \
     macro(PannerNode) \
     macro(PaymentAddress) \

--- a/Source/WebCore/dom/EventInterfaces.in
+++ b/Source/WebCore/dom/EventInterfaces.in
@@ -111,3 +111,4 @@ XRSessionEvent conditional=WEBXR
 NotificationEvent conditional=NOTIFICATION_EVENT
 ContentVisibilityAutoStateChangeEvent
 GPUUncapturedErrorEvent
+CanvasPaintEvent

--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -182,6 +182,7 @@
     "pagereveal": { },
     "pageshow": { },
     "pageswap": { },
+    "paint": { },
     "paste": { },
     "pause": { },
     "payerdetailchange": { },

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -182,6 +182,7 @@ kind
 label
 lang
 language
+layoutsubtree
 leftmargin
 link
 list

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alp Toker <alp@atoker.com>
  * Copyright (C) 2010 Torch Mobile (Beijing) Co. Ltd. All rights reserved.
  *
@@ -36,6 +36,7 @@
 #include "CanvasRenderingContext2D.h"
 #include "CanvasRenderingContext2DSettings.h"
 #include "ContainerNodeInlines.h"
+#include "DOMMatrix.h"
 #include "DocumentQuirks.h"
 #include "DocumentView.h"
 #include "ElementInlines.h"
@@ -210,6 +211,30 @@ ExceptionOr<void> HTMLCanvasElement::setWidth(unsigned value)
         return Exception { ExceptionCode::InvalidStateError };
     setAttributeWithoutSynchronization(widthAttr, AtomString::number(limitToOnlyHTMLNonNegative(value, defaultWidth)));
     return { };
+}
+
+void HTMLCanvasElement::setLayoutSubtree(bool layoutSubtree)
+{
+    setBooleanAttribute(layoutsubtreeAttr, layoutSubtree);
+}
+
+bool HTMLCanvasElement::layoutSubtree() const
+{
+    return hasAttributeWithoutSynchronization(layoutsubtreeAttr);
+}
+
+void HTMLCanvasElement::requestPaint()
+{
+}
+
+ExceptionOr<Ref<DOMMatrix>> HTMLCanvasElement::getElementTransform(const CanvasElementImageSource&, DOMMatrix&)
+{
+    return Exception { ExceptionCode::InvalidStateError };
+}
+
+ExceptionOr<Ref<CanvasElementImage>> HTMLCanvasElement::captureElementImage(Element&)
+{
+    return Exception { ExceptionCode::InvalidStateError };
 }
 
 void HTMLCanvasElement::setSizeForControllingContext(IntSize newSize)

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alp Toker <alp@atoker.com>
  * Copyright (C) 2010 Torch Mobile (Beijing) Co. Ltd. All rights reserved.
  *
@@ -30,6 +30,7 @@
 #include <JavaScriptCore/JSCJSValue.h>
 #include <WebCore/ActiveDOMObject.h>
 #include <WebCore/CanvasBase.h>
+#include <WebCore/CanvasElementImage.h>
 #include <WebCore/Document.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/GraphicsTypes.h>
@@ -47,6 +48,7 @@ namespace WebCore {
 class BlobCallback;
 class CanvasRenderingContext;
 class CanvasRenderingContext2D;
+class DOMMatrix;
 class GPU;
 class GPUCanvasContext;
 class GraphicsContext;
@@ -73,9 +75,21 @@ public:
     static Ref<HTMLCanvasElement> create(const QualifiedName&, Document&);
     virtual ~HTMLCanvasElement();
 
-
     WEBCORE_EXPORT ExceptionOr<void> setWidth(unsigned);
     WEBCORE_EXPORT ExceptionOr<void> setHeight(unsigned);
+
+    // `layoutSubtree` attribute opts in canvas descendants to layout and participate in hit testing.
+    // It causes the direct children of the <canvas> to have a stacking context, become a containing
+    // block for all descendants, and create RenderElements. These RenderElements behave as if they
+    // are visible, but their drawing is not visible to the user. They are recorded in DisplayLists
+    // and these DisplayLists are replayed back into the canvas only via calls to drawElementImage().
+    void setLayoutSubtree(bool);
+    bool layoutSubtree() const;
+
+    void requestPaint();
+
+    ExceptionOr<Ref<DOMMatrix>> getElementTransform(const CanvasElementImageSource&, DOMMatrix& drawTransform);
+    ExceptionOr<Ref<CanvasElementImage>> captureElementImage(Element&);
 
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
     ExceptionOr<std::optional<RenderingContext>> getContext(JSC::JSGlobalObject&, const String& contextId, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments);

--- a/Source/WebCore/html/HTMLCanvasElement.idl
+++ b/Source/WebCore/html/HTMLCanvasElement.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Torch Mobile (Beijing) Co. Ltd. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,6 +33,8 @@ typedef (
     ImageBitmapRenderingContext or 
     CanvasRenderingContext2D) RenderingContext;
 
+typedef (Element or CanvasElementImage) CanvasElementImageSource;
+
 [
     ExportMacro=WEBCORE_EXPORT,
     ActiveDOMObject,
@@ -42,6 +44,12 @@ typedef (
 ] interface HTMLCanvasElement : HTMLElement {
     [CEReactions=NotNeeded, CallTracer=InspectorCanvasCallTracer] attribute unsigned long width;
     [CEReactions=NotNeeded, CallTracer=InspectorCanvasCallTracer] attribute unsigned long height;
+
+    [EnabledBySetting=HTMLInCanvasEnabled] attribute boolean layoutSubtree;
+    [EnabledBySetting=HTMLInCanvasEnabled] attribute EventHandler onpaint;
+    [EnabledBySetting=HTMLInCanvasEnabled] undefined requestPaint();
+    [EnabledBySetting=HTMLInCanvasEnabled, RaisesException] DOMMatrix getElementTransform(CanvasElementImageSource source, DOMMatrix drawTransform);
+    [EnabledBySetting=HTMLInCanvasEnabled, RaisesException] CanvasElementImage captureElementImage(Element element);
 
     [CallWith=CurrentGlobalObject] RenderingContext? getContext(DOMString contextId, any... arguments);
 

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -33,6 +33,7 @@
 #include "CanvasRenderingContext.h"
 #include "ContextDestructionObserverInlines.h"
 #include "Chrome.h"
+#include "DOMMatrix.h"
 #include "Document.h"
 #include "EventDispatcher.h"
 #include "EventNames.h"
@@ -176,6 +177,11 @@ void OffscreenCanvas::didUpdateSizeProperties(bool sizeChanged)
         m_context->didUpdateCanvasSizeProperties(sizeChanged);
     notifyObserversCanvasResized();
     scheduleCommitToPlaceholderCanvas();
+}
+
+ExceptionOr<Ref<DOMMatrix>> OffscreenCanvas::getElementTransform(const CanvasElementImageSource&, DOMMatrix&)
+{
+    return Exception { ExceptionCode::InvalidStateError };
 }
 
 ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContext(JSC::JSGlobalObject& state, RenderingContextType contextType, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments)

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -30,6 +30,7 @@
 #include <WebCore/ActiveDOMObject.h>
 #include <WebCore/AffineTransform.h>
 #include <WebCore/CanvasBase.h>
+#include <WebCore/CanvasElementImage.h>
 #include <WebCore/ContextDestructionObserver.h>
 #include <WebCore/EventTarget.h>
 #include <WebCore/EventTargetInterfaces.h>
@@ -52,6 +53,7 @@
 namespace WebCore {
 
 class CanvasRenderingContext;
+class DOMMatrix;
 class DeferredPromise;
 class GPU;
 class GPUCanvasContext;
@@ -129,6 +131,8 @@ public:
     void setWidth(unsigned);
     void setHeight(unsigned);
     void setSizeForControllingContext(IntSize) final;
+
+    ExceptionOr<Ref<DOMMatrix>> getElementTransform(const CanvasElementImageSource&, DOMMatrix& drawTransform);
 
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
 

--- a/Source/WebCore/html/OffscreenCanvas.idl
+++ b/Source/WebCore/html/OffscreenCanvas.idl
@@ -48,6 +48,8 @@ enum OffscreenRenderingContextType {
    "webgpu"
 };
 
+typedef (Element or CanvasElementImage) CanvasElementImageSource;
+
 // https://html.spec.whatwg.org/multipage/canvas.html#offscreencanvas
 [
     ActiveDOMObject,
@@ -63,6 +65,8 @@ enum OffscreenRenderingContextType {
 
     [CallTracer=InspectorCanvasCallTracer] attribute [EnforceRange] unsigned long width;
     [CallTracer=InspectorCanvasCallTracer] attribute [EnforceRange] unsigned long height;
+
+    [EnabledBySetting=HTMLInCanvasEnabled, RaisesException] DOMMatrix getElementTransform(CanvasElementImageSource source, DOMMatrix drawTransform);
 
     [CallWith=CurrentGlobalObject] OffscreenRenderingContext? getContext(OffscreenRenderingContextType contextType, any... arguments);
     // FIXME: `transferToImageBitmap` should not return a nullable type.

--- a/Source/WebCore/html/canvas/CanvasDrawElementImage.idl
+++ b/Source/WebCore/html/canvas/CanvasDrawElementImage.idl
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+typedef (Element or CanvasElementImage) CanvasElementImageSource;
+
+// https://github.com/WICG/html-in-canvas
+[
+    EnabledBySetting=HTMLInCanvasEnabled
+] interface mixin CanvasDrawElementImage {
+    DOMMatrix drawElementImage(CanvasElementImageSource source, unrestricted double dx, unrestricted double dy);
+
+    DOMMatrix drawElementImage(CanvasElementImageSource source, unrestricted double dx, unrestricted double dy, unrestricted double dwidth, unrestricted double dheight);
+
+    DOMMatrix drawElementImage(CanvasElementImageSource source, unrestricted double sx, unrestricted double sy, unrestricted double swidth, unrestricted double sheight, unrestricted double dx, unrestricted double dy);
+
+    DOMMatrix drawElementImage(CanvasElementImageSource source, unrestricted double sx, unrestricted double sy, unrestricted double swidth, unrestricted double sheight, unrestricted double dx, unrestricted double dy, unrestricted double dwidth, unrestricted double dheight);
+};

--- a/Source/WebCore/html/canvas/CanvasElementImage.cpp
+++ b/Source/WebCore/html/canvas/CanvasElementImage.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CanvasElementImage.h"
+
+namespace WebCore {
+
+Ref<CanvasElementImage> CanvasElementImage::create(Ref<const DisplayList::DisplayList>&& displayList)
+{
+    return adoptRef(*new CanvasElementImage(WTF::move(displayList)));
+}
+
+CanvasElementImage::CanvasElementImage(Ref<const DisplayList::DisplayList>&& displayList)
+    : m_displayList(WTF::move(displayList))
+{
+}
+
+double CanvasElementImage::width() const
+{
+    return 0;
+}
+
+double CanvasElementImage::height() const
+{
+    return 0;
+}
+
+void CanvasElementImage::close()
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasElementImage.h
+++ b/Source/WebCore/html/canvas/CanvasElementImage.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/DisplayList.h>
+
+namespace WebCore {
+
+class Element;
+
+class CanvasElementImage : public RefCounted<CanvasElementImage> {
+public:
+    static Ref<CanvasElementImage> create(Ref<const DisplayList::DisplayList>&&);
+
+    double width() const;
+    double height() const;
+    void close();
+
+private:
+    CanvasElementImage(Ref<const DisplayList::DisplayList>&&);
+
+    Ref<const DisplayList::DisplayList> m_displayList;
+};
+
+using CanvasElementImageSource = Variant<Ref<Element>, Ref<CanvasElementImage>>;
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasElementImage.idl
+++ b/Source/WebCore/html/canvas/CanvasElementImage.idl
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+// https://github.com/WICG/html-in-canvas
+[
+    Exposed=(Window,Worker),
+    EnabledBySetting=HTMLInCanvasEnabled,
+    InterfaceName=ElementImage,
+    Transferable
+] interface CanvasElementImage {
+    readonly attribute double width;
+    readonly attribute double height;
+    undefined close();
+};

--- a/Source/WebCore/html/canvas/CanvasPaintEvent.cpp
+++ b/Source/WebCore/html/canvas/CanvasPaintEvent.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CanvasPaintEvent.h"
+
+#include "Element.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CanvasPaintEvent);
+
+Ref<CanvasPaintEvent> CanvasPaintEvent::create(const AtomString& type, Init&& initializer)
+{
+    return adoptRef(*new CanvasPaintEvent(type, WTF::move(initializer)));
+}
+
+CanvasPaintEvent::CanvasPaintEvent(const AtomString& type, Init&& initializer)
+    : Event(EventInterfaceType::CanvasPaintEvent, type, WTF::move(initializer), IsTrusted::No)
+{
+}
+
+Vector<Ref<Element>> CanvasPaintEvent::changedElements() const
+{
+    return { };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasPaintEvent.h
+++ b/Source/WebCore/html/canvas/CanvasPaintEvent.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Event.h"
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+class Element;
+
+class CanvasPaintEvent final : public Event {
+    WTF_MAKE_TZONE_ALLOCATED(CanvasPaintEvent);
+public:
+    struct Init : EventInit {
+        Vector<Ref<Element>> changedElements;
+    };
+    static Ref<CanvasPaintEvent> create(const AtomString& type, Init&&);
+
+    Vector<Ref<Element>> changedElements() const;
+
+private:
+    CanvasPaintEvent(const AtomString& type, Init&&);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasPaintEvent.idl
+++ b/Source/WebCore/html/canvas/CanvasPaintEvent.idl
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+// https://github.com/WICG/html-in-canvas
+[
+    Exposed=Window,
+    InterfaceName=PaintEvent,
+    EnabledBySetting=HTMLInCanvasEnabled
+] interface CanvasPaintEvent : Event {
+  constructor([AtomString] DOMString type, optional CanvasPaintEventInit eventInitDict = {});
+
+  readonly attribute FrozenArray<Element> changedElements;
+};
+
+dictionary CanvasPaintEventInit : EventInit {
+  sequence<Element> changedElements = [];
+};

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -85,3 +85,4 @@ CanvasRenderingContext2D includes CanvasImageData;
 CanvasRenderingContext2D includes CanvasPathDrawingStyles;
 CanvasRenderingContext2D includes CanvasTextDrawingStyles;
 CanvasRenderingContext2D includes CanvasPath;
+CanvasRenderingContext2D includes CanvasDrawElementImage;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2010 Nokia Corporation and/or its subsidiary(-ies)
  * Copyright (C) 2007 Alp Toker <alp@atoker.com>
  * Copyright (C) 2008 Eric Seidel <eric@webkit.org>
@@ -1981,6 +1981,26 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(ImageBitmap& imageBitm
 
     didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : dstRect, defaultDidDrawOptionsWithoutPostProcessing());
     return { };
+}
+
+ExceptionOr<Ref<DOMMatrix>> CanvasRenderingContext2DBase::drawElementImage(CanvasElementImageSource&&, float, float)
+{
+    return Exception { ExceptionCode::NotSupportedError };
+}
+
+ExceptionOr<Ref<DOMMatrix>> CanvasRenderingContext2DBase::drawElementImage(CanvasElementImageSource&&, float, float, float, float)
+{
+    return Exception { ExceptionCode::NotSupportedError };
+}
+
+ExceptionOr<Ref<DOMMatrix>> CanvasRenderingContext2DBase::drawElementImage(CanvasElementImageSource&&, float, float, float, float, float, float)
+{
+    return Exception { ExceptionCode::NotSupportedError };
+}
+
+ExceptionOr<Ref<DOMMatrix>> CanvasRenderingContext2DBase::drawElementImage(CanvasElementImageSource&&, float, float, float, float, float, float, float, float)
+{
+    return Exception { ExceptionCode::NotSupportedError };
 }
 
 void CanvasRenderingContext2DBase::clearCanvas()

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #include "AffineTransform.h"
 #include "CanvasDirection.h"
+#include "CanvasElementImage.h"
 #include "CanvasFillRule.h"
 #include "CanvasLineCap.h"
 #include "CanvasLineJoin.h"
@@ -215,6 +216,11 @@ public:
     ExceptionOr<void> drawImage(CanvasImageSource&&, float dx, float dy);
     ExceptionOr<void> drawImage(CanvasImageSource&&, float dx, float dy, float dw, float dh);
     ExceptionOr<void> drawImage(CanvasImageSource&&, float sx, float sy, float sw, float sh, float dx, float dy, float dw, float dh);
+
+    ExceptionOr<Ref<DOMMatrix>> drawElementImage(CanvasElementImageSource&&, float dx, float dy);
+    ExceptionOr<Ref<DOMMatrix>> drawElementImage(CanvasElementImageSource&&, float dx, float dy, float dw, float dh);
+    ExceptionOr<Ref<DOMMatrix>> drawElementImage(CanvasElementImageSource&&, float sx, float sy, float sw, float sh, float dx, float dy);
+    ExceptionOr<Ref<DOMMatrix>> drawElementImage(CanvasElementImageSource&&, float sx, float sy, float sw, float sh, float dx, float dy, float dw, float dh);
 
     void clearCanvas();
 

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2017 Apple Inc. All rights reserved.
+* Copyright (C) 2017-2026 Apple Inc. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -55,3 +55,4 @@ OffscreenCanvasRenderingContext2D includes CanvasImageData;
 OffscreenCanvasRenderingContext2D includes CanvasPathDrawingStyles;
 OffscreenCanvasRenderingContext2D includes CanvasTextDrawingStyles;
 OffscreenCanvasRenderingContext2D includes CanvasPath;
+OffscreenCanvasRenderingContext2D includes CanvasDrawElementImage;

--- a/Source/WebCore/html/canvas/WebGLCopyElementImageConfig.h
+++ b/Source/WebCore/html/canvas/WebGLCopyElementImageConfig.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+struct WebGLCopyElementImageConfig {
+    std::optional<float> sx;
+    std::optional<float> sy;
+    std::optional<float> swidth;
+    std::optional<float> sheight;
+    std::optional<int> width;
+    std::optional<int> height;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLCopyElementImageConfig.idl
+++ b/Source/WebCore/html/canvas/WebGLCopyElementImageConfig.idl
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+typedef long GLsizei;
+typedef unrestricted float GLfloat;
+
+// https://github.com/WICG/html-in-canvas
+[
+    EnabledBySetting=HTMLInCanvasEnabled,
+] dictionary WebGLCopyElementImageConfig {
+    GLfloat sx;
+    GLfloat sy;
+    GLfloat swidth;
+    GLfloat sheight;
+    GLsizei width;
+    GLsizei height;
+};

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -3787,6 +3787,11 @@ ExceptionOr<void> WebGLRenderingContextBase::texSubImage2D(GCGLenum target, GCGL
     }
 
     return texImageSourceHelper(TexImageFunctionID::TexSubImage2D, target, level, 0, 0, format, type, xoffset, yoffset, 0, sentinelEmptyRect(), 1, 0, WTF::move(*source));
+}
+
+ExceptionOr<void> WebGLRenderingContextBase::texElementImage2D(GCGLenum, GCGLenum, std::optional<CanvasElementImageSource>, std::optional<WebGLCopyElementImageConfig>)
+{
+    return Exception { ExceptionCode::InvalidStateError };
 }
 
 bool WebGLRenderingContextBase::validateTypeAndArrayBufferType(ASCIILiteral functionName, ArrayBufferViewFunctionType functionType, GCGLenum type, ArrayBufferView* pixels)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBGL)
 
+#include "CanvasElementImage.h"
 #include "EventLoop.h"
 #include "GPUBasedCanvasRenderingContext.h"
 #include "GraphicsContextGL.h"
@@ -37,6 +38,7 @@
 #include "WebGLAny.h"
 #include "WebGLBuffer.h"
 #include "WebGLContextAttributes.h"
+#include "WebGLCopyElementImageConfig.h"
 #include "WebGLExtension.h"
 #include "WebGLExtensionAny.h"
 #include "WebGLFramebuffer.h"
@@ -336,6 +338,8 @@ public:
     // These must be virtual so more validation can be added in WebGL 2.0.
     virtual void texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&&);
     virtual ExceptionOr<void> texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLenum format, GCGLenum type, std::optional<TexImageSource>&&);
+
+    virtual ExceptionOr<void> texElementImage2D(GCGLenum target, GCGLenum internalformat, std::optional<CanvasElementImageSource>, std::optional<WebGLCopyElementImageConfig>);
 
     template<typename TypedArray, typename DataType>
     class TypedList {

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.idl
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,8 @@ typedef (HTMLCanvasElement or OffscreenCanvas) WebGLCanvas;
 #else
 typedef (HTMLCanvasElement) WebGLCanvas;
 #endif
+
+typedef (Element or CanvasElementImage) CanvasElementImageSource;
 
 [
     Conditional=WEBGL,
@@ -513,6 +515,8 @@ typedef (HTMLCanvasElement) WebGLCanvas;
 
     undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
     undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLenum format, GLenum type, TexImageSource source);
+
+    [EnabledBySetting=HTMLInCanvasEnabled] undefined texElementImage2D(GLenum target, GLenum internalformat, CanvasElementImageSource source, optional WebGLCopyElementImageConfig options = {});
 
     undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, [AllowShared] ArrayBufferView data);
     undefined compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, [AllowShared] ArrayBufferView data);

--- a/Source/WebCore/inspector/InspectorCanvasArguments.cpp
+++ b/Source/WebCore/inspector/InspectorCanvasArguments.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -59,6 +60,12 @@ auto InspectorCanvasArgumentProcessor<IDLDictionary<DOMMatrix2DInit>>::operator(
 }
 
 auto InspectorCanvasArgumentProcessor<IDLDictionary<ImageDataSettings>>::operator()(InspectorCanvas&, const ImageDataSettings&) -> std::optional<InspectorCanvasProcessedArgument>
+{
+    // FIXME: Implement.
+    return std::nullopt;
+}
+
+auto InspectorCanvasArgumentProcessor<IDLDictionary<WebGLCopyElementImageConfig>>::operator()(InspectorCanvas&, const WebGLCopyElementImageConfig&) -> std::optional<InspectorCanvasProcessedArgument>
 {
     // FIXME: Implement.
     return std::nullopt;
@@ -158,6 +165,11 @@ auto InspectorCanvasArgumentProcessor<IDLInterface<ImageBitmap>>::operator()(Ins
 auto InspectorCanvasArgumentProcessor<IDLInterface<ImageData>>::operator()(InspectorCanvas& context, const Ref<ImageData>& argument) -> std::optional<InspectorCanvasProcessedArgument>
 {
     return {{ context.valueIndexForData(argument), RecordingSwizzleType::ImageData }};
+}
+
+auto InspectorCanvasArgumentProcessor<IDLInterface<CanvasElementImage>>::operator()(InspectorCanvas& context, const Ref<CanvasElementImage>&) -> std::optional<InspectorCanvasProcessedArgument>
+{
+    return {{ context.valueIndexForData("CanvasElementImage"_s), RecordingSwizzleType::None }};
 }
 
 #if ENABLE(OFFSCREEN_CANVAS)
@@ -283,6 +295,15 @@ auto InspectorCanvasArgumentProcessor<IDLCanvasPathRadiusUnion>::operator()(Insp
         },
         [](double radius) -> std::optional<InspectorCanvasProcessedArgument> {
             return {{ JSON::Value::create(radius), RecordingSwizzleType::Number }};
+        }
+    );
+}
+
+auto InspectorCanvasArgumentProcessor<IDLCanvasElementImageSourceUnion>::operator()(InspectorCanvas& context, const CanvasElementImageSource& argument) -> std::optional<InspectorCanvasProcessedArgument>
+{
+    return WTF::switchOn(argument,
+        [&]<typename T>(const Ref<T>& value) {
+            return InspectorCanvasArgumentProcessor<IDLInterface<T>>{}(context, value);
         }
     );
 }

--- a/Source/WebCore/inspector/InspectorCanvasArguments.h
+++ b/Source/WebCore/inspector/InspectorCanvasArguments.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +27,7 @@
 #pragma once
 
 #include "CSSStyleImageValue.h"
+#include "CanvasElementImage.h"
 #include "CanvasGradient.h"
 #include "CanvasPattern.h"
 #include "CanvasRenderingContext2DBase.h"
@@ -44,6 +46,7 @@
 #include "JSDOMConvertBufferSource.h"
 #include "SVGImageElement.h"
 #include "WebGL2RenderingContext.h"
+#include "WebGLCopyElementImageConfig.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/ArrayBufferView.h>
 #include <JavaScriptCore/TypedArrays.h>
@@ -138,6 +141,10 @@ template<> struct InspectorCanvasArgumentProcessor<IDLDictionary<ImageDataSettin
     std::optional<InspectorCanvasProcessedArgument> NODELETE operator()(InspectorCanvas&, const ImageDataSettings&);
 };
 
+template<> struct InspectorCanvasArgumentProcessor<IDLDictionary<WebGLCopyElementImageConfig>> {
+    std::optional<InspectorCanvasProcessedArgument> NODELETE operator()(InspectorCanvas&, const WebGLCopyElementImageConfig&);
+};
+
 // MARK: - Strings
 
 template<> struct InspectorCanvasArgumentProcessor<IDLDOMString> {
@@ -221,6 +228,10 @@ template<> struct InspectorCanvasArgumentProcessor<IDLInterface<ImageBitmap>> {
 
 template<> struct InspectorCanvasArgumentProcessor<IDLInterface<ImageData>> {
     std::optional<InspectorCanvasProcessedArgument> operator()(InspectorCanvas&, const Ref<ImageData>&);
+};
+
+template<> struct InspectorCanvasArgumentProcessor<IDLInterface<CanvasElementImage>> {
+    std::optional<InspectorCanvasProcessedArgument> operator()(InspectorCanvas&, const Ref<CanvasElementImage>&);
 };
 
 #if ENABLE(OFFSCREEN_CANVAS)
@@ -329,6 +340,11 @@ using IDLCanvasPathRadiusUnion = IDLUnion<
     IDLDictionary<DOMPointInit>
 >;
 
+using IDLCanvasElementImageSourceUnion = IDLUnion<
+    IDLInterface<Element>,
+    IDLInterface<CanvasElementImage>
+>;
+
 template<> struct InspectorCanvasArgumentProcessor<IDLCanvasImageSourceUnion> {
     std::optional<InspectorCanvasProcessedArgument> operator()(InspectorCanvas&, const CanvasImageSource&);
 };
@@ -339,6 +355,10 @@ template<> struct InspectorCanvasArgumentProcessor<IDLCanvasStyleVariantUnion> {
 
 template<> struct InspectorCanvasArgumentProcessor<IDLCanvasPathRadiusUnion> {
     std::optional<InspectorCanvasProcessedArgument> operator()(InspectorCanvas&, const CanvasPath::RadiusVariant&);
+};
+
+template<> struct InspectorCanvasArgumentProcessor<IDLCanvasElementImageSourceUnion> {
+    std::optional<InspectorCanvasProcessedArgument> operator()(InspectorCanvas&, const CanvasElementImageSource&);
 };
 
 #if ENABLE(WEBGL)


### PR DESCRIPTION
#### 94e061f54bdab7b585afe1445375d14103ba50b6
<pre>
[HTML-in-Canvas] Implement the IDL changes for HTML-in-Canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=320677">https://bugs.webkit.org/show_bug.cgi?id=320677</a>
<a href="https://rdar.apple.com/183661820">rdar://183661820</a>

Reviewed by Simon Fraser.

This change implements the IDL additions which are required for HTML-in-Canvas[1].
The WebCore sources were changed just to allow compiling. New functionalities will
be filled later. Here is the summary of this change:

1. The attribute layoutSubtree is added to HTMLCanvasElement. This attribute will
   force the layout for the canvas children.

2. The interface ElementImage is added. It represents a the drawing of an Element
   into a DisplayList

3. The event Paint is added. This event will fire any time, a canvas child is
   repainted.

4. The ElementImage drawing functions to HTMLCanvasElement, OffscreenCanvas, WebGL
   and WebGPU are added.

5. Capturing a canvas child Element to ElementImage is added.

[1] <a href="https://github.com/WICG/html-in-canvas">https://github.com/WICG/html-in-canvas</a>

* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/WebGPU/GPUCopyElementImageDestination.h: Added.
* Source/WebCore/Modules/WebGPU/GPUCopyElementImageDestination.idl: Added.
* Source/WebCore/Modules/WebGPU/GPUCopyElementImageSource.h: Added.
* Source/WebCore/Modules/WebGPU/GPUCopyElementImageSource.idl: Added.
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::GPUQueue::copyElementImageToTexture):
* Source/WebCore/Modules/WebGPU/GPUQueue.h:
* Source/WebCore/Modules/WebGPU/GPUQueue.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/EventInterfaces.in:
* Source/WebCore/dom/EventNames.json:
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::setLayoutSubtree):
(WebCore::HTMLCanvasElement::layoutSubtree const):
(WebCore::HTMLCanvasElement::requestPaint):
(WebCore::HTMLCanvasElement::getElementTransform):
(WebCore::HTMLCanvasElement::captureElementImage):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLCanvasElement.idl:
* Source/WebCore/html/canvas/CanvasDrawElementImage.idl: Added.
* Source/WebCore/html/canvas/CanvasElementImage.cpp: Added.
(WebCore::CanvasElementImage::create):
(WebCore::CanvasElementImage::CanvasElementImage):
(WebCore::CanvasElementImage::width const):
(WebCore::CanvasElementImage::height const):
(WebCore::CanvasElementImage::close):
* Source/WebCore/html/canvas/CanvasElementImage.h: Added.
* Source/WebCore/html/canvas/CanvasElementImage.idl: Added.
* Source/WebCore/html/canvas/CanvasPaintEvent.cpp: Added.
(WebCore::CanvasPaintEvent::create):
(WebCore::CanvasPaintEvent::CanvasPaintEvent):
(WebCore::CanvasPaintEvent::changedElements const):
* Source/WebCore/html/canvas/CanvasPaintEvent.h: Added.
* Source/WebCore/html/canvas/CanvasPaintEvent.idl: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2D.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawElementImage):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl:
* Source/WebCore/html/canvas/WebGLCopyElementImageConfig.h: Added.
* Source/WebCore/html/canvas/WebGLCopyElementImageConfig.idl: Added.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texElementImage2D):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.idl:
* Source/WebCore/inspector/InspectorCanvasArguments.cpp:
(WebCore::InspectorCanvasArgumentProcessor&lt;IDLDictionary&lt;WebGLCopyElementImageConfig&gt;&gt;::operator):
(WebCore::InspectorCanvasArgumentProcessor&lt;IDLInterface&lt;CanvasElementImage&gt;&gt;::operator):
(WebCore::InspectorCanvasArgumentProcessor&lt;IDLCanvasElementImageSourceUnion&gt;::operator):
* Source/WebCore/inspector/InspectorCanvasArguments.h:
* Source/WebCore/Headers.cmake:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::getElementTransform):
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/OffscreenCanvas.idl:

Canonical link: <a href="https://commits.webkit.org/318425@main">https://commits.webkit.org/318425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcc3fbb90b2dfa5f6d2adc284feb52bf55bdce1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178266 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141514 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27e1f2a2-35c5-4de2-b9e5-2557778febeb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138970 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd55f776-f012-4868-8e59-9b01da9d235a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119425 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26342447-f33a-47fd-a119-35eedcaa2f4c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41192 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39547 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151592 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39231 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36337 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190307 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51872 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148120 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39777 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52554 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147893 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42608 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124818 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119404 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51072 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14206 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50457 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50697 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->