### PR TITLE
[AX] Add foundation for PDF accessibility modes

### DIFF
--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4890,6 +4890,7 @@
 		29CD55A8128E294F00133C85 /* WKAccessibilityWebPageObjectBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKAccessibilityWebPageObjectBase.h; sourceTree = "<group>"; };
 		29CD55A9128E294F00133C85 /* WKAccessibilityWebPageObjectBase.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKAccessibilityWebPageObjectBase.mm; sourceTree = "<group>"; };
 		29D04E2821F7C73D0076741D /* ApplicationServicesSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ApplicationServicesSPI.h; sourceTree = "<group>"; };
+		2A7DD481301BDCFA00386BB1 /* PDFAccessibilityDisplayMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PDFAccessibilityDisplayMode.h; sourceTree = "<group>"; };
 		2A96B7172EB4A74700E2B46F /* AdditionalButtonMasksIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AdditionalButtonMasksIOS.h; path = ios/AdditionalButtonMasksIOS.h; sourceTree = "<group>"; };
 		2B1B1C352E3A86F400D7D9ED /* UncheckedCallArgsCheckerExpectations */ = {isa = PBXFileReference; lastKnownFileType = text; path = UncheckedCallArgsCheckerExpectations; sourceTree = "<group>"; };
 		2B1B1C372E3A86F400D7D9ED /* UncountedCallArgsCheckerExpectations */ = {isa = PBXFileReference; lastKnownFileType = text; path = UncountedCallArgsCheckerExpectations; sourceTree = "<group>"; };
@@ -10020,6 +10021,7 @@
 			children = (
 				0F23ADDE2B7D240B00E6199B /* AsyncPDFRenderer.h */,
 				0F23ADDF2B7D240C00E6199B /* AsyncPDFRenderer.mm */,
+				2A7DD481301BDCFA00386BB1 /* PDFAccessibilityDisplayMode.h */,
 				33DAECEC2B99D052005C596E /* PDFDataDetectorItem.h */,
 				33DAECED2B99D05A005C596E /* PDFDataDetectorItem.mm */,
 				33DAECEE2B9AAE91005C596E /* PDFDataDetectorOverlayController.h */,

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(UNIFIED_PDF)
 
+#include "PDFAccessibilityDisplayMode.h"
 #include "PDFDocumentLayout.h"
 #include "PDFPageCoverage.h"
 #include <WebCore/FloatRect.h>
@@ -47,6 +48,7 @@
 #endif
 
 OBJC_CLASS PDFDocument;
+OBJC_CLASS PDFPage;
 
 namespace WebCore {
 class GraphicsLayer;
@@ -71,17 +73,23 @@ WTF::TextStream& operator<<(WTF::TextStream&, const TileForGrid&);
 struct PDFTileRenderType;
 using PDFTileRenderIdentifier = ObjectIdentifier<PDFTileRenderType>;
 
+void applyPDFContentAXColorAdjustment(CGContextRef, PDFPage *, PDFAccessibilityDisplayMode);
+WebCore::Color pdfPageBackgroundColor(PDFAccessibilityDisplayMode);
+WebCore::BlendMode pdfSelectionBlendMode(PDFAccessibilityDisplayMode);
+WebCore::ScrollbarOverlayStyle pdfScrollbarOverlayStyle(PDFAccessibilityDisplayMode, bool pageUsesDarkAppearance);
+
 struct TileRenderInfo {
     WebCore::FloatRect tileRect;
     WebCore::FloatRect renderRect; // Represents the portion of the tile that needs rendering (in the same coordinate system as tileRect).
     RefPtr<WebCore::NativeImage> background; // Optional existing content around renderRect, will be rendered to tileRect.
     PDFPageCoverageAndScales pageCoverage;
     bool showDebugIndicators { false };
+    PDFAccessibilityDisplayMode accessibilityDisplayMode { PDFAccessibilityDisplayMode::None };
 
     bool operator==(const TileRenderInfo&) const = default;
     bool equivalentForPainting(const TileRenderInfo& other) const
     {
-        return tileRect == other.tileRect && pageCoverage == other.pageCoverage;
+        return tileRect == other.tileRect && pageCoverage == other.pageCoverage && accessibilityDisplayMode == other.accessibilityDisplayMode;
     }
 };
 
@@ -113,6 +121,7 @@ struct PDFPagePreviewRenderRequest {
     WebCore::FloatRect normalizedPageBounds;
     float scale { 1.0f };
     bool showDebugIndicators { false };
+    PDFAccessibilityDisplayMode accessibilityDisplayMode { PDFAccessibilityDisplayMode::None };
 };
 
 struct PDFPagePreviewRenderKeyHash {
@@ -192,6 +201,8 @@ public:
     void teardown();
 
     void releaseMemory();
+
+    void invalidateAllRenderedContent();
 
     bool paintTilesForPage(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, float documentScale, const WebCore::FloatRect& clipRect, const WebCore::FloatRect& clipRectInPageCoordinates, const WebCore::FloatRect& pageBoundsInPaintingCoordinates, PDFDocumentLayout::PageIndex);
     void paintPagePreview(WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect, const WebCore::FloatRect& pageBoundsInPaintingCoordinates, PDFDocumentLayout::PageIndex);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -118,6 +118,16 @@ void AsyncPDFRenderer::releaseMemory()
     LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::releaseMemory - reduced page preview count from " << oldPagePreviewCount << " to " << m_pagePreviews.size());
 }
 
+void AsyncPDFRenderer::invalidateAllRenderedContent()
+{
+    clearRequestsAndCachedTiles();
+    m_rendereredTiles.clear();
+    m_rendereredTilesForOldState.clear();
+    m_pendingPagePreviewOrder.clear();
+    m_pendingPagePreviews.clear();
+    m_pagePreviews.clear();
+}
+
 void AsyncPDFRenderer::startTrackingLayer(GraphicsLayer& layer)
 {
     CheckedPtr tiledBacking = layer.tiledBacking();
@@ -172,6 +182,7 @@ static RefPtr<NativeImage> renderPDFPagePreview(RetainPtr<PDFDocument>&& pdfDocu
         RetainPtr platformContext = context.platformContext();
         CGContextSetShouldSubpixelQuantizeFonts(platformContext.get(), false);
         CGContextSetAllowsFontSubpixelPositioning(platformContext.get(), true);
+        applyPDFContentAXColorAdjustment(platformContext, pdfPage, request.accessibilityDisplayMode);
         LOG_WITH_STREAM(PDFAsyncRendering, stream << "renderPDFPagePreview - page:" << request.pageIndex);
         [pdfPage drawWithBox:kPDFDisplayBoxCropBox toContext:platformContext.get()];
     }
@@ -197,7 +208,7 @@ void AsyncPDFRenderer::generatePreviewImageForPage(PDFDocumentLayout::PageIndex 
     auto pageBounds = presentationController->layoutBoundsForPageAtIndex(pageIndex);
     pageBounds.setLocation({ });
 
-    PDFPagePreviewRenderRequest request { pageIndex, pageBounds, scale, m_showDebugBorders };
+    PDFPagePreviewRenderRequest request { pageIndex, pageBounds, scale, m_showDebugBorders, presentationController->accessibilityDisplayMode() };
     m_pendingPagePreviews.set(key, request);
     m_pendingPagePreviewOrder.appendOrMoveToLast(key);
     serviceRequestQueues();
@@ -550,7 +561,7 @@ TileRenderInfo AsyncPDFRenderer::renderInfoForTile(const TiledBacking& tiledBack
 
     auto pageCoverage = presentationController->pageCoverageAndScalesForContentsRect(paintingClipRect, layoutRow, tilingScaleFactor);
 
-    return TileRenderInfo { tileRect, encloseRectToDevicePixels(renderRect, pageCoverage.deviceScaleFactor), WTF::move(background), pageCoverage, m_showDebugBorders };
+    return TileRenderInfo { tileRect, encloseRectToDevicePixels(renderRect, pageCoverage.deviceScaleFactor), WTF::move(background), pageCoverage, m_showDebugBorders, presentationController->accessibilityDisplayMode() };
 }
 
 static void renderPDFTile(PDFDocument *pdfDocument, const TileRenderInfo& renderInfo, GraphicsContext& context)
@@ -570,7 +581,7 @@ static void renderPDFTile(PDFDocument *pdfDocument, const TileRenderInfo& render
         auto destinationRect = pageInfo.pageBounds;
         auto pageStateSaver = GraphicsContextStateSaver(context);
         context.clip(destinationRect);
-        context.fillRect(destinationRect, Color::white);
+        context.fillRect(destinationRect, pdfPageBackgroundColor(renderInfo.accessibilityDisplayMode));
         if (renderInfo.showDebugIndicators)
             context.fillRect(destinationRect, Color::green.colorWithAlphaByte(32));
 
@@ -580,7 +591,9 @@ static void renderPDFTile(PDFDocument *pdfDocument, const TileRenderInfo& render
         context.scale({ 1, -1 });
 
         LOG_WITH_STREAM(PDFAsyncRendering, stream << "renderPDFTile renderInfo:" << renderInfo << ", PDF page:" << pageInfo.pageIndex << " destinationRect:" << destinationRect);
-        [pdfPage drawWithBox:kPDFDisplayBoxCropBox toContext:RetainPtr { context.platformContext() }.get()];
+        RetainPtr platformContext = context.platformContext();
+        applyPDFContentAXColorAdjustment(platformContext, pdfPage, renderInfo.accessibilityDisplayMode);
+        [pdfPage drawWithBox:kPDFDisplayBoxCropBox toContext:platformContext];
     }
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFAccessibilityDisplayMode.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFAccessibilityDisplayMode.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(UNIFIED_PDF)
+
+#if ENABLE(AX_PDF_SUPPORT)
+#include <WebKitAdditions/PDFAccessibilityDisplayModeAdditions.h>
+#else
+
+namespace WebKit {
+
+enum class PDFAccessibilityDisplayMode : uint8_t {
+    None,
+};
+
+} // namespace WebKit
+
+#endif
+
+#endif

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
@@ -77,6 +77,7 @@ private:
 
     void updateIsInWindow(bool isInWindow) override;
     void updateDebugBorders(bool showDebugBorders, bool showRepaintCounters) override;
+    void updateForAccessibilityDisplayModeChange(PDFAccessibilityDisplayMode) override;
     void updateForCurrentScrollability(OptionSet<WebCore::TiledBackingScrollability>) override;
 
     Vector<LayerCoverage> layerCoveragesForRepaintPageCoverage(RepaintRequirements, const PDFPageCoverage&) override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -1127,7 +1127,7 @@ void PDFDiscretePresentationController::buildRows()
         rowSelectionLayer->setAnchorPoint({ });
         rowSelectionLayer->setDrawsContent(true);
         rowSelectionLayer->setAcceleratesDrawing(true);
-        rowSelectionLayer->setBlendMode(BlendMode::Multiply);
+        rowSelectionLayer->setBlendMode(pdfSelectionBlendMode(accessibilityDisplayMode()));
         m_layerToRowIndexMap.set(WTF::move(rowSelectionLayer), rowIndex);
 
         parentRowLayers(row);
@@ -1320,6 +1320,25 @@ void PDFDiscretePresentationController::updateDebugBorders(bool showDebugBorders
 
     if (RefPtr asyncRenderer = asyncRendererIfExists())
         asyncRenderer->setShowDebugBorders(showDebugBorders);
+}
+
+void PDFDiscretePresentationController::updateForAccessibilityDisplayModeChange(PDFAccessibilityDisplayMode accessibilityDisplayMode)
+{
+    auto applyToBackgroundLayer = [backgroundColor = pdfPageBackgroundColor(accessibilityDisplayMode)](GraphicsLayer& layer) {
+        layer.setBackgroundColor(backgroundColor);
+        layer.setNeedsDisplay();
+    };
+
+    for (auto& row : m_rows) {
+        if (row.leftPageContainerLayer)
+            applyToBackgroundLayer(row.leftPageBackgroundLayer());
+
+        if (RefPtr rightPageBackgroundLayer = row.rightPageBackgroundLayer())
+            applyToBackgroundLayer(*rightPageBackgroundLayer);
+
+        if (RefPtr selectionLayer = row.selectionLayer)
+            selectionLayer->setBlendMode(pdfSelectionBlendMode(accessibilityDisplayMode));
+    }
 }
 
 void PDFDiscretePresentationController::updateForCurrentScrollability(OptionSet<TiledBackingScrollability> scrollability)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -87,6 +87,8 @@ public:
     virtual void updateIsInWindow(bool isInWindow) = 0;
     virtual void updateDebugBorders(bool showDebugBorders, bool showRepaintCounters) = 0;
 
+    virtual void updateForAccessibilityDisplayModeChange(PDFAccessibilityDisplayMode) = 0;
+
     virtual void updateForCurrentScrollability(OptionSet<WebCore::TiledBackingScrollability>) = 0;
 
     virtual void didGeneratePreviewForPage(PDFDocumentLayout::PageIndex) = 0;
@@ -115,8 +117,11 @@ public:
     virtual bool handleWheelEvent(const WebWheelEvent&) { return false; }
 
     void releaseMemory();
+
+    void invalidateRenderedContentForAccessibilityDisplayModeChange();
     RetainPtr<PDFDocument> pluginPDFDocument() const;
     bool pluginShouldCachePagePreviews() const;
+    PDFAccessibilityDisplayMode accessibilityDisplayMode() const;
 
     virtual std::optional<WebCore::PlatformLayerIdentifier> contentsLayerIdentifier() const { return std::nullopt; }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -128,7 +128,7 @@ Ref<GraphicsLayer> PDFPresentationController::makePageContainerLayer(PDFDocument
     pageContainerLayer->setAnchorPoint({ });
 
     pageBackgroundLayer->setAnchorPoint({ });
-    pageBackgroundLayer->setBackgroundColor(Color::white);
+    pageBackgroundLayer->setBackgroundColor(pdfPageBackgroundColor(accessibilityDisplayMode()));
     pageBackgroundLayer->setDrawsContent(true);
     pageBackgroundLayer->setAcceleratesDrawing(!shouldUseInProcessBackingStore());
     pageBackgroundLayer->setShouldUpdateRootRelativeScaleFactor(false);
@@ -156,6 +156,12 @@ void PDFPresentationController::releaseMemory()
         asyncRenderer->releaseMemory();
 }
 
+void PDFPresentationController::invalidateRenderedContentForAccessibilityDisplayModeChange()
+{
+    if (RefPtr asyncRenderer = asyncRendererIfExists())
+        asyncRenderer->invalidateAllRenderedContent();
+}
+
 RetainPtr<PDFDocument> PDFPresentationController::pluginPDFDocument() const
 {
     return m_plugin->pdfDocument();
@@ -169,6 +175,11 @@ FloatRect PDFPresentationController::layoutBoundsForPageAtIndex(PDFDocumentLayou
 bool PDFPresentationController::pluginShouldCachePagePreviews() const
 {
     return m_plugin->shouldCachePagePreviews();
+}
+
+PDFAccessibilityDisplayMode PDFPresentationController::accessibilityDisplayMode() const
+{
+    return m_plugin->accessibilityDisplayMode();
 }
 
 float PDFPresentationController::scaleForPagePreviews() const

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
@@ -64,6 +64,7 @@ private:
 
     void updateIsInWindow(bool isInWindow) override;
     void updateDebugBorders(bool showDebugBorders, bool showRepaintCounters) override;
+    void updateForAccessibilityDisplayModeChange(PDFAccessibilityDisplayMode) override;
     void updateForCurrentScrollability(OptionSet<WebCore::TiledBackingScrollability>) override;
 
     GraphicsLayerClient& graphicsLayerClient() override { return *this; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -169,7 +169,7 @@ void PDFScrollingPresentationController::setupLayers(GraphicsLayer& scrolledCont
         selectionLayer->setAnchorPoint({ });
         selectionLayer->setDrawsContent(true);
         selectionLayer->setAcceleratesDrawing(true);
-        selectionLayer->setBlendMode(BlendMode::Multiply);
+        selectionLayer->setBlendMode(pdfSelectionBlendMode(accessibilityDisplayMode()));
 
         // m_selectionLayer will be parented on-demand in `setSelectionLayerEnabled`.
     }
@@ -312,6 +312,27 @@ void PDFScrollingPresentationController::updateDebugBorders(bool showDebugBorder
 
     if (RefPtr asyncRenderer = asyncRendererIfExists())
         asyncRenderer->setShowDebugBorders(showDebugBorders);
+}
+
+void PDFScrollingPresentationController::updateForAccessibilityDisplayModeChange(PDFAccessibilityDisplayMode accessibilityDisplayMode)
+{
+#if ENABLE(PDFKIT_PAINTED_SELECTIONS)
+    if (RefPtr selectionLayer = m_selectionLayer)
+        selectionLayer->setBlendMode(pdfSelectionBlendMode(accessibilityDisplayMode));
+#endif
+
+    RefPtr pageBackgroundsContainerLayer = m_pageBackgroundsContainerLayer;
+    if (!pageBackgroundsContainerLayer)
+        return;
+
+    auto backgroundColor = pdfPageBackgroundColor(accessibilityDisplayMode);
+    for (auto& pageContainerLayer : pageBackgroundsContainerLayer->children()) {
+        if (!pageContainerLayer->children().size())
+            continue;
+        Ref pageBackgroundLayer = pageBackgroundLayerForPageContainerLayer(pageContainerLayer);
+        pageBackgroundLayer->setBackgroundColor(backgroundColor);
+        pageBackgroundLayer->setNeedsDisplay();
+    }
 }
 
 void PDFScrollingPresentationController::updateForCurrentScrollability(OptionSet<TiledBackingScrollability> scrollability)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(UNIFIED_PDF)
 
+#include "PDFAccessibilityDisplayMode.h"
 #include "PDFDocumentLayout.h"
 #include "PDFPageCoverage.h"
 #include "PDFPluginBase.h"
@@ -170,6 +171,8 @@ public:
     float documentFittingScale() const { return m_documentLayout.scale(); }
 
     bool shouldCachePagePreviews() const;
+
+    PDFAccessibilityDisplayMode accessibilityDisplayMode() const;
 
     WebCore::FloatRect convertFromPDFPageToScreenForAccessibility(const WebCore::FloatRect&, PDFDocumentLayout::PageIndex) const;
 #if PLATFORM(MAC)
@@ -746,6 +749,8 @@ private:
     HashMap<WebFoundTextRange::PDFData, RetainPtr<PDFSelection>> m_webFoundTextRangePDFDataSelectionMap;
 
     mutable std::optional<bool> m_cachedIsFullMainFramePlugin;
+
+    PDFAccessibilityDisplayMode m_accessibilityDisplayMode { PDFAccessibilityDisplayMode::None };
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, RepaintRequirement);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -173,6 +173,34 @@ using namespace WebKit::PDFAnnotationTypeHelpers;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(UnifiedPDFPlugin);
 
+#if ENABLE(AX_PDF_SUPPORT)
+#include <WebKitAdditions/UnifiedPDFPluginAdditions.mm>
+#else
+PDFAccessibilityDisplayMode UnifiedPDFPlugin::accessibilityDisplayMode() const
+{
+    return PDFAccessibilityDisplayMode::None;
+}
+
+void applyPDFContentAXColorAdjustment(CGContextRef, PDFPage *, PDFAccessibilityDisplayMode)
+{
+}
+
+WebCore::Color pdfPageBackgroundColor(PDFAccessibilityDisplayMode)
+{
+    return WebCore::Color::white;
+}
+
+WebCore::BlendMode pdfSelectionBlendMode(PDFAccessibilityDisplayMode)
+{
+    return WebCore::BlendMode::Multiply;
+}
+
+WebCore::ScrollbarOverlayStyle pdfScrollbarOverlayStyle(PDFAccessibilityDisplayMode, bool pageUsesDarkAppearance)
+{
+    return pageUsesDarkAppearance ? WebCore::ScrollbarOverlayStyle::Light : WebCore::ScrollbarOverlayStyle::Default;
+}
+#endif
+
 Ref<UnifiedPDFPlugin> UnifiedPDFPlugin::create(HTMLPlugInElement& pluginElement)
 {
     return adoptRef(*new UnifiedPDFPlugin(pluginElement));
@@ -187,6 +215,8 @@ UnifiedPDFPlugin::UnifiedPDFPlugin(HTMLPlugInElement& element)
 {
     this->setVerticalScrollElasticity(ScrollElasticity::Automatic);
     this->setHorizontalScrollElasticity(ScrollElasticity::Automatic);
+
+    m_accessibilityDisplayMode = accessibilityDisplayMode();
 
     Ref document = element.document();
     Ref annotationContainer = document->createElement(HTMLNames::divTag, false);
@@ -751,6 +781,17 @@ void UnifiedPDFPlugin::didChangeSettings()
         propagateSettingsToLayer(*layerForScrollCorner);
 
     protect(m_presentationController)->updateDebugBorders(showDebugBorders, showRepaintCounter);
+
+    auto displayMode = accessibilityDisplayMode();
+    if (m_accessibilityDisplayMode != displayMode) {
+        m_accessibilityDisplayMode = displayMode;
+
+        RefPtr presentationController = m_presentationController;
+        presentationController->invalidateRenderedContentForAccessibilityDisplayModeChange();
+        presentationController->updateForAccessibilityDisplayModeChange(displayMode);
+        updateScrollbarOverlayStyle();
+        setNeedsRepaintForIncrementalLoad();
+    }
 }
 
 void UnifiedPDFPlugin::notifyFlushRequired(const GraphicsLayer*)
@@ -857,6 +898,7 @@ void UnifiedPDFPlugin::paintPDFContent(const WebCore::GraphicsLayer* layer, Grap
     auto stateSaver = GraphicsContextStateSaver(context);
 
     auto showDebugIndicators = shouldShowDebugIndicators();
+    auto displayMode = accessibilityDisplayMode();
 
     auto pageWithAnnotation = pageIndexWithHoveredAnnotation();
 
@@ -905,7 +947,7 @@ void UnifiedPDFPlugin::paintPDFContent(const WebCore::GraphicsLayer* layer, Grap
         context.clip(pageDestinationRect);
 
         if (!asyncRenderer)
-            context.fillRect(pageDestinationRect, Color::white);
+            context.fillRect(pageDestinationRect, pdfPageBackgroundColor(displayMode));
 
         // Translate the context to the bottom of pageBounds and flip, so that PDFKit operates
         // from this page's drawing origin.
@@ -914,7 +956,9 @@ void UnifiedPDFPlugin::paintPDFContent(const WebCore::GraphicsLayer* layer, Grap
 
         if (!asyncRenderer) {
             LOG_WITH_STREAM(PDF, stream << "UnifiedPDFPlugin: painting PDF page " << pageInfo.pageIndex << " into rect " << pageDestinationRect << " with clip " << clipRect);
-            [page drawWithBox:kPDFDisplayBoxCropBox toContext:protect(context.platformContext()).get()];
+            RetainPtr platformContext = context.platformContext();
+            applyPDFContentAXColorAdjustment(platformContext, page.get(), displayMode);
+            [page drawWithBox:kPDFDisplayBoxCropBox toContext:platformContext];
         }
 
         if constexpr (hasFullAnnotationSupport) {
@@ -947,13 +991,14 @@ void UnifiedPDFPlugin::paintPDFSelection(const GraphicsLayer* layer, GraphicsCon
     if (RefPtr page = this->page())
         isVisibleAndActive = page->isVisibleAndActive();
 
-    auto selectionColor = [renderer = CheckedPtr { m_element->renderer() }, isVisibleAndActive] {
+    auto displayMode = accessibilityDisplayMode();
+    auto selectionColor = [renderer = CheckedPtr { m_element->renderer() }, isVisibleAndActive, displayMode] {
         auto& renderTheme = renderer ? renderer->theme() : RenderTheme::singleton();
         OptionSet<StyleColorOptions> styleColorOptions;
         if (renderer)
             styleColorOptions = renderer->styleColorOptions() - WebCore::StyleColorOptions::UseDarkAppearance;
         auto selectionColor = isVisibleAndActive ? renderTheme.activeSelectionBackgroundColor(styleColorOptions) : renderTheme.inactiveSelectionBackgroundColor(styleColorOptions);
-        return blendSourceOver(Color::white, selectionColor);
+        return blendSourceOver(pdfPageBackgroundColor(displayMode), selectionColor);
     }();
 
     auto tilingScaleFactor = 1.0f;
@@ -1719,15 +1764,12 @@ void UnifiedPDFPlugin::scrollbarStyleChanged(WebCore::ScrollbarStyle, bool force
 
 void UnifiedPDFPlugin::updateScrollbarOverlayStyle()
 {
-    if (!isFullMainFramePlugin())
-        return;
-
     RefPtr page = this->page();
     if (!page)
         return;
 
-    using enum WebCore::ScrollbarOverlayStyle;
-    setScrollbarOverlayStyle(page->useDarkAppearance() ? Light : Default);
+    auto overlayStyle = pdfScrollbarOverlayStyle(accessibilityDisplayMode(), isFullMainFramePlugin() && page->useDarkAppearance());
+    setScrollbarOverlayStyle(overlayStyle);
 
     if (m_scrollingNodeID) {
         if (RefPtr scrollingCoordinator = page->scrollingCoordinator())


### PR DESCRIPTION
#### 6867fc6a135399bfb87863ef3146d0c7aeb410a4
<pre>
[AX] Add foundation for PDF accessibility modes
<a href="https://bugs.webkit.org/show_bug.cgi?id=320678">https://bugs.webkit.org/show_bug.cgi?id=320678</a>
<a href="https://rdar.apple.com/183607479">rdar://183607479</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Add foundation for PDF accessibility modes which alter the
appearance of a rendered PDF.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
(WebKit::TileRenderInfo::equivalentForPainting const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::invalidateAllRenderedContent):
(WebKit::renderPDFPagePreview):
(WebKit::AsyncPDFRenderer::generatePreviewImageForPage):
(WebKit::AsyncPDFRenderer::renderInfoForTile const):
(WebKit::renderPDFTile):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFAccessibilityDisplayMode.h: Added.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::buildRows):
(WebKit::PDFDiscretePresentationController::updateForAccessibilityDisplayModeChange):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm:
(WebKit::PDFPresentationController::makePageContainerLayer):
(WebKit::PDFPresentationController::invalidateRenderedContentForAccessibilityDisplayModeChange):
(WebKit::PDFPresentationController::accessibilityDisplayMode const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::setupLayers):
(WebKit::PDFScrollingPresentationController::updateForAccessibilityDisplayModeChange):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::accessibilityDisplayMode const):
(WebKit::applyPDFContentAXColorAdjustment):
(WebKit::pdfPageBackgroundColor):
(WebKit::pdfSelectionBlendMode):
(WebKit::pdfScrollbarOverlayStyle):
(WebKit::UnifiedPDFPlugin::UnifiedPDFPlugin):
(WebKit::UnifiedPDFPlugin::didChangeSettings):
(WebKit::UnifiedPDFPlugin::paintPDFContent):
(WebKit::UnifiedPDFPlugin::paintPDFSelection):
(WebKit::UnifiedPDFPlugin::updateScrollbarOverlayStyle):

Canonical link: <a href="https://commits.webkit.org/318307@main">https://commits.webkit.org/318307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62f61af552cc28d9d181a27c824e744ff0be4159

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187538 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/82d8ee21-14c1-4a72-b6fb-617f767cd21d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138692 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b91c0d5-807c-4443-9300-c435748ff5f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42229 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119155 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75f5920e-c63d-4858-b9d8-59ee1f65a213) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40892 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151297 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/38933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35999 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44458 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189967 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51533 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147822 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52215 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147603 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26977 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42312 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118910 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50723 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13913 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50119 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50359 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50181 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->