### PR TITLE
[WebAudio] AudioContext leaves its media session registered after frame teardown

### DIFF
--- a/LayoutTests/platform/mac/media/webaudio-session-removed-when-frame-is-destroyed-expected.txt
+++ b/LayoutTests/platform/mac/media/webaudio-session-removed-when-frame-is-destroyed-expected.txt
@@ -1,0 +1,11 @@
+A WebAudio context in a subframe destroyed without close() must have its media session removed by AudioContext::stop(), deactivating the audio session promptly rather than leaking it until the context is garbage-collected.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS audioSessionActive is true
+PASS audioSessionDeactivated is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac/media/webaudio-session-removed-when-frame-is-destroyed.html
+++ b/LayoutTests/platform/mac/media/webaudio-session-removed-when-frame-is-destroyed.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<iframe></iframe>
+<script>
+description("A WebAudio context in a subframe destroyed without close() must have its media session removed by AudioContext::stop(), deactivating the audio session promptly rather than leaking it until the context is garbage-collected.");
+jsTestIsAsync = true;
+
+async function waitForCondition(predicate)
+{
+    for (let i = 0; i < 200; ++i) {
+        if (predicate())
+            return true;
+        await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    return false;
+}
+
+onload = async () => {
+    if (!window.internals) {
+        testFailed("This test requires the Internals API");
+        finishJSTest();
+        return;
+    }
+
+    internals.settings.setShouldDeactivateAudioSession(true);
+
+    const frame = document.querySelector("iframe");
+    await new Promise(resolve => {
+        window.onmessage = event => {
+            if (event.data === "active")
+                resolve();
+        };
+        frame.srcdoc = `<script>
+            internals.settings.setShouldDeactivateAudioSession(true);
+            internals.withUserGesture(() => {
+                window.context = new AudioContext();
+                const oscillator = context.createOscillator();
+                const gain = context.createGain();
+                gain.gain.value = 0.001;
+                oscillator.connect(gain);
+                gain.connect(context.destination);
+                oscillator.start();
+                context.resume();
+            });
+            (async () => {
+                for (let i = 0; i < 200; ++i) {
+                    if (internals.audioSessionActive()) {
+                        parent.postMessage("active", "*");
+                        return;
+                    }
+                    await new Promise(resolve => setTimeout(resolve, 10));
+                }
+                parent.postMessage("inactive", "*");
+            })();
+        <\/script>`;
+    });
+
+    audioSessionActive = internals.audioSessionActive();
+    shouldBeTrue("audioSessionActive");
+
+    // Destroy the subframe without closing its AudioContext.
+    frame.remove();
+
+    audioSessionDeactivated = await waitForCondition(() => !internals.audioSessionActive());
+    shouldBeTrue("audioSessionDeactivated");
+
+    finishJSTest();
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -192,6 +192,8 @@ void AudioContext::stop()
     if (RefPtr document = this->document())
         document->removeAudioProducer(*this);
     BaseAudioContext::stop();
+
+    m_mediaSession->setActive(false);
 }
 
 double AudioContext::baseLatency()


### PR DESCRIPTION
#### 9f60bad504c7d2484e156301d360042fc318dc1a
<pre>
[WebAudio] AudioContext leaves its media session registered after frame teardown
<a href="https://bugs.webkit.org/show_bug.cgi?id=320689">https://bugs.webkit.org/show_bug.cgi?id=320689</a>
<a href="https://rdar.apple.com/183672900">rdar://183672900</a>

Reviewed by Jean-Yves Avenard.

AudioContext::stop() (document/frame teardown) stopped the audio thread but never removed the
context&apos;s PlatformMediaSession -- unlike close(), it left the session registered with the manager
until the context was garbage-collected, keeping the audio session (and NowPlaying) alive on behalf
of a context whose frame was already gone.

Remove the media session in stop(), mirroring close(). setActive(false) is a no-op if the context
never activated.

Test: platform/mac/media/webaudio-session-removed-when-frame-is-destroyed.html

* LayoutTests/platform/mac/media/webaudio-session-removed-when-frame-is-destroyed-expected.txt: Added.
* LayoutTests/platform/mac/media/webaudio-session-removed-when-frame-is-destroyed.html: Added.
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::stop):

Canonical link: <a href="https://commits.webkit.org/318283@main">https://commits.webkit.org/318283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e715fb9ae73d4d6f837a90ac0329a25e4b8cd38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51810 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187482 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6792555-d5b0-4ec8-afe9-30fd739d640e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51519 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4fcf598b-d7d8-4c00-9641-9353d9828378) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42176 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119101 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8522bf27-8bd6-4937-b67b-9011c15ed12d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151244 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38884 "Build is in progress. Recent messages:") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35943 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/44401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189911 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/158920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39688 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52159 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147551 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/42263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118842 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50667 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/13863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50063 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->