### PR TITLE
[MathML] Remove duplicated mathvariant invalidation from MathMLMathElement::attributeChanged

### DIFF
--- a/Source/WebCore/mathml/MathMLMathElement.cpp
+++ b/Source/WebCore/mathml/MathMLMathElement.cpp
@@ -31,7 +31,6 @@
 #if ENABLE(MATHML)
 
 #include "ContainerNodeInlines.h"
-#include "MathMLNames.h"
 #include "RenderMathMLMath.h"
 #include "Settings.h"
 #include "StyleComputedStyle.h"
@@ -40,8 +39,6 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MathMLMathElement);
-
-using namespace MathMLNames;
 
 inline MathMLMathElement::MathMLMathElement(const QualifiedName& tagName, Document& document)
     : MathMLRowElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
@@ -56,17 +53,6 @@ Ref<MathMLMathElement> MathMLMathElement::create(const QualifiedName& tagName, D
 RenderPtr<RenderElement> MathMLMathElement::createElementRenderer(Style::ComputedStyle&& style, const RenderTreePosition&)
 {
     return createRenderer<RenderMathMLMath>(*this, WTF::move(style));
-}
-
-void MathMLMathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
-{
-    if (name == mathvariantAttr && acceptsLegacyMathVariantAttribute()) {
-        m_mathVariant = std::nullopt;
-        if (renderer())
-            MathMLStyle::resolveMathMLStyleTree(renderer());
-    }
-
-    MathMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void MathMLMathElement::didAttachRenderers()

--- a/Source/WebCore/mathml/MathMLMathElement.h
+++ b/Source/WebCore/mathml/MathMLMathElement.h
@@ -41,7 +41,6 @@ public:
 
 private:
     MathMLMathElement(const QualifiedName& tagName, Document&);
-    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void didAttachRenderers() final;
 
     bool acceptsLegacyMathVariantAttribute() final;


### PR DESCRIPTION
#### 4629e1b12aed6c812c42f21432241798bf8e4a52
<pre>
[MathML] Remove duplicated mathvariant invalidation from MathMLMathElement::attributeChanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=320712">https://bugs.webkit.org/show_bug.cgi?id=320712</a>
<a href="https://rdar.apple.com/183698921">rdar://183698921</a>

Reviewed by Frédéric Wang Nélar.

MathMLMathElement::attributeChanged() reproduced the body of
MathMLPresentationElement::attributeChanged() verbatim and then chained
straight to MathMLElement::attributeChanged() so the invalidation would
not run twice.

MathMLRowElement does not override attributeChanged(), so the inherited
implementation for &lt;math&gt; is MathMLPresentationElement&apos;s, which is
identical. acceptsLegacyMathVariantAttribute() is virtual, so the base
implementation still dispatches to MathMLMathElement&apos;s override. The
whole override is therefore redundant and is removed, along with the
now-unused MathMLNames include and using-directive.

No change in behavior.

* Source/WebCore/mathml/MathMLMathElement.cpp:
(WebCore::MathMLMathElement::attributeChanged): Deleted.
* Source/WebCore/mathml/MathMLMathElement.h:

Canonical link: <a href="https://commits.webkit.org/318310@main">https://commits.webkit.org/318310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88ec902440a7c7e3406916f320cccff3ff4bbe2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187525 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42527d91-9a7b-48fe-8579-86914b37376b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138680 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e6e73ad-53bf-4425-9d4c-72e7d58f4370) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119143 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eba8cbe0-199c-4486-9705-a80d440522fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40879 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39235 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151284 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38921 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35986 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189954 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51520 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147809 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39704 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52202 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147590 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42298 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124454 "Build is in progress. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Found 27123 issues") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118891 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50710 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13901 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50106 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50346 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50168 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->