### PR TITLE
Web Inspector: Canvas: instrument WebGPU devices

### DIFF
--- a/LayoutTests/inspector/canvas/create-context-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-webgpu-expected.txt
@@ -1,0 +1,18 @@
+Test that CanvasManager tracks creation and destruction of WebGPU devices.
+
+
+== Running test suite: Canvas.CreateContextWebGPU
+-- Running test case: Canvas.CreateContextWebGPU.NoDevices
+PASS: CanvasManager should initially have no canvases.
+
+-- Running test case: Canvas.CreateContextWebGPU.DeviceLifecycle
+PASS: Added a Canvas.
+PASS: Canvas should represent a WebGPU device.
+PASS: CanvasManager should contain one Canvas.
+PASS: Canvas should contain WebGPU features.
+PASS: Canvas should report every enabled WebGPU feature.
+PASS: Canvas should report the enabled WebGPU feature names.
+PASS: Canvas should not report WebGPU features as extensions.
+PASS: Removed the previously added Canvas.
+PASS: CanvasManager should again have no canvases.
+

--- a/LayoutTests/inspector/canvas/create-context-webgpu.html
+++ b/LayoutTests/inspector/canvas/create-context-webgpu.html
@@ -1,0 +1,78 @@
+<!-- webkit-test-runner [ WebGPUEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+let adapter = null;
+let device = null;
+let garbageCollectionInterval = null;
+
+async function createDevice() {
+    adapter = await navigator.gpu.requestAdapter();
+    let firstSupportedFeature = adapter.features.values().next().value;
+    device = await adapter.requestDevice({requiredFeatures: firstSupportedFeature ? [firstSupportedFeature] : []});
+    TestPage.dispatchEventToFrontend("WebGPUDeviceReady");
+}
+
+function releaseDevice() {
+    device = null;
+    adapter = null;
+    garbageCollectionInterval = setInterval(() => { GCController.collect(); }, 0);
+}
+
+function stopCollectingGarbage() {
+    clearInterval(garbageCollectionInterval);
+    garbageCollectionInterval = null;
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("Canvas.CreateContextWebGPU");
+
+    suite.addTestCase({
+        name: "Canvas.CreateContextWebGPU.NoDevices",
+        description: "Check that the CanvasManager has no WebGPU devices initially.",
+        test(resolve, reject) {
+            InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 0, "CanvasManager should initially have no canvases.");
+            resolve();
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.CreateContextWebGPU.DeviceLifecycle",
+        description: "Check that creating and collecting a GPUDevice adds and removes a WebGPU Canvas.",
+        async test() {
+            let canvasAddedPromise = WI.canvasManager.canvasCollection.awaitEvent(WI.Collection.Event.ItemAdded);
+            let deviceReadyPromise = InspectorTest.awaitEvent("WebGPUDeviceReady");
+            InspectorTest.evaluateInPage(`void createDevice()`);
+
+            let canvasAddedEvent = await canvasAddedPromise;
+            await deviceReadyPromise;
+            let canvas = canvasAddedEvent.data.item;
+            InspectorTest.expectThat(canvas instanceof WI.Canvas, "Added a Canvas.");
+            InspectorTest.expectEqual(canvas.contextType, WI.Canvas.ContextType.WebGPU, "Canvas should represent a WebGPU device.");
+            InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "CanvasManager should contain one Canvas.");
+            let enabledFeatures = JSON.parse(await InspectorTest.evaluateInPage(`JSON.stringify(Array.from(device.features))`));
+            InspectorTest.expectTrue(Array.isArray(canvas.features), "Canvas should contain WebGPU features.");
+            InspectorTest.expectEqual(canvas.features.length, enabledFeatures.length, "Canvas should report every enabled WebGPU feature.");
+            InspectorTest.expectTrue(enabledFeatures.every((feature) => canvas.features.includes(feature)), "Canvas should report the enabled WebGPU feature names.");
+            InspectorTest.expectEqual(canvas.extensions.size, 0, "Canvas should not report WebGPU features as extensions.");
+
+            let canvasRemovedPromise = WI.canvasManager.canvasCollection.awaitEvent(WI.Collection.Event.ItemRemoved);
+            InspectorTest.evaluateInPage(`releaseDevice()`);
+
+            let canvasRemovedEvent = await canvasRemovedPromise;
+            InspectorTest.expectEqual(canvasRemovedEvent.data.item, canvas, "Removed the previously added Canvas.");
+            InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 0, "CanvasManager should again have no canvases.");
+            await InspectorTest.evaluateInPage(`stopCollectingGarbage()`);
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Test that CanvasManager tracks creation and destruction of WebGPU devices.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/canvas/requestClientNodes-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/requestClientNodes-webgpu-expected.txt
@@ -1,0 +1,33 @@
+Test that CanvasAgent tracks GPUCanvasContext client nodes for WebGPU devices.
+
+
+== Running test suite: Canvas.requestClientNodes.WebGPU
+-- Running test case: Canvas.requestClientNodes.WebGPU.Initial
+PASS: GPUDevice should initially have no client nodes.
+
+-- Running test case: Canvas.requestClientNodes.WebGPU.Configure
+PASS: Client nodes changed for the expected Canvas.
+PASS: GPUDevice should have one client node.
+PASS: Client node should be the configured canvas element.
+PASS: GPUCanvasContext should not create a separate Canvas.
+
+-- Running test case: Canvas.requestClientNodes.WebGPU.MultipleCanvases
+PASS: Client nodes changed for the expected Canvas.
+PASS: GPUDevice should have two client nodes.
+PASS: GPUDevice should include the original canvas element.
+PASS: GPUDevice should include the additional canvas element.
+PASS: Two GPUCanvasContexts should still create only one Canvas.
+PASS: Client nodes changed after unconfiguring one canvas.
+PASS: GPUDevice should retain one client node.
+PASS: Remaining client node should be the original canvas element.
+PASS: Unconfiguring one client should preserve the single GPUDevice Canvas.
+
+-- Running test case: Canvas.requestClientNodes.WebGPU.Unconfigure
+PASS: Client nodes changed for the expected Canvas.
+PASS: GPUDevice should again have no client nodes.
+
+-- Running test case: Canvas.requestClientNodes.WebGPU.OffscreenCanvas
+PASS: Client nodes changed for the expected Canvas.
+PASS: OffscreenCanvas should not create a DOM client node.
+PASS: OffscreenCanvas GPUCanvasContext should not create a separate Canvas.
+

--- a/LayoutTests/inspector/canvas/requestClientNodes-webgpu.html
+++ b/LayoutTests/inspector/canvas/requestClientNodes-webgpu.html
@@ -1,0 +1,163 @@
+<!-- webkit-test-runner [ WebGPUEnabled=true OffscreenCanvasEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+let adapter = null;
+let device = null;
+let clientCanvas = null;
+let clientContext = null;
+let additionalClientCanvas = null;
+let additionalClientContext = null;
+let offscreenCanvas = null;
+let offscreenContext = null;
+
+async function load() {
+    adapter = await navigator.gpu.requestAdapter();
+    device = await adapter.requestDevice();
+    runTest();
+}
+
+function configureClient() {
+    clientCanvas = document.body.appendChild(document.createElement("canvas"));
+    clientCanvas.id = "webgpu-client";
+    clientContext = clientCanvas.getContext("webgpu");
+    clientContext.configure({
+        device,
+        format: navigator.gpu.getPreferredCanvasFormat(),
+    });
+}
+
+function unconfigureClient() {
+    clientContext.unconfigure();
+    clientCanvas.remove();
+    clientContext = null;
+    clientCanvas = null;
+}
+
+function configureAdditionalClient() {
+    additionalClientCanvas = document.body.appendChild(document.createElement("canvas"));
+    additionalClientCanvas.id = "additional-webgpu-client";
+    additionalClientContext = additionalClientCanvas.getContext("webgpu");
+    additionalClientContext.configure({
+        device,
+        format: navigator.gpu.getPreferredCanvasFormat(),
+    });
+}
+
+function unconfigureAdditionalClient() {
+    additionalClientContext.unconfigure();
+    additionalClientCanvas.remove();
+    additionalClientContext = null;
+    additionalClientCanvas = null;
+}
+
+function configureOffscreenClient() {
+    offscreenCanvas = new OffscreenCanvas(4, 4);
+    offscreenContext = offscreenCanvas.getContext("webgpu");
+    offscreenContext.configure({
+        device,
+        format: navigator.gpu.getPreferredCanvasFormat(),
+    });
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("Canvas.requestClientNodes.WebGPU");
+    let canvas = Array.from(WI.canvasManager.canvasCollection).find((canvas) => canvas.contextType === WI.Canvas.ContextType.WebGPU);
+    InspectorTest.assert(canvas, "There should be a WebGPU Canvas.");
+
+    function requestClientNodes() {
+        return new Promise((resolve) => canvas.requestClientNodes(resolve));
+    }
+
+    suite.addTestCase({
+        name: "Canvas.requestClientNodes.WebGPU.Initial",
+        description: "Check that an unused GPUDevice has no client nodes.",
+        async test() {
+            let clientNodes = await requestClientNodes();
+            InspectorTest.expectEqual(clientNodes.length, 0, "GPUDevice should initially have no client nodes.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.requestClientNodes.WebGPU.Configure",
+        description: "Check that configuring a GPUCanvasContext adds its canvas as a GPUDevice client node.",
+        async test() {
+            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            InspectorTest.evaluateInPage(`configureClient()`);
+
+            let event = await clientNodesChangedPromise;
+            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
+            let clientNodes = await requestClientNodes();
+            InspectorTest.expectEqual(clientNodes.length, 1, "GPUDevice should have one client node.");
+            InspectorTest.expectEqual(clientNodes[0].appropriateSelectorFor(), "canvas#webgpu-client", "Client node should be the configured canvas element.");
+            InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "GPUCanvasContext should not create a separate Canvas.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.requestClientNodes.WebGPU.MultipleCanvases",
+        description: "Check that one GPUDevice simultaneously tracks multiple canvas client nodes and preserves one when the other is unconfigured.",
+        async test() {
+            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            InspectorTest.evaluateInPage(`configureAdditionalClient()`);
+
+            let event = await clientNodesChangedPromise;
+            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
+            let clientNodes = await requestClientNodes();
+            InspectorTest.expectEqual(clientNodes.length, 2, "GPUDevice should have two client nodes.");
+            let selectors = new Set(clientNodes.map((node) => node.appropriateSelectorFor()));
+            InspectorTest.expectTrue(selectors.has("canvas#webgpu-client"), "GPUDevice should include the original canvas element.");
+            InspectorTest.expectTrue(selectors.has("canvas#additional-webgpu-client"), "GPUDevice should include the additional canvas element.");
+            InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "Two GPUCanvasContexts should still create only one Canvas.");
+
+            clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            InspectorTest.evaluateInPage(`unconfigureAdditionalClient()`);
+
+            event = await clientNodesChangedPromise;
+            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed after unconfiguring one canvas.");
+            clientNodes = await requestClientNodes();
+            InspectorTest.expectEqual(clientNodes.length, 1, "GPUDevice should retain one client node.");
+            InspectorTest.expectEqual(clientNodes[0].appropriateSelectorFor(), "canvas#webgpu-client", "Remaining client node should be the original canvas element.");
+            InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "Unconfiguring one client should preserve the single GPUDevice Canvas.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.requestClientNodes.WebGPU.Unconfigure",
+        description: "Check that unconfiguring a GPUCanvasContext removes its canvas from the GPUDevice client nodes.",
+        async test() {
+            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            InspectorTest.evaluateInPage(`unconfigureClient()`);
+
+            let event = await clientNodesChangedPromise;
+            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
+            let clientNodes = await requestClientNodes();
+            InspectorTest.expectEqual(clientNodes.length, 0, "GPUDevice should again have no client nodes.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.requestClientNodes.WebGPU.OffscreenCanvas",
+        description: "Check that an OffscreenCanvas can use the GPUDevice without creating a DOM client node or a separate Canvas.",
+        async test() {
+            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            InspectorTest.evaluateInPage(`configureOffscreenClient()`);
+
+            let event = await clientNodesChangedPromise;
+            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
+            let clientNodes = await requestClientNodes();
+            InspectorTest.expectEqual(clientNodes.length, 0, "OffscreenCanvas should not create a DOM client node.");
+            InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "OffscreenCanvas GPUCanvasContext should not create a separate Canvas.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="window.testRunner?.waitUntilDone(); load()">
+    <p>Test that CanvasAgent tracks GPUCanvasContext client nodes for WebGPU devices.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/canvas/resolveContext-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/resolveContext-webgpu-expected.txt
@@ -1,0 +1,10 @@
+Tests Canvas.resolveContext for WebGPU devices.
+
+
+== Running test suite: Canvas.resolveContextWebGPU
+-- Running test case: Canvas.resolveContextWebGPU.ValidIdentifier
+PASS: There should be one Canvas.
+PASS: Canvas should represent a WebGPU device.
+PASS: Payload should have type "object".
+PASS: Payload should have className "GPUDevice".
+

--- a/LayoutTests/inspector/canvas/resolveContext-webgpu.html
+++ b/LayoutTests/inspector/canvas/resolveContext-webgpu.html
@@ -1,0 +1,43 @@
+<!-- webkit-test-runner [ WebGPUEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+let adapter = null;
+let device = null;
+
+async function load() {
+    adapter = await navigator.gpu.requestAdapter();
+    device = await adapter.requestDevice();
+    runTest();
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("Canvas.resolveContextWebGPU");
+
+    suite.addTestCase({
+        name: "Canvas.resolveContextWebGPU.ValidIdentifier",
+        description: "Check that resolving a WebGPU Canvas returns its GPUDevice wrapper.",
+        async test() {
+            let canvases = Array.from(WI.canvasManager.canvasCollection);
+            InspectorTest.expectEqual(canvases.length, 1, "There should be one Canvas.");
+
+            let canvas = canvases[0];
+            InspectorTest.expectEqual(canvas.contextType, WI.Canvas.ContextType.WebGPU, "Canvas should represent a WebGPU device.");
+
+            const objectGroup = "test";
+            let {object} = await canvas.target.CanvasAgent.resolveContext(canvas.identifier, objectGroup);
+            InspectorTest.expectEqual(object.type, "object", `Payload should have type "object".`);
+            InspectorTest.expectEqual(object.className, "GPUDevice", `Payload should have className "GPUDevice".`);
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="window.testRunner?.waitUntilDone(); load()">
+    <p>Tests Canvas.resolveContext for WebGPU devices.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/canvas/resources/webgpu-worker.js
+++ b/LayoutTests/inspector/canvas/resources/webgpu-worker.js
@@ -1,0 +1,18 @@
+let adapter = null;
+let device = null;
+let offscreenCanvas = null;
+let offscreenContext = null;
+
+async function initialize() {
+    adapter = await navigator.gpu.requestAdapter();
+    device = await adapter.requestDevice();
+
+    let format = navigator.gpu.getPreferredCanvasFormat();
+    offscreenCanvas = new OffscreenCanvas(4, 4);
+    offscreenContext = offscreenCanvas.getContext("webgpu");
+    offscreenContext.configure({device, format});
+
+    postMessage("ready");
+}
+
+initialize();

--- a/LayoutTests/inspector/canvas/worker-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/worker-webgpu-expected.txt
@@ -1,0 +1,16 @@
+Test WebGPU Canvas instrumentation for a Worker rendering to an OffscreenCanvas.
+
+
+== Running test suite: Canvas.WebGPU.Worker
+-- Running test case: Canvas.WebGPU.Worker.Device
+PASS: Worker target should expose the Canvas domain.
+PASS: WebGPU Canvas should belong to the Worker target.
+PASS: Payload should have type "object".
+PASS: Payload should have className "GPUDevice".
+PASS: Worker GPUDevice should have no DOM client nodes.
+
+-- Running test case: Canvas.WebGPU.Worker.Terminate
+PASS: Removed the expected Worker target.
+PASS: Removed the Worker GPUDevice Canvas.
+PASS: CanvasManager should not retain the Worker GPUDevice Canvas.
+

--- a/LayoutTests/inspector/canvas/worker-webgpu.html
+++ b/LayoutTests/inspector/canvas/worker-webgpu.html
@@ -1,0 +1,72 @@
+<!-- webkit-test-runner [ WebGPUEnabled=true OffscreenCanvasEnabled=true OffscreenCanvasInWorkersEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="../worker/resources/worker-utilities.js"></script>
+<script>
+let workerReadyPromise = Promise.withResolvers();
+let worker = new Worker("resources/webgpu-worker.js");
+worker.addEventListener("message", (event) => {
+    if (event.data === "ready")
+        workerReadyPromise.resolve();
+});
+worker.addEventListener("error", workerReadyPromise.reject);
+
+function terminateWorker() {
+    worker.terminate();
+}
+
+async function test() {
+    let suite = InspectorTest.createAsyncSuite("Canvas.WebGPU.Worker");
+    let workerTarget = await window.awaitTarget((target) => target instanceof WI.WorkerTarget && target.displayName.endsWith("webgpu-worker.js"));
+    InspectorTest.assert(workerTarget, "There should be a Worker target.");
+
+    let findCanvas = () => Array.from(WI.canvasManager.canvasCollection).find((canvas) => canvas.target === workerTarget && canvas.contextType === WI.Canvas.ContextType.WebGPU);
+    let canvas = findCanvas();
+    while (!canvas) {
+        await WI.canvasManager.canvasCollection.awaitEvent(WI.Collection.Event.ItemAdded);
+        canvas = findCanvas();
+    }
+    InspectorTest.assert(canvas, "There should be a worker-owned WebGPU Canvas.");
+
+    suite.addTestCase({
+        name: "Canvas.WebGPU.Worker.Device",
+        description: "Check that a GPUDevice created in a Worker is discovered on the Worker target and can be resolved.",
+        async test() {
+            InspectorTest.expectTrue(workerTarget.hasDomain("Canvas"), "Worker target should expose the Canvas domain.");
+            InspectorTest.expectEqual(canvas.target, workerTarget, "WebGPU Canvas should belong to the Worker target.");
+
+            const objectGroup = "test";
+            let {object} = await canvas.target.CanvasAgent.resolveContext(canvas.identifier, objectGroup);
+            InspectorTest.expectEqual(object.type, "object", `Payload should have type "object".`);
+            InspectorTest.expectEqual(object.className, "GPUDevice", `Payload should have className "GPUDevice".`);
+
+            let clientNodes = await new Promise((resolve) => canvas.requestClientNodes(resolve));
+            InspectorTest.expectEqual(clientNodes.length, 0, "Worker GPUDevice should have no DOM client nodes.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.WebGPU.Worker.Terminate",
+        description: "Check that terminating a Worker removes its WebGPU Canvas.",
+        async test() {
+            let targetRemovedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetRemoved);
+            let canvasRemovedPromise = WI.canvasManager.canvasCollection.awaitEvent(WI.Collection.Event.ItemRemoved);
+            InspectorTest.evaluateInPage(`terminateWorker()`);
+
+            let [targetRemovedEvent, canvasRemovedEvent] = await Promise.all([targetRemovedPromise, canvasRemovedPromise]);
+            InspectorTest.expectEqual(targetRemovedEvent.data.target, workerTarget, "Removed the expected Worker target.");
+            InspectorTest.expectEqual(canvasRemovedEvent.data.item, canvas, "Removed the Worker GPUDevice Canvas.");
+            InspectorTest.expectFalse(WI.canvasManager.canvasCollection.has(canvas), "CanvasManager should not retain the Worker GPUDevice Canvas.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="testRunner.waitUntilDone(); workerReadyPromise.promise.then(runTest)">
+    <p>Test WebGPU Canvas instrumentation for a Worker rendering to an OffscreenCanvas.</p>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4244,6 +4244,10 @@ webkit.org/b/236298 fast/text/combining-character-sequence-vertical.html [ Image
 
 fast/webgpu [ Skip ]
 http/tests/webgpu/webgpu/api/operation/memory_sync/buffer/multiple_buffers.html [ Skip ]
+inspector/canvas/create-context-webgpu.html [ Skip ]
+inspector/canvas/requestClientNodes-webgpu.html [ Skip ]
+inspector/canvas/resolveContext-webgpu.html [ Skip ]
+inspector/canvas/worker-webgpu.html [ Skip ]
 
 # NetworkStorageSession::deleteCookies() doesn't obey partitioning for glib ports.
 http/wpt/clear-site-data/partitioning.html [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -112,6 +112,10 @@ fast/webcodecs/audio-data-copy-to-crash.html [ Skip ]
 # WebGPU is disabled
 http/tests/webgpu [ Skip ]
 fast/webgpu [ Skip ]
+inspector/canvas/create-context-webgpu.html [ Skip ]
+inspector/canvas/requestClientNodes-webgpu.html [ Skip ]
+inspector/canvas/resolveContext-webgpu.html [ Skip ]
+inspector/canvas/worker-webgpu.html [ Skip ]
 
 # QUOTA is disabled
 fast/workers/worker-storagequota-query-usage.html [ Skip ]

--- a/Source/JavaScriptCore/inspector/protocol/Canvas.json
+++ b/Source/JavaScriptCore/inspector/protocol/Canvas.json
@@ -27,7 +27,8 @@
                 "canvas-2d", "offscreen-canvas-2d",
                 "bitmaprenderer", "offscreen-bitmaprenderer",
                 "webgl", "offscreen-webgl",
-                "webgl2", "offscreen-webgl2"
+                "webgl2", "offscreen-webgl2",
+                "webgpu"
             ],
             "description": "The type of rendering context backing the canvas element."
         },
@@ -68,11 +69,12 @@
             "properties": [
                 { "name": "canvasId", "$ref": "CanvasId", "description": "Canvas identifier." },
                 { "name": "contextType", "$ref": "ContextType", "description": "The type of rendering context backing the canvas." },
-                { "name": "width", "type": "number", "description": "Width of the canvas in pixels." },
-                { "name": "height", "type": "number", "description": "Height of the canvas in pixels." },
+                { "name": "width", "type": "number", "optional": true, "description": "Width of the canvas in pixels." },
+                { "name": "height", "type": "number", "optional": true, "description": "Height of the canvas in pixels." },
                 { "name": "nodeId", "$ref": "DOM.NodeId", "optional": true, "description": "The corresponding DOM node id." },
                 { "name": "cssCanvasName", "type": "string", "optional": true, "description": "The CSS canvas identifier, for canvases created with <code>document.getCSSCanvasContext</code>." },
                 { "name": "contextAttributes", "$ref": "ContextAttributes", "optional": true, "description": "Context attributes for rendering contexts." },
+                { "name": "features", "type": "array", "items": { "type": "string" }, "optional": true, "description": "Enabled WebGPU device features." },
                 { "name": "memoryCost", "type": "number", "optional": true, "description": "Memory usage of the canvas in bytes." },
                 { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "Backtrace that was captured when this canvas context was created." }
             ]

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -63,6 +63,7 @@
 #include "GPUTextureFormat.h"
 #include "GPUUncapturedErrorEvent.h"
 #include "HTMLVideoElement.h"
+#include "InspectorInstrumentation.h"
 #include "JSDOMConvertInterface.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSGPUComputePipeline.h"
@@ -77,11 +78,34 @@
 #include "SecurityOrigin.h"
 #include "WebGPUXRBinding.h"
 #include "XRGPUBinding.h"
+#include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GPUDevice);
+
+Lock GPUDevice::s_instancesLock;
+
+HashSet<GPUDevice*>& GPUDevice::instances()
+{
+    static NeverDestroyed<HashSet<GPUDevice*>> instances;
+    return instances;
+}
+
+Lock& GPUDevice::instancesLock()
+{
+    return s_instancesLock;
+}
+
+Ref<GPUDevice> GPUDevice::create(ScriptExecutionContext* scriptExecutionContext, Ref<WebGPU::Device>&& backing, String&& queueLabel, GPUAdapterInfo& adapterInfo)
+{
+    Ref device = adoptRef(*new GPUDevice(scriptExecutionContext, WTF::move(backing), WTF::move(queueLabel), adapterInfo));
+
+    InspectorInstrumentation::didCreateWebGPUDevice(device);
+
+    return device;
+}
 
 GPUDevice::GPUDevice(ScriptExecutionContext* scriptExecutionContext, Ref<WebGPU::Device>&& backing, String&& queueLabel, GPUAdapterInfo& adapterInfo)
     : ActiveDOMObject { scriptExecutionContext }
@@ -92,11 +116,30 @@ GPUDevice::GPUDevice(ScriptExecutionContext* scriptExecutionContext, Ref<WebGPU:
     , m_features(GPUSupportedFeatures::create(m_backing->features()))
     , m_limits(GPUSupportedLimits::create(m_backing->limits()))
     , m_adapterInfo(adapterInfo)
+    , m_owningThreadUID(currentThreadID())
 {
     m_queue->setLabel(WTF::move(queueLabel));
+
+    Locker locker { instancesLock() };
+    instances().add(this);
 }
 
-GPUDevice::~GPUDevice() = default;
+GPUDevice::~GPUDevice()
+{
+    {
+        Locker locker { instancesLock() };
+        instances().remove(this);
+    }
+
+    InspectorInstrumentation::willDestroyWebGPUDevice(*this);
+}
+
+void GPUDevice::contextDestroyed()
+{
+    InspectorInstrumentation::willDestroyWebGPUDevice(*this);
+
+    ActiveDOMObject::contextDestroyed();
+}
 
 String GPUDevice::label() const
 {

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -39,6 +39,9 @@
 #include "ScriptExecutionContext.h"
 #include "WebGPUDevice.h"
 #include <optional>
+#include <wtf/CurrentThread.h>
+#include <wtf/HashSet.h>
+#include <wtf/Lock.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
@@ -92,16 +95,19 @@ class XRBinding;
 class GPUDevice : public RefCounted<GPUDevice>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_TZONE_ALLOCATED(GPUDevice);
 public:
-    static Ref<GPUDevice> create(ScriptExecutionContext* scriptExecutionContext, Ref<WebGPU::Device>&& backing, String&& queueLabel, GPUAdapterInfo& info)
-    {
-        return adoptRef(*new GPUDevice(scriptExecutionContext, WTF::move(backing), WTF::move(queueLabel), info));
-    }
+    static Ref<GPUDevice> create(ScriptExecutionContext*, Ref<WebGPU::Device>&&, String&& queueLabel, GPUAdapterInfo&);
+
+    static HashSet<GPUDevice*>& NODELETE instances() WTF_REQUIRES_LOCK(instancesLock());
+    static Lock& NODELETE instancesLock() WTF_RETURNS_LOCK(s_instancesLock);
 
     virtual ~GPUDevice();
+
+    bool isContextThread() const { return m_owningThreadUID == currentThreadID(); }
 
     // ContextDestructionObserver.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
+    void contextDestroyed() final;
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     String NODELETE label() const;
@@ -149,6 +155,8 @@ public:
     using LostPromise = DOMPromiseProxy<IDLInterface<GPUDeviceLostInfo>>;
     LostPromise& lost() LIFETIME_BOUND;
 
+    ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
+
     WebGPU::Device& backing() { return m_backing; }
     const WebGPU::Device& backing() const { return m_backing; }
     void removeBufferToUnmap(GPUBuffer&);
@@ -167,9 +175,10 @@ private:
 
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::GPUDevice; }
-    ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
+
+    static Lock s_instancesLock;
 
     const UniqueRef<LostPromise> m_lostPromise;
     const Ref<WebGPU::Device> m_backing;
@@ -187,6 +196,7 @@ private:
     const Ref<GPUSupportedFeatures> m_features;
     const Ref<GPUSupportedLimits> m_limits;
     const Ref<GPUAdapterInfo> m_adapterInfo;
+    const uint32_t m_owningThreadUID;
 
     bool m_waitingForDeviceLostPromise { false };
     bool m_listeningForUncapturedErrors { false };

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -192,7 +192,6 @@ html/canvas/PlaceholderRenderingContext.cpp
 inspector/DOMEditor.cpp
 inspector/InspectorAuditAccessibilityObject.cpp
 inspector/InspectorCanvas.cpp
-inspector/InspectorCanvas.h
 inspector/InspectorCanvasCallTracer.cpp
 inspector/InspectorOverlay.cpp
 inspector/InspectorResourceUtilities.cpp

--- a/Source/WebCore/html/canvas/GPUCanvasContext.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.h
@@ -40,6 +40,7 @@ namespace WebCore {
 class CanvasBase;
 class Document;
 class GPU;
+class GPUDevice;
 class GPUTexture;
 class ImageBitmap;
 struct GPUCanvasConfiguration;
@@ -61,6 +62,7 @@ public:
     virtual ExceptionOr<void> configure(GPUCanvasConfiguration&&) = 0;
     virtual void unconfigure() = 0;
     virtual std::optional<GPUCanvasConfiguration> getConfiguration() const = 0;
+    virtual GPUDevice* device() const = 0;
     virtual ExceptionOr<Ref<GPUTexture>> getCurrentTexture() = 0;
 
 protected:

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -51,6 +51,8 @@ class GPUCanvasContextCocoa final : public GPUCanvasContext {
 public:
     static std::unique_ptr<GPUCanvasContextCocoa> create(CanvasBase&, GPU&, Document*);
 
+    ~GPUCanvasContextCocoa();
+
     DestinationColorSpace colorSpace() const override;
     bool compositingResultsNeedUpdating() const override { return m_compositingResultsNeedsUpdating; }
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
@@ -68,6 +70,7 @@ public:
     ExceptionOr<void> configure(GPUCanvasConfiguration&&) override;
     void unconfigure() override;
     std::optional<GPUCanvasConfiguration> getConfiguration() const override;
+    GPUDevice* device() const override { return m_configuration ? m_configuration->device.ptr() : nullptr; }
     ExceptionOr<Ref<GPUTexture>> getCurrentTexture() override;
     RefPtr<ImageBuffer> transferToImageBuffer() override;
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -29,6 +29,7 @@
 #include "DestinationColorSpace.h"
 #include "GPUAdapter.h"
 #include "GPUCanvasConfiguration.h"
+#include "GPUDevice.h"
 #include "GPUPresentationContext.h"
 #include "GPUPresentationContextDescriptor.h"
 #include "GPUTextureDescriptor.h"
@@ -36,6 +37,7 @@
 #include "GraphicsLayerContentsDisplayDelegate.h"
 #include "GraphicsLayerEnums.h"
 #include "ImageBitmap.h"
+#include "InspectorInstrumentation.h"
 #include "PlatformCALayerDelegatedContents.h"
 #include "PlatformScreen.h"
 #include "RenderBox.h"
@@ -205,6 +207,14 @@ GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, Ref<GPUComposit
 #endif
 }
 
+GPUCanvasContextCocoa::~GPUCanvasContextCocoa()
+{
+    CanvasRenderingContext::updateMemoryCost(0);
+
+    if (auto configuration = std::exchange(m_configuration, std::nullopt))
+        InspectorInstrumentation::didChangeGPUDeviceClientNodes(configuration->device);
+}
+
 #if HAVE(SUPPORT_HDR_DISPLAY)
 static float NODELETE interpolateHeadroom(float headroomForLow, float headroomForHigh, float limit, float limitLow, float limitHigh)
 {
@@ -335,6 +345,8 @@ void GPUCanvasContextCocoa::didUpdateCanvasSizeProperties(bool)
 
     auto configuration = WTF::move(m_configuration);
     m_configuration.reset();
+    if (configuration)
+        InspectorInstrumentation::didChangeGPUDeviceClientNodes(configuration->device);
     unconfigure();
     if (configuration) {
         GPUCanvasConfiguration canvasConfiguration {
@@ -519,6 +531,7 @@ ExceptionOr<void> GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& conf
         WTF::move(renderBuffers),
         0,
     };
+    InspectorInstrumentation::didChangeGPUDeviceClientNodes(m_configuration->device);
     return { };
 }
 
@@ -530,11 +543,14 @@ ExceptionOr<void> GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& conf
 void GPUCanvasContextCocoa::unconfigure()
 {
     m_presentationContext->unconfigure();
-    m_configuration = std::nullopt;
+    auto configuration = std::exchange(m_configuration, std::nullopt);
     m_currentTexture = nullptr;
     m_readDisplayBuffer = nullptr;
     updateMemoryCost();
     ASSERT(!isConfigured());
+
+    if (configuration)
+        InspectorInstrumentation::didChangeGPUDeviceClientNodes(configuration->device);
 }
 
 std::optional<GPUCanvasConfiguration> GPUCanvasContextCocoa::getConfiguration() const

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -39,6 +39,8 @@
 #include "Document.h"
 #include "Element.h"
 #include "FloatPoint.h"
+#include "GPUCanvasContext.h"
+#include "GPUDevice.h"
 #include "Gradient.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
@@ -61,6 +63,7 @@
 #include "JSCanvasTextBaseline.h"
 #include "JSDOMWrapperCache.h"
 #include "JSExecState.h"
+#include "JSGPUDevice.h"
 #include "JSImageBitmapRenderingContext.h"
 #include "JSImageSmoothingQuality.h"
 #include "JSPredefinedColorSpace.h"
@@ -72,6 +75,7 @@
 #include <JavaScriptCore/IdentifiersFactory.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/Function.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Scope.h>
@@ -94,58 +98,155 @@ Ref<InspectorCanvas> InspectorCanvas::create(CanvasRenderingContext& context)
     return adoptRef(*new InspectorCanvas(context));
 }
 
+Ref<InspectorCanvas> InspectorCanvas::create(GPUDevice& device)
+{
+    return adoptRef(*new InspectorCanvas(device));
+}
+
 InspectorCanvas::InspectorCanvas(CanvasRenderingContext& context)
     : m_identifier(makeString("canvas:"_s, IdentifiersFactory::createIdentifier()))
     , m_context(context)
 {
 }
 
+CanvasRenderingContext* InspectorCanvas::canvasContext() const
+{
+    auto* context = std::get_if<WeakRef<CanvasRenderingContext>>(&m_context);
+    return context ? context->ptr() : nullptr;
+}
+
+InspectorCanvas::InspectorCanvas(GPUDevice& device)
+    : m_identifier(makeString("canvas:"_s, IdentifiersFactory::createIdentifier()))
+    , m_context(device)
+{
+}
+
+GPUDevice* InspectorCanvas::deviceContext() const
+{
+    auto* device = std::get_if<WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>>(&m_context);
+    return device ? device->ptr() : nullptr;
+}
+
+static bool canvasContextMatchesDevice(const CanvasRenderingContext& context, const GPUDevice& device)
+{
+    auto* gpuCanvasContext = dynamicDowncast<GPUCanvasContext>(context);
+    return gpuCanvasContext && gpuCanvasContext->device() == &device;
+}
+
 HTMLCanvasElement* InspectorCanvas::canvasElement() const
 {
-    return dynamicDowncast<HTMLCanvasElement>(m_context->canvasBase());
+    return WTF::switchOn(m_context,
+        [](const WeakRef<CanvasRenderingContext>& weakContext) {
+            Ref context = weakContext;
+            return dynamicDowncast<HTMLCanvasElement>(context->canvasBase());
+        },
+        [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>&) -> HTMLCanvasElement* {
+            return nullptr;
+        }
+    );
 }
 
 ScriptExecutionContext* InspectorCanvas::scriptExecutionContext() const
 {
-    return protect(m_context)->canvasBase().scriptExecutionContext();
+    return WTF::switchOn(m_context,
+        [](const WeakRef<CanvasRenderingContext>& weakContext) {
+            Ref context = weakContext;
+            return context->canvasBase().scriptExecutionContext();
+        },
+        [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>& weakDevice) {
+            Ref device = weakDevice;
+            return device->scriptExecutionContext();
+        }
+    );
 }
 
 JSC::JSValue InspectorCanvas::resolveContext(JSC::JSGlobalObject* exec)
 {
     JSC::JSLockHolder lock(exec);
     auto* globalObject = deprecatedGlobalObjectForPrototype(exec);
-    if (is<CanvasRenderingContext2D>(m_context))
-        return toJS(exec, globalObject, protect(downcast<CanvasRenderingContext2D>(m_context.get())));
+
+    return WTF::switchOn(m_context,
+        [&](const WeakRef<CanvasRenderingContext>& weakContext) {
+            Ref context = weakContext;
+            if (is<CanvasRenderingContext2D>(context))
+                return toJS(exec, globalObject, downcast<CanvasRenderingContext2D>(context));
 #if ENABLE(OFFSCREEN_CANVAS)
-    if (is<OffscreenCanvasRenderingContext2D>(m_context))
-        return toJS(exec, globalObject, protect(downcast<OffscreenCanvasRenderingContext2D>(m_context.get())));
+            if (is<OffscreenCanvasRenderingContext2D>(context))
+                return toJS(exec, globalObject, downcast<OffscreenCanvasRenderingContext2D>(context));
 #endif
-    if (is<ImageBitmapRenderingContext>(m_context))
-        return toJS(exec, globalObject, protect(downcast<ImageBitmapRenderingContext>(m_context.get())));
+            if (is<ImageBitmapRenderingContext>(context))
+                return toJS(exec, globalObject, downcast<ImageBitmapRenderingContext>(context));
 #if ENABLE(WEBGL)
-    if (is<WebGLRenderingContext>(m_context))
-        return toJS(exec, globalObject, protect(downcast<WebGLRenderingContext>(m_context.get())));
-    if (is<WebGL2RenderingContext>(m_context))
-        return toJS(exec, globalObject, protect(downcast<WebGL2RenderingContext>(m_context.get())));
+            if (is<WebGLRenderingContext>(context))
+                return toJS(exec, globalObject, downcast<WebGLRenderingContext>(context));
+            if (is<WebGL2RenderingContext>(context))
+                return toJS(exec, globalObject, downcast<WebGL2RenderingContext>(context));
 #endif
-    RELEASE_ASSERT_NOT_REACHED();
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>& weakDevice) {
+            Ref device = weakDevice;
+            return toJS(exec, globalObject, device);
+        }
+    );
 }
 
 HashSet<Element*> InspectorCanvas::clientNodes() const
 {
-    return protect(m_context)->canvasBase().cssCanvasClients();
+    return WTF::switchOn(m_context,
+        [](const WeakRef<CanvasRenderingContext>& weakContext) {
+            Ref context = weakContext;
+            return context->canvasBase().cssCanvasClients();
+        },
+        [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>& weakDevice) {
+            Ref device = weakDevice;
+            HashSet<Element*> clientNodes;
+            Locker locker { CanvasRenderingContext::instancesLock() };
+            for (SUPPRESS_UNCOUNTED_ARG auto* context : CanvasRenderingContext::instances()) {
+                if (!context->isContextThread() || !canvasContextMatchesDevice(*context, device))
+                    continue;
+                if (RefPtr canvasElement = dynamicDowncast<HTMLCanvasElement>(context->canvasBase()))
+                    clientNodes.add(canvasElement);
+            }
+            return clientNodes;
+        }
+    );
+}
+
+size_t InspectorCanvas::memoryCost() const
+{
+    return WTF::switchOn(m_context,
+        [](const WeakRef<CanvasRenderingContext>& weakContext) {
+            Ref context = weakContext;
+
+            return context->memoryCost();
+        },
+        [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>& weakDevice) -> size_t {
+            Ref device = weakDevice;
+
+            CheckedSize memoryCost;
+            Locker locker { CanvasRenderingContext::instancesLock() };
+            for (SUPPRESS_UNCOUNTED_ARG auto* context : CanvasRenderingContext::instances()) {
+                if (!context->isContextThread() || !canvasContextMatchesDevice(*context, device))
+                    continue;
+                memoryCost += context->memoryCost();
+            }
+            return memoryCost;
+        }
+    );
 }
 
 void InspectorCanvas::canvasChanged()
 {
-    if (!m_context->hasActiveInspectorCanvasCallTracer())
+    Ref context = std::get<WeakRef<CanvasRenderingContext>>(m_context);
+    if (!context->hasActiveInspectorCanvasCallTracer())
         return;
 
     // Since 2D contexts are able to be fully reproduced in the frontend, we don't need snapshots.
-    if (is<CanvasRenderingContext2D>(m_context))
+    if (is<CanvasRenderingContext2D>(context))
         return;
 #if ENABLE(OFFSCREEN_CANVAS)
-    if (is<OffscreenCanvasRenderingContext2D>(m_context))
+    if (is<OffscreenCanvasRenderingContext2D>(context))
         return;
 #endif
 
@@ -168,7 +269,8 @@ void InspectorCanvas::resetRecordingData()
 
     // FIXME: <https://webkit.org/b/201651> Web Inspector: Canvas: support canvas recordings for WebGPUDevice
 
-    m_context->setHasActiveInspectorCanvasCallTracer(false);
+    Ref context = std::get<WeakRef<CanvasRenderingContext>>(m_context);
+    context->setHasActiveInspectorCanvasCallTracer(false);
 }
 
 bool InspectorCanvas::hasRecordingData() const
@@ -234,12 +336,13 @@ void InspectorCanvas::recordAction(String&& name, InspectorCanvasProcessedArgume
 
     // FIXME: <https://webkit.org/b/201651> Web Inspector: Canvas: support canvas recordings for WebGPUDevice
 
-    if (is<ImageBitmapRenderingContext>(m_context) && shouldSnapshotBitmapRendererAction(name))
+    Ref context = std::get<WeakRef<CanvasRenderingContext>>(m_context);
+    if (is<ImageBitmapRenderingContext>(context) && shouldSnapshotBitmapRendererAction(name))
         m_contentChanged = true;
 #if ENABLE(WEBGL)
-    else if (is<WebGLRenderingContext>(m_context) && shouldSnapshotWebGLAction(name))
+    else if (is<WebGLRenderingContext>(context) && shouldSnapshotWebGLAction(name))
         m_contentChanged = true;
-    else if (is<WebGL2RenderingContext>(m_context) && shouldSnapshotWebGL2Action(name))
+    else if (is<WebGL2RenderingContext>(context) && shouldSnapshotWebGL2Action(name))
         m_contentChanged = true;
 #endif
 
@@ -363,66 +466,88 @@ static RefPtr<Inspector::Protocol::Canvas::ContextAttributes> buildObjectForCanv
 
 Ref<Inspector::Protocol::Canvas::Canvas> InspectorCanvas::buildObjectForCanvas(bool captureBacktrace)
 {
-    auto contextType = [&] {
-        bool isOffscreen = false;
+    Ref canvas = WTF::switchOn(m_context,
+        [&](const WeakRef<CanvasRenderingContext>& weakContext) {
+            Ref context = weakContext;
+
+            auto contextType = [&] {
+                bool isOffscreen = false;
 #if ENABLE(OFFSCREEN_CANVAS)
-        if (is<OffscreenCanvas>(m_context->canvasBase()))
-            isOffscreen = true;
+                if (is<OffscreenCanvas>(context->canvasBase()))
+                    isOffscreen = true;
 #endif
 
-        if (is<CanvasRenderingContext2D>(m_context)) {
-            ASSERT(!isOffscreen);
-            return Inspector::Protocol::Canvas::ContextType::Canvas2D;
-        }
+                if (is<CanvasRenderingContext2D>(context)) {
+                    ASSERT(!isOffscreen);
+                    return Inspector::Protocol::Canvas::ContextType::Canvas2D;
+                }
 #if ENABLE(OFFSCREEN_CANVAS)
-        if (is<OffscreenCanvasRenderingContext2D>(m_context)) {
-            ASSERT(isOffscreen);
-            return Inspector::Protocol::Canvas::ContextType::OffscreenCanvas2D;
-        }
+                if (is<OffscreenCanvasRenderingContext2D>(context)) {
+                    ASSERT(isOffscreen);
+                    return Inspector::Protocol::Canvas::ContextType::OffscreenCanvas2D;
+                }
 #endif
-        if (is<ImageBitmapRenderingContext>(m_context)) {
-            if (isOffscreen)
-                return Inspector::Protocol::Canvas::ContextType::OffscreenBitmapRenderer;
-            return Inspector::Protocol::Canvas::ContextType::BitmapRenderer;
-        }
+                if (is<ImageBitmapRenderingContext>(context)) {
+                    if (isOffscreen)
+                        return Inspector::Protocol::Canvas::ContextType::OffscreenBitmapRenderer;
+                    return Inspector::Protocol::Canvas::ContextType::BitmapRenderer;
+                }
 #if ENABLE(WEBGL)
-        if (is<WebGLRenderingContext>(m_context)) {
-            if (isOffscreen)
-                return Inspector::Protocol::Canvas::ContextType::OffscreenWebGL;
-            return Inspector::Protocol::Canvas::ContextType::WebGL;
-        }
-        if (is<WebGL2RenderingContext>(m_context)) {
-            if (isOffscreen)
-                return Inspector::Protocol::Canvas::ContextType::OffscreenWebGL2;
-            return Inspector::Protocol::Canvas::ContextType::WebGL2;
-        }
+                if (is<WebGLRenderingContext>(context)) {
+                    if (isOffscreen)
+                        return Inspector::Protocol::Canvas::ContextType::OffscreenWebGL;
+                    return Inspector::Protocol::Canvas::ContextType::WebGL;
+                }
+                if (is<WebGL2RenderingContext>(context)) {
+                    if (isOffscreen)
+                        return Inspector::Protocol::Canvas::ContextType::OffscreenWebGL2;
+                    return Inspector::Protocol::Canvas::ContextType::WebGL2;
+                }
 #endif
 
-        ASSERT_NOT_REACHED();
-        return Inspector::Protocol::Canvas::ContextType::Canvas2D;
-    }();
+                RELEASE_ASSERT_NOT_REACHED();
+            }();
 
-    const auto& size = m_context->canvasBase().size();
+            auto result = Inspector::Protocol::Canvas::Canvas::create()
+                .setCanvasId(m_identifier)
+                .setContextType(contextType)
+                .release();
 
-    auto canvas = Inspector::Protocol::Canvas::Canvas::create()
-        .setCanvasId(m_identifier)
-        .setContextType(contextType)
-        .setWidth(size.width())
-        .setHeight(size.height())
-        .release();
+            const auto& size = context->canvasBase().size();
+            result->setWidth(size.width());
+            result->setHeight(size.height());
 
-    if (RefPtr node = canvasElement()) {
-        String cssCanvasName = node->document().nameForCSSCanvasElement(*node);
-        if (!cssCanvasName.isEmpty())
-            canvas->setCssCanvasName(cssCanvasName);
+            if (RefPtr node = dynamicDowncast<HTMLCanvasElement>(context->canvasBase())) {
+                String cssCanvasName = node->document().nameForCSSCanvasElement(*node);
+                if (!cssCanvasName.isEmpty())
+                    result->setCssCanvasName(cssCanvasName);
 
-        // FIXME: <https://webkit.org/b/178282> Web Inspector: send a DOM node with each Canvas payload and eliminate Canvas.requestNode
-    }
+                // FIXME: <https://webkit.org/b/178282> Web Inspector: send a DOM node with each Canvas payload and eliminate Canvas.requestNode
+            }
 
-    if (auto attributes = buildObjectForCanvasContextAttributes(protect(m_context.get())))
-        canvas->setContextAttributes(attributes.releaseNonNull());
+            if (auto attributes = buildObjectForCanvasContextAttributes(context))
+                result->setContextAttributes(attributes.releaseNonNull());
 
-    if (size_t memoryCost = m_context->memoryCost())
+            return result;
+        },
+        [&](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>& weakDevice) {
+            Ref device = weakDevice;
+
+            auto result = Inspector::Protocol::Canvas::Canvas::create()
+                .setCanvasId(m_identifier)
+                .setContextType(Inspector::Protocol::Canvas::ContextType::WebGPU)
+                .release();
+
+            auto features = JSON::ArrayOf<String>::create();
+            for (const String& feature : device->backing().features().features())
+                features->addItem(feature);
+            result->setFeatures(WTF::move(features));
+
+            return result;
+        }
+    );
+
+    if (size_t memoryCost = this->memoryCost())
         canvas->setMemoryCost(memoryCost);
 
     if (captureBacktrace) {
@@ -439,29 +564,30 @@ Ref<Inspector::Protocol::Recording::Recording> InspectorCanvas::releaseObjectFor
     ASSERT(!m_lastRecordedAction);
     ASSERT(!m_frames);
 
+    Ref context = std::get<WeakRef<CanvasRenderingContext>>(m_context);
     // FIXME: <https://webkit.org/b/201651> Web Inspector: Canvas: support canvas recordings for WebGPUDevice
 
     bool isOffscreen = false;
 #if ENABLE(OFFSCREEN_CANVAS)
-    if (is<OffscreenCanvas>(m_context->canvasBase()))
+    if (is<OffscreenCanvas>(context->canvasBase()))
         isOffscreen = true;
 #endif
 
     Inspector::Protocol::Recording::Type type;
-    if (is<CanvasRenderingContext2D>(m_context)) {
+    if (is<CanvasRenderingContext2D>(context)) {
         ASSERT(!isOffscreen);
         type = Inspector::Protocol::Recording::Type::Canvas2D;
 #if ENABLE(OFFSCREEN_CANVAS)
-    } else if (is<OffscreenCanvasRenderingContext2D>(m_context)) {
+    } else if (is<OffscreenCanvasRenderingContext2D>(context)) {
         ASSERT(isOffscreen);
         type = Inspector::Protocol::Recording::Type::OffscreenCanvas2D;
 #endif
-    } else if (is<ImageBitmapRenderingContext>(m_context)) {
+    } else if (is<ImageBitmapRenderingContext>(context)) {
         type = isOffscreen ? Inspector::Protocol::Recording::Type::OffscreenCanvasBitmapRenderer : Inspector::Protocol::Recording::Type::CanvasBitmapRenderer;
 #if ENABLE(WEBGL)
-    } else if (is<WebGLRenderingContext>(m_context)) {
+    } else if (is<WebGLRenderingContext>(context)) {
         type = isOffscreen ? Inspector::Protocol::Recording::Type::OffscreenCanvasWebGL : Inspector::Protocol::Recording::Type::CanvasWebGL;
-    } else if (is<WebGL2RenderingContext>(m_context)) {
+    } else if (is<WebGL2RenderingContext>(context)) {
         type = isOffscreen ? Inspector::Protocol::Recording::Type::OffscreenCanvasWebGL2 : Inspector::Protocol::Recording::Type::CanvasWebGL2;
 #endif
     } else {
@@ -488,6 +614,19 @@ Inspector::Protocol::ErrorStringOr<String> InspectorCanvas::getContentAsDataURL(
 {
     auto surfaceBuffer = context.compositingResultsNeedUpdating() ? CanvasRenderingContext::SurfaceBuffer::DrawingBuffer : CanvasRenderingContext::SurfaceBuffer::DisplayBuffer;
     return encodeDataURL(context.surfaceBufferToImageBuffer(surfaceBuffer), "image/png"_s);
+}
+
+Inspector::Protocol::ErrorStringOr<String> InspectorCanvas::getContentAsDataURL()
+{
+    return WTF::switchOn(m_context,
+        [](const WeakRef<CanvasRenderingContext>& weakContext) {
+            Ref context = weakContext;
+            return getContentAsDataURL(context);
+        },
+        [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>&) -> Inspector::Protocol::ErrorStringOr<String> {
+            return makeUnexpected("Canvas content is not available for WebGPU devices"_s);
+        }
+    );
 }
 
 void InspectorCanvas::appendActionSnapshotIfNeeded()
@@ -673,19 +812,20 @@ static Ref<JSON::ArrayOf<double>> buildArrayForAffineTransform(const AffineTrans
 
 Ref<Inspector::Protocol::Recording::InitialState> InspectorCanvas::buildInitialState()
 {
+    Ref context = std::get<WeakRef<CanvasRenderingContext>>(m_context);
     // FIXME: <https://webkit.org/b/201651> Web Inspector: Canvas: support canvas recordings for WebGPUDevice
 
     auto initialStatePayload = Inspector::Protocol::Recording::InitialState::create().release();
 
     auto attributesPayload = JSON::Object::create();
-    attributesPayload->setInteger("width"_s, protect(m_context)->canvasBase().width());
-    attributesPayload->setInteger("height"_s, protect(m_context)->canvasBase().height());
+    attributesPayload->setInteger("width"_s, context->canvasBase().width());
+    attributesPayload->setInteger("height"_s, context->canvasBase().height());
 
     auto statesPayload = JSON::ArrayOf<JSON::Object>::create();
 
     auto parametersPayload = JSON::ArrayOf<JSON::Value>::create();
 
-    if (RefPtr context2d = dynamicDowncast<CanvasRenderingContext2DBase>(m_context.get())) {
+    if (RefPtr context2d = dynamicDowncast<CanvasRenderingContext2DBase>(context)) {
         for (auto& state : context2d->stateStack()) {
             auto statePayload = JSON::Object::create();
 
@@ -743,7 +883,7 @@ Ref<Inspector::Protocol::Recording::InitialState> InspectorCanvas::buildInitialS
         }
     }
 
-    if (auto contextAttributes = buildObjectForCanvasContextAttributes(protect(m_context.get())))
+    if (auto contextAttributes = buildObjectForCanvasContextAttributes(context))
         parametersPayload->addItem(contextAttributes.releaseNonNull());
 
     initialStatePayload->setAttributes(WTF::move(attributesPayload));
@@ -754,7 +894,7 @@ Ref<Inspector::Protocol::Recording::InitialState> InspectorCanvas::buildInitialS
     if (parametersPayload->length())
         initialStatePayload->setParameters(WTF::move(parametersPayload));
 
-    if (auto content = getContentAsDataURL())
+    if (auto content = getContentAsDataURL(context))
         initialStatePayload->setContent(*content);
 
     return initialStatePayload;

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -35,6 +35,7 @@
 #include <JavaScriptCore/ScriptCallFrame.h>
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <wtf/HashSet.h>
+#include <wtf/Variant.h>
 #include <wtf/WeakRef.h>
 
 namespace JSC {
@@ -47,6 +48,7 @@ namespace WebCore {
 class CanvasGradient;
 class CanvasPattern;
 class Element;
+class GPUDevice;
 class HTMLCanvasElement;
 class HTMLImageElement;
 class HTMLVideoElement;
@@ -54,26 +56,30 @@ class ImageBitmap;
 class ImageData;
 class OffscreenCanvas;
 class CSSStyleImageValue;
+class WeakPtrImplWithEventTargetData;
 
 template<typename> struct InspectorCanvasArgumentProcessor;
 
 class InspectorCanvas final : public RefCountedAndCanMakeWeakPtr<InspectorCanvas> {
 public:
     static Ref<InspectorCanvas> create(CanvasRenderingContext&);
+    static Ref<InspectorCanvas> create(GPUDevice&);
 
     const String& identifier() const LIFETIME_BOUND { return m_identifier; }
 
-    const CanvasRenderingContext& canvasContext() const { return m_context; }
-    CanvasRenderingContext& canvasContext() { return m_context; }
-    HTMLCanvasElement* NODELETE canvasElement() const;
+    CanvasRenderingContext* canvasContext() const;
+    GPUDevice* deviceContext() const;
+
+    HTMLCanvasElement* canvasElement() const;
 
     ScriptExecutionContext* scriptExecutionContext() const;
 
     JSC::JSValue resolveContext(JSC::JSGlobalObject*);
 
     HashSet<Element*> clientNodes() const;
+    size_t memoryCost() const;
 
-    void NODELETE canvasChanged();
+    void canvasChanged();
 
     void resetRecordingData();
     bool NODELETE hasRecordingData() const;
@@ -99,12 +105,13 @@ public:
     Ref<Inspector::Protocol::Recording::Recording> releaseObjectForRecording();
 
     static Inspector::Protocol::ErrorStringOr<String> getContentAsDataURL(CanvasRenderingContext&);
-    Inspector::Protocol::ErrorStringOr<String> getContentAsDataURL() { return getContentAsDataURL(m_context); };
+    Inspector::Protocol::ErrorStringOr<String> getContentAsDataURL();
 
 private:
     template<typename> friend struct InspectorCanvasArgumentProcessor;
 
     explicit InspectorCanvas(CanvasRenderingContext&);
+    explicit InspectorCanvas(GPUDevice&);
 
     void appendActionSnapshotIfNeeded();
 
@@ -139,7 +146,10 @@ private:
 
     String m_identifier;
 
-    WeakRef<CanvasRenderingContext> m_context;
+    Variant<
+        WeakRef<CanvasRenderingContext>,
+        WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>
+    > m_context;
 
     RefPtr<Inspector::Protocol::Recording::InitialState> m_initialState;
     RefPtr<JSON::ArrayOf<Inspector::Protocol::Recording::Frame>> m_frames;

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1310,6 +1310,24 @@ bool InspectorInstrumentation::isWebGLProgramHighlightedImpl(InstrumentingAgents
 }
 #endif
 
+void InspectorInstrumentation::didCreateWebGPUDeviceImpl(InstrumentingAgents& instrumentingAgents, GPUDevice& device)
+{
+    if (CheckedPtr canvasAgent = instrumentingAgents.enabledCanvasAgent())
+        canvasAgent->didCreateWebGPUDevice(device);
+}
+
+void InspectorInstrumentation::willDestroyWebGPUDeviceImpl(InstrumentingAgents& instrumentingAgents, GPUDevice& device)
+{
+    if (CheckedPtr canvasAgent = instrumentingAgents.enabledCanvasAgent())
+        canvasAgent->willDestroyWebGPUDevice(device);
+}
+
+void InspectorInstrumentation::didChangeGPUDeviceClientNodesImpl(InstrumentingAgents& instrumentingAgents, GPUDevice& device)
+{
+    if (CheckedPtr pageCanvasAgent = instrumentingAgents.enabledPageCanvasAgent())
+        pageCanvasAgent->didChangeGPUDeviceClientNodes(device);
+}
+
 void InspectorInstrumentation::willApplyKeyframeEffectImpl(InstrumentingAgents& instrumentingAgents, const Styleable& target, KeyframeEffect& effect, const ComputedEffectTiming& computedTiming)
 {
     if (CheckedPtr animationAgent = instrumentingAgents.trackingAnimationAgent())

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -39,6 +39,7 @@
 #include "EventTarget.h"
 #include "FormData.h"
 #include "Frame.h"
+#include "GPUDevice.h"
 #include "HitTestResult.h"
 #include "InspectorInstrumentationPublic.h"
 #include "InstrumentingAgents.h"
@@ -83,6 +84,7 @@ class Document;
 class DocumentLoader;
 class DocumentThreadableLoader;
 class EventListener;
+class GPUDevice;
 class HTTPHeaderMap;
 class InspectorTimelineAgent;
 class InstrumentingAgents;
@@ -330,6 +332,9 @@ public:
     static bool isWebGLProgramDisabled(WebGLRenderingContextBase&, WebGLProgram&);
     static bool isWebGLProgramHighlighted(WebGLRenderingContextBase&, WebGLProgram&);
 #endif
+    static void didCreateWebGPUDevice(GPUDevice&);
+    static void willDestroyWebGPUDevice(GPUDevice&);
+    static void didChangeGPUDeviceClientNodes(GPUDevice&);
 
     static void willApplyKeyframeEffect(const Styleable&, KeyframeEffect&, const ComputedEffectTiming&);
     static void didChangeWebAnimationName(WebAnimation&);
@@ -537,6 +542,9 @@ private:
     static bool isWebGLProgramDisabledImpl(InstrumentingAgents&, WebGLProgram&);
     static bool isWebGLProgramHighlightedImpl(InstrumentingAgents&, WebGLProgram&);
 #endif
+    static void didCreateWebGPUDeviceImpl(InstrumentingAgents&, GPUDevice&);
+    static void willDestroyWebGPUDeviceImpl(InstrumentingAgents&, GPUDevice&);
+    static void didChangeGPUDeviceClientNodesImpl(InstrumentingAgents&, GPUDevice&);
 
     static void willApplyKeyframeEffectImpl(InstrumentingAgents&, const Styleable&, KeyframeEffect&, const ComputedEffectTiming&);
     static void didChangeWebAnimationNameImpl(InstrumentingAgents&, WebAnimation&);
@@ -1509,6 +1517,27 @@ inline bool InspectorInstrumentation::isWebGLProgramHighlighted(WebGLRenderingCo
     return false;
 }
 #endif
+
+inline void InspectorInstrumentation::didCreateWebGPUDevice(GPUDevice& device)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (RefPtr agents = instrumentingAgents(protect(device.scriptExecutionContext())))
+        didCreateWebGPUDeviceImpl(*agents, device);
+}
+
+inline void InspectorInstrumentation::willDestroyWebGPUDevice(GPUDevice& device)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (RefPtr agents = instrumentingAgents(protect(device.scriptExecutionContext())))
+        willDestroyWebGPUDeviceImpl(*agents, device);
+}
+
+inline void InspectorInstrumentation::didChangeGPUDeviceClientNodes(GPUDevice& device)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (RefPtr agents = instrumentingAgents(protect(device.scriptExecutionContext())))
+        didChangeGPUDeviceClientNodesImpl(*agents, device);
+}
 
 inline void InspectorInstrumentation::willApplyKeyframeEffect(const Styleable& target, KeyframeEffect& effect, const ComputedEffectTiming& computedTiming)
 {

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -35,6 +35,8 @@
 #include "DOMMatrix2DInit.h"
 #include "DOMPointInit.h"
 #include "EventLoop.h"
+#include "GPUCanvasContext.h"
+#include "GPUDevice.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLVideoElement.h"
@@ -169,6 +171,24 @@ void InspectorCanvasAgent::internalEnable()
         }
     }
 
+    Vector<WeakPtr<GPUDevice, WeakPtrImplWithEventTargetData>> devices;
+    {
+        Locker locker { GPUDevice::instancesLock() };
+        for (SUPPRESS_UNCOUNTED_ARG auto* device : GPUDevice::instances()) {
+            if (!device->isContextThread())
+                continue;
+            RefPtr scriptExecutionContext = device->scriptExecutionContext();
+            if (!scriptExecutionContext)
+                continue;
+            if (matchesCurrentContext(scriptExecutionContext))
+                devices.append(*device);
+        }
+    }
+    for (auto& device : devices) {
+        if (device)
+            bindCanvas(*device, false);
+    }
+
 #if ENABLE(WEBGL)
     {
         Locker locker { WebGLProgram::instancesLock() };
@@ -209,7 +229,11 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObjec
     if (!inspectorCanvas)
         return makeUnexpected(errorString);
 
-    auto* state = protect(inspectorCanvas->scriptExecutionContext())->globalObject();
+    RefPtr scriptExecutionContext = inspectorCanvas->scriptExecutionContext();
+    if (!scriptExecutionContext)
+        return makeUnexpected("Canvas is detached from context"_s);
+
+    auto* state = scriptExecutionContext->globalObject();
     auto injectedScript = m_injectedScriptManager->injectedScriptFor(state);
     ASSERT(!injectedScript.hasNoValue());
 
@@ -244,9 +268,11 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::startRecording(co
     if (!inspectorCanvas)
         return makeUnexpected(errorString);
 
-    Ref context = inspectorCanvas->canvasContext();
+    RefPtr context = inspectorCanvas->canvasContext();
 
     // FIXME: <https://webkit.org/b/201651> Web Inspector: Canvas: support canvas recordings for WebGPUDevice
+    if (!context)
+        return makeUnexpected("WebGPU recording is not supported."_s);
 
     if (context->hasActiveInspectorCanvasCallTracer())
         return makeUnexpected("Already recording canvas"_s);
@@ -269,14 +295,16 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::stopRecording(con
     if (!inspectorCanvas)
         return makeUnexpected(errorString);
 
-    Ref context = inspectorCanvas->canvasContext();
+    RefPtr context = inspectorCanvas->canvasContext();
 
     // FIXME: <https://webkit.org/b/201651> Web Inspector: Canvas: support canvas recordings for WebGPUDevice
+    if (!context)
+        return makeUnexpected("WebGPU recording is not supported."_s);
 
     if (!context->hasActiveInspectorCanvasCallTracer())
         return makeUnexpected("Not recording canvas"_s);
 
-    didFinishRecordingCanvasFrame(context, true);
+    didFinishRecordingCanvasFrame(*context, true);
 
     return { };
 }
@@ -363,18 +391,26 @@ void InspectorCanvasAgent::didChangeCanvasSize(CanvasRenderingContext& context)
     if (!inspectorCanvas)
         return;
 
-    const auto& size = inspectorCanvas->canvasContext().canvasBase().size();
+    const auto& size = context.canvasBase().size();
     m_frontendDispatcher->canvasSizeChanged(inspectorCanvas->identifier(), size.width(), size.height());
 }
 
 void InspectorCanvasAgent::didChangeCanvasMemory(const CanvasRenderingContext& context)
 {
-    RefPtr inspectorCanvas = findInspectorCanvas(context);
+    RefPtr<InspectorCanvas> inspectorCanvas;
+    if (WeakPtr gpuCanvasContext = dynamicDowncast<GPUCanvasContext>(context)) {
+        WeakPtr device = gpuCanvasContext->device();
+        if (!device)
+            return;
+        inspectorCanvas = findInspectorCanvas(*device);
+    } else
+        inspectorCanvas = findInspectorCanvas(context);
+
     ASSERT(inspectorCanvas);
     if (!inspectorCanvas)
         return;
 
-    m_frontendDispatcher->canvasMemoryChanged(inspectorCanvas->identifier(), inspectorCanvas->canvasContext().memoryCost());
+    m_frontendDispatcher->canvasMemoryChanged(inspectorCanvas->identifier(), inspectorCanvas->memoryCost());
 }
 
 void InspectorCanvasAgent::canvasChanged(CanvasBase& canvasBase, const FloatRect&)
@@ -522,6 +558,25 @@ bool InspectorCanvasAgent::isWebGLProgramHighlighted(WebGLProgram& program)
 
 #endif // ENABLE(WEBGL)
 
+void InspectorCanvasAgent::didCreateWebGPUDevice(GPUDevice& device)
+{
+    if (findInspectorCanvas(device)) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    bindCanvas(device, true);
+}
+
+void InspectorCanvasAgent::willDestroyWebGPUDevice(GPUDevice& device)
+{
+    RefPtr inspectorCanvas = findInspectorCanvas(device);
+    if (!inspectorCanvas)
+        return;
+
+    unbindCanvas(*inspectorCanvas);
+}
+
 void InspectorCanvasAgent::recordAction(CanvasRenderingContext& canvasRenderingContext, String&& name, InspectorCanvasProcessedArguments&& arguments)
 {
     ASSERT(canvasRenderingContext.hasActiveInspectorCanvasCallTracer());
@@ -544,11 +599,13 @@ void InspectorCanvasAgent::recordAction(CanvasRenderingContext& canvasRenderingC
                     if (!inspectorCanvas)
                         continue;
 
-                    Ref canvasRenderingContext = inspectorCanvas->canvasContext();
+                    RefPtr canvasRenderingContext = inspectorCanvas->canvasContext();
                     // FIXME: <https://webkit.org/b/201651> Web Inspector: Canvas: support canvas recordings for WebGPUDevice
+                    if (!canvasRenderingContext)
+                        continue;
 
                     if (canvasRenderingContext->hasActiveInspectorCanvasCallTracer())
-                        canvasAgent->didFinishRecordingCanvasFrame(canvasRenderingContext);
+                        canvasAgent->didFinishRecordingCanvasFrame(*canvasRenderingContext);
                 }
 
                 canvasAgent->m_recordingCanvasIdentifiers.clear();
@@ -566,8 +623,10 @@ void InspectorCanvasAgent::recordAction(CanvasRenderingContext& canvasRenderingC
 
 void InspectorCanvasAgent::startRecording(InspectorCanvas& inspectorCanvas, Inspector::Protocol::Recording::Initiator initiator, RecordingOptions&& recordingOptions)
 {
-    Ref context = inspectorCanvas.canvasContext();
+    RefPtr context = inspectorCanvas.canvasContext();
     // FIXME: <https://webkit.org/b/201651> Web Inspector: Canvas: support canvas recordings for WebGPUDevice
+    if (!context)
+        return;
 
     if (!is<CanvasRenderingContext2D>(context)
         && !is<ImageBitmapRenderingContext>(context)
@@ -624,8 +683,10 @@ void InspectorCanvasAgent::programDestroyedTimerFired()
 
 void InspectorCanvasAgent::reset()
 {
-    for (auto& inspectorCanvas : m_identifierToInspectorCanvas.values())
-        inspectorCanvas->canvasContext().canvasBase().removeObserver(*this);
+    for (auto& inspectorCanvas : m_identifierToInspectorCanvas.values()) {
+        if (RefPtr context = inspectorCanvas->canvasContext())
+            context->canvasBase().removeObserver(*this);
+    }
 
     m_identifierToInspectorCanvas.clear();
     m_removedCanvasIdentifiers.clear();
@@ -666,9 +727,22 @@ InspectorCanvas& InspectorCanvasAgent::bindCanvas(CanvasRenderingContext& contex
     return inspectorCanvas.unsafeGet();
 }
 
+InspectorCanvas& InspectorCanvasAgent::bindCanvas(GPUDevice& device, bool captureBacktrace)
+{
+    auto inspectorCanvas = InspectorCanvas::create(device);
+    m_identifierToInspectorCanvas.set(inspectorCanvas->identifier(), inspectorCanvas.copyRef());
+
+    m_frontendDispatcher->canvasAdded(inspectorCanvas->buildObjectForCanvas(captureBacktrace));
+
+    return inspectorCanvas.unsafeGet();
+}
+
 void InspectorCanvasAgent::unbindCanvas(InspectorCanvas& inspectorCanvas)
 {
-    didFinishRecordingCanvasFrame(protect(inspectorCanvas.canvasContext()), true);
+    if (RefPtr context = inspectorCanvas.canvasContext()) {
+        didFinishRecordingCanvasFrame(*context, true);
+        context->canvasBase().removeObserver(*this);
+    }
 
 #if ENABLE(WEBGL)
     Vector<InspectorShaderProgram*> programsToRemove;
@@ -679,8 +753,6 @@ void InspectorCanvasAgent::unbindCanvas(InspectorCanvas& inspectorCanvas)
     for (RefPtr inspectorProgram : programsToRemove)
         unbindProgram(*inspectorProgram);
 #endif
-
-    inspectorCanvas.canvasContext().canvasBase().removeObserver(*this);
 
     String identifier = inspectorCanvas.identifier();
     m_identifierToInspectorCanvas.remove(identifier);
@@ -707,8 +779,17 @@ RefPtr<InspectorCanvas> InspectorCanvasAgent::assertInspectorCanvas(Inspector::P
 RefPtr<InspectorCanvas> InspectorCanvasAgent::findInspectorCanvas(const CanvasRenderingContext& context)
 {
     for (auto& inspectorCanvas : m_identifierToInspectorCanvas.values()) {
-        if (&inspectorCanvas->canvasContext() == &context)
+        if (inspectorCanvas->canvasContext() == &context)
             return inspectorCanvas.ptr();
+    }
+    return nullptr;
+}
+
+RefPtr<InspectorCanvas> InspectorCanvasAgent::findInspectorCanvas(const GPUDevice& device)
+{
+    for (auto& inspectorCanvas : m_identifierToInspectorCanvas.values()) {
+        if (inspectorCanvas->deviceContext() == &device)
+            return protect(inspectorCanvas);
     }
     return nullptr;
 }

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -50,6 +50,7 @@ class InjectedScriptManager;
 namespace WebCore {
 
 class CanvasRenderingContext;
+class GPUDevice;
 class ScriptExecutionContext;
 
 #if ENABLE(WEBGL)
@@ -108,11 +109,14 @@ public:
     bool isWebGLProgramDisabled(WebGLProgram&);
     bool isWebGLProgramHighlighted(WebGLProgram&);
 #endif // ENABLE(WEBGL)
+    void didCreateWebGPUDevice(GPUDevice&);
+    void willDestroyWebGPUDevice(GPUDevice&);
 
     void recordAction(CanvasRenderingContext&, String&&, InspectorCanvasProcessedArguments&& = { });
 
     RefPtr<InspectorCanvas> assertInspectorCanvas(Inspector::Protocol::ErrorString&, const String& canvasId);
-    RefPtr<InspectorCanvas> NODELETE findInspectorCanvas(const CanvasRenderingContext&);
+    RefPtr<InspectorCanvas> findInspectorCanvas(const CanvasRenderingContext&);
+    RefPtr<InspectorCanvas> findInspectorCanvas(const GPUDevice&);
 
 protected:
     InspectorCanvasAgent(WebAgentContext&);
@@ -143,6 +147,7 @@ private:
 #endif // ENABLE(WEBGL)
 
     InspectorCanvas& bindCanvas(CanvasRenderingContext&, bool captureBacktrace);
+    InspectorCanvas& bindCanvas(GPUDevice&, bool captureBacktrace);
 
 #if ENABLE(WEBGL)
     void unbindProgram(InspectorShaderProgram&);

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
@@ -159,6 +159,15 @@ void PageCanvasAgent::didChangeCSSCanvasClientNodes(CanvasBase& canvasBase)
     m_frontendDispatcher->clientNodesChanged(inspectorCanvas->identifier());
 }
 
+void PageCanvasAgent::didChangeGPUDeviceClientNodes(GPUDevice& device)
+{
+    RefPtr inspectorCanvas = findInspectorCanvas(device);
+    if (!inspectorCanvas)
+        return;
+
+    m_frontendDispatcher->clientNodesChanged(inspectorCanvas->identifier());
+}
+
 bool PageCanvasAgent::matchesCurrentContext(ScriptExecutionContext* scriptExecutionContext) const
 {
     auto* document = dynamicDowncast<Document>(scriptExecutionContext);

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.h
@@ -48,6 +48,7 @@ public:
     // InspectorInstrumentation
     void frameNavigated(LocalFrame&);
     void didChangeCSSCanvasClientNodes(CanvasBase&);
+    void didChangeGPUDeviceClientNodes(GPUDevice&);
 
 private:
     bool enabled() const override;

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -784,6 +784,7 @@ localizedStrings["Failed to upgrade"] = "Failed to upgrade";
 localizedStrings["Failure status code"] = "Failure status code";
 /* Section title for font feature properties. */
 localizedStrings["Feature Properties @ Font Details Sidebar Section"] = "Feature Properties";
+localizedStrings["Features"] = "Features";
 /* Resource loaded via 'fetch' method */
 localizedStrings["Fetch"] = "Fetch";
 /* Resources loaded via 'fetch' method */

--- a/Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js
@@ -313,7 +313,12 @@ WI.CanvasManager = class CanvasManager extends WI.Object
     {
         let {target} = event.data;
 
-        this._canvasForIdentifierForTargetMap.delete(target);
+        for (let canvas of (this._canvasForIdentifierForTargetMap.take(target)?.values() || [])) {
+            this._saveRecordings(canvas);
+            this._canvasCollection.remove(canvas);
+            canvas.shaderProgramCollection.clear();
+        }
+
         this._shaderProgramForIdentifierForTargetMap.delete(target);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Models/Canvas.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Canvas.js
@@ -25,7 +25,7 @@
 
 WI.Canvas = class Canvas extends WI.Object
 {
-    constructor(target, identifier, contextType, size, {domNode, cssCanvasName, contextAttributes, memoryCost, stackTrace} = {})
+    constructor(target, identifier, contextType, size, {domNode, cssCanvasName, contextAttributes, features, memoryCost, stackTrace} = {})
     {
         super();
 
@@ -42,6 +42,7 @@ WI.Canvas = class Canvas extends WI.Object
         this._domNode = domNode || null;
         this._cssCanvasName = cssCanvasName || "";
         this._contextAttributes = contextAttributes || {};
+        this._features = features || [];
         this._extensions = new Set;
         this._memoryCost = memoryCost || NaN;
         this._stackTrace = stackTrace || null;
@@ -121,6 +122,7 @@ WI.Canvas = class Canvas extends WI.Object
             domNode: payload.nodeId ? WI.domManager.nodeForId(payload.nodeId) : null,
             cssCanvasName: payload.cssCanvasName,
             contextAttributes: payload.contextAttributes,
+            features: payload.features,
             memoryCost: payload.memoryCost,
             stackTrace: WI.StackTrace.fromPayload(target, payload.stackTrace),
         });
@@ -194,6 +196,7 @@ WI.Canvas = class Canvas extends WI.Object
     get memoryCost() { return this._memoryCost; }
     get cssCanvasName() { return this._cssCanvasName; }
     get contextAttributes() { return this._contextAttributes; }
+    get features() { return this._features; }
     get extensions() { return this._extensions; }
     get stackTrace() { return this._stackTrace; }
     get shaderProgramCollection() { return this._shaderProgramCollection; }

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.js
@@ -128,6 +128,10 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         this._extensionsSection.element.hidden = true;
         this._sections.push(this._extensionsSection);
 
+        this._featuresSection = new WI.DetailsSection("canvas-features", WI.UIString("Features"));
+        this._featuresSection.element.hidden = true;
+        this._sections.push(this._featuresSection);
+
         this._clientNodesRow = new WI.DetailsSectionSimpleRow(WI.UIString("Nodes"));
 
         this._clientsSection = new WI.DetailsSection("canvas-clients", WI.UIString("Clients"));
@@ -168,6 +172,7 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         this._refreshSourceSection();
         this._refreshAttributesSection();
         this._refreshExtensionsSection();
+        this._refreshFeaturesSection();
         this._refreshClientsSection();
         this._refreshBacktraceSection();
     }
@@ -301,6 +306,21 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
             listElement.textContent = extension;
         }
         this._extensionsSection.groups = [{element}];
+    }
+
+    _refreshFeaturesSection()
+    {
+        let hasFeatures = this._canvas.features.length > 0;
+        this._featuresSection.element.hidden = !hasFeatures;
+        if (!hasFeatures)
+            return;
+
+        let element = document.createElement("ul");
+        for (let feature of this._canvas.features) {
+            let listElement = element.appendChild(document.createElement("li"));
+            listElement.textContent = feature;
+        }
+        this._featuresSection.groups = [{element}];
     }
 
     _refreshClientsSection()


### PR DESCRIPTION
#### f3e34dde7c9d3ed83bca6c9445800cb499bd8b5d
<pre>
Web Inspector: Canvas: instrument WebGPU devices
<a href="https://bugs.webkit.org/show_bug.cgi?id=320694">https://bugs.webkit.org/show_bug.cgi?id=320694</a>

Reviewed by Mike Wyrzykowski.

* Source/WebCore/Modules/WebGPU/GPUDevice.h:
(WebCore::GPUDevice::create):
(WebCore::GPUDevice::instances): Added.
(WebCore::GPUDevice::instancesLock): Added.
(WebCore::GPUDevice::isContextThread const): Added.
(WebCore::GPUDevice::contextDestroyed): Added.
(WebCore::GPUDevice::scriptExecutionContext const):
* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::instances): Added.
(WebCore::GPUDevice::instancesLock): Added.
(WebCore::GPUDevice::create):
(WebCore::GPUDevice::GPUDevice):
(WebCore::GPUDevice::~GPUDevice):
(WebCore::GPUDevice::contextDestroyed): Added.
Notify inspector after creation and before destruction.
Track all live `GPUDevice` so inspector can instrument them when the frontend is opened.

* Source/WebCore/html/canvas/GPUCanvasContext.h:
(WebCore::GPUCanvasContext::device const): Added.
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
(WebCore::GPUCanvasContextCocoa::~GPUCanvasContextCocoa): Added.
(WebCore::GPUCanvasContextCocoa::device const): Added.
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::~GPUCanvasContextCocoa): Added.
(WebCore::GPUCanvasContextCocoa::didUpdateCanvasSizeProperties):
(WebCore::GPUCanvasContextCocoa::configure):
(WebCore::GPUCanvasContextCocoa::unconfigure):
Expose the `GPUDevice` configured for a `&lt;canvas&gt;` and notify inspector whenever a `&lt;canvas&gt;` starts/stops using a `GPUDevice`.

* Source/WebCore/inspector/InspectorCanvas.h:
(WebCore::InspectorCanvas::create):
(WebCore::InspectorCanvas::canvasContext const):
(WebCore::InspectorCanvas::canvasContext): Deleted.
(WebCore::InspectorCanvas::deviceContext const): Added.
(WebCore::InspectorCanvas::getContentAsDataURL):
(WebCore::InspectorCanvas::InspectorCanvas):
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::create):
(WebCore::InspectorCanvas::InspectorCanvas):
(WebCore::InspectorCanvas::canvasContext const): Added.
(WebCore::InspectorCanvas::deviceContext const): Added.
(WebCore::canvasContextMatchesDevice): Added.
(WebCore::InspectorCanvas::canvasElement const):
(WebCore::InspectorCanvas::scriptExecutionContext const):
(WebCore::InspectorCanvas::resolveContext):
(WebCore::InspectorCanvas::memoryCost const):
(WebCore::InspectorCanvas::clientNodes const):
(WebCore::InspectorCanvas::canvasChanged):
(WebCore::InspectorCanvas::resetRecordingData):
(WebCore::InspectorCanvas::recordAction):
(WebCore::InspectorCanvas::buildObjectForCanvas):
(WebCore::InspectorCanvas::releaseObjectForRecording):
(WebCore::InspectorCanvas::getContentAsDataURL): Added.
(WebCore::InspectorCanvas::buildInitialState):
Store either a `CanvasRenderingContext` or a `GPUDevice` in a `Variant` instead of always assuming the former.
Expose `features` on the `Canvas.Canvas` since they&apos;re immutable at creation (unlike `Canvas.ContextAttributes`).

* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didCreateWebGPUDevice): Added.
(WebCore::InspectorInstrumentation::willDestroyWebGPUDevice): Added.
(WebCore::InspectorInstrumentation::didChangeGPUDeviceClientNodes): Added.
(WebCore::InspectorInstrumentation::didCreateWebGPUDeviceImpl): Added.
(WebCore::InspectorInstrumentation::willDestroyWebGPUDeviceImpl): Added.
(WebCore::InspectorInstrumentation::didChangeGPUDeviceClientNodesImpl): Added.
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didCreateWebGPUDeviceImpl): Added.
(WebCore::InspectorInstrumentation::willDestroyWebGPUDeviceImpl): Added.
(WebCore::InspectorInstrumentation::didChangeGPUDeviceClientNodesImpl): Added.
Forward `GPUDevice` lifecycle and `&lt;canvas&gt;` changes.

* Source/JavaScriptCore/inspector/protocol/Canvas.json:
* Source/WebCore/inspector/agents/InspectorCanvasAgent.h:
(WebCore::InspectorCanvasAgent::didCreateWebGPUDevice): Added.
(WebCore::InspectorCanvasAgent::willDestroyWebGPUDevice): Added.
(WebCore::InspectorCanvasAgent::findInspectorCanvas): Added WebGPU overload.
(WebCore::InspectorCanvasAgent::bindCanvas): Added WebGPU overload.
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::internalEnable):
(WebCore::InspectorCanvasAgent::resolveContext):
(WebCore::InspectorCanvasAgent::startRecording):
(WebCore::InspectorCanvasAgent::stopRecording):
(WebCore::InspectorCanvasAgent::didChangeCanvasSize):
(WebCore::InspectorCanvasAgent::didChangeCanvasMemory):
(WebCore::InspectorCanvasAgent::didCreateWebGPUDevice): Added.
(WebCore::InspectorCanvasAgent::willDestroyWebGPUDevice): Added.
(WebCore::InspectorCanvasAgent::recordAction):
(WebCore::InspectorCanvasAgent::reset):
(WebCore::InspectorCanvasAgent::bindCanvas):
(WebCore::InspectorCanvasAgent::unbindCanvas):
(WebCore::InspectorCanvasAgent::findInspectorCanvas):
Discover existing `GPUDevice` when `Canvas` instrumentation is enabled.

* Source/WebCore/inspector/agents/page/PageCanvasAgent.h:
(WebCore::PageCanvasAgent::didChangeGPUDeviceClientNodes): Added.
* Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp:
(WebCore::PageCanvasAgent::didChangeGPUDeviceClientNodes): Added.
Collect every `&lt;canvas&gt;` configured for the `GPUDevice` for `Canvas.getClientNodes`.

* Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js:
(WI.CanvasManager.prototype._handleTargetRemoved):
Remove all `WI.Canvas` when a `WI.Target` is destroyed.

* Source/WebInspectorUI/UserInterface/Models/Canvas.js:
(WI.Canvas):
(WI.Canvas.fromPayload):
(WI.Canvas.prototype.features): Added.
* Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.js:
(WI.CanvasDetailsSidebarPanel.prototype.initialLayout):
(WI.CanvasDetailsSidebarPanel.prototype.layout):
(WI.CanvasDetailsSidebarPanel.prototype._refreshFeaturesSection): Added.
Show a new &quot;Features&quot; panel in the details sidebar.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

* LayoutTests/inspector/canvas/resources/webgpu-worker.js: Added.
* LayoutTests/inspector/canvas/create-context-webgpu.html: Added.
* LayoutTests/inspector/canvas/create-context-webgpu-expected.txt: Added.
* LayoutTests/inspector/canvas/requestClientNodes-webgpu.html: Added.
* LayoutTests/inspector/canvas/requestClientNodes-webgpu-expected.txt: Added.
* LayoutTests/inspector/canvas/resolveContext-webgpu.html: Added.
* LayoutTests/inspector/canvas/resolveContext-webgpu-expected.txt: Added.
* LayoutTests/inspector/canvas/worker-webgpu.html: Added.
* LayoutTests/inspector/canvas/worker-webgpu-expected.txt: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/win/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/318336@main">https://commits.webkit.org/318336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6761227e19285afef1102bc19d85087975909537

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177983 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187593 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51630 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138735 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed layout tests; layout-tests (exception)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119198 "Passed tests") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40941 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed layout tests; layout-tests (exception)") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39300 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; run-api-tests (cancelled)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1167 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; jscore-tests (cancelled)") | 
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7985 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; jscore-tests (cancelled)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151346 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; run-api-tests (cancelled)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38988 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Passed layout tests; layout-tests (exception)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36054 "Built successfully") | 
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39254 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled JSC (warnings); jscore-tests (cancelled)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44524 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43536 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed layout tests; layout-tests (exception)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190023 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159021 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147873 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed layout tests; layout-tests (exception)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39710 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52270 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147654 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42361 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124534 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118999 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50778 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13965 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50236 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->