### PR TITLE
[GFC] Generalize distribute extra space to handle base sizes and growth limits

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -55,10 +55,41 @@ struct FlexTrack {
     }
 };
 
+enum class ExtraSpaceDistributionTarget : bool { BaseSizes, GrowthLimits };
+
 struct UnsizedTrack {
     LayoutUnit baseSize;
     LayoutUnit growthLimit;
     const TrackSizingFunctions trackSizingFunction;
+    // https://drafts.csswg.org/css-grid-1/#infinitely-growable
+    // FIXME: Add a RAII helper to set this flag when a track's growth limit is changed from infinite to finite
+    // while resolving intrinsic maximums.
+    bool infinitelyGrowable { false };
+
+    // https://drafts.csswg.org/css-grid-1/#extra-space
+    // This track's affected size: its base size when affecting base sizes, its growth limit when
+    // affecting growth limits. Per the spec: "For infinite growth limits, substitute the track's base
+    // size."
+    LayoutUnit affectedSize(ExtraSpaceDistributionTarget spaceDistributionTarget) const
+    {
+        if (spaceDistributionTarget == ExtraSpaceDistributionTarget::BaseSizes)
+            return baseSize;
+        // Growth limits: substitute the base size for an infinite growth limit.
+        return growthLimit == LayoutUnit::max() ? baseSize : growthLimit;
+    }
+
+    // https://drafts.csswg.org/css-grid-1/#extra-space
+    // The limit at which this track's item-incurred increase freezes. For base sizes, that's the
+    // growth limit. For growth limits, it's the growth limit if finite and not infinitely growable,
+    // otherwise infinity.
+    // FIXME: handle fit-content() argument if it has one.
+    LayoutUnit freezeLimit(ExtraSpaceDistributionTarget spaceDistributionTarget) const
+    {
+        if (spaceDistributionTarget == ExtraSpaceDistributionTarget::BaseSizes)
+            return growthLimit;
+        // Growth limits: an infinitely-growable track has no ceiling; otherwise its growth limit.
+        return infinitelyGrowable ? LayoutUnit::max() : growthLimit;
+    }
 };
 
 using GridItemIndexes = Vector<size_t>;
@@ -388,11 +419,11 @@ static void sizeTracksToFitNonSpanningItems(const ResolveIntrinsicTrackSizesCont
 
 // Used for space distribution.
 static Vector<size_t> indexesForUnfrozenAffectedTracks(const Vector<size_t>& spannedAffectedTracks,
-    const UnsizedTracks& unsizedTracks, const Vector<LayoutUnit>& itemIncurredIncreases)
+    const UnsizedTracks& unsizedTracks, const Vector<LayoutUnit>& itemIncurredIncreases, ExtraSpaceDistributionTarget target)
 {
     Vector<size_t> indexes;
     for (auto trackIndex : spannedAffectedTracks) {
-        if (unsizedTracks[trackIndex].baseSize + itemIncurredIncreases[trackIndex] < unsizedTracks[trackIndex].growthLimit)
+        if (unsizedTracks[trackIndex].affectedSize(target) + itemIncurredIncreases[trackIndex] < unsizedTracks[trackIndex].freezeLimit(target))
             indexes.append(trackIndex);
     }
     return indexes;
@@ -403,26 +434,27 @@ static Vector<size_t> indexesForUnfrozenAffectedTracks(const Vector<size_t>& spa
 // freezing a track’s item-incurred increase as its affected size + item-incurred increase
 // reaches its limit (and continuing to grow the unfrozen tracks as needed).
 static void distributeSpaceEquallyAmongTracks(LayoutUnit& space, const Vector<size_t>& trackIndexes,
-    const UnsizedTracks& unsizedTracks, Vector<LayoutUnit>& itemIncurredIncreases)
+    const UnsizedTracks& unsizedTracks, Vector<LayoutUnit>& itemIncurredIncreases, ExtraSpaceDistributionTarget target)
 {
-    auto unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(trackIndexes, unsizedTracks, itemIncurredIncreases);
+    auto unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(trackIndexes, unsizedTracks, itemIncurredIncreases, target);
     while (!unfrozenTrackIndexes.isEmpty() && space > 0) {
         auto tracksRemainingForDistributionCount = unfrozenTrackIndexes.size();
         for (auto trackIndex : unfrozenTrackIndexes) {
             auto& track = unsizedTracks[trackIndex];
-            auto spaceRemainingUntilGrowthLimit = track.growthLimit - (track.baseSize + itemIncurredIncreases[trackIndex]);
-            auto spaceDistributed = std::min(space / tracksRemainingForDistributionCount, spaceRemainingUntilGrowthLimit);
+            auto spaceRemainingUntilLimit = track.freezeLimit(target) - (track.affectedSize(target) + itemIncurredIncreases[trackIndex]);
+            auto spaceDistributed = std::min(space / tracksRemainingForDistributionCount, spaceRemainingUntilLimit);
             itemIncurredIncreases[trackIndex] += spaceDistributed;
             space -= spaceDistributed;
             --tracksRemainingForDistributionCount;
         }
-        unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(trackIndexes, unsizedTracks, itemIncurredIncreases);
+        unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(trackIndexes, unsizedTracks, itemIncurredIncreases, target);
     }
 }
 
 // https://drafts.csswg.org/css-grid-1/#extra-space
-static void distributeExtraSpaceToBaseSizes(UnsizedTracks& unsizedTracks, const GridItemIndexes& accommodatedItemsIndexes,
-    const PlacedGridItemSpanList& gridItemSpanList, const Vector<LayoutUnit>& sizeContributions, const TrackIndexes& affectedTracksIndexes)
+static void distributeExtraSpace(ExtraSpaceDistributionTarget spaceDistributionTarget, const TrackIndexes& affectedTracksIndexes,
+    const Vector<LayoutUnit>& sizeContributions, const GridItemIndexes& accommodatedItemsIndexes,
+    const PlacedGridItemSpanList& gridItemSpanList, UnsizedTracks& unsizedTracks)
 {
     ASSERT(accommodatedItemsIndexes.size() == sizeContributions.size());
 
@@ -446,18 +478,18 @@ static void distributeExtraSpaceToBaseSizes(UnsizedTracks& unsizedTracks, const 
                 spannedAffectedTracks.append(trackIndex);
         }
 
-        // 2.1. Find the space to distribute: the item's size contribution minus the base sizes of
+        // 2.1. Find the space to distribute: the item's size contribution minus the affected size of
         // every track it spans, floored at zero.
-        LayoutUnit spannedBaseSizes;
+        LayoutUnit spannedSizes;
         for (size_t trackIndex = itemSpan.begin(); trackIndex < itemSpan.end(); ++trackIndex)
-            spannedBaseSizes += unsizedTracks[trackIndex].baseSize;
-        auto spaceToDistribute = std::max(0_lu, sizeContributions[contributionIndex] - spannedBaseSizes);
+            spannedSizes += unsizedTracks[trackIndex].affectedSize(spaceDistributionTarget);
+        auto spaceToDistribute = std::max(0_lu, sizeContributions[contributionIndex] - spannedSizes);
         if (!spaceToDistribute)
             continue;
 
         // 2.2. Distribute space up to limits:
         Vector<LayoutUnit> itemIncurredIncreases(unsizedTracks.size());
-        distributeSpaceEquallyAmongTracks(spaceToDistribute, spannedAffectedTracks, unsizedTracks, itemIncurredIncreases);
+        distributeSpaceEquallyAmongTracks(spaceToDistribute, spannedAffectedTracks, unsizedTracks, itemIncurredIncreases, spaceDistributionTarget);
 
         // 2.3. Distribute space to non-affected tracks: if extra space remains and the item spans
         // both affected and non-affected tracks, distribute it into the non-affected tracks.
@@ -479,9 +511,21 @@ static void distributeExtraSpaceToBaseSizes(UnsizedTracks& unsizedTracks, const 
             plannedIncreases[trackIndex] = std::max(plannedIncreases[trackIndex], itemIncurredIncreases[trackIndex]);
     }
 
-    // 3. Update the affected tracks' base sizes by adding in the planned increase.
-    for (auto trackIndex : affectedTracksIndexes)
-        unsizedTracks[trackIndex].baseSize += plannedIncreases[trackIndex];
+    // 3. "Update the tracks' affected sizes by adding in the planned increase [...] (If the affected
+    // size is an infinite growth limit, set it to the track's base size plus the planned increase.)"
+    if (spaceDistributionTarget == ExtraSpaceDistributionTarget::BaseSizes) {
+        for (auto trackIndex : affectedTracksIndexes)
+            unsizedTracks[trackIndex].baseSize += plannedIncreases[trackIndex];
+    } else {
+        for (auto trackIndex : affectedTracksIndexes) {
+            auto& track = unsizedTracks[trackIndex];
+            auto plannedIncrease = plannedIncreases[trackIndex];
+            if (track.growthLimit != LayoutUnit::max())
+                track.growthLimit += plannedIncrease;
+            else
+                track.growthLimit = track.baseSize + plannedIncrease;
+        }
+    }
 }
 
 template<typename MinTrackSizingFunctionPredicate>
@@ -531,7 +575,7 @@ static void increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks(const 
     auto minimumSizeContributions = isSizedUnderMinOrMaxContentConstraint(resolveIntrinsicTrackSizesContext.axisConstraint)
         ? limitedContentContributions(minContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions), fixedMaxTrackSizingFunctionSums, minimumContributionsList)
         : minimumContributionsList;
-    distributeExtraSpaceToBaseSizes(unsizedTracks, spanningItems, gridItemSpanList, minimumSizeContributions, flexibleTracksWithIntrinsicMinimums);
+    distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, flexibleTracksWithIntrinsicMinimums, minimumSizeContributions, spanningItems, gridItemSpanList, unsizedTracks);
 
     // For content-based minimums: continue to distribute extra space to the base sizes of tracks with
     // a min track sizing function of min-content or max-content, to accommodate the items' min-content
@@ -540,7 +584,7 @@ static void increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks(const 
     auto flexibleTracksWithContentBasedMinimums = flexibleTracksMatching(unsizedTracks, [](const auto& trackSize) {
         return trackSize.isLength() && (trackSize.length().isMinContent() || trackSize.length().isMaxContent());
     });
-    distributeExtraSpaceToBaseSizes(unsizedTracks, spanningItems, gridItemSpanList, minContentSizeContributions, flexibleTracksWithContentBasedMinimums);
+    distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, flexibleTracksWithContentBasedMinimums, minContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks);
 
     // For max-content minimums: if the grid container is being sized under a max-content constraint
     if (scenario == AxisConstraint::FreeSpaceScenario::MaxContent) {
@@ -550,7 +594,7 @@ static void increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks(const 
             return trackSize.isAuto() || (trackSize.isLength() && trackSize.length().isMaxContent());
         });
         auto limitedMaxContentSizeContributions = limitedContentContributions(maxContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions), fixedMaxTrackSizingFunctionSums, minimumContributionsList);
-        distributeExtraSpaceToBaseSizes(unsizedTracks, spanningItems, gridItemSpanList, limitedMaxContentSizeContributions, flexibleTracksWithAutoOrMaxContentMinimums);
+        distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, flexibleTracksWithAutoOrMaxContentMinimums, limitedMaxContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks);
     }
     // ...In all cases, distribute to tracks with a max-content min track sizing function
     // to accommodate the items' max-content contributions.
@@ -558,7 +602,7 @@ static void increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks(const 
         return trackSize.isLength() && trackSize.length().isMaxContent();
     });
     auto maxContentSizeContributions = maxContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions);
-    distributeExtraSpaceToBaseSizes(unsizedTracks, spanningItems, gridItemSpanList, maxContentSizeContributions, flexibleTracksWithMaxContentMinimums);
+    distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, flexibleTracksWithMaxContentMinimums, maxContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks);
 
     // 4. If at this point any track's growth limit is now less than its base size, increase its
     //    growth limit to match its base size.


### PR DESCRIPTION
#### 3fa15f4bde1da85913741e44234fd96b3204654d
<pre>
[GFC] Generalize distribute extra space to handle base sizes and growth limits
<a href="https://bugs.webkit.org/show_bug.cgi?id=320696">https://bugs.webkit.org/show_bug.cgi?id=320696</a>
&lt;<a href="https://rdar.apple.com/183677981">rdar://183677981</a>&gt;

Reviewed by Sammy Gill.

Generalizes the intrinsic track-sizing space distribution to grow either
base sizes or growth limits based on ExtraSpaceDistributionTarget.

Updates UnsizedTrack to wrap the accessor logic for afectedSize()
freezeLimit() and adds the infinitelyGrowable flag. Note that we currently
only grow base sizes and do not yet handle growth limit changes.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::UnsizedTrack::affectedSize const):
(WebCore::Layout::UnsizedTrack::freezeLimit const):
(WebCore::Layout::indexesForUnfrozenAffectedTracks):
(WebCore::Layout::distributeSpaceEquallyAmongTracks):
(WebCore::Layout::distributeExtraSpaceForTarget):
(WebCore::Layout::increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks):
(WebCore::Layout::distributeExtraSpaceToBaseSizes): Deleted.
(WebCore::Layout::distributeExtraSpace):

Canonical link: <a href="https://commits.webkit.org/318351@main">https://commits.webkit.org/318351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd5f3ece61f62cc87513e1d7e95386f2150866de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187670 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0f296a4-7743-42d7-9fd2-0bee9d261173) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51704 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ab909c6-1fb8-45a5-af5e-338041c1d1fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42340 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119251 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8f6f02f5-5fcf-4fdb-aca5-4e0543c42f4e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41006 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39044 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36128 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44594 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190097 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51663 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39726 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52345 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147713 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42421 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124608 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119078 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50863 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14016 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50248 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50488 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50310 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->