### PR TITLE
[CMake] Enable explicit module builds for the TestWebKitAPI Swift targets

### DIFF
--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -53,6 +53,16 @@ set(TESTWEBKITAPI_SWIFT_FLAGS
     "$<$<COMPILE_LANGUAGE:Swift>:-F${CMAKE_LIBRARY_OUTPUT_DIRECTORY}>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${CMAKE_BINARY_DIR}>"
 )
+
+# Mirrors the EMB block in _WEBKIT_TARGET_SETUP, which these hand-rolled flags
+# bypass. The -Xcc flags are required: clang rejects the cached SwiftShims PCM
+# without them.
+list(APPEND TESTWEBKITAPI_SWIFT_FLAGS
+    "$<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-bounds-safety-attributes>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-late-parse-attributes>"
+)
+
 foreach (_f IN LISTS _test_swift_cc_flags)
     list(APPEND TESTWEBKITAPI_SWIFT_FLAGS "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc ${_f}>")
 endforeach ()


### PR DESCRIPTION
#### 681430f8805ed3bd1367d1bb0cead18f5c668766
<pre>
[CMake] Enable explicit module builds for the TestWebKitAPI Swift targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=320684">https://bugs.webkit.org/show_bug.cgi?id=320684</a>
<a href="https://rdar.apple.com/183668313">rdar://183668313</a>

Reviewed by Elliott Williams.

The Test* targets hand-roll their Swift flags in TESTWEBKITAPI_SWIFT_FLAGS
rather than going through _WEBKIT_TARGET_SETUP, so they never reached the
explicit-module-build block that WebKit, WebGPU and PAL opt into via
${_target}_SWIFT_EXPLICIT_MODULE_BUILD. Setting that variable here has no
effect; the flags have to be passed directly.

All seven Test* targets compile the same five Runner/*.swift files against
the same C++ interop modules, so with implicit modules the first target to
run populates the whole Clang module cache from scratch while the rest wait
on it. Measured on a mac-dev-debug build (M3 Max), rebuilding the seven
runner Swift edges with a cold SwiftModuleCache:

                        wall     cold edge   sum of edges   module cache
    implicit modules    203s        192.3s        236.4s    985 MB / 540 PCMs
    explicit modules     38s         29.0s         71.0s    498 MB / 1448 PCMs

That is a 165s (-81%) improvement, and the cache is half the size despite
holding finer-grained, deduplicated modules. The clean-build benchmark
deletes the build directory, so it always starts from a cold module cache
and sees the full win. Warm edges are ~7s either way, so incremental builds
are unaffected.

This matches Xcode, which already builds these targets with explicit Swift
modules: Tools/TestWebKitAPI/Configurations/Base.xcconfig sets
_SWIFT_EXPLICIT_MODULES_ALLOW_CXX_INTEROP to WK_SUPPORTS_SWIFT_OBJCXX_INTEROP.
No SDK gating is needed -- the only setter that carves out SDKs is bmalloc,
whose constraint is about SDKs tc module, and this
whole block is already inside if (WEBKIT_SDK_IS_MACOS), where
WK_SUPPORTS_SWIFT_OBJCXX_INTEROP

The two -Xcc experimental-attribt optional: without
them clang rejects the cached SwiftShims PCM with &quot;experimental late parsing
of attributes was enabled in prently disabled&quot;.
They mirror the other three explicit-module-build sites in the CMake build
(WebKitMacros.cmake for WebKit/W and
_WebKit_SwiftUI in Source/WebKit/PlatformCocoa.cmake). They are a CMake-only
workaround; Xcode needs neither.

* Tools/TestWebKitAPI/PlatformCocoa.cmake:

Canonical link: <a href="https://commits.webkit.org/318339@main">https://commits.webkit.org/318339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3228b4e1e2a28c01e31fd2254340799b7e8df50e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187442 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d9e9d78c-67fa-4e59-b20e-70eaa96c7f3a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51479 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138611 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f75244d7-c0c6-4beb-b32c-f6fe7782f1df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159359 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119074 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a63d00d3-f31b-4e03-9e38-2f1f21e7a101) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40813 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39169 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; 1 api test failed or timed out") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151218 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38854 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35903 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189871 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51437 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147730 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39717 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52119 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35483 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147516 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42240 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118802 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50627 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13833 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50023 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50085 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->