### PR TITLE
[Win] `navigator.clipboard.readText()` always rejects

### DIFF
--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1416,6 +1416,14 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 
 webkit.org/b/203100 editing/async-clipboard [ Skip ]
 
+# Run the basic API and plain text coverage now that the async clipboard API is implemented.
+editing/async-clipboard/clipboard-item-basic.html [ Pass ]
+editing/async-clipboard/clipboard-read-text-same-origin.html [ Pass ]
+editing/async-clipboard/clipboard-read-text.html [ Pass ]
+editing/async-clipboard/clipboard-write-text.html [ Pass ]
+editing/async-clipboard/clipboard-wrapper-stays-alive.html [ Pass ]
+editing/async-clipboard/clipboard-write-text-requires-user-gesture.html [ Pass ]
+
 ###### Selection
 editing/selection/context-menu-text-selection-lookup.html [ Failure ]
 editing/selection/extend-selection-word.html [ Failure ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -694,7 +694,21 @@ AsyncClipboardAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)" : true
+      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)" : true
+      default: false
+    WebCore:
+      default: false
+
+AsyncClipboardRichContentEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Async clipboard rich content"
+  humanReadableDescription: "Enable rich content types in the async clipboard API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
       default: false
@@ -2436,7 +2450,7 @@ DOMPasteAccessRequestsEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(IOS) || PLATFORM(MAC) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(VISION)": true
+      "PLATFORM(IOS) || PLATFORM(MAC) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN) || PLATFORM(VISION)": true
       default: false
     WebCore:
       default: false

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -186,7 +186,7 @@ void Clipboard::writeText(const String& data, Ref<DeferredPromise>&& promise)
     PasteboardCustomData customData;
     customData.writeString(textPlainContentTypeAtom(), data);
     customData.setOrigin(document->originIdentifierForPasteboard());
-    Pasteboard::createForCopyAndPaste(PagePasteboardContext::create(frame->pageID()))->writeCustomData({ WTF::move(customData) });
+    Pasteboard::createForCopyAndPaste(PagePasteboardContext::create(frame->pageID()))->writeCustomData({ WTF::move(customData) }, PasteboardWriteType::AsyncClipboard);
     promise->resolve();
 }
 
@@ -420,6 +420,18 @@ void Clipboard::ItemWriter::didSetAllData()
     }
 
     auto dataToWrite = std::exchange(m_dataToWrite, { });
+    RefPtr context = m_clipboard ? m_clipboard->scriptExecutionContext() : nullptr;
+    if (!context) {
+        reject();
+        return;
+    }
+
+    bool supportsRichContent = context->settingsValues().asyncClipboardRichContentEnabled;
+    if (!supportsRichContent && dataToWrite.size() != 1) {
+        reject();
+        return;
+    }
+
     Vector<PasteboardCustomData> customData;
     customData.reserveInitialCapacity(dataToWrite.size());
     for (auto data : dataToWrite) {
@@ -427,10 +439,27 @@ void Clipboard::ItemWriter::didSetAllData()
             reject();
             return;
         }
+
+        if (!supportsRichContent) {
+            bool hasPlainText = false;
+            bool hasUnsupportedData = false;
+            data->forEachPlatformStringOrBuffer([&](auto& type, auto& value) {
+                if (type != textPlainContentTypeAtom() || !std::holds_alternative<String>(value)) {
+                    hasUnsupportedData = true;
+                    return;
+                }
+                hasPlainText = true;
+            });
+            if (!hasPlainText || hasUnsupportedData) {
+                reject();
+                return;
+            }
+        }
+
         customData.append(*data);
     }
 
-    m_pasteboard->writeCustomData(WTF::move(customData));
+    m_pasteboard->writeCustomData(WTF::move(customData), PasteboardWriteType::AsyncClipboard);
     promise->resolve();
     m_promise = nullptr;
 

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
@@ -36,6 +36,7 @@
 #include "Navigator.h"
 #include "PasteboardCustomData.h"
 #include "PasteboardItemInfo.h"
+#include "Settings.h"
 #include "SharedBuffer.h"
 
 namespace WebCore {
@@ -101,13 +102,18 @@ void ClipboardItem::getType(const String& type, Ref<DeferredPromise>&& promise)
     m_dataSource->getType(type, WTF::move(promise));
 }
 
-bool ClipboardItem::supports(const String& type)
+bool ClipboardItem::supports(ScriptExecutionContext& context, const String& type)
 {
+    if (type == textPlainContentTypeAtom())
+        return true;
+
+    if (!context.settingsValues().asyncClipboardRichContentEnabled)
+        return false;
+
     // FIXME: Custom format starts with `"web "`("web" followed by U+0020 SPACE) prefix
     // and suffix (after stripping out `"web "`) passes the parsing a MIME type check.
     // https://webkit.org/b/280664
-    return type == textPlainContentTypeAtom()
-        || type == textHTMLContentTypeAtom()
+    return type == textHTMLContentTypeAtom()
         || type == "image/png"_s
         || type == "text/uri-list"_s
         || type == "image/svg+xml"_s;

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.h
@@ -62,7 +62,7 @@ public:
 
     Vector<String> types() const;
     void getType(const String&, Ref<DeferredPromise>&&);
-    static bool supports(const String& type);
+    static bool supports(ScriptExecutionContext&, const String& type);
 
     void collectDataForWriting(Clipboard& destination, CompletionHandler<void(std::optional<PasteboardCustomData>)>&&);
 

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.idl
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.idl
@@ -44,7 +44,7 @@ dictionary ClipboardItemOptions {
 
     readonly attribute FrozenArray<DOMString> types;
     [NewObject] Promise<Blob> getType(DOMString type);
-    static boolean supports(DOMString type);
+    [CallWith=CurrentScriptExecutionContext] static boolean supports(DOMString type);
 
     readonly attribute PresentationStyle presentationStyle;
 };

--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -101,6 +101,7 @@ list(APPEND WebCore_SOURCES
     platform/win/MainThreadSharedTimerWin.cpp
     platform/win/PasteboardWin.cpp
     platform/win/PlatformMouseEventWin.cpp
+    platform/win/PlatformPasteboardWin.cpp
     platform/win/PlatformScreenWin.cpp
     platform/win/SearchPopupMenuDB.cpp
     platform/win/SharedMemoryWin.cpp

--- a/Source/WebCore/platform/Pasteboard.cpp
+++ b/Source/WebCore/platform/Pasteboard.cpp
@@ -63,7 +63,7 @@ Vector<String> Pasteboard::readAllStrings(const String& type)
 
 std::optional<Vector<PasteboardItemInfo>> Pasteboard::allPasteboardItemInfo() const
 {
-#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
     if (CheckedPtr strategy = platformStrategies()->pasteboardStrategy())
         return strategy->allPasteboardItemInfo(name(), m_changeCount, context());
 #endif
@@ -72,7 +72,7 @@ std::optional<Vector<PasteboardItemInfo>> Pasteboard::allPasteboardItemInfo() co
 
 std::optional<PasteboardItemInfo> Pasteboard::pasteboardItemInfo(size_t index) const
 {
-#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
     if (CheckedPtr strategy = platformStrategies()->pasteboardStrategy())
         return strategy->informationForItemAtIndex(index, name(), m_changeCount, context());
 #else

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -80,6 +80,7 @@ static constexpr auto pasteboardExpirationDelay = 8_min;
 
 enum class PlainTextURLReadingPolicy : bool { IgnoreURL, AllowURL };
 enum class WebContentReadingPolicy : bool { AnyType, OnlyRichTextTypes };
+enum class PasteboardWriteType : bool { General, AsyncClipboard };
 enum ShouldSerializeSelectedTextForDataTransfer { DefaultSelectedTextType, IncludeImageAltTextForDataTransfer };
 
 // For writing to the pasteboard. Generally sorted with the richest formats on top.
@@ -246,7 +247,7 @@ public:
     virtual WEBCORE_EXPORT void write(const PasteboardBuffer&);
     virtual WEBCORE_EXPORT void write(const PasteboardWebContent&);
 
-    virtual WEBCORE_EXPORT void writeCustomData(const Vector<PasteboardCustomData>&);
+    virtual WEBCORE_EXPORT void writeCustomData(const Vector<PasteboardCustomData>&, PasteboardWriteType = PasteboardWriteType::General);
 
     enum class FileContentState : uint8_t { NoFileOrImageData, InMemoryImage, MayContainFilePaths };
     virtual WEBCORE_EXPORT FileContentState fileContentState();
@@ -298,7 +299,7 @@ public:
     const PasteboardCustomData& readCustomData();
 #endif
 
-#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
     int64_t changeCount() const;
 #else
     int64_t changeCount() const { return 0; }
@@ -393,6 +394,9 @@ private:
     COMPtr<IDataObject> m_dataObject;
     COMPtr<WCDataObject> m_writableDataObject;
     DragDataMap m_dragDataMap;
+    // Drag and drop pasteboards use their own data object, so only the copy and paste pasteboard is backed by the clipboard.
+    bool m_forCopyAndPaste { false };
+    int64_t m_changeCount { 0 };
 #endif
 };
 

--- a/Source/WebCore/platform/PasteboardStrategy.h
+++ b/Source/WebCore/platform/PasteboardStrategy.h
@@ -96,11 +96,14 @@ public:
     virtual RefPtr<SharedBuffer> readBufferFromClipboard(const String& pasteboardName, const String& pasteboardType) = 0;
     virtual void writeToClipboard(const String& pasteboardName, SelectionData&&) = 0;
     virtual void clearClipboard(const String& pasteboardName) = 0;
-    virtual int64_t changeCount(const String& pasteboardName) = 0;
 #elif USE(LIBWPE)
     virtual void getTypes(Vector<String>& types) = 0;
     virtual void writeToPasteboard(const PasteboardWebContent&) = 0;
     virtual void writeToPasteboard(const String& pasteboardType, const String&) = 0;
+#endif
+
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
+    virtual int64_t changeCount(const String& pasteboardName) = 0;
 #endif
 
 protected:

--- a/Source/WebCore/platform/PlatformPasteboard.h
+++ b/Source/WebCore/platform/PlatformPasteboard.h
@@ -109,6 +109,10 @@ public:
     WEBCORE_EXPORT Vector<String> typesSafeForDOMToReadAndWrite(const String& origin) const;
     WEBCORE_EXPORT bool containsStringSafeForDOMToReadForType(const String&) const;
 
+#if PLATFORM(WIN)
+    WEBCORE_EXPORT std::optional<PasteboardCustomData> readCustomData() const;
+#endif
+
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT bool containsURLStringSuitableForLoading();
     WEBCORE_EXPORT String urlStringSuitableForLoading(String& title);

--- a/Source/WebCore/platform/StaticPasteboard.h
+++ b/Source/WebCore/platform/StaticPasteboard.h
@@ -66,7 +66,7 @@ public:
     void writeMarkup(const String&) final;
     void writePlainText(const String&, SmartReplaceOption) final;
 
-    void writeCustomData(const Vector<PasteboardCustomData>&) final { }
+    void writeCustomData(const Vector<PasteboardCustomData>&, PasteboardWriteType = PasteboardWriteType::General) final { }
 
     Pasteboard::FileContentState fileContentState() final { return m_fileContentState; }
     bool canSmartReplace() final { return false; }

--- a/Source/WebCore/platform/cocoa/PasteboardCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PasteboardCocoa.mm
@@ -294,7 +294,7 @@ const PasteboardCustomData& Pasteboard::readCustomData()
     return *m_customDataCache; 
 }
 
-void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
+void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data, PasteboardWriteType)
 {
     m_changeCount = platformStrategies()->pasteboardStrategy()->writeCustomData(data, name(), context());
 }

--- a/Source/WebCore/platform/glib/PasteboardGLib.cpp
+++ b/Source/WebCore/platform/glib/PasteboardGLib.cpp
@@ -504,7 +504,7 @@ void Pasteboard::writeMarkup(const String&)
 {
 }
 
-void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
+void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data, PasteboardWriteType)
 {
     if (m_selectionData) {
         if (!data.isEmpty()) {

--- a/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
+++ b/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
@@ -152,7 +152,7 @@ void Pasteboard::writePlainText(const String& text, SmartReplaceOption)
     writeString("text/plain;charset=utf-8"_s, text);
 }
 
-void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>&)
+void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>&, PasteboardWriteType)
 {
 }
 

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -42,6 +42,12 @@
 
 namespace WebCore {
 
+UINT customDataClipboardFormat()
+{
+    static UINT format = ::RegisterClipboardFormat(L"WebKit Custom Data Format");
+    return format;
+}
+
 FORMATETC* cfHDropFormat()
 {
     static FORMATETC urlFormat = {CF_HDROP, 0, DVASPECT_CONTENT, -1, TYMED_HGLOBAL};

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
@@ -35,6 +35,8 @@ namespace WebCore {
 class Document;
 class DocumentFragment;
 
+UINT customDataClipboardFormat();
+
 HGLOBAL createGlobalData(const String&);
 HGLOBAL createGlobalData(const Vector<char>&);
 HGLOBAL createGlobalData(const URL& url, const String& title);

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -45,6 +45,8 @@
 #include "ImageAdapter.h"
 #include "LocalFrameInlines.h"
 #include "NotImplemented.h"
+#include "PasteboardStrategy.h"
+#include "PlatformStrategies.h"
 #include "Range.h"
 #include "RenderImage.h"
 #include "SharedBuffer.h"
@@ -69,7 +71,6 @@ namespace WebCore {
 static UINT HTMLClipboardFormat = 0;
 static UINT BookmarkClipboardFormat = 0;
 static UINT WebSmartPasteFormat = 0;
-static UINT CustomDataClipboardFormat = 0;
 
 static LRESULT CALLBACK PasteboardOwnerWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
@@ -141,13 +142,14 @@ void Pasteboard::finishCreatingPasteboard()
     HTMLClipboardFormat = ::RegisterClipboardFormat(L"HTML Format");
     BookmarkClipboardFormat = ::RegisterClipboardFormat(L"UniformResourceLocatorW");
     WebSmartPasteFormat = ::RegisterClipboardFormat(L"WebKit Smart Paste Format");
-    CustomDataClipboardFormat = ::RegisterClipboardFormat(L"WebKit Custom Data Format");
 }
 
 Pasteboard::Pasteboard(std::unique_ptr<PasteboardContext>&& context)
     : m_context(WTF::move(context))
     , m_dataObject(0)
     , m_writableDataObject(0)
+    , m_forCopyAndPaste(true)
+    , m_changeCount(platformStrategies()->pasteboardStrategy()->changeCount(name()))
 {
     finishCreatingPasteboard();
 }
@@ -253,8 +255,8 @@ static void addMIMETypesForFormat(OrderedHashSet<String>& results, const FORMATE
 
 std::optional<PasteboardCustomData> Pasteboard::readPasteboardCustomData()
 {
-    if (::IsClipboardFormatAvailable(CustomDataClipboardFormat) && ::OpenClipboard(m_owner)) {
-        if (HANDLE cbData = ::GetClipboardData(CustomDataClipboardFormat)) {
+    if (::IsClipboardFormatAvailable(customDataClipboardFormat()) && ::OpenClipboard(m_owner)) {
+        if (HANDLE cbData = ::GetClipboardData(customDataClipboardFormat())) {
             size_t size = GlobalSize(cbData);
             auto data = static_cast<uint8_t*>(GlobalLock(cbData));
             auto customData = PasteboardCustomData::fromPersistenceDecoder({{ data, size }});
@@ -268,6 +270,14 @@ std::optional<PasteboardCustomData> Pasteboard::readPasteboardCustomData()
     }
 
     return std::nullopt;
+}
+
+int64_t Pasteboard::changeCount() const
+{
+    if (!m_forCopyAndPaste)
+        return 0;
+
+    return platformStrategies()->pasteboardStrategy()->changeCount(name());
 }
 
 Vector<String> Pasteboard::typesSafeForBindings(const String& origin)
@@ -834,8 +844,13 @@ bool Pasteboard::canSmartReplace()
     return ::IsClipboardFormatAvailable(WebSmartPasteFormat);
 }
 
-void Pasteboard::read(PasteboardPlainText& text, PlainTextURLReadingPolicy, std::optional<size_t>)
+void Pasteboard::read(PasteboardPlainText& text, PlainTextURLReadingPolicy, std::optional<size_t> index)
 {
+    if (index) {
+        text.text = platformStrategies()->pasteboardStrategy()->readStringFromPasteboard(index.value_or(0), textPlainContentTypeAtom(), name(), context());
+        return;
+    }
+
     if (::IsClipboardFormatAvailable(CF_UNICODETEXT) && ::OpenClipboard(m_owner)) {
         if (HANDLE cbData = ::GetClipboardData(CF_UNICODETEXT)) {
             text.text = static_cast<wchar_t*>(GlobalLock(cbData));
@@ -1137,10 +1152,15 @@ void Pasteboard::write(const PasteboardBuffer&)
 {
 }
 
-void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
+void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data, PasteboardWriteType type)
 {
     if (data.isEmpty() || data.size() > 1) {
         // We don't support more than one custom item in the clipboard.
+        return;
+    }
+
+    if (type == PasteboardWriteType::AsyncClipboard) {
+        m_changeCount = platformStrategies()->pasteboardStrategy()->writeCustomData(data, name(), context());
         return;
     }
 
@@ -1149,30 +1169,30 @@ void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
     if (::OpenClipboard(m_owner)) {
         const auto& customData = data.first();
         customData.forEachPlatformStringOrBuffer([](auto& type, auto& stringOrBuffer) {
-            if (std::holds_alternative<String>(stringOrBuffer)) {
-                ClipboardDataType dataType = clipboardTypeFromMIMEType(type);
+            if (!std::holds_alternative<String>(stringOrBuffer))
+                return;
 
-                String str = std::get<String>(stringOrBuffer);
-                replaceNewlinesWithWindowsStyleNewlines(str);
-                HGLOBAL cbData = createGlobalData(str);
+            ClipboardDataType dataType = clipboardTypeFromMIMEType(type);
+            String str = std::get<String>(stringOrBuffer);
+            replaceNewlinesWithWindowsStyleNewlines(str);
+            HGLOBAL cbData = createGlobalData(str);
 
-                if (dataType == ClipboardDataTypeText) {
-                    if (cbData && !::SetClipboardData(CF_UNICODETEXT, cbData))
-                        ::GlobalFree(cbData);
-                } else if (dataType == ClipboardDataTypeURL) {
-                    if (cbData && !::SetClipboardData(BookmarkClipboardFormat, cbData))
-                        ::GlobalFree(cbData);
-                } else if (dataType == ClipboardDataTypeTextHTML) {
-                    if (cbData && !::SetClipboardData(HTMLClipboardFormat, cbData))
-                        ::GlobalFree(cbData);
-                }
+            if (dataType == ClipboardDataTypeText) {
+                if (cbData && !::SetClipboardData(CF_UNICODETEXT, cbData))
+                    ::GlobalFree(cbData);
+            } else if (dataType == ClipboardDataTypeURL) {
+                if (cbData && !::SetClipboardData(BookmarkClipboardFormat, cbData))
+                    ::GlobalFree(cbData);
+            } else if (dataType == ClipboardDataTypeTextHTML) {
+                if (cbData && !::SetClipboardData(HTMLClipboardFormat, cbData))
+                    ::GlobalFree(cbData);
             }
         });
 
         if (customData.hasSameOriginCustomData() || !customData.origin().isEmpty()) {
             auto sharedBuffer = customData.createSharedBuffer();
             HGLOBAL cbData = createGlobalData(sharedBuffer->span());
-            if (cbData && !::SetClipboardData(CustomDataClipboardFormat, cbData))
+            if (cbData && !::SetClipboardData(customDataClipboardFormat(), cbData))
                 ::GlobalFree(cbData);
         }
 

--- a/Source/WebCore/platform/win/PlatformPasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PlatformPasteboardWin.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2026 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PlatformPasteboard.h"
+
+#if PLATFORM(WIN)
+
+#include "ClipboardUtilitiesWin.h"
+#include "CommonAtomStrings.h"
+#include "PasteboardCustomData.h"
+#include "PasteboardItemInfo.h"
+#include "SharedBuffer.h"
+#include "WebCoreInstanceHandle.h"
+#include <windows.h>
+#include <wtf/ListHashSet.h>
+#include <wtf/MainThread.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+// `EmptyClipboard` makes the owner of an unowned clipboard `nullptr`, which then makes `SetClipboardData` fail.
+static HWND clipboardOwner()
+{
+    ASSERT(isMainThread());
+
+    static HWND owner = []() -> HWND {
+        WNDCLASS windowClass { };
+        windowClass.lpfnWndProc = ::DefWindowProc;
+        windowClass.hInstance = WebCore::instanceHandle();
+        windowClass.lpszClassName = L"PlatformPasteboardOwnerWindowClass";
+        if (!::RegisterClass(&windowClass) && ::GetLastError() != ERROR_CLASS_ALREADY_EXISTS)
+            return nullptr;
+        return ::CreateWindow(windowClass.lpszClassName, L"PlatformPasteboardOwnerWindow", 0, 0, 0, 0, 0, HWND_MESSAGE, 0, windowClass.hInstance, 0);
+    }();
+    return owner;
+}
+
+PlatformPasteboard::PlatformPasteboard(const String&)
+{
+}
+
+void PlatformPasteboard::performAsDataOwner(DataOwnerType, NOESCAPE Function<void()>&& actions)
+{
+    actions();
+}
+
+int64_t PlatformPasteboard::changeCount() const
+{
+    return ::GetClipboardSequenceNumber();
+}
+
+void PlatformPasteboard::getTypes(Vector<String>& types) const
+{
+    if (::IsClipboardFormatAvailable(CF_UNICODETEXT) || ::IsClipboardFormatAvailable(CF_TEXT))
+        types.append(textPlainContentTypeAtom());
+}
+
+static String readClipboardString(UINT format)
+{
+    if (!::IsClipboardFormatAvailable(format) || !::OpenClipboard(clipboardOwner()))
+        return { };
+
+    String string;
+    if (HANDLE data = ::GetClipboardData(format)) {
+        if (auto* characters = ::GlobalLock(data)) {
+            if (format == CF_TEXT) {
+                // FIXME: This treats the characters as Latin-1, not UTF-8 or even Windows Latin-1. Is that the right encoding?
+                string = String::fromLatin1(static_cast<const char*>(characters));
+            } else
+                string = static_cast<const wchar_t*>(characters);
+            ::GlobalUnlock(data);
+        }
+    }
+    ::CloseClipboard();
+    return string;
+}
+
+std::optional<PasteboardCustomData> PlatformPasteboard::readCustomData() const
+{
+    if (!::IsClipboardFormatAvailable(customDataClipboardFormat()) || !::OpenClipboard(clipboardOwner()))
+        return std::nullopt;
+
+    std::optional<PasteboardCustomData> customData;
+    if (HANDLE data = ::GetClipboardData(customDataClipboardFormat())) {
+        // Custom data is a serialized buffer rather than text, so it is read by length.
+        auto size = ::GlobalSize(data);
+        if (auto* bytes = static_cast<const uint8_t*>(::GlobalLock(data))) {
+            customData = PasteboardCustomData::fromPersistenceDecoder({ { bytes, size } });
+            ::GlobalUnlock(data);
+        }
+    }
+    ::CloseClipboard();
+    return customData;
+}
+
+String PlatformPasteboard::readString(size_t index, const String& type) const
+{
+    // The clipboard holds a single item.
+    if (index)
+        return { };
+
+    if (!type.startsWith(textPlainContentTypeAtom()))
+        return { };
+
+    auto text = readClipboardString(CF_UNICODETEXT);
+    return text.isNull() ? readClipboardString(CF_TEXT) : text;
+}
+
+Vector<String> PlatformPasteboard::typesSafeForDOMToReadAndWrite(const String& origin) const
+{
+    ListHashSet<String> domTypes;
+
+    if (auto customData = readCustomData(); customData && customData->origin() == origin) {
+        for (auto& type : customData->orderedTypes())
+            domTypes.add(type);
+    }
+
+    if (::IsClipboardFormatAvailable(CF_UNICODETEXT) || ::IsClipboardFormatAvailable(CF_TEXT))
+        domTypes.add(textPlainContentTypeAtom());
+
+    return copyToVector(domTypes);
+}
+
+std::optional<PasteboardItemInfo> PlatformPasteboard::informationForItemAtIndex(size_t index, int64_t changeCount)
+{
+    // The clipboard holds a single item, and `std::nullopt` means that it changed while it was being read.
+    if (index || changeCount != this->changeCount())
+        return std::nullopt;
+
+    PasteboardItemInfo info;
+    getTypes(info.platformTypesByFidelity);
+    info.webSafeTypesByFidelity = info.platformTypesByFidelity;
+    return info;
+}
+
+std::optional<Vector<PasteboardItemInfo>> PlatformPasteboard::allPasteboardItemInfo(int64_t changeCount)
+{
+    auto info = informationForItemAtIndex(0, changeCount);
+    if (!info)
+        return std::nullopt;
+
+    if (info->platformTypesByFidelity.isEmpty())
+        return Vector<PasteboardItemInfo> { };
+
+    return Vector<PasteboardItemInfo> { WTF::move(*info) };
+}
+
+int PlatformPasteboard::count() const
+{
+    Vector<String> types;
+    getTypes(types);
+    return types.isEmpty() ? 0 : 1;
+}
+
+// The caller is responsible for having opened the clipboard.
+static void setClipboardData(UINT format, HGLOBAL data)
+{
+    if (!data)
+        return;
+    if (!::SetClipboardData(format, data))
+        ::GlobalFree(data);
+}
+
+int64_t PlatformPasteboard::write(const PasteboardCustomData& data, PasteboardDataLifetime)
+{
+    String text;
+    data.forEachPlatformStringOrBuffer([&](auto& type, auto& value) {
+        if (type != textPlainContentTypeAtom() || !std::holds_alternative<String>(value))
+            return;
+        text = std::get<String>(value);
+    });
+    if (text.isNull())
+        return changeCount();
+
+    // A failed write leaves the clipboard, and so its change count, alone.
+    if (!::OpenClipboard(clipboardOwner()))
+        return changeCount();
+
+    if (!::EmptyClipboard()) {
+        ::CloseClipboard();
+        return changeCount();
+    }
+
+    replaceNewlinesWithWindowsStyleNewlines(text);
+    setClipboardData(CF_UNICODETEXT, createGlobalData(text));
+
+    if (data.hasSameOriginCustomData() || !data.origin().isEmpty())
+        setClipboardData(customDataClipboardFormat(), createGlobalData(data.createSharedBuffer()->span()));
+
+    ::CloseClipboard();
+
+    return changeCount();
+}
+
+int64_t PlatformPasteboard::write(const Vector<PasteboardCustomData>& data, PasteboardDataLifetime pasteboardDataLifetime)
+{
+    // More than one custom item in the clipboard is not supported.
+    if (data.isEmpty() || data.size() > 1)
+        return changeCount();
+
+    return write(data[0], pasteboardDataLifetime);
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(WIN)

--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -58,6 +58,7 @@ list(APPEND WebKit_SOURCES
     UIProcess/win/PageClientImpl.cpp
     UIProcess/win/WebContextMenuProxyWin.cpp
     UIProcess/win/WebPageProxyWin.cpp
+    UIProcess/win/WebPasteboardProxyWin.cpp
     UIProcess/win/WebPopupMenuProxyWin.cpp
     UIProcess/win/WebProcessPoolWin.cpp
     UIProcess/win/WebView.cpp

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.cpp
@@ -75,7 +75,7 @@ RefPtr<WebProcessProxy> WebPasteboardProxy::webProcessProxyForConnection(IPC::Co
 
 #if !PLATFORM(COCOA)
 
-#if !PLATFORM(GTK) && !PLATFORM(WPE)
+#if !PLATFORM(GTK) && !PLATFORM(WPE) && !PLATFORM(WIN)
 void WebPasteboardProxy::typesSafeForDOMToReadAndWrite(IPC::Connection&, const String&, const String&, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(Vector<String>&&)>&& completionHandler)
 {
     completionHandler({ });
@@ -112,7 +112,7 @@ void WebPasteboardProxy::readBufferFromPasteboard(IPC::Connection&, std::optiona
 }
 #endif
 
-#if !USE(LIBWPE) || PLATFORM(WPE)
+#if (!USE(LIBWPE) || PLATFORM(WPE)) && !PLATFORM(WIN)
 
 void WebPasteboardProxy::readStringFromPasteboard(IPC::Connection&, uint64_t, const String&, const String&, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(String&&)>&& completionHandler)
 {

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -146,11 +146,14 @@ private:
     void readBuffer(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
     void writeToClipboard(const String& pasteboardName, WebCore::SelectionData&&);
     void clearClipboard(const String& pasteboardName);
-    void getPasteboardChangeCount(IPC::Connection&, const String& pasteboardName, CompletionHandler<void(int64_t)>&&);
 #elif USE(LIBWPE)
     void getPasteboardTypes(CompletionHandler<void(Vector<String>&&)>&&);
     void writeWebContentToPasteboard(const WebCore::PasteboardWebContent&);
     void writeStringToPasteboard(const String& pasteboardType, const String&);
+#endif
+
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
+    void getPasteboardChangeCount(IPC::Connection&, const String& pasteboardName, CompletionHandler<void(int64_t)>&&);
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
@@ -78,12 +78,15 @@ messages -> WebPasteboardProxy {
     ReadBuffer(String pasteboardName, String pasteboardType) -> (RefPtr<WebCore::SharedBuffer> buffer) Synchronous
     WriteToClipboard(String pasteboardName, WebCore::SelectionData pasteboardContent)
     ClearClipboard(String pasteboardName)
-    GetPasteboardChangeCount(String pasteboardName) -> (int64_t changeCount) Synchronous
 #endif
 
 #if USE(LIBWPE) && !PLATFORM(WPE)
     GetPasteboardTypes() -> (Vector<String> types) Synchronous
     WriteWebContentToPasteboard(struct WebCore::PasteboardWebContent content)
     WriteStringToPasteboard(String pasteboardType, String text)
+#endif
+
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
+    GetPasteboardChangeCount(String pasteboardName) -> (int64_t changeCount) Synchronous
 #endif
 }

--- a/Source/WebKit/UIProcess/win/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.cpp
@@ -38,6 +38,8 @@
 #include <WebCore/DOMPasteAccess.h>
 #include <WebCore/LocalizedStrings.h>
 #include <WebCore/NotImplemented.h>
+#include <WebCore/PasteboardCustomData.h>
+#include <WebCore/PlatformPasteboard.h>
 
 #if USE(GRAPHICS_LAYER_WC)
 #include "DrawingAreaProxyWC.h"
@@ -439,8 +441,18 @@ HWND PageClientImpl::viewWidget()
     return m_view.window();
 }
 
-void PageClientImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::DOMPasteRequiresInteraction, WebCore::FrameIdentifier, const IntRect&, const String&, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&& completionHandler)
+void PageClientImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::DOMPasteRequiresInteraction requiresInteraction, WebCore::FrameIdentifier, const IntRect&, const String& originIdentifier, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&& completionHandler)
 {
+    // Reading back what the same origin just wrote needs no permission.
+    if (requiresInteraction == WebCore::DOMPasteRequiresInteraction::No) {
+        auto customData = WebCore::PlatformPasteboard(emptyString()).readCustomData();
+        if (customData && customData->origin() == originIdentifier) {
+            completionHandler(WebCore::DOMPasteAccessResponse::GrantedForGesture);
+            return;
+        }
+    }
+
+    // FIXME: Ask the embedder for permission rather than denying outright.
     completionHandler(WebCore::DOMPasteAccessResponse::DeniedForGesture);
 }
 

--- a/Source/WebKit/UIProcess/win/WebPasteboardProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPasteboardProxyWin.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebPasteboardProxy.h"
+
+#if PLATFORM(WIN)
+
+#include "Connection.h"
+#include <WebCore/Pasteboard.h>
+#include <WebCore/PasteboardCustomData.h>
+#include <WebCore/PasteboardItemInfo.h>
+#include <WebCore/PlatformPasteboard.h>
+#include <WebCore/SharedBuffer.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+// The pasteboard name is unused because Windows has a single system clipboard.
+
+void WebPasteboardProxy::getPasteboardChangeCount(IPC::Connection&, const String& pasteboardName, CompletionHandler<void(int64_t)>&& completionHandler)
+{
+    completionHandler(PlatformPasteboard(pasteboardName).changeCount());
+}
+
+void WebPasteboardProxy::typesSafeForDOMToReadAndWrite(IPC::Connection&, const String& pasteboardName, const String& origin, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(Vector<String>&&)>&& completionHandler)
+{
+    completionHandler(PlatformPasteboard(pasteboardName).typesSafeForDOMToReadAndWrite(origin));
+}
+
+void WebPasteboardProxy::writeCustomData(IPC::Connection&, const Vector<PasteboardCustomData>& data, const String& pasteboardName, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(int64_t)>&& completionHandler)
+{
+    completionHandler(PlatformPasteboard(pasteboardName).write(data));
+}
+
+void WebPasteboardProxy::allPasteboardItemInfo(IPC::Connection&, const String& pasteboardName, int64_t changeCount, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(std::optional<Vector<PasteboardItemInfo>>&&)>&& completionHandler)
+{
+    completionHandler(PlatformPasteboard(pasteboardName).allPasteboardItemInfo(changeCount));
+}
+
+void WebPasteboardProxy::informationForItemAtIndex(IPC::Connection&, uint64_t index, const String& pasteboardName, int64_t changeCount, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(std::optional<PasteboardItemInfo>&&)>&& completionHandler)
+{
+    completionHandler(PlatformPasteboard(pasteboardName).informationForItemAtIndex(index, changeCount));
+}
+
+void WebPasteboardProxy::getPasteboardItemsCount(IPC::Connection&, const String& pasteboardName, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(uint64_t)>&& completionHandler)
+{
+    completionHandler(PlatformPasteboard(pasteboardName).count());
+}
+
+void WebPasteboardProxy::readStringFromPasteboard(IPC::Connection&, uint64_t index, const String& pasteboardType, const String& pasteboardName, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(String&&)>&& completionHandler)
+{
+    completionHandler(PlatformPasteboard(pasteboardName).readString(index, pasteboardType));
+}
+
+void WebPasteboardProxy::readURLFromPasteboard(IPC::Connection&, uint64_t, const String&, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(String&& url, String&& title)>&& completionHandler)
+{
+    completionHandler({ }, { });
+}
+
+void WebPasteboardProxy::readBufferFromPasteboard(IPC::Connection&, std::optional<uint64_t>, const String&, const String&, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(RefPtr<SharedBuffer>&&)>&& completionHandler)
+{
+    completionHandler({ });
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(WIN)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -427,13 +427,6 @@ void WebPlatformStrategies::clearClipboard(const String& pasteboardName)
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebPasteboardProxy::ClearClipboard(pasteboardName), 0);
 }
 
-int64_t WebPlatformStrategies::changeCount(const String& pasteboardName)
-{
-    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardChangeCount(pasteboardName), 0);
-    auto [changeCount] = sendResult.takeReplyOr(0);
-    return changeCount;
-}
-
 #elif USE(LIBWPE)
 // PasteboardStrategy
 
@@ -455,6 +448,17 @@ void WebPlatformStrategies::writeToPasteboard(const String& pasteboardType, cons
 }
 
 #endif // USE(LIBWPE)
+
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
+
+int64_t WebPlatformStrategies::changeCount(const String& pasteboardName)
+{
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardChangeCount(pasteboardName), 0);
+    auto [changeCount] = sendResult.takeReplyOr(0);
+    return changeCount;
+}
+
+#endif // PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
 
 Vector<String> WebPlatformStrategies::typesSafeForDOMToReadAndWrite(const String& pasteboardName, const String& origin, const PasteboardContext* context)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
@@ -94,11 +94,14 @@ private:
     RefPtr<WebCore::SharedBuffer> readBufferFromClipboard(const String& pasteboardName, const String& pasteboardType) override;
     void writeToClipboard(const String& pasteboardName, WebCore::SelectionData&&) override;
     void clearClipboard(const String& pasteboardName) override;
-    int64_t changeCount(const String& pasteboardName) override;
 #elif USE(LIBWPE)
     void getTypes(Vector<String>& types) override;
     void writeToPasteboard(const WebCore::PasteboardWebContent&) override;
     void writeToPasteboard(const String& pasteboardType, const String&) override;
+#endif
+
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
+    int64_t changeCount(const String& pasteboardName) override;
 #endif
 
     String readStringFromPasteboard(size_t index, const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*) override;

--- a/Tools/TestWebKitAPI/Tests/WebCore/TestPlatformStrategies.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TestPlatformStrategies.cpp
@@ -127,11 +127,13 @@ public:
     RefPtr<SharedBuffer> readBufferFromClipboard(const String&, const String&) final { return nullptr; }
     void writeToClipboard(const String&, SelectionData&&) final { }
     void clearClipboard(const String&) final { }
-    int64_t changeCount(const String&) final { return 0; }
 #elif USE(LIBWPE)
     void getTypes(Vector<String>&) final { }
     void writeToPasteboard(const PasteboardWebContent&) final { }
     void writeToPasteboard(const String&, const String&) final { }
+#endif
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
+    int64_t changeCount(const String&) final { return 0; }
 #endif
 };
 


### PR DESCRIPTION
#### 8f8836b26a36d8d6a0e2a508c3c2422437fb0ad1
<pre>
[Win] `navigator.clipboard.readText()` always rejects
<a href="https://bugs.webkit.org/show_bug.cgi?id=320659">https://bugs.webkit.org/show_bug.cgi?id=320659</a>

Reviewed by Ian Grunert.

Give Windows a `PlatformPasteboard` and a `WebPasteboardProxy` so that plain text reaches the clipboard the same way it does on the ports that already support the async clipboard API.

`Clipboard::readText()` rejects as soon as `Pasteboard::allPasteboardItemInfo()` returns `std::nullopt`, and that is all it can ever return on Windows because the function is only implemented for `PLATFORM(COCOA)`, `PLATFORM(GTK)`, and `PLATFORM(WPE)`.
It cannot be implemented for Windows while the clipboard is reached straight from `Win32` in the WebProcess rather than through a pasteboard strategy.

* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
(WebCore::Clipboard::writeText):
(WebCore::Clipboard::ItemWriter::didSetAllData):
* Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp:
(WebCore::ClipboardItem::supports):
* Source/WebCore/Modules/async-clipboard/ClipboardItem.h:
* Source/WebCore/Modules/async-clipboard/ClipboardItem.idl:
Pass the current `ScriptExecutionContext` to `ClipboardItem.supports()` and consult `AsyncClipboardRichContentEnabled` instead of branching on the platform in async clipboard code.
Use the same runtime capability to reject multiple items, non-plain types, and buffer-backed data before the clipboard is touched.
Mark async writes explicitly with `PasteboardWriteType::AsyncClipboard`.

* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::Pasteboard::Pasteboard):
(WebCore::Pasteboard::changeCount const): Added.
(WebCore::Pasteboard::read):
(WebCore::Pasteboard::writeCustomData):
* Source/WebCore/platform/Pasteboard.cpp:
(WebCore::Pasteboard::allPasteboardItemInfo const):
(WebCore::Pasteboard::pasteboardItemInfo const):
* Source/WebCore/platform/Pasteboard.h:
Ask the strategy for the item info, change count, types, and text of the copy and paste clipboard, so that a single place owns it.
Route only writes marked `PasteboardWriteType::AsyncClipboard` through the strategy.
Leave drag, `DataTransfer`, and legacy copy and paste behavior unchanged.

* Source/WebCore/platform/win/PlatformPasteboardWin.cpp: Added.
(WebCore::clipboardOwner): Added.
(WebCore::readClipboardString): Added.
(WebCore::setClipboardData): Added.
(WebCore::PlatformPasteboard::PlatformPasteboard): Added.
(WebCore::PlatformPasteboard::performAsDataOwner): Added.
(WebCore::PlatformPasteboard::changeCount const): Added.
(WebCore::PlatformPasteboard::getTypes const): Added.
(WebCore::PlatformPasteboard::readCustomData const): Added.
(WebCore::PlatformPasteboard::readString const): Added.
(WebCore::PlatformPasteboard::typesSafeForDOMToReadAndWrite const): Added.
(WebCore::PlatformPasteboard::informationForItemAtIndex): Added.
(WebCore::PlatformPasteboard::allPasteboardItemInfo): Added.
(WebCore::PlatformPasteboard::count const): Added.
(WebCore::PlatformPasteboard::write): Added.
* Source/WebCore/platform/PlatformPasteboard.h:
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::customDataClipboardFormat): Added.
* Source/WebCore/platform/win/ClipboardUtilitiesWin.h:
Implement the plain text and same-origin metadata operations that the async clipboard API needs on top of the `Win32` clipboard.
Reads and writes go through a message only owner window, because `EmptyClipboard()` makes the owner of an unowned clipboard null and `SetClipboardData()` then fails.
Read serialized custom data by length rather than as a null terminated string.
Ignore unsupported data without changing the clipboard.

* Source/WebKit/UIProcess/win/WebPasteboardProxyWin.cpp: Added.
(WebKit::WebPasteboardProxy::getPasteboardChangeCount): Added.
(WebKit::WebPasteboardProxy::typesSafeForDOMToReadAndWrite): Added.
(WebKit::WebPasteboardProxy::writeCustomData): Added.
(WebKit::WebPasteboardProxy::allPasteboardItemInfo): Added.
(WebKit::WebPasteboardProxy::informationForItemAtIndex): Added.
(WebKit::WebPasteboardProxy::getPasteboardItemsCount): Added.
(WebKit::WebPasteboardProxy::readStringFromPasteboard): Added.
(WebKit::WebPasteboardProxy::readURLFromPasteboard): Added.
(WebKit::WebPasteboardProxy::readBufferFromPasteboard): Added.
* Source/WebKit/UIProcess/WebPasteboardProxy.cpp:
Answer the pasteboard messages for Windows in the UIProcess.

* Source/WebKit/UIProcess/win/PageClientImpl.cpp:
(WebKit::PageClientImpl::requestDOMPasteAccess):
Grant paste access when the origin asking for it is the one that wrote the clipboard, matching WPE.

* Source/WebCore/platform/cocoa/PasteboardCocoa.mm:
(WebCore::Pasteboard::writeCustomData):
* Source/WebCore/platform/glib/PasteboardGLib.cpp:
(WebCore::Pasteboard::writeCustomData):
* Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp:
(WebCore::Pasteboard::writeCustomData):
* Source/WebCore/platform/StaticPasteboard.h:
(WebCore::StaticPasteboard::writeCustomData):
Accept `PasteboardWriteType` without changing the existing behavior on other platforms.

* Source/WebCore/platform/PasteboardStrategy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::changeCount):
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h:
* Source/WebKit/UIProcess/WebPasteboardProxy.h:
* Source/WebKit/UIProcess/WebPasteboardProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebCore/TestPlatformStrategies.cpp:
(TestWebKitAPI::TestPasteboardStrategy::changeCount): Added.
Make `GetPasteboardChangeCount` available to Windows alongside GTK and WPE.
Keep the test pasteboard strategy concrete on Windows.

* LayoutTests/platform/win/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/PlatformWin.cmake:
* Source/WebKit/PlatformWin.cmake:

Canonical link: <a href="https://commits.webkit.org/318587@main">https://commits.webkit.org/318587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9de77081afbd972c1d40412978ce5fc6b6476bfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187475 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141112 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138642 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119105 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40834 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39191 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1074 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7878 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38878 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35936 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39136 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44394 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189904 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51470 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147766 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39877 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52152 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147550 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42255 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124404 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118835 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50660 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13857 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50056 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->