### PR TITLE
[Custom Highlight] ::highlight() pseudo-elements should inherit from the parent element's highlight.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5687,12 +5687,6 @@ webkit.org/b/217931 imported/w3c/web-platform-tests/html/semantics/scripting-1/t
 webkit.org/b/217931 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/move-back-iframe-success-external-module.html [ Pass Failure ]
 webkit.org/b/217931 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/move-back-iframe-success-inline-classic.html [ Pass Failure ]
 
-webkit.org/b/220325 imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-cascade.html [ ImageOnlyFailure ]
-
-# Tests need updating relating to Highlight Spec
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-inheritance-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-inheritance-002.html [ ImageOnlyFailure ]
-
 http/tests/webgl/1.0.x/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html [ Skip ]
 http/tests/webgl/2.0.y/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html [ Skip ]
 http/tests/webgl/2.0.y/conformance2/textures/misc/origin-clean-conformance-offscreencanvas.html [ Skip ]

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1934,6 +1934,9 @@ const Style::ComputedStyle* RenderElement::lazyPseudoElementStyle(const Style::P
 
 std::unique_ptr<Style::ComputedStyle> RenderElement::resolvePseudoElementStyle(const Style::PseudoElementRequest& pseudoElementRequest, const Style::ComputedStyle* parentStyle, const Style::ComputedStyle* ownStyle) const
 {
+    if (pseudoElementRequest.type() == PseudoElementType::Highlight && !ownStyle && !isAnonymous() && element())
+        return resolveHighlightPseudoElementStyleWithInheritance(pseudoElementRequest, parentStyle ? *parentStyle : style());
+
     if (allPublicPseudoElementTypes.contains(pseudoElementRequest.type()) && !ownStyle && !style().hasPseudoStyle(pseudoElementRequest.type()))
         return nullptr;
 
@@ -1955,6 +1958,33 @@ std::unique_ptr<Style::ComputedStyle> RenderElement::resolvePseudoElementStyle(c
     Style::loadPendingResources(*resolvedStyle->style, protect(document()), element.ptr());
 
     return WTF::move(resolvedStyle->style);
+}
+
+std::unique_ptr<Style::ComputedStyle> RenderElement::resolveHighlightPseudoElementStyleWithInheritance(const Style::PseudoElementRequest& pseudoElementRequest, const Style::ComputedStyle& rootParentStyle) const
+{
+    if (isAnonymous() || !element())
+        return nullptr;
+
+    Ref element = *this->element();
+    Ref styleResolver = element->styleResolver();
+
+    if (auto resolvedStyle = styleResolver->styleForPseudoElement(element, pseudoElementRequest, { &rootParentStyle })) {
+        Style::loadPendingResources(*resolvedStyle->style, protect(document()), element.ptr());
+        return WTF::move(resolvedStyle->style);
+    }
+
+    RefPtr parentElement = element->parentElement();
+    if (!parentElement)
+        return nullptr;
+    CheckedPtr parentRenderer = parentElement->renderer();
+    if (!parentRenderer)
+        return nullptr;
+
+    auto parentHighlightStyle = parentRenderer->resolveHighlightPseudoElementStyleWithInheritance(pseudoElementRequest, parentRenderer->style());
+    if (!parentHighlightStyle)
+        return nullptr;
+
+    return Style::ComputedStyle::clonePtr(*parentHighlightStyle);
 }
 
 RenderElement* RenderElement::rendererForPseudoStyleAcrossShadowBoundary() const

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -93,6 +93,7 @@ public:
     // Resolves and caches the style for a lazily-resolved pseudo-element.
     const Style::ComputedStyle* lazyPseudoElementStyle(const Style::PseudoElementIdentifier&, const Style::ComputedStyle* parentStyle = nullptr) const LIFETIME_BOUND;
     std::unique_ptr<Style::ComputedStyle> resolvePseudoElementStyle(const Style::PseudoElementRequest&, const Style::ComputedStyle* parentStyle = nullptr, const Style::ComputedStyle* ownStyle = nullptr) const;
+    std::unique_ptr<Style::ComputedStyle> resolveHighlightPseudoElementStyleWithInheritance(const Style::PseudoElementRequest&, const Style::ComputedStyle& rootParentStyle) const;
 
     // This is null for anonymous renderers.
     inline Element* element() const; // Defined in RenderElementInlines.h


### PR DESCRIPTION
#### 2b33e6ff78f6d7c79d1a8ae7e693630c5fec7148
<pre>
[Custom Highlight] ::highlight() pseudo-elements should inherit from the parent element&apos;s highlight.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320716">https://bugs.webkit.org/show_bug.cgi?id=320716</a>
<a href="https://rdar.apple.com/183702060">rdar://183702060</a>

Reviewed by NOBODY (OOPS!).

Per the highlight cascade (<a href="https://drafts.csswg.org/css-pseudo-4/#highlight-cascade)">https://drafts.csswg.org/css-pseudo-4/#highlight-cascade)</a>, a
highlight pseudo-element inherits from the same-named highlight pseudo-element of its
originating element&apos;s parent, rather than from the originating element. A highlighted
descendant with no ::highlight() rule of its own still takes the highlight styles
(including normally non-inherited properties such as background-color) established by an
ancestor&apos;s ::highlight().

WebKit previously resolved each element&apos;s highlight pseudo-element against the element&apos;s own
style. As a result, a highlighted descendant without a matching ::highlight() rule got no
highlight style at all, and scoped highlight rules did not propagate down the element tree.

Resolve a highlight pseudo-element by walking the element tree: if the element matches its
own ::highlight() rule, resolve it normally (against the element&apos;s own font and resolution
context); otherwise inherit the parent element&apos;s highlight computed style. This keeps
font/viewport/logical length resolution correct for elements that carry their own rule while
letting rule-less descendants inherit the ancestor&apos;s highlight.

LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-cascade.html:
LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-inheritance-001.html:
LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-inheritance-002.html:

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::resolvePseudoElementStyle const):
(WebCore::RenderElement::resolveHighlightPseudoElementStyleWithInheritance const):
* Source/WebCore/rendering/RenderElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b33e6ff78f6d7c79d1a8ae7e693630c5fec7148

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51859 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45653 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187531 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141168 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2886d60b-b471-471c-b24d-11180ebf82c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138687 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96378 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd7b00fd-3937-41f5-8f0c-0969182709cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119150 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50f0ae62-5b42-41c4-b77b-a1ab6bc789ac) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40887 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39244 "Build is in progress. Recent messages:Running configuration; Running checkout-pull-request; 2 api tests failed or timed out; 1 api test failed or timed out") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151292 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38929 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35992 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189960 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147817 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52208 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147598 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42307 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124460 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118903 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50716 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13909 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50112 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50352 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50174 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->