### PR TITLE
Hook up WebTransportDatagramDuplexStream.outgoingMaxAge to the datagram sending nw_content_context_t

### DIFF
--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -160,11 +160,6 @@ void NetworkTransportSession::datagramIncomingMaxAgeUpdated(std::optional<double
     // FIXME: Use this value.
 }
 
-void NetworkTransportSession::datagramOutgoingMaxAgeUpdated(std::optional<double>)
-{
-    // FIXME: Use this value.
-}
-
 void NetworkTransportSession::incomingMaxBufferedDatagramsUpdated(uint32_t)
 {
     // FIXME: Use this value.
@@ -264,6 +259,10 @@ bool NetworkTransportSession::isSessionClosed() const
 void NetworkTransportSession::exportKeyingMaterial(std::span<const uint8_t>, std::span<const uint8_t>, uint32_t, CompletionHandler<void(std::optional<Vector<uint8_t>>)>&& completionHandler)
 {
     completionHandler(std::nullopt);
+}
+
+void NetworkTransportSession::datagramOutgoingMaxAgeUpdated(std::optional<double>)
+{
 }
 #endif
 

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -91,7 +91,7 @@ public:
     void streamSendBytes(WebCore::WebTransportStreamIdentifier, std::span<const uint8_t>, bool withFin, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
     void terminate(WebCore::WebTransportSessionErrorCode, CString&&);
     void NODELETE datagramIncomingMaxAgeUpdated(std::optional<double>);
-    void NODELETE datagramOutgoingMaxAgeUpdated(std::optional<double>);
+    void datagramOutgoingMaxAgeUpdated(std::optional<double>);
     void NODELETE incomingMaxBufferedDatagramsUpdated(uint32_t);
     void NODELETE outgoingMaxBufferedDatagramsUpdated(uint32_t);
 
@@ -141,6 +141,7 @@ private:
     const WebCore::WebTransportOptions m_options;
     HashMap<WebCore::WebTransportSendGroupIdentifier, uint64_t> m_datagramBytesSent;
     uint64_t m_datagramBytesReceived { 0 };
+    std::optional<double> m_datagramOutgoingMaxAge;
 
     struct StreamRequestBeforeInitialization {
         NetworkTransportStreamType streamType;
@@ -163,6 +164,7 @@ private:
     const RefPtr<SecurityProtocolMetadata> m_securityProtocolMetadata;
     RetainPtr<nw_connection_t> m_datagramConnection;
     RetainPtr<nw_protocol_metadata_t> m_sessionMetadata;
+    RetainPtr<nw_content_context_t> m_datagramContext;
 #endif
 };
 

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -437,9 +437,16 @@ void NetworkTransportSession::sendDatagram(std::optional<WebCore::WebTransportSe
         }).iterator->value += data.size();
     }
     ASSERT(m_datagramConnection);
-    nw_connection_send(m_datagramConnection.get(), makeDispatchData(Vector(data)).get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([completionHandler = WTF::move(completionHandler)] (nw_error_t error) mutable {
+
+    if (!m_datagramContext && m_datagramOutgoingMaxAge) {
+        m_datagramContext = adoptNS(nw_content_context_create("WebTransportDatagramSend"));
+        nw_content_context_set_expiration_milliseconds(m_datagramContext.get(), *m_datagramOutgoingMaxAge);
+    }
+
+    nw_connection_send(m_datagramConnection.get(), makeDispatchData(Vector(data)).get(), m_datagramContext ? m_datagramContext.get() : NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([completionHandler = WTF::move(completionHandler)] (nw_error_t error) mutable {
         if (error) {
-            if (nw_error_get_error_domain(error) == nw_error_domain_posix && nw_error_get_error_code(error) == ECANCELED)
+            auto posixErrorCode = nw_error_get_error_domain(error) == nw_error_domain_posix ? nw_error_get_error_code(error) : 0;
+            if (posixErrorCode == ECANCELED || posixErrorCode == ETIME || posixErrorCode == ETIMEDOUT)
                 completionHandler(std::nullopt);
             else
                 completionHandler(WebCore::Exception(WebCore::ExceptionCode::NetworkError));
@@ -604,6 +611,12 @@ void NetworkTransportSession::exportKeyingMaterial(std::span<const uint8_t> labe
         return request;
     };
     completionHandler(vectorFromData(data.get()));
+}
+
+void NetworkTransportSession::datagramOutgoingMaxAgeUpdated(std::optional<double> maxAge)
+{
+    m_datagramOutgoingMaxAge = maxAge;
+    m_datagramContext = nullptr;
 }
 
 }


### PR DESCRIPTION
#### 86c3114f75ede42b0e5e0163a0b1bf9a678a5749
<pre>
Hook up WebTransportDatagramDuplexStream.outgoingMaxAge to the datagram sending nw_content_context_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=320704">https://bugs.webkit.org/show_bug.cgi?id=320704</a>
<a href="https://rdar.apple.com/183686584">rdar://183686584</a>

Reviewed by NOBODY (OOPS!).

Datagrams are also lost, so there isn&apos;t a way to test this deterministically.

* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::datagramOutgoingMaxAgeUpdated):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::sendDatagram):
(WebKit::NetworkTransportSession::datagramOutgoingMaxAgeUpdated):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86c3114f75ede42b0e5e0163a0b1bf9a678a5749

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141219 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e407b75-5f68-400c-b041-54ea9176ddf4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138726 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96383 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2324ab8d-cb75-4e60-8a8c-7ebda7c1506a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119189 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1ffea3e8-55cb-49fb-97af-f6e65eea9489) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40933 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39291 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38976 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36043 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190011 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51577 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147860 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52259 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147641 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42353 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124512 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118983 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50767 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13954 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50163 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50403 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50225 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->