### PR TITLE
[GFC] Generate leading implicit tracks for negative line placements

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -53,27 +53,35 @@ GridFormattingContext::GridFormattingContext(const ElementBox& gridBox, LayoutSt
 {
 }
 
-UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
+static LogicalGridItems constructLogicalGridItems(const ElementBox& gridBox)
 {
-    struct GridItem {
-        CheckedRef<const ElementBox> layoutBox;
-        int order;
-    };
+    LogicalGridItems logicalGridItems;
+    for (CheckedRef gridItem : childrenOfType<ElementBox>(gridBox)) {
+        if (gridItem->isOutOfFlowPositioned())
+            continue;
 
+        logicalGridItems.append(gridItem);
+    }
+
+    std::ranges::stable_sort(logicalGridItems, { }, [](auto& gridItem) {
+        return gridItem->style().order().value;
+    });
+    return logicalGridItems;
+}
+
+static LeadingImplicitTracks computeLeadingImplicitTracks(const ElementBox& gridBox, const LogicalGridItems& logicalGridItems)
+{
     // Negative line placements are resolved against the explicit grid track count, which can still
     // produce a negative line when the placement counts past the start edge of the explicit grid.
     // Those are normalized by shifting every line forward by the magnitude of the most-negative
     // resolved line, so e.g. with 3 explicit columns a column-start of -5 resolves to line -1,
-    // which shifts all column lines forward by 1 and maps to matrix column 0.
-    auto explicitColumnCount = m_gridBox->style().gridTemplateColumns().sizes.size();
-    auto explicitRowCount = m_gridBox->style().gridTemplateRows().sizes.size();
+    // which shifts all column lines forward by 1 and maps to matrix column 0. That magnitude is
+    // also the number of leading implicit tracks the grid needs to generate.
+    auto explicitColumnCount = gridBox.style().gridTemplateColumns().sizes.size();
+    auto explicitRowCount = gridBox.style().gridTemplateRows().sizes.size();
     int minimumColumnLine = 0;
     int minimumRowLine = 0;
-    Vector<GridItem> gridItems;
-    for (CheckedRef gridItem : childrenOfType<ElementBox>(m_gridBox)) {
-        if (gridItem->isOutOfFlowPositioned())
-            continue;
-
+    for (auto& gridItem : logicalGridItems) {
         CheckedRef gridItemStyle = gridItem->style();
         if (auto columnRange = UnplacedGridItem::resolveDefinitePosition(gridItemStyle->gridItemColumnStart(), gridItemStyle->gridItemColumnEnd(), explicitColumnCount)) {
             auto [startLine, endLine] = *columnRange;
@@ -83,18 +91,22 @@ UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
             auto [startLine, endLine] = *rowRange;
             minimumRowLine = std::min({ minimumRowLine, startLine, endLine });
         }
-
-        gridItems.append({ gridItem, gridItemStyle->order().value });
     }
 
-    std::ranges::stable_sort(gridItems, { }, &GridItem::order);
+    return {
+        minimumColumnLine < 0 ? static_cast<size_t>(-minimumColumnLine) : 0,
+        minimumRowLine < 0 ? static_cast<size_t>(-minimumRowLine) : 0
+    };
+}
 
-    size_t columnNegativeLineOffset = minimumColumnLine < 0 ? static_cast<size_t>(-minimumColumnLine) : 0;
-    size_t rowNegativeLineOffset = minimumRowLine < 0 ? static_cast<size_t>(-minimumRowLine) : 0;
+UnplacedGridItems GridFormattingContext::constructUnplacedGridItems(const LogicalGridItems& logicalGridItems, LeadingImplicitTracks leadingImplicitTracks) const
+{
+    auto explicitColumnCount = m_gridBox->style().gridTemplateColumns().sizes.size();
+    auto explicitRowCount = m_gridBox->style().gridTemplateRows().sizes.size();
 
     UnplacedGridItems unplacedGridItems;
-    for (auto& gridItem : gridItems) {
-        CheckedRef gridItemStyle = gridItem.layoutBox->style();
+    for (auto& gridItem : logicalGridItems) {
+        CheckedRef gridItemStyle = gridItem->style();
 
         auto gridItemColumnStart = gridItemStyle->gridItemColumnStart();
         auto gridItemColumnEnd = gridItemStyle->gridItemColumnEnd();
@@ -102,15 +114,15 @@ UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
         auto gridItemRowEnd = gridItemStyle->gridItemRowEnd();
 
         UnplacedGridItem unplacedGridItem {
-            gridItem.layoutBox,
+            gridItem,
             gridItemColumnStart,
             gridItemColumnEnd,
             gridItemRowStart,
             gridItemRowEnd,
             explicitColumnCount,
             explicitRowCount,
-            columnNegativeLineOffset,
-            rowNegativeLineOffset
+            leadingImplicitTracks.columnsCount,
+            leadingImplicitTracks.rowsCount
         };
 
         // https://drafts.csswg.org/css-grid-1/#auto-placement-algo
@@ -185,7 +197,9 @@ static Style::GridTemplateList gridTemplateListWithPercentagesConvertedToAuto(co
 
 GridLayoutResult GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)
 {
-    auto unplacedGridItems = constructUnplacedGridItems();
+    auto logicalGridItems = constructLogicalGridItems(root());
+    auto leadingImplicitTracks = computeLeadingImplicitTracks(root(), logicalGridItems);
+    auto unplacedGridItems = constructUnplacedGridItems(logicalGridItems, leadingImplicitTracks);
     CheckedRef gridStyle = root().style();
 
     GridAutoFlowOptions autoFlowOptions {
@@ -213,7 +227,7 @@ GridLayoutResult GridFormattingContext::layout(GridLayoutConstraints layoutConst
 
     GridLayoutState layoutState { layoutConstraints, gridDefinition, usedJustifyContent, usedAlignContent, usedGapValue(gridStyle->columnGap(), gridStyle), usedGapValue(gridStyle->rowGap(), gridStyle) };
 
-    auto [ usedTrackSizes, gridItemRects ] = GridLayout { *this }.layout(unplacedGridItems, layoutState);
+    auto [ usedTrackSizes, gridItemRects ] = GridLayout { *this }.layout(unplacedGridItems, leadingImplicitTracks, layoutState);
 
     // Grid layout positions each item within its containing block which is the grid area.
     // Here we translate it to the coordinate space of the grid.
@@ -323,7 +337,9 @@ GridFormattingContext::IntrinsicWidths GridFormattingContext::computeIntrinsicWi
     auto usedColumnGap = usedGapValue(gridStyle->columnGap(), gridStyle);
     auto usedRowGap = usedGapValue(gridStyle->rowGap(), gridStyle);
 
-    auto unplacedGridItems = constructUnplacedGridItems();
+    auto logicalGridItems = constructLogicalGridItems(root());
+    auto leadingImplicitTracks = computeLeadingImplicitTracks(root(), logicalGridItems);
+    auto unplacedGridItems = constructUnplacedGridItems(logicalGridItems, leadingImplicitTracks);
 
     auto columnSizesForConstraint = [&](AxisConstraint intrinsicConstraint) -> TrackSizes {
         GridLayoutConstraints layoutConstraints {
@@ -341,7 +357,7 @@ GridFormattingContext::IntrinsicWidths GridFormattingContext::computeIntrinsicWi
             ? GridLayoutScope::ColumnSizingOnly
             : GridLayoutScope::Full;
 
-        return GridLayout { *this }.layout(unplacedGridItemsForScenario, layoutState, scope).usedTrackSizes.columnSizes;
+        return GridLayout { *this }.layout(unplacedGridItemsForScenario, leadingImplicitTracks, layoutState, scope).usedTrackSizes.columnSizes;
     };
 
     TrackSizes minContentColumnSizes = columnSizesForConstraint(AxisConstraint::minContent());

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -67,6 +67,16 @@ struct GridLayoutResult {
     GridItemRects gridItemRects;
 };
 
+// The number of implicit tracks generated before the start of the explicit grid, per axis, because
+// an item is placed with a negative line that resolves before line 1. Every item's resolved line is
+// shifted forward by these counts when the UnplacedGridItems are constructed so that matrix indices
+// are non-negative, and layout uses them to include the leading tracks in the grid's initial
+// dimensions and track sizing functions.
+struct LeadingImplicitTracks {
+    size_t columnsCount { 0 };
+    size_t rowsCount { 0 };
+};
+
 // https://drafts.csswg.org/css-grid-1/#grid-definition
 struct GridDefinition {
     Style::GridTemplateList gridTemplateColumns;
@@ -130,7 +140,7 @@ public:
     }
 
 private:
-    UnplacedGridItems constructUnplacedGridItems() const;
+    UnplacedGridItems constructUnplacedGridItems(const LogicalGridItems&, LeadingImplicitTracks) const;
 
     IntrinsicWidthSizingPath classifyIntrinsicWidthSizingPath() const;
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -61,10 +61,17 @@ GridLayout::GridLayout(const GridFormattingContext& gridFormattingContext)
 {
 }
 
-GridDimensions GridLayout::calculateInitialImplicitGridDimensions(const UnplacedGridItems& unplacedGridItems, size_t explicitColumnsCount, size_t explicitRowsCount)
+// FIXME: Try moving this to GridFormattingContext to simplify the layout code. The initial implicit
+// grid dimensions depend only on the resolved definite item placements (from constructUnplacedGridItems),
+// the explicit track counts (from style), and the leading implicit track counts, which are all
+// available before layout, so it may be possible to compute them there instead of on GridLayout.
+GridDimensions GridLayout::calculateInitialImplicitGridDimensions(const UnplacedGridItems& unplacedGridItems, LeadingImplicitTracks leadingImplicitTracks, size_t explicitColumnsCount, size_t explicitRowsCount)
 {
-    size_t maximumColumnIndex = explicitColumnsCount;
-    size_t maximumRowIndex = explicitRowsCount;
+    // The explicit grid is preceded by any leading implicit tracks generated for items placed with
+    // a negative line that resolves before the grid start. Every item's line has already been
+    // shifted forward by this amount, so include the leading tracks in the initial bounds.
+    size_t maximumColumnIndex = explicitColumnsCount + leadingImplicitTracks.columnsCount;
+    size_t maximumRowIndex = explicitRowsCount + leadingImplicitTracks.rowsCount;
 
     auto updateGridBounds = [&](const UnplacedGridItem& item) {
         if (item.hasDefiniteRowPosition()) {
@@ -95,10 +102,10 @@ GridDimensions GridLayout::calculateInitialImplicitGridDimensions(const Unplaced
     };
 }
 
-ImplicitGrid GridLayout::constructInitialImplicitGrid(const UnplacedGridItems& unplacedGridItems, size_t explicitColumnsCount, size_t explicitRowsCount)
+ImplicitGrid GridLayout::constructInitialImplicitGrid(const UnplacedGridItems& unplacedGridItems, LeadingImplicitTracks leadingImplicitTracks, size_t explicitColumnsCount, size_t explicitRowsCount)
 {
     auto initialDimensions = calculateInitialImplicitGridDimensions(
-        unplacedGridItems, explicitColumnsCount, explicitRowsCount);
+        unplacedGridItems, leadingImplicitTracks, explicitColumnsCount, explicitRowsCount);
 
     ImplicitGrid implicitGrid(initialDimensions.totalColumns, initialDimensions.totalRows);
     // 3. Determine the columns in the implicit grid.
@@ -112,7 +119,7 @@ ImplicitGrid GridLayout::constructInitialImplicitGrid(const UnplacedGridItems& u
 
 // 8.5. Grid Item Placement Algorithm.
 // https://drafts.csswg.org/css-grid-1/#auto-placement-algo
-auto GridLayout::placeGridItems(UnplacedGridItems& unplacedGridItems, const Vector<Style::GridTrackSize>& gridTemplateColumnsTrackSizes,
+auto GridLayout::placeGridItems(UnplacedGridItems& unplacedGridItems, LeadingImplicitTracks leadingImplicitTracks, const Vector<Style::GridTrackSize>& gridTemplateColumnsTrackSizes,
     const Vector<Style::GridTrackSize>& gridTemplateRowsTrackSizes, GridAutoFlowOptions autoFlowOptions)
 {
     struct Result {
@@ -121,7 +128,7 @@ auto GridLayout::placeGridItems(UnplacedGridItems& unplacedGridItems, const Vect
         size_t rowsCount;
     };
 
-    auto implicitGrid = constructInitialImplicitGrid(unplacedGridItems, gridTemplateColumnsTrackSizes.size(), gridTemplateRowsTrackSizes.size());
+    auto implicitGrid = constructInitialImplicitGrid(unplacedGridItems, leadingImplicitTracks, gridTemplateColumnsTrackSizes.size(), gridTemplateRowsTrackSizes.size());
 
     // 1. Position anything that's not auto-positioned.
     for (auto& nonAutoPositionedItem : unplacedGridItems.nonAutoPositionedItems)
@@ -183,7 +190,7 @@ static GridAreaSizes computeGridAreaSizes(const PlacedGridItems& gridItems, cons
 }
 
 // https://drafts.csswg.org/css-grid-1/#layout-algorithm
-GridLayoutResult GridLayout::layout(UnplacedGridItems& unplacedGridItems, const GridLayoutState& gridLayoutState, GridLayoutScope scope)
+GridLayoutResult GridLayout::layout(UnplacedGridItems& unplacedGridItems, LeadingImplicitTracks leadingImplicitTracks, const GridLayoutState& gridLayoutState, GridLayoutScope scope)
 {
     auto& gridDefinition = gridLayoutState.gridDefinition;
     auto& gridTemplateColumnsTrackSizes = gridDefinition.gridTemplateColumns.sizes;
@@ -191,11 +198,11 @@ GridLayoutResult GridLayout::layout(UnplacedGridItems& unplacedGridItems, const 
 
     auto& formattingContext = this->formattingContext();
     // 1. Run the Grid Item Placement Algorithm to resolve the placement of all grid items in the grid.
-    auto [ gridAreas, columnsCount, rowsCount ] = placeGridItems(unplacedGridItems, gridTemplateColumnsTrackSizes, gridTemplateRowsTrackSizes, gridDefinition.autoFlowOptions);
+    auto [ gridAreas, columnsCount, rowsCount ] = placeGridItems(unplacedGridItems, leadingImplicitTracks, gridTemplateColumnsTrackSizes, gridTemplateRowsTrackSizes, gridDefinition.autoFlowOptions);
     auto placedGridItems = formattingContext.constructPlacedGridItems(gridAreas);
 
-    auto columnTrackSizingFunctionsList = trackSizingFunctions(columnsCount, gridTemplateColumnsTrackSizes, gridDefinition.gridAutoColumns, gridDefinition.zoom);
-    auto rowTrackSizingFunctionsList = trackSizingFunctions(rowsCount, gridTemplateRowsTrackSizes, gridDefinition.gridAutoRows, gridDefinition.zoom);
+    auto columnTrackSizingFunctionsList = trackSizingFunctions(columnsCount, leadingImplicitTracks.columnsCount, gridTemplateColumnsTrackSizes, gridDefinition.gridAutoColumns, gridDefinition.zoom);
+    auto rowTrackSizingFunctionsList = trackSizingFunctions(rowsCount, leadingImplicitTracks.rowsCount, gridTemplateRowsTrackSizes, gridDefinition.gridAutoRows, gridDefinition.zoom);
 
     // https://drafts.csswg.org/css-grid-1/#algo-grid-sizing
     // Fast path: the caller only needs the column sizes resolved by step 1 of the grid sizing
@@ -328,13 +335,16 @@ TrackSizingFunctions GridLayout::convertGridTrackSizeToTrackSizingFunctions(cons
     return TrackSizingFunctions { minTrackSizingFunction(), maxTrackSizingFunction(), zoom };
 }
 
-// Generates track sizing functions for implicit tracks using grid-auto-{columns,rows}
-// FIXME: This function only supports appended tracks but not prepended tracks.
-TrackSizingFunctionsList GridLayout::generateImplicitTrackSizingFunctions(size_t explicitTracksCount, size_t totalTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor& zoom)
+// Generates track sizing functions for implicitTracksCount implicit tracks using
+// grid-auto-{columns,rows}, cycling forwards through the provided sizes starting from the first.
+// FIXME: This produces the correct sizes for trailing implicit tracks (after the explicit grid) and
+// for any single-value grid-auto-{columns,rows}, but not for leading implicit tracks (before the
+// explicit grid) when grid-auto-{columns,rows} lists multiple track sizes. Per spec the leading
+// tracks cycle backwards -- "the last implicit grid track before the explicit grid receives the
+// last specified size, and so on backwards" -- whereas this always cycles forwards from the first
+// size. https://drafts.csswg.org/css-grid-1/#auto-tracks
+TrackSizingFunctionsList GridLayout::generateImplicitTrackSizingFunctions(size_t implicitTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor& zoom)
 {
-    // https://drafts.csswg.org/css-grid-1/#auto-tracks
-    size_t implicitTracksCount = totalTracksCount - explicitTracksCount;
-
     TrackSizingFunctionsList trackSizingFunctionsForImplicitGrid;
     trackSizingFunctionsForImplicitGrid.reserveInitialCapacity(implicitTracksCount);
 
@@ -347,25 +357,29 @@ TrackSizingFunctionsList GridLayout::generateImplicitTrackSizingFunctions(size_t
     return trackSizingFunctionsForImplicitGrid;
 }
 
-TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t totalTracksCount, const Vector<Style::GridTrackSize>& gridTemplateTrackSizes, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor& zoom)
+TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t totalTracksCount, size_t leadingImplicitTracksCount, const Vector<Style::GridTrackSize>& gridTemplateTrackSizes, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor& zoom)
 {
-    // FIXME: This function only supports appended tracks but not prepended tracks.
-    // Per spec, we should support both forward and backward implicit tracks.
-    ASSERT_WITH_MESSAGE(totalTracksCount >= gridTemplateTrackSizes.size(), "Total tracks should be at least as many as explicit tracks");
+    auto explicitTracksCount = gridTemplateTrackSizes.size();
+    ASSERT_WITH_MESSAGE(totalTracksCount >= leadingImplicitTracksCount + explicitTracksCount, "Total tracks should be at least as many as the leading implicit tracks plus the explicit tracks");
 
     TrackSizingFunctionsList trackSizingFunctions;
     trackSizingFunctions.reserveInitialCapacity(totalTracksCount);
+
+    // https://drafts.csswg.org/css-grid-1/#auto-tracks
+    // Leading implicit tracks are generated before the start of the explicit grid (for items placed
+    // with a negative line that resolves before line 1) and are sized by grid-auto-{columns,rows}.
+    trackSizingFunctions.appendVector(generateImplicitTrackSizingFunctions(leadingImplicitTracksCount, gridAutoTrackSizes, zoom));
 
     // https://drafts.csswg.org/css-grid-1/#algo-terms
     // Map explicit tracks from grid-template-{columns,rows}
     for (auto& gridTrackSize : gridTemplateTrackSizes)
         trackSizingFunctions.append(convertGridTrackSizeToTrackSizingFunctions(gridTrackSize, zoom));
 
-    // Generate implicit tracks using grid-auto-{columns,rows}
+    // Generate trailing implicit tracks using grid-auto-{columns,rows}
     // https://drafts.csswg.org/css-grid-1/#auto-tracks
     // "The first track after the last explicitly-sized track receives the first specified size, and so on forwards"
-    auto implicitTrackSizingFunctions = generateImplicitTrackSizingFunctions(gridTemplateTrackSizes.size(), totalTracksCount, gridAutoTrackSizes, zoom);
-    trackSizingFunctions.appendVector(implicitTrackSizingFunctions);
+    auto trailingImplicitTracksCount = totalTracksCount - leadingImplicitTracksCount - explicitTracksCount;
+    trackSizingFunctions.appendVector(generateImplicitTrackSizingFunctions(trailingImplicitTracksCount, gridAutoTrackSizes, zoom));
 
     ASSERT(trackSizingFunctions.size() == totalTracksCount);
     return trackSizingFunctions;

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -60,19 +60,19 @@ class GridLayout {
 public:
     GridLayout(const GridFormattingContext&);
 
-    GridLayoutResult layout(UnplacedGridItems&, const GridLayoutState&, GridLayoutScope = GridLayoutScope::Full);
+    GridLayoutResult layout(UnplacedGridItems&, LeadingImplicitTracks, const GridLayoutState&, GridLayoutScope = GridLayoutScope::Full);
 
 private:
 
-    auto placeGridItems(UnplacedGridItems&, const Vector<Style::GridTrackSize>& gridTemplateColumnsTrackSizes,
+    auto placeGridItems(UnplacedGridItems&, LeadingImplicitTracks, const Vector<Style::GridTrackSize>& gridTemplateColumnsTrackSizes,
         const Vector<Style::GridTrackSize>& gridTemplateRowsTrackSizes, GridAutoFlowOptions);
 
-    static GridDimensions calculateInitialImplicitGridDimensions(const UnplacedGridItems&, size_t explicitColumnsCount, size_t explicitRowsCount);
-    ImplicitGrid constructInitialImplicitGrid(const UnplacedGridItems&, size_t explicitColumnsCount, size_t explicitRowsCount);
+    static GridDimensions calculateInitialImplicitGridDimensions(const UnplacedGridItems&, LeadingImplicitTracks, size_t explicitColumnsCount, size_t explicitRowsCount);
+    ImplicitGrid constructInitialImplicitGrid(const UnplacedGridItems&, LeadingImplicitTracks, size_t explicitColumnsCount, size_t explicitRowsCount);
 
     static TrackSizingFunctions convertGridTrackSizeToTrackSizingFunctions(const Style::GridTrackSize&, const Style::ZoomFactor&);
-    static TrackSizingFunctionsList generateImplicitTrackSizingFunctions(size_t explicitTracksCount, size_t totalTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor&);
-    static TrackSizingFunctionsList trackSizingFunctions(size_t totalTracksCount, const Vector<Style::GridTrackSize>& gridTemplateTrackSizes, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor&);
+    static TrackSizingFunctionsList generateImplicitTrackSizingFunctions(size_t implicitTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor&);
+    static TrackSizingFunctionsList trackSizingFunctions(size_t totalTracksCount, size_t leadingImplicitTracksCount, const Vector<Style::GridTrackSize>& gridTemplateTrackSizes, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor&);
 
     UsedTrackSizes performGridSizingAlgorithm(const GridLayoutState&, const PlacedGridItems&, const TrackSizingFunctionsList&, const TrackSizingFunctionsList&) const;
     TrackSizes sizeColumnTracks(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctions, const TrackSizingFunctionsList& rowTrackSizingFunctions, const GridLayoutState&) const;

--- a/Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h
@@ -36,6 +36,7 @@ class LayoutUnit;
 
 namespace Layout {
 
+class ElementBox;
 class PlacedGridItem;
 class UnplacedGridItem;
 
@@ -54,6 +55,7 @@ using GridAreas = HashMap<UnplacedGridItem, GridAreaLines>;
 using GridCell = Vector<UnplacedGridItem, 1>;
 using GridItemRects = Vector<GridItemRect>;
 using GridMatrix = Vector<Vector<GridCell>>;
+using LogicalGridItems = Vector<WTF::CheckedRef<const ElementBox>>;
 using PlacedGridItems = Vector<PlacedGridItem>;
 using PlacedGridItemSpanList = Vector<WTF::Range<size_t>>;
 using TrackSizes = Vector<LayoutUnit>;

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
@@ -42,8 +42,8 @@ namespace Layout {
 // index. For example, with 3 explicit columns (lines 0..3):
 //     -1 -> 3 (last line), -4 -> 0 (first line), -5 -> -1, -6 -> -2 (two lines before the start).
 // A negative index is not a valid matrix position on its own; GridFormattingContext computes the
-// most-negative line across all items and shifts every line forward by that magnitude (the
-// negative-line offset) so, e.g., -2 above maps to matrix column 0. See GridPosition::create().
+// most-negative line across all items and shifts every line forward by that magnitude (the number
+// of leading implicit tracks) so, e.g., -2 above maps to matrix column 0. See GridPosition::create().
 static int explicitLineToIndex(const Style::GridPosition& position, size_t explicitTrackCount)
 {
     ASSERT(position.isExplicit());
@@ -53,7 +53,7 @@ static int explicitLineToIndex(const Style::GridPosition& position, size_t expli
     return line > 0 ? line - 1 : static_cast<int>(explicitTrackCount) + 1 + line;
 }
 
-UnplacedGridItem::GridPosition UnplacedGridItem::GridPosition::create(const Style::GridPosition& start, const Style::GridPosition& end, size_t explicitTrackCount, size_t negativeLineOffset)
+UnplacedGridItem::GridPosition UnplacedGridItem::GridPosition::create(const Style::GridPosition& start, const Style::GridPosition& end, size_t explicitTrackCount, size_t leadingImplicitTracksCount)
 {
     auto explicitRange = UnplacedGridItem::resolveDefinitePosition(start, end, explicitTrackCount);
     if (!explicitRange) {
@@ -67,12 +67,12 @@ UnplacedGridItem::GridPosition UnplacedGridItem::GridPosition::create(const Styl
         return AutoPosition { span };
     }
 
-    // Shift the resolved range forward by the negative-line offset. The offset is the magnitude of
-    // the most-negative line across all items, so applying it maps every line to a non-negative
-    // matrix index.
+    // Shift the resolved range forward by the number of leading implicit tracks. That count is the
+    // magnitude of the most-negative line across all items, so applying it maps every line to a
+    // non-negative matrix index.
     auto [rawStartLine, rawEndLine] = *explicitRange;
-    int startLine = rawStartLine + static_cast<int>(negativeLineOffset);
-    int endLine = rawEndLine + static_cast<int>(negativeLineOffset);
+    int startLine = rawStartLine + static_cast<int>(leadingImplicitTracksCount);
+    int endLine = rawEndLine + static_cast<int>(leadingImplicitTracksCount);
 
     ASSERT(startLine >= 0 && endLine >= 0);
     // The range is always forward. The span/auto branches derive endLine from startLine, and the
@@ -122,10 +122,10 @@ size_t UnplacedGridItem::GridPosition::span() const
 
 UnplacedGridItem::UnplacedGridItem(const ElementBox& layoutBox, Style::GridPosition columnStart, Style::GridPosition columnEnd,
     Style::GridPosition rowStart, Style::GridPosition rowEnd, size_t explicitColumnCount, size_t explicitRowCount,
-    size_t columnNegativeLineOffset, size_t rowNegativeLineOffset)
+    size_t leadingImplicitColumnsCount, size_t leadingImplicitRowsCount)
     : m_layoutBox(layoutBox)
-    , m_columnPosition(GridPosition::create(columnStart, columnEnd, explicitColumnCount, columnNegativeLineOffset))
-    , m_rowPosition(GridPosition::create(rowStart, rowEnd, explicitRowCount, rowNegativeLineOffset))
+    , m_columnPosition(GridPosition::create(columnStart, columnEnd, explicitColumnCount, leadingImplicitColumnsCount))
+    , m_rowPosition(GridPosition::create(rowStart, rowEnd, explicitRowCount, leadingImplicitRowsCount))
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -60,10 +60,10 @@ private:
     class GridPosition {
     public:
         // explicitTrackCount is the number of explicit tracks in the axis, used to resolve negative
-        // lines against the end of the explicit grid. The negative-line offset then shifts negative
-        // resolved lines forward so the range maps to non-negative matrix indices. See
+        // lines against the end of the explicit grid. The leading implicit track count then shifts
+        // negative resolved lines forward so the range maps to non-negative matrix indices. See
         // UnplacedGridItem::resolveDefinitePosition().
-        static GridPosition create(const Style::GridPosition& start, const Style::GridPosition& end, size_t explicitTrackCount, size_t negativeLineOffset);
+        static GridPosition create(const Style::GridPosition& start, const Style::GridPosition& end, size_t explicitTrackCount, size_t leadingImplicitTracksCount);
 
         bool isDefinite() const { return std::holds_alternative<DefinitePosition>(m_position); }
         bool isAuto() const { return std::holds_alternative<AutoPosition>(m_position); }
@@ -86,7 +86,7 @@ private:
     };
 
 public:
-    UnplacedGridItem(const ElementBox&, Style::GridPosition columnStart, Style::GridPosition columnEnd, Style::GridPosition rowStart, Style::GridPosition rowEnd, size_t explicitColumnCount, size_t explicitRowCount, size_t columnNegativeLineOffset, size_t rowNegativeLineOffset);
+    UnplacedGridItem(const ElementBox&, Style::GridPosition columnStart, Style::GridPosition columnEnd, Style::GridPosition rowStart, Style::GridPosition rowEnd, size_t explicitColumnCount, size_t explicitRowCount, size_t leadingImplicitColumnsCount, size_t leadingImplicitRowsCount);
     UnplacedGridItem(WTF::HashTableEmptyValueType);
 
     bool operator==(const UnplacedGridItem& other) const;
@@ -108,7 +108,7 @@ public:
     // Resolves the 0-based explicit line range [start, end) for an axis, or std::nullopt when the
     // axis is auto-positioned. explicitTrackCount is used to resolve negative lines against the end
     // of the explicit grid; the resolved lines may still be negative for negative line placements
-    // that count past the start edge, and the negative-line offset is applied later in
+    // that count past the start edge, and the leading implicit track count is applied later in
     // GridPosition::create().
     static std::optional<std::pair<int, int>> resolveDefinitePosition(const Style::GridPosition& start, const Style::GridPosition& end, size_t explicitTrackCount);
 


### PR DESCRIPTION
#### a64300296c7752fbd4ae85a9621f2f277a4ebb59
<pre>
[GFC] Generate leading implicit tracks for negative line placements
<a href="https://bugs.webkit.org/show_bug.cgi?id=320680">https://bugs.webkit.org/show_bug.cgi?id=320680</a>
<a href="https://rdar.apple.com/problem/183664987">rdar://problem/183664987</a>

Reviewed by Alan Baradlay.

When a grid item is placed with a negative line that resolves before the start of
the explicit grid, leading implicit tracks must be generated before the explicit
grid. GridFormattingContext already computes a count of those tracks and shifts
every item&apos;s line forward so that its DefinitePosition, if it has one,
is non-negative during layout (relative to the implicit grid). However,
grid layout does not know how many of those leading implicit tracks
there are which is an additional piece of information that it will need
to keep track of.

In GridFormattingContext we compute the number of implicit tracks and
pass that as input to GridLayout just like how the number of explicit
tracks is already a part of the input. It can then use those when
creating the ImplicitGrid and also generate the track sizing functions
for them.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::computeLeadingImplicitTracks const):
Refactor out the logic that computes the number of leading implicit
tracks into a dedicated function since it does not really belong to
unplaced grid item construction. Also rename the values from columnNegativeLineOffset
to LeadingImplicitColumns with a column/track count since that is a bit
more descriptive of what it represents.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::calculateInitialImplicitGridDimensions):
Now the initial dimensions of the ImplicitGrid will be the number of
explicit tracks + the number of leading implicit tracks instead of it
just being the explicit ones.

(WebCore::Layout::GridLayout::constructInitialImplicitGrid):
(WebCore::Layout::GridLayout::placeGridItems):
(WebCore::Layout::GridLayout::layout):
(WebCore::Layout::GridLayout::generateImplicitTrackSizingFunctions):
Takes in the number of implicit tracks directly rather then computing it
itself based off the number of total tracks and explicit ones. This
currently is really only correct when grid-auto-columns/rows contains a
single value (e.g. grid-auto-columns: 100px rather than grid-auto-columns: 100px min-content)
but we gate taking GFC on this anyways so it isn&apos;t a problem. Before we
relax that condition we will need to implement this to handle that case.

(WebCore::Layout::GridLayout::trackSizingFunctions):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
* Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp:
(WebCore::Layout::UnplacedGridItem::GridPosition::create):
(WebCore::Layout::UnplacedGridItem::UnplacedGridItem):
* Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h:
Basically just making sure we are consistent and are using the new
&quot;leading implicit columns/rows,&quot; term rather than &quot;negative line offset.&quot;

Canonical link: <a href="https://commits.webkit.org/318485@main">https://commits.webkit.org/318485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be32ae707b0f8dea5cfbe351812d3b9c1562d2ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187674 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141308 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138798 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119254 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c99ee30b-6f50-4418-a712-a457923b3aa4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41011 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39364 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39048 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36132 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190101 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/177464 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51667 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147939 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39812 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52349 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147715 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42426 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124612 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119085 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50867 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14020 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50252 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50492 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50314 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->