### PR TITLE
Implement child model loading IPC for spatial portals

### DIFF
--- a/LayoutTests/spatial-css/resources/spatial-portal-utils.js
+++ b/LayoutTests/spatial-css/resources/spatial-portal-utils.js
@@ -1,0 +1,16 @@
+const createPortal = test => {
+    const portal = document.createElement("div");
+    portal.className = "portal";
+    document.body.appendChild(portal);
+    test.add_cleanup(() => portal.remove());
+    return portal;
+};
+
+const appendModel = (portal, asset) => {
+    const model = document.createElement("model");
+    portal.appendChild(model);
+    const source = document.createElement("source");
+    source.src = `../model-element/resources/${asset}`;
+    model.appendChild(source);
+    return model;
+};

--- a/LayoutTests/spatial-css/spatial-portal-multi-model-error-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-multi-model-error-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A failing <model> in a spatial portal does not prevent its sibling from loading
+

--- a/LayoutTests/spatial-css/spatial-portal-multi-model-error.html
+++ b/LayoutTests/spatial-css/spatial-portal-multi-model-error.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+// error-case.usdz downloads successfully but cannot be decoded, so the failure is reported by the
+// model player rather than by the resource load, and `ready` rejects with an AbortError.
+promise_test(async t => {
+    const portal = createPortal(t);
+    const valid = appendModel(portal, "cube.usdz");
+    const invalid = appendModel(portal, "error-case.usdz");
+
+    await promise_rejects_dom(t, "AbortError", invalid.ready, "the undecodable model rejects its ready promise");
+    await valid.ready;
+
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 2, "the failed load leaves both models registered with the portal");
+    assert_equals(internals.numberOfLoadedModelsInSpatialPortal(portal), 1, "only the valid model is loaded");
+}, "A failing <model> in a spatial portal does not prevent its sibling from loading");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-multi-model-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-multi-model-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Two <model>s nested in a spatial portal both load
+PASS Two <model>s with the same source both load in a spatial portal
+

--- a/LayoutTests/spatial-css/spatial-portal-multi-model-insert-remove-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-multi-model-insert-remove-expected.txt
@@ -1,0 +1,4 @@
+
+PASS A <model> added to a spatial portal that already hosts models loads as well
+PASS Removing one of two <model>s from a spatial portal leaves its sibling loaded
+

--- a/LayoutTests/spatial-css/spatial-portal-multi-model-insert-remove.html
+++ b/LayoutTests/spatial-css/spatial-portal-multi-model-insert-remove.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const first = appendModel(portal, "cube.usdz");
+    const second = appendModel(portal, "cube.usdz");
+    await Promise.all([first.ready, second.ready]);
+
+    const third = appendModel(portal, "2x2x2-center.usdz");
+    await third.ready;
+
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 3, "the portal hosts the dynamically added model too");
+}, "A <model> added to a spatial portal that already hosts models loads as well");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const staying = appendModel(portal, "cube.usdz");
+    const removed = appendModel(portal, "cube.usdz");
+    await Promise.all([staying.ready, removed.ready]);
+
+    removed.remove();
+    await UIHelper.ensureStablePresentationUpdate();
+
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 1, "the portal still hosts the remaining model");
+    await staying.ready;
+}, "Removing one of two <model>s from a spatial portal leaves its sibling loaded");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-multi-model-move-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-multi-model-move-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Moving one of two <model>s out of a spatial portal leaves its sibling hosted
+

--- a/LayoutTests/spatial-css/spatial-portal-multi-model-move.html
+++ b/LayoutTests/spatial-css/spatial-portal-multi-model-move.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const portalA = createPortal(t);
+    const portalB = createPortal(t);
+
+    const staying = appendModel(portalA, "cube.usdz");
+    const moving = appendModel(portalA, "cube.usdz");
+    await Promise.all([staying.ready, moving.ready]);
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portalA), 2, "portal A hosts both models");
+
+    portalB.appendChild(moving);
+    await UIHelper.ensureStablePresentationUpdate();
+
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portalA), 1, "portal A still hosts the model that stayed");
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portalB), 1, "portal B hosts the moved model");
+}, "Moving one of two <model>s out of a spatial portal leaves its sibling hosted");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-multi-model-source-change-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-multi-model-source-change-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Changing the source of one <model> in a spatial portal leaves its sibling loaded
+PASS Clearing the source of one <model> in a spatial portal unloads only that model
+

--- a/LayoutTests/spatial-css/spatial-portal-multi-model-source-change.html
+++ b/LayoutTests/spatial-css/spatial-portal-multi-model-source-change.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const changing = appendModel(portal, "cube.usdz");
+    const untouched = appendModel(portal, "cube.usdz");
+    await Promise.all([changing.ready, untouched.ready]);
+
+    const untouchedReadyBeforeChange = untouched.ready;
+    changing.querySelector("source").src = "../model-element/resources/2x2x2-center.usdz";
+    await changing.ready;
+
+    assert_equals(untouched.ready, untouchedReadyBeforeChange, "the sibling's ready promise was not reset");
+    await untouched.ready;
+    assert_equals(internals.numberOfLoadedModelsInSpatialPortal(portal), 2, "both models are loaded after the source swap");
+}, "Changing the source of one <model> in a spatial portal leaves its sibling loaded");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const unloading = appendModel(portal, "cube.usdz");
+    const untouched = appendModel(portal, "cube.usdz");
+    await Promise.all([unloading.ready, untouched.ready]);
+
+    const unloadingReadyBeforeChange = unloading.ready;
+    const untouchedReadyBeforeChange = untouched.ready;
+    const errored = new Promise(resolve => unloading.addEventListener("error", resolve, { once: true }));
+
+    unloading.querySelector("source").remove();
+    await errored;
+
+    assert_not_equals(unloading.ready, unloadingReadyBeforeChange, "the unsourced model's ready promise was replaced");
+    assert_equals(untouched.ready, untouchedReadyBeforeChange, "the sibling's ready promise was not reset");
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 2, "the unsourced model stays registered with the portal");
+    assert_equals(internals.numberOfLoadedModelsInSpatialPortal(portal), 1, "only the sibling is still loaded");
+    await untouched.ready;
+}, "Clearing the source of one <model> in a spatial portal unloads only that model");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-multi-model.html
+++ b/LayoutTests/spatial-css/spatial-portal-multi-model.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const first = appendModel(portal, "cube.usdz");
+    const second = appendModel(portal, "2x2x2-center.usdz");
+
+    let firstLoadFired = false;
+    let secondLoadFired = false;
+    first.addEventListener("load", () => firstLoadFired = true, { once: true });
+    second.addEventListener("load", () => secondLoadFired = true, { once: true });
+
+    await Promise.all([first.ready, second.ready]);
+
+    assert_true(firstLoadFired, "load event fired on the first child model");
+    assert_true(secondLoadFired, "load event fired on the second child model");
+    assert_equals(first.getBoundingClientRect().width, 0, "the first delegated <model> has no box of its own");
+    assert_equals(second.getBoundingClientRect().width, 0, "the second delegated <model> has no box of its own");
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 2, "the portal hosts both nested models");
+}, "Two <model>s nested in a spatial portal both load");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const first = appendModel(portal, "cube.usdz");
+    const second = appendModel(portal, "cube.usdz");
+
+    await Promise.all([first.ready, second.ready]);
+
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 2, "models sharing a source are hosted independently");
+}, "Two <model>s with the same source both load in a spatial portal");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-scroll-to-load.html
+++ b/LayoutTests/spatial-css/spatial-portal-scroll-to-load.html
@@ -24,11 +24,11 @@ promise_test(async t => {
     model.appendChild(source);
 
     await UIHelper.ensureStablePresentationUpdate();
-    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 0, "portal does not host its model while off-screen");
+    assert_equals(internals.numberOfLoadedModelsInSpatialPortal(portal), 0, "portal does not load its model while off-screen");
 
     portal.scrollIntoView();
     await model.ready;
-    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 1, "portal hosts the model after scrolling into view");
+    assert_equals(internals.numberOfLoadedModelsInSpatialPortal(portal), 1, "portal loads the model after scrolling into view");
 }, "A <model> in a spatial portal loads only once the portal is scrolled into view");
 </script>
 </body>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -316,6 +316,11 @@ void HTMLModelElement::setSourceURL(const URL& url)
     m_readyPromise = makeUniqueRef<ReadyPromise>(*this, &HTMLModelElement::readyPromiseResolve);
     m_shouldCreateModelPlayerUponRendererAttachment = false;
 
+#if ENABLE(SPATIAL_PORTAL)
+    if (CheckedPtr controller = findPortalController())
+        controller->childModelDidChange(*this);
+#endif
+
     if (m_sourceURL.isEmpty()) {
         ActiveDOMObject::queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
         reportExtraMemoryCost();

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
@@ -51,6 +51,7 @@
 #include "ResourceError.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/RefCounted.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -175,64 +176,90 @@ SpatialPortalController::~SpatialPortalController()
 {
     if (RefPtr observer = m_intersectionObserver)
         observer->disconnect();
-    unloadModel();
+    deleteModelPlayer();
+}
+
+unsigned SpatialPortalController::numberOfLoadedModels() const
+{
+    unsigned count = 0;
+    for (auto& hostedModel : m_hostedModels.values()) {
+        if (hostedModel.loadedModel)
+            ++count;
+    }
+    return count;
+}
+
+HTMLModelElement* SpatialPortalController::hostedModelElement(NodeIdentifier nodeID) const
+{
+    auto it = m_hostedModels.find(nodeID);
+    if (it == m_hostedModels.end())
+        return nullptr;
+    return it->value.element.get();
 }
 
 void SpatialPortalController::unregisterChildModel(HTMLModelElement& model)
 {
-    if (m_childModel.get() != &model)
+    auto nodeID = model.nodeIdentifier();
+    if (hostedModelElement(nodeID) != &model)
         return;
-    m_childModel = nullptr;
-    unloadModel();
+
+    unloadChildModel(nodeID);
+    m_hostedModels.remove(nodeID);
+
+    if (m_hostedModels.isEmpty())
+        deleteModelPlayer();
 }
 
 void SpatialPortalController::registerChildModel(HTMLModelElement& model)
 {
-    if (m_childModel && m_childModel.get() != &model) {
-        // FIXME: rdar://182292429
-        model.didFailLoadingInsidePortal(ResourceError { errorDomainWebKitInternal, 0, { }, "Only one model is supported per spatial portal"_s });
-        return;
-    }
-    m_childModel = model;
+    m_hostedModels.ensure(model.nodeIdentifier(), [&] {
+        return HostedModel { model, nullptr };
+    });
 
     observePortalVisibility();
 
     model.visibilityStateChanged();
-    loadChildModelIfReady();
+    loadChildModelIfReady(model);
 }
 
 void SpatialPortalController::childModelDidChange(HTMLModelElement& model)
 {
-    if (m_childModel.get() != &model)
+    if (hostedModelElement(model.nodeIdentifier()) != &model)
         return;
-    loadChildModelIfReady();
+    loadChildModelIfReady(model);
 }
 
-void SpatialPortalController::loadChildModelIfReady()
+void SpatialPortalController::loadChildModelsIfReady()
 {
-    RefPtr child = m_childModel.get();
-    if (!child)
+    for (auto& hostedModel : copyToVector(m_hostedModels.values())) {
+        if (RefPtr element = hostedModel.element.get())
+            loadChildModelIfReady(*element);
+    }
+}
+
+void SpatialPortalController::loadChildModelIfReady(HTMLModelElement& model)
+{
+    auto nodeID = model.nodeIdentifier();
+
+    RefPtr modelData = model.model();
+    if (!modelData) {
+        unloadChildModel(nodeID);
         return;
+    }
 
     if (!isPortalVisible())
         return;
 
-    RefPtr modelData = child->model();
-    if (!modelData)
+    auto it = m_hostedModels.find(nodeID);
+    if (it == m_hostedModels.end() || it->value.loadedModel == modelData)
         return;
-
-    if (m_modelPlayer && m_model == modelData)
-        return;
-
-    if (m_modelPlayer)
-        unloadModel();
 
     RefPtr player = ensureModelPlayer();
     if (!player)
         return;
 
-    m_model = modelData;
-    player->load(child->nodeIdentifier(), *modelData, portalContentSize(), false);
+    it->value.loadedModel = modelData;
+    player->load(nodeID, *modelData, portalContentSize(), false);
 }
 
 void SpatialPortalController::observePortalVisibility()
@@ -265,11 +292,13 @@ void SpatialPortalController::viewportIntersectionChanged(bool isIntersecting)
     if (RefPtr player = m_modelPlayer)
         player->visibilityStateDidChange();
 
-    if (RefPtr child = m_childModel.get())
-        child->visibilityStateChanged();
+    for (auto& hostedModel : copyToVector(m_hostedModels.values())) {
+        if (RefPtr element = hostedModel.element.get())
+            element->visibilityStateChanged();
+    }
 
     if (isIntersecting)
-        loadChildModelIfReady();
+        loadChildModelsIfReady();
 }
 
 ModelPlayer* SpatialPortalController::ensureModelPlayer()
@@ -297,15 +326,27 @@ ModelPlayer* SpatialPortalController::ensureModelPlayer()
     return m_modelPlayer.get();
 }
 
-void SpatialPortalController::unloadModel()
+void SpatialPortalController::deleteModelPlayer()
 {
     if (m_modelPlayer) {
-        // FIXME: rdar://182292429 - Remove model without destroying the player.
         if (RefPtr provider = m_modelPlayerProvider.get())
             provider->deleteModelPlayer(*m_modelPlayer);
         m_modelPlayer = nullptr;
     }
-    m_model = nullptr;
+    for (auto& hostedModel : m_hostedModels.values())
+        hostedModel.loadedModel = nullptr;
+}
+
+void SpatialPortalController::unloadChildModel(NodeIdentifier nodeID)
+{
+    auto it = m_hostedModels.find(nodeID);
+    if (it == m_hostedModels.end() || !it->value.loadedModel)
+        return;
+
+    it->value.loadedModel = nullptr;
+
+    if (RefPtr player = m_modelPlayer)
+        player->unload(nodeID);
 }
 
 LayoutSize SpatialPortalController::portalContentSize() const
@@ -324,13 +365,12 @@ void SpatialPortalController::configureGraphicsLayer(GraphicsLayer& graphicsLaye
     if (!player)
         return;
 
-    RefPtr child = m_childModel.get();
     player->configureGraphicsLayer(graphicsLayer, {
-        .model = m_model,
+        .model = nullptr,
         .contentSize = portalContentSize(),
         .contentOrigin = LayoutPoint(graphicsLayer.contentsRect().location()),
         .backgroundColor = backgroundColor,
-        .isInteractive = child && child->isInteractive(),
+        .isInteractive = false,
 #if ENABLE(MODEL_ELEMENT_PORTAL)
         .hasPortal = true, // N/A
 #endif
@@ -348,8 +388,8 @@ void SpatialPortalController::sizeMayHaveChanged()
 
 void SpatialPortalController::modelDidFinishLoading(ModelPlayer&, NodeIdentifier nodeID)
 {
-    RefPtr child = m_childModel.get();
-    if (!child || child->nodeIdentifier() != nodeID)
+    RefPtr child = hostedModelElement(nodeID);
+    if (!child)
         return;
 
     child->didFinishLoadingInsidePortal();
@@ -359,11 +399,14 @@ void SpatialPortalController::modelDidFinishLoading(ModelPlayer&, NodeIdentifier
 
 void SpatialPortalController::modelDidFailLoading(ModelPlayer&, NodeIdentifier nodeID, const ResourceError& error)
 {
-    RefPtr child = m_childModel.get();
-    if (!child || child->nodeIdentifier() != nodeID)
+    auto it = m_hostedModels.find(nodeID);
+    if (it == m_hostedModels.end())
         return;
 
-    child->didFailLoadingInsidePortal(error);
+    it->value.loadedModel = nullptr;
+
+    if (RefPtr child = it->value.element.get())
+        child->didFailLoadingInsidePortal(error);
 }
 
 void SpatialPortalController::modelDidUnload(ModelPlayer& player)
@@ -372,9 +415,9 @@ void SpatialPortalController::modelDidUnload(ModelPlayer& player)
     if (m_modelPlayer != &player)
         return;
 
-    unloadModel();
+    deleteModelPlayer();
     // FIXME: rdar://148027600 Prevent infinite reloading of model.
-    loadChildModelIfReady();
+    loadChildModelsIfReady();
 }
 
 void SpatialPortalController::modelDidUpdate(ModelPlayer&)

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.h
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.h
@@ -30,6 +30,7 @@
 #include "LayoutSize.h"
 #include <WebCore/NodeIdentifier.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -64,7 +65,8 @@ public:
     void childModelDidChange(HTMLModelElement&);
 
     ModelPlayer* modelPlayer() const { return m_modelPlayer.get(); }
-    unsigned numberOfHostedModels() const { return m_model ? 1 : 0; }
+    unsigned numberOfHostedModels() const { return m_hostedModels.size(); }
+    WEBCORE_EXPORT unsigned numberOfLoadedModels() const;
     void configureGraphicsLayer(GraphicsLayer&, const Color& backgroundColor);
     void sizeMayHaveChanged();
 
@@ -80,18 +82,26 @@ private:
     void viewportIntersectionChanged(bool isIntersecting);
 
     ModelPlayer* ensureModelPlayer();
-    void loadChildModelIfReady();
-    void unloadModel();
+    void loadChildModelsIfReady();
+    void loadChildModelIfReady(HTMLModelElement&);
+    void deleteModelPlayer();
+    void unloadChildModel(NodeIdentifier);
+    HTMLModelElement* hostedModelElement(NodeIdentifier) const;
     void reconfigurePortalLayer();
     void observePortalVisibility();
     LayoutSize portalContentSize() const;
 
     const WeakPtr<Element, WeakPtrImplWithEventTargetData> m_portalElement;
-    WeakPtr<HTMLModelElement, WeakPtrImplWithEventTargetData> m_childModel;
+
+    struct HostedModel {
+        WeakPtr<HTMLModelElement, WeakPtrImplWithEventTargetData> element;
+        RefPtr<Model> loadedModel;
+    };
+    HashMap<NodeIdentifier, HostedModel> m_hostedModels;
+
     WeakPtr<ModelPlayerProvider> m_modelPlayerProvider;
     RefPtr<ModelPlayer> m_modelPlayer;
     const RefPtr<PortalModelPlayerClient> m_playerClient;
-    RefPtr<Model> m_model;
     RefPtr<IntersectionObserver> m_intersectionObserver;
     bool m_isIntersectingViewport { false };
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -8769,6 +8769,12 @@ unsigned Internals::numberOfHostedModelsInSpatialPortal(Element& element)
     return controller ? controller->numberOfHostedModels() : 0;
 }
 
+unsigned Internals::numberOfLoadedModelsInSpatialPortal(Element& element)
+{
+    CheckedPtr controller = element.spatialPortalController();
+    return controller ? controller->numberOfLoadedModels() : 0;
+}
+
 bool Internals::establishesSpatialPortal(Element& element)
 {
     return element.establishesSpatialPortal();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1695,6 +1695,7 @@ public:
 
 #if ENABLE(SPATIAL_PORTAL)
     unsigned NODELETE numberOfHostedModelsInSpatialPortal(Element&);
+    unsigned NODELETE numberOfLoadedModelsInSpatialPortal(Element&);
     bool NODELETE establishesSpatialPortal(Element&);
 #endif
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1552,6 +1552,7 @@ enum ContentsFormat {
     [Conditional=MODEL_ELEMENT] boolean isModelElementIntersectingViewport(HTMLModelElement element);
 
     [Conditional=SPATIAL_PORTAL] unsigned long numberOfHostedModelsInSpatialPortal(Element element);
+    [Conditional=SPATIAL_PORTAL] unsigned long numberOfLoadedModelsInSpatialPortal(Element element);
     [Conditional=SPATIAL_PORTAL] boolean establishesSpatialPortal(Element element);
 
     undefined copyImageAtLocation(long x, long y);

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -77,6 +77,7 @@ public:
 #include <WebCore/StageModeOperations.h>
 #include <WebCore/TransformationMatrix.h>
 #include <simd/simd.h>
+#include <wtf/HashMap.h>
 #include <wtf/Markable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
@@ -120,12 +121,12 @@ public:
     void unloadModelTimerFired();
     void updateTransformAfterLayout();
     void updateOpacity();
-    void startAnimating();
     void animationPlaybackStateDidUpdate();
 
     // Messages
     void createLayer();
     void loadModel(WebCore::NodeIdentifier, Ref<WebCore::Model>&&, WebCore::LayoutSize, bool);
+    void unloadModel(WebCore::NodeIdentifier);
     void reloadModel(WebCore::NodeIdentifier, Ref<WebCore::Model>&&, WebCore::LayoutSize, std::optional<WebCore::TransformationMatrix> transformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore);
     void modelVisibilityDidChange(bool isVisible);
 
@@ -187,6 +188,15 @@ public:
 private:
     ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&, const std::optional<String>&, std::optional<int>, std::optional<int>);
 
+    struct HostedModelEntity {
+        RefPtr<WebCore::REModelLoader> loader;
+        RetainPtr<WKRKEntity> entity;
+        simd_float3 originalEntityScale { simd_make_float3(1, 1, 1) };
+        simd_float3 originalBoundingBoxCenter { simd_make_float3(0, 0, 0) };
+        simd_float3 originalBoundingBoxExtents { simd_make_float3(0, 0, 0) };
+    };
+    using HostedModelEntityMap = HashMap<WebCore::NodeIdentifier, HostedModelEntity>;
+
     RESRT modelStandardizedTransformSRT(RESRT originalSRT);
     RESRT modelLocalizedTransformSRT(RESRT originalSRT);
     void computeTransform(bool);
@@ -198,6 +208,11 @@ private:
     void notifyModelPlayerOfEntityTransformChange();
     void applyDefaultIBL();
     void updateForCurrentStageMode();
+    void setUpLoadedEntity(WKRKEntity *);
+    simd_float3 reportingModelScale() const;
+    void clearReportingModelIfNeeded(WebCore::NodeIdentifier);
+    HostedModelEntityMap::iterator findHostedEntityForLoader(const WebCore::REModelLoader&);
+    void cancelAllLoaders();
 #if HAVE(CORE_RE)
     void ensurePortalEntityHierarchy();
     void parentToContainer(WKRKEntity *);
@@ -213,7 +228,11 @@ private:
 
     std::unique_ptr<LayerHostingContext> m_layerHostingContext;
     RetainPtr<WKModelProcessModelLayer> m_layer;
-    RefPtr<WebCore::REModelLoader> m_loader;
+
+    HostedModelEntityMap m_hostedEntities;
+
+    // The first model loaded reports animation playback state for the portal until that is
+    // generalized: rdar://182292543 (Child model animation forwarding).
     RetainPtr<WKRKEntity> m_modelRKEntity;
 #if HAVE(CORE_RE)
     REPtr<RESceneRef> m_scene;
@@ -223,9 +242,6 @@ private:
 #endif
     RetainPtr<WKModelProcessModelPlayerProxyObjCAdapter> m_objCAdapter;
 
-    simd_float3 m_originalBoundingBoxCenter { simd_make_float3(0, 0, 0) };
-    simd_float3 m_originalBoundingBoxExtents { simd_make_float3(0, 0, 0) };
-    simd_float3 m_originalEntityScale { simd_make_float3(1, 1, 1) };
     float m_pitch { 0 };
 
     RESRT m_transformSRT; // SRT=Scaling/Rotation/Translation. This is stricter than a WebCore::TransformationMatrix.

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -36,6 +36,7 @@ messages -> ModelProcessModelPlayerProxy {
     
     # WebCore::ModelPlayer
     LoadModel(WebCore::NodeIdentifier nodeID, Ref<WebCore::Model> url, WebCore::LayoutSize layoutSize, bool isForImmersive)
+    UnloadModel(WebCore::NodeIdentifier nodeID)
     SizeDidChange(WebCore::LayoutSize layoutSize)
     SetEntityTransform(WebCore::NodeIdentifier nodeID, WebCore::TransformationMatrix transform)
     SetAutoplay(WebCore::NodeIdentifier nodeID, bool autoplay)

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -336,8 +336,7 @@ ModelProcessModelPlayerProxy::ModelProcessModelPlayerProxy(ModelProcessModelPlay
 
 ModelProcessModelPlayerProxy::~ModelProcessModelPlayerProxy()
 {
-    if (m_loader)
-        m_loader->cancel();
+    cancelAllLoaders();
 
 #if HAVE(CORE_RE)
     if (m_containerEntity.get())
@@ -412,8 +411,6 @@ void ModelProcessModelPlayerProxy::loadModel(WebCore::NodeIdentifier nodeID, Ref
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
 
-    m_nodeID = nodeID;
-
 #if HAVE(CORE_RE)
     if (model->mimeType() != usdzMIMEType) {
         Ref<WebCore::SharedBuffer> modelData = model->data();
@@ -444,7 +441,6 @@ void ModelProcessModelPlayerProxy::loadModel(WebCore::NodeIdentifier nodeID, Ref
 
 void ModelProcessModelPlayerProxy::reloadModel(WebCore::NodeIdentifier nodeID, Ref<WebCore::Model>&& model, WebCore::LayoutSize layoutSize, std::optional<WebCore::TransformationMatrix> entityTransformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore)
 {
-    m_nodeID = nodeID;
     m_entityTransformToRestore = WTF::move(entityTransformToRestore);
     m_animationStateToRestore = WTF::move(animationStateToRestore);
     if (m_animationStateToRestore) {
@@ -482,10 +478,7 @@ void ModelProcessModelPlayerProxy::unloadModelTimerFired()
     if (!strongManager)
         return;
 
-    if (m_loader) {
-        m_loader->cancel();
-        m_loader = nullptr;
-    }
+    cancelAllLoaders();
 
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::unloadModelTimerFired(): inform manager to unload model id=%" PRIu64, this, m_id.toUInt64());
     strongManager->unloadModelPlayer(m_id);
@@ -603,16 +596,53 @@ RESRT ModelProcessModelPlayerProxy::modelLocalizedTransformSRT(RESRT originalSRT
 
 void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
 {
-    if (!m_modelRKEntity || !m_layer)
+    if (m_hostedEntities.isEmpty() || !m_layer)
         return;
 
+    // The portal is fitted to every model it hosts, so the union of their bounding boxes drives the
+    // container transform.
+    // FIXME: rdar://182292321 - Models are all placed at the container origin until portal-transform
+    // and spatial positioning land, so the union is centred on that origin.
+    simd_float3 minBound = simd_make_float3(0, 0, 0);
+    simd_float3 maxBound = simd_make_float3(0, 0, 0);
+    bool hasBounds = false;
+
+    for (auto& hostedEntity : m_hostedEntities.values()) {
+        if (!hostedEntity.entity)
+            continue;
+
+        simd_float3 halfExtents = hostedEntity.originalBoundingBoxExtents / 2;
+        simd_float3 entityMin = hostedEntity.originalBoundingBoxCenter - halfExtents;
+        simd_float3 entityMax = hostedEntity.originalBoundingBoxCenter + halfExtents;
+
+        minBound = hasBounds ? simd_min(minBound, entityMin) : entityMin;
+        maxBound = hasBounds ? simd_max(maxBound, entityMax) : entityMax;
+        hasBounds = true;
+    }
+
+    if (!hasBounds)
+        return;
+
+    simd_float3 boundingBoxExtents = maxBound - minBound;
+    simd_float3 boundingBoxCenter = (maxBound + minBound) / 2;
+
+    // Each model's bounding sphere has to be reached from the merged centre, not from its own, so
+    // an off-centre sibling widens the radius by its distance rather than being swallowed by it.
+    float boundingRadius = 0;
+    for (auto& hostedEntity : m_hostedEntities.values()) {
+        if (!hostedEntity.entity)
+            continue;
+
+        float entityRadius = [hostedEntity.entity boundingRadius] * hostedEntity.originalEntityScale.x;
+        boundingRadius = std::max(boundingRadius, simd_length(hostedEntity.originalBoundingBoxCenter - boundingBoxCenter) + entityRadius);
+    }
+
     // FIXME: Use the value of the 'object-fit' property here to compute an appropriate SRT.
-    float boundingRadius = [m_modelRKEntity boundingRadius] * m_originalEntityScale.x;
     simd_quatf currentModelRotation = setDefaultRotation ? simd_quaternion(0, simd_make_float3(1, 0, 0)) : m_transformSRT.rotation;
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    RESRT newSRT = computeSRT(m_layer.get(), m_originalBoundingBoxExtents, m_originalBoundingBoxCenter, boundingRadius, m_hasPortal, effectivePointsPerMeter(m_layer.get()), m_stageModeOperation, currentModelRotation, m_immersivePresentation);
+    RESRT newSRT = computeSRT(m_layer.get(), boundingBoxExtents, boundingBoxCenter, boundingRadius, m_hasPortal, effectivePointsPerMeter(m_layer.get()), m_stageModeOperation, currentModelRotation, m_immersivePresentation);
 #else
-    RESRT newSRT = computeSRT(m_layer.get(), m_originalBoundingBoxExtents, m_originalBoundingBoxCenter, boundingRadius, m_hasPortal, effectivePointsPerMeter(m_layer.get()), m_stageModeOperation, currentModelRotation, false);
+    RESRT newSRT = computeSRT(m_layer.get(), boundingBoxExtents, boundingBoxCenter, boundingRadius, m_hasPortal, effectivePointsPerMeter(m_layer.get()), m_stageModeOperation, currentModelRotation, false);
 #endif
     m_transformSRT = newSRT;
 
@@ -639,15 +669,18 @@ void ModelProcessModelPlayerProxy::updateTransform()
     if (!m_containerEntityWrapper)
         return;
 
-    // The container owns the global transforms (stagemode, portal-transform) and the model sits beneath with only its original scale applied.
+    // The container owns the global transforms (stagemode, portal-transform) and each model sits beneath with only its original scale applied.
     [m_containerEntityWrapper setTransform:WKEntityTransform({ m_transformSRT.scale, m_transformSRT.rotation, m_transformSRT.translation })];
-    if (m_modelRKEntity)
-        [m_modelRKEntity setTransform:WKEntityTransform({ m_originalEntityScale, simd_quaternion(0, simd_make_float3(1, 0, 0)), simd_make_float3(0, 0, 0) })];
+    for (auto& hostedEntity : m_hostedEntities.values()) {
+        if (hostedEntity.entity)
+            [hostedEntity.entity setTransform:WKEntityTransform({ hostedEntity.originalEntityScale, simd_quaternion(0, simd_make_float3(1, 0, 0)), simd_make_float3(0, 0, 0) })];
+    }
 #else
-    if (!m_modelRKEntity)
+    RetainPtr reportingEntity = m_modelRKEntity;
+    if (!reportingEntity)
         return;
 
-    [m_modelRKEntity setTransform:WKEntityTransform({ m_transformSRT.scale * m_originalEntityScale, m_transformSRT.rotation, m_transformSRT.translation })];
+    [reportingEntity setTransform:WKEntityTransform({ m_transformSRT.scale * reportingModelScale(), m_transformSRT.rotation, m_transformSRT.translation })];
 #endif
 }
 
@@ -669,20 +702,11 @@ void ModelProcessModelPlayerProxy::updateTransformAfterLayout()
 
 void ModelProcessModelPlayerProxy::updateOpacity()
 {
-    if (!m_modelRKEntity || !m_layer)
+    if (!m_layer)
         return;
 
-    [m_modelRKEntity setOpacity:[m_layer opacity]];
-}
-
-void ModelProcessModelPlayerProxy::startAnimating()
-{
-    if (!m_modelRKEntity || !m_layer)
-        return;
-
-    [m_modelRKEntity setUpAnimationWithAutoPlay:m_autoplay];
-    [m_modelRKEntity setLoop:m_loop];
-    [m_modelRKEntity setPlaybackRate:m_playbackRate];
+    for (auto& hostedEntity : m_hostedEntities.values())
+        [hostedEntity.entity setOpacity:[m_layer opacity]];
 }
 
 void ModelProcessModelPlayerProxy::animationPlaybackStateDidUpdate()
@@ -711,45 +735,60 @@ static RECALayerService *webDefaultLayerService(void)
 void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& loader, Ref<WebCore::REModel> model)
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
-    ASSERT(&loader == m_loader.get());
 
-    m_loader = nullptr;
-
-    if (!m_nodeID)
+    auto it = findHostedEntityForLoader(loader);
+    if (it == m_hostedEntities.end())
         return;
 
-    auto nodeID = *m_nodeID;
+    auto nodeID = it->key;
+    it->value.loader = nullptr;
 
+    RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy finished loading model nodeID=%" PRIu64 " id=%" PRIu64, this, nodeID.toUInt64(), m_id.toUInt64());
+
+    RetainPtr<WKRKEntity> loadedEntity;
 #if HAVE(CORE_RE)
     bool canLoadWithRealityKit = [getWKRKEntityClassSingleton() isLoadFromDataAvailable];
     if (canLoadWithRealityKit)
-        m_modelRKEntity = model->rootRKEntity();
+        loadedEntity = model->rootRKEntity();
     else if (model->rootEntity())
-        m_modelRKEntity = adoptNS([allocWKRKEntityInstance() initWithCoreEntity:model->rootEntity()]);
+        loadedEntity = adoptNS([allocWKRKEntityInstance() initWithCoreEntity:model->rootEntity()]);
 #else
-    m_modelRKEntity = model->rootRKEntity();
+    loadedEntity = model->rootRKEntity();
 #endif
 
-    [m_modelRKEntity setDelegate:m_objCAdapter.get()];
+    it->value.entity = loadedEntity;
 
-    // Capture the root entity's original scale before any transform is applied.
-    WKEntityTransform originalTransform = [m_modelRKEntity transform];
-    m_originalEntityScale = originalTransform.scale;
+    // The entity's bounding box is relative to its own coordinate space, so the original scale
+    // still has to be applied.
+    WKEntityTransform originalTransform = [loadedEntity transform];
+    it->value.originalEntityScale = originalTransform.scale;
+    it->value.originalBoundingBoxExtents = [loadedEntity boundingBoxExtents] * it->value.originalEntityScale;
+    it->value.originalBoundingBoxCenter = [loadedEntity boundingBoxCenter] * it->value.originalEntityScale;
 
-    // The bounding box is relative to the entity's coordinate space so we still need to apply the scale.
-    m_originalBoundingBoxExtents = [m_modelRKEntity boundingBoxExtents] * m_originalEntityScale;
-    m_originalBoundingBoxCenter = [m_modelRKEntity boundingBoxCenter] * m_originalEntityScale;
+    simd_float3 boundingBoxCenter = it->value.originalBoundingBoxCenter;
+    simd_float3 boundingBoxExtents = it->value.originalBoundingBoxExtents;
 
 #if HAVE(CORE_RE)
     ensurePortalEntityHierarchy();
 
-    [m_modelRKEntity setName:@"WebKit:ModelRootEntity"];
-    parentToContainer(m_modelRKEntity.get());
-
-    applyStageModeOperationToDriver();
+    [loadedEntity setName:@"WebKit:ModelRootEntity"];
+    parentToContainer(loadedEntity.get());
 
     if (!canLoadWithRealityKit)
         RENetworkMarkEntityMetadataDirty(model->rootEntity());
+#endif // HAVE(CORE_RE)
+
+    // The first model loaded reports animation playback state for the portal and receives its
+    // environment map: rdar://182292543 (Child model animation forwarding).
+    bool isReportingModel = !m_nodeID || *m_nodeID == nodeID;
+    if (isReportingModel) {
+        m_nodeID = nodeID;
+        m_modelRKEntity = loadedEntity;
+        [loadedEntity setDelegate:m_objCAdapter.get()];
+    }
+
+#if HAVE(CORE_RE)
+    applyStageModeOperationToDriver();
 #endif // HAVE(CORE_RE)
 
     if (m_entityTransformToRestore) {
@@ -766,29 +805,32 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
 #endif // HAVE(CORE_RE)
 
     updateOpacity();
-    startAnimating();
+    setUpLoadedEntity(loadedEntity.get());
+
     if (m_animationStateToRestore) {
-        [m_modelRKEntity setPaused:m_animationStateToRestore->paused()];
-        [m_modelRKEntity setCurrentTime:m_animationStateToRestore->currentTime().seconds()];
+        [loadedEntity setPaused:m_animationStateToRestore->paused()];
+        [loadedEntity setCurrentTime:m_animationStateToRestore->currentTime().seconds()];
         m_animationStateToRestore = std::nullopt;
     }
 
-    applyEnvironmentMapDataAndRelease([weakThis = WeakPtr { *this }] () mutable {
+    if (isReportingModel) {
+        applyEnvironmentMapDataAndRelease([weakThis = WeakPtr { *this }] () mutable {
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    if (RefPtr protectedThis = weakThis.get())
-        protectedThis->triggerModelLoadedCallbacks(true);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->triggerModelLoadedCallbacks(true);
 #endif
-    });
+        });
+    } else
+        [loadedEntity applyDefaultIBL];
 
-    send(Messages::ModelProcessModelPlayer::DidFinishLoading(nodeID, WebCore::FloatPoint3D(m_originalBoundingBoxCenter.x, m_originalBoundingBoxCenter.y, m_originalBoundingBoxCenter.z), WebCore::FloatPoint3D(m_originalBoundingBoxExtents.x, m_originalBoundingBoxExtents.y, m_originalBoundingBoxExtents.z)));
+    send(Messages::ModelProcessModelPlayer::DidFinishLoading(nodeID, WebCore::FloatPoint3D(boundingBoxCenter.x, boundingBoxCenter.y, boundingBoxCenter.z), WebCore::FloatPoint3D(boundingBoxExtents.x, boundingBoxExtents.y, boundingBoxExtents.z)));
 }
 
 void ModelProcessModelPlayerProxy::didFailLoading(WebCore::REModelLoader& loader, const WebCore::ResourceError& error)
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
-    ASSERT(&loader == m_loader.get());
 
-    m_loader = nullptr;
+    auto it = findHostedEntityForLoader(loader);
 
     RELEASE_LOG_ERROR(ModelElement, "%p - ModelProcessModelPlayerProxy failed to load model id=%" PRIu64 " error=\"%@\"", this, m_id.toUInt64(), error.nsError().localizedDescription);
 
@@ -796,10 +838,14 @@ void ModelProcessModelPlayerProxy::didFailLoading(WebCore::REModelLoader& loader
     triggerModelLoadedCallbacks(false);
 #endif
 
-    if (!m_nodeID)
+    if (it == m_hostedEntities.end())
         return;
 
-    send(Messages::ModelProcessModelPlayer::DidFailLoading(*m_nodeID));
+    auto nodeID = it->key;
+    m_hostedEntities.remove(it);
+    clearReportingModelIfNeeded(nodeID);
+
+    send(Messages::ModelProcessModelPlayer::DidFailLoading(nodeID));
 }
 
 // MARK: - WebCore::ModelPlayer
@@ -843,13 +889,28 @@ void ModelProcessModelPlayerProxy::load(WebCore::NodeIdentifier nodeID, WebCore:
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
 
-    m_nodeID = nodeID;
+    auto& hostedEntity = m_hostedEntities.ensure(nodeID, [] {
+        return HostedModelEntity { };
+    }).iterator->value;
+    if (RefPtr previousLoader = std::exchange(hostedEntity.loader, nullptr))
+        previousLoader->cancel();
+
+    auto previousEntity = std::exchange(hostedEntity.entity, nullptr);
+    if (previousEntity) {
+        clearReportingModelIfNeeded(nodeID);
+        [previousEntity removeFromParentEntity];
+    }
+
+    // The reporting model is designated before its load completes because the immersive paths need
+    // a node id while a load is still in flight; the entity itself is adopted in didFinishLoading.
+    if (!m_nodeID)
+        m_nodeID = nodeID;
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     m_currentModel = &model;
 #endif
 
-    RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::load size=%zu isForImmersive=%d id=%" PRIu64, this, model.data()->size(), isForImmersive, m_id.toUInt64());
+    RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::load nodeID=%" PRIu64 " size=%zu isForImmersive=%d id=%" PRIu64, this, nodeID.toUInt64(), model.data()->size(), isForImmersive, m_id.toUInt64());
     sizeDidChange(layoutSize);
 
 #if HAVE(CORE_RE) || ENABLE(MODEL_ELEMENT_IMMERSIVE)
@@ -860,16 +921,25 @@ void ModelProcessModelPlayerProxy::load(WebCore::NodeIdentifier nodeID, WebCore:
 #endif
 
 #if HAVE(CORE_RE)
-    WKREEngine::singleton().runWithSharedScene([this, protectedThis = protect(*this), model = protect(model), memoryLimit] (RESceneRef scene) {
+    WKREEngine::singleton().runWithSharedScene([this, protectedThis = protect(*this), model = protect(model), memoryLimit, nodeID] (RESceneRef scene) {
+        dispatch_assert_queue(mainDispatchQueueSingleton());
         m_scene = scene;
+        RefPtr<WebCore::REModelLoader> loader;
         if ([getWKRKEntityClassSingleton() isLoadFromDataAvailable])
-            m_loader = RKUSDModelLoadScheduler::singleton().scheduleModelLoad(model.get(), m_attributionTaskID, memoryLimit, *this);
+            loader = RKUSDModelLoadScheduler::singleton().scheduleModelLoad(model.get(), m_attributionTaskID, memoryLimit, *this);
         else
-            m_loader = WebCore::loadREModel(model.get(), *this);
+            loader = WebCore::loadREModel(model.get(), *this);
+
+        auto it = m_hostedEntities.find(nodeID);
+        if (it == m_hostedEntities.end()) {
+            loader->cancel();
+            return;
+        }
+        it->value.loader = WTF::move(loader);
     });
 #else
     auto loader = SimpleModelLoader::create();
-    m_loader = loader.ptr();
+    hostedEntity.loader = loader.ptr();
 
     RetainPtr<NSData> modelData = model.data()->createNSData();
     [getWKRKEntityClassSingleton() loadFromData:modelData.get() withAttributionTaskID:nil entityMemoryLimit:0 completionHandler:makeBlockPtr([weakThis = WeakPtr { *this }, loader = WTF::move(loader)] (WKRKEntity *entity) mutable {
@@ -890,6 +960,78 @@ void ModelProcessModelPlayerProxy::load(WebCore::NodeIdentifier nodeID, WebCore:
 #endif
 }
 
+void ModelProcessModelPlayerProxy::unloadModel(WebCore::NodeIdentifier nodeID)
+{
+    dispatch_assert_queue(mainDispatchQueueSingleton());
+
+    auto it = m_hostedEntities.find(nodeID);
+    if (it == m_hostedEntities.end())
+        return;
+
+    RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::unloadModel nodeID=%" PRIu64 " id=%" PRIu64, this, nodeID.toUInt64(), m_id.toUInt64());
+
+    auto hostedEntity = WTF::move(it->value);
+    m_hostedEntities.remove(it);
+
+    if (RefPtr loader = hostedEntity.loader)
+        loader->cancel();
+
+    if (hostedEntity.entity)
+        [hostedEntity.entity removeFromParentEntity];
+
+    clearReportingModelIfNeeded(nodeID);
+
+    // The portal-wide fit covered the removed model, so it has to be recomputed without it.
+    computeTransform(true);
+    updateTransform();
+}
+
+void ModelProcessModelPlayerProxy::clearReportingModelIfNeeded(WebCore::NodeIdentifier nodeID)
+{
+    if (!m_nodeID || *m_nodeID != nodeID)
+        return;
+
+    [m_modelRKEntity setDelegate:nil];
+
+    m_nodeID = std::nullopt;
+    m_modelRKEntity = nil;
+}
+
+simd_float3 ModelProcessModelPlayerProxy::reportingModelScale() const
+{
+    if (!m_nodeID)
+        return simd_make_float3(1, 1, 1);
+
+    auto it = m_hostedEntities.find(*m_nodeID);
+    return it == m_hostedEntities.end() ? simd_make_float3(1, 1, 1) : it->value.originalEntityScale;
+}
+
+ModelProcessModelPlayerProxy::HostedModelEntityMap::iterator ModelProcessModelPlayerProxy::findHostedEntityForLoader(const WebCore::REModelLoader& loader)
+{
+    return std::ranges::find_if(m_hostedEntities, [&](auto& entry) {
+        return entry.value.loader.get() == &loader;
+    });
+}
+
+void ModelProcessModelPlayerProxy::cancelAllLoaders()
+{
+    for (auto& hostedEntity : m_hostedEntities.values()) {
+        if (RefPtr loader = std::exchange(hostedEntity.loader, nullptr))
+            loader->cancel();
+    }
+}
+
+// FIXME: rdar://182292543 - Playback state should be per model.
+void ModelProcessModelPlayerProxy::setUpLoadedEntity(WKRKEntity *entity)
+{
+    if (!entity || !m_layer)
+        return;
+
+    [entity setUpAnimationWithAutoPlay:m_autoplay];
+    [entity setLoop:m_loop];
+    [entity setPlaybackRate:m_playbackRate];
+}
+
 void ModelProcessModelPlayerProxy::sizeDidChange(WebCore::LayoutSize layoutSize)
 {
     RELEASE_LOG_INFO(ModelElement, "%p - ModelProcessModelPlayerProxy::sizeDidChange w=%lf h=%lf id=%" PRIu64, this, layoutSize.width().toDouble(), layoutSize.height().toDouble(), m_id.toUInt64());
@@ -903,7 +1045,7 @@ void ModelProcessModelPlayerProxy::sizeDidChange(WebCore::LayoutSize layoutSize)
 
     auto width = layoutSize.width().toDouble();
     auto height = layoutSize.height().toDouble();
-    if (!m_transformNeedsUpdateAfterNextLayout && m_modelRKEntity && m_layer)
+    if (!m_transformNeedsUpdateAfterNextLayout && !m_hostedEntities.isEmpty() && m_layer)
         m_transformNeedsUpdateAfterNextLayout = width != CGRectGetWidth([m_layer frame]) || height != CGRectGetHeight([m_layer frame]);
     [m_layer setFrame:CGRectMake(0, 0, width, height)];
 }
@@ -1184,7 +1326,7 @@ void ModelProcessModelPlayerProxy::updateForCurrentStageMode()
 #if HAVE(CORE_RE)
         [m_containerEntityWrapper recenterEntityAtTransform:WKEntityTransform({ m_transformSRT.scale, m_transformSRT.rotation, m_transformSRT.translation })];
 #else
-        [m_modelRKEntity recenterEntityAtTransform:WKEntityTransform({ m_transformSRT.scale * m_originalEntityScale, m_transformSRT.rotation, m_transformSRT.translation })];
+        [m_modelRKEntity recenterEntityAtTransform:WKEntityTransform({ m_transformSRT.scale * reportingModelScale(), m_transformSRT.rotation, m_transformSRT.translation })];
 #endif
         updateTransformSRT();
     }
@@ -1225,7 +1367,7 @@ void ModelProcessModelPlayerProxy::updateTransformSRT()
 
     WKEntityTransform entityTransform = [m_modelRKEntity transform];
     m_transformSRT = RESRT {
-        .scale = entityTransform.scale / m_originalEntityScale,
+        .scale = entityTransform.scale / reportingModelScale(),
         .rotation = entityTransform.rotation,
         .translation = entityTransform.translation
     };
@@ -1316,10 +1458,8 @@ void ModelProcessModelPlayerProxy::applyDefaultIBL()
 
 void ModelProcessModelPlayerProxy::teardownEntity()
 {
-    if (m_loader) {
-        m_loader->cancel();
-        m_loader = nullptr;
-    }
+    cancelAllLoaders();
+    m_hostedEntities.clear();
 #if HAVE(CORE_RE)
     if (m_containerEntity.get())
         REEntityRemoveFromSceneOrParent(m_containerEntity.get());
@@ -1334,9 +1474,6 @@ void ModelProcessModelPlayerProxy::teardownEntity()
     m_stageModeInteractionDriver = nil;
 #endif
     m_modelRKEntity = nil;
-    m_originalBoundingBoxExtents = simd_make_float3(0, 0, 0);
-    m_originalBoundingBoxCenter = simd_make_float3(0, 0, 0);
-    m_originalEntityScale = simd_make_float3(1, 1, 1);
     m_loadedEntityMemoryLimit = std::nullopt;
 }
 
@@ -1358,6 +1495,12 @@ void ModelProcessModelPlayerProxy::captureStateForReload()
 
 void ModelProcessModelPlayerProxy::ensureImmersivePresentation(CompletionHandler<void(std::optional<WebCore::LayerHostingContextIdentifier>)>&& completion)
 {
+    // FIXME: Add immersive presentation for spatial portal
+    if (m_hostedEntities.size() > 1) {
+        RELEASE_LOG_ERROR(ModelElement, "%p - ModelProcessModelPlayerProxy::ensureImmersivePresentation: unsupported for %u hosted models id=%" PRIu64, this, m_hostedEntities.size(), m_id.toUInt64());
+        return completion(std::nullopt);
+    }
+
     int targetLimit = entityMemoryLimit(true);
     bool atTargetLimit = m_loadedEntityMemoryLimit && *m_loadedEntityMemoryLimit == targetLimit;
 
@@ -1366,7 +1509,7 @@ void ModelProcessModelPlayerProxy::ensureImmersivePresentation(CompletionHandler
 
     setImmersivePresentation(true);
 
-    if (m_nodeID && m_currentModel && (m_modelRKEntity || m_loader) && !atTargetLimit) {
+    if (m_nodeID && m_currentModel && !m_hostedEntities.isEmpty() && !atTargetLimit) {
         RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::ensureImmersivePresentation: reloading at %dMB id=%" PRIu64, this, targetLimit, m_id.toUInt64());
         teardownEntity();
         load(*m_nodeID, *m_currentModel, m_layoutSize, true);
@@ -1396,7 +1539,7 @@ void ModelProcessModelPlayerProxy::exitImmersivePresentation(CompletionHandler<v
 
     setImmersivePresentation(false);
 
-    if (m_nodeID && m_currentModel && (m_modelRKEntity || m_loader) && !atTargetLimit) {
+    if (m_nodeID && m_currentModel && !m_hostedEntities.isEmpty() && !atTargetLimit) {
         RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::exitImmersivePresentation: reloading at %dMB id=%" PRIu64, this, targetLimit, m_id.toUInt64());
         teardownEntity();
         load(*m_nodeID, *m_currentModel, m_layoutSize, false);

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h
@@ -78,6 +78,7 @@ NS_SWIFT_UI_ACTOR
 - (void)interactionContainerDidRecenterFromTransform:(simd_float4x4)transform;
 - (void)recenterEntityAtTransform:(WKEntityTransform)transform;
 - (void)applyDefaultIBL;
+- (void)removeFromParentEntity;
 
 #if HAVE(CORE_RE)
 - (instancetype)initWithCoreEntity:(REEntityRef)coreEntity;

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
@@ -494,6 +494,10 @@ extension WKRKEntity {
     }
     #endif
 
+    func removeFromParentEntity() {
+        entity.removeFromParent()
+    }
+
     @objc(interactionContainerDidRecenterFromTransform:)
     func interactionContainerDidRecenter(fromTransform transform: simd_float4x4) {
         entity.setTransformMatrix(transform, relativeTo: nil)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -187,6 +187,13 @@ void ModelProcessModelPlayer::load(WebCore::NodeIdentifier nodeID, WebCore::Mode
     send(Messages::ModelProcessModelPlayerProxy::LoadModel(nodeID, model, size, isForImmersive));
 }
 
+void ModelProcessModelPlayer::unload(WebCore::NodeIdentifier nodeID)
+{
+    RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer unload model nodeID=%" PRIu64 " id=%" PRIu64, this, nodeID.toUInt64(), m_id.toUInt64());
+
+    send(Messages::ModelProcessModelPlayerProxy::UnloadModel(nodeID));
+}
+
 void ModelProcessModelPlayer::didUnload()
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer unload model id=%" PRIu64, this, m_id.toUInt64());

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -86,6 +86,7 @@ private:
     std::optional<WebCore::ModelPlayerAnimationState> currentAnimationState(WebCore::NodeIdentifier) const final;
     std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> currentTransformState(WebCore::NodeIdentifier) const final;
     void load(WebCore::NodeIdentifier, WebCore::Model&, WebCore::LayoutSize, bool) final;
+    void unload(WebCore::NodeIdentifier) final;
     void reload(WebCore::NodeIdentifier, WebCore::Model&, WebCore::LayoutSize, WebCore::ModelPlayerAnimationState&, std::unique_ptr<WebCore::ModelPlayerTransformState>&&) final;
     void visibilityStateDidChange() final;
     void sizeDidChange(WebCore::LayoutSize) final;

--- a/Tools/TestWebKitAPI/Resources/spatial-portal-two-models-page.html
+++ b/Tools/TestWebKitAPI/Resources/spatial-portal-two-models-page.html
@@ -10,6 +10,5 @@
 </div>
 <script>
     const models = [...document.querySelectorAll('model')];
-    // FIXME: rdar://182292429 (Multi model support, switch to Promise.all)
-    Promise.allSettled(models.map(model => model.ready)).then(() => window.webkit.messageHandlers.modelLoading.postMessage('READY'));
+    Promise.all(models.map(model => model.ready)).finally(() => window.webkit.messageHandlers.modelLoading.postMessage('READY'));
 </script>


### PR DESCRIPTION
#### 0a2f1dc58ef4988d8790951481df1854c5c3b2fc
<pre>
Implement child model loading IPC for spatial portals
<a href="https://bugs.webkit.org/show_bug.cgi?id=320724">https://bugs.webkit.org/show_bug.cgi?id=320724</a>
<a href="https://rdar.apple.com/182292429">rdar://182292429</a>

Reviewed by Etienne Segonzac.

Let a spatial portal host more than one &lt;model&gt; child. SpatialPortalController
tracks its children in a map keyed by NodeIdentifier, loading each one and
routing callbacks back to the right child. The Model process keeps one entity
per node, and a new UnloadModel message removes one without tearing down the
player the other models share.

The container transform fits the union of every hosted model&apos;s bounding box.
The first model to load still owns stage mode, animation reporting and the
environment map, so the single-model case is unchanged.

Tests: spatial-css/spatial-portal-multi-model-error.html
       spatial-css/spatial-portal-multi-model-insert-remove.html
       spatial-css/spatial-portal-multi-model-move.html
       spatial-css/spatial-portal-multi-model-source-change.html
       spatial-css/spatial-portal-multi-model.html

* LayoutTests/spatial-css/resources/spatial-portal-utils.js: Added.
(const.appendModel):
* LayoutTests/spatial-css/spatial-portal-multi-model-error-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-multi-model-error.html: Added.
* LayoutTests/spatial-css/spatial-portal-multi-model-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-multi-model-insert-remove-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-multi-model-insert-remove.html: Added.
* LayoutTests/spatial-css/spatial-portal-multi-model-move-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-multi-model-move.html: Added.
* LayoutTests/spatial-css/spatial-portal-multi-model-source-change-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-multi-model-source-change.html: Added.
* LayoutTests/spatial-css/spatial-portal-multi-model.html: Added.
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::setSourceURL):
* Source/WebCore/Modules/model-element/SpatialPortalController.cpp:
(WebCore::SpatialPortalController::~SpatialPortalController):
(WebCore::SpatialPortalController::hostedModelElement const):
(WebCore::SpatialPortalController::unregisterChildModel):
(WebCore::SpatialPortalController::registerChildModel):
(WebCore::SpatialPortalController::childModelDidChange):
(WebCore::SpatialPortalController::loadChildModelsIfReady):
(WebCore::SpatialPortalController::loadChildModelIfReady):
(WebCore::SpatialPortalController::viewportIntersectionChanged):
(WebCore::SpatialPortalController::deleteModelPlayer):
(WebCore::SpatialPortalController::unloadChildModel):
(WebCore::SpatialPortalController::configureGraphicsLayer):
(WebCore::SpatialPortalController::modelDidFinishLoading):
(WebCore::SpatialPortalController::modelDidFailLoading):
(WebCore::SpatialPortalController::modelDidUnload):
(WebCore::SpatialPortalController::unloadModel): Deleted.
* Source/WebCore/Modules/model-element/SpatialPortalController.h:
(WebCore::SpatialPortalController::numberOfHostedModels const):
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::~ModelProcessModelPlayerProxy):
(WebKit::ModelProcessModelPlayerProxy::loadModel):
(WebKit::ModelProcessModelPlayerProxy::reloadModel):
(WebKit::ModelProcessModelPlayerProxy::unloadModelTimerFired):
(WebKit::ModelProcessModelPlayerProxy::computeTransform):
(WebKit::ModelProcessModelPlayerProxy::updateTransform):
(WebKit::ModelProcessModelPlayerProxy::updateOpacity):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::didFailLoading):
(WebKit::ModelProcessModelPlayerProxy::load):
(WebKit::ModelProcessModelPlayerProxy::unloadModel):
(WebKit::ModelProcessModelPlayerProxy::clearReportingModelIfNeeded):
(WebKit::ModelProcessModelPlayerProxy::reportingModelScale const):
(WebKit::ModelProcessModelPlayerProxy::findHostedEntityForLoader):
(WebKit::ModelProcessModelPlayerProxy::cancelAllLoaders):
(WebKit::ModelProcessModelPlayerProxy::setUpLoadedEntity):
(WebKit::ModelProcessModelPlayerProxy::sizeDidChange):
(WebKit::ModelProcessModelPlayerProxy::updateForCurrentStageMode):
(WebKit::ModelProcessModelPlayerProxy::updateTransformSRT):
(WebKit::ModelProcessModelPlayerProxy::teardownEntity):
(WebKit::ModelProcessModelPlayerProxy::ensureImmersivePresentation):
(WebKit::ModelProcessModelPlayerProxy::exitImmersivePresentation):
(WebKit::ModelProcessModelPlayerProxy::startAnimating): Deleted.
* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h:
* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift:
(WKRKEntity.removeFromParentEntity):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::unload):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
* Tools/TestWebKitAPI/Resources/spatial-portal-two-models-page.html:

Canonical link: <a href="https://commits.webkit.org/318406@main">https://commits.webkit.org/318406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0df61263ed0b6576f00850656d32ca69b9776af8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187807 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51840 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138908 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5a4cb8b-fde8-4817-af34-28805e52e293) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119364 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b456a093-83e6-42d6-80af-e61c532f4ac9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41134 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39486 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39171 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36264 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190234 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148060 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39762 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52481 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147833 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42547 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124745 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119295 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50999 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14147 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50384 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50624 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50446 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->