### PR TITLE
[Site Isolation] Web Inspector: inspector/worker/resources-in-(sub)worker.html fails

### DIFF
--- a/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
@@ -190,16 +190,13 @@ void FrameNetworkAgentProxy::willSendRequest(ResourceLoaderIdentifier resourceID
 
     auto timestamp = MonotonicTime::now().secondsSinceEpoch().value();
     auto walltime = WallTime::now().secondsSinceEpoch().value();
+    auto targetId = request.initiatorIdentifier();
     auto documentURL = protectedLoader->url().string();
     std::optional<ResourceResponse> optionalRedirectResponse;
     if (!redirectResponse.isNull())
         optionalRedirectResponse = redirectResponse;
 
-    protect(WebProcess::singleton().parentProcessConnection())->send(
-        Messages::ProxyingNetworkAgent::RequestWillBeSent(
-            qualifyResourceID(resourceID), *frameID, loaderId, String(), documentURL, request,
-            WTF::move(optionalRedirectResponse), resourceType, timestamp, walltime),
-        page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::ProxyingNetworkAgent::RequestWillBeSent(qualifyResourceID(resourceID), *frameID, loaderId, targetId, documentURL, request, WTF::move(optionalRedirectResponse), resourceType, timestamp, walltime), page->identifier());
 }
 
 void FrameNetworkAgentProxy::willSendRequestOfType(ResourceLoaderIdentifier resourceID, DocumentLoader* loader, ResourceRequest& request, Inspector::UncachedLoadType)
@@ -228,13 +225,10 @@ void FrameNetworkAgentProxy::willSendRequestOfType(ResourceLoaderIdentifier reso
 
     auto timestamp = MonotonicTime::now().secondsSinceEpoch().value();
     auto walltime = WallTime::now().secondsSinceEpoch().value();
+    auto targetId = request.initiatorIdentifier();
     auto documentURL = protectedLoader->url().string();
 
-    protect(WebProcess::singleton().parentProcessConnection())->send(
-        Messages::ProxyingNetworkAgent::RequestWillBeSent(
-            qualifyResourceID(resourceID), *frameID, loaderId, String(), documentURL, request,
-            std::nullopt, ResourceType::Other, timestamp, walltime),
-        page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::ProxyingNetworkAgent::RequestWillBeSent(qualifyResourceID(resourceID), *frameID, loaderId, targetId, documentURL, request, std::nullopt, ResourceType::Other, timestamp, walltime), page->identifier());
 }
 
 void FrameNetworkAgentProxy::didReceiveResponse(ResourceLoaderIdentifier resourceID, DocumentLoader* loader, const ResourceResponse& response, ResourceLoader*)


### PR DESCRIPTION
#### fef07bcf3dae12cae0afaacf6d98d0c4fc5da47b
<pre>
[Site Isolation] Web Inspector: inspector/worker/resources-in-(sub)worker.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=320691">https://bugs.webkit.org/show_bug.cgi?id=320691</a>
<a href="https://rdar.apple.com/183674115">rdar://183674115</a>

Reviewed by NOBODY (OOPS!).

FrameNetworkAgentProxy sent an empty targetId for worker-initiated
requests. The frontend treats an empty targetId as WI.mainTarget, so
the worker&apos;s resources (its main script, importScripts, and its XHR
and fetch loads) were attributed to the main frame rather than the
worker target, and the tests timed out waiting for the worker&apos;s
resource-added events.

The targetId of such a request is the request&apos;s initiator
identifier: a worker&apos;s loads carry initiatorIdentifier() set to the
worker&apos;s inspector identifier, which is the identifier the frontend
registers the worker target under. Forward it as the targetId, as
InspectorNetworkAgent::willSendRequest already does.

 - Document and subresource loads set no initiator identifier, so their
   targetId stays empty and their main-target attribution is unchanged.

The following two tests now progress under site isolation
(timeout with exceptions -&gt; pass):
- inspector/worker/resources-in-worker.html
- inspector/worker/resources-in-subworker.html

* Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp:
(WebKit::FrameNetworkAgentProxy::willSendRequest):
(WebKit::FrameNetworkAgentProxy::willSendRequestOfType):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fef07bcf3dae12cae0afaacf6d98d0c4fc5da47b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177880 "Failed to checkout and rebase branch from PR 70563") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51818 "Failed to checkout and rebase branch from PR 70563") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187490 "Failed to checkout and rebase branch from PR 70563") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53111 "Failed to checkout and rebase branch from PR 70563") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51527 "Failed to checkout and rebase branch from PR 70563") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/187490 "Failed to checkout and rebase branch from PR 70563") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180836 "Failed to checkout and rebase branch from PR 70563") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/53111 "Failed to checkout and rebase branch from PR 70563") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/45612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/187490 "Failed to checkout and rebase branch from PR 70563") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/53111 "Failed to checkout and rebase branch from PR 70563") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/51527 "Failed to checkout and rebase branch from PR 70563") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/187490 "Failed to checkout and rebase branch from PR 70563") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/45612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/53111 "Failed to checkout and rebase branch from PR 70563") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35951 "") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/44409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/51527 "Failed to checkout and rebase branch from PR 70563") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189919 "Failed to checkout and rebase branch from PR 70563") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/45612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/189919 "Failed to checkout and rebase branch from PR 70563") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52167 "") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/189919 "Failed to checkout and rebase branch from PR 70563") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/52167 "") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/50675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/45612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->