### PR TITLE
[CMake] Don't gate compiles on dependency framework code signing

### DIFF
--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -663,6 +663,7 @@ function(_WEBKIT_ADD_CODE_SIGN _target)
         COMMENT "Code signing ${_target}")
     add_custom_target(${_target}_CodeSign ALL DEPENDS ${_stamp})
     add_dependencies(${_target}_CodeSign ${_target})
+    set_target_properties(${_target} PROPERTIES CODESIGN_STAMP ${_stamp})
 endfunction()
 
 macro(_WEBKIT_TARGET_INTERFACE _target)
@@ -680,7 +681,16 @@ macro(_WEBKIT_TARGET_INTERFACE _target)
         target_compile_definitions(${_target}_PostBuild INTERFACE "STATICALLY_LINKED_WITH_${_target}")
     endif ()
     if (TARGET ${_target}_CodeSign)
-        add_dependencies(${_target}_PostBuild ${_target}_CodeSign)
+        get_target_property(_codesign_stamp ${_target} CODESIGN_STAMP)
+        if (_codesign_stamp)
+            # add_dependencies() on a utility target would order every consumer's
+            # objects behind signing; only linking reads the signed binary.
+            set_property(TARGET ${_target}_PostBuild APPEND PROPERTY
+                INTERFACE_LINK_DEPENDS ${_codesign_stamp})
+        else ()
+            # Executables sign in POST_BUILD and have no stamp.
+            add_dependencies(${_target}_PostBuild ${_target}_CodeSign)
+        endif ()
     endif ()
     add_library(WebKit::${_target} ALIAS ${_target}_PostBuild)
 endmacro()


### PR DESCRIPTION
#### 050a60948e62dcc9d9a0c4c6028235b889aece75
<pre>
[CMake] Don&apos;t gate compiles on dependency framework code signing
<a href="https://bugs.webkit.org/show_bug.cgi?id=320682">https://bugs.webkit.org/show_bug.cgi?id=320682</a>
<a href="https://rdar.apple.com/183667606">rdar://183667606</a>

Reviewed by Elliott Williams.

_WEBKIT_TARGET_INTERFACE attached ${_target}_CodeSign to the interface
library that every consumer links. CMake cannot know what a utility target
produces, so it conservatively makes each one in a consumer&apos;s dependency
closure an order-only dependency of every one of that consumer&apos;s object
files. Nothing in WebCore compiled until JavaScriptCore had linked and been
signed, nothing in WebKit until WebCore and WebKitLegacy had, and so on;
JavaScriptCore_CodeSign alone gated 877 compile edges, 51% of the build&apos;s
compile work.

Depend on the code signing stamp file instead, via INTERFACE_LINK_DEPENDS.
Compiling against a framework needs its staged headers and module maps,
which ${_target}_INTERFACE_DEPENDENCIES already orders; only linking reads
the binary that `codesign --force` rewrites in place. Depending on the stamp
also keeps signing ordered ahead of a directly built target, which the
ALL-ness of ${_target}_CodeSign did not guarantee. Executables sign in a
POST_BUILD command and have no stamp, so they keep the existing target-level
dependency.

39 of 82 cmake_object_order_depends_target_* phonies carried a *_CodeSign
dependency before, 0 after; on iOS, 29 of 79 before, 0 after.

* Source/cmake/WebKitMacros.cmake:

Canonical link: <a href="https://commits.webkit.org/318344@main">https://commits.webkit.org/318344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9abed8dab36d5177e2dd9da80fa474f9d3d23017

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187631 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e9e708b-ce2a-4572-a6f1-3e05657b3be1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138763 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fab7a296-91d0-4930-a8b5-8d6300c9f3a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119219 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb7ccabf-48b3-4e74-b2da-55fddc286a1f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40973 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39326 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1188 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8004 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151373 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39012 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36089 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39290 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190058 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51624 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39716 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52306 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147676 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42390 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119039 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50814 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13984 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50209 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50449 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50271 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->