### PR TITLE
Make it possible to run a subset of Interop tests via `run-webkit-tests`

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/interop/__init__.py
+++ b/Tools/Scripts/webkitpy/layout_tests/interop/__init__.py
@@ -1,0 +1,1 @@
+# Required for Python to search this directory for module files

--- a/Tools/Scripts/webkitpy/layout_tests/interop/interop_data.py
+++ b/Tools/Scripts/webkitpy/layout_tests/interop/interop_data.py
@@ -1,0 +1,404 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Find the WPT tests which make up the Interop project's focus areas.
+
+The Interop project (https://wpt.fyi/interop-2026) groups WPT tests into focus
+areas. Each focus area maps to one or more labels, and wpt.fyi's metadata API
+maps those labels to the tests which carry them.
+"""
+
+import logging
+from collections import defaultdict
+from collections.abc import Mapping, Sequence, Set
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Callable, Optional
+from urllib.parse import urljoin
+
+import requests
+
+_log = logging.getLogger(__name__)
+
+DEFAULT_WPT_FYI = "https://wpt.fyi/"
+DEFAULT_CATEGORY_URL = (
+    "https://raw.githubusercontent.com/web-platform-tests/"
+    "results-analysis/main/interop-scoring/category-data.json"
+)
+INTEROP_DATA_URL = "/static/interop-data.json"
+
+# This needs to include product=chrome because of https://github.com/web-platform-tests/wpt.fyi/issues/4324
+METADATA_URL = "/api/metadata?includeTestLevel=true&product=chrome"
+
+DEFAULT_TIMEOUT_SECONDS = 120
+
+
+class InteropDataError(ValueError):
+    """Raised when the Interop data doesn't contain what was asked for."""
+
+
+def fetch_json(url: str, timeout: int = DEFAULT_TIMEOUT_SECONDS) -> Any:
+    response = requests.get(url, timeout=timeout)
+    response.raise_for_status()
+    return response.json()
+
+
+@dataclass(frozen=True)
+class InteropYear:
+    start_date: date  # inclusive
+    end_date: date  # inclusive
+
+    def __post_init__(self) -> None:
+        if self.start_date > self.end_date:
+            raise ValueError("Start date cannot be after the end date")
+
+    @property
+    def year(self) -> int:
+        return self.start_date.year
+
+
+known_interop_years: Set[InteropYear] = {
+    InteropYear(start_date=date(2021, 3, 22), end_date=date(2021, 12, 31)),
+    InteropYear(start_date=date(2022, 3, 3), end_date=date(2022, 12, 31)),
+    InteropYear(start_date=date(2023, 2, 1), end_date=date(2024, 2, 1)),
+    InteropYear(start_date=date(2024, 2, 1), end_date=date(2025, 2, 6)),
+    InteropYear(start_date=date(2025, 2, 12), end_date=date(2026, 2, 12)),
+    InteropYear(start_date=date(2026, 2, 12), end_date=date(2027, 12, 31)),
+}
+
+
+class LabelledTestFinder:
+    def __init__(self, json_fetcher: Optional[Callable[[str], Any]] = None) -> None:
+        self._json_fetcher = json_fetcher if json_fetcher is not None else fetch_json
+        self._interop_data = None
+        self._category_data = None
+        self._metadata_data = None
+
+    @property
+    def interop_data(self) -> Any:
+        if self._interop_data is None:
+            url = urljoin(DEFAULT_WPT_FYI, INTEROP_DATA_URL)
+            _log.info("Loading Interop data from %s", url)
+            self._interop_data = self._json_fetcher(url)
+            _log.debug("Loaded Interop data")
+        return self._interop_data
+
+    @property
+    def category_data(self) -> Any:
+        if self._category_data is None:
+            url = urljoin(DEFAULT_WPT_FYI, DEFAULT_CATEGORY_URL)
+            _log.info("Loading Interop category data from %s", url)
+            self._category_data = self._json_fetcher(url)
+            _log.debug("Loaded Interop category data")
+        return self._category_data
+
+    @property
+    def metadata_data(self) -> Any:
+        if self._metadata_data is None:
+            url = urljoin(DEFAULT_WPT_FYI, METADATA_URL)
+            _log.info("Loading WPT metadata from %s", url)
+            self._metadata_data = self._json_fetcher(url)
+            _log.debug("Loaded WPT metadata")
+        return self._metadata_data
+
+    def category_for_focus_area(self, year: int, focus_area: str) -> str:
+        year_key = str(year)
+        if year_key not in self.interop_data:
+            raise InteropDataError(f"Unknown year: {year}")
+
+        by_name = {
+            v["description"]: k
+            for k, v in self.interop_data[year_key]["focus_areas"].items()
+        }
+
+        categories = self.interop_data[year_key]["focus_areas"].keys()
+
+        assert len(categories) == len(
+            by_name
+        ), "duplicate descriptions should not exist"
+
+        if focus_area not in by_name:
+            raise InteropDataError(f"Unknown focus area: {focus_area}")
+
+        category = by_name[focus_area]
+        assert isinstance(category, str)
+        return category
+
+    def categories_for_year(
+        self,
+        year: int,
+        *,
+        only_active: bool = True,
+        use_interop_scoring_categories: bool = False,
+    ) -> Set[str]:
+        if only_active and use_interop_scoring_categories:
+            raise InteropDataError(
+                "Cannot select only active categories when using category data"
+            )
+
+        year_key = str(year)
+
+        if use_interop_scoring_categories:
+            if year_key not in self.category_data:
+                raise InteropDataError(f"Unknown year: {year}")
+
+            return {i["name"] for i in self.category_data[year_key]["categories"]}
+
+        if year_key not in self.interop_data:
+            raise InteropDataError(f"Unknown year: {year}")
+
+        return {
+            key
+            for key, value in self.interop_data[year_key]["focus_areas"].items()
+            if not only_active or value["countsTowardScore"]
+        }
+
+    def labels_for_categories(
+        self, year: int, *, use_interop_scoring_labels: bool = False
+    ) -> Mapping[str, Set[str]]:
+        year_key = str(year)
+
+        if use_interop_scoring_labels:
+            if year_key not in self.category_data:
+                raise InteropDataError(f"Unknown year: {year}")
+
+            return {
+                v["name"]: set(v["labels"])
+                for v in self.category_data[year_key]["categories"]
+            }
+
+        if year_key not in self.category_data:
+            raise InteropDataError(f"Unknown year: {year}")
+
+        return {
+            k: set(v["labels"])
+            for k, v in self.interop_data[year_key]["focus_areas"].items()
+        }
+
+    def discover_years_from_data(
+        self, *, use_interop_scoring_categories: bool = False
+    ) -> Set[int]:
+        """Extract all years available in interop_data or category_data.
+
+        Returns a set of year integers found in the data source.
+        """
+        if use_interop_scoring_categories:
+            data = self.category_data
+        else:
+            data = self.interop_data
+
+        # Extract year keys and convert to integers
+        return {int(year_key) for year_key in data.keys() if year_key.isdigit()}
+
+    def tests_for_labels(self) -> Mapping[str, Set[str]]:
+        rv = defaultdict(set)
+        for test, metadata in self.metadata_data.items():
+            if test.endswith("/*"):
+                test = test[:-1]
+            for meta_item in metadata:
+                if meta_item.get("label"):
+                    rv[meta_item["label"]].add(test)
+        return rv
+
+
+def find_wpt_tests(
+    *,
+    years: Optional[Sequence[int]] = None,
+    categories: Optional[Sequence[str]] = None,
+    focus_areas: Optional[Sequence[str]] = None,
+    labels: Optional[Sequence[str]] = None,
+    only_active: bool = True,
+    use_interop_scoring_categories: bool = False,
+    use_interop_scoring_labels: bool = False,
+    include_unknown_years: bool = True,
+    today: Optional[date] = None,
+    finder: Optional[LabelledTestFinder] = None,
+) -> Sequence[str]:
+    """Find the WPT tests which are part of the given Interop selection.
+
+    Focus areas resolve to categories, categories resolve to labels, and labels
+    resolve to tests. Specifying no focus areas, categories or labels finds all
+    of the tests in the given (or currently active) Interop years.
+
+    :return List[str]: WPT test URLs, e.g. "/css/css-scroll-snap/snap-area-overflow-boundary.html"
+    """
+
+    # Canonicalize these to empty lists:
+    years = list(years) if years is not None else []
+    focus_areas = list(focus_areas) if focus_areas is not None else []
+
+    # This are mutable things we might add to:
+    search_labels = list(labels) if labels is not None else []
+    search_categories = list(categories) if categories is not None else []
+
+    if today is None:
+        today = datetime.now(timezone.utc).date()
+
+    if finder is None:
+        finder = LabelledTestFinder()
+
+    # Searching for labels alone doesn't need any Interop data, so don't fetch it
+    # (or complain about the years it contains) unless the years actually matter.
+    if years or focus_areas or search_categories or not search_labels:
+        years = _resolve_years(
+            finder,
+            years,
+            today=today,
+            needs_default=bool(focus_areas or search_categories or not search_labels),
+            include_unknown_years=include_unknown_years,
+            use_interop_scoring_categories=use_interop_scoring_categories,
+        )
+
+    if len(years) > 1 and (focus_areas or search_categories):
+        _log.warning(
+            "Multiple years specified, may have surprising results with focus areas and categories"
+        )
+
+    # Nothing specified, default to everything in the year:
+    if not search_categories and not focus_areas and not search_labels:
+        for year in years:
+            _log.info(
+                "No categories or focus areas specified, "
+                "defaulting to all tests in Interop %d",
+                year,
+            )
+            search_categories.extend(
+                finder.categories_for_year(
+                    year,
+                    only_active=only_active,
+                    use_interop_scoring_categories=use_interop_scoring_categories,
+                )
+            )
+
+    if focus_areas:
+        for year in years:
+            _log.debug(
+                "Finding the categories which make up Interop %d focus areas: %s",
+                year,
+                ", ".join(focus_areas),
+            )
+            search_categories.extend(
+                finder.category_for_focus_area(year, focus_area)
+                for focus_area in focus_areas
+            )
+
+    if search_categories:
+        for year in years:
+            _log.debug(
+                "Finding the labels which make up Interop %d categories: %s",
+                year,
+                ", ".join(search_categories),
+            )
+            search_labels.extend(
+                set().union(
+                    *(
+                        v
+                        for k, v in finder.labels_for_categories(
+                            year, use_interop_scoring_labels=use_interop_scoring_labels
+                        ).items()
+                        if k in search_categories
+                    )
+                )
+            )
+
+    if not search_labels:
+        raise InteropDataError("We cannot find tests without any labels to search for")
+
+    _log.debug("Finding tests with labels: %s", ", ".join(search_labels))
+    tests = set().union(
+        *(v for k, v in finder.tests_for_labels().items() if k in search_labels)
+    )
+
+    return sorted(tests, key=lambda x: x.split("/"))
+
+
+def _resolve_years(
+    finder: LabelledTestFinder,
+    years: Sequence[int],
+    *,
+    today: date,
+    needs_default: bool,
+    include_unknown_years: bool,
+    use_interop_scoring_categories: bool,
+) -> Sequence[int]:
+    """Validate the given Interop years, defaulting to the active ones if needed."""
+
+    all_interop_years: dict = {interop.year: interop for interop in known_interop_years}
+
+    if include_unknown_years:
+        discovered_years = finder.discover_years_from_data(
+            use_interop_scoring_categories=use_interop_scoring_categories
+        )
+        for year in discovered_years - all_interop_years.keys():
+            # Each year has typically run from early Feb to mid Feb, so let's assume Feb
+            # 1 till the last day of the following Feb.
+            all_interop_years[year] = InteropYear(
+                start_date=date(year, 2, 1),
+                end_date=date(year + 1, 3, 1) - timedelta(days=1),
+            )
+            _log.warning(
+                "Year %d found in data sources but not in known years list. "
+                "Assuming it runs from %s to %s.",
+                year,
+                all_interop_years[year].start_date,
+                all_interop_years[year].end_date,
+            )
+
+    for year in years:
+        try:
+            interop_year = all_interop_years[year]
+        except KeyError:
+            _log.warning(
+                "Interop %d is unknown, only the following years are known: %s",
+                year,
+                ", ".join(str(y) for y in sorted(all_interop_years)),
+            )
+            continue
+
+        if interop_year.start_date > today:
+            _log.warning(
+                "Interop %d is yet to launch; it will launch on %s",
+                interop_year.year,
+                interop_year.start_date,
+            )
+
+        if interop_year.end_date < today:
+            _log.warning(
+                "Interop %d has ended with its results frozen since %s",
+                interop_year.year,
+                interop_year.end_date,
+            )
+
+    if not years and needs_default:
+        years = sorted(
+            {
+                item.year
+                for item in all_interop_years.values()
+                if item.start_date <= today <= item.end_date
+            }
+        )
+        _log.info(
+            "No years specified, defaulting to active Interop years: %s",
+            ", ".join(str(y) for y in years),
+        )
+
+    return years

--- a/Tools/Scripts/webkitpy/layout_tests/interop/interop_data_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/interop/interop_data_unittest.py
@@ -1,0 +1,229 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+from datetime import date
+
+from webkitpy.layout_tests.interop.interop_data import (
+    DEFAULT_CATEGORY_URL,
+    INTEROP_DATA_URL,
+    METADATA_URL,
+    InteropDataError,
+    InteropYear,
+    LabelledTestFinder,
+    find_wpt_tests,
+)
+
+INTEROP_DATA = {
+    '2026': {
+        'focus_areas': {
+            'scroll-snap': {
+                'description': 'Scroll Snap',
+                'countsTowardScore': True,
+                'labels': ['interop-2026-scroll-snap'],
+            },
+            'webrtc': {
+                'description': 'WebRTC',
+                'countsTowardScore': False,
+                'labels': ['interop-2026-webrtc'],
+            },
+        },
+    },
+}
+
+CATEGORY_DATA = {
+    '2026': {
+        'categories': [{
+            'name': 'Scroll Snap and friends',
+            'labels': ['interop-2026-scroll-snap', 'interop-2026-scroll-animations'],
+        }],
+    },
+}
+
+METADATA = {
+    '/css/css-scroll-snap/snap-area.html': [{'label': 'interop-2026-scroll-snap'}],
+    '/css/css-scroll-snap/scroll-snap-type.html': [{'label': 'interop-2026-scroll-snap'}],
+    '/css/css-scroll-snap/nested/*': [{'label': 'interop-2026-scroll-snap'}],
+    '/scroll-animations/view-timeline.html': [{'label': 'interop-2026-scroll-animations'}],
+    '/webrtc/RTCPeerConnection.html': [{'label': 'interop-2026-webrtc'}],
+    '/dom/Node-appendChild.html': [{'url': 'https://webkit.org/b/1'}],
+}
+
+DURING_2026 = date(2026, 7, 29)
+
+
+class MockJSONFetcher(object):
+    def __init__(self):
+        self.fetched_urls = []
+
+    def __call__(self, url):
+        self.fetched_urls.append(url)
+        if url.endswith(INTEROP_DATA_URL):
+            return INTEROP_DATA
+        if url == DEFAULT_CATEGORY_URL:
+            return CATEGORY_DATA
+        if url.endswith(METADATA_URL):
+            return METADATA
+        raise AssertionError('unexpected URL: {}'.format(url))
+
+
+class InteropYearTest(unittest.TestCase):
+    def test_year_is_the_start_year(self):
+        self.assertEqual(2026, InteropYear(start_date=date(2026, 2, 12), end_date=date(2027, 12, 31)).year)
+
+    def test_end_before_start_is_rejected(self):
+        with self.assertRaises(ValueError):
+            InteropYear(start_date=date(2026, 2, 12), end_date=date(2025, 2, 12))
+
+
+class LabelledTestFinderTest(unittest.TestCase):
+    def finder(self):
+        return LabelledTestFinder(json_fetcher=MockJSONFetcher())
+
+    def test_tests_for_labels(self):
+        tests_for_labels = self.finder().tests_for_labels()
+        self.assertEqual({
+            '/css/css-scroll-snap/snap-area.html',
+            '/css/css-scroll-snap/scroll-snap-type.html',
+            # A "/*" directory entry keeps its trailing slash.
+            '/css/css-scroll-snap/nested/',
+        }, tests_for_labels['interop-2026-scroll-snap'])
+        self.assertEqual({'/webrtc/RTCPeerConnection.html'}, tests_for_labels['interop-2026-webrtc'])
+        # Metadata without a label (e.g. a bug link) isn't a label.
+        self.assertNotIn('/dom/Node-appendChild.html', set().union(*tests_for_labels.values()))
+
+    def test_category_for_focus_area(self):
+        self.assertEqual('scroll-snap', self.finder().category_for_focus_area(2026, 'Scroll Snap'))
+
+    def test_category_for_unknown_focus_area(self):
+        with self.assertRaises(InteropDataError):
+            self.finder().category_for_focus_area(2026, 'Scroll Snapp')
+
+    def test_category_for_focus_area_in_unknown_year(self):
+        with self.assertRaises(InteropDataError):
+            self.finder().category_for_focus_area(2019, 'Scroll Snap')
+
+    def test_categories_for_year(self):
+        self.assertEqual({'scroll-snap'}, self.finder().categories_for_year(2026))
+        self.assertEqual({'scroll-snap', 'webrtc'}, self.finder().categories_for_year(2026, only_active=False))
+
+    def test_interop_scoring_categories_require_no_only_active(self):
+        with self.assertRaises(InteropDataError):
+            self.finder().categories_for_year(2026, only_active=True, use_interop_scoring_categories=True)
+        self.assertEqual(
+            {'Scroll Snap and friends'},
+            self.finder().categories_for_year(2026, only_active=False, use_interop_scoring_categories=True),
+        )
+
+    def test_labels_for_categories(self):
+        self.assertEqual(
+            {'scroll-snap': {'interop-2026-scroll-snap'}, 'webrtc': {'interop-2026-webrtc'}},
+            self.finder().labels_for_categories(2026),
+        )
+        self.assertEqual(
+            {'Scroll Snap and friends': {'interop-2026-scroll-snap', 'interop-2026-scroll-animations'}},
+            self.finder().labels_for_categories(2026, use_interop_scoring_labels=True),
+        )
+
+    def test_discover_years_from_data(self):
+        self.assertEqual({2026}, self.finder().discover_years_from_data())
+        self.assertEqual({2026}, self.finder().discover_years_from_data(use_interop_scoring_categories=True))
+
+    def test_data_is_only_fetched_once(self):
+        fetcher = MockJSONFetcher()
+        finder = LabelledTestFinder(json_fetcher=fetcher)
+        finder.tests_for_labels()
+        finder.tests_for_labels()
+        self.assertEqual(1, len(fetcher.fetched_urls))
+
+
+class FindWPTTestsTest(unittest.TestCase):
+    def find(self, fetcher=None, **kwargs):
+        fetcher = fetcher if fetcher is not None else MockJSONFetcher()
+        kwargs.setdefault('today', DURING_2026)
+        return find_wpt_tests(finder=LabelledTestFinder(json_fetcher=fetcher), **kwargs)
+
+    def test_labels(self):
+        self.assertEqual([
+            '/css/css-scroll-snap/nested/',
+            '/css/css-scroll-snap/scroll-snap-type.html',
+            '/css/css-scroll-snap/snap-area.html',
+        ], self.find(labels=['interop-2026-scroll-snap']))
+
+    def test_labels_alone_only_fetch_metadata(self):
+        fetcher = MockJSONFetcher()
+        self.find(fetcher=fetcher, labels=['interop-2026-scroll-snap'])
+        self.assertEqual(1, len(fetcher.fetched_urls))
+        self.assertTrue(fetcher.fetched_urls[0].endswith(METADATA_URL), fetcher.fetched_urls)
+
+    def test_unknown_label_finds_nothing(self):
+        self.assertEqual([], self.find(labels=['interop-2026-scroll-snapp']))
+
+    def test_focus_areas(self):
+        self.assertEqual([
+            '/css/css-scroll-snap/nested/',
+            '/css/css-scroll-snap/scroll-snap-type.html',
+            '/css/css-scroll-snap/snap-area.html',
+        ], self.find(years=[2026], focus_areas=['Scroll Snap']))
+
+    def test_categories(self):
+        self.assertEqual(
+            ['/webrtc/RTCPeerConnection.html'],
+            self.find(years=[2026], categories=['webrtc']),
+        )
+
+    def test_interop_scoring_categories(self):
+        self.assertEqual([
+            '/css/css-scroll-snap/nested/',
+            '/css/css-scroll-snap/scroll-snap-type.html',
+            '/css/css-scroll-snap/snap-area.html',
+            '/scroll-animations/view-timeline.html',
+        ], self.find(
+            years=[2026],
+            categories=['Scroll Snap and friends'],
+            use_interop_scoring_labels=True,
+        ))
+
+    def test_no_selection_defaults_to_active_categories_of_active_years(self):
+        # WebRTC doesn't count toward the score, so it isn't active.
+        self.assertEqual([
+            '/css/css-scroll-snap/nested/',
+            '/css/css-scroll-snap/scroll-snap-type.html',
+            '/css/css-scroll-snap/snap-area.html',
+        ], self.find())
+
+    def test_no_selection_with_inactive_categories(self):
+        self.assertEqual([
+            '/css/css-scroll-snap/nested/',
+            '/css/css-scroll-snap/scroll-snap-type.html',
+            '/css/css-scroll-snap/snap-area.html',
+            '/webrtc/RTCPeerConnection.html',
+        ], self.find(only_active=False))
+
+    def test_no_labels_to_search_for(self):
+        # No Interop year is active in 2019, so there are no categories to expand.
+        with self.assertRaises(InteropDataError):
+            self.find(today=date(2019, 7, 29))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/webkitpy/layout_tests/interop/layout_test_paths.py
+++ b/Tools/Scripts/webkitpy/layout_tests/interop/layout_test_paths.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Map the WPT tests in an Interop focus area onto imported LayoutTests paths."""
+
+import logging
+import re
+
+_log = logging.getLogger(__name__)
+
+IMPORTED_WPT_DIR = "imported/w3c/web-platform-tests"
+
+# The part of a test URL which isn't part of the file name on disk.
+_variant_re = re.compile(r"[?#]")
+
+
+def layout_test_path_for_wpt_test(wpt_test):
+    """Convert a WPT test URL into a LayoutTests-relative test path.
+
+    e.g. "/css/css-scroll-snap/snap-area.html?basic" becomes
+    "imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area.html?basic".
+
+    :param str wpt_test: a WPT test URL, or a directory of tests ending in "/"
+    :return str: the test path, relative to the LayoutTests directory
+    """
+    return "{}/{}".format(IMPORTED_WPT_DIR, wpt_test.lstrip("/").rstrip("/"))
+
+
+def imported_layout_test_paths(fs, layout_tests_dir, wpt_tests):
+    """Filter WPT tests down to the ones imported into LayoutTests.
+
+    Interop covers all of WPT, but WebKit only imports some of it, so tests
+    which aren't in this checkout are of no use to run-webkit-tests.
+
+    :param FileSystem fs: the current filesystem object
+    :param str layout_tests_dir: the LayoutTests directory (see: Port.layout_tests_dir())
+    :param Iterable[str] wpt_tests: WPT test URLs (see: find_wpt_tests())
+    :return Tuple[List[str], List[str]]: the LayoutTests-relative paths of the
+        imported tests, and the URLs of the tests which aren't imported
+    """
+    paths = []
+    not_imported = []
+
+    for wpt_test in wpt_tests:
+        path = layout_test_path_for_wpt_test(wpt_test)
+        # Variants ("?...") and fragments ("#...") aren't part of the file name.
+        file_path = _variant_re.split(path, 1)[0]
+        if fs.exists(fs.join(layout_tests_dir, *file_path.split("/"))):
+            paths.append(path)
+        else:
+            not_imported.append(wpt_test)
+
+    return paths, not_imported

--- a/Tools/Scripts/webkitpy/layout_tests/interop/layout_test_paths_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/interop/layout_test_paths_unittest.py
@@ -1,0 +1,121 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.layout_tests.interop.layout_test_paths import (
+    imported_layout_test_paths,
+    layout_test_path_for_wpt_test,
+)
+
+LAYOUT_TESTS_DIR = '/mock-checkout/LayoutTests'
+WPT_DIR = LAYOUT_TESTS_DIR + '/imported/w3c/web-platform-tests'
+
+
+class LayoutTestPathForWPTTestTest(unittest.TestCase):
+    def test_test_url(self):
+        self.assertEqual(
+            'imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area.html',
+            layout_test_path_for_wpt_test('/css/css-scroll-snap/snap-area.html'),
+        )
+
+    def test_url_without_leading_slash(self):
+        self.assertEqual(
+            'imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area.html',
+            layout_test_path_for_wpt_test('css/css-scroll-snap/snap-area.html'),
+        )
+
+    def test_variant_is_kept(self):
+        self.assertEqual(
+            'imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area.html?basic',
+            layout_test_path_for_wpt_test('/css/css-scroll-snap/snap-area.html?basic'),
+        )
+
+    def test_directory(self):
+        self.assertEqual(
+            'imported/w3c/web-platform-tests/css/css-scroll-snap',
+            layout_test_path_for_wpt_test('/css/css-scroll-snap/'),
+        )
+
+
+class ImportedLayoutTestPathsTest(unittest.TestCase):
+    def paths_for(self, wpt_tests):
+        fs = MockFileSystem(
+            files={
+                WPT_DIR + '/css/css-scroll-snap/snap-area.html': '',
+                WPT_DIR + '/css/css-scroll-snap/variants.html': '',
+                WPT_DIR + '/fetch/api/basic/accept-header.any.worker.html': '',
+            },
+            dirs={WPT_DIR + '/css/css-scroll-snap'},
+        )
+        return imported_layout_test_paths(fs, LAYOUT_TESTS_DIR, wpt_tests)
+
+    def test_imported_test(self):
+        self.assertEqual(
+            (['imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area.html'], []),
+            self.paths_for(['/css/css-scroll-snap/snap-area.html']),
+        )
+
+    def test_test_which_is_not_imported(self):
+        self.assertEqual(
+            ([], ['/css/css-scroll-snap/not-imported.html']),
+            self.paths_for(['/css/css-scroll-snap/not-imported.html']),
+        )
+
+    def test_variants_and_fragments_are_not_part_of_the_file_name(self):
+        self.assertEqual(([
+            'imported/w3c/web-platform-tests/css/css-scroll-snap/variants.html?a=b',
+            'imported/w3c/web-platform-tests/css/css-scroll-snap/variants.html#frag',
+        ], []), self.paths_for([
+            '/css/css-scroll-snap/variants.html?a=b',
+            '/css/css-scroll-snap/variants.html#frag',
+        ]))
+
+    def test_generated_test(self):
+        # WebKit's WPT import writes out the tests generated from .any.js files.
+        self.assertEqual(
+            (['imported/w3c/web-platform-tests/fetch/api/basic/accept-header.any.worker.html'], []),
+            self.paths_for(['/fetch/api/basic/accept-header.any.worker.html']),
+        )
+
+    def test_directory_of_tests(self):
+        self.assertEqual(
+            (['imported/w3c/web-platform-tests/css/css-scroll-snap'], []),
+            self.paths_for(['/css/css-scroll-snap/']),
+        )
+
+    def test_order_is_preserved(self):
+        paths, not_imported = self.paths_for([
+            '/css/css-scroll-snap/variants.html',
+            '/css/css-scroll-snap/not-imported.html',
+            '/css/css-scroll-snap/snap-area.html',
+        ])
+        self.assertEqual([
+            'imported/w3c/web-platform-tests/css/css-scroll-snap/variants.html',
+            'imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area.html',
+        ], paths)
+        self.assertEqual(['/css/css-scroll-snap/not-imported.html'], not_imported)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -37,7 +37,7 @@ import traceback
 from webkitpy.common.host import Host
 from webkitpy.common.interrupt_debugging import log_stack_trace_on_signal
 from webkitpy.layout_tests.controllers.manager import Manager
-from webkitpy.layout_tests.models.test_run_results import INTERRUPTED_EXIT_STATUS
+from webkitpy.layout_tests.models.test_run_results import INTERRUPTED_EXIT_STATUS, RunDetails
 from webkitpy.port import configuration_options, platform_options
 from webkitpy.layout_tests.views import buildbot_results
 from webkitpy.layout_tests.views import printing
@@ -84,6 +84,11 @@ def main(argv, stdout, stderr):
         logger = logging.getLogger()
         logger.setLevel(logging.DEBUG if options.debug_rwt_logging else logging.INFO)
         printer = printing.Printer(port, options, stderr, logger=logger)
+
+        if options.interop_labels:
+            args = _add_interop_tests(port, options, args)
+            if args is None:
+                return EXCEPTIONAL_EXIT_STATUS
 
         _set_up_derived_options(port, options)
         manager = Manager(port, options, printer)
@@ -283,6 +288,10 @@ def parse_args(args):
             help="directories or test to ignore (may specify multiple times)"),
         optparse.make_option("--test-list", action="append",
             help="read list of tests to run from file", metavar="FILE"),
+        optparse.make_option("--interop-label", action="append", default=[], dest="interop_labels", metavar="LABEL",
+            help="Run the imported WPT tests which carry this Interop label on wpt.fyi "
+                 "(e.g. interop-2026-scroll-snap). Tests which aren't imported into LayoutTests "
+                 "are ignored. Specify multiple times to run multiple labels."),
         optparse.make_option("--skipped", action="store", default="default",
             choices=["default", "ignore", "only", "always"],
             help=("control how tests marked SKIP are run. "
@@ -468,6 +477,39 @@ def parse_args(args):
     return options, args
 
 
+def _add_interop_tests(port, options, args):
+    """Expand --interop-label into the paths of the matching imported WPT tests.
+
+    :return Optional[List[str]]: the test paths to run, or None if the labels
+        don't match any test in this checkout.
+    """
+    # Imported lazily, since this hits the network and most runs don't need it.
+    from webkitpy.layout_tests.interop.interop_data import find_wpt_tests
+    from webkitpy.layout_tests.interop.layout_test_paths import imported_layout_test_paths
+
+    labels = ', '.join(options.interop_labels)
+    _log.info('Looking up the tests labelled %s on wpt.fyi ...' % labels)
+
+    try:
+        wpt_tests = find_wpt_tests(labels=options.interop_labels)
+    except Exception as e:
+        _log.critical('Unable to find the tests labelled %s: %s' % (labels, str(e)))
+        return None
+
+    if not wpt_tests:
+        _log.critical('No WPT test is labelled %s, see https://wpt.fyi/ for the labels in use' % labels)
+        return None
+
+    paths, not_imported = imported_layout_test_paths(port.host.filesystem, port.layout_tests_dir(), wpt_tests)
+    if not paths:
+        _log.critical('None of the %d tests labelled %s are imported into LayoutTests' % (len(wpt_tests), labels))
+        return None
+
+    _log.info('Found %d of the %d tests labelled %s in LayoutTests' % (len(paths), len(wpt_tests), labels))
+    if not_imported:
+        _log.debug('Tests labelled %s which are not imported into LayoutTests:\n  %s' % (labels, '\n  '.join(not_imported)))
+
+    return args + paths
 
 
 def _set_up_derived_options(port, options):
@@ -606,6 +648,11 @@ def run(port, options, args, logging_stream):
                 GDBCrashLogStartupHandler()
             except (OSError, ImportError) as e:
                 _log.error(f'Failed to initialize crash log handler: {e}')
+
+        if options.interop_labels:
+            args = _add_interop_tests(port, options, args)
+            if args is None:
+                return RunDetails(exit_code=-1)
 
         _set_up_derived_options(port, options)
         manager = Manager(port, options, printer)


### PR DESCRIPTION
#### c142f5fa6211796bcbd399b2d838f263e4fd0727
<pre>
Make it possible to run a subset of Interop tests via `run-webkit-tests`
<a href="https://bugs.webkit.org/show_bug.cgi?id=319357">https://bugs.webkit.org/show_bug.cgi?id=319357</a>
<a href="https://rdar.apple.com/182166955">rdar://182166955</a>

Reviewed by NOBODY (OOPS!).

Add an `--interop-label` argument to `run-webkit-tests`. This will fetch the list
of WPTs with this label from wpt.fyi, via the newly added
`webkitpy/layout_tests/interop/interop_data.py` module, and then run those tests
from `LayoutTests/imported/w3c/web-platform-tests`.

It will warn if not all of the tests in the list are present in the WebKit repo,
indicating that some tests have not been imported.

* Tools/Scripts/webkitpy/layout_tests/interop/__init__.py: Added.
* Tools/Scripts/webkitpy/layout_tests/interop/interop_data.py: Added.
(InteropDataError):
(fetch_json):
(InteropYear):
(InteropYear.__post_init__):
(InteropYear.year):
(LabelledTestFinder):
(LabelledTestFinder.__init__):
(LabelledTestFinder.interop_data):
(LabelledTestFinder.category_data):
(LabelledTestFinder.metadata_data):
(LabelledTestFinder.category_for_focus_area):
(LabelledTestFinder.categories_for_year):
(LabelledTestFinder.labels_for_categories):
(LabelledTestFinder.discover_years_from_data):
(LabelledTestFinder.tests_for_labels):
(find_wpt_tests):
(_resolve_years):
* Tools/Scripts/webkitpy/layout_tests/interop/interop_data_unittest.py: Added.
(MockJSONFetcher):
(MockJSONFetcher.__init__):
(MockJSONFetcher.__call__):
(InteropYearTest):
(InteropYearTest.test_year_is_the_start_year):
(InteropYearTest.test_end_before_start_is_rejected):
(LabelledTestFinderTest):
(LabelledTestFinderTest.finder):
(LabelledTestFinderTest.test_tests_for_labels):
(LabelledTestFinderTest.test_category_for_focus_area):
(LabelledTestFinderTest.test_category_for_unknown_focus_area):
(LabelledTestFinderTest.test_category_for_focus_area_in_unknown_year):
(LabelledTestFinderTest.test_categories_for_year):
(LabelledTestFinderTest.test_interop_scoring_categories_require_no_only_active):
(LabelledTestFinderTest.test_labels_for_categories):
(LabelledTestFinderTest.test_discover_years_from_data):
(LabelledTestFinderTest.test_data_is_only_fetched_once):
(FindWPTTestsTest):
(FindWPTTestsTest.find):
(FindWPTTestsTest.test_labels):
(FindWPTTestsTest.test_labels_alone_only_fetch_metadata):
(FindWPTTestsTest.test_unknown_label_finds_nothing):
(FindWPTTestsTest.test_focus_areas):
(FindWPTTestsTest.test_categories):
(FindWPTTestsTest.test_interop_scoring_categories):
(FindWPTTestsTest.test_no_selection_defaults_to_active_categories_of_active_years):
(FindWPTTestsTest.test_no_selection_with_inactive_categories):
(FindWPTTestsTest.test_no_labels_to_search_for):
* Tools/Scripts/webkitpy/layout_tests/interop/layout_test_paths.py: Added.
(layout_test_path_for_wpt_test):
(imported_layout_test_paths):
* Tools/Scripts/webkitpy/layout_tests/interop/layout_test_paths_unittest.py: Added.
(LayoutTestPathForWPTTestTest):
(LayoutTestPathForWPTTestTest.test_test_url):
(LayoutTestPathForWPTTestTest.test_url_without_leading_slash):
(LayoutTestPathForWPTTestTest.test_variant_is_kept):
(LayoutTestPathForWPTTestTest.test_directory):
(ImportedLayoutTestPathsTest):
(ImportedLayoutTestPathsTest.paths_for):
(ImportedLayoutTestPathsTest.test_imported_test):
(ImportedLayoutTestPathsTest.test_test_which_is_not_imported):
(ImportedLayoutTestPathsTest.test_variants_and_fragments_are_not_part_of_the_file_name):
(ImportedLayoutTestPathsTest.test_generated_test):
(ImportedLayoutTestPathsTest.test_directory_of_tests):
(ImportedLayoutTestPathsTest.test_order_is_preserved):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(main):
(parse_args):
(_add_interop_tests):
(run):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c142f5fa6211796bcbd399b2d838f263e4fd0727

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177822 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141069 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3da7854-2d5b-42ac-b1ac-2363b688231e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138605 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96356 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aee4178c-2253-416b-8a3a-82a97c449a87) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180778 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119068 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/afb76eb3-874c-4ca7-bd5c-063aed00013f) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/177145 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40797 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39157 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151202 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38848 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35893 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189861 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51427 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147725 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52109 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147511 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42225 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118792 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50617 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13827 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50013 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50253 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50075 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->