### PR TITLE
Implement at-rule function for use with @supports

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/supports-at-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/supports-at-rule-expected.txt
@@ -1,26 +1,26 @@
 
-FAIL @supports at-rule assert_equals: CSS.supports(at-rule(@supports)) expected true but got false
-FAIL @supports at-rule 1 assert_equals: CSS.supports(at-rule( @supports)) expected true but got false
-FAIL @supports at-rule 2 assert_equals: CSS.supports(at-rule(@supports )) expected true but got false
-FAIL @supports at-rule 3 assert_equals: CSS.supports(at-rule(@media)) expected true but got false
-FAIL @supports at-rule 4 assert_equals: CSS.supports(at-rule(@counter-style)) expected true but got false
+PASS @supports at-rule
+PASS @supports at-rule 1
+PASS @supports at-rule 2
+PASS @supports at-rule 3
+PASS @supports at-rule 4
 PASS @supports at-rule 5
-FAIL @supports at-rule 6 assert_equals: CSS.supports(at-rule(@import)) expected true but got false
-FAIL @supports at-rule 7 assert_equals: CSS.supports(at-rule(@swash)) expected true but got false
-FAIL @supports at-rule 8 assert_equals: CSS.supports(at-rule(@starting-style)) expected true but got false
+PASS @supports at-rule 6
+PASS @supports at-rule 7
+PASS @supports at-rule 8
 PASS @supports at-rule 9
 PASS @supports at-rule 10
-FAIL @supports at-rule 11 assert_equals: CSS.supports(at-rule(@supports) and (color: red)) expected true but got false
-FAIL @supports at-rule 12 assert_equals: CSS.supports(at-rule(@media) and (display: flex)) expected true but got false
+PASS @supports at-rule 11
+PASS @supports at-rule 12
 PASS @supports at-rule 13
 PASS @supports at-rule 14
 PASS @supports at-rule 15
 PASS @supports at-rule 16
-FAIL @supports at-rule 17 assert_equals: CSS.supports(at-rule(@supports) or (doesnotexist: red)) expected true but got false
+PASS @supports at-rule 17
 PASS @supports at-rule 18
-FAIL @supports at-rule 19 assert_equals: CSS.supports(not at-rule(@supports)) expected false but got true
+PASS @supports at-rule 19
 PASS @supports at-rule 20
-FAIL @supports at-rule 21 assert_equals: CSS.supports((color: red) and at-rule(@supports)) expected true but got false
+PASS @supports at-rule 21
 PASS @supports at-rule 22
 PASS @supports at-rule 23
 PASS @supports at-rule 24

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1797,9 +1797,11 @@ words
 // https://drafts.csswg.org/css-conditional-4/#typedef-supports-selector-fn
 // https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-format-fn
 // https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-tech-fn
+// https://drafts.csswg.org/css-conditional-5/#typedef-supports-at-rule-fn
 selector
 font-format
 font-tech
+at-rule
 
 // math-depth
 auto-add

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -30,8 +30,10 @@
 #include "config.h"
 #include "CSSSupportsParser.h"
 
+#include "CSSAtRuleID.h"
 #include "CSSParser.h"
 #include "CSSPropertyParserConsumer+Font.h"
+#include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParserState.h"
 #include "CSSSelectorParser.h"
 #include "CSSTokenizer.h"
@@ -148,6 +150,8 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFunction(CSS
         return consumeSupportsFontFormatFunction(range);
     case CSSValueFontTech:
         return consumeSupportsFontTechFunction(range);
+    case CSSValueAtRule:
+        return consumeSupportsAtRuleFunction(range);
     default: // Unknown functions should parse as unsupported.
         range.consumeComponentValue();
         return Unsupported;
@@ -199,6 +203,24 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFontTechFunc
         return Unsupported;
     ASSERT(technologies.size() == 1);
     return FontCustomPlatformData::supportsTechnology(technologies[0]) ? Supported : Unsupported;
+}
+
+// <supports-at-rule-fn> = at-rule( <at-keyword-token> )
+CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsAtRuleFunction(CSSParserTokenRange& range)
+{
+    ASSERT(range.peek().type() == FunctionToken && range.peek().functionId() == CSSValueAtRule);
+
+    auto function = CSSPropertyParserHelpers::consumeFunction(range);
+    auto atKeywordToken = function.consumeIncludingWhitespace();
+    if (atKeywordToken.type() != AtKeywordToken)
+        return Invalid;
+    if (!function.atEnd())
+        return Invalid;
+
+    auto atRuleID = cssAtRuleID(atKeywordToken.value());
+
+    // Per spec, @charset is not an at-rule.
+    return ((atRuleID != CSSAtRuleInvalid) && (atRuleID != CSSAtRuleCharset)) ? Supported : Unsupported;
 }
 
 // <supports-in-parens> = ( <supports-condition> ) | <supports-feature> | <general-enclosed>

--- a/Source/WebCore/css/parser/CSSSupportsParser.h
+++ b/Source/WebCore/css/parser/CSSSupportsParser.h
@@ -72,6 +72,9 @@ private:
     // https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-tech-fn
     SupportsResult consumeSupportsFontTechFunction(CSSParserTokenRange&);
 
+    // https://drafts.csswg.org/css-conditional-5/#typedef-supports-at-rule-fn
+    SupportsResult consumeSupportsAtRuleFunction(CSSParserTokenRange&);
+
     SupportsResult consumeConditionInParenthesis(CSSParserTokenRange&, CSSParserTokenType);
 
     CSSParser& m_parser;


### PR DESCRIPTION
#### 2554611264c43093962c273f23a634ae437a0bde
<pre>
Implement at-rule function for use with @supports
<a href="https://rdar.apple.com/87884897">rdar://87884897</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=235400">https://bugs.webkit.org/show_bug.cgi?id=235400</a>

Reviewed by Tim Nguyen.

Implement @supports at-rule(&lt;at-rule&gt;), which evaluates to Supported if
the CSS at-rule is supported.

Test: imported/w3c/web-platform-tests/css/css-conditional/js/supports-at-rule.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/supports-at-rule-expected.txt:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSSupportsParser.cpp:
(WebCore::CSSSupportsParser::consumeSupportsFunction):
(WebCore::CSSSupportsParser::consumeSupportsAtRuleFunction):
(WebCore::CSSSupportsParser::consumeSupportsFontTechFunction):
* Source/WebCore/css/parser/CSSSupportsParser.h:

Canonical link: <a href="https://commits.webkit.org/318482@main">https://commits.webkit.org/318482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e0a69169eb4d2c17125a905148a94c38d5e9ef5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141266 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7b97d75-2475-4fe5-bf16-569a18b90539) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179882 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138771 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e9569c8f-6b1b-436c-b0ce-e66571a52322) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119227 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40978 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39328 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151378 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39019 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Skipped layout-tests; 344 new passes 5 flakes") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36090 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190059 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51625 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147905 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39808 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52307 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35643 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147684 "Found 1 new API test failure: TestWebKit.WebKit.MouseMoveAfterCrash (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42392 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124570 "Build is in progress. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Found 27163 issues") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119040 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50815 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13991 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50210 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50450 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50272 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->