### PR TITLE
Allow wildcard domains/subdomains externally_connectable.matches

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -1725,13 +1725,7 @@ void WebExtension::populateExternallyConnectableIfNeeded()
                 continue;
 
             if (RefPtr matchPattern = WebExtensionMatchPattern::getOrCreate(matchPatternString)) {
-                if (matchPattern->matchesAllURLs() || !matchPattern->isSupported()) {
-                    shouldReportError = true;
-                    continue;
-                }
-
-                // URL patterns must contain at least a second-level domain. Top level domains and wildcards are not standalone patterns.
-                if (matchPattern->hostIsPublicSuffix()) {
+                if (!matchPattern || !matchPattern->isSupported()) {
                     shouldReportError = true;
                     continue;
                 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtension.mm
@@ -2310,23 +2310,17 @@ TEST(WKWebExtension, ExternallyConnectableParsing)
     EXPECT_EQ(testExtension.allRequestedMatchPatterns.count, 0ul);
     EXPECT_EQ(testExtension.errors.count, 1ul);
 
-    // Expect an error if <all_urls> is specified.
-    testManifestDictionary[@"externally_connectable"] = @{ @"matches": @[ @"<all_urls>" ] };
+    // Should not expect an error if <all_urls> or "*://*/*" are specified, since wildcard hosts are allowed.
+    testManifestDictionary[@"externally_connectable"] = @{ @"matches": @[ @"<all_urls>", @"*://*/*" ] };
     testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.allRequestedMatchPatterns.count, 0ul);
-    EXPECT_EQ(testExtension.errors.count, 1ul);
+    EXPECT_EQ(testExtension.allRequestedMatchPatterns.count, 2ul);
+    EXPECT_EQ(testExtension.errors.count, 0ul);
 
-    // Still expect the error, but have a valid requested match pattern.
-    testManifestDictionary[@"externally_connectable"] = @{ @"matches": @[ @"*://*.example.com/", @"<all_urls>" ] };
-    testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.allRequestedMatchPatterns.count, 1ul);
-    EXPECT_EQ(testExtension.errors.count, 1ul);
-
-    // Expect an error for not have a second level domain.
+    // Should not expect an error for a wildcard subdomain of a top level domain.
     testManifestDictionary[@"externally_connectable"] = @{ @"matches": @[ @"*://*.com/" ] };
     testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.allRequestedMatchPatterns.count, 0ul);
-    EXPECT_EQ(testExtension.errors.count, 1ul);
+    EXPECT_EQ(testExtension.allRequestedMatchPatterns.count, 1ul);
+    EXPECT_EQ(testExtension.errors.count, 0ul);
 
     // Should have a match for *://*.example.com/*.
     auto *matchingPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/" ];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebExtension.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebExtension.cpp
@@ -1116,24 +1116,23 @@ static void testExternallyConnectableParsing(Test*, gconstpointer)
     g_assert_null(webkit_web_extension_get_all_requested_match_patterns(extension.get()));
     g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
 
-    // Expect an error if <all_urls> is specified.
-    extension = parse("{ \"externally_connectable\": { \"matches\": [ \"<all_urls>\" ] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
-    g_assert_null(webkit_web_extension_get_all_requested_match_patterns(extension.get()));
-    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
-
-    // Still expect the errork, but have a valid match pattern
-    extension = parse("{ \"externally_connectable\": { \"matches\": [ \"*://*.example.com/\", \"<all_urls>\" ] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    // Should not expect an error if <all_urls> or "*://*/*" are specified, since wildcard hosts are allowed.
+    extension = parse("{ \"externally_connectable\": { \"matches\": [ \"<all_urls>\", \"*://*/*\" ] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
     guint patternLength = 0;
     auto matchPatterns = webkit_web_extension_get_all_requested_match_patterns(extension.get());
     for (; *matchPatterns != nullptr; matchPatterns++)
         patternLength++;
-    g_assert_cmpint(patternLength, ==, 1);
-    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_cmpint(patternLength, ==, 2);
+    g_assert_no_error(error.get());
 
-    // Expect an error for not having a second level domain.
+    // Expect no error for a wildcard subdomain of a top level domain.
     extension = parse("{ \"externally_connectable\": { \"matches\": [ \"*://*.com/\" ] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
-    g_assert_null(webkit_web_extension_get_all_requested_match_patterns(extension.get()));
-    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    patternLength = 0;
+    matchPatterns = webkit_web_extension_get_all_requested_match_patterns(extension.get());
+    for (; *matchPatterns != nullptr; matchPatterns++)
+        patternLength++;
+    g_assert_cmpint(patternLength, ==, 1);
+    g_assert_no_error(error.get());
 
     // Match for *://*.example.com/*
     auto* matchingPattern = webkit_web_extension_match_pattern_new_with_string("*://*.example.com/", nullptr);


### PR DESCRIPTION
#### 9d5eac09331904f9547925cf3afffd712aea60dd
<pre>
Allow wildcard domains/subdomains externally_connectable.matches
<a href="https://bugs.webkit.org/show_bug.cgi?id=320663">https://bugs.webkit.org/show_bug.cgi?id=320663</a>
<a href="https://rdar.apple.com/183642164">rdar://183642164</a>

Reviewed by Brian Weinstein and Timothy Hatcher.

In the WECG, <a href="https://github.com/w3c/webextensions/issues/94">https://github.com/w3c/webextensions/issues/94</a>, we aligned on supporting
wildcards for domains/subdomains for externally_connectable match patterns.

* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::populateExternallyConnectableIfNeeded):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, ExternallyConnectableParsing)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebExtension.cpp:
(testExternallyConnectableParsing):

Canonical link: <a href="https://commits.webkit.org/318361@main">https://commits.webkit.org/318361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd9a65c66cca2d4456b45bb383a4f5d6b5668b6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187615 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6bbaca6-a10b-4dea-8606-1305d3bb71d1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138751 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/841972bf-9cf8-4924-8dbf-8cad76e3f65e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119207 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f1b614f-575b-495c-99e6-b3d0ffa740fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40963 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39311 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151362 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38997 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36075 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190044 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51610 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147888 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52292 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147667 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27005 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42379 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124555 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119025 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50799 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13969 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50195 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50435 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->