### PR TITLE
[Memory64] Expand memory's declared limits in Memory64 case

### DIFF
--- a/JSTests/wasm/stress/memory64-oversized-limits.js
+++ b/JSTests/wasm/stress/memory64-oversized-limits.js
@@ -1,0 +1,51 @@
+//@ skip if $addressBits <= 32
+import * as assert from "../assert.js";
+
+function leb128(value) {
+    const bytes = [];
+    let n = BigInt(value);
+    do {
+        let byte = Number(n & 0x7fn);
+        n >>= 7n;
+        if (n !== 0n)
+            byte |= 0x80;
+        bytes.push(byte);
+    } while (n !== 0n);
+    return bytes;
+}
+
+// A module whose only content is a memory with the given limits.
+function moduleBytesWithMemoryLimits({ initial, maximum, is64bit = true }) {
+    const hasMaximum = maximum !== undefined;
+    const limitsFlags = (is64bit ? 0x04 : 0x00) | (hasMaximum ? 0x01 : 0x00); // bit 2: 64-bit index type, bit 0: has a maximum
+    const limits = [limitsFlags, ...leb128(initial), ...(hasMaximum ? leb128(maximum) : [])];
+    const memorySectionBody = [0x01, ...limits]; // 1 memory
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
+        0x05, ...leb128(memorySectionBody.length), ...memorySectionBody, // memory section
+    ]);
+}
+
+// The JS API caps a memory64 memory's limits at 2**37 - 1 pages, far more than can be allocated.
+// https://www.w3.org/TR/wasm-js-api-2/#limits
+const maxMemory64Pages = (1n << 37n) - 1n;
+const formerInvalidPageCountSentinel = (1n << 32n) - 1n;
+
+// An initial page count that can be declared but not allocated compiles, and must be rejected at
+// instantiation rather than truncated to an allocatable size.
+for (const initial of [maxMemory64Pages, 1n << 32n, (1n << 32n) + 5n, formerInvalidPageCountSentinel]) {
+    const module = new WebAssembly.Module(moduleBytesWithMemoryLimits({ initial }));
+    assert.throws(() => new WebAssembly.Instance(module), RangeError, "Out of memory");
+}
+
+// A maximum is only a declaration: an unallocatable one doesn't prevent instantiation.
+for (const maximum of [maxMemory64Pages, 1n << 32n, formerInvalidPageCountSentinel])
+    new WebAssembly.Instance(new WebAssembly.Module(moduleBytesWithMemoryLimits({ initial: 1n, maximum })));
+
+// Anything above the limit is invalid, and so is a memory32 above 2**16 pages.
+for (const [limits, message] of [
+    [{ initial: maxMemory64Pages + 1n }, `Memory's initial page count of ${maxMemory64Pages + 1n} is invalid`],
+    [{ initial: 0n, maximum: maxMemory64Pages + 1n }, `Memory's maximum page count of ${maxMemory64Pages + 1n} is invalid`],
+    [{ initial: 65537n, is64bit: false }, "Memory's initial page count of 65537 is invalid"],
+])
+    assert.throws(() => new WebAssembly.Module(moduleBytesWithMemoryLimits(limits)), WebAssembly.CompileError, message);

--- a/Source/JavaScriptCore/runtime/PageCount.h
+++ b/Source/JavaScriptCore/runtime/PageCount.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <algorithm>
-#include <limits.h>
+#include <limits>
 #include <wtf/MathExtras.h>
 
 namespace WTF {
@@ -48,10 +48,8 @@ static_assert(sizeof(size_t) == sizeof(uint32_t));
 class PageCount {
 public:
     PageCount()
-        : m_pageCount(UINT_MAX)
-    {
-        static_assert(maxPageCount < UINT_MAX, "We rely on this here.");
-    }
+        : m_pageCount(invalidPageCount)
+    { }
 
     PageCount(uint64_t pageCount)
         : m_pageCount(pageCount)
@@ -97,7 +95,7 @@ public:
 
     explicit operator bool() const
     {
-        return m_pageCount != UINT_MAX;
+        return m_pageCount != invalidPageCount;
     }
 
     friend auto operator<=>(const PageCount&, const PageCount&) = default;
@@ -120,6 +118,8 @@ private:
     // that large will fail, which is acceptable according to the spec. Nevertheless, we should
     // be able to parse such a memory and instantiate it with a smaller initial size.
     static constexpr uint32_t maxPageCount = std::max<uint32_t>(64*1024, MAX_ARRAY_BUFFER_SIZE / static_cast<uint64_t>(pageSize));
+    static constexpr uint64_t invalidPageCount = std::numeric_limits<uint64_t>::max();
+    static_assert(maxPageCount < invalidPageCount);
 
     uint64_t m_pageCount;
 };

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -65,6 +65,9 @@ constexpr size_t maxTableEntries = 10000000;
 constexpr size_t maxTableInitializationEntries = 10000000;
 constexpr unsigned maxTables = 100000;
 
+constexpr uint64_t maxMemoryPages = 1ULL << 16;
+constexpr uint64_t maxMemory64Pages = (1ULL << 37) - 1;
+
 // Limit of GC arrays in bytes. This is not included in the limits in the
 // JS API spec, but we set a limit to avoid complicated boundary conditions.
 constexpr size_t maxArraySizeInBytes = 1 << 30;

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -410,7 +410,9 @@ auto SectionParser::parseMemoryHelper(bool isImport) -> PartialResult
         if (!limits) [[unlikely]]
             return makeUnexpected(WTF::move(limits.error()));
         ASSERT(!maximum || *maximum >= initial);
-        WASM_PARSER_FAIL_IF(!PageCount::isValid(initial), "Memory's initial page count of "_s, initial, " is invalid"_s);
+
+        const uint64_t maxDeclarablePageCount = isMemory64 ? maxMemory64Pages : maxMemoryPages;
+        WASM_PARSER_FAIL_IF(initial > maxDeclarablePageCount, "Memory's initial page count of "_s, initial, " is invalid"_s);
 
         // FIXME(wasm-memory64): for now IPInt checks m_cachedIsMemory64 (flag if memory 0 is 64-bit)
         // no matter which memory is being accessed
@@ -420,7 +422,7 @@ auto SectionParser::parseMemoryHelper(bool isImport) -> PartialResult
         initialPageCount = PageCount(initial);
 
         if (maximum) {
-            WASM_PARSER_FAIL_IF(!PageCount::isValid(*maximum), "Memory's maximum page count of "_s, *maximum, " is invalid"_s);
+            WASM_PARSER_FAIL_IF(*maximum > maxDeclarablePageCount, "Memory's maximum page count of "_s, *maximum, " is invalid"_s);
             maximumPageCount = PageCount(*maximum);
         }
     }


### PR DESCRIPTION
#### bf0425598904dd7ae7929e7e9e4ac248d93b9bdd
<pre>
[Memory64] Expand memory&apos;s declared limits in Memory64 case
<a href="https://bugs.webkit.org/show_bug.cgi?id=320681">https://bugs.webkit.org/show_bug.cgi?id=320681</a>
<a href="https://rdar.apple.com/183666875">rdar://183666875</a>

Reviewed by Keith Miller.

We rejected at parse time any memory declaring more than 65,536 pages,
regardless of index type. This is right for only the memory32 case.
The JS API limits a 64-bit memory&apos;s min and max to 2^37-1 pages, which
is far more than can be allocated. Such a module must compile and fail
at instantiation instead.

Bound the declared limits by index type in the memory section parser, using
new limits in WasmLimits.h alongside the other JS API limits it mirrors. A
declaration above what can be allocated is still rejected by
Memory::tryCreate(), matching how oversized table sizes are handled.

PageCount&apos;s sentinel for &quot;no page count&quot; moves from UINT_MAX to UINT64_MAX:
2^32-1 pages is now a legal declared page count, so it can no longer double
as the sentinel.

Note that memory64.wast.js still fails at memory64.wast:8 and :9, which
declare 2^48 pages. That is the core spec&apos;s bound; the JS API&apos;s is lower, and
the imported wasm/core tests do not account for it. This behavior matches
Chrome, and FireFox.

* JSTests/wasm/stress/memory64-oversized-limits.js: Added.
(leb128):
(moduleBytesWithMemoryLimits):
* Source/JavaScriptCore/runtime/PageCount.h:
(JSC::PageCount::PageCount):
(JSC::PageCount::operator bool const):
* Source/JavaScriptCore/wasm/WasmLimits.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseMemoryHelper):

Canonical link: <a href="https://commits.webkit.org/318282@main">https://commits.webkit.org/318282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bc6470175a48cfecdb02511b02aed7d3b019341

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187437 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8bf06869-c977-400a-90fb-93a1d3290433) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51474 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e011ecc-e03b-4e83-bea3-1814990c12aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119095 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8acacfc-df53-47d7-81b3-348c6d86908c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40804 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39162 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1064 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7853 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38853 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35898 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39098 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/44356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43398 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189866 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51432 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147733 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39689 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52114 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147519 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42230 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124366 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118797 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50622 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13832 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50018 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50258 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50080 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->