### PR TITLE
XMLHttpRequest::memoryCost() ignores binary response data

### DIFF
--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -789,9 +789,13 @@ void XMLHttpRequest::abortError()
 
 size_t XMLHttpRequest::memoryCost() const
 {
-    if (readyState() == DONE)
-        return m_responseBuilder.length() * 2;
-    return 0;
+    if (readyState() != DONE)
+        return 0;
+
+    // Text responses are decoded into m_responseBuilder, binary ones (arraybuffer / blob) are
+    // accumulated in m_binaryResponseBuilder. Only one of the two is populated for a given
+    // response type.
+    return m_responseBuilder.length() * 2 + m_binaryResponseBuilder.size();
 }
 
 ExceptionOr<void> XMLHttpRequest::overrideMimeType(const String& mimeType)


### PR DESCRIPTION
#### fe933794faba09e65adac61b0f862560186a8247
<pre>
XMLHttpRequest::memoryCost() ignores binary response data
<a href="https://bugs.webkit.org/show_bug.cgi?id=320713">https://bugs.webkit.org/show_bug.cgi?id=320713</a>
<a href="https://rdar.apple.com/183699140">rdar://183699140</a>

Reviewed by Chris Dumez.

memoryCost() only counted m_responseBuilder, the decoded-text buffer.
&quot;arraybuffer&quot; and &quot;blob&quot; responses accumulate into m_binaryResponseBuilder
instead, so they reported 0 to Heap::reportExtraMemoryAllocated() at DONE
and applied no GC pressure. Sum both buffers; didReceiveData() populates
exactly one of them per response type, so nothing is double counted.

No new tests, as memoryCost() has no web-exposed observable -- its only
consumer is a JSC GC heuristic.

* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::memoryCost const):

Canonical link: <a href="https://commits.webkit.org/318421@main">https://commits.webkit.org/318421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/beef6ec72093e1863cef470998a2160a396dd064

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187526 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141163 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aeff94a2-818e-4e79-9521-d62c1b93b5e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138681 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8f24c56b-c0cf-43fa-8f27-178baf527eab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119144 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7dd5d58-f3f6-4562-a760-9a4100c40a2e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40880 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39236 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151285 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38920 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35987 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189955 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51521 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147810 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39775 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52203 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147591 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42300 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124455 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118892 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50711 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13900 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Uploaded test results") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50107 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50347 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50169 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->