### PR TITLE
[Site Isolation] [iOS] Drag gesture doesn't register inside cross-origin iframe (douban.com captcha)

### DIFF
--- a/LayoutTests/http/tests/site-isolation/touch-events/drag-nested-cross-origin-frame-in-offset-subframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/touch-events/drag-nested-cross-origin-frame-in-offset-subframe-expected.txt
@@ -1,0 +1,12 @@
+Dragging inside a cross-origin iframe that is nested inside an offset same-site subframe must deliver touches at coordinates local to that iframe.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS events[0] is 'touchstart 50,50'
+PASS events[events.length - 1] is 'touchend 150,100'
+PASS events.some((each) => each.startsWith('touchmove')) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/touch-events/drag-nested-cross-origin-frame-in-offset-subframe.html
+++ b/LayoutTests/http/tests/site-isolation/touch-events/drag-nested-cross-origin-frame-in-offset-subframe.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Dragging inside a cross-origin iframe that is nested inside an offset same-site subframe must deliver touches at coordinates local to that iframe.");
+jsTestIsAsync = true;
+
+let events = [];
+addEventListener("message", (event) => {
+    if (event.data === "ready") {
+        UIHelper.dragFromPointToPoint(400, 350, 500, 400, 0.5);
+        return;
+    }
+
+    events.push(event.data);
+    if (event.data.startsWith("touchend")) {
+        shouldBe("events[0]", "'touchstart 50,50'");
+        shouldBe("events[events.length - 1]", "'touchend 150,100'");
+        shouldBeTrue("events.some((each) => each.startsWith('touchmove'))");
+        finishJSTest();
+    }
+});
+
+addEventListener("touchstart", () => { testFailed("This event listener should not be called.") });
+</script>
+</head>
+<body>
+<iframe style="position: absolute; left: 350px; top: 300px; width: 300px; height: 250px; border: none;" src="http://127.0.0.1:8000/site-isolation/touch-events/resources/samesite-offset-container-touch.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/touch-events/drag-nested-cross-origin-frame-in-scrolled-subframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/touch-events/drag-nested-cross-origin-frame-in-scrolled-subframe-expected.txt
@@ -1,0 +1,13 @@
+Dragging inside a cross-origin iframe nested inside a same-site subframe that is both offset and scrolled must deliver touches at coordinates local to that iframe.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is "scrolled 100"
+PASS events[0] is 'touchstart 50,50'
+PASS events[events.length - 1] is 'touchend 150,100'
+PASS events.some((each) => each.startsWith('touchmove')) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/touch-events/drag-nested-cross-origin-frame-in-scrolled-subframe.html
+++ b/LayoutTests/http/tests/site-isolation/touch-events/drag-nested-cross-origin-frame-in-scrolled-subframe.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Dragging inside a cross-origin iframe nested inside a same-site subframe that is both offset and scrolled must deliver touches at coordinates local to that iframe.");
+jsTestIsAsync = true;
+
+let events = [];
+addEventListener("message", (event) => {
+    if (event.data.startsWith("scrolled")) {
+        shouldBeEqualToString("event.data", "scrolled 100");
+        UIHelper.dragFromPointToPoint(400, 350, 500, 400, 0.5);
+        return;
+    }
+
+    if (event.data === "ready")
+        return;
+
+    events.push(event.data);
+    if (event.data.startsWith("touchend")) {
+        shouldBe("events[0]", "'touchstart 50,50'");
+        shouldBe("events[events.length - 1]", "'touchend 150,100'");
+        shouldBeTrue("events.some((each) => each.startsWith('touchmove'))");
+        finishJSTest();
+    }
+});
+
+addEventListener("touchstart", () => { testFailed("This event listener should not be called.") });
+</script>
+</head>
+<body>
+<iframe style="position: absolute; left: 350px; top: 300px; width: 300px; height: 250px; border: none;" src="http://127.0.0.1:8000/site-isolation/touch-events/resources/samesite-scrolled-container-touch.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/touch-events/resources/nested-frame-reports-touch-coordinates.html
+++ b/LayoutTests/http/tests/site-isolation/touch-events/resources/nested-frame-reports-touch-coordinates.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+function coordinates(event) {
+    return event.pageX + "," + event.pageY;
+}
+
+addEventListener("touchstart", (event) => window.top.postMessage("touchstart " + coordinates(event), "*"));
+addEventListener("touchmove", (event) => window.top.postMessage("touchmove " + coordinates(event), "*"));
+addEventListener("touchend", (event) => window.top.postMessage("touchend " + coordinates(event), "*"));
+
+window.top.postMessage("ready", "*");
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/touch-events/resources/samesite-offset-container-touch.html
+++ b/LayoutTests/http/tests/site-isolation/touch-events/resources/samesite-offset-container-touch.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+html, body { margin: 0; height: 100%; }
+iframe { display: block; width: 100%; height: 100%; border: none; }
+</style>
+</head>
+<body>
+<iframe src="http://localhost:8000/site-isolation/touch-events/resources/nested-frame-reports-touch-coordinates.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/touch-events/resources/samesite-scrolled-container-touch.html
+++ b/LayoutTests/http/tests/site-isolation/touch-events/resources/samesite-scrolled-container-touch.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body { margin: 0; }
+</style>
+</head>
+<body>
+<div style="height: 100px;"></div>
+<iframe style="display: block; width: 300px; height: 400px; border: none;" src="http://localhost:8000/site-isolation/touch-events/resources/nested-frame-reports-touch-coordinates.html"></iframe>
+<script>
+onload = () => {
+    scrollTo(0, 100);
+    window.top.postMessage("scrolled " + scrollY, "*");
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/RemoteFrameGeometryTransformer.cpp
+++ b/Source/WebCore/page/RemoteFrameGeometryTransformer.cpp
@@ -62,4 +62,9 @@ DoublePoint RemoteFrameGeometryTransformer::transformToRemoteFrameCoordinates(Do
     return Ref { m_remoteView }->convertFromRootView(Ref { m_localView }->contentsToRootView(pointInContents));
 }
 
+DoublePoint RemoteFrameGeometryTransformer::transformRootViewPointToRemoteFrameCoordinates(DoublePoint pointInRootView) const
+{
+    return Ref { m_remoteView }->convertFromRootView(pointInRootView);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrameGeometryTransformer.h
+++ b/Source/WebCore/page/RemoteFrameGeometryTransformer.h
@@ -47,6 +47,7 @@ public:
     WEBCORE_EXPORT IntPoint transformToRemoteFrameCoordinates(IntPoint pointInContents) const;
     WEBCORE_EXPORT FloatPoint transformToRemoteFrameCoordinates(FloatPoint pointInContents) const;
     WEBCORE_EXPORT DoublePoint transformToRemoteFrameCoordinates(DoublePoint pointInContents) const;
+    WEBCORE_EXPORT DoublePoint transformRootViewPointToRemoteFrameCoordinates(DoublePoint pointInRootView) const;
     FrameIdentifier remoteFrameID() const { return m_remoteFrameID; }
 
 private:

--- a/Source/WebKit/Shared/WebTouchEvent.cpp
+++ b/Source/WebKit/Shared/WebTouchEvent.cpp
@@ -56,7 +56,7 @@ void WebTouchEvent::transformToRemoteFrameCoordinates(const WebCore::RemoteFrame
 {
     ASSERT(!std::exchange(m_hasTransformedToRemoteFrameCoordinates, true));
 
-    m_position = transformer.transformToRemoteFrameCoordinates(m_position);
+    m_position = transformer.transformRootViewPointToRemoteFrameCoordinates(m_position);
     for (auto& touchPoint : m_touchPoints)
         touchPoint.transformToRemoteFrameCoordinates(transformer);
     for (auto& event : m_coalescedEvents)
@@ -67,8 +67,8 @@ void WebTouchEvent::transformToRemoteFrameCoordinates(const WebCore::RemoteFrame
 
 void WebPlatformTouchPoint::transformToRemoteFrameCoordinates(const WebCore::RemoteFrameGeometryTransformer& transformer)
 {
-    m_locationInRootView = transformer.transformToRemoteFrameCoordinates(m_locationInRootView);
-    m_previousLocationInRootView = transformer.transformToRemoteFrameCoordinates(m_previousLocationInRootView);
+    m_locationInRootView = transformer.transformRootViewPointToRemoteFrameCoordinates(m_locationInRootView);
+    m_previousLocationInRootView = transformer.transformRootViewPointToRemoteFrameCoordinates(m_previousLocationInRootView);
 
     // When translating to the coordinate space of a site isolated iframe,
     // viewport coordinates become the same as root view coordinates because


### PR DESCRIPTION
#### 20e4b95ce5e0453f3c9017d4dbe7c0255340c403
<pre>
[Site Isolation] [iOS] Drag gesture doesn&apos;t register inside cross-origin iframe (douban.com captcha)
<a href="https://bugs.webkit.org/show_bug.cgi?id=320725">https://bugs.webkit.org/show_bug.cgi?id=320725</a>
<a href="https://rdar.apple.com/183709792">rdar://183709792</a>

Reviewed by Abrar Rahman Protyasha and Lily Spiniolas.

This is a generic coordinate conversion issue; a few places in `WebTouchEvent` were passing in a location
in root view to a function that expected a location in contents view.

Fix by adding a transformation function that accepts a point in root view coordinates, and fix the call sites.

Test: http/tests/site-isolation/touch-events/drag-nested-cross-origin-frame-in-offset-subframe.html

* LayoutTests/http/tests/site-isolation/touch-events/drag-nested-cross-origin-frame-in-offset-subframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/touch-events/drag-nested-cross-origin-frame-in-offset-subframe.html: Added.
* LayoutTests/http/tests/site-isolation/touch-events/resources/nested-frame-reports-touch-coordinates.html: Added.
* LayoutTests/http/tests/site-isolation/touch-events/resources/samesite-offset-container-touch.html: Added.
* Source/WebCore/page/RemoteFrameGeometryTransformer.cpp:
(WebCore::RemoteFrameGeometryTransformer::transformRootViewPointToRemoteFrameCoordinates const):
* Source/WebCore/page/RemoteFrameGeometryTransformer.h:
* Source/WebKit/Shared/WebTouchEvent.cpp:
(WebKit::WebTouchEvent::transformToRemoteFrameCoordinates):
(WebKit::WebPlatformTouchPoint::transformToRemoteFrameCoordinates):

Canonical link: <a href="https://commits.webkit.org/318338@main">https://commits.webkit.org/318338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d7650bfcf0c4a33bd372f2a280e75953426d436

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187614 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/284d3ff1-cd16-4739-bbe0-3d959403c819) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53234 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138752 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37c1dd20-078e-4f23-9a35-a202aa5ab5fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42296 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159505 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119208 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9bcc9404-f3b3-4c38-baa4-b04f10b3e84a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40962 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39003 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36074 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190043 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159031 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147886 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39714 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52291 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147665 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42375 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124554 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119024 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50798 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13975 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50194 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50434 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50256 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->