### PR TITLE
[JSC] Scan an int token in a single pass

### DIFF
--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -2656,17 +2656,15 @@ start:
             if (m_buffer8.isEmpty()) [[likely]] {
                 auto start = m_code;
                 auto ptr = m_code + 1;
-                while (ptr < m_codeEnd && isASCIIDigit(*ptr))
+                uint64_t result = *start - '0';
+                while (ptr < m_codeEnd && isASCIIDigit(*ptr)) {
+                    result = result * 10 + (*ptr - '0');
                     ++ptr;
+                }
 
                 // The limit is 1 << (52 - 1) = 2251799813685248
                 const int numberOfDigitsForSafeInt52 = 15;
                 if (ptr < m_codeEnd && (*ptr != '.' && cannotBeIdentStart(*ptr)) && (ptr - start) <= numberOfDigitsForSafeInt52) {
-                    int64_t result = 0;
-                    auto cursor = start;
-                    do {
-                        result = result * 10 + (*cursor++) - '0';
-                    } while (cursor < ptr);
                     tokenData->doubleValue = result;
                     token = INTEGER;
                     m_code = ptr;


### PR DESCRIPTION
#### c2beca7a439f62be8619f7a86dbea17cecad5d14
<pre>
[JSC] Scan an int token in a single pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=320708">https://bugs.webkit.org/show_bug.cgi?id=320708</a>
<a href="https://rdar.apple.com/183694790">rdar://183694790</a>

Reviewed by Yusuke Suzuki.

On the fast path for scanning an int token, we scan a token it two passes. First we scan
the input to find the end of the token, then if the token is not too long, we scan it
again to accumulate the value. We can instead accumulate the value as we are scanning for
the end. The accumulated result will overflow on long tokens, but that&apos;s okay because we
only use it if the token is short.

The type of `result` is changed from signed to unsigned because a signed overflow is UB,
so with UBSan we would get false alarms on long int tokens.

* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;T&gt;::lexWithoutClearingLineTerminator):

Canonical link: <a href="https://commits.webkit.org/318347@main">https://commits.webkit.org/318347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf32a30aba3aa1cf25831dd78b4d6f0e653d1cb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187521 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5fba83f9-5973-4f10-962f-5d7e9b3ceb50) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138674 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b84f2d5b-7a1b-4a2b-81be-3909768ce82b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119137 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b601586-67d3-4c8d-8a68-655ba1c12326) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40877 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39230 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1106 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7913 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151282 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38913 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35982 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39182 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189950 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51516 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147805 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39724 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52198 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147586 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42293 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124450 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118884 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50706 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13893 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50102 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50342 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50164 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->