### PR TITLE
Take a StringView in MathMLPresentationElement::parseMathMLLength

### DIFF
--- a/Source/WebCore/mathml/MathMLPresentationElement.cpp
+++ b/Source/WebCore/mathml/MathMLPresentationElement.cpp
@@ -175,7 +175,7 @@ MathMLElement::Length MathMLPresentationElement::parseNamedSpace(StringView stri
     return length;
 }
 
-MathMLElement::Length MathMLPresentationElement::parseMathMLLength(const String& string, bool acceptLegacyMathMLLengths)
+MathMLElement::Length MathMLPresentationElement::parseMathMLLength(StringView string, bool acceptLegacyMathMLLengths)
 {
     // The regular expression from the MathML Relax NG schema is as follows:
     //
@@ -185,8 +185,7 @@ MathMLElement::Length MathMLPresentationElement::parseMathMLLength(const String&
     // Instead, we just use isASCIIWhitespace and toFloat to parse these parts.
 
     // We first skip whitespace from both ends of the string.
-    StringView stringView = string;
-    StringView trimmedLength = stringView.trim(isASCIIWhitespaceWithoutFF<char16_t>);
+    StringView trimmedLength = string.trim(isASCIIWhitespaceWithoutFF<char16_t>);
 
     if (trimmedLength.isEmpty())
         return Length();

--- a/Source/WebCore/mathml/MathMLPresentationElement.h
+++ b/Source/WebCore/mathml/MathMLPresentationElement.h
@@ -46,7 +46,7 @@ protected:
     static std::optional<bool> toOptionalBool(const BooleanValue& value) { return value == BooleanValue::Default ? std::nullopt : std::optional<bool>(value == BooleanValue::True); }
     const BooleanValue& NODELETE cachedBooleanAttribute(const QualifiedName&, std::optional<BooleanValue>&);
 
-    static Length parseMathMLLength(const String&, bool acceptLegacyMathMLLengths);
+    static Length parseMathMLLength(StringView, bool acceptLegacyMathMLLengths);
     const Length& cachedMathMLLength(const QualifiedName&, std::optional<Length>&);
 
     virtual bool acceptsLegacyMathVariantAttribute() { return false; }


### PR DESCRIPTION
#### 4cf1ce000dad0bd6ebc8fa09c572997ce0a20b42
<pre>
Take a StringView in MathMLPresentationElement::parseMathMLLength
<a href="https://bugs.webkit.org/show_bug.cgi?id=320711">https://bugs.webkit.org/show_bug.cgi?id=320711</a>
<a href="https://rdar.apple.com/183698156">rdar://183698156</a>

Reviewed by Chris Dumez and Frédéric Wang Nélar.

parseMathMLLength took a const String&amp; only to immediately convert it to a
StringView and trim it, unlike its two sibling helpers parseNumberAndUnit and
parseNamedSpace, which already take StringView. Take a StringView directly and
drop the intermediate local.

All three call sites pass an AtomString returned by
attributeWithoutSynchronization(), which converts to StringView just as it did
to const String&amp;, so no string is allocated or copied either way. This just
lets the function accept a StringView caller without materializing a String.

* Source/WebCore/mathml/MathMLPresentationElement.cpp:
(WebCore::MathMLPresentationElement::parseMathMLLength):
* Source/WebCore/mathml/MathMLPresentationElement.h:

Canonical link: <a href="https://commits.webkit.org/318309@main">https://commits.webkit.org/318309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1488b31dcca5f2214fd721aee55182a718c47dec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187524 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a90e74b0-d93c-43db-996a-38a0e16370ab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138679 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42e1e9bb-c5cd-4251-b919-95aa577a32c3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119142 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e016ea84-3b89-480e-8c8f-efc28df09fe1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40878 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38919 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35985 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44444 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43470 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189953 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51519 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147808 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39703 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52201 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147589 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42296 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124453 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118888 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50709 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13899 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50105 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50345 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50167 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->