### PR TITLE
[libpas] pas_thread_local_cache_for_all clobbers its should-go-again result

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -1143,7 +1143,7 @@ bool pas_thread_local_cache_for_all(pas_allocator_scavenge_action allocator_acti
         case pas_deallocator_scavenge_flush_log_if_clean_action:
             if (cache->deallocation_log_dirty) {
                 cache->deallocation_log_dirty = false;
-                result = !!cache->deallocation_log_index;
+                result |= !!cache->deallocation_log_index;
             } else
                 flush_deallocation_log_for_scavenger(cache);
             break;


### PR DESCRIPTION
#### ead6285911f66363c2654c28de293f5c773c0741
<pre>
[libpas] pas_thread_local_cache_for_all clobbers its should-go-again result
<a href="https://bugs.webkit.org/show_bug.cgi?id=320686">https://bugs.webkit.org/show_bug.cgi?id=320686</a>
<a href="https://rdar.apple.com/183670692">rdar://183670692</a>

Reviewed by Yusuke Suzuki.

The result flag means &quot;more memory could be returned if this was called
again&quot;, accumulated across every TLC node in the iteration. The dirty
deallocation log case assigned to it instead of OR-ing, so it could clear a
true set by an earlier node. Instead, accumulate result similarly to how it
is handled in the other cases.

* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:
(pas_thread_local_cache_for_all):

Canonical link: <a href="https://commits.webkit.org/318320@main">https://commits.webkit.org/318320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74fbe593aa21ef033e342461d6ffd7b2c0f00bfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187450 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138618 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119081 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40808 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39173 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1050 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7862 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151213 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38862 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35911 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39111 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189879 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51445 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147737 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52127 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35491 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Running run-layout-tests-in-stress-mode; 344 new passes 10 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147523 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26986 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42238 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118810 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50635 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13841 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50031 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50093 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->