### PR TITLE
[MathML] Use SpaceSplitString to parse the <menclose> notation attribute instead of a hand-rolled tokenizer

### DIFF
--- a/Source/WebCore/mathml/MathMLMencloseElement.cpp
+++ b/Source/WebCore/mathml/MathMLMencloseElement.cpp
@@ -32,6 +32,7 @@
 #include "ElementInlines.h"
 #include "MathMLNames.h"
 #include "RenderMathMLMenclose.h"
+#include "SpaceSplitString.h"
 #include "StyleComputedStyle.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -110,20 +111,8 @@ void MathMLMencloseElement::parseNotationAttribute()
         return;
     }
     // We parse the list of whitespace-separated notation names.
-    StringView value = attributeWithoutSynchronization(notationAttr).string();
-    unsigned length = value.length();
-    unsigned start = 0;
-    while (start < length) {
-        if (isASCIIWhitespace(value[start])) {
-            start++;
-            continue;
-        }
-        unsigned end = start + 1;
-        while (end < length && !isASCIIWhitespace(value[end]))
-            end++;
-        addNotationFlags(value.substring(start, end - start));
-        start = end;
-    }
+    for (auto& notation : SpaceSplitString { attributeWithoutSynchronization(notationAttr), SpaceSplitString::ShouldFoldCase::No })
+        addNotationFlags(notation);
 }
 
 bool MathMLMencloseElement::hasNotation(MencloseNotationFlag notationFlag)


### PR DESCRIPTION
#### e61b71940cb9b5d2b61651c7e31e46f79062a57e
<pre>
[MathML] Use SpaceSplitString to parse the &lt;menclose&gt; notation attribute instead of a hand-rolled tokenizer
<a href="https://bugs.webkit.org/show_bug.cgi?id=320710">https://bugs.webkit.org/show_bug.cgi?id=320710</a>
<a href="https://rdar.apple.com/183698052">rdar://183698052</a>

Reviewed by Frédéric Wang Nélar.

MathMLMencloseElement::parseNotationAttribute() open-coded whitespace
splitting to walk the notation attribute. The notation attribute is an
unordered set of unique space-separated tokens, which is exactly what
SpaceSplitString models, so use it and delete the hand-rolled loop.

No change in behavior: SpaceSplitString tokenizes on isASCIIWhitespace()
just as the removed loop did, matching is still case-sensitive
(ShouldFoldCase::No), and a missing, empty, or whitespace-only attribute
still yields no notation flags (the default longdiv case is handled
before this point).

* Source/WebCore/mathml/MathMLMencloseElement.cpp:
(WebCore::MathMLMencloseElement::parseNotationAttribute):

Canonical link: <a href="https://commits.webkit.org/318306@main">https://commits.webkit.org/318306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ff349cce45d1f4f780f4be238cc85dfae535cee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187523 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2607992-5ac5-4fa6-9a9f-8c7f73fa28a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138678 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0d2a986-484d-49c5-adc9-c85a880c5421) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119141 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3fa7f850-c844-4411-b5b0-721aa32cdbb6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40875 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151280 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38917 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35984 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44443 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189952 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51518 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147807 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39701 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52200 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147588 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42295 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124452 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118887 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50708 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13897 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50104 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50344 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50166 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->