### PR TITLE
MathMLOperatorElement::parseOperatorChar() needlessly allocates a String when trimming whitespace

### DIFF
--- a/Source/WebCore/mathml/MathMLOperatorElement.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorElement.cpp
@@ -56,10 +56,10 @@ Ref<MathMLOperatorElement> MathMLOperatorElement::create(const QualifiedName& ta
     return adoptRef(*new MathMLOperatorElement(tagName, document));
 }
 
-MathMLOperatorElement::OperatorChar MathMLOperatorElement::parseOperatorChar(const String& string)
+MathMLOperatorElement::OperatorChar MathMLOperatorElement::parseOperatorChar(StringView string)
 {
     OperatorChar operatorChar;
-    String trimmed = string.trim(isASCIIWhitespaceWithoutFF<UChar>);
+    auto trimmed = string.trim(isASCIIWhitespaceWithoutFF<UChar>);
     if (trimmed.isEmpty())
         return operatorChar;
 
@@ -83,7 +83,7 @@ MathMLOperatorElement::OperatorChar MathMLOperatorElement::parseOperatorChar(con
 
     if (length == 2) {
         // A surrogate pair encoding a single code point (e.g. U+1EEF0, U+1EEF1).
-        if (auto codePoint = StringView(trimmed).convertToSingleCodePoint()) {
+        if (auto codePoint = trimmed.convertToSingleCodePoint()) {
             setOperatorChar(codePoint.value());
             return operatorChar;
         }

--- a/Source/WebCore/mathml/MathMLOperatorElement.h
+++ b/Source/WebCore/mathml/MathMLOperatorElement.h
@@ -30,6 +30,7 @@
 #include "MathMLOperatorDictionary.h"
 #include "MathMLTokenElement.h"
 #include <array>
+#include <wtf/text/StringView.h>
 
 namespace WebCore {
 
@@ -54,7 +55,7 @@ public:
             {
             }
     };
-    static OperatorChar parseOperatorChar(const String&);
+    static OperatorChar parseOperatorChar(StringView);
     const OperatorChar& operatorChar() LIFETIME_BOUND;
     void setOperatorFormDirty();
     MathMLOperatorDictionary::Form form() { return dictionaryProperty().form; }


### PR DESCRIPTION
#### 801e9b5ab020287e8be5a18cf5a332c551dce9c5
<pre>
MathMLOperatorElement::parseOperatorChar() needlessly allocates a String when trimming whitespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=320707">https://bugs.webkit.org/show_bug.cgi?id=320707</a>
<a href="https://rdar.apple.com/183692683">rdar://183692683</a>

Reviewed by Chris Dumez and Frédéric Wang Nélar.

String::trim() allocates a new StringImpl whenever there is actually something
to trim, so the common `&lt;mo&gt; + &lt;/mo&gt;` allocated on every parse. The function
only needs isEmpty(), length(), two indexed code units and
convertToSingleCodePoint(), so take a StringView and use StringView::trim(),
which returns a view over the existing buffer.

No change in behavior.

* Source/WebCore/mathml/MathMLOperatorElement.cpp:
(WebCore::MathMLOperatorElement::parseOperatorChar):
* Source/WebCore/mathml/MathMLOperatorElement.h:

Canonical link: <a href="https://commits.webkit.org/318301@main">https://commits.webkit.org/318301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10752b5ba121388c69bae93daf48fa67c31a8b8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187515 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29c4562a-c06e-4a29-9501-274c49a6ae82) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138670 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12983be6-af3e-499e-b974-169618be4156) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42205 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159413 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119133 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4af8713-6190-41bb-aed2-6548ff266b32) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/177228 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40868 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39223 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151273 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38907 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35976 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44434 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189944 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51510 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147799 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39697 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52192 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147580 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42288 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124444 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118878 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50700 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13887 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50096 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50336 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50158 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->