### PR TITLE
REGRESSION(288096@main): ITP may cap the expiry of cookies set by a top-level navigation's own response

### DIFF
--- a/LayoutTests/http/tests/resourceLoadStatistics/cname-cloaking-top-level-navigation-not-capped.https-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/cname-cloaking-top-level-navigation-not-capped.https-expected.txt
@@ -1,0 +1,10 @@
+No cookie expiry capping for a cookie set by the top-level navigation's own response.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Cookie set by the top-level navigation response was not capped.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/resourceLoadStatistics/cname-cloaking-top-level-navigation-not-capped.https.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/cname-cloaking-top-level-navigation-not-capped.https.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="resources/util.js"></script>
+</head>
+<body onload="runTest()">
+<script>
+    description("No cookie expiry capping for a cookie set by the top-level navigation's own response.");
+    jsTestIsAsync = true;
+
+    const cookieName = "cnameTestCookie";
+    const oneWeekInMilliseconds = 7 * 24 * 60 * 60 * 1000;
+
+    function checkCookie() {
+        let cookie = internals.getCookies().find((cookie) => cookie.name === cookieName);
+        if (!cookie)
+            testFailed("Cookie was not set.");
+        else if (cookie.expires > Date.now() + oneWeekInMilliseconds)
+            testPassed("Cookie set by the top-level navigation response was not capped.");
+        else
+            testFailed("Cookie set by the top-level navigation response was capped.");
+
+        setEnableFeature(false, finishJSTest);
+    }
+
+    function runTest() {
+        if (document.location.search === "?step=check") {
+            checkCookie();
+            return;
+        }
+
+        setEnableFeature(true, function() {
+            testRunner.statisticsSetThirdPartyCNAMEDomain("http://3rdpartytestwebkit.org", function() {
+                document.location.href = "resources/set-cookie.py?name=" + cookieName + "&value=value#" + document.location.href + "?step=check";
+            });
+        });
+    }
+</script>
+</body>
+</html>

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -194,6 +194,11 @@ void NetworkTaskCocoa::setCookieTransformForFirstPartyRequest(const WebCore::Res
         return;
     }
 
+    if (request.isTopSite()) {
+        protect(task()).get()._cookieTransformCallback = nil;
+        return;
+    }
+
     // Cap expiry of incoming cookies in response if it is a same-site subresource but
     // it resolves to a different CNAME or IP address range than the top site request,
     // i.e. third-party CNAME or IP address cloaking.


### PR DESCRIPTION
#### ee54ef0cddb03af6ebea7c38c2f2fdab1f1dd30d
<pre>
REGRESSION(288096@main): ITP may cap the expiry of cookies set by a top-level navigation&apos;s own response
<a href="https://bugs.webkit.org/show_bug.cgi?id=320690">https://bugs.webkit.org/show_bug.cgi?id=320690</a>
<a href="https://rdar.apple.com/183664485">rdar://183664485</a>

Reviewed by Matthew Finkel.

Third-party CNAME and IP-address cloaking are defined in terms of first-party subresources, but
288096@main dropped the top-level navigation exemption and now installs the cookie transform for
every first-party request. As a result, a site whose own hostname is CNAMEd across registrable
domains has cookies set by its own top-level response capped to 7 days.

Restore the exemption inside setCookieTransformForFirstPartyRequest().

Test: http/tests/resourceLoadStatistics/cname-cloaking-top-level-navigation-not-capped.https.html

* LayoutTests/http/tests/resourceLoadStatistics/cname-cloaking-top-level-navigation-not-capped.https-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/cname-cloaking-top-level-navigation-not-capped.https.html: Added.
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::setCookieTransformForFirstPartyRequest):

Canonical link: <a href="https://commits.webkit.org/318332@main">https://commits.webkit.org/318332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a277c8e23c67fbc98b0998c58fd0e5aec2a2779

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187474 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7555afb-08a5-413e-9efe-7a9ac7e53740) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138636 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4387572c-9f13-4c69-90e4-08ba67ace0c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119099 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da3324f0-1c19-479f-b4d7-c38e6898c234) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40827 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39186 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151232 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38877 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Passed layout tests; 344 new passes 8 flakes") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35935 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44393 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189903 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147757 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52151 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147542 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26997 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42257 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124403 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118834 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50659 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13856 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50055 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50295 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50117 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->