### PR TITLE
Null-deref crash in RenderElement::resolvePseudoElementStyle() when a <details> element has `display: contents` and its ::details-content establishes a scrollable area

### DIFF
--- a/LayoutTests/fast/html/details-display-contents-scrollable-content-crash-expected.txt
+++ b/LayoutTests/fast/html/details-display-contents-scrollable-content-crash-expected.txt
@@ -1,0 +1,7 @@
+Tests that a <details> element with `display: contents` whose `::details-content` establishes a scrollable area does not crash. Test passes if WebKit does not crash. PASS.
+toggle
+content
+toggle
+content
+toggle
+content

--- a/LayoutTests/fast/html/details-display-contents-scrollable-content-crash.html
+++ b/LayoutTests/fast/html/details-display-contents-scrollable-content-crash.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+/* The scroll corner style is resolved against the shadow host, which has no
+   renderer because of `display: contents`. */
+#scroll-corner { display: contents; }
+#scroll-corner::details-content { height: 0; overflow: hidden; }
+
+/* Same for the resizer style, which is resolved along a separate code path. */
+#resizer { display: contents; }
+#resizer::details-content { height: 0; overflow: hidden; resize: both; }
+
+/* And for scrollbar creation, which looks up the same renderer. */
+#scrollbar { display: contents; }
+#scrollbar::details-content { height: 10px; overflow: scroll; }
+</style>
+</head>
+<body>
+<p>Tests that a &lt;details&gt; element with `display: contents` whose `::details-content` establishes a scrollable area does not crash. Test passes if WebKit does not crash. PASS.</p>
+<details id="scroll-corner" open><summary>toggle</summary><div>content</div></details>
+<details id="resizer" open><summary>toggle</summary><div>content</div></details>
+<details id="scrollbar" open><summary>toggle</summary><div style="height: 500px; width: 500px;">content</div></details>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+// Force a layout so the scrollable areas, and with them the scroll corner,
+// resizer and scrollbar styles, get resolved.
+document.body.offsetHeight;
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -882,8 +882,10 @@ static inline RenderElement* rendererForScrollbar(RenderLayerModelObject& render
 {
     if (auto* element = renderer.element()) {
         if (auto* shadowRoot = element->containingShadowRoot()) {
-            if (shadowRoot->mode() == ShadowRootMode::UserAgent)
-                return shadowRoot->host()->renderer();
+            if (shadowRoot->mode() == ShadowRootMode::UserAgent) {
+                if (auto* hostRenderer = shadowRoot->host()->renderer())
+                    return hostRenderer;
+            }
         }
     }
 


### PR DESCRIPTION
#### 9510cbdd84529cbaf291ed6b395ccd5d55731102
<pre>
Null-deref crash in RenderElement::resolvePseudoElementStyle() when a &lt;details&gt; element has `display: contents` and its ::details-content establishes a scrollable area
<a href="https://bugs.webkit.org/show_bug.cgi?id=320447">https://bugs.webkit.org/show_bug.cgi?id=320447</a>
<a href="https://rdar.apple.com/183445758">rdar://183445758</a>

Reviewed by Simon Fraser.

rendererForScrollbar() maps a renderer inside a user agent shadow root to its
shadow host&apos;s renderer, so that scrollbar pseudo element styles are resolved
against the host. It returned the host&apos;s renderer unconditionally, but a host
with `display: contents` has no renderer. Its user agent shadow content can
still establish a scrollable area, so all three callers dereferenced null.

A &lt;details&gt; is exactly that case: its ::details-content is a slot in the user
agent shadow root, so giving the &lt;details&gt; `display: contents` and the
::details-content non-visible overflow crashed the WebContent process while
resolving the scroll corner style during render tree construction. This is the
standard way to build an animated disclosure widget whose summary participates
in a parent grid, so it is reachable from ordinary content.

Null check the host&apos;s renderer and fall back to the renderer establishing the
scrollable area, which is the pre-existing behavior for content outside a user
agent shadow root. Only the null case changes behavior.

* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::rendererForScrollbar): The host is not guaranteed to have a renderer.
It has none when it is `display: contents`, even though its user agent shadow
content may still establish a scrollable area. Fall back to the renderer
establishing the scrollable area rather than returning null, since the callers
all dereference the result to resolve the scrollbar pseudo element styles
against it: updateScrollCornerStyle(), updateResizerStyle() and
createScrollbar().

* LayoutTests/fast/html/details-display-contents-scrollable-content-crash.html: Added.
* LayoutTests/fast/html/details-display-contents-scrollable-content-crash-expected.txt: Added.
Covers all three call sites: a scroll corner, a resizer (`resize: both`) and
scrollbar creation (`overflow: scroll` with overflowing content). Crashes
without the fix, passes with it.

Canonical link: <a href="https://commits.webkit.org/318661@main">https://commits.webkit.org/318661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/795539c390f151991b9f87984fd23efcbbe22844

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141150 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138668 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96683 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159416 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119131 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40869 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39224 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151274 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38910 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189942 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147797 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39919 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52190 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147578 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42287 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124662 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118875 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50698 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13890 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50094 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->