### PR TITLE
[css-conditional-5] Support @supports named-feature()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-named-feature-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-named-feature-001-expected.txt
@@ -1,7 +1,10 @@
 
 PASS can detect whether anchor position follows transforms
-FAIL @supports named-feature(anchor-position-follows-transforms) should be false assert_equals: expected "1" but got "auto"
-FAIL @supports named-feature( anchor-position-follows-transforms ) should be false assert_equals: expected "2" but got "auto"
+FAIL @supports named-feature(anchor-position-follows-transforms) should be true assert_equals: expected "1" but got "auto"
+FAIL @supports named-feature( anchor-position-follows-transforms ) should be true assert_equals: expected "2" but got "auto"
+PASS @supports named-feature(  foo   anchor-position-follows-transforms  ) should be false
+PASS @supports named-feature(  anchor-position-follows-transforms  bar) should be false
+PASS @supports named-feature(anchor-position-follows-transforms single-axis-scroll-container) should be false
 PASS @supports named-feature(unknown-feature) should be false
 PASS @supports named-feature(named-feature) should be false
 PASS @supports named-feature(color) should be false

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-named-feature-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-named-feature-001.html
@@ -30,7 +30,7 @@ function test_supports_condition(condition, expected) {
     `;
     assert_equals(getComputedStyle(document.getElementById("target")).zIndex,
                   expected ? "" + gGlobalCounter : "auto");
-  }, `@supports ${condition} should be ${Boolean.prototype.toString(expected)}`);
+  }, `@supports ${condition} should be ${expected}`);
 }
 
 let is_anchor_position_follows_transforms_supported;
@@ -78,6 +78,13 @@ test(() => {
 
 test_supports_condition("named-feature(anchor-position-follows-transforms)", is_anchor_position_follows_transforms_supported);
 test_supports_condition("named-feature( anchor-position-follows-transforms )", is_anchor_position_follows_transforms_supported);
+
+test_supports_condition("named-feature(  foo   anchor-position-follows-transforms  )", false);
+test_supports_condition("named-feature(  anchor-position-follows-transforms  bar)", false);
+
+// A browser might support all two, but named-feature can only test one at a time.
+test_supports_condition("named-feature(anchor-position-follows-transforms single-axis-scroll-container)", false);
+
 test_supports_condition("named-feature(unknown-feature)", false);
 test_supports_condition("named-feature(named-feature)", false);
 test_supports_condition("named-feature(color)", false);

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1805,6 +1805,14 @@ font-format
 font-tech
 at-rule
 
+// @supports named-feature
+// https://drafts.csswg.org/css-conditional-5/#funcdef-supports-named-feature
+named-feature
+// List of named features
+// https://drafts.csswg.org/css-conditional-5/#dfn-support-named-feature
+anchor-position-follows-transforms
+single-axis-scroll-container
+
 // math-depth
 auto-add
 // add

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -33,6 +33,7 @@
 #include "CSSAtRuleID.h"
 #include "CSSParser.h"
 #include "CSSPropertyParserConsumer+Font.h"
+#include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParserState.h"
 #include "CSSSelectorParser.h"
@@ -152,6 +153,8 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFunction(CSS
         return consumeSupportsFontTechFunction(range);
     case CSSValueAtRule:
         return consumeSupportsAtRuleFunction(range);
+    case CSSValueNamedFeature:
+        return consumeSupportsNamedFeatureFunction(range);
     default: // Unknown functions should parse as unsupported.
         range.consumeComponentValue();
         return Unsupported;
@@ -221,6 +224,34 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsAtRuleFuncti
 
     // Per spec, @charset is not an at-rule.
     return ((atRuleID != CSSAtRuleInvalid) && (atRuleID != CSSAtRuleCharset)) ? Supported : Unsupported;
+}
+
+// <supports-named-feature-fn> = named-feature( <ident> )
+CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsNamedFeatureFunction(CSSParserTokenRange& range)
+{
+    ASSERT(range.peek().type() == FunctionToken && range.peek().functionId() == CSSValueNamedFeature);
+
+    auto functionArgs = CSSPropertyParserHelpers::consumeFunction(range);
+    auto namedFeature = CSSPropertyParserHelpers::consumeIdentRaw(functionArgs);
+
+    if (!namedFeature)
+        return Invalid;
+    if (!functionArgs.atEnd())
+        return Invalid;
+
+    switch (*namedFeature) {
+    // FIXME (webkit.org/b/321970): remaining issue before transformed anchor is fully supported.
+    case CSSValueAnchorPositionFollowsTransforms:
+        return Unsupported;
+
+    // FIXME: not implemented yet
+    // https://github.com/WebKit/standards-positions/issues/680
+    case CSSValueSingleAxisScrollContainer:
+        return Unsupported;
+
+    default:
+        return Unsupported;
+    }
 }
 
 // <supports-in-parens> = ( <supports-condition> ) | <supports-feature> | <general-enclosed>

--- a/Source/WebCore/css/parser/CSSSupportsParser.h
+++ b/Source/WebCore/css/parser/CSSSupportsParser.h
@@ -75,6 +75,9 @@ private:
     // https://drafts.csswg.org/css-conditional-5/#typedef-supports-at-rule-fn
     SupportsResult consumeSupportsAtRuleFunction(CSSParserTokenRange&);
 
+    // https://drafts.csswg.org/css-conditional-5/#typedef-supports-named-feature-fn
+    SupportsResult consumeSupportsNamedFeatureFunction(CSSParserTokenRange&);
+
     SupportsResult consumeConditionInParenthesis(CSSParserTokenRange&, CSSParserTokenType);
 
     CSSParser& m_parser;


### PR DESCRIPTION
#### e7caeaf2119343d7c74b4673ff736c80298d9ae8
<pre>
[css-conditional-5] Support @supports named-feature()
<a href="https://rdar.apple.com/183688843">rdar://183688843</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320705">https://bugs.webkit.org/show_bug.cgi?id=320705</a>

Reviewed by Tim Nguyen.

This patch implements parsing support for @supports named-feature().
The supported name features are hardcoded; it&apos;s expected that features
will be added rather sparingly (at most one or two yearly), and only
when it&apos;s implemented in WebKit.

Test: imported/w3c/web-platform-tests/css/css-conditional/at-supports-named-feature-001.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-named-feature-001-expected.txt:
    - Test progression.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-named-feature-001.html:
    - Add some invalid test cases.
    - Fix a bug where the test uses `Boolean.prototype.toString` to
      serialize a string, but that method returns &quot;false&quot; for every
      input, including `true`.

* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSSupportsParser.cpp:
(WebCore::CSSSupportsParser::consumeSupportsFunction):
(WebCore::CSSSupportsParser::consumeSupportsNamedFeatureFunction):
* Source/WebCore/css/parser/CSSSupportsParser.h:

Canonical link: <a href="https://commits.webkit.org/319412@main">https://commits.webkit.org/319412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cdd3e0dc9024f3463ed14f6627db21f8b75b904

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145510 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43e72a21-315f-4a36-ac29-714fc93bfb55) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141403 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98075 "5 flakes 11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b7a580e2-7695-420f-82b8-1d607f0851b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162145 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121854 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4a774f3-47db-4c29-9289-91eeaeb69d63) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43736 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42012 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41672 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2563 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193336 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161660 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150783 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40437 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55486 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150499 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45089 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127754 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123312 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54003 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16668 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53385 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53622 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53450 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->