### PR TITLE
[YARR] v-mode class set operations produce stale character widths

### DIFF
--- a/JSTests/stress/regexp-v-flag-class-set-op-character-widths.js
+++ b/JSTests/stress/regexp-v-flag-class-set-op-character-widths.js
@@ -1,0 +1,45 @@
+function shouldBe(actual, expected, description) {
+    if (actual !== expected)
+        throw new Error(`${description}: expected ${expected} but got ${actual}`);
+}
+
+function test(pattern, input, expected) {
+    const regexp = new RegExp(pattern, "v");
+    for (let i = 0; i < 1e4; ++i)
+        shouldBe(regexp.test(input), expected, `/${pattern}/v.test(${JSON.stringify(input)})`);
+}
+
+// A nested class-set operand merged via union.
+test("^[\\u{10001}-\\u{10002}\\p{Ll}]$", "a", true);
+test("^[\\u{10001}-\\u{10002}\\p{Ll}]$", "\u{10001}", true);
+test("^[\\u{10001}-\\u{10002}\\p{Ll}]$", "A", false);
+test("^[[\\u{10000}-\\u{10002}][\\u{ff}]\\u{ff}]$", "\u{10000}", true);
+test("^[[\\u{10000}-\\u{10002}][\\u{ff}]\\u{ff}]$", "\u{ff}", true);
+test("^[[\\u{10000}-\\u{10002}][\\u{ff}]\\u{ff}]$", "a", false);
+
+// Same as above, but with quantifiers so that the fixed-count fast paths are also exercised.
+test("^[\\u{10001}-\\u{10002}\\p{Ll}]{3}$", "a\u{10001}b", true);
+test("^[\\u{10001}-\\u{10002}\\p{Ll}]{3}$", "abc", true);
+test("^[\\u{10001}-\\u{10002}\\p{Ll}]{3}$", "\u{10001}\u{10002}\u{10001}", true);
+test("^[\\u{10001}-\\u{10002}\\p{Ll}]{3}$", "ab", false);
+
+// A single non-BMP character coming from a one character string disjunction.
+test("^[\\q{\u{10000}}a]$", "\u{10000}", true);
+test("^[\\q{\u{10000}}a]$", "a", true);
+test("^[\\q{\u{10000}}a]$", "\u{10001}", false);
+
+// Intersection and subtraction can narrow the character widths of the resulting class.
+test("^[[a\\u{10000}]&&[a-z]]$", "a", true);
+test("^[[a\\u{10000}]&&[a-z]]$", "\u{10000}", false);
+test("^[[a\\u{10000}]--[a-z]]$", "\u{10000}", true);
+test("^[[a\\u{10000}]--[a-z]]$", "a", false);
+test("^[[a\\u{10000}]--[\\u{10000}-\\u{10001}]]$", "a", true);
+test("^[[a\\u{10000}]--[\\u{10000}-\\u{10001}]]$", "\u{10000}", false);
+
+// A negated nested class covers both BMP and non-BMP code points.
+test("^[[^a]]$", "b", true);
+test("^[[^a]]$", "\u{10000}", true);
+test("^[[^a]]$", "a", false);
+test("^[[^\\u{10000}]]$", "a", true);
+test("^[[^\\u{10000}]]$", "\u{10001}", true);
+test("^[[^\\u{10000}]]$", "\u{10000}", false);

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -53,7 +53,6 @@ public:
         , m_mayContainStrings(false)
         , m_invertedStrings(false)
         , m_compileMode(compileMode)
-        , m_characterWidths(CharacterClassWidths::Unknown)
         , m_canonicalMode(compileMode == CompileMode::Legacy ? CanonicalMode::UCS2 : CanonicalMode::Unicode)
     {
     }
@@ -69,7 +68,6 @@ public:
         m_anyCharacter = false;
         m_mayContainStrings = false;
         m_invertedStrings = false;
-        m_characterWidths = CharacterClassWidths::Unknown;
     }
 
     void NODELETE combiningSetOp(CharacterClassSetOp setOp)
@@ -476,12 +474,11 @@ public:
         characterClass->m_matches32.swap(m_matches32);
         characterClass->m_ranges32.swap(m_ranges32);
         characterClass->m_anyCharacter = anyCharacter();
-        characterClass->m_characterWidths = characterWidths();
+        characterClass->m_characterWidths = characterWidths(*characterClass);
 
         buildLatin1TableIfBeneficial(*characterClass);
 
         m_anyCharacter = false;
-        m_characterWidths = CharacterClassWidths::Unknown;
 
         return characterClass;
     }
@@ -540,8 +537,6 @@ private:
         unsigned pos = 0;
         unsigned range = matches.size();
 
-        m_characterWidths |= (U_IS_BMP(ch) ? CharacterClassWidths::HasBMPChars : CharacterClassWidths::HasNonBMPChars);
-
         // binary chop, find position to insert char.
         while (range) {
             unsigned index = range >> 1;
@@ -587,11 +582,6 @@ private:
 
     void addSortedRange(Vector<CharacterRange>& ranges, char32_t lo, char32_t hi)
     {
-        if (U_IS_BMP(lo))
-            m_characterWidths |= CharacterClassWidths::HasBMPChars;
-        if (!U_IS_BMP(hi))
-            m_characterWidths |= CharacterClassWidths::HasNonBMPChars;
-
         auto iter = std::lower_bound(ranges.begin(), ranges.end(), lo,
             [](const CharacterRange& range, char32_t value) {
                 return static_cast<uint64_t>(range.end) + 1 < value;
@@ -1115,14 +1105,24 @@ private:
             m_anyCharacter = true;
     }
 
-    bool hasNonBMPCharacters()
+    static CharacterClassWidths characterWidths(const CharacterClass& characterClass)
     {
-        return m_characterWidths & CharacterClassWidths::HasNonBMPChars;
-    }
-
-    CharacterClassWidths NODELETE characterWidths()
-    {
-        return m_characterWidths;
+        CharacterClassWidths widths = CharacterClassWidths::Unknown;
+        if (!characterClass.m_matches8.isEmpty() || !characterClass.m_ranges8.isEmpty())
+            widths |= CharacterClassWidths::HasBMPChars;
+        if (!characterClass.m_matches32.isEmpty()) {
+            if (U_IS_BMP(characterClass.m_matches32.first()))
+                widths |= CharacterClassWidths::HasBMPChars;
+            if (!U_IS_BMP(characterClass.m_matches32.last()))
+                widths |= CharacterClassWidths::HasNonBMPChars;
+        }
+        if (!characterClass.m_ranges32.isEmpty()) {
+            if (U_IS_BMP(characterClass.m_ranges32.first().begin))
+                widths |= CharacterClassWidths::HasBMPChars;
+            if (!U_IS_BMP(characterClass.m_ranges32.last().end))
+                widths |= CharacterClassWidths::HasNonBMPChars;
+        }
+        return widths;
     }
 
     bool NODELETE anyCharacter()
@@ -1139,8 +1139,6 @@ private:
 
     CharacterClassSetOp m_setOp { CharacterClassSetOp::Default };
     CompileMode m_compileMode;
-    CharacterClassWidths m_characterWidths;
-    
     CanonicalMode m_canonicalMode;
 
     Vector<Vector<char32_t>> m_strings;


### PR DESCRIPTION
#### 540f0965c655f2b6a78683c12ea43fd269978886
<pre>
[YARR] v-mode class set operations produce stale character widths
<a href="https://bugs.webkit.org/show_bug.cgi?id=320720">https://bugs.webkit.org/show_bug.cgi?id=320720</a>

Reviewed by Yusuke Suzuki.

CharacterClassConstructor tracked m_characterWidths incrementally in
addSorted / addSortedRange, but the UnicodeSets set-op and inversion paths
(latin1Op, nonLatin1OpSorted, invertMatches) rebuild the match / range
vectors by swapping in new ones without touching the width bits. So the
bits went stale: unions dropped the rhs widths (wrong fixed offsets and an
assertion failure in hasSharedLeadSurrogate), and intersections /
subtractions left over-wide widths behind.

    new RegExp(&quot;^[\\u{10001}-\\u{10002}\\p{Ll}]$&quot;, &quot;v&quot;).test(&quot;a&quot;)
    // was false

Instead, derive CharacterClass::m_characterWidths from the final vectors
in charClass(). The widths are just an O(1) summary of the sorted match /
range vectors (emptiness plus first / last code point), so deriving them
once at the constructor&apos;s exit is cheaper and simpler than keeping an
incremental copy in sync at every set-op site.

Test: JSTests/stress/regexp-v-flag-class-set-op-character-widths.js

* JSTests/stress/regexp-v-flag-class-set-op-character-widths.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::CharacterClassConstructor):
(JSC::Yarr::CharacterClassConstructor::reset):
(JSC::Yarr::CharacterClassConstructor::charClass):
(JSC::Yarr::CharacterClassConstructor::addSorted):
(JSC::Yarr::CharacterClassConstructor::addSortedRange):
(JSC::Yarr::CharacterClassConstructor::characterWidths):
(JSC::Yarr::CharacterClassConstructor::hasNonBMPCharacters): Deleted.

Canonical link: <a href="https://commits.webkit.org/318416@main">https://commits.webkit.org/318416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a22bc45f2f478f6aec9f6127afe585f7c52ed32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141169 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138685 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119148 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40884 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39243 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1117 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7926 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38926 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35993 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39193 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189961 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51527 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147815 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39771 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52209 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147596 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42304 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124461 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118904 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50717 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13906 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->