### PR TITLE
[YARR] Do not filter the contents of a lookbehind in `optimizeBOL`

### DIFF
--- a/JSTests/stress/regexp-lookahead-with-bol-inside-lookbehind-is-not-dropped.js
+++ b/JSTests/stress/regexp-lookahead-with-bol-inside-lookbehind-is-not-dropped.js
@@ -1,0 +1,43 @@
+// A lookbehind walks back from wherever the outer match starts, so a ^ inside it can reach the start
+// of the input even when the match itself does not start there. The once-through/loop split in
+// optimizeBOL() must therefore not filter ^-anchored alternatives out of anything nested in a
+// lookbehind, including a lookahead, which is parsed as Forward again. See copyTerm() in
+// YarrPattern.cpp. The bug is in Yarr's pattern analysis, so it reproduces in every tier; the loop
+// only makes sure the JIT tiers agree.
+
+function shouldBe(actual, expected, context) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected + " for " + context);
+}
+
+function check(re, string, expectedTest, expectedMatch, expectedIndex) {
+    const context = re + " against " + JSON.stringify(string);
+    shouldBe(re.test(string), expectedTest, context);
+    const result = re.exec(string);
+    if (expectedMatch === null) {
+        shouldBe(result, null, context);
+        return;
+    }
+    shouldBe(result[0], expectedMatch, context);
+    shouldBe(result.index, expectedIndex, context);
+}
+
+function step() {
+    check(/(?<=(?=^)a)b|c/, "ab", true, "b", 1);
+    check(/(?<=(?=^)a)b|c/, "abc", true, "b", 1);
+    check(/(?<=(?=^)a)b|c/, "xab", false, null);
+    check(/(?<=(?=^)a)b|c/, "xabc", true, "c", 3);
+    check(/(?<=(?=^)a)b|c/, "b", false, null);
+    check(/c|(?<=(?=^)a)b/, "ab", true, "b", 1);
+    check(/(?<=(?:(?=^))a)b|c/, "ab", true, "b", 1);
+    check(/(?<=((?=^)a))b|c/, "ab", true, "b", 1);
+    check(/(?<=(?=^)aa)b|c/, "aab", true, "b", 2);
+    check(/(?<=(?=^|zz)a)b|c/, "ab", true, "b", 1);
+    shouldBe("ab".search(/(?<=(?=^)a)b|c/), 1, "search");
+    shouldBe("ab".replace(/(?<=(?=^)a)b|c/, "Z"), "aZ", "replace at 1");
+    shouldBe("cab".replace(/(?<=(?=^)a)b|c/, "Z"), "Zab", "replace at 0");
+    shouldBe(JSON.stringify("ab ab".match(/(?<=(?=^)a)b|c/g)), '["b"]', "match global");
+}
+
+for (var i = 0; i < testLoopCount; ++i)
+    step();

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1719,8 +1719,10 @@ public:
         std::unique_ptr<PatternDisjunction> newDisjunction;
         for (unsigned alt = 0; alt < disjunction->m_alternatives.size(); ++alt) {
             PatternAlternative* alternative = disjunction->m_alternatives[alt].get();
-            if (filterStartsWithBOL && alternative->m_startsWithBOL && alternative->matchDirection() != Backward)
+            if (filterStartsWithBOL && alternative->m_startsWithBOL) {
+                ASSERT(alternative->matchDirection() == Forward);
                 continue;
+            }
 
             auto copiedTerms = copyTerms(alternative, filterStartsWithBOL);
             if (!copiedTerms)
@@ -1785,7 +1787,7 @@ public:
         if ((term.type != PatternTerm::Type::ParenthesesSubpattern) && (term.type != PatternTerm::Type::ParentheticalAssertion))
             return PatternTerm(term);
         
-        if (auto* newDisjunction = copyDisjunction(term.parentheses.disjunction, filterStartsWithBOL && !term.invert())) {
+        if (auto* newDisjunction = copyDisjunction(term.parentheses.disjunction, filterStartsWithBOL && !term.invert() && term.matchDirection() == Forward)) {
             PatternTerm termCopy = term;
             termCopy.parentheses.disjunction = newDisjunction;
             m_pattern.m_hasCopiedParenSubexpressions = true;


### PR DESCRIPTION
#### 29d016fbd9f466795ace2e38d9508523633202e7
<pre>
[YARR] Do not filter the contents of a lookbehind in `optimizeBOL`
<a href="https://bugs.webkit.org/show_bug.cgi?id=320722">https://bugs.webkit.org/show_bug.cgi?id=320722</a>

Reviewed by Yusuke Suzuki.

    /(?&lt;=(?=^)a)b|c/.exec(&quot;ab&quot;) // null, should be [&quot;b&quot;]

optimizeBOL()&apos;s loop copy drops alternatives that can only match at the start of
the input. A lookbehind walks backwards from the match position, so a ^ inside it
can reach position 0 even when the match itself starts later.

copyDisjunction() exempted Backward alternatives, but a lookahead nested inside a
lookbehind is parsed as Forward again, so its ^-anchored alternative was filtered
out and the whole lookbehind-containing alternative got dropped from the loop copy.

copyTerm() now stops filtering at any Backward term instead, which subsumes the
per-alternative exemption in copyDisjunction().

Test: JSTests/stress/regexp-lookahead-with-bol-inside-lookbehind-is-not-dropped.js

* JSTests/stress/regexp-lookahead-with-bol-inside-lookbehind-is-not-dropped.js: Added.
(shouldBe):
(check):
(step):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::copyDisjunction):
(JSC::Yarr::YarrPatternConstructor::copyTerm):

Canonical link: <a href="https://commits.webkit.org/318418@main">https://commits.webkit.org/318418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58d9e878527c175d68c8a664c74e46415537b4d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39772 "Built successfully and passed tests") | [⏳ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->