### PR TITLE
MathML and SVG elements do not reset tabIndex when tabindex is changed to an invalid value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-003-expected.txt
@@ -1,0 +1,226 @@
+
+PASS changing tabindex from "3" to "" resets a.tabIndex
+PASS changing tabindex from "3" to "invalid" resets a.tabIndex
+PASS changing tabindex from "3" to " " resets a.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets a.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets a.tabIndex
+PASS trailing garbage after the digits of a's tabindex is ignored
+PASS removing tabindex resets a.tabIndex
+PASS changing tabindex from "3" to "" resets annotation.tabIndex
+PASS changing tabindex from "3" to "invalid" resets annotation.tabIndex
+PASS changing tabindex from "3" to " " resets annotation.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets annotation.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets annotation.tabIndex
+PASS trailing garbage after the digits of annotation's tabindex is ignored
+PASS removing tabindex resets annotation.tabIndex
+PASS changing tabindex from "3" to "" resets annotation-xml.tabIndex
+PASS changing tabindex from "3" to "invalid" resets annotation-xml.tabIndex
+PASS changing tabindex from "3" to " " resets annotation-xml.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets annotation-xml.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets annotation-xml.tabIndex
+PASS trailing garbage after the digits of annotation-xml's tabindex is ignored
+PASS removing tabindex resets annotation-xml.tabIndex
+PASS changing tabindex from "3" to "" resets maction.tabIndex
+PASS changing tabindex from "3" to "invalid" resets maction.tabIndex
+PASS changing tabindex from "3" to " " resets maction.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets maction.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets maction.tabIndex
+PASS trailing garbage after the digits of maction's tabindex is ignored
+PASS removing tabindex resets maction.tabIndex
+PASS changing tabindex from "3" to "" resets menclose.tabIndex
+PASS changing tabindex from "3" to "invalid" resets menclose.tabIndex
+PASS changing tabindex from "3" to " " resets menclose.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets menclose.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets menclose.tabIndex
+PASS trailing garbage after the digits of menclose's tabindex is ignored
+PASS removing tabindex resets menclose.tabIndex
+PASS changing tabindex from "3" to "" resets merror.tabIndex
+PASS changing tabindex from "3" to "invalid" resets merror.tabIndex
+PASS changing tabindex from "3" to " " resets merror.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets merror.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets merror.tabIndex
+PASS trailing garbage after the digits of merror's tabindex is ignored
+PASS removing tabindex resets merror.tabIndex
+PASS changing tabindex from "3" to "" resets mfrac.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mfrac.tabIndex
+PASS changing tabindex from "3" to " " resets mfrac.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mfrac.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mfrac.tabIndex
+PASS trailing garbage after the digits of mfrac's tabindex is ignored
+PASS removing tabindex resets mfrac.tabIndex
+PASS changing tabindex from "3" to "" resets mi.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mi.tabIndex
+PASS changing tabindex from "3" to " " resets mi.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mi.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mi.tabIndex
+PASS trailing garbage after the digits of mi's tabindex is ignored
+PASS removing tabindex resets mi.tabIndex
+PASS changing tabindex from "3" to "" resets mmultiscripts.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mmultiscripts.tabIndex
+PASS changing tabindex from "3" to " " resets mmultiscripts.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mmultiscripts.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mmultiscripts.tabIndex
+PASS trailing garbage after the digits of mmultiscripts's tabindex is ignored
+PASS removing tabindex resets mmultiscripts.tabIndex
+PASS changing tabindex from "3" to "" resets mn.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mn.tabIndex
+PASS changing tabindex from "3" to " " resets mn.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mn.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mn.tabIndex
+PASS trailing garbage after the digits of mn's tabindex is ignored
+PASS removing tabindex resets mn.tabIndex
+PASS changing tabindex from "3" to "" resets mo.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mo.tabIndex
+PASS changing tabindex from "3" to " " resets mo.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mo.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mo.tabIndex
+PASS trailing garbage after the digits of mo's tabindex is ignored
+PASS removing tabindex resets mo.tabIndex
+PASS changing tabindex from "3" to "" resets mover.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mover.tabIndex
+PASS changing tabindex from "3" to " " resets mover.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mover.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mover.tabIndex
+PASS trailing garbage after the digits of mover's tabindex is ignored
+PASS removing tabindex resets mover.tabIndex
+PASS changing tabindex from "3" to "" resets mpadded.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mpadded.tabIndex
+PASS changing tabindex from "3" to " " resets mpadded.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mpadded.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mpadded.tabIndex
+PASS trailing garbage after the digits of mpadded's tabindex is ignored
+PASS removing tabindex resets mpadded.tabIndex
+PASS changing tabindex from "3" to "" resets mphantom.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mphantom.tabIndex
+PASS changing tabindex from "3" to " " resets mphantom.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mphantom.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mphantom.tabIndex
+PASS trailing garbage after the digits of mphantom's tabindex is ignored
+PASS removing tabindex resets mphantom.tabIndex
+PASS changing tabindex from "3" to "" resets mprescripts.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mprescripts.tabIndex
+PASS changing tabindex from "3" to " " resets mprescripts.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mprescripts.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mprescripts.tabIndex
+PASS trailing garbage after the digits of mprescripts's tabindex is ignored
+PASS removing tabindex resets mprescripts.tabIndex
+PASS changing tabindex from "3" to "" resets mroot.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mroot.tabIndex
+PASS changing tabindex from "3" to " " resets mroot.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mroot.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mroot.tabIndex
+PASS trailing garbage after the digits of mroot's tabindex is ignored
+PASS removing tabindex resets mroot.tabIndex
+PASS changing tabindex from "3" to "" resets mrow.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mrow.tabIndex
+PASS changing tabindex from "3" to " " resets mrow.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mrow.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mrow.tabIndex
+PASS trailing garbage after the digits of mrow's tabindex is ignored
+PASS removing tabindex resets mrow.tabIndex
+PASS changing tabindex from "3" to "" resets ms.tabIndex
+PASS changing tabindex from "3" to "invalid" resets ms.tabIndex
+PASS changing tabindex from "3" to " " resets ms.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets ms.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets ms.tabIndex
+PASS trailing garbage after the digits of ms's tabindex is ignored
+PASS removing tabindex resets ms.tabIndex
+PASS changing tabindex from "3" to "" resets mspace.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mspace.tabIndex
+PASS changing tabindex from "3" to " " resets mspace.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mspace.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mspace.tabIndex
+PASS trailing garbage after the digits of mspace's tabindex is ignored
+PASS removing tabindex resets mspace.tabIndex
+PASS changing tabindex from "3" to "" resets msqrt.tabIndex
+PASS changing tabindex from "3" to "invalid" resets msqrt.tabIndex
+PASS changing tabindex from "3" to " " resets msqrt.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets msqrt.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets msqrt.tabIndex
+PASS trailing garbage after the digits of msqrt's tabindex is ignored
+PASS removing tabindex resets msqrt.tabIndex
+PASS changing tabindex from "3" to "" resets mstyle.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mstyle.tabIndex
+PASS changing tabindex from "3" to " " resets mstyle.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mstyle.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mstyle.tabIndex
+PASS trailing garbage after the digits of mstyle's tabindex is ignored
+PASS removing tabindex resets mstyle.tabIndex
+PASS changing tabindex from "3" to "" resets msub.tabIndex
+PASS changing tabindex from "3" to "invalid" resets msub.tabIndex
+PASS changing tabindex from "3" to " " resets msub.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets msub.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets msub.tabIndex
+PASS trailing garbage after the digits of msub's tabindex is ignored
+PASS removing tabindex resets msub.tabIndex
+PASS changing tabindex from "3" to "" resets msubsup.tabIndex
+PASS changing tabindex from "3" to "invalid" resets msubsup.tabIndex
+PASS changing tabindex from "3" to " " resets msubsup.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets msubsup.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets msubsup.tabIndex
+PASS trailing garbage after the digits of msubsup's tabindex is ignored
+PASS removing tabindex resets msubsup.tabIndex
+PASS changing tabindex from "3" to "" resets msup.tabIndex
+PASS changing tabindex from "3" to "invalid" resets msup.tabIndex
+PASS changing tabindex from "3" to " " resets msup.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets msup.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets msup.tabIndex
+PASS trailing garbage after the digits of msup's tabindex is ignored
+PASS removing tabindex resets msup.tabIndex
+PASS changing tabindex from "3" to "" resets mtable.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mtable.tabIndex
+PASS changing tabindex from "3" to " " resets mtable.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mtable.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mtable.tabIndex
+PASS trailing garbage after the digits of mtable's tabindex is ignored
+PASS removing tabindex resets mtable.tabIndex
+PASS changing tabindex from "3" to "" resets mtd.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mtd.tabIndex
+PASS changing tabindex from "3" to " " resets mtd.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mtd.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mtd.tabIndex
+PASS trailing garbage after the digits of mtd's tabindex is ignored
+PASS removing tabindex resets mtd.tabIndex
+PASS changing tabindex from "3" to "" resets mtext.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mtext.tabIndex
+PASS changing tabindex from "3" to " " resets mtext.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mtext.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mtext.tabIndex
+PASS trailing garbage after the digits of mtext's tabindex is ignored
+PASS removing tabindex resets mtext.tabIndex
+PASS changing tabindex from "3" to "" resets mtr.tabIndex
+PASS changing tabindex from "3" to "invalid" resets mtr.tabIndex
+PASS changing tabindex from "3" to " " resets mtr.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets mtr.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets mtr.tabIndex
+PASS trailing garbage after the digits of mtr's tabindex is ignored
+PASS removing tabindex resets mtr.tabIndex
+PASS changing tabindex from "3" to "" resets munder.tabIndex
+PASS changing tabindex from "3" to "invalid" resets munder.tabIndex
+PASS changing tabindex from "3" to " " resets munder.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets munder.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets munder.tabIndex
+PASS trailing garbage after the digits of munder's tabindex is ignored
+PASS removing tabindex resets munder.tabIndex
+PASS changing tabindex from "3" to "" resets munderover.tabIndex
+PASS changing tabindex from "3" to "invalid" resets munderover.tabIndex
+PASS changing tabindex from "3" to " " resets munderover.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets munderover.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets munderover.tabIndex
+PASS trailing garbage after the digits of munderover's tabindex is ignored
+PASS removing tabindex resets munderover.tabIndex
+PASS changing tabindex from "3" to "" resets none.tabIndex
+PASS changing tabindex from "3" to "invalid" resets none.tabIndex
+PASS changing tabindex from "3" to " " resets none.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets none.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets none.tabIndex
+PASS trailing garbage after the digits of none's tabindex is ignored
+PASS removing tabindex resets none.tabIndex
+PASS changing tabindex from "3" to "" resets semantics.tabIndex
+PASS changing tabindex from "3" to "invalid" resets semantics.tabIndex
+PASS changing tabindex from "3" to " " resets semantics.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets semantics.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets semantics.tabIndex
+PASS trailing garbage after the digits of semantics's tabindex is ignored
+PASS removing tabindex resets semantics.tabIndex
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-003.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>MathML tabIndex attribute: resetting an explicitly set value</title>
+<link rel="help" href="https://w3c.github.io/mathml-core/#attributes-common-to-html-and-mathml-elements">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex">
+<meta name="assert" content="Verify that an explicitly set tabIndex is reset to the default value when the tabindex attribute is changed to a value that is not a valid integer, or removed">
+
+<script src="/mathml/support/mathml-fragments.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <div id="log"></div>
+  <math>
+  </math>
+  <script>
+    // tabindex is defined by HTML, which parses the attribute as an integer and
+    // falls back to the default tab index for any value that fails to parse.
+    // That includes the empty string, garbage, and out-of-range integers.
+    const invalidValues = ["", "invalid", " ", "9999999999", "-9999999999"];
+
+    // The HTML rules for parsing integers stop at the first non-digit and keep
+    // the digits collected so far, so these are valid despite the trailing junk.
+    const valuesWithTrailingGarbage = [["1.5", 1], ["4abc", 4], ["-2 ", -2]];
+
+    Object.keys(MathMLFragments).forEach(elName => {
+        const mathEl = document.querySelector('math');
+
+        // <a> needs an href to be focusable by default, and so to have a
+        // default tab index of 0 rather than -1.
+        const href = elName == 'a' ? ' href="#"' : '';
+        mathEl.innerHTML = `<${elName} id="el"${href}></${elName}>`;
+        const el = mathEl.querySelector('#el');
+        const expectedDefault = elName == 'a' ? 0 : -1;
+
+        invalidValues.forEach(invalidValue => {
+            test(() => {
+                el.setAttribute("tabindex", "3");
+                assert_equals(el.tabIndex, 3, "valid value");
+
+                el.setAttribute("tabindex", invalidValue);
+                assert_equals(el.getAttribute("tabindex"), invalidValue);
+                assert_equals(el.tabIndex, expectedDefault, "invalid value");
+            }, `changing tabindex from "3" to "${invalidValue}" resets ${elName}.tabIndex`);
+        });
+
+        test(() => {
+            valuesWithTrailingGarbage.forEach(([value, expectedTabIndex]) => {
+                el.setAttribute("tabindex", "3");
+                assert_equals(el.tabIndex, 3, "valid value");
+
+                el.setAttribute("tabindex", value);
+                assert_equals(el.tabIndex, expectedTabIndex, `"${value}"`);
+            });
+            el.removeAttribute("tabindex");
+        }, `trailing garbage after the digits of ${elName}'s tabindex is ignored`);
+
+        test(() => {
+            el.setAttribute("tabindex", "3");
+            assert_equals(el.tabIndex, 3, "valid value");
+
+            el.removeAttribute("tabindex");
+            assert_equals(el.tabIndex, expectedDefault, "attribute removed");
+        }, `removing tabindex resets ${elName}.tabIndex`);
+    });
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/focus-tabindex-invalid-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/focus-tabindex-invalid-value-expected.txt
@@ -1,0 +1,50 @@
+
+PASS default value of anchor.tabIndex
+PASS changing tabindex from "3" to "" resets anchor.tabIndex
+PASS changing tabindex from "3" to "invalid" resets anchor.tabIndex
+PASS changing tabindex from "3" to " " resets anchor.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets anchor.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets anchor.tabIndex
+PASS trailing garbage after the digits of anchor's tabindex is ignored
+PASS removing tabindex resets anchor.tabIndex
+PASS default value of rect.tabIndex
+PASS changing tabindex from "3" to "" resets rect.tabIndex
+PASS changing tabindex from "3" to "invalid" resets rect.tabIndex
+PASS changing tabindex from "3" to " " resets rect.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets rect.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets rect.tabIndex
+PASS trailing garbage after the digits of rect's tabindex is ignored
+PASS removing tabindex resets rect.tabIndex
+PASS default value of g.tabIndex
+PASS changing tabindex from "3" to "" resets g.tabIndex
+PASS changing tabindex from "3" to "invalid" resets g.tabIndex
+PASS changing tabindex from "3" to " " resets g.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets g.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets g.tabIndex
+PASS trailing garbage after the digits of g's tabindex is ignored
+PASS removing tabindex resets g.tabIndex
+PASS default value of circle.tabIndex
+PASS changing tabindex from "3" to "" resets circle.tabIndex
+PASS changing tabindex from "3" to "invalid" resets circle.tabIndex
+PASS changing tabindex from "3" to " " resets circle.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets circle.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets circle.tabIndex
+PASS trailing garbage after the digits of circle's tabindex is ignored
+PASS removing tabindex resets circle.tabIndex
+PASS default value of text.tabIndex
+PASS changing tabindex from "3" to "" resets text.tabIndex
+PASS changing tabindex from "3" to "invalid" resets text.tabIndex
+PASS changing tabindex from "3" to " " resets text.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets text.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets text.tabIndex
+PASS trailing garbage after the digits of text's tabindex is ignored
+PASS removing tabindex resets text.tabIndex
+PASS default value of nested.tabIndex
+PASS changing tabindex from "3" to "" resets nested.tabIndex
+PASS changing tabindex from "3" to "invalid" resets nested.tabIndex
+PASS changing tabindex from "3" to " " resets nested.tabIndex
+PASS changing tabindex from "3" to "9999999999" resets nested.tabIndex
+PASS changing tabindex from "3" to "-9999999999" resets nested.tabIndex
+PASS trailing garbage after the digits of nested's tabindex is ignored
+PASS removing tabindex resets nested.tabIndex
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/focus-tabindex-invalid-value.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/focus-tabindex-invalid-value.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+    <title>SVG Test: focus - resetting an explicitly set tabindex</title>
+    <metadata>
+        <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#Focus"/>
+        <h:link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex"/>
+        <h:meta name="assert" content="Verify that an explicitly set tabIndex is reset to the default value when the tabindex attribute is changed to a value that is not a valid integer, or removed"/>
+    </metadata>
+    <a id="anchor" href="#"></a>
+    <rect id="rect"></rect>
+    <g id="g"></g>
+    <circle id="circle"></circle>
+    <text id="text"></text>
+    <svg id="nested"></svg>
+    <h:script src="/resources/testharness.js"/>
+    <h:script src="/resources/testharnessreport.js"/>
+    <script><![CDATA[
+    // tabindex is defined by HTML, which parses the attribute as an integer and
+    // falls back to the default tab index for any value that fails to parse.
+    // That includes the empty string, garbage, and out-of-range integers.
+    const invalidValues = ["", "invalid", " ", "9999999999", "-9999999999"];
+
+    // The HTML rules for parsing integers stop at the first non-digit and keep
+    // the digits collected so far, so these are valid despite the trailing junk.
+    const valuesWithTrailingGarbage = [["1.5", 1], ["4abc", 4], ["-2 ", -2]];
+
+    // [id, default tabIndex]
+    const elements = [
+        ["anchor", 0],
+        ["rect", -1],
+        ["g", -1],
+        ["circle", -1],
+        ["text", -1],
+        ["nested", -1],
+    ];
+
+    for (const [id, expectedDefault] of elements) {
+        const el = document.getElementById(id);
+
+        test(() => {
+            assert_equals(el.tabIndex, expectedDefault);
+        }, `default value of ${id}.tabIndex`);
+
+        for (const invalidValue of invalidValues) {
+            test(() => {
+                el.setAttribute("tabindex", "3");
+                assert_equals(el.tabIndex, 3, "valid value");
+
+                el.setAttribute("tabindex", invalidValue);
+                assert_equals(el.getAttribute("tabindex"), invalidValue);
+                assert_equals(el.tabIndex, expectedDefault, "invalid value");
+
+                el.removeAttribute("tabindex");
+            }, `changing tabindex from "3" to "${invalidValue}" resets ${id}.tabIndex`);
+        }
+
+        test(() => {
+            valuesWithTrailingGarbage.forEach(([value, expectedTabIndex]) => {
+                el.setAttribute("tabindex", "3");
+                assert_equals(el.tabIndex, 3, "valid value");
+
+                el.setAttribute("tabindex", value);
+                assert_equals(el.tabIndex, expectedTabIndex, `"${value}"`);
+            });
+            el.removeAttribute("tabindex");
+        }, `trailing garbage after the digits of ${id}'s tabindex is ignored`);
+
+        test(() => {
+            el.setAttribute("tabindex", "3");
+            assert_equals(el.tabIndex, 3, "valid value");
+
+            el.removeAttribute("tabindex");
+            assert_equals(el.tabIndex, expectedDefault, "attribute removed");
+        }, `removing tabindex resets ${id}.tabIndex`);
+    }
+    ]]></script>
+</svg>

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009 Alex Milowski (alex@milowski.com). All rights reserved.
- * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2010 François Sausset (sausset@gmail.com). All rights reserved.
  * Copyright (C) 2016 Igalia S.L.
  *
@@ -96,10 +96,10 @@ void MathMLElement::attributeChanged(const QualifiedName& name, const AtomString
             downcast<RenderTableCell>(*renderer()).colSpanOrRowSpanChanged();
         break;
     case AttributeNames::tabindexAttr:
-        if (newValue.isEmpty())
-            setTabIndexExplicitly(std::nullopt);
-        else if (auto optionalTabIndex = parseHTMLInteger(newValue))
+        if (auto optionalTabIndex = parseHTMLInteger(newValue))
             setTabIndexExplicitly(optionalTabIndex.value());
+        else
+            setTabIndexExplicitly(std::nullopt);
         break;
     default:
         if (auto& eventName = HTMLElement::eventNameForEventHandlerAttribute(name); !eventName.isNull()) {

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2008 Rob Buis <buis@kde.org>
- * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2024 Google Inc. All rights reserved.
  * Copyright (C) 2008 Alp Toker <alp@atoker.com>
  * Copyright (C) 2009 Cameron McCormack <cam@mcc.id.au>
@@ -536,10 +536,10 @@ void SVGElement::attributeChanged(const QualifiedName& name, const AtomString& o
         m_className->setBaseValInternal(newValue);
         break;
     case AttributeNames::tabindexAttr:
-        if (newValue.isEmpty())
-            setTabIndexExplicitly(std::nullopt);
-        else if (auto optionalTabIndex = parseHTMLInteger(newValue))
+        if (auto optionalTabIndex = parseHTMLInteger(newValue))
             setTabIndexExplicitly(optionalTabIndex.value());
+        else
+            setTabIndexExplicitly(std::nullopt);
         break;
     default:
         if (auto& eventName = HTMLElement::eventNameForEventHandlerAttribute(name); !eventName.isNull())


### PR DESCRIPTION
#### 0985315890a7ba02b5e034deaf980fc8ab177faf
<pre>
MathML and SVG elements do not reset tabIndex when tabindex is changed to an invalid value
<a href="https://bugs.webkit.org/show_bug.cgi?id=320709">https://bugs.webkit.org/show_bug.cgi?id=320709</a>
<a href="https://rdar.apple.com/183696552">rdar://183696552</a>

Reviewed by Frédéric Wang Nélar and Ryosuke Niwa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

MathMLElement::attributeChanged() and SVGElement::attributeChanged() only cleared the
explicitly set tab index when the new value was empty, leaving a previously parsed value
in place for any other value that failed to parse. So after

   &lt;mi tabindex=&quot;3&quot;&gt;.setAttribute(&quot;tabindex&quot;, &quot;abc&quot;)

mi.tabIndex kept reporting 3 instead of falling back to the default of -1.

HTML resets the tab index for any value that is not a valid integer, not just the empty
string, and both MathML Core and SVG2 defer tabindex to HTML. HTMLElement::attributeChanged()
already implements this; the MathML and SVG copies predate that fix. Match them.

Tests: imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-003.html
 imported/w3c/web-platform-tests/svg/interact/scripted/focus-tabindex-invalid-value.svg

* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-003-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/focus-tabindex-invalid-value-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/focus-tabindex-invalid-value.svg: Added.
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::attributeChanged):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/318303@main">https://commits.webkit.org/318303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39b682116236126b5df2a879914fc8c630def785

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45641 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187519 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ad4f1f75-829f-4afd-9b23-7d17b7d1ce34) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138672 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55d68dfd-bcfa-4341-b818-7559041fe67d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119135 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7f9c664f-4f9a-4181-b481-ca36bda4eb37) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40872 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39228 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151277 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38912 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35980 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44439 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43464 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189948 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147801 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39700 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52196 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147582 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42291 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118882 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50704 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13892 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50100 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50340 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50162 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->