### PR TITLE
TLF: Report EWS test failures and flakiness to the results database

### DIFF
--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -22,6 +22,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from . import loadConfig
+from .steps import ResultsDatabase, ResultsDBReportMixin, RunJavaScriptCoreTests
 import os
 import unittest
 
@@ -1016,6 +1017,21 @@ class TestExpectedBuildSteps(unittest.TestCase):
                 buildSteps.append(step_name)
             self.assertTrue(builder['name'] in self.expected_steps, 'Missing expected steps for builder: %s\n Actual result is %s' % (builder['name'], buildSteps))
             self.assertListEqual(self.expected_steps[builder['name']], buildSteps, msg="Expected steps don't match for builder %s" % builder['name'])
+
+    def test_steps_that_report_declare_the_suite_they_run(self):
+        for builder in self.config['builders']:
+            for step in builder['factory'].steps:
+                step_class = step.step_class
+                if not issubclass(step_class, ResultsDBReportMixin) or not step_class.reports_to_results_db:
+                    continue
+
+                expected_suite = 'javascriptcore-tests' if issubclass(step_class, RunJavaScriptCoreTests) else 'layout-tests'
+                self.assertIn(step_class.suite, ResultsDatabase.SUITES, msg='%s reports %s to the unknown suite %r' % (
+                    builder['name'], step_class.__name__, step_class.suite,
+                ))
+                self.assertEqual(step_class.suite, expected_suite, msg='%s reports %s to the %r suite' % (
+                    builder['name'], step_class.__name__, step_class.suite,
+                ))
 
     def test_unnecessary_expected_steps(self):
         builders = set()

--- a/Tools/CISupport/ews-build/layout_test_failures.py
+++ b/Tools/CISupport/ews-build/layout_test_failures.py
@@ -30,10 +30,15 @@ class LayoutTestFailures(object):
     _JSON_PREFIX = "ADD_RESULTS("
     _JSON_SUFFIX = ");"
 
-    def __init__(self, failing_tests, flaky_tests, did_exceed_test_failure_limit):
-        self.failing_tests = failing_tests
-        self.flaky_tests = flaky_tests
+    # run-webkit-tests reports these for all non-pass results.
+    FAILURE_REPORTS = ('REGRESSION', 'MISSING')
+    FLAKY_REPORTS = ('FLAKY',)
+
+    def __init__(self, results, did_exceed_test_failure_limit):
+        self.results = results
         self.did_exceed_test_failure_limit = did_exceed_test_failure_limit
+        self.flaky_results = {test: result for test, result in results.items() if result.get('report') in self.FLAKY_REPORTS}
+        self.failing_tests = [test for test, result in results.items() if result.get('report') in self.FAILURE_REPORTS]
 
     @classmethod
     def _strip_json_wrapper(cls, json_content):
@@ -56,17 +61,14 @@ class LayoutTestFailures(object):
             _log.info('Exception while parsing layout-test json: %s, json data being parsed: %s', e, string)
             return None
 
-        failing_tests = []
-        flaky_tests = []
+        results = {}
 
-        def get_failing_tests(test, result):
-            if result.get('report') in ['REGRESSION', 'MISSING']:
-                failing_tests.append(test)
-            elif result.get('report') in ['FLAKY']:
-                flaky_tests.append(test)
+        def collect_tests_that_did_not_pass(test, result):
+            if result.get('report') in cls.FAILURE_REPORTS + cls.FLAKY_REPORTS:
+                results[test] = result
 
-        cls.parse_full_results_json(json_dict['tests'], get_failing_tests)
-        return cls(failing_tests, flaky_tests, json_dict.get('interrupted', False))
+        cls.parse_full_results_json(json_dict['tests'], collect_tests_that_did_not_pass)
+        return cls(results, json_dict.get('interrupted', False))
 
     @classmethod
     def parse_full_results_json(cls, tree, handler, prefix=''):

--- a/Tools/CISupport/ews-build/layout_test_failures_unittest.py
+++ b/Tools/CISupport/ews-build/layout_test_failures_unittest.py
@@ -45,14 +45,30 @@ class TestLayoutTestFailures(unittest.TestCase):
             f"ADD_RESULTS({sample_json});"
         )
         self.assertEqual(sample_failing_tests, failures.failing_tests)
-        self.assertEqual(sample_flaky_tests, failures.flaky_tests)
+        self.assertEqual(sample_flaky_tests, list(failures.flaky_results))
         self.assertEqual(False, failures.did_exceed_test_failure_limit)
 
     def test_results_from_string_valid_json(self):
         failures = LayoutTestFailures.results_from_string(sample_json)
         self.assertEqual(sample_failing_tests, failures.failing_tests)
-        self.assertEqual(sample_flaky_tests, failures.flaky_tests)
+        self.assertEqual(sample_flaky_tests, list(failures.flaky_results))
         self.assertEqual(False, failures.did_exceed_test_failure_limit)
+
+    def test_results_records_the_result_leaf_for_every_reported_test(self):
+        failures = LayoutTestFailures.results_from_string(sample_json)
+        self.assertEqual(sorted(failures.results), sorted(sample_failing_tests + sample_flaky_tests))
+        self.assertEqual(
+            failures.results['fast/scrolling/ios/reconcile-layer-position-recursive.html'],
+            {'report': 'REGRESSION', 'expected': 'PASS', 'actual': 'TEXT'},
+        )
+
+    def test_results_skips_tests_that_are_neither_failing_nor_flaky(self):
+        json_dict = json.loads(sample_json)
+        json_dict['tests']['fast']['expected-crash.html'] = {'expected': 'CRASH', 'actual': 'CRASH'}
+        failures = LayoutTestFailures.results_from_string(json.dumps(json_dict))
+        self.assertNotIn('fast/expected-crash.html', failures.results)
+        self.assertNotIn('fast/expected-crash.html', failures.failing_tests)
+        self.assertNotIn('fast/expected-crash.html', failures.flaky_results)
 
     def test_results_from_string_invalid_json(self):
         failures = LayoutTestFailures.results_from_string(sample_json + " invalid JSON")
@@ -104,5 +120,5 @@ class TestLayoutTestFailures(unittest.TestCase):
 
         failures = LayoutTestFailures.results_from_string(new_json)
         self.assertEqual(sample_failing_tests, failures.failing_tests)
-        self.assertEqual(sample_flaky_tests, failures.flaky_tests)
+        self.assertEqual(sample_flaky_tests, list(failures.flaky_results))
         self.assertEqual(False, failures.did_exceed_test_failure_limit)

--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -35,7 +35,7 @@ from twisted.internet import defer, reactor
 
 
 class ResultsDatabase(object):
-    HOSTNAME = 'https://results.webkit.org'
+    HOSTNAME = os.environ.get('RESULTS_SERVER_HOST', 'https://results.webkit.org').rstrip('/')
     # TODO: Support more suites (Note, the API we're talking to already does)
     DEFAULT_SUITE = 'layout-tests'
     SUITES = ('layout-tests', 'api-tests', 'safer-cpp-checks', 'javascriptcore-tests')
@@ -78,16 +78,17 @@ class ResultsDatabase(object):
         if commit:
             params['ref'] = commit
 
-        response = yield TwistedAdditions.request(f"{cls.HOSTNAME}/api/{endpoint}/{urllib.parse.quote(suite)}{f'/{urllib.parse.quote(test)}' if test else ''}", params=params, logger=logger)
+        url = f"{cls.HOSTNAME}/api/{endpoint}/{urllib.parse.quote(suite)}{f'/{urllib.parse.quote(test)}' if test else ''}"
+        response = yield TwistedAdditions.request(url, params=params, logger=logger)
 
         if not response:
-            logger(f'No response from {cls.HOSTNAME}\n')
+            logger(f'No response from {url}\n')
             defer.returnValue(None)
             return
         if response.status_code == 200:
             defer.returnValue(response.json())
             return
-        logger(f'Failed to query results summary with status code {response.status_code}\n')
+        logger(f'Failed to query {url} (status {response.status_code})\n{response.content}\n')
         defer.returnValue(None)
 
     @classmethod
@@ -181,10 +182,58 @@ class ResultsDatabase(object):
     @defer.inlineCallbacks
     def has_commit(cls, commit, logger=None):
         response = yield TwistedAdditions.request(f'{cls.HOSTNAME}/api/commits', params=dict(ref=commit), logger=logger)
-        if not response or response.status_code != 200:
-            defer.returnValue(False)
-        else:
-            defer.returnValue(True)
+        defer.returnValue(response and response.status_code == 200)
+
+    @classmethod
+    @defer.inlineCallbacks
+    def report_ews(cls, suite, results, configuration, commits, timestamp, details, flaky_type=None, logger=lambda _: None):
+        if not results:
+            return False
+
+        payload = {
+            'suite': suite,
+            'flaky_type': flaky_type,
+            'configuration': configuration,
+            'commits': commits,
+            'test_results': {'results': results},
+            'timestamp': timestamp,
+            'details': details,
+            'api_key': os.environ.get('RESULTS_SERVER_API_KEY', ''),
+        }
+
+        url = f'{cls.HOSTNAME}/api/upload/ews'
+        label = f'{flaky_type} flaky tests' if flaky_type else 'failed tests'
+        logger(f"Reporting {label} to {url}: {', '.join(sorted(results))}\n")
+        # FIXME: Remove the request and response dumps once reporting has been validated against a
+        # deployed results database. api_key must stay redacted, build logs are not private.
+        logger(f"Request:\n{json.dumps({**payload, 'api_key': '<redacted>'}, indent=2, sort_keys=True)}\n")
+
+        response = yield TwistedAdditions.request(url, type=b'POST', json=payload, logger=logger)
+        if not response:
+            logger(f'No response from {url}, so {label} were not reported\n')
+            return False
+
+        logger(f'Response from {url} ({response.status_code}):\n{response.content}\n')
+        if response.status_code != 200:
+            logger(f'Failed to report {label} (status {response.status_code})\n{response.content}\n')
+            return False
+
+        try:
+            stored = (response.json() or {}).get('tests')
+        except ValueError:
+            logger(f'{url} answered 200 with a body that is not JSON\n{response.content}\n')
+            return False
+
+        if stored is None:
+            logger(f'{url} stored {label}, but does not report which tests\n')
+            return True
+
+        logger(f"Reported {label}: {', '.join(sorted(stored))}\n")
+        dropped = sorted(set(results) - set(stored))
+        if dropped:
+            logger(f"{url} did not store {', '.join(dropped)}\n")
+            return False
+        return True
 
     @classmethod
     def main(cls, args=None):

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -38,6 +38,7 @@ from .results_db import ResultsDatabase
 from .twisted_additions import TwistedAdditions
 from .utils import load_password, get_custom_suffix
 
+import abc
 import json
 import os
 import re
@@ -561,6 +562,134 @@ class AddToLogMixin(object):
         log.addStdout(message)
 
 
+class ResultsDBReportMixin(abc.ABC):
+    """
+    Reports test results to the results database. Hosts supply AddToLogMixin, a `suite`, and
+    call report_to_results_db() once per report as soon as that report is derived.
+    """
+    results_db_log_name = 'results-db'
+    reports_to_results_db = True
+
+    # From Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/configuration.py
+    RESULTS_REQUIRED_CONFIG = ['platform', 'is_simulator', 'version', 'architecture']
+    RESULTS_OPTIONAL_CONFIG = ['version_name', 'model', 'style', 'flavor']
+
+    @property
+    @abc.abstractmethod
+    def suite(self) -> str:
+        """The resultsdb suite this step's tests belong to."""
+
+    def results_db_query_configuration(self) -> dict:
+        """Partial config for querying. Fetches all values from the missing dimensions."""
+        configuration = {}
+        if platform := self.getProperty('platform', None):
+            configuration['platform'] = ResultsDatabase.platform_for_query(platform)
+        if (style := self.getProperty('configuration', None)) in ('debug', 'release'):
+            configuration['style'] = style
+        if (flavor := self.getProperty('flavor', None)) in ('wk1', 'wk2'):
+            configuration['flavor'] = flavor
+        return configuration
+
+    def results_db_configuration(self):
+        architecture = self.getProperty('machine_architecture', None) or self.getProperty('architecture', None)
+        return {
+            **self.results_db_query_configuration(),
+            'version': self.getProperty('os_version', None) or None,
+            'architecture': architecture if architecture and ' ' not in architecture else None,
+            'is_simulator': 'simulator' in (self.getProperty('fullPlatform', '') or ''),
+        }
+
+    def results_db_details(self):
+        """Extra build metadata folded into each row's `details` blob, non-queryable."""
+        authors = self.getProperty('owners', []) or [self.getProperty('patch_author', None)]
+        return {
+            'worker': self.getProperty('workername', None),
+            'remote': self.getProperty('remote', None),
+            'pr_number': self.getProperty('github.number', None),
+            'commit_hash': self.getProperty('github.head.sha', None),
+            'retry_count': self.getProperty('retry_count', 0),
+            'authors': [author for author in authors if author],
+            'build_url': f'{self.master.config.buildbotURL}#/builders/{self.build._builderid}/builds/{self.build.number}',
+        }
+
+    def merged_results(self, test_filter, runs):
+        """
+        One result per test in test_filter, across every run in `runs`, which maps a stage name to
+        the property holding that stage's results.
+
+        A single run already reports `actual` as the outcomes of its own retries in the order they
+        happened ('TIMEOUT PASS'), so merging concatenates those sequences and drops repeats without
+        reordering. That flattening loses the run boundaries — 'TEXT PASS TIMEOUT' could be
+        'TEXT PASS' then 'TIMEOUT' or 'TEXT' then 'PASS TIMEOUT' — so each run's own outcome is kept
+        alongside it in actual_by_run. `actual` keeps the shape run-webkit-tests uses, since that is
+        what anything reading it will expect.
+
+        ```
+        self.setProperty('first_run_results', {'foo.html': {'actual': 'CRASH'}})
+        self.setProperty('second_run_results', {'foo.html': {'actual': 'TEXT'}})
+        self.merged_results({'foo.html'}, {'first-run': 'first_run_results', 'second-run': 'second_run_results'})
+        {'foo.html': {'actual': 'CRASH TEXT', 'actual_by_run': {'first-run': 'CRASH', 'second-run': 'TEXT'}}}
+        ```
+        """
+        merged = {}
+        for stage, name in runs.items():
+            for test, result in self.getProperty(name, {}).items():
+                if test not in test_filter:
+                    continue
+
+                prev = merged.get(test, {})
+                seen = f"{prev.get('actual', '')} {result.get('actual', '')}".split()
+                merged[test] = {
+                    **result,
+                    'actual': ' '.join(dict.fromkeys(seen)),
+                    'actual_by_run': {**prev.get('actual_by_run', {}), stage: result.get('actual', '')},
+                }
+        return merged
+
+    @defer.inlineCallbacks
+    def report_to_results_db(self, results, flaky_type=None, stage=None):
+        """
+        Never raises and never returns a step result: an unreachable results database does not
+        change the verdict of the step that ran the tests.
+        """
+        if not self.reports_to_results_db or not results:
+            return False
+
+        config = self.results_db_configuration()
+        if missing := [m for m in self.RESULTS_REQUIRED_CONFIG if config.get(m) is None]:
+            yield self._addToLog(self.results_db_log_name, f"Not reporting to the resultsdb, this build has no {', '.join(missing)}\n")
+            return False
+
+        commit = {
+            'repository_id': 'webkit',
+            'hash': self.getProperty('ews_revision') or self.getProperty('got_revision'),
+            'branch': self.getProperty('github.base.ref', DEFAULT_BRANCH),
+        }
+
+        if commit_timestamp := self.getProperty('commit_timestamp'):
+            commit['timestamp'] = commit_timestamp
+            if identifier := self.getProperty('identifier', None):
+                commit['identifier'] = identifier
+        else:
+            yield self._addToLog(self.results_db_log_name, 'No commit timestamp, so the commit has to be looked up instead of registered\n')
+
+        try:
+            reported = yield ResultsDatabase.report_ews(
+                configuration=config,
+                suite=self.suite,
+                commits=[commit],
+                flaky_type=flaky_type,
+                results=results,
+                timestamp=getattr(self, 'run_started_at', None) or int(time.time()),
+                details={**self.results_db_details(), 'stage': stage},
+                logger=lambda log: self._addToLog(self.results_db_log_name, log),
+            )
+        except Exception as error:
+            yield self._addToLog(self.results_db_log_name, f'Failed to report to the results database: {error}\n')
+            return False
+        return reported
+
+
 class Contributors(object):
     url = f'https://raw.githubusercontent.com/{CANONICAL_GITHUB_PROJECT}/main/metadata/contributors.json'
     contributors = {}
@@ -936,7 +1065,6 @@ class FetchBranches(steps.ShellSequence, ShellMixin):
 
 class ShowIdentifier(shell.ShellCommand):
     name = 'show-identifier'
-    identifier_re = r'^Identifier: (.*)$'
     flunkOnFailure = False
     haltOnFailure = False
 
@@ -956,18 +1084,23 @@ class ShowIdentifier(shell.ShellCommand):
                 revision = candidate
                 break
 
-        self.command = ['python3', 'Tools/Scripts/git-webkit', 'find', revision]
+        # --json reports the commit timestamp as a Unix timestamp
+        self.command = ['python3', 'Tools/Scripts/git-webkit', 'find', revision, '--json']
         rc = yield super().run()
 
         if rc != SUCCESS:
             return defer.returnValue(rc)
 
-        log_text = self.log_observer.getStdout()
-        match = re.search(self.identifier_re, log_text, re.MULTILINE)
-        if match:
-            identifier = match.group(1)
-            if identifier:
-                identifier = identifier.replace('master', DEFAULT_BRANCH)
+        try:
+            commit = json.loads(self.log_observer.getStdout())
+        except json.JSONDecodeError:
+            commit = {}
+
+        if commit_timestamp := commit.get('timestamp'):
+            self.setProperty('commit_timestamp', commit_timestamp)
+
+        if identifier := commit.get('identifier'):
+            identifier = identifier.replace('master', DEFAULT_BRANCH)
             self.setProperty('identifier', identifier)
             if CheckOutSpecificRevision.doCheckOutSpecificRevision(self):
                 step = self.getLastBuildStepByName(CheckOutSpecificRevision.name)
@@ -4203,7 +4336,7 @@ class WaitForCrashCollection(shell.Compile):
         return super().getResultSummary()
 
 
-class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
+class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin):
     name = 'layout-tests'
     description = ['layout-tests running']
     descriptionDone = ['layout-tests']
@@ -4212,6 +4345,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
     logfiles = {'json': jsonFileName}
     test_failures_log_name = 'test-failures'
     results_db_log_name = 'results-db'
+    suite = 'layout-tests'
     ENABLE_GUARD_MALLOC = False
     ENABLE_ADDITIONAL_ARGUMENTS = True
     EXIT_AFTER_FAILURES = '60'
@@ -4284,6 +4418,12 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
         self.log_observer_json = logobserver.BufferLogObserver()
         self.addLogObserver('json', self.log_observer_json)
         self.setLayoutTestCommand()
+
+        if self.layout_test_driver == 'DumpRenderTree':
+            self.setProperty('flavor', 'wk1')
+        elif self.layout_test_driver == 'WebKitTestRunner':
+            self.setProperty('flavor', 'wk2')
+
         if SHOULD_FILTER_LOGS is True:
             self.command = self.shell_command(' '.join(quote(str(c)) for c in self.command) + ' 2>&1 | Tools/Scripts/filter-test-logs layout')
         rc = yield super().run()
@@ -4328,6 +4468,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
 
     @defer.inlineCallbacks
     def runCommand(self, command):
+        self.run_started_at = int(time.time())
         yield super().runCommand(command)
 
         yield self._addToLog('json', '\n')
@@ -4340,7 +4481,9 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
         if first_results:
             self.setProperty('first_results_exceed_failure_limit', first_results.did_exceed_test_failure_limit)
             self.setProperty('first_run_failures', sorted(first_results.failing_tests))
-            self.setProperty('first_run_flakies', sorted(first_results.flaky_tests))
+            self.setProperty('first_run_flakies', sorted(first_results.flaky_results))
+            self.setProperty('first_run_results', first_results.results)
+
             if first_results.failing_tests:
                 yield self._addToLog(self.test_failures_log_name, '\n'.join(first_results.failing_tests))
 
@@ -4349,26 +4492,17 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
                 self.setProperty('first_run_failures_filtered', sorted(self.failing_tests_filtered))
                 self.setProperty('results-db_first_run_pre_existing', sorted(self.preexisting_failures_in_results_db))
 
+            yield self.report_to_results_db(first_results.flaky_results, flaky_type='WithinStepDirtyTree', stage='first-run')
+
         self._parseRunWebKitTestsOutput(logText)
 
     @defer.inlineCallbacks
     def filter_failures_using_results_db(self, failing_tests):
         self.failing_tests_filtered = failing_tests.copy()
         identifier = self.getProperty('identifier', None)
-        platform = self.getProperty('platform', None)
-        configuration = {}
-        if platform:
-            configuration['platform'] = ResultsDatabase.platform_for_query(platform)
-        style = self.getProperty('configuration', None)
-        if style and style in ['debug', 'release']:
-            configuration['style'] = style
+        configuration = self.results_db_query_configuration()
 
-        if self.layout_test_driver == 'DumpRenderTree':
-            configuration['flavor'] = 'wk1'
-        elif self.layout_test_driver == 'WebKitTestRunner':
-            configuration['flavor'] = 'wk2'
-
-        yield self._addToLog(self.results_db_log_name, f'Checking Results database for failing tests. Identifier: {identifier}, configuration: {configuration}')
+        yield self._addToLog(self.results_db_log_name, f'Checking Results database for failing tests. Identifier: {identifier}, configuration: {configuration}\n')
         has_commit = False
         if failing_tests and identifier:
             has_commit = yield ResultsDatabase.has_commit(commit=identifier)
@@ -4380,6 +4514,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
                 test, configuration=configuration,
                 commit=identifier if has_commit else None,
             )
+
             yield self._addToLog(self.results_db_log_name, f"\n{test}: pass_rate: {data['pass_rate']}, pre-existing-failure={data['is_existing_failure']}\nResponse from results-db: {data['raw_data']}\n{data['logs']}")
             if data['is_existing_failure']:
                 self.preexisting_failures_in_results_db.append(test)
@@ -4494,6 +4629,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
 
 
 class RunWebKitTestsInStressMode(RunWebKitTests):
+    reports_to_results_db = False
     name = 'run-layout-tests-in-stress-mode'
     suffix = 'stress-mode'
     EXIT_AFTER_FAILURES = '10'
@@ -4588,20 +4724,24 @@ class RunWebKitTestsInSiteIsolationMode(RunWebKitTestsInStressMode):
 
 
 class RunWebKitTestsEWSSiteIsolation(RunWebKitTests):
+    reports_to_results_db = False
     name = 'layout-tests-site-isolation'
+
+    def results_db_query_configuration(self) -> dict:
+        # Use flavor='site-isolation' without a platform filter so that results from
+        # Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests (the closest post-commit queue)
+        # are consulted. Once a mac-sequoia site-isolation post-commit bot exists its
+        # results will automatically be included as well.
+        configuration = super().results_db_query_configuration()
+        configuration['flavor'] = 'site-isolation'
+        configuration.pop('platform')
+        return configuration
 
     @defer.inlineCallbacks
     def filter_failures_using_results_db(self, failing_tests):
         self.failing_tests_filtered = failing_tests.copy()
         identifier = self.getProperty('identifier', None)
-        # Use flavor='site-isolation' without a platform filter so that results from
-        # Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests (the closest post-commit queue)
-        # are consulted. Once a mac-sequoia site-isolation post-commit bot exists its
-        # results will automatically be included as well.
-        configuration = {'flavor': 'site-isolation'}
-        style = self.getProperty('configuration', None)
-        if style and style in ['debug', 'release']:
-            configuration['style'] = style
+        configuration = self.results_db_query_configuration()
 
         yield self._addToLog(self.results_db_log_name, f'Checking Results database for failing tests. Identifier: {identifier}, configuration: {configuration}')
         has_commit = False
@@ -4765,6 +4905,7 @@ class ReRunWebKitTests(RunWebKitTests):
 
     @defer.inlineCallbacks
     def runCommand(self, command):
+        self.run_started_at = int(time.time())
         yield shell.Test.runCommand(self, command)
 
         yield self._addToLog('json', '\n')
@@ -4777,7 +4918,8 @@ class ReRunWebKitTests(RunWebKitTests):
         if second_results:
             self.setProperty('second_results_exceed_failure_limit', second_results.did_exceed_test_failure_limit)
             self.setProperty('second_run_failures', sorted(second_results.failing_tests))
-            self.setProperty('second_run_flakies', sorted(second_results.flaky_tests))
+            self.setProperty('second_run_flakies', sorted(second_results.flaky_results))
+            self.setProperty('second_run_results', second_results.results)
             if second_results.failing_tests:
                 yield self._addToLog(self.test_failures_log_name, '\n'.join(second_results.failing_tests))
 
@@ -4785,6 +4927,17 @@ class ReRunWebKitTests(RunWebKitTests):
                 yield self.filter_failures_using_results_db(second_results.failing_tests)
                 self.setProperty('second_run_failures_filtered', sorted(self.failing_tests_filtered))
                 self.setProperty('results-db_second_run_pre_existing', sorted(self.preexisting_failures_in_results_db))
+
+            yield self.report_to_results_db(second_results.flaky_results, flaky_type='WithinStepDirtyTree', stage='second-run')
+
+            # A test failing one of the two runs and passing the other flaked across the steps.
+            if (first_run_failures := self.getProperty('first_run_failures', None)) is not None:
+                if self.getProperty('first_results_exceed_failure_limit', False) or second_results.did_exceed_test_failure_limit:
+                    yield self._addToLog(self.results_db_log_name, 'A run exceeded the failure limit, so the two runs are not comparable\n')
+                else:
+                    unique_fails = set(first_run_failures) ^ set(second_results.failing_tests)
+                    results = self.merged_results(unique_fails, {'first-run': 'first_run_results', 'second-run': 'second_run_results'})
+                    yield self.report_to_results_db(results, flaky_type='BetweenStepsDirtyTree')
         self._parseRunWebKitTestsOutput(logText)
 
     def send_email_for_flaky_failure(self, test_name):
@@ -4841,6 +4994,7 @@ class RunWebKitTestsWithoutChange(RunWebKitTests):
 
     @defer.inlineCallbacks
     def runCommand(self, command):
+        self.run_started_at = int(time.time())
         yield shell.Test.runCommand(self, command)
 
         yield self._addToLog('json', '\n')
@@ -4852,9 +5006,11 @@ class RunWebKitTestsWithoutChange(RunWebKitTests):
         if clean_tree_results:
             self.setProperty('clean_tree_results_exceed_failure_limit', clean_tree_results.did_exceed_test_failure_limit)
             self.setProperty('clean_tree_run_failures', clean_tree_results.failing_tests)
-            self.setProperty('clean_tree_run_flakies', sorted(clean_tree_results.flaky_tests))
+            self.setProperty('clean_tree_run_flakies', sorted(clean_tree_results.flaky_results))
             if clean_tree_results.failing_tests:
                 yield self._addToLog(self.test_failures_log_name, '\n'.join(clean_tree_results.failing_tests))
+
+            yield self.report_to_results_db(clean_tree_results.flaky_results, flaky_type='WithinStepCleanTree', stage='clean-tree')
         self._parseRunWebKitTestsOutput(logText)
 
     def setLayoutTestCommand(self):
@@ -4911,8 +5067,9 @@ class RunWebKitTestsWithoutChange(RunWebKitTests):
         return positional_test_paths
 
 
-class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin):
+class AnalyzeLayoutTestsResults(ResultsDBReportMixin, buildstep.BuildStep, BugzillaMixin, GitHubMixin):
     name = 'analyze-layout-tests-results'
+    suite = 'layout-tests'
     description = ['analyze-layout-test-results']
     descriptionDone = ['analyze-layout-tests-results']
     NUM_FAILURES_TO_DISPLAY = 10
@@ -4923,6 +5080,14 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
         if not new_failures:
             message = 'Found unexpected failure with change' if not failure_message else failure_message
         else:
+            self.setProperty('new_failures_introduced_by_patch', sorted(new_failures))
+            runs = {
+                'first-run': 'first_run_results',
+                'second-run': 'second_run_results',
+                'redtree-with-change': 'with_change_repeat_results',
+            }
+            yield self.report_to_results_db(self.merged_results(new_failures, runs))
+
             pluralSuffix = 's' if len(new_failures) > 1 else ''
             if exceed_failure_limit:
                 message = 'Failure limit exceed. At least found'
@@ -5161,7 +5326,7 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
                 return defer.returnValue(rc)
             return defer.returnValue(self.retry_build())
 
-        # FIXME: Here it could be a good idea to also use the info of results.flaky_tests from the runs
+        # FIXME: Here it could be a good idea to also use the info of results.flaky_results from the runs
         if self._results_failed_different_tests(first_results_failing_tests, second_results_failing_tests):
             tests_that_only_failed_first = first_results_failing_tests.difference(second_results_failing_tests)
             self._report_flaky_tests(tests_that_only_failed_first)
@@ -5340,6 +5505,7 @@ class RunWebKitTestsRepeatFailuresRedTree(RunWebKitTestsRedTree):
 
     @defer.inlineCallbacks
     def runCommand(self, command):
+        self.run_started_at = int(time.time())
         yield shell.Test.runCommand(self, command)
         yield self._addToLog('json', '\n')
         logText = self.log_observer.getStdout() + self.log_observer.getStderr()
@@ -5348,9 +5514,15 @@ class RunWebKitTestsRepeatFailuresRedTree(RunWebKitTestsRedTree):
         if with_change_repeat_failures_results:
             self.setProperty('with_change_repeat_failures_results_exceed_failure_limit', with_change_repeat_failures_results.did_exceed_test_failure_limit)
             self.setProperty('with_change_repeat_failures_results_nonflaky_failures', sorted(with_change_repeat_failures_results.failing_tests))
-            self.setProperty('with_change_repeat_failures_results_flakies', sorted(with_change_repeat_failures_results.flaky_tests))
+            self.setProperty('with_change_repeat_failures_results_flakies', sorted(with_change_repeat_failures_results.flaky_results))
+            self.setProperty('with_change_repeat_results', with_change_repeat_failures_results.results)
             if with_change_repeat_failures_results.failing_tests:
                 yield self._addToLog(self.test_failures_log_name, '\n'.join(with_change_repeat_failures_results.failing_tests))
+
+            yield self.report_to_results_db(
+                with_change_repeat_failures_results.flaky_results,
+                flaky_type='WithinStepDirtyTree', stage='redtree-with-change',
+            )
         command_timedout = self._did_command_timed_out(self.log_observer.getHeaders())
         self.setProperty('with_change_repeat_failures_timedout', command_timedout)
         self._parseRunWebKitTestsOutput(logText)
@@ -5409,6 +5581,7 @@ class RunWebKitTestsRepeatFailuresWithoutChangeRedTree(RunWebKitTestsRedTree):
 
     @defer.inlineCallbacks
     def runCommand(self, command):
+        self.run_started_at = int(time.time())
         yield shell.Test.runCommand(self, command)
         yield self._addToLog('json', '\n')
         logText = self.log_observer.getStdout() + self.log_observer.getStderr()
@@ -5417,9 +5590,14 @@ class RunWebKitTestsRepeatFailuresWithoutChangeRedTree(RunWebKitTestsRedTree):
         if without_change_repeat_failures_results:
             self.setProperty('without_change_repeat_failures_results_exceed_failure_limit', without_change_repeat_failures_results.did_exceed_test_failure_limit)
             self.setProperty('without_change_repeat_failures_results_nonflaky_failures', sorted(without_change_repeat_failures_results.failing_tests))
-            self.setProperty('without_change_repeat_failures_results_flakies', sorted(without_change_repeat_failures_results.flaky_tests))
+            self.setProperty('without_change_repeat_failures_results_flakies', sorted(without_change_repeat_failures_results.flaky_results))
             if without_change_repeat_failures_results.failing_tests:
                 yield self._addToLog(self.test_failures_log_name, '\n'.join(without_change_repeat_failures_results.failing_tests))
+
+            yield self.report_to_results_db(
+                without_change_repeat_failures_results.flaky_results,
+                flaky_type='WithinStepCleanTree', stage='redtree-without-change',
+            )
         command_timedout = self._did_command_timed_out(self.log_observer.getHeaders())
         self.setProperty('without_change_repeat_failures_timedout', command_timedout)
         self._parseRunWebKitTestsOutput(logText)

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -128,6 +128,13 @@ class ExpectMasterShellCommand(object):
 
 
 class BuildStepMixinAdditions(BuildStepMixin, TestReactorMixin):
+    @staticmethod
+    def layout_test_failures(failing_tests, flaky_tests, did_exceed_test_failure_limit):
+        return LayoutTestFailures({
+            **{test: {'report': 'REGRESSION', 'expected': 'PASS', 'actual': 'TEXT'} for test in failing_tests},
+            **{test: {'report': 'FLAKY', 'expected': 'PASS', 'actual': 'TIMEOUT PASS'} for test in flaky_tests},
+        }, did_exceed_test_failure_limit)
+
     def setup_test_build_step(self):
         self.patch(reactor, 'spawnProcess', lambda *args, **kwargs: self._checkSpawnProcess(*args, **kwargs))
         self.patch(send_email, 'send_email', self._send_email)
@@ -136,6 +143,19 @@ class BuildStepMixinAdditions(BuildStepMixin, TestReactorMixin):
         self._emails_list = []
         self._expected_local_commands = []
         self.setup_test_reactor()
+
+        # Test steps report to the results database as they run, so stub the one network call they
+        # make rather than each step that makes it.
+        self.results_db_reports = []
+
+        def record_report_ews(suite=None, results=None, flaky_type=None, commits=None, configuration=None, details=None, timestamp=None, logger=None):
+            self.results_db_reports.append(dict(
+                suite=suite, results=results, flaky_type=flaky_type, commits=commits,
+                configuration=configuration, details=details, timestamp=timestamp,
+            ))
+            return defer.succeed(True)
+
+        self.patch(ResultsDatabase, 'report_ews', record_report_ews)
 
         self._temp_directory = tempfile.mkdtemp()
         os.chdir(self._temp_directory)
@@ -3207,6 +3227,28 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         yield step.filter_failures_using_results_db(['real.html'])
         self.assertEqual(configurations, [dict(platform='WPE', style='release')])
 
+    def test_queries_include_the_flavor_being_tested(self):
+        # wk1 and wk2 record separate history for the same test.
+        self.setup_step(RunWebKitTests())
+        self.setProperty('platform', 'mac')
+        self.setProperty('configuration', 'release')
+        self.setProperty('flavor', 'wk2')
+        self.assertEqual(
+            self.get_nth_step(0).results_db_query_configuration(),
+            {'platform': 'mac', 'style': 'release', 'flavor': 'wk2'},
+        )
+
+    def test_site_isolation_queries_across_platforms(self):
+        # There is no mac-sequoia site-isolation post-commit queue, so the query has to reach the
+        # closest one on another platform rather than filter itself down to nothing.
+        self.setup_step(RunWebKitTestsEWSSiteIsolation())
+        self.setProperty('platform', 'mac')
+        self.setProperty('configuration', 'release')
+        self.assertEqual(
+            self.get_nth_step(0).results_db_query_configuration(),
+            {'style': 'release', 'flavor': 'site-isolation'},
+        )
+
     @defer.inlineCallbacks
     def test_caps_number_of_results_db_queries(self):
         # Only the first MAX_FAILURES_TO_CHECK_RESULTS_DB failures are checked against results-db.
@@ -3228,13 +3270,6 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         failing_tests = [f'test{i}.html' for i in range(cap + 10)]
         yield step.filter_failures_using_results_db(failing_tests)
         self.assertEqual(len(queried), cap)
-
-
-class MockLayoutTestFailures(object):
-    def __init__(self, failing_tests, flaky_tests, did_exceed_test_failure_limit):
-        self.failing_tests = failing_tests
-        self.flaky_tests = flaky_tests
-        self.did_exceed_test_failure_limit = did_exceed_test_failure_limit
 
 
 class TestRunWebKitTestsRedTree(BuildStepMixinAdditions, unittest.TestCase):
@@ -3281,7 +3316,7 @@ class TestRunWebKitTestsRedTree(BuildStepMixinAdditions, unittest.TestCase):
         )
         # Patch LayoutTestFailures.results_from_string() to report the expected values
         # Check this values end on the properties this class should define
-        mock_test_failures = MockLayoutTestFailures(first_run_failures, first_run_flakies, False)
+        mock_test_failures = self.layout_test_failures(first_run_failures, first_run_flakies, False)
         self.patch(LayoutTestFailures, 'results_from_string', lambda f: mock_test_failures)
         self.expect_outcome(result=FAILURE, state_string='layout-tests (failure)')
         rc = self.run_step()
@@ -3317,6 +3352,431 @@ class TestRunWebKitTestsRedTree(BuildStepMixinAdditions, unittest.TestCase):
         self.assertFalse(InstallWpeDependencies() in next_steps)
         self.assertFalse(RunWebKitTestsWithoutChangeRedTree() in next_steps)
         self.assertTrue(AnalyzeLayoutTestsResultsRedTree() in next_steps)
+
+
+class TestReportToResultsDB(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def configureStep(self, StepClass=RunWebKitTests):
+        self.setup_step(StepClass())
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-sonoma')
+        self.setProperty('os_version', '14.6.1')
+        self.setProperty('configuration', 'release')
+        self.setProperty('flavor', 'wk2')
+        self.setProperty('identifier', '286000@main')
+        self.setProperty('remote', 'https://github.com/WebKit/WebKit')
+        self.setProperty('github.number', 12345)
+        self.setProperty('github.head.sha', 'abc123')
+        self.setProperty('got_revision', 'def456')
+        self.setProperty('commit_timestamp', 1599000000)
+        self.setProperty('buildnumber', 678)
+        self.setProperty('architecture', 'arm64')
+        self.setProperty('workername', 'bot123')
+        self.setProperty('owners', ['jdoe'])
+        self.setProperty('retry_count', 0)
+        return step
+
+    FLAKE = {'fast/flaky.html': dict(expected='PASS', actual='TEXT PASS')}
+
+    @defer.inlineCallbacks
+    def test_reports_the_configuration_the_tests_ran_in(self):
+        step = self.configureStep()
+        yield step.report_to_results_db(self.FLAKE, flaky_type='WithinStepDirtyTree', stage='first-run')
+
+        self.assertEqual(len(self.results_db_reports), 1)
+        report = self.results_db_reports[0]
+        self.assertEqual(report['suite'], 'layout-tests')
+        self.assertEqual(report['flaky_type'], 'WithinStepDirtyTree')
+        self.assertEqual(report['configuration'], dict(
+            platform='mac', version='14.6.1', is_simulator=False,
+            style='release', flavor='wk2', architecture='arm64',
+        ))
+        self.assertEqual(report['results'], self.FLAKE)
+
+    @defer.inlineCallbacks
+    def test_folds_build_provenance_into_details(self):
+        # Provenance isn't queryable, so it rides along in details rather than the configuration.
+        step = self.configureStep()
+        yield step.report_to_results_db(self.FLAKE, stage='first-run')
+
+        details = self.results_db_reports[0]['details']
+        self.assertEqual(details['stage'], 'first-run')
+        self.assertEqual(details['worker'], 'bot123')
+        self.assertEqual(details['authors'], ['jdoe'])
+        self.assertEqual(details['retry_count'], 0)
+        self.assertEqual(details['remote'], 'https://github.com/WebKit/WebKit')
+        self.assertEqual(details['pr_number'], 12345)
+        self.assertEqual(details['commit_hash'], 'abc123')
+        self.assertEqual(details['build_url'], 'http://localhost:8080/#/builders/1/builds/13')
+
+    @defer.inlineCallbacks
+    def test_authors_fall_back_to_the_patch_author(self):
+        step = self.configureStep()
+        self.setProperty('owners', [])
+        self.setProperty('patch_author', 'jdoe@apple.com')
+        yield step.report_to_results_db(self.FLAKE)
+
+        self.assertEqual(self.results_db_reports[0]['details']['authors'], ['jdoe@apple.com'])
+
+    @defer.inlineCallbacks
+    def test_reports_the_commit_ews_tested(self):
+        step = self.configureStep()
+        self.setProperty('ews_revision', 'aaa111')
+        yield step.report_to_results_db(self.FLAKE)
+
+        self.assertEqual(self.results_db_reports[0]['commits'], [{
+            'repository_id': 'webkit',
+            'hash': 'aaa111',
+            'branch': 'main',
+            'timestamp': 1599000000,
+            'identifier': '286000@main',
+        }])
+
+    @defer.inlineCallbacks
+    def test_commit_is_left_resolvable_without_a_timestamp(self):
+        # The endpoint refuses to look a commit up when a timestamp or a second reference is present.
+        step = self.configureStep()
+        self.setProperty('commit_timestamp', None)
+        yield step.report_to_results_db(self.FLAKE)
+
+        self.assertEqual(self.results_db_reports[0]['commits'], [{
+            'repository_id': 'webkit',
+            'hash': 'def456',
+            'branch': 'main',
+        }])
+
+    @defer.inlineCallbacks
+    def test_reports_when_the_run_started(self):
+        # Reports from one build share a partition and a commit-derived uuid, so two that also
+        # shared a timestamp would collide on the primary key and overwrite each other.
+        step = self.configureStep()
+        step.run_started_at = 1600000000
+        yield step.report_to_results_db(self.FLAKE)
+
+        self.assertEqual(self.results_db_reports[0]['timestamp'], 1600000000)
+
+    @defer.inlineCallbacks
+    def test_falls_back_to_the_current_time_when_no_run_was_timed(self):
+        step = self.configureStep(StepClass=AnalyzeLayoutTestsResults)
+        yield step.report_to_results_db(self.FLAKE)
+
+        self.assertLessEqual(abs(self.results_db_reports[0]['timestamp'] - int(time.time())), 60)
+
+    def test_merge_skips_a_test_no_run_produced_a_result_for(self):
+        # Callers pass the tests a report covers, and a run that never saw one of them has nothing
+        # to say about it. Reporting it anyway would upload an empty result leaf.
+        step = self.configureStep()
+        self.setProperty('first_run_results', {'fast/a.html': dict(expected='PASS', actual='TEXT')})
+        self.assertEqual(
+            step.merged_results({'fast/a.html', 'fast/never-ran.html'}, {'first-run': 'first_run_results'}),
+            {'fast/a.html': dict(expected='PASS', actual='TEXT', actual_by_run={'first-run': 'TEXT'})},
+        )
+
+    @defer.inlineCallbacks
+    def test_records_results_against_the_branch_the_change_targets(self):
+        step = self.configureStep()
+        self.setProperty('github.base.ref', 'safari-7620-branch')
+        yield step.report_to_results_db(self.FLAKE)
+
+        self.assertEqual(len(self.results_db_reports), 1)
+        self.assertEqual(self.results_db_reports[0]['commits'][0]['branch'], 'safari-7620-branch')
+
+    @defer.inlineCallbacks
+    def test_reports_nothing_without_a_version(self):
+        # PrintConfiguration only reports an OS version for apple platforms, and the resultsdb
+        # rejects a configuration without one.
+        step = self.configureStep()
+        self.setProperty('platform', 'wpe')
+        self.setProperty('os_version', None)
+        logs = []
+        step._addToLog = lambda logName, message: logs.append(message) or defer.succeed(None)
+        yield step.report_to_results_db(self.FLAKE)
+
+        self.assertEqual(self.results_db_reports, [])
+        self.assertIn('this build has no version', ''.join(logs))
+
+    @defer.inlineCallbacks
+    def test_reports_nothing_without_an_architecture(self):
+        # A tester triggered by nothing inherits no architecture, e.g. JSC-Tests-O3-Debug-arm64-EWS.
+        step = self.configureStep()
+        self.setProperty('architecture', None)
+        logs = []
+        step._addToLog = lambda logName, message: logs.append(message) or defer.succeed(None)
+        yield step.report_to_results_db(self.FLAKE)
+
+        self.assertEqual(self.results_db_reports, [])
+        self.assertIn('this build has no architecture', ''.join(logs))
+
+    @defer.inlineCallbacks
+    def test_reports_the_architecture_the_tests_ran_on(self):
+        # The builder config only knows what its build queue produces, so the macOS-Sequoia testers
+        # inherit both architectures. PrintConfiguration reads the tester's own.
+        step = self.configureStep()
+        self.setProperty('architecture', 'x86_64 arm64')
+        self.setProperty('machine_architecture', 'x86_64')
+        yield step.report_to_results_db(self.FLAKE)
+
+        self.assertEqual(self.results_db_reports[0]['configuration']['architecture'], 'x86_64')
+
+    @defer.inlineCallbacks
+    def test_reports_nothing_for_several_architectures_at_once(self):
+        step = self.configureStep()
+        self.setProperty('architecture', 'x86_64 arm64')
+        logs = []
+        step._addToLog = lambda logName, message: logs.append(message) or defer.succeed(None)
+        yield step.report_to_results_db(self.FLAKE)
+
+        self.assertEqual(self.results_db_reports, [])
+        self.assertIn('this build has no architecture', ''.join(logs))
+
+    @defer.inlineCallbacks
+    def test_reports_for_a_wildcard_builder_that_resolves_to_apple(self):
+        # A builder configured with platform '*' only has one at run time, so the decision can't be
+        # made when the factory is built.
+        step = self.configureStep()
+        self.setProperty('platform', 'ios-simulator-26')
+        self.setProperty('fullPlatform', 'ios-simulator-26')
+        yield step.report_to_results_db(self.FLAKE)
+
+        self.assertEqual(len(self.results_db_reports), 1)
+        self.assertTrue(self.results_db_reports[0]['configuration']['is_simulator'])
+
+    @defer.inlineCallbacks
+    def test_a_step_that_provokes_flakiness_reports_nothing(self):
+        # Ten iterations of the tests a change touched are not evidence the tests are flaky.
+        step = self.configureStep(StepClass=RunWebKitTestsInStressMode)
+        yield step.report_to_results_db(self.FLAKE)
+
+        self.assertEqual(self.results_db_reports, [])
+
+    @defer.inlineCallbacks
+    def test_an_unreachable_results_database_does_not_fail_the_step(self):
+        # Reporting runs inside the steps whose verdict gates the pull request.
+        def explode(**kwargs):
+            raise RuntimeError('results.webkit.org is unreachable')
+
+        step = self.configureStep()
+        self.patch(ResultsDatabase, 'report_ews', explode)
+        reported = yield step.report_to_results_db(self.FLAKE)
+
+        self.assertFalse(reported)
+
+    def test_uploads_the_platform_name_queries_ask_for(self):
+        step = self.configureStep()
+        self.setProperty('platform', 'wpe')
+        self.assertEqual(step.results_db_configuration()['platform'], 'WPE')
+
+    def test_merges_a_tests_outcomes_across_runs_without_repeating_them(self):
+        step = self.configureStep()
+
+        self.setProperty('first_run_results', {'fast/a.html': dict(expected='PASS', actual='CRASH')})
+        self.setProperty('second_run_results', {'fast/a.html': dict(expected='PASS', actual='TEXT')})
+        self.assertEqual(
+            step.merged_results({'fast/a.html'}, {'first-run': 'first_run_results', 'second-run': 'second_run_results'}),
+            {'fast/a.html': dict(
+                expected='PASS', actual='CRASH TEXT',
+                actual_by_run={'first-run': 'CRASH', 'second-run': 'TEXT'},
+            )},
+        )
+
+        self.setProperty('second_run_results', {'fast/a.html': dict(expected='PASS', actual='CRASH')})
+        self.assertEqual(
+            step.merged_results({'fast/a.html'}, {'first-run': 'first_run_results', 'second-run': 'second_run_results'}),
+            {'fast/a.html': dict(
+                expected='PASS', actual='CRASH',
+                actual_by_run={'first-run': 'CRASH', 'second-run': 'CRASH'},
+            )},
+        )
+
+
+class TestLayoutTestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestCase):
+    """Each report has to leave the step that derived it: the analyze steps end the build outright,
+    so anything queued behind them never runs."""
+
+    FLAKY = '{"tests":{"fast":{"flaky.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS"}}},"num_regressions":0,"interrupted":false,"num_flaky":1,"version":4}'
+    FLAKY_AND_REGRESSED = '{"tests":{"fast":{"flaky.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS"},"b.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"both.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}},"num_regressions":2,"interrupted":false,"num_flaky":1,"version":4}'
+    TRUNCATED = '{"tests":{"fast":{"flaky.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS"},"b.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"both.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}},"num_regressions":2,"interrupted":true,"num_flaky":1,"version":4}'
+
+    class FakeLogObserver(object):
+        def __init__(self, stdout=''):
+            self.stdout = stdout
+
+        def getStdout(self):
+            return self.stdout
+
+        def getStderr(self):
+            return ''
+
+        def getHeaders(self):
+            return ''
+
+    def setUp(self):
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def configureStep(self, StepClass, results_json):
+        self.setup_step(StepClass())
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-sonoma')
+        self.setProperty('os_version', '14.6.1')
+        self.setProperty('configuration', 'release')
+        self.setProperty('architecture', 'arm64')
+        self.setProperty('got_revision', 'def456')
+        self.setProperty('commit_timestamp', 1599000000)
+
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        step._parseRunWebKitTestsOutput = lambda logText: None
+        step.log_observer = self.FakeLogObserver()
+        step.log_observer_json = self.FakeLogObserver(f'ADD_RESULTS({results_json});')
+
+        def fake_filter(failing_tests):
+            step.failing_tests_filtered = list(failing_tests)
+            step.preexisting_failures_in_results_db = []
+            return defer.succeed(None)
+
+        step.filter_failures_using_results_db = fake_filter
+        self.patch(shell.Test, 'runCommand', lambda *args, **kwargs: defer.succeed(None))
+        return step
+
+    def reported(self):
+        return [
+            (report['flaky_type'], (report['details'] or {}).get('stage'), sorted(report['results']))
+            for report in self.results_db_reports
+        ]
+
+    @defer.inlineCallbacks
+    def test_the_first_run_reports_its_own_flakes(self):
+        step = self.configureStep(RunWebKitTests, self.FLAKY)
+        yield step.runCommand(['run-webkit-tests'])
+
+        self.assertEqual(self.reported(), [('WithinStepDirtyTree', 'first-run', ['fast/flaky.html'])])
+
+    @defer.inlineCallbacks
+    def test_the_first_run_records_its_failures_for_later_reports(self):
+        # It reports only its flakes, but a later step merging across runs needs the failures too:
+        # inter-step and new-failure reports are about tests that failed one run and not another.
+        step = self.configureStep(RunWebKitTests, self.FLAKY_AND_REGRESSED)
+        yield step.runCommand(['run-webkit-tests'])
+
+        self.assertEqual(self.reported(), [('WithinStepDirtyTree', 'first-run', ['fast/flaky.html'])])
+        self.assertEqual(
+            sorted(self.getProperty('first_run_results')),
+            ['fast/b.html', 'fast/both.html', 'fast/flaky.html'],
+        )
+
+    @defer.inlineCallbacks
+    def test_the_rerun_reports_its_flakes_and_what_differed_from_the_first_run(self):
+        step = self.configureStep(ReRunWebKitTests, self.FLAKY_AND_REGRESSED)
+        self.setProperty('first_run_failures', ['fast/a.html', 'fast/both.html'])
+        self.setProperty('first_run_results', {
+            'fast/a.html': dict(expected='PASS', actual='TEXT'),
+            'fast/both.html': dict(expected='PASS', actual='TEXT'),
+        })
+        yield step.runCommand(['run-webkit-tests'])
+
+        self.assertEqual(self.reported(), [
+            ('WithinStepDirtyTree', 'second-run', ['fast/flaky.html']),
+            ('BetweenStepsDirtyTree', None, ['fast/a.html', 'fast/b.html']),
+        ])
+
+    @defer.inlineCallbacks
+    def test_the_rerun_reports_no_inter_step_flakes_when_its_own_run_was_truncated(self):
+        # Once a run stops at the failure limit the two runs cover different subsets, so a test in
+        # only one of them was never run rather than passing.
+        step = self.configureStep(ReRunWebKitTests, self.TRUNCATED)
+        self.setProperty('first_run_failures', ['fast/a.html', 'fast/both.html'])
+        self.setProperty('first_run_results', {
+            'fast/a.html': dict(expected='PASS', actual='TEXT'),
+            'fast/both.html': dict(expected='PASS', actual='TEXT'),
+        })
+        yield step.runCommand(['run-webkit-tests'])
+
+        self.assertEqual(self.reported(), [('WithinStepDirtyTree', 'second-run', ['fast/flaky.html'])])
+
+    @defer.inlineCallbacks
+    def test_the_rerun_reports_no_inter_step_flakes_when_the_first_run_was_truncated(self):
+        step = self.configureStep(ReRunWebKitTests, self.FLAKY_AND_REGRESSED)
+        self.setProperty('first_results_exceed_failure_limit', True)
+        self.setProperty('first_run_failures', ['fast/a.html', 'fast/both.html'])
+        self.setProperty('first_run_results', {
+            'fast/a.html': dict(expected='PASS', actual='TEXT'),
+            'fast/both.html': dict(expected='PASS', actual='TEXT'),
+        })
+        yield step.runCommand(['run-webkit-tests'])
+
+        self.assertEqual(self.reported(), [('WithinStepDirtyTree', 'second-run', ['fast/flaky.html'])])
+
+    @defer.inlineCallbacks
+    def test_the_rerun_reports_no_inter_step_flakes_without_a_first_run_to_compare(self):
+        step = self.configureStep(ReRunWebKitTests, self.FLAKY)
+        yield step.runCommand(['run-webkit-tests'])
+
+        self.assertEqual(self.reported(), [('WithinStepDirtyTree', 'second-run', ['fast/flaky.html'])])
+
+    @defer.inlineCallbacks
+    def test_the_clean_tree_run_reports_flakes_the_change_cannot_have_caused(self):
+        step = self.configureStep(RunWebKitTestsWithoutChange, self.FLAKY)
+        yield step.runCommand(['run-webkit-tests'])
+
+        self.assertEqual(self.reported(), [('WithinStepCleanTree', 'clean-tree', ['fast/flaky.html'])])
+
+    @defer.inlineCallbacks
+    def test_the_redtree_repeat_run_reports_with_change_flakes(self):
+        step = self.configureStep(RunWebKitTestsRepeatFailuresRedTree, self.FLAKY)
+        yield step.runCommand(['run-webkit-tests'])
+
+        self.assertEqual(self.reported(), [('WithinStepDirtyTree', 'redtree-with-change', ['fast/flaky.html'])])
+
+    @defer.inlineCallbacks
+    def test_the_redtree_clean_tree_repeat_run_reports_without_change_flakes(self):
+        step = self.configureStep(RunWebKitTestsRepeatFailuresWithoutChangeRedTree, self.FLAKY)
+        yield step.runCommand(['run-webkit-tests'])
+
+        self.assertEqual(self.reported(), [('WithinStepCleanTree', 'redtree-without-change', ['fast/flaky.html'])])
+
+    @defer.inlineCallbacks
+    def test_the_analyze_step_reports_the_failures_it_attributes_to_the_change(self):
+        # The one report derived from comparing runs rather than produced by one.
+        self.setup_step(AnalyzeLayoutTestsResults())
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-sonoma')
+        self.setProperty('os_version', '14.6.1')
+        self.setProperty('configuration', 'release')
+        self.setProperty('architecture', 'arm64')
+        self.setProperty('got_revision', 'def456')
+        self.setProperty('commit_timestamp', 1599000000)
+        self.setProperty('first_run_results', {'fast/b.html': dict(expected='PASS', actual='CRASH')})
+        self.setProperty('second_run_results', {'fast/b.html': dict(expected='PASS', actual='TEXT')})
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        step.send_email_for_new_test_failures = lambda *args, **kwargs: defer.succeed(None)
+        self.patch(AnalyzeLayoutTestsResults, 'getResultSummary', lambda self: {})
+
+        yield step.report_failure(new_failures=['fast/b.html'])
+
+        # No flaky_type: a failure attributed to the change is not flakiness.
+        self.assertEqual(self.reported(), [(None, None, ['fast/b.html'])])
+        self.assertEqual(
+            self.results_db_reports[0]['results']['fast/b.html']['actual'], 'CRASH TEXT',
+            msg='the reported outcome should span both with-change runs',
+        )
+        self.assertEqual(
+            self.results_db_reports[0]['results']['fast/b.html']['actual_by_run'],
+            {'first-run': 'CRASH', 'second-run': 'TEXT'},
+            msg='a flattened actual cannot say which run saw which outcome',
+        )
 
 
 class TestRunWebKitTestsRepeatFailuresRedTree(BuildStepMixinAdditions, unittest.TestCase):
@@ -3399,7 +3859,7 @@ class TestRunWebKitTestsRepeatFailuresRedTree(BuildStepMixinAdditions, unittest.
         # Check this fake values do not end on the properties that belong to the superclass.
         fake_failing_tests = ['fake/should/not/happen/failure1.html', 'imported/fake/failure2.html']
         fake_flaky_tests = ['fake/should/not/happen/flaky1.html', 'imported/fake/flaky2.html']
-        fake_layout_test_failures = MockLayoutTestFailures(fake_failing_tests, fake_flaky_tests, True)
+        fake_layout_test_failures = self.layout_test_failures(fake_failing_tests, fake_flaky_tests, True)
         self.patch(LayoutTestFailures, 'results_from_string', lambda f: fake_layout_test_failures)
         self.expect_outcome(result=FAILURE, state_string='layout-tests (failure)')
         rc = yield self.run_step()
@@ -3534,7 +3994,7 @@ class TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree(BuildStepMixinAdditio
         # Check this fake values do not end on the properties that belong to the superclass.
         fake_failing_tests = ['fake/should/not/happen/failure1.html', 'imported/fake/failure2.html']
         fake_flaky_tests = ['fake/should/not/happen/flaky1.html', 'imported/fake/flaky2.html']
-        fake_layout_test_failures = MockLayoutTestFailures(fake_failing_tests, fake_flaky_tests, True)
+        fake_layout_test_failures = self.layout_test_failures(fake_failing_tests, fake_flaky_tests, True)
         self.patch(LayoutTestFailures, 'results_from_string', lambda f: fake_layout_test_failures)
         self.expect_outcome(result=FAILURE, state_string='layout-tests (failure)')
         rc = yield self.run_step()
@@ -8604,6 +9064,63 @@ class TestShowIdentifier(BuildStepMixinAdditions, unittest.TestCase):
     def tearDown(self):
         return self.tear_down_test_build_step()
 
+    def test_records_commit_timestamp(self):
+        previous_steps = {
+            CheckOutSpecificRevision.name: self.MockPreviousStep(),
+            CheckOutSource.name: self.MockPreviousStep(),
+        }
+        ShowIdentifier.getLastBuildStepByName = lambda _, name: previous_steps.get(name, self.MockPreviousStep())
+        self.setup_step(ShowIdentifier())
+        self.setProperty('ews_revision', '51a6aec9f664')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        timeout=300,
+                        log_environ=False,
+                        command=['python3', 'Tools/Scripts/git-webkit', 'find', '51a6aec9f664', '--json'])
+            .log('stdio', stdout=json.dumps({'identifier': '233175@main', 'timestamp': 1599031200}))
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Identifier: 233175@main')
+        rc = self.run_step()
+        self.expect_property('identifier', '233175@main')
+        self.expect_property('commit_timestamp', 1599031200)
+        return rc
+
+    def test_no_commit_timestamp_when_absent(self):
+        ShowIdentifier.getLastBuildStepByName = lambda _, name: self.MockPreviousStep()
+        self.setup_step(ShowIdentifier())
+        self.setProperty('ews_revision', '51a6aec9f664')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        timeout=300,
+                        log_environ=False,
+                        command=['python3', 'Tools/Scripts/git-webkit', 'find', '51a6aec9f664', '--json'])
+            .log('stdio', stdout=json.dumps({'identifier': '233175@main'}))
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Identifier: 233175@main')
+        rc = self.run_step()
+        self.assertIsNone(self.get_nth_step(0).getProperty('commit_timestamp'))
+        return rc
+
+    def test_output_that_is_not_json_does_not_fail_the_step(self):
+        ShowIdentifier.getLastBuildStepByName = lambda _, name: self.MockPreviousStep()
+        self.setup_step(ShowIdentifier())
+        self.setProperty('ews_revision', '51a6aec9f664')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        timeout=300,
+                        log_environ=False,
+                        command=['python3', 'Tools/Scripts/git-webkit', 'find', '51a6aec9f664', '--json'])
+            .log('stdio', stdout='Identifier: 233175@main\n')
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Failed to find identifier')
+        rc = self.run_step()
+        self.assertIsNone(self.get_nth_step(0).getProperty('identifier'))
+        self.assertIsNone(self.get_nth_step(0).getProperty('commit_timestamp'))
+        return rc
+
     @expectedFailure
     def test_success(self):
         previous_steps = {
@@ -8617,8 +9134,8 @@ class TestShowIdentifier(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         timeout=300,
                         log_environ=False,
-                        command=['python3', 'Tools/Scripts/git-webkit', 'find', '51a6aec9f664'])
-            .log('stdio', stdout='Identifier: 233175@main\n')
+                        command=['python3', 'Tools/Scripts/git-webkit', 'find', '51a6aec9f664', '--json'])
+            .log('stdio', stdout=json.dumps({'identifier': '233175@main'}))
             .exit(0),
         )
         self.expect_outcome(result=SUCCESS, state_string='Identifier: 233175@main')
@@ -8643,8 +9160,8 @@ class TestShowIdentifier(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         timeout=300,
                         log_environ=False,
-                        command=['python3', 'Tools/Scripts/git-webkit', 'find', '51a6aec9f664'])
-            .log('stdio', stdout='Identifier: 233175@main\n')
+                        command=['python3', 'Tools/Scripts/git-webkit', 'find', '51a6aec9f664', '--json'])
+            .log('stdio', stdout=json.dumps({'identifier': '233175@main'}))
             .exit(0),
         )
         self.expect_outcome(result=SUCCESS, state_string='Identifier: 233175@main')
@@ -8664,8 +9181,8 @@ class TestShowIdentifier(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         timeout=300,
                         log_environ=False,
-                        command=['python3', 'Tools/Scripts/git-webkit', 'find', '51a6aec9f664'])
-            .log('stdio', stdout='Identifier: 233175@main\n')
+                        command=['python3', 'Tools/Scripts/git-webkit', 'find', '51a6aec9f664', '--json'])
+            .log('stdio', stdout=json.dumps({'identifier': '233175@main'}))
             .exit(0),
         )
         self.expect_outcome(result=SUCCESS, state_string='Identifier: 233175@main')
@@ -8679,7 +9196,7 @@ class TestShowIdentifier(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         timeout=300,
                         log_environ=False,
-                        command=['python3', 'Tools/Scripts/git-webkit', 'find', 'HEAD'])
+                        command=['python3', 'Tools/Scripts/git-webkit', 'find', 'HEAD', '--json'])
             .log('stdio', stdout='Unexpected failure')
             .exit(2),
         )
@@ -11917,6 +12434,85 @@ class TestResultsDatabaseFailureHandling(unittest.TestCase):
         with self._mock_twisted_request(self._ok_response({'pass': 95})):
             result = yield ResultsDatabase.make_request('results-summary', suite='layout-tests', test='foo')
         self.assertEqual(result, {'pass': 95})
+
+    COMPLETE_CONFIGURATION = {'platform': 'mac', 'version': '14.6.1', 'is_simulator': False, 'architecture': 'arm64'}
+    REPORTED_RESULTS = {'fast/b.html': {'actual': 'TEXT'}, 'fast/a.html': {'actual': 'CRASH'}}
+    REPORTED_COMMITS = [{'repository_id': 'webkit', 'hash': 'def456', 'branch': 'main', 'timestamp': 1599000000}]
+
+    @defer.inlineCallbacks
+    def report_ews(self, response, flaky_type='WithinStepDirtyTree'):
+        logs = []
+        with self._mock_twisted_request(response):
+            reported = yield ResultsDatabase.report_ews(
+                suite='layout-tests', results=self.REPORTED_RESULTS, flaky_type=flaky_type,
+                configuration=self.COMPLETE_CONFIGURATION, commits=self.REPORTED_COMMITS,
+                timestamp=1600000000, details={'stage': 'first-run'},
+                logger=lambda log: logs.append(log),
+            )
+        return (reported, ''.join(logs))
+
+    @defer.inlineCallbacks
+    def test_report_ews_labels_non_flaky_failures(self):
+        reported, logs = yield self.report_ews(
+            self._ok_response({'status': 'ok', 'tests': ['fast/a.html', 'fast/b.html']}),
+            flaky_type=None,
+        )
+        self.assertTrue(reported)
+        self.assertIn('Reported failed tests: fast/a.html, fast/b.html', logs)
+
+    @defer.inlineCallbacks
+    def test_report_ews_logs_the_request_without_the_api_key(self):
+        with patch.dict(os.environ, {'RESULTS_SERVER_API_KEY': 'super-secret'}):
+            reported, logs = yield self.report_ews(self._ok_response({
+                'status': 'ok', 'tests': ['fast/a.html', 'fast/b.html'],
+            }))
+        self.assertTrue(reported)
+        self.assertIn('"api_key": "<redacted>"', logs)
+        self.assertNotIn('super-secret', logs)
+        self.assertIn('"suite": "layout-tests"', logs)
+        self.assertIn('(200):', logs)
+
+    @defer.inlineCallbacks
+    def test_report_ews_logs_the_tests_the_server_stored(self):
+        reported, logs = yield self.report_ews(self._ok_response({
+            'status': 'ok', 'tests': ['fast/b.html', 'fast/a.html'],
+        }))
+        self.assertTrue(reported)
+        self.assertIn('Reported WithinStepDirtyTree flaky tests: fast/a.html, fast/b.html', logs)
+
+    @defer.inlineCallbacks
+    def test_report_ews_reports_tests_the_server_dropped(self):
+        reported, logs = yield self.report_ews(self._ok_response({'status': 'ok', 'tests': ['fast/a.html']}))
+        self.assertFalse(reported)
+        self.assertIn('Reported WithinStepDirtyTree flaky tests: fast/a.html', logs)
+        self.assertIn('did not store fast/b.html', logs)
+
+    @defer.inlineCallbacks
+    def test_report_ews_does_not_raise_on_a_body_that_is_not_json(self):
+        reported, logs = yield self.report_ews(TwistedAdditions.Response(status_code=200, content=b''))
+        self.assertFalse(reported)
+        self.assertIn('not JSON', logs)
+
+    @defer.inlineCallbacks
+    def test_report_ews_does_not_claim_a_write_a_silent_server_cannot_confirm(self):
+        reported, logs = yield self.report_ews(self._ok_response({'status': 'ok'}))
+        self.assertTrue(reported)
+        self.assertIn('does not report which tests', logs)
+        self.assertNotIn('Reported WithinStepDirtyTree flaky tests:', logs)
+
+    @defer.inlineCallbacks
+    def test_report_ews_does_not_claim_success_when_the_server_rejects_the_write(self):
+        reported, logs = yield self.report_ews(TwistedAdditions.Response(
+            status_code=400,
+            content=json.dumps({
+                'description': 'Cannot insert to ews_flakes_by_start_time with a partial configuration',
+                'error': 'Bad Request', 'status': 'error',
+            }).encode('utf-8'),
+        ))
+        self.assertFalse(reported)
+        self.assertIn('Failed to report WithinStepDirtyTree flaky tests (status 400)', logs)
+        self.assertIn('Cannot insert to ews_flakes_by_start_time', logs)
+        self.assertNotIn('Reported WithinStepDirtyTree flaky tests:', logs)
 
     @defer.inlineCallbacks
     def test_does_result_match_returns_none_on_request_failure_even_with_default(self):

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py
@@ -59,9 +59,9 @@ class EWSContext(UploadCallbackContext):
     class EWSFailedTestsByStartTime(EWSResultsBase):
         __table_name__ = 'ews_failed_tests_by_start_time'
 
-    class EWSFlakyTestsByStartTime(EWSResultsBase):
-        __table_name__ = 'ews_flaky_tests_by_start_time'
-        flaky_type = columns.Text(required=True)  # WithinStepDirtyTree, BetweenStepsDirtyTree, WithinStepCleanTree
+    class EWSFlakesByStartTime(EWSResultsBase):
+        __table_name__ = 'ews_flakes_by_start_time'
+        flaky_type = columns.Text(primary_key=True, required=True)
 
         def unpack(self):
             results = super().unpack()
@@ -80,7 +80,7 @@ class EWSContext(UploadCallbackContext):
 
         with self:
             self.cassandra.create_table(self.EWSFailedTestsByStartTime)
-            self.cassandra.create_table(self.EWSFlakyTestsByStartTime)
+            self.cassandra.create_table(self.EWSFlakesByStartTime)
             self.cassandra.create_table(self.EWSTestNameBySuite)
 
     def record_results(self, configuration, commits, suite, test_results, timestamp=None, flaky_type=None, details=None):
@@ -95,7 +95,7 @@ class EWSContext(UploadCallbackContext):
         ttl = int(ttl) if ttl else None
 
         extra = dict(flaky_type=flaky_type) if flaky_type is not None else {}
-        table = self.EWSFlakyTestsByStartTime if flaky_type is not None else self.EWSFailedTestsByStartTime
+        table = self.EWSFlakesByStartTime if flaky_type is not None else self.EWSFailedTestsByStartTime
 
         with self, self.cassandra.batch_query_context():
             for branch in self.commit_context.branch_keys_for_commits(commits):
@@ -126,7 +126,7 @@ class EWSContext(UploadCallbackContext):
             return [row.test for row in self.cassandra.select_from_table(self.EWSTestNameBySuite.__table_name__, **args)]
 
     def find_for_test(self, configurations, suite, test, flaky, branch=None, recent=True, begin_query_time=None, end_query_time=None, limit=100):
-        table = self.EWSFlakyTestsByStartTime if flaky else self.EWSFailedTestsByStartTime
+        table = self.EWSFlakesByStartTime if flaky else self.EWSFailedTestsByStartTime
 
         def get_time(time):
             return time if isinstance(time, datetime) else datetime.utcfromtimestamp(int(time)) if time else None

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context_unittest.py
@@ -128,6 +128,28 @@ class EWSContextTest(WaitForDockerTestCase):
         self.assertEqual(len(self._find(self.REGRESSION_TEST, flaky=False)), 0)
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_both_flaky_types_from_one_run_are_kept(self, redis=StrictRedis, cassandra=CassandraContext):
+        """A re-run reports a test flaky within its own step and flaky across the two steps. Those
+        share a start_time and a commit, so flaky_type has to be part of the key to keep both."""
+        timestamp = int(time.time())
+        self.init_database(redis=redis, cassandra=cassandra, flaky_type='WithinStepDirtyTree', timestamps=[timestamp])
+
+        with MockModelFactory.safari(), MockModelFactory.webkit():
+            MockModelFactory.add_mock_ews_results(
+                test_results=self.DEFAULT_TEST_RESULTS, model=self.model,
+                flaky_type='BetweenStepsDirtyTree', timestamp=timestamp,
+            )
+
+        rows = list(self._find(self.REGRESSION_TEST, flaky=True).values())[0]
+        types_by_run = {}
+        for row in rows:
+            types_by_run.setdefault((row['uuid'], row['start_time']), set()).add(row['flaky_type'])
+
+        self.assertTrue(types_by_run)
+        for run, flaky_types in types_by_run.items():
+            self.assertEqual(flaky_types, {'WithinStepDirtyTree', 'BetweenStepsDirtyTree'}, run)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     def test_retries_preserved_for_same_commit(self, redis=StrictRedis, cassandra=CassandraContext):
         """EWS may run the same commit more than once. Each run should be preserved as a distinct row in the database."""
         base = int(time.time())


### PR DESCRIPTION
#### 4d47d17af08a370737e69269fb7ad8bd63aa9786
<pre>
TLF: Report EWS test failures and flakiness to the results database
<a href="https://bugs.webkit.org/show_bug.cgi?id=318291">https://bugs.webkit.org/show_bug.cgi?id=318291</a>
<a href="https://rdar.apple.com/157892382">rdar://157892382</a>

Reviewed by Aakash Jain and Sam Sneddon.

Record what layout tests did on EWS so a later change can consult that history. New failures and
each category of flake are uploaded with the real per-test result, the commit EWS tested against,
and enough build context to attribute a row later.

Each report leaves the step that derived it rather than a trailing step of its own. EWS calls
buildFinished() as ordinary control flow, and alwaysRun does not survive it, so a step queued
behind the analyze steps never runs at all: on a failing build, which is the only interesting
kind, everything the build observed would be discarded.

A test can flake three ways, and they are not equally damning. It can flake inside a single step&apos;s
own retries, fail one of the two runs and pass the other, or flake on the clean tree, where the
change cannot be responsible. Each is reported under its own flaky_type as soon as it is known,
and a report spanning both runs keeps each run&apos;s own outcome alongside the merged sequence, since
flattening them loses which run saw what.

The timestamp is per run rather than per build, so the several reports one build makes do not
collide on a primary key whose uuid is commit-derived. Two classifications of the same test within
one run collide the same way, so flaky_type joins the flaky table&apos;s clustering key. Cassandra
cannot add a clustering column to an existing table, so that table is created under a new name
instead of requiring a manual DROP TABLE wherever it has already been deployed.

Reporting is skipped unless the build can describe itself completely enough to be found again.
The architecture comes from the machine that ran the tests, not from the builder configuration,
which for the macOS-Sequoia queues names both architectures at once and so matches no machine.
The comparison between the two runs is skipped when either hit its failure limit, since a
truncated run covers a different subset of the suite and a test missing from one of them was
never run rather than passing.

An unreachable results database never changes a step&apos;s verdict.

* Tools/CISupport/ews-build/results_db.py:
(ResultsDatabase.report_ews): Upload to /api/upload/ews, and log the tests the server says it
stored rather than the ones we sent.
(ResultsDatabase):
(ResultsDatabase.make_request):
(ResultsDatabase.has_commit):
* Tools/CISupport/ews-build/steps.py:
(ResultsDBReportMixin): Reporting shared by every suite; hosts supply the suite and the reports.
(ResultsDBReportMixin.suite):
(ResultsDBReportMixin.results_db_query_configuration):
(ResultsDBReportMixin.results_db_configuration):
(ResultsDBReportMixin.results_db_details):
(ResultsDBReportMixin.merged_results): One result per test across runs, keeping each run&apos;s own
outcome as well as the merged sequence.
(ResultsDBReportMixin.report_to_results_db):
(ShowIdentifier):
(ShowIdentifier.run): Read the commit timestamp from git-webkit find --json, so the commit is
fully defined without reinterpreting a human-readable date.
(RunWebKitTests):
(RunWebKitTests.run):
(RunWebKitTests.runCommand):
(RunWebKitTests.filter_failures_using_results_db):
(RunWebKitTestsInStressMode):
(RunWebKitTestsEWSSiteIsolation):
(RunWebKitTestsEWSSiteIsolation.results_db_query_configuration):
(RunWebKitTestsEWSSiteIsolation.filter_failures_using_results_db):
(ReRunWebKitTests.runCommand):
(RunWebKitTestsWithoutChange.runCommand):
(AnalyzeLayoutTestsResults):
(AnalyzeLayoutTestsResults.report_failure):
(AnalyzeLayoutTestsResults.run):
(RunWebKitTestsRepeatFailuresRedTree.runCommand):
(RunWebKitTestsRepeatFailuresWithoutChangeRedTree.runCommand):
* Tools/CISupport/ews-build/layout_test_failures.py:
(LayoutTestFailures): Keep each reported test&apos;s result leaf.
(LayoutTestFailures.__init__):
(LayoutTestFailures.results_from_string):
(LayoutTestFailures.results_from_string.collect_tests_that_did_not_pass):
(LayoutTestFailures.results_from_string.get_failing_tests): Deleted.
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps.test_steps_that_report_declare_the_suite_they_run):
* Tools/CISupport/ews-build/layout_test_failures_unittest.py:
(TestLayoutTestFailures.test_results_from_string_valid_jsonp):
(TestLayoutTestFailures.test_results_from_string_valid_json):
(TestLayoutTestFailures.test_results_records_the_result_leaf_for_every_reported_test):
(TestLayoutTestFailures):
(TestLayoutTestFailures.test_results_skips_tests_that_are_neither_failing_nor_flaky):
(TestLayoutTestFailures.test_results_from_string_split_at_4096):
* Tools/CISupport/ews-build/steps_unittest.py:
(BuildStepMixinAdditions):
(BuildStepMixinAdditions.layout_test_failures):
(BuildStepMixinAdditions.setup_test_build_step):
(BuildStepMixinAdditions.setup_test_build_step.record_report_ews):
(TestFilterLayoutTestFailuresUsingResultsDB.test_queries_include_the_flavor_being_tested):
(TestFilterLayoutTestFailuresUsingResultsDB):
(TestFilterLayoutTestFailuresUsingResultsDB.test_site_isolation_queries_across_platforms):
(TestFilterLayoutTestFailuresUsingResultsDB.test_caps_number_of_results_db_queries):
(TestRunWebKitTestsRedTree.test_set_properties_when_executed_scope_this_class):
(TestReportToResultsDB):
(TestReportToResultsDB.setUp):
(TestReportToResultsDB.tearDown):
(TestReportToResultsDB.configureStep):
(TestReportToResultsDB.test_reports_the_configuration_the_tests_ran_in):
(TestReportToResultsDB.test_folds_build_provenance_into_details):
(TestReportToResultsDB.test_authors_fall_back_to_the_patch_author):
(TestReportToResultsDB.test_reports_the_commit_ews_tested):
(TestReportToResultsDB.test_commit_is_left_resolvable_without_a_timestamp):
(TestReportToResultsDB.test_reports_when_the_run_started):
(TestReportToResultsDB.test_falls_back_to_the_current_time_when_no_run_was_timed):
(TestReportToResultsDB.test_merge_skips_a_test_no_run_produced_a_result_for):
(TestReportToResultsDB.test_records_results_against_the_branch_the_change_targets):
(TestReportToResultsDB.test_reports_nothing_without_a_version):
(TestReportToResultsDB.test_reports_nothing_without_an_architecture):
(TestReportToResultsDB.test_reports_the_architecture_the_tests_ran_on):
(TestReportToResultsDB.test_reports_nothing_for_several_architectures_at_once):
(TestReportToResultsDB.test_reports_for_a_wildcard_builder_that_resolves_to_apple):
(TestReportToResultsDB.test_a_step_that_provokes_flakiness_reports_nothing):
(TestReportToResultsDB.test_an_unreachable_results_database_does_not_fail_the_step):
(TestReportToResultsDB.test_an_unreachable_results_database_does_not_fail_the_step.explode):
(TestReportToResultsDB.test_uploads_the_platform_name_queries_ask_for):
(TestReportToResultsDB.test_merges_a_tests_outcomes_across_runs_without_repeating_them):
(TestLayoutTestStepsReportAsTheyRun):
(TestLayoutTestStepsReportAsTheyRun.FakeLogObserver):
(TestLayoutTestStepsReportAsTheyRun.FakeLogObserver.__init__):
(TestLayoutTestStepsReportAsTheyRun.FakeLogObserver.getStdout):
(TestLayoutTestStepsReportAsTheyRun.FakeLogObserver.getStderr):
(TestLayoutTestStepsReportAsTheyRun.FakeLogObserver.getHeaders):
(TestLayoutTestStepsReportAsTheyRun.setUp):
(TestLayoutTestStepsReportAsTheyRun.tearDown):
(TestLayoutTestStepsReportAsTheyRun.configureStep):
(TestLayoutTestStepsReportAsTheyRun.configureStep.fake_filter):
(TestLayoutTestStepsReportAsTheyRun.reported):
(TestLayoutTestStepsReportAsTheyRun.test_the_first_run_reports_its_own_flakes):
(TestLayoutTestStepsReportAsTheyRun.test_the_first_run_records_its_failures_for_later_reports):
(TestLayoutTestStepsReportAsTheyRun.test_the_rerun_reports_its_flakes_and_what_differed_from_the_first_run):
(TestLayoutTestStepsReportAsTheyRun.test_the_rerun_reports_no_inter_step_flakes_when_its_own_run_was_truncated):
(TestLayoutTestStepsReportAsTheyRun.test_the_rerun_reports_no_inter_step_flakes_when_the_first_run_was_truncated):
(TestLayoutTestStepsReportAsTheyRun.test_the_rerun_reports_no_inter_step_flakes_without_a_first_run_to_compare):
(TestLayoutTestStepsReportAsTheyRun.test_the_clean_tree_run_reports_flakes_the_change_cannot_have_caused):
(TestLayoutTestStepsReportAsTheyRun.test_the_redtree_repeat_run_reports_with_change_flakes):
(TestLayoutTestStepsReportAsTheyRun.test_the_redtree_clean_tree_repeat_run_reports_without_change_flakes):
(TestLayoutTestStepsReportAsTheyRun.test_the_analyze_step_reports_the_failures_it_attributes_to_the_change):
(TestRunWebKitTestsRepeatFailuresRedTree.test_set_properties_when_executed_scope_this_class):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.test_set_properties_when_executed_scope_this_class):
(MockLayoutTestFailures): Deleted.
(MockLayoutTestFailures.__init__): Deleted.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py:
(EWSContext.EWSFlakesByStartTime): flaky_type joins the clustering key, under a new table name
since a clustering column cannot be added to an existing table.
(EWSContext.__init__):
(EWSContext.record_results):
(EWSContext.find_for_test):
(EWSContext.EWSFlakyTestsByStartTime): Deleted.
(EWSContext.EWSFlakyTestsByStartTime.unpack): Deleted.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context_unittest.py:
(EWSContextTest):
(EWSContextTest.test_both_flaky_types_from_one_run_are_kept):

Canonical link: <a href="https://commits.webkit.org/319195@main">https://commits.webkit.org/319195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e9a0f0f96f26a7c49a20020682304044a22442f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145096 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141011 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183728 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/44675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121463 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180097 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41293 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2147 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192921 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/180174 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54384 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150393 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40246 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55072 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150110 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44703 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122624 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53589 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16286 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52971 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53208 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53036 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->