### PR TITLE
parks.ca.gov: Text highlight is misleading when image above is a float

### DIFF
--- a/LayoutTests/editing/selection/selection-does-not-extend-over-preceding-float-expected.txt
+++ b/LayoutTests/editing/selection/selection-does-not-extend-over-preceding-float-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that selecting text on the first line of a block whose first line is pushed below an intrusive float does not extend the selection up over that float. To run the test manually, select the word below the gray box and make sure the gray box does not get highlighted.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Selection did not start above the float's bottom edge.
+PASS Selection height did not extend over the float.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Selected

--- a/LayoutTests/editing/selection/selection-does-not-extend-over-preceding-float.html
+++ b/LayoutTests/editing/selection/selection-does-not-extend-over-preceding-float.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<style>
+#container {
+    width: 200px;
+    font: 16px/18px Ahem;
+}
+
+#float {
+    float: left;
+    width: 199px;
+    height: 100px;
+    background: silver;
+}
+
+#target {
+    margin: 0;
+    outline: none;
+}
+</style>
+</head>
+<body>
+<div id="container">
+    <p style="margin: 0"><span id="float"></span></p>
+    <p id="target">Selected</p>
+</div>
+<script>
+description("This test verifies that selecting text on the first line of a block whose first line is pushed below an intrusive float does not extend the selection up over that float. To run the test manually, select the word below the gray box and make sure the gray box does not get highlighted.");
+
+if (window.testRunner) {
+    const target = document.getElementById("target");
+    const floatBox = document.getElementById("float");
+
+    getSelection().selectAllChildren(target);
+
+    const selectionRect = internals.selectionBounds();
+    const floatBottom = floatBox.getBoundingClientRect().bottom + scrollY;
+
+    if (selectionRect.top >= floatBottom - 1)
+        testPassed(`Selection did not start above the float's bottom edge.`);
+    else
+        testFailed(`Selection started ${floatBottom - selectionRect.top}px above the float's bottom edge (selection top: ${selectionRect.top}, float bottom: ${floatBottom}).`);
+
+    if (selectionRect.height < 50)
+        testPassed(`Selection height did not extend over the float.`);
+    else
+        testFailed(`Selection height was too tall (observed: ${selectionRect.height}).`);
+
+    getSelection().removeAllRanges();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -61,12 +61,17 @@ public:
     {
         if (formattingContextRoot().writingMode().isLineInverted() || !m_lineIndex)
             return contentLogicalTop();
-        auto precedingLineBox = LineBoxIteratorModernPath { *m_inlineContent, m_lineIndex - 1 };
-        // A line with a block level box on it does not share the space below it with this line. That space is the box's
-        // margin, and the box covers it itself.
-        if (precedingLineBox.hasBlockLevelBox())
-            return contentLogicalTop();
-        return precedingLineBox.contentLogicalBottom();
+        for (auto precedingLineIndex = m_lineIndex; precedingLineIndex--;) {
+            auto precedingLineBox = LineBoxIteratorModernPath { *m_inlineContent, precedingLineIndex };
+            if (!precedingLineBox.line().hasContentfulInFlowBox())
+                continue;
+            if (precedingLineBox.hasBlockLevelBox())
+                break;
+            if (precedingLineBox.logicalBottom() < logicalTop())
+                break;
+            return precedingLineBox.contentLogicalBottom();
+        }
+        return contentLogicalTop();
     }
     float contentLogicalBottomAdjustedForFollowingLineBox() const
     {


### PR DESCRIPTION
#### d34f39ba6c661d3cdd54f1a9b56f9f681c2669cd
<pre>
parks.ca.gov: Text highlight is misleading when image above is a float
<a href="https://bugs.webkit.org/show_bug.cgi?id=320703">https://bugs.webkit.org/show_bug.cgi?id=320703</a>
<a href="https://rdar.apple.com/109610452">rdar://109610452</a>

Reviewed by Megan Gardner.

Selecting text on a line pushed below an intrusive float highlighted the float as well, so on
parks.ca.gov selecting text under a wide float:left image filled the whole image with selection
colour rather than just the text.

A line&apos;s selection top is inherited from the preceding line box to cover the half-leading gap
between lines. That inheritance was unconditional, so a line pushed below a float inherited from a
line box that does not reach it and started its selection at the block&apos;s content top instead. Only
inherit when the preceding line box is adjacent, otherwise start at this line&apos;s own content top.

* LayoutTests/editing/selection/selection-does-not-extend-over-preceding-float-expected.txt: Added.
* LayoutTests/editing/selection/selection-does-not-extend-over-preceding-float.html: Added.
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h:
(WebCore::InlineIterator::LineBoxIteratorModernPath::contentLogicalTopAdjustedForPrecedingLineBox const):

Canonical link: <a href="https://commits.webkit.org/319128@main">https://commits.webkit.org/319128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44f5b920c796ff326bf51a08029e512b97f641f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190526 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144636 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140640 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42971 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41273 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153374 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40947 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1685 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192461 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149992 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40207 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54614 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149715 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44352 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126877 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122039 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53131 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15936 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52513 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52750 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->