### PR TITLE
Cherry-pick 318208@main (6ce79778ca49). https://bugs.webkit.org/show_bug.cgi?id=320534

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioParam.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParam.cpp
@@ -268,7 +268,9 @@ bool AudioParam::hasSampleAccurateValues() const
 
 float AudioParam::finalValue()
 {
-    float value;
+    // Initialize to the intrinsic value since calculateFinalValues() may bail out
+    // without writing anything (e.g. when called off the audio thread).
+    float value = m_value;
     calculateFinalValues(singleElementSpan(value), false);
     return value;
 }

--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -8,7 +8,6 @@ Modules/webtransport/WebTransportDatagramsWritable.cpp
 css/CSSComputedStyleDeclaration.cpp
 css/CSSPropertyInitialValues.cpp
 css/DOMMatrixReadOnly.cpp
-css/PropertySetCSSDescriptors.cpp
 css/SelectorChecker.cpp
 css/StyleSheetList.cpp
 css/parser/CSSPropertyParserConsumer+String.cpp

--- a/Source/WebCore/css/CSSFontFaceRule.cpp
+++ b/Source/WebCore/css/CSSFontFaceRule.cpp
@@ -73,7 +73,7 @@ void CSSFontFaceRule::reattach(StyleRuleBase& rule)
 {
     m_fontFaceRule = downcast<StyleRuleFontFace>(rule);
     if (m_propertiesCSSOMWrapper)
-        m_propertiesCSSOMWrapper->reattach(protect(m_fontFaceRule)->mutableProperties());
+        protect(m_propertiesCSSOMWrapper)->reattach(protect(protect(m_fontFaceRule)->mutableProperties()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPageRule.cpp
+++ b/Source/WebCore/css/CSSPageRule.cpp
@@ -89,7 +89,7 @@ void CSSPageRule::reattach(StyleRuleBase& rule)
 {
     m_pageRule = downcast<StyleRulePage>(rule);
     if (m_propertiesCSSOMWrapper)
-        m_propertiesCSSOMWrapper->reattach(m_pageRule.get().mutableProperties());
+        protect(m_propertiesCSSOMWrapper)->reattach(protect(m_pageRule.get().mutableProperties()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPositionTryRule.cpp
+++ b/Source/WebCore/css/CSSPositionTryRule.cpp
@@ -96,7 +96,7 @@ void CSSPositionTryRule::reattach(StyleRuleBase& rule)
 {
     m_positionTryRule = downcast<StyleRulePositionTry>(rule);
     if (RefPtr propertiesCSSOMWrapper = m_propertiesCSSOMWrapper)
-        propertiesCSSOMWrapper->reattach(protect(positionTryRule())->mutableProperties());
+        propertiesCSSOMWrapper->reattach(protect(protect(positionTryRule())->mutableProperties()));
 }
 
 String CSSPositionTryRule::name() const

--- a/Source/WebCore/css/PropertySetCSSDescriptors.h
+++ b/Source/WebCore/css/PropertySetCSSDescriptors.h
@@ -46,7 +46,7 @@ public:
     virtual ~PropertySetCSSDescriptors();
 
     void clearParentRule() { m_parentRule = nullptr; }
-    void NODELETE reattach(MutableStyleProperties&);
+    void reattach(MutableStyleProperties&);
 
     virtual StyleRuleType ruleType() const = 0;
 

--- a/Source/WebCore/css/calc/CSSCalcTree.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree.cpp
@@ -304,7 +304,8 @@ Product multiply(Child&& a, Child&& b)
 
 Sum subtract(Child&& a, Child&& b)
 {
-    return add(WTF::move(a), makeChild(Negate { .a = WTF::move(b) }, getType(b)));
+    auto type = getType(b);
+    return add(WTF::move(a), makeChild(Negate { .a = WTF::move(b) }, type));
 }
 
 Child makeChildWithValueBasedOn(double value, const Number&)

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1220,7 +1220,7 @@ static void dispatchInputEvents(RefPtr<Element> startRoot, RefPtr<Element> endRo
     const String& data = { }, RefPtr<DataTransfer>&& dataTransfer = nullptr, const Vector<Ref<StaticRange>>& targetRanges = { })
 {
     if (startRoot)
-        dispatchInputEvent(*startRoot, inputTypeName, isInputMethodComposing, data, WTF::move(dataTransfer), targetRanges);
+        dispatchInputEvent(*startRoot, inputTypeName, isInputMethodComposing, data, dataTransfer.copyRef(), targetRanges);
     if (endRoot && endRoot != startRoot)
         dispatchInputEvent(*endRoot, inputTypeName, isInputMethodComposing, data, WTF::move(dataTransfer), targetRanges);
 }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2416,7 +2416,7 @@ bool RenderLayerBacking::updateAncestorClippingStack(Vector<CompositedClipData>&
         return false;
     }
     
-    m_ancestorClippingStack->updateWithClipData(scrollingCoordinator, WTF::move(clippingData));
+    m_ancestorClippingStack->updateWithClipData(scrollingCoordinator, Vector { clippingData });
     LOG_WITH_STREAM(Compositing, stream << "layer " << &m_owningLayer << " ancestorClippingStack " << *m_ancestorClippingStack);
     if (m_overflowControlsHostLayerAncestorClippingStack)
         m_overflowControlsHostLayerAncestorClippingStack->updateWithClipData(scrollingCoordinator, WTF::move(clippingData));

--- a/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
@@ -128,9 +128,10 @@ void CustomPropertyRegistry::registerFromStylesheet(const StyleRuleProperty::Des
 
     // Last rule wins.
     // https://drafts.css-houdini.org/css-properties-values-api/#determining-registration
-    m_propertiesFromStylesheet.set(property.name, makeUniqueRef<CSSRegisteredCustomProperty>(WTF::move(property)));
+    auto name = property.name;
+    m_propertiesFromStylesheet.set(name, makeUniqueRef<CSSRegisteredCustomProperty>(WTF::move(property)));
 
-    invalidate(property.name);
+    invalidate(name);
 }
 
 void CustomPropertyRegistry::clearRegisteredFromStylesheets()

--- a/Source/WebCore/style/values/masking/StyleClipPath.h
+++ b/Source/WebCore/style/values/masking/StyleClipPath.h
@@ -45,7 +45,7 @@ struct ClipPath {
     ClipPath(BoxPath&& box) : operation { WTF::move(box.operation) } { }
     ClipPath(const BoxPath& box) : operation { box.operation } { }
 
-    explicit ClipPath(RefPtr<PathOperation>&& operation) : operation { WTF::move(operation) } { RELEASE_ASSERT(isValid(operation)); }
+    explicit ClipPath(RefPtr<PathOperation>&& operation) : operation { WTF::move(operation) } { RELEASE_ASSERT(isValid(this->operation)); }
     explicit ClipPath(const RefPtr<PathOperation>& operation) : operation { operation } { RELEASE_ASSERT(isValid(operation)); }
 
     bool isNone() const { return !operation; }

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -146,7 +146,7 @@ void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecut
     ThreadableLoaderOptions options { WTF::move(fetchOptions) };
     options.sendLoadCallbacks = SendCallbackPolicy::SendCallbacks;
     options.contentSecurityPolicyEnforcement = contentSecurityPolicyEnforcement;
-    if (fetchOptions.destination == FetchOptions::Destination::Serviceworker)
+    if (options.destination == FetchOptions::Destination::Serviceworker)
         options.certificateInfoPolicy = CertificateInfoPolicy::IncludeCertificateInfo;
 
     // FIXME: We should drop the sameOriginDataURLFlag flag and implement the latest Fetch specification.

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -451,9 +451,10 @@ void ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent(BackgroundFetchInf
         RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread()->identifier().toUInt64());
 
         Ref manager = ServiceWorkerRegistrationBackgroundFetchAPI::backgroundFetch(serviceWorkerGlobalScope->registration());
+        auto failureReason = info.failureReason;
         BackgroundFetchEventInit eventInit { { }, manager->backgroundFetchRegistrationInstance(serviceWorkerGlobalScope, WTF::move(info)) };
         RefPtr<ExtendableEvent> event;
-        switch (info.failureReason) {
+        switch (failureReason) {
         case BackgroundFetchFailureReason::EmptyString:
             event = BackgroundFetchUpdateUIEvent::create(eventNames().backgroundfetchsuccessEvent, WTF::move(eventInit), Event::IsTrusted::Yes);
             break;

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1047,11 +1047,12 @@ void SWServer::tryInstallContextData(const std::optional<ProcessIdentifier>& req
     RefPtr connection = contextConnectionForRegistrableDomain(site.domain(), workerCOEP);
     if (!connection) {
         auto firstPartyForCookies = data.registration.key.firstPartyForCookies();
+        auto serviceWorkerPageIdentifier = data.serviceWorkerPageIdentifier;
         m_pendingContextDatas.ensure(ContextConnectionKey { site.domain(), workerCOEP }, [] {
             return Vector<ServiceWorkerContextData> { };
         }).iterator->value.append(WTF::move(data));
 
-        createContextConnection(site, data.serviceWorkerPageIdentifier, workerCOEP);
+        createContextConnection(site, serviceWorkerPageIdentifier, workerCOEP);
         return;
     }
 

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
@@ -92,12 +92,13 @@ void NetworkCORSPreflightChecker::startPreflight()
 
 void NetworkCORSPreflightChecker::willPerformHTTPRedirection(WebCore::ResourceResponse&& response, WebCore::ResourceRequest&&, RedirectCompletionHandler&& completionHandler)
 {
+    auto httpStatusCode = response.httpStatusCode();
     if (m_shouldCaptureExtraNetworkLoadMetrics)
         m_loadInformation.response = WTF::move(response);
 
     CORS_CHECKER_RELEASE_LOG("willPerformHTTPRedirection");
     completionHandler({ });
-    m_completionCallback(ResourceError { errorDomainWebKitInternal, 0, m_parameters.originalRequest.url(), makeString("Preflight response is not successful. Status code: "_s, response.httpStatusCode()), ResourceError::Type::AccessControl });
+    m_completionCallback(ResourceError { errorDomainWebKitInternal, 0, m_parameters.originalRequest.url(), makeString("Preflight response is not successful. Status code: "_s, httpStatusCode), ResourceError::Type::AccessControl });
 }
 
 void NetworkCORSPreflightChecker::didReceiveChallenge(WebCore::AuthenticationChallenge&& challenge, NegotiatedLegacyTLS negotiatedLegacyTLS, ChallengeCompletionHandler&& completionHandler)

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -427,9 +427,9 @@ void WebProcessPool::setAutomationClient(std::unique_ptr<API::AutomationClient>&
 
 void WebProcessPool::setOverrideLanguages(Vector<String>&& languages)
 {
+    LOG_WITH_STREAM(Language, stream << "WebProcessPool is setting OverrideLanguages: " << languages);
     WebKit::setOverrideLanguages(WTF::move(languages));
 
-    LOG_WITH_STREAM(Language, stream << "WebProcessPool is setting OverrideLanguages: " << languages);
     sendToAllProcesses(Messages::WebProcess::UserPreferredLanguagesChanged(overrideLanguages()));
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1126,7 +1126,8 @@ void WebProcessProxy::assumeReadAccessToBaseURLs(WebPageProxy& page, const Vecto
     if (!networkProcessWillCheckBlobFileAccess())
         return completionHandler();
 
-    protect(dataStore->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(coreProcessIdentifier(), WTF::move(paths)), [weakThis = WeakPtr { *this }, weakPage = WeakPtr { page }, paths, completionHandler = WTF::move(completionHandler)] mutable {
+    auto messagePaths = paths;
+    protect(dataStore->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(coreProcessIdentifier(), WTF::move(messagePaths)), [weakThis = WeakPtr { *this }, weakPage = WeakPtr { page }, paths = WTF::move(paths), completionHandler = WTF::move(completionHandler)] mutable {
         if (!weakThis || !weakPage)
             return completionHandler();
 

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -824,8 +824,8 @@ void PushService::updateTopicLists(CompletionHandler<void()>&& completionHandler
         PushServiceConnection::TopicLists topicLists;
         topicLists.enabledTopics = WTF::move(topics.enabledTopics);
         topicLists.ignoredTopics = WTF::move(topics.ignoredTopics);
-        protectedThis->m_connection->setTopicLists(WTF::move(topicLists));
         protectedThis->m_topicCount = topicLists.enabledTopics.size() + topicLists.ignoredTopics.size();
+        protectedThis->m_connection->setTopicLists(WTF::move(topicLists));
         completionHandler();
     });
 }


### PR DESCRIPTION
#### a964221281a93baa4c5ac890b9238191ba235ff0
<pre>
Cherry-pick 318208@main (6ce79778ca49). <a href="https://bugs.webkit.org/show_bug.cgi?id=320534">https://bugs.webkit.org/show_bug.cgi?id=320534</a>

    Fix several use-after-moves in the codebase
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320534">https://bugs.webkit.org/show_bug.cgi?id=320534</a>

    Reviewed by Darin Adler.

    * Source/WebCore/css/calc/CSSCalcTree.cpp:
    (WebCore::CSSCalc::subtract):
    * Source/WebCore/editing/Editor.cpp:
    * Source/WebCore/rendering/RenderLayerBacking.cpp:
    (WebCore::RenderLayerBacking::updateAncestorClippingStack):
    * Source/WebCore/style/StyleCustomPropertyRegistry.cpp:
    (WebCore::Style::CustomPropertyRegistry::registerFromStylesheet):
    * Source/WebCore/style/values/masking/StyleClipPath.h:
    (WebCore::Style::ClipPath::ClipPath):
    * Source/WebCore/workers/WorkerScriptLoader.cpp:
    (WebCore::WorkerScriptLoader::loadAsynchronously):
    * Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
    (WebCore::ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent):
    * Source/WebCore/workers/service/server/SWServer.cpp:
    (WebCore::SWServer::tryInstallContextData):
    * Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp:
    (WebKit::NetworkCORSPreflightChecker::willPerformHTTPRedirection):
    * Source/WebKit/UIProcess/WebProcessPool.cpp:
    (WebKit::WebProcessPool::setOverrideLanguages):
    * Source/WebKit/UIProcess/WebProcessProxy.cpp:
    (WebKit::WebProcessProxy::assumeReadAccessToBaseURLs):
    * Source/WebKit/webpushd/PushService.mm:
    (WebPushD::PushService::updateTopicLists):

    Canonical link: <a href="https://commits.webkit.org/318208@main">https://commits.webkit.org/318208@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.16@webkitglib/2.54">https://commits.webkit.org/317695.16@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 942d71542b61a05af83db19f68cf2944579e6c96
<pre>
Cherry-pick 318052@main (2a2036f697b1). <a href="https://bugs.webkit.org/show_bug.cgi?id=320375">https://bugs.webkit.org/show_bug.cgi?id=320375</a>

    AudioParam::finalValue() returns an uninitialized float when calculateFinalValues() bails out
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320375">https://bugs.webkit.org/show_bug.cgi?id=320375</a>
    <a href="https://rdar.apple.com/183342212">rdar://183342212</a>

    Reviewed by Chris Dumez.

    finalValue() declared `float value;` uninitialized and relied on calculateFinalValues()
    to write it, but that function early-returns without touching the output span when there
    is no context, we are off the audio thread, or the span is empty. The garbage value then
    flows into DSP as an oscillator frequency, filter cutoff, delay time, pan, compressor
    threshold, etc.

    Initialize `value` to m_value, which is always set from defaultValue in the constructor.
    The k-rate path fills the span with m_value anyway, so this only changes the
    previously-garbage path.

    No new test.

    * Source/WebCore/Modules/webaudio/AudioParam.cpp:
    (WebCore::AudioParam::finalValue):

    Canonical link: <a href="https://commits.webkit.org/318052@main">https://commits.webkit.org/318052@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.15@webkitglib/2.54">https://commits.webkit.org/317695.15@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 0582ef48cd207c3e1f83b2f960eb89d5691198e1
<pre>
Cherry-pick 318054@main (b64f79b00305). <a href="https://bugs.webkit.org/show_bug.cgi?id=320417">https://bugs.webkit.org/show_bug.cgi?id=320417</a>

    Remove incorrect `NODELETE` annotation from `PropertySetCSSDescriptors::reattach()`
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320417">https://bugs.webkit.org/show_bug.cgi?id=320417</a>
    <a href="https://rdar.apple.com/183378247">rdar://183378247</a>

    Reviewed by Chris Dumez.

    Drop `NODELETE` from a function that destroys objects since it is a lie.

    * Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations:
    * Source/WebCore/css/CSSFontFaceRule.cpp:
    (WebCore::CSSFontFaceRule::reattach):
    * Source/WebCore/css/CSSPageRule.cpp:
    (WebCore::CSSPageRule::reattach):
    * Source/WebCore/css/CSSPositionTryRule.cpp:
    (WebCore::CSSPositionTryRule::reattach):
    * Source/WebCore/css/PropertySetCSSDescriptors.h:

    Canonical link: <a href="https://commits.webkit.org/318054@main">https://commits.webkit.org/318054@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.14@webkitglib/2.54">https://commits.webkit.org/317695.14@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d5bce7574a8e239d278c214ebc96ae18e662804

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177825 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/51763 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45557 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187435 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141072 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179688 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53055 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51472 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138608 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141072 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180781 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53055 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/45557 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119071 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53055 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51472 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/45557 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53055 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45557 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35896 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/44354 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/51472 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190014 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51430 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/45557 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147861 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/52112 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45557 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147642 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26990 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/52112 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124364 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118795 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/50620 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/45557 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50016 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50256 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50078 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->