### PR TITLE
Use default member initializers for XMLHttpRequest's bitfields

### DIFF
--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -112,16 +112,6 @@ Ref<XMLHttpRequest> XMLHttpRequest::create(ScriptExecutionContext& context)
 
 XMLHttpRequest::XMLHttpRequest(ScriptExecutionContext& context)
     : ActiveDOMObject(&context)
-    , m_async(true)
-    , m_includeCredentials(false)
-    , m_sendFlag(false)
-    , m_createdDocument(false)
-    , m_error(false)
-    , m_uploadListenerFlag(false)
-    , m_uploadComplete(false)
-    , m_responseCacheIsValid(false)
-    , m_readyState(static_cast<unsigned>(UNSENT))
-    , m_responseType(static_cast<unsigned>(ResponseType::EmptyString))
     , m_progressEventThrottle(makeUniqueRef<XMLHttpRequestProgressEventThrottle>(*this))
     , m_timeoutTimer(*this, &XMLHttpRequest::timeoutTimerFired)
 {
@@ -262,7 +252,7 @@ ExceptionOr<void> XMLHttpRequest::setResponseType(ResponseType type)
         return Exception { ExceptionCode::InvalidAccessError };
     }
 
-    m_responseType = static_cast<unsigned>(type);
+    m_responseType = type;
     return { };
 }
 
@@ -290,7 +280,7 @@ void XMLHttpRequest::changeState(State newState)
         // of this scope.
         auto eventFiringActivity = makePendingActivity(*this);
 
-        m_readyState = static_cast<State>(newState);
+        m_readyState = newState;
         if (readyState() == DONE) {
             // The XHR object itself holds on to the responseText, and
             // thus has extra cost even independent of any
@@ -716,7 +706,7 @@ void XMLHttpRequest::abort()
         dispatchErrorEvents(eventNames().abortEvent);
     }
     if (readyState() == DONE)
-        m_readyState = static_cast<State>(UNSENT);
+        m_readyState = UNSENT;
 }
 
 bool XMLHttpRequest::internalAbort()
@@ -1186,7 +1176,7 @@ void XMLHttpRequest::didReachTimeout()
     m_exceptionCode = ExceptionCode::TimeoutError;
 
     if (!m_async) {
-        m_readyState = static_cast<State>(DONE);
+        m_readyState = DONE;
         m_exceptionCode = ExceptionCode::TimeoutError;
         return;
     }

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -86,7 +86,7 @@ public:
     const URL& url() const LIFETIME_BOUND { return m_url; }
     String statusText() const;
     int status() const;
-    State readyState() const { return static_cast<State>(m_readyState); }
+    State readyState() const { return m_readyState; }
     bool withCredentials() const { return m_includeCredentials; }
     ExceptionOr<void> setWithCredentials(bool);
     ExceptionOr<void> open(const String& method, const String& url);
@@ -125,7 +125,7 @@ public:
         Text = 5,
     };
     ExceptionOr<void> setResponseType(ResponseType);
-    ResponseType responseType() const { return static_cast<ResponseType>(m_responseType); }
+    ResponseType responseType() const { return m_responseType; }
 
     String responseURL() const;
 
@@ -209,16 +209,16 @@ private:
 
     Ref<TextResourceDecoder> createDecoder() const;
 
-    unsigned m_async : 1;
-    unsigned m_includeCredentials : 1;
-    unsigned m_sendFlag : 1;
-    unsigned m_createdDocument : 1;
-    unsigned m_error : 1;
-    unsigned m_uploadListenerFlag : 1;
-    unsigned m_uploadComplete : 1;
-    unsigned m_responseCacheIsValid : 1;
-    unsigned m_readyState : 3; // State
-    unsigned m_responseType : 3; // ResponseType
+    bool m_async : 1 { true };
+    bool m_includeCredentials : 1 { false };
+    bool m_sendFlag : 1 { false };
+    bool m_createdDocument : 1 { false };
+    bool m_error : 1 { false };
+    bool m_uploadListenerFlag : 1 { false };
+    bool m_uploadComplete : 1 { false };
+    bool m_responseCacheIsValid : 1 { false };
+    State m_readyState : 3 { UNSENT };
+    ResponseType m_responseType : 3 { ResponseType::EmptyString };
 
     unsigned m_timeoutMilliseconds { 0 };
 


### PR DESCRIPTION
#### 3224b48bd584c46f47834f8935371ea84f570481
<pre>
Use default member initializers for XMLHttpRequest&apos;s bitfields
<a href="https://bugs.webkit.org/show_bug.cgi?id=320679">https://bugs.webkit.org/show_bug.cgi?id=320679</a>
<a href="https://rdar.apple.com/183663124">rdar://183663124</a>

Reviewed by Chris Dumez.

XMLHttpRequest declares ten bitfields that were all initialized in the constructor&apos;s
initializer list, which puts the default state of each flag far from its declaration.
All ten were declared as plain unsigned, and the two multi-bit ones, m_readyState and
m_responseType, carried a trailing comment naming the enum they actually hold, so
every read and write had to launder the value through a static_cast.

Move the defaults to default member initializers and give each field its real type:
bool for the eight single-bit flags, State and ResponseType for the two multi-bit
fields, which lets the accessors and assignments use the values directly. State and
ResponseType both have uint8_t as their underlying type and still fit in three bits,
so sizeof(XMLHttpRequest) is unchanged.

* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::XMLHttpRequest): Drop the ten bitfield initializers.
(WebCore::XMLHttpRequest::setResponseType): Assign the enum directly.
(WebCore::XMLHttpRequest::changeState): Ditto.
(WebCore::XMLHttpRequest::abort): Ditto.
(WebCore::XMLHttpRequest::didReachTimeout): Ditto.
* Source/WebCore/xml/XMLHttpRequest.h:
(WebCore::XMLHttpRequest::readyState const): Return m_readyState without a cast.
(WebCore::XMLHttpRequest::responseType const): Ditto for m_responseType.

Canonical link: <a href="https://commits.webkit.org/318443@main">https://commits.webkit.org/318443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62ea5c6ca4f20c57acac5789ac1803113e6f7938

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141570 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c94c552-b745-40a1-95d4-c47e9b3640b5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139011 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb0e64e9-8046-4314-bb33-fe84c6178838) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119466 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dbdc7870-5dd2-44b2-8d86-8ce9c32f048a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41243 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39593 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151643 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39275 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36393 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44860 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43835 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190365 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51928 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148165 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39786 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52610 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147940 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42654 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124875 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119474 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51128 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14250 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50513 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50753 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50575 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->