### PR TITLE
Track if a video layer is visible rather than only relying on player's viewport position

### DIFF
--- a/LayoutTests/media/media-visible-in-viewport-in-fullscreen-expected.txt
+++ b/LayoutTests/media/media-visible-in-viewport-in-fullscreen-expected.txt
@@ -1,30 +1,37 @@
 
 RUN(internals.settings.setAllowsPictureInPictureMediaPlayback(true))
 RUN(internals.setMockVideoPresentationModeEnabled(true))
+RUN(internals.settings.setVideoLayerVisibilityDelay(0))
 RUN(video.src = findMediaFile("video", "content/test"))
 EVENT(canplaythrough)
 EXPECTED (internals.mediaElementViewportVisibility(video) == 'NotVisible') OK
+EXPECTED (internals.isVideoVisible(video) == 'false') OK
 
 Test viewport visibility in Picture-in-Picture:
 RUN(video.requestPictureInPicture())
 EVENT(enterpictureinpicture)
 EXPECTED (internals.mediaElementViewportVisibility(video) == 'VisibleInPictureInPicture') OK
+EXPECTED (internals.isVideoVisible(video) == 'true') OK
 EXPECTED (internals.isChangingPresentationMode(video) == 'false') OK
 RUN(document.exitPictureInPicture())
 EVENT(leavepictureinpicture)
 EXPECTED (internals.mediaElementViewportVisibility(video) == 'NotVisible') OK
+EXPECTED (internals.isVideoVisible(video) == 'false') OK
 
 Test viewport visibility in Fullscreen:
 RUN(video.webkitEnterFullscreen())
 EVENT(webkitpresentationmodechanged)
 EXPECTED (internals.isChangingPresentationMode(video) == 'false') OK
 EXPECTED (internals.mediaElementViewportVisibility(video) == 'VisibleInFullscreen') OK
+EXPECTED (internals.isVideoVisible(video) == 'true') OK
 RUN(video.webkitExitFullscreen())
 EVENT(webkitpresentationmodechanged)
 EXPECTED (internals.mediaElementViewportVisibility(video) == 'NotVisible') OK
+EXPECTED (internals.isVideoVisible(video) == 'false') OK
 
 Ensure video becomes visible-in-viewport when scrolled on-screen:
 RUN(video.scrollIntoView())
 EXPECTED (internals.mediaElementViewportVisibility(video) == 'VisibleInViewport') OK
+EXPECTED (internals.isVideoVisible(video) == 'true') OK
 END OF TEST
 

--- a/LayoutTests/media/media-visible-in-viewport-in-fullscreen.html
+++ b/LayoutTests/media/media-visible-in-viewport-in-fullscreen.html
@@ -20,11 +20,15 @@
 
         run('internals.settings.setAllowsPictureInPictureMediaPlayback(true)');
         run('internals.setMockVideoPresentationModeEnabled(true)');
+        // Release the renderer as soon as the video stops being visible, rather than after the
+        // usual delay, so that becoming invisible can be asserted here.
+        run('internals.settings.setVideoLayerVisibilityDelay(0)');
 
 		findMediaElement();
 		run('video.src = findMediaFile("video", "content/test")');
 		await waitFor(video, 'canplaythrough');
 		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'NotVisible', '==', 1000);
+		testExpected('internals.isVideoVisible(video)', false);
 
 		consoleWrite('');
 		consoleWrite('Test viewport visibility in Picture-in-Picture:');
@@ -33,6 +37,8 @@
 		});
 		await waitFor(video, 'enterpictureinpicture');
 		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'VisibleInPictureInPicture', '==', 1000);
+		// The box is still off screen; picture-in-picture is what makes the video visible.
+		testExpected('internals.isVideoVisible(video)', true);
 
         await testExpectedEventually("internals.isChangingPresentationMode(video)", false);
 		internals.withUserGesture(() => {
@@ -40,6 +46,7 @@
 		});
 		await waitFor(video, 'leavepictureinpicture');
 		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'NotVisible', '==', 1000);
+		await testExpectedEventually('internals.isVideoVisible(video)', false, '==', 1000);
 
 		consoleWrite('');
 		consoleWrite('Test viewport visibility in Fullscreen:');
@@ -49,17 +56,21 @@
 		await waitFor(video, 'webkitpresentationmodechanged');
         await testExpectedEventually("internals.isChangingPresentationMode(video)", false);
 		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'VisibleInFullscreen', '==', 1000);
+		// Likewise: fullscreen is on screen even though the element's box is not.
+		testExpected('internals.isVideoVisible(video)', true);
 
 		internals.withUserGesture(() => {
 			return run('video.webkitExitFullscreen()');
 		});
 		await waitFor(video, 'webkitpresentationmodechanged');
 		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'NotVisible', '==', 1000);
+		await testExpectedEventually('internals.isVideoVisible(video)', false, '==', 1000);
 
 		consoleWrite('');
 		consoleWrite('Ensure video becomes visible-in-viewport when scrolled on-screen:');
 		run('video.scrollIntoView()');
 		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'VisibleInViewport', '==', 1000);
+		testExpected('internals.isVideoVisible(video)', true);
 	}
 	</script>
 </head>

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -148,7 +148,6 @@ enum class SDKAlignedBehavior {
     ScrollPocketInFullscreen,
     IgnorePageLocationDuringHardPocketEligibilityCheck,
     AdjustColorExtensionsForHorizontalBannerViewOverlays,
-    NoMediaLayerTeardownOnPageVisibilityChangeQuirk,
 
     NumberOfBehaviors
 };
@@ -231,7 +230,6 @@ WTF_EXPORT_PRIVATE bool isWebProcess();
 WTF_EXPORT_PRIVATE bool isMobileStore();
 WTF_EXPORT_PRIVATE bool isUNIQLOApp();
 WTF_EXPORT_PRIVATE bool isDOFUSTouch();
-WTF_EXPORT_PRIVATE bool isMoonPlayer();
 WTF_EXPORT_PRIVATE bool isMyRideK12();
 WTF_EXPORT_PRIVATE bool isTableau();
 WTF_EXPORT_PRIVATE bool isTubular();

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -643,12 +643,6 @@ bool IOSApplication::isDOFUSTouch()
     return isDOFUSTouch;
 }
 
-bool IOSApplication::isMoonPlayer()
-{
-    static bool isMoonPlayer = applicationBundleIsEqualTo("com.innovis.moonplayer"_s);
-    return isMoonPlayer;
-}
-
 bool IOSApplication::isMyRideK12()
 {
     static bool isMyRideK12 = applicationBundleIsEqualTo("com.tylertech.myridek12"_s);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2109,7 +2109,6 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
         .contentType = WTF::move(contentType),
         .requiresRemotePlayback = !!m_remotePlaybackConfiguration,
         .supportsLimitedMatroska = limitedMatroskaSupportEnabled(),
-        .disableTeardownOnVisibilityChange = protect(document())->quirks().shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk(),
 #if ENABLE(MEDIA_SOURCE)
         .supportsProgressMonitoringOverride = protect(document())->quirks().needsSupportsProgressMonitoring() ? std::optional<bool> { true } : std::nullopt,
 #endif

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2112,6 +2112,7 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
 #if ENABLE(MEDIA_SOURCE)
         .supportsProgressMonitoringOverride = protect(document())->quirks().needsSupportsProgressMonitoring() ? std::optional<bool> { true } : std::nullopt,
 #endif
+        .videoLayerVisibilityDelay = Seconds { document().settings().videoLayerVisibilityDelay() },
     };
 
 #if ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -184,7 +184,9 @@ void HTMLVideoElement::computeAcceleratedRenderingStateAndUpdateMediaPlayer()
     bool isInFullScreen = false;
 #endif
     CheckedPtr renderer = this->renderer();
-    bool canBeAccelerated = player->supportsAcceleratedRendering() && (isInFullScreen || (m_isIntersectingViewport && renderer && protect(renderer->view())->compositor().hasAcceleratedCompositing()));
+    // Whether anything can be seen is not asked here: that is resolved by MediaPlayer and acted
+    // on through setIsVisible(). This answers only whether a layer could be composited for us.
+    bool canBeAccelerated = player->supportsAcceleratedRendering() && (isInFullScreen || (renderer && protect(renderer->view())->compositor().hasAcceleratedCompositing()));
     if (canBeAccelerated == m_renderingCanBeAccelerated)
         return;
     m_renderingCanBeAccelerated = canBeAccelerated;
@@ -800,6 +802,19 @@ void HTMLVideoElement::stop()
     HTMLMediaElement::stop();
 }
 
+void HTMLVideoElement::setVideoLayerIsVisible(std::optional<bool> isVisible)
+{
+    // std::nullopt means the layer has gone, and with it any knowledge of what is on screen;
+    // the decision then falls back to the page and the viewport.
+    if (m_videoLayerIsVisible == isVisible)
+        return;
+
+    m_videoLayerIsVisible = isVisible;
+
+    if (RefPtr player = this->player())
+        player->setVideoLayerIsVisible(isVisible);
+}
+
 void HTMLVideoElement::viewportIntersectionChanged(bool isIntersecting)
 {
     if (m_isIntersectingViewport == isIntersecting)
@@ -874,6 +889,12 @@ void HTMLVideoElement::serviceRequestVideoFrameCallbacks(ReducedResolutionSecond
 void HTMLVideoElement::mediaPlayerEngineUpdated()
 {
     HTMLMediaElement::mediaPlayerEngineUpdated();
+
+    if (m_videoLayerIsVisible) {
+        if (RefPtr player = this->player())
+            player->setVideoLayerIsVisible(m_videoLayerIsVisible);
+    }
+
     if (!m_videoFrameRequests.isEmpty()) {
         if (RefPtr player = this->player())
             player->startVideoFrameMetadataGathering();

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -33,7 +33,6 @@
 #include "ChromeClient.h"
 #include "Document.h"
 #include "DocumentPage.h"
-#include "DocumentQuirks.h"
 #include "DocumentView.h"
 #include "ElementInlines.h"
 #include "EventNames.h"
@@ -185,11 +184,7 @@ void HTMLVideoElement::computeAcceleratedRenderingStateAndUpdateMediaPlayer()
     bool isInFullScreen = false;
 #endif
     CheckedPtr renderer = this->renderer();
-    // 311380@main added the viewport intersection to this condition. Some clients keep
-    // displaying the video layer they host after scrolling it out of view or hiding their
-    // web view, so for those ignore it as it was before.
-    bool isIntersectingViewport = m_isIntersectingViewport || protect(document())->quirks().shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk();
-    bool canBeAccelerated = player->supportsAcceleratedRendering() && (isInFullScreen || (isIntersectingViewport && renderer && protect(renderer->view())->compositor().hasAcceleratedCompositing()));
+    bool canBeAccelerated = player->supportsAcceleratedRendering() && (isInFullScreen || (m_isIntersectingViewport && renderer && protect(renderer->view())->compositor().hasAcceleratedCompositing()));
     if (canBeAccelerated == m_renderingCanBeAccelerated)
         return;
     m_renderingCanBeAccelerated = canBeAccelerated;

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -155,6 +155,11 @@ public:
     bool isIntersectingViewport() const final { return m_isIntersectingViewport; }
     void viewportIntersectionChanged(bool isIntersecting);
 
+    // Reported by the UI process: whether the video's layer is actually on screen. A client
+    // may host that layer outside of the web view, where the page's visibility no longer
+    // says anything about whether the video can be seen.
+    WEBCORE_EXPORT void setVideoLayerIsVisible(std::optional<bool>);
+
 private:
     friend class HTMLVideoElementPictureInPicture;
     HTMLVideoElement(const QualifiedName&, Document&, bool createdByParser);
@@ -220,6 +225,7 @@ private:
     Vector<UniqueRef<VideoFrameRequest>> m_servicedVideoFrameRequests;
     unsigned m_nextVideoFrameRequestIndex { 0 };
     bool m_isIntersectingViewport { false };
+    std::optional<bool> m_videoLayerIsVisible;
 
 #if USE(GSTREAMER)
     bool m_enableGStreamerHolePunching { false };

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1821,16 +1821,6 @@ bool Quirks::shouldDisableLazyIframeLoadingQuirk() const
     return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldDisableLazyIframeLoadingQuirk);
 }
 
-// Moon Player app (rdar://162452658): the app hides its WKWebView while continuing to display
-// the video layer it hosts, so page visibility does not indicate whether the video is on screen.
-// Tearing the layer down when the page becomes hidden leaves the app displaying a black frame.
-bool Quirks::shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk() const
-{
-    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
-
-    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk);
-}
-
 // reddit.com with Sink It extension (rdar://176377447) and apple.com/retail (rdar://181007316).
 bool Quirks::shouldDisableScrollAnchoringQuirk() const
 {
@@ -4143,15 +4133,11 @@ void Quirks::determineRelevantQuirks()
 #if PLATFORM(IOS_FAMILY)
     static const bool shouldDisableLazyIframeLoadingQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoUNIQLOLazyIframeLoadingQuirk) && WTF::IOSApplication::isUNIQLOApp();
     static const bool needsResettingTransitionCancelsRunningTransitionQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ResettingTransitionCancelsRunningTransitionQuirk) && WTF::IOSApplication::isDOFUSTouch();
-    static const bool shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoMediaLayerTeardownOnPageVisibilityChangeQuirk) && WTF::IOSApplication::isMoonPlayer();
 
     m_quirksData.setQuirkState(QuirksData::SiteSpecificQuirk::ShouldDisableLazyIframeLoadingQuirk, shouldDisableLazyIframeLoadingQuirk);
 
     // DOFUS Touch app (rdar://112679186)
     m_quirksData.setQuirkState(QuirksData::SiteSpecificQuirk::NeedsResettingTransitionCancelsRunningTransitionQuirk, needsResettingTransitionCancelsRunningTransitionQuirk);
-
-    // Moon Player app (rdar://162452658)
-    m_quirksData.setQuirkState(QuirksData::SiteSpecificQuirk::ShouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk, shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk);
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -248,7 +248,6 @@ public:
     WEBCORE_EXPORT bool shouldDisableAdSkippingInPip() const;
 #endif
     bool shouldDisableLazyIframeLoadingQuirk() const;
-    bool shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk() const;
 
     bool shouldBlockFetchWithNewlineAndLessThan() const;
     bool shouldDisableFetchMetadata() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -188,7 +188,6 @@ struct QuirksData {
         ShouldAllowMediaStreamTrackSerializationQuirk,
 #endif
         ShouldDisableLazyIframeLoadingQuirk,
-        ShouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk,
 #if PLATFORM(IOS_FAMILY)
         ShouldDisablePointerEventsQuirk,
 #endif

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -490,6 +490,16 @@ ValidationMessageTimerMagnification:
     WebCore:
       default: 50
 
+VideoLayerVisibilityDelay:
+  comment: >
+    Seconds a video layer has to stay invisible before the renderer behind it is
+    released. Brief disappearances - a layer being reparented, animated or
+    momentarily clipped - should not cost a renderer, so the decision is delayed.
+  type: double
+  defaultValue:
+    WebCore:
+      default: 10
+
 WebGLErrorsToConsoleEnabled:
   type: bool
   defaultValue:

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -154,7 +154,7 @@ public:
     bool hasVideo() const final { return false; }
     bool hasAudio() const final { return false; }
 
-    void setPageIsVisible(bool) final { }
+    void setIsVisible(bool) final { }
 
     Ref<MediaTimePromise> seekToTarget(const SeekTarget&) final { return MediaTimePromise::createAndReject(PlatformMediaError::Cancelled); }
 
@@ -515,6 +515,7 @@ MediaPlayer::MediaPlayer(MediaPlayerClient& client)
     : m_client(client)
     , m_reloadTimer(*this, &MediaPlayer::reloadTimerFired)
     , m_private(NullMediaPlayerPrivate::create(*this))
+    , m_visibilityTimer(*this, &MediaPlayer::visibilityTimerFired)
     , m_preferredDynamicRangeMode(DynamicRangeMode::Standard)
 {
 }
@@ -524,6 +525,7 @@ MediaPlayer::MediaPlayer(MediaPlayerClient& client, MediaPlayerEnums::MediaEngin
     , m_reloadTimer(*this, &MediaPlayer::reloadTimerFired)
     , m_private(NullMediaPlayerPrivate::create(*this))
     , m_activeEngineIdentifier(mediaEngineIdentifier)
+    , m_visibilityTimer(*this, &MediaPlayer::visibilityTimerFired)
     , m_preferredDynamicRangeMode(DynamicRangeMode::Standard)
 {
 }
@@ -680,8 +682,8 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
             protect(client())->mediaPlayerEngineUpdated();
             playerPrivate->setMessageClientForTesting(m_internalMessageClient);
 
-            if (m_pageIsVisible)
-                playerPrivate->setPageIsVisible(m_pageIsVisible);
+            if (m_isVisible)
+                playerPrivate->setIsVisible(m_isVisible);
             playerPrivate->setViewportVisibility(m_viewportVisibility);
             if (m_isGatheringVideoFrameMetadata)
                 playerPrivate->startVideoFrameMetadataGathering();
@@ -1178,10 +1180,95 @@ void MediaPlayer::setPresentationSize(const IntSize& size)
     protect(m_private)->setPresentationSize(size);
 }
 
+bool MediaPlayer::isVisible() const
+{
+    return m_isVisible;
+}
+
+bool MediaPlayer::isVisibleForCanvas() const
+{
+    return m_visibleForCanvas;
+}
+
+auto MediaPlayer::viewportVisibility() const -> ViewportVisibility
+{
+    return m_viewportVisibility;
+}
+
 void MediaPlayer::setPageIsVisible(bool visible)
 {
     m_pageIsVisible = visible;
-    protect(m_private)->setPageIsVisible(visible);
+    updateVisibility();
+}
+
+void MediaPlayer::setVideoLayerIsVisible(std::optional<bool> visible)
+{
+    m_videoLayerIsVisible = visible;
+    updateVisibility();
+}
+
+bool MediaPlayer::computeIsVisible() const
+{
+    // A video being drawn into a canvas has to keep decoding whether or not anything on screen
+    // shows it, so this outranks every other input.
+    if (m_visibleForCanvas)
+        return true;
+
+    // The video layer's own visibility is the direct answer, and the only one that accounts
+    // for a client hosting that layer outside of the web view. Where there is no layer to ask
+    // - audio only, and every port that does not report one - fall back to what the page and
+    // the viewport say, which is what this decision was made from before.
+    return m_videoLayerIsVisible.value_or(m_pageIsVisible && m_viewportVisibility != ViewportVisibility::NotVisible);
+}
+
+void MediaPlayer::updateVisibility()
+{
+    if (m_visibilityIsDecidedElsewhere)
+        return;
+
+    bool visible = computeIsVisible();
+    if (visible == m_isVisible) {
+        // Visible again before the delay elapsed: nothing to tear down after all.
+        m_visibilityTimer.stop();
+        return;
+    }
+
+    // Report becoming visible immediately: the renderer has to exist before anything can be
+    // displayed. Defer becoming invisible, as a video that is briefly hidden - moved between
+    // views, animated, momentarily clipped - would otherwise lose its renderer and have to
+    // build a new one before it could show a frame again.
+    if (!visible) {
+        if (!m_visibilityTimer.isActive())
+            m_visibilityTimer.startOneShot(m_loadOptions.videoLayerVisibilityDelay);
+        return;
+    }
+
+    m_visibilityTimer.stop();
+    m_isVisible = visible;
+    protect(m_private)->setIsVisible(visible);
+}
+
+void MediaPlayer::setIsVisible(bool visible)
+{
+    // This player is being told the answer instead of the inputs it would derive one from -
+    // the GPU process's player, whose page, layer and delay were all resolved in the web
+    // content process. Deriving our own would only fight with what we are being told.
+    m_visibilityIsDecidedElsewhere = true;
+    m_visibilityTimer.stop();
+    if (visible == m_isVisible)
+        return;
+
+    m_isVisible = visible;
+    protect(m_private)->setIsVisible(visible);
+}
+
+void MediaPlayer::visibilityTimerFired()
+{
+    // updateVisibility() stops this timer as soon as we become visible again, so reaching
+    // here means we have been invisible for the whole delay.
+    ASSERT(!computeIsVisible());
+    m_isVisible = false;
+    protect(m_private)->setIsVisible(false);
 }
 
 void MediaPlayer::setVisibleForCanvas(bool visible)
@@ -1191,6 +1278,7 @@ void MediaPlayer::setVisibleForCanvas(bool visible)
 
     m_visibleForCanvas = visible;
     protect(m_private)->setVisibleForCanvas(visible);
+    updateVisibility();
 }
 
 void MediaPlayer::setViewportVisibility(ViewportVisibility visibility)
@@ -1200,6 +1288,7 @@ void MediaPlayer::setViewportVisibility(ViewportVisibility visibility)
 
     m_viewportVisibility = visibility;
     protect(m_private)->setViewportVisibility(visibility);
+    updateVisibility();
 }
 
 void MediaPlayer::setResourceOwner(const ProcessIdentity& processIdentity)

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -187,7 +187,6 @@ struct MediaPlayerLoadOptions {
     ContentType contentType { };
     bool requiresRemotePlayback { false };
     bool supportsLimitedMatroska { false };
-    bool disableTeardownOnVisibilityChange { false };
     std::optional<bool> supportsProgressMonitoringOverride { };
     VideoRendererPreferences videoRendererPreferences { };
 };

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -189,6 +189,8 @@ struct MediaPlayerLoadOptions {
     bool supportsLimitedMatroska { false };
     std::optional<bool> supportsProgressMonitoringOverride { };
     VideoRendererPreferences videoRendererPreferences { };
+    // How long the video has to stay invisible before its renderer is released.
+    Seconds videoLayerVisibilityDelay { 10_s };
 };
 
 class WEBCORE_EXPORT MediaPlayerClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaPlayerClient> {
@@ -444,13 +446,37 @@ public:
 #endif
     void cancelLoad();
 
-    bool pageIsVisible() const { return m_pageIsVisible; }
+    // Whether the video can be seen is resolved here, from three inputs, and only the answer
+    // is passed on to the MediaPlayerPrivate. See computeIsVisible().
+    //
+    //   setPageIsVisible()       the page holding the element is on screen.
+    //   setViewportVisibility()  where the element's box sits in the viewport, or that the
+    //                            video is in fullscreen or picture-in-picture.
+    //   setVideoLayerIsVisible() the video's own layer is on screen, reported by the UI
+    //                            process where it hosts one. std::nullopt means there is no
+    //                            layer to ask, either not yet or no longer.
+    //
+    // The layer wins whenever it has an answer, because it is the only one that survives a
+    // client hosting the layer outside of the web view: such a client keeps displaying the
+    // video after hiding the web view, so the page and the box both claim it cannot be seen
+    // while it plainly can. With no layer to ask - audio only, ports that report none, a
+    // layer since torn down - the page and the box are all there is.
+    //
+    // Becoming invisible is acted on only after a delay, so that a video briefly hidden
+    // while its layer is reparented, animated or clipped does not lose its renderer.
+    bool isVisible() const;
     void setPageIsVisible(bool);
-    void setVisibleForCanvas(bool);
-    bool isVisibleForCanvas() const { return m_visibleForCanvas; }
-
     void setViewportVisibility(ViewportVisibility);
-    ViewportVisibility viewportVisibility() const { return m_viewportVisibility; }
+    void setVideoLayerIsVisible(std::optional<bool>);
+    ViewportVisibility viewportVisibility() const;
+
+    // For a player whose visibility has already been decided elsewhere, as is the case in
+    // the GPU process: the client's player resolved the inputs above and waited out the
+    // delay before sending this, so apply it as-is rather than deciding again.
+    void setIsVisible(bool);
+
+    void setVisibleForCanvas(bool);
+    bool isVisibleForCanvas() const;
 
     void prepareToPlay();
     void play();
@@ -833,6 +859,9 @@ private:
 
     MediaPlayerClient& client() const { return *m_client; }
 
+    bool computeIsVisible() const;
+    void updateVisibility();
+    void visibilityTimerFired();
 
     CheckedPtr<const MediaPlayerFactory> nextBestMediaEngine(const MediaPlayerFactory*);
     void loadWithNextMediaEngine(const MediaPlayerFactory*);
@@ -866,6 +895,14 @@ private:
     Preload m_preload { Preload::Auto };
     double m_volume { 1 };
     bool m_pageIsVisible { false };
+    std::optional<bool> m_videoLayerIsVisible;
+    bool m_isVisible { false };
+    // Set once someone hands us the answer rather than the inputs; see setIsVisible().
+    bool m_visibilityIsDecidedElsewhere { false };
+    // Becoming visible takes effect at once; becoming invisible only does so after this
+    // delay, so that transient changes don't cost us the video renderer and the time it
+    // takes to build a new one.
+    Timer m_visibilityTimer;
     bool m_visibleForCanvas { false };
     bool m_muted { false };
     bool m_preservesPitch { true };

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -127,11 +127,29 @@ public:
     virtual bool hasVideo() const = 0;
     virtual bool hasAudio() const = 0;
 
-    virtual void setPageIsVisible(bool) = 0;
-    virtual void setVisibleForCanvas(bool visible) { setPageIsVisible(visible); }
-
     using ViewportVisibility = MediaPlayer::ViewportVisibility;
+
+    // These two answer different questions, and only the first one is about whether anything
+    // can be seen.
+    //
+    // setIsVisible() is the resolved answer to "can this video be seen at all", which
+    // MediaPlayer works out from the video layer's own visibility where a layer reports it -
+    // a client may host that layer outside of the web view, where the element's position in
+    // the page says nothing - and from the page and the viewport where none does. This is
+    // what to consult before giving up a layer or a renderer.
+    //
+    // setViewportVisibility() describes where the element's box sits in the viewport, plus
+    // the fullscreen and picture-in-picture cases where the video is on screen although its
+    // box may not be. It is an input to the above, not a substitute for it, and is passed on
+    // for decisions that are genuinely about the box - whether it is worth keeping a pipeline
+    // running for something scrolled far away, say - rather than about visibility.
+    virtual void setIsVisible(bool) = 0;
     virtual void setViewportVisibility(ViewportVisibility) { }
+
+    // Latched on, and never off, the first time the video is drawn into a canvas. Such a video
+    // has to keep decoding while nothing on screen shows it, so this arrives independently of
+    // the visibility above rather than as another input to it.
+    virtual void setVisibleForCanvas(bool visible) { setIsVisible(visible); }
 
     virtual MediaTime duration() const { return MediaTime::zeroTime(); }
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -93,7 +93,7 @@ private:
     FloatSize naturalSize() const final { return { }; }
     bool hasVideo() const final { return true; }
     bool hasAudio() const final;
-    void setPageIsVisible(bool) final { }
+    void setIsVisible(bool) final { }
     Ref<MediaTimePromise> seekToTarget(const SeekTarget&) final;
     bool paused() const final;
     MediaPlayer::NetworkState networkState() const final { return m_networkState; }

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -888,7 +888,11 @@ void AudioVideoRendererAVFObjC::setIsVisible(bool visible)
 {
     if (m_visible == visible)
         return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, visible);
     m_visible = visible;
+    // There is no point holding on to a video renderer for something nobody can see.
+    updateDisplayLayerIfNeeded();
 #if HAVE(SPATIAL_TRACKING_LABEL)
     updateSpatialTrackingLabel();
 #endif
@@ -1314,7 +1318,7 @@ bool AudioVideoRendererAVFObjC::shouldEnsureLayerOrVideoRenderer() const
     if (!canUseDecompressionSession())
         return true;
 
-    return m_renderingCanBeAccelerated;
+    return m_renderingCanBeAccelerated && m_visible;
 }
 
 WebSampleBufferVideoRendering *AudioVideoRendererAVFObjC::layerOrVideoRenderer() const

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -205,12 +205,6 @@ void MediaPlayerPrivateAVFoundation::load(const String& url)
     setPreload(m_preload);
 }
 
-void MediaPlayerPrivateAVFoundation::load(const URL& url, const LoadOptions& options)
-{
-    m_disableTeardownOnVisibilityChange = options.disableTeardownOnVisibilityChange;
-    load(url.string());
-}
-
 #if ENABLE(MEDIA_SOURCE)
 void MediaPlayerPrivateAVFoundation::load(const URL&, const LoadOptions&, MediaSourcePrivateClient&)
 {

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -70,7 +70,7 @@ MediaPlayerPrivateAVFoundation::MediaPlayerPrivateAVFoundation(MediaPlayer& play
     , m_delayCharacteristicsChangedNotification(0)
     , m_mainThreadCallPending(false)
     , m_assetIsPlayable(false)
-    , m_pageIsVisible(false)
+    , m_isVisible(false)
     , m_loadingMetadata(false)
     , m_isAllowedToRender(false)
     , m_cachedHasAudio(false)
@@ -480,7 +480,7 @@ bool MediaPlayerPrivateAVFoundation::isReadyForVideoSetup() const
     // AVFoundation will not return true for firstVideoFrameAvailable until
     // an AVPlayerLayer has been added to the AVPlayerItem, so allow video setup
     // here if a video track to trigger allocation of a AVPlayerLayer.
-    return (m_isAllowedToRender || m_cachedHasVideo) && m_readyState >= MediaPlayer::ReadyState::HaveMetadata && m_pageIsVisible;
+    return (m_isAllowedToRender || m_cachedHasVideo) && m_readyState >= MediaPlayer::ReadyState::HaveMetadata && m_isVisible;
 }
 
 void MediaPlayerPrivateAVFoundation::prepareForRendering()
@@ -607,28 +607,18 @@ void MediaPlayerPrivateAVFoundation::updateStates()
         setUpVideoRendering();
 }
 
-void MediaPlayerPrivateAVFoundation::setPageIsVisible(bool visible)
+void MediaPlayerPrivateAVFoundation::setIsVisible(bool visible)
 {
-    if (m_pageIsVisible == visible)
+    if (m_isVisible == visible)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, visible);
 
-    m_pageIsVisible = visible;
+    m_isVisible = visible;
     if (visible)
         setUpVideoRendering();
 
-    platformPageIsVisibleChanged(visible);
-}
-
-void MediaPlayerPrivateAVFoundation::setViewportVisibility(ViewportVisibility visibility)
-{
-    if (m_viewportVisibility == visibility)
-        return;
-
-    ALWAYS_LOG(LOGIDENTIFIER, visibility);
-    m_viewportVisibility = visibility;
-    platformViewportVisibilityChanged(visibility);
+    platformIsVisibleChanged(visible);
 }
 
 void MediaPlayerPrivateAVFoundation::acceleratedRenderingStateChanged()

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -184,10 +184,8 @@ protected:
     FloatSize naturalSize() const override;
     bool hasVideo() const override { return m_cachedHasVideo; }
     bool hasAudio() const override { return m_cachedHasAudio; }
-    bool pageIsVisible() const { return m_pageIsVisible; }
-    void setPageIsVisible(bool) final;
-    ViewportVisibility viewportVisibility() const { return m_viewportVisibility; }
-    void setViewportVisibility(ViewportVisibility) final;
+    bool isVisible() const { return m_isVisible; }
+    void setIsVisible(bool) final;
     MediaTime duration() const override;
     MediaTime currentTime() const override = 0;
     Ref<MediaTimePromise> seekToTarget(const SeekTarget&) final;
@@ -250,8 +248,7 @@ protected:
     virtual AssetStatus assetStatus() const = 0;
     virtual long assetErrorCode() const = 0;
 
-    virtual void platformPageIsVisibleChanged(bool) = 0;
-    virtual void platformViewportVisibilityChanged(ViewportVisibility) = 0;
+    virtual void platformIsVisibleChanged(bool) = 0;
     virtual void platformPlay() = 0;
     virtual void platformPause() = 0;
     virtual bool platformPaused() const { return !rate(); }
@@ -367,7 +364,7 @@ protected:
     int m_delayCharacteristicsChangedNotification;
     bool m_mainThreadCallPending;
     bool m_assetIsPlayable;
-    bool m_pageIsVisible { false };
+    bool m_isVisible { false };
     bool m_loadingMetadata;
     bool m_isAllowedToRender;
     bool m_cachedHasAudio;
@@ -379,7 +376,6 @@ protected:
     bool m_shouldMaintainAspectRatio;
     bool m_seeking;
     bool m_needsRenderingModeChanged { false };
-    ViewportVisibility m_viewportVisibility { ViewportVisibility::NotVisible };
 
 private:
     void seekInternal(const SeekTarget&);

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -168,7 +168,6 @@ protected:
 
     // MediaPlayerPrivatePrivateInterface overrides.
     void load(const String& url) override;
-    void load(const URL&, const LoadOptions&) override;
 #if ENABLE(MEDIA_SOURCE)
     void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) override;
 #endif
@@ -381,7 +380,6 @@ protected:
     bool m_seeking;
     bool m_needsRenderingModeChanged { false };
     ViewportVisibility m_viewportVisibility { ViewportVisibility::NotVisible };
-    bool m_disableTeardownOnVisibilityChange { false };
 
 private:
     void seekInternal(const SeekTarget&);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -166,8 +166,7 @@ private:
     void synchronizeTextTrackState() final;
 
     bool timeIsProgressing() const final { return effectiveRate(); }
-    void platformPageIsVisibleChanged(bool) final;
-    void platformViewportVisibilityChanged(ViewportVisibility) final;
+    void platformIsVisibleChanged(bool) final;
 
     void platformPlay() final;
     void platformPause() final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1440,16 +1440,11 @@ void MediaPlayerPrivateAVFoundationObjC::didEnd(double now)
     MediaPlayerPrivateAVFoundation::didEnd(now);
 }
 
-void MediaPlayerPrivateAVFoundationObjC::platformPageIsVisibleChanged(bool)
+void MediaPlayerPrivateAVFoundationObjC::platformIsVisibleChanged(bool)
 {
 #if HAVE(SPATIAL_TRACKING_LABEL)
     updateSpatialTrackingLabel();
 #endif
-    updateLayerAttachment();
-}
-
-void MediaPlayerPrivateAVFoundationObjC::platformViewportVisibilityChanged(ViewportVisibility)
-{
     updateLayerAttachment();
 }
 
@@ -4161,7 +4156,7 @@ void MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel()
         RetainPtr experience = createSpatialAudioExperienceWithOptions({
             .hasLayer = !!m_videoLayer,
             .hasTarget = !!m_videoTarget,
-            .isVisible = pageIsVisible(),
+            .isVisible = isVisible(),
             .soundStageSize = player->soundStageSize(),
             .sceneIdentifier = player->sceneIdentifier(),
 #if HAVE(SPATIAL_TRACKING_LABEL)
@@ -4184,7 +4179,7 @@ void MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel()
         return;
     }
 
-    if (m_videoLayer && pageIsVisible()) {
+    if (m_videoLayer && isVisible()) {
         // If the media player has a renderer, and that renderer belongs to a page that is visible,
         // then let AVPlayer manage setting the spatial tracking label in its AVPlayerLayer itself;
         ALWAYS_LOG(LOGIDENTIFIER, "No videoLayer, set STSLabel: nil");
@@ -4325,13 +4320,7 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldAttachLayerToPlayer()
         return false;
 #endif
 
-    if (!pageIsVisible())
-        return false;
-
-    if (viewportVisibility() == ViewportVisibility::NotVisible)
-        return false;
-
-    return true;
+    return isVisible();
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -4325,12 +4325,6 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldAttachLayerToPlayer()
         return false;
 #endif
 
-    // 311380@main started detaching the video layer from the player when the page or the
-    // element became non-visible. Some clients keep displaying the video layer they host
-    // after hiding their web view, so for those keep the layer attached as it was before.
-    if (m_disableTeardownOnVisibilityChange)
-        return true;
-
     if (!pageIsVisible())
         return false;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -210,7 +210,6 @@ private:
     void setPageIsVisible(bool) final;
     void setViewportVisibility(ViewportVisibility) final;
     void updateRendererVisibility();
-    bool shouldTeardownOnVisibilityChange() const;
 
     MediaTime duration() const override;
     MediaTime startTime() const override;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -207,8 +207,7 @@ private:
     bool hasVideo() const override;
     bool hasAudio() const override;
 
-    void setPageIsVisible(bool) final;
-    void setViewportVisibility(ViewportVisibility) final;
+    void setIsVisible(bool) final;
     void updateRendererVisibility();
 
     MediaTime duration() const override;
@@ -377,8 +376,7 @@ private:
     mutable bool m_loadingProgressed WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
     bool m_hasAvailableVideoFrame WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
     bool m_allRenderersHaveAvailableSamples WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
-    bool m_pageIsVisible WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
-    ViewportVisibility m_viewportVisibility WTF_GUARDED_BY_CAPABILITY(mainThread) { ViewportVisibility::NotVisible };
+    bool m_isVisible WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     RefPtr<MediaPlaybackTarget> m_playbackTarget WTF_GUARDED_BY_CAPABILITY(mainThread);
     bool m_shouldPlayToTarget WTF_GUARDED_BY_CAPABILITY(mainThread) { false };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -108,8 +108,7 @@ MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC(Media
     , m_rendererFinishSeekRequest(NativePromiseRequest::create())
     , m_stallRequest(NativePromiseRequest::create())
     , m_networkState(MediaPlayer::NetworkState::Empty)
-    , m_pageIsVisible { player.pageIsVisible() }
-    , m_viewportVisibility { player.viewportVisibility() }
+    , m_isVisible { player.isVisible() }
     , m_logger(player.mediaPlayerLogger())
     , m_logIdentifier(player.mediaPlayerLogIdentifier())
 #if HAVE(SPATIAL_TRACKING_LABEL)
@@ -308,6 +307,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::load(const URL&, const LoadOptions& o
         m_renderer->setPresentationSize(player->presentationSize());
         m_renderer->setVideoLayerSize(player->videoLayerSize());
         m_renderer->renderingCanBeAcceleratedChanged(player->renderingCanBeAccelerated());
+        m_renderer->setIsVisible(m_isVisible);
         m_renderer->setVolume(player->volume());
         m_renderer->setMuted(player->muted());
         m_renderer->setPreservesPitchAndCorrectionAlgorithm(player->preservesPitch(), player->pitchCorrectionAlgorithm());
@@ -432,34 +432,28 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::hasAudio() const
     return mediaSourcePrivate && mediaSourcePrivate->hasAudio();
 }
 
-void MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible(bool visible)
+void MediaPlayerPrivateMediaSourceAVFObjC::setIsVisible(bool visible)
 {
     assertIsMainThread();
-    if (m_pageIsVisible == visible)
+    if (m_isVisible == visible)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, visible);
-    m_pageIsVisible = visible;
-    updateRendererVisibility();
-}
-
-void MediaPlayerPrivateMediaSourceAVFObjC::setViewportVisibility(ViewportVisibility visibility)
-{
-    assertIsMainThread();
-    if (m_viewportVisibility == visibility)
-        return;
-
-    ALWAYS_LOG(LOGIDENTIFIER, visibility);
-    m_viewportVisibility = visibility;
+    m_isVisible = visible;
     updateRendererVisibility();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::updateRendererVisibility()
 {
     assertIsMainThread();
-    bool visible = m_pageIsVisible && m_viewportVisibility != ViewportVisibility::NotVisible;
+    // The viewport intersection is not consulted: the visibility of the video's own layer,
+    // which MediaPlayer has already folded into m_isVisible, covers a video scrolled out of
+    // view as well as one whose page or hosting client has hidden it.
+    bool visible = m_isVisible;
+    ALWAYS_LOG(LOGIDENTIFIER, "visible: ", visible);
+    // Whether the renderer needs to exist is the renderer's own call: it knows whether it is
+    // visible and whether it can render accelerated, which are separate questions.
     m_renderer->setIsVisible(visible);
-    acceleratedRenderingStateChanged();
 }
 
 MediaTime MediaPlayerPrivateMediaSourceAVFObjC::duration() const
@@ -971,12 +965,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged()
     assertIsMainThread();
 
     RefPtr player = m_player.get();
-
-    // Don't create a layer if the player is not visible:
-    bool canBeAccelerated = m_pageIsVisible
-        && m_viewportVisibility != ViewportVisibility::NotVisible
-        && player
-        && player->renderingCanBeAccelerated();
+    bool canBeAccelerated = player && player->renderingCanBeAccelerated();
     m_renderer->renderingCanBeAcceleratedChanged(canBeAccelerated);
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -432,16 +432,6 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::hasAudio() const
     return mediaSourcePrivate && mediaSourcePrivate->hasAudio();
 }
 
-bool MediaPlayerPrivateMediaSourceAVFObjC::shouldTeardownOnVisibilityChange() const
-{
-    assertIsMainThread();
-    // Some clients continue to display the video layer they host after hiding their web view.
-    // For those, neither the page's visibility nor the element's position in the viewport
-    // indicate whether the video is on screen, and tearing the layer down would leave the
-    // client displaying a black frame.
-    return !m_loadOptions.disableTeardownOnVisibilityChange;
-}
-
 void MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible(bool visible)
 {
     assertIsMainThread();
@@ -469,11 +459,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateRendererVisibility()
     assertIsMainThread();
     bool visible = m_pageIsVisible && m_viewportVisibility != ViewportVisibility::NotVisible;
     m_renderer->setIsVisible(visible);
-    // 311380@main started letting the page's and the element's visibility release the video
-    // renderer. Some clients keep displaying the video layer they host after hiding their web
-    // view, so for those restore the previous behaviour where visibility had no such effect.
-    if (shouldTeardownOnVisibilityChange())
-        acceleratedRenderingStateChanged();
+    acceleratedRenderingStateChanged();
 }
 
 MediaTime MediaPlayerPrivateMediaSourceAVFObjC::duration() const
@@ -986,11 +972,11 @@ void MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged()
 
     RefPtr player = m_player.get();
 
-    bool canBeAccelerated = player && player->renderingCanBeAccelerated();
-
     // Don't create a layer if the player is not visible:
-    if (shouldTeardownOnVisibilityChange())
-        canBeAccelerated = canBeAccelerated && m_pageIsVisible && m_viewportVisibility != ViewportVisibility::NotVisible;
+    bool canBeAccelerated = m_pageIsVisible
+        && m_viewportVisibility != ViewportVisibility::NotVisible
+        && player
+        && player->renderingCanBeAccelerated();
     m_renderer->renderingCanBeAcceleratedChanged(canBeAccelerated);
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -132,9 +132,8 @@ private:
     bool hasVideo() const override;
     bool hasAudio() const override;
 
-    void setPageIsVisible(bool) final;
+    void setIsVisible(bool) final;
     void setVisibleForCanvas(bool) final;
-    void setViewportVisibility(ViewportVisibility) final;
 
     MediaTime duration() const override;
     MediaTime currentTime() const override;
@@ -306,8 +305,7 @@ private:
     bool m_muted { false };
     bool m_ended { false };
     bool m_hasEverEnqueuedVideoFrame { false };
-    bool m_isPageVisible { false };
-    bool m_isVisibleInViewPort { false };
+    bool m_isVisible { false };
     bool m_haveSeenMetadata { false };
     bool m_waitingForFirstImage { false };
     bool m_isActiveVideoTrackEnabled { true };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -255,7 +255,8 @@ void MediaPlayerPrivateMediaStreamAVFObjC::videoFrameAvailable(VideoFrame& video
 
 void MediaPlayerPrivateMediaStreamAVFObjC::enqueueVideoFrame(VideoFrame& videoFrame)
 {
-    if (!m_isPageVisible || !m_isVisibleInViewPort)
+    // Nothing to draw into: skip the work rather than enqueue frames nobody can see.
+    if (!m_isVisible)
         return;
 
     if (!m_sampleBufferDisplayLayerLock.tryLock())
@@ -700,27 +701,19 @@ bool MediaPlayerPrivateMediaStreamAVFObjC::hasAudio() const
     return !m_audioTrackMap.isEmpty();
 }
 
-void MediaPlayerPrivateMediaStreamAVFObjC::setPageIsVisible(bool isVisible)
+void MediaPlayerPrivateMediaStreamAVFObjC::setIsVisible(bool isVisible)
 {
-    if (m_isPageVisible == isVisible)
+    if (m_isVisible == isVisible)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, isVisible);
-    m_isPageVisible = isVisible;
+    m_isVisible = isVisible;
     flushRenderers();
     reenqueueCurrentVideoFrameIfNeeded();
 }
 
 void MediaPlayerPrivateMediaStreamAVFObjC::setVisibleForCanvas(bool)
 {
-}
-
-void MediaPlayerPrivateMediaStreamAVFObjC::setViewportVisibility(ViewportVisibility visibility)
-{
-    if (visibility == ViewportVisibility::NotVisible || visibility == ViewportVisibility::IntersectingViewport)
-        m_isVisibleInViewPort = false;
-    else
-        m_isVisibleInViewPort = true;
 }
 
 MediaTime MediaPlayerPrivateMediaStreamAVFObjC::duration() const

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -138,7 +138,7 @@ private:
     bool hasVideo() const final { return m_hasVideo.load(std::memory_order_relaxed); }
     bool hasAudio() const final { return m_hasAudio.load(std::memory_order_relaxed); }
 
-    void setPageIsVisible(bool) final;
+    void setIsVisible(bool) final;
 
     MediaTime timeFudgeFactor() const { return { 1, 10 }; }
     MediaTime currentTime() const final;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -546,7 +546,7 @@ bool MediaPlayerPrivateWebM::timeIsProgressing() const
     return m_renderer->timeIsProgressing();
 }
 
-void MediaPlayerPrivateWebM::setPageIsVisible(bool visible)
+void MediaPlayerPrivateWebM::setIsVisible(bool visible)
 {
     assertIsMainThread();
     if (m_visible == visible)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4235,7 +4235,7 @@ void MediaPlayerPrivateGStreamer::paint(GraphicsContext& context, const FloatRec
     if (context.paintingDisabled())
         return;
 
-    if (!m_pageIsVisible || isSuspended())
+    if (!m_isVisible || isSuspended())
         return;
 
     // Keep a reference to the sample to avoid keeping the sampleMutex locked, which would be prone

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -160,7 +160,7 @@ public:
     void setMuted(bool) final;
     MediaPlayer::NetworkState networkState() const final;
     MediaPlayer::ReadyState readyState() const final;
-    void setPageIsVisible(bool visible) final { m_pageIsVisible = visible; }
+    void setIsVisible(bool visible) final { m_isVisible = visible; }
     void setViewportVisibility(ViewportVisibility) final;
     void setPresentationSize(const IntSize&) final;
     MediaTime duration() const override;
@@ -628,8 +628,8 @@ private:
 
     bool m_isVisibleInViewport { true };
 
-    // Whether the page containing the HTMLMediaElement is visible, reflects: setPageIsVisible()
-    bool m_pageIsVisible { false };
+    // Whether the page containing the HTMLMediaElement is visible, reflects: setIsVisible()
+    bool m_isVisible { false };
 
     // playbin3 only:
     bool m_waitingForStreamsSelectedEvent { true };

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
@@ -72,7 +72,7 @@ public:
     bool hasVideo() const final { return false; };
     bool hasAudio() const final { return false; };
 
-    void setPageIsVisible(bool) final { };
+    void setIsVisible(bool) final { };
 
     Ref<MediaTimePromise> seekToTarget(const SeekTarget&) final { return MediaTimePromise::createAndResolve(MediaTime::zeroTime()); }
 

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
@@ -276,7 +276,7 @@ bool MediaPlayerPrivateMediaFoundation::hasAudio() const
     return m_hasAudio;
 }
 
-void MediaPlayerPrivateMediaFoundation::setPageIsVisible(bool visible)
+void MediaPlayerPrivateMediaFoundation::setIsVisible(bool visible)
 {
     m_visible = visible;
 }

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
@@ -83,7 +83,7 @@ public:
     bool hasVideo() const final;
     bool hasAudio() const final;
 
-    void setPageIsVisible(bool) final;
+    void setIsVisible(bool) final;
 
     Ref<MediaTimePromise> seekToTarget(const SeekTarget&) final;
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -166,7 +166,7 @@ void MockMediaPlayerMediaSource::characteristicsFromMediaSourceChanged()
         player->characteristicChanged();
 }
 
-void MockMediaPlayerMediaSource::setPageIsVisible(bool)
+void MockMediaPlayerMediaSource::setIsVisible(bool)
 {
 }
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -88,7 +88,7 @@ private:
     FloatSize naturalSize() const override;
     bool hasVideo() const override;
     bool hasAudio() const override;
-    void setPageIsVisible(bool) final;
+    void setIsVisible(bool) final;
     Ref<MediaTimePromise> seekToTarget(const SeekTarget&) final;
     bool paused() const override;
     MediaPlayer::NetworkState networkState() const override;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5627,6 +5627,15 @@ bool Internals::isPlayerVisibleInViewport(const HTMLMediaElement& element) const
     return player && player->viewportVisibility() == HTMLMediaElement::ViewportVisibility::VisibleInViewport;
 }
 
+// Whether the video can be seen at all, as MediaPlayer resolved it from the video layer, the
+// page and the viewport. Distinct from isPlayerVisibleInViewport(), which reports only where
+// the element's box sits.
+bool Internals::isVideoVisible(const HTMLMediaElement& element) const
+{
+    RefPtr player = element.player();
+    return player && player->isVisible();
+}
+
 bool Internals::isPlayerMuted(const HTMLMediaElement& element) const
 {
     RefPtr player = element.player();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -942,6 +942,7 @@ public:
     void activeAudioRouteDidChange(bool shouldPause);
     bool NODELETE elementIsBlockingDisplaySleep(const HTMLMediaElement&) const;
     bool NODELETE isPlayerVisibleInViewport(const HTMLMediaElement&) const;
+    bool isVideoVisible(const HTMLMediaElement&) const;
     bool isPlayerMuted(const HTMLMediaElement&) const;
     bool isPlayerPaused(const HTMLMediaElement&) const;
     double effectiveRate(const HTMLMediaElement&) const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1144,6 +1144,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] undefined simulateSystemWake();
     [Conditional=VIDEO] boolean elementIsBlockingDisplaySleep(HTMLMediaElement element);
     [Conditional=VIDEO] boolean isPlayerVisibleInViewport(HTMLMediaElement element);
+    [Conditional=VIDEO] boolean isVideoVisible(HTMLMediaElement element);
     [Conditional=VIDEO] boolean isPlayerMuted(HTMLMediaElement element);
     [Conditional=VIDEO] boolean isPlayerPaused(HTMLMediaElement element);
     [Conditional=VIDEO] double effectiveRate(HTMLMediaElement element);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -321,10 +321,12 @@ void RemoteMediaPlayerProxy::prepareForRendering()
     protect(m_player)->prepareForRendering();
 }
 
-void RemoteMediaPlayerProxy::setPageIsVisible(bool visible)
+void RemoteMediaPlayerProxy::setIsVisible(bool visible)
 {
     ALWAYS_LOG(LOGIDENTIFIER, visible);
-    protect(m_player)->setPageIsVisible(visible);
+    // The WebContent process's MediaPlayer has already resolved the page's and the video
+    // layer's visibility into this single value, and delayed it as needed.
+    protect(m_player)->setIsVisible(visible);
 }
 
 void RemoteMediaPlayerProxy::setViewportVisibility(ViewportVisibility visibility)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -169,7 +169,7 @@ public:
     void setPreservesPitch(bool);
     void setPitchCorrectionAlgorithm(WebCore::MediaPlayer::PitchCorrectionAlgorithm);
 
-    void setPageIsVisible(bool);
+    void setIsVisible(bool);
 
     using ViewportVisibility = WebCore::MediaPlayer::ViewportVisibility;
     void setViewportVisibility(ViewportVisibility);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -51,7 +51,7 @@ messages -> RemoteMediaPlayerProxy {
     SetPitchCorrectionAlgorithm(enum:uint8_t WebCore::MediaPlayerPitchCorrectionAlgorithm algorithm)
 
     PrepareForRendering()
-    SetPageIsVisible(bool visible)
+    SetIsVisible(bool visible)
     SetViewportVisibility(enum:uint8_t WebCore::MediaPlayerViewportVisibility visibility)
     SetShouldMaintainAspectRatio(bool maintainAspectRatio)
     AcceleratedRenderingStateChanged(bool canBeAccelerated)

--- a/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
@@ -254,7 +254,6 @@ header: <WebCore/MediaPlayer.h>
     WebCore::ContentType contentType;
     bool requiresRemotePlayback;
     bool supportsLimitedMatroska;
-    bool disableTeardownOnVisibilityChange;
     std::optional<bool> supportsProgressMonitoringOverride;
     OptionSet<WebCore::VideoRendererPreference> videoRendererPreferences;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
@@ -256,6 +256,7 @@ header: <WebCore/MediaPlayer.h>
     bool supportsLimitedMatroska;
     std::optional<bool> supportsProgressMonitoringOverride;
     OptionSet<WebCore::VideoRendererPreference> videoRendererPreferences;
+    Seconds videoLayerVisibilityDelay;
 };
 
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -43,8 +43,10 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/MachSendRightAnnotated.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/Observer.h>
 #include <wtf/RefPtr.h>
+#include <wtf/RunLoop.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
@@ -211,6 +213,21 @@ public:
     PlatformLayerContainer createLayerWithID(PlaybackSessionContextIdentifier, const WebCore::HostingContext&, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& nativeSize, float hostingScaleFactor);
 
     void willRemoveLayerForID(PlaybackSessionContextIdentifier);
+
+    // Tell the web process whether the video layer we vended is actually on screen. A client
+    // may host it outside of the web view, in which case the page's own visibility says
+    // nothing about whether the video can be seen.
+    //
+    // Anything that moves, resizes or clips a video layer reaches us as a layer tree commit,
+    // but working out what is on screen means walking a superview chain per video and commits
+    // arrive every frame. Note that something changed instead and coalesce the answer, so the
+    // cost is paid at most once per updateVideoLayerIsVisibleInterval.
+    void videoLayerTreeDidChange();
+    void applicationDidEnterBackground();
+    void applicationWillEnterForeground();
+    void updateVideoLayerIsVisibleTimerFired();
+    void updateVideoLayerIsVisible(PlaybackSessionContextIdentifier, ASCIILiteral reason);
+    void updateVideoLayerIsVisibleForAllContexts(ASCIILiteral reason);
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;
 
     void swapFullscreenModes(PlaybackSessionContextIdentifier, PlaybackSessionContextIdentifier);
@@ -319,6 +336,12 @@ private:
     const Ref<PlaybackSessionManagerProxy> m_playbackSessionManagerProxy;
     HashMap<PlaybackSessionContextIdentifier, ModelInterfacePair> m_contextMap;
     HashMap<PlaybackSessionContextIdentifier, int> m_clientCounts;
+    HashMap<PlaybackSessionContextIdentifier, bool> m_videoLayerIsVisible;
+#if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)
+    static constexpr Seconds updateVideoLayerIsVisibleInterval { 100_ms };
+    RunLoop::Timer m_updateVideoLayerIsVisibleTimer;
+    MonotonicTime m_lastVideoLayerIsVisibleUpdate;
+#endif
     Vector<CompletionHandler<void()>> m_closeCompletionHandlers;
     WeakHashSet<VideoInPictureInPictureDidChangeObserver> m_pipChangeObservers;
     Markable<PlaybackSessionContextIdentifier> m_lastInteractedWithVideo;

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -514,15 +514,21 @@ void VideoPresentationModelContext::requestRouteSharingPolicyAndContextUID(Compl
 void VideoPresentationModelContext::didEnterPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (RefPtr manager = m_manager.get())
+    if (RefPtr manager = m_manager.get()) {
         manager->hasVideoInPictureInPictureDidChange(true);
+        // Entering or leaving picture-in-picture changes whether the application being in the
+        // background hides this video, and may not produce a layer tree commit to notice it by.
+        manager->updateVideoLayerIsVisible(m_contextId, "didEnterPictureInPicture"_s);
+    }
 }
 
 void VideoPresentationModelContext::didExitPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (RefPtr manager = m_manager.get())
+    if (RefPtr manager = m_manager.get()) {
         manager->hasVideoInPictureInPictureDidChange(false);
+        manager->updateVideoLayerIsVisible(m_contextId, "didExitPictureInPicture"_s);
+    }
 }
 
 void VideoPresentationModelContext::willEnterPictureInPicture()
@@ -607,6 +613,9 @@ Ref<VideoPresentationManagerProxy> VideoPresentationManagerProxy::create(WebPage
 VideoPresentationManagerProxy::VideoPresentationManagerProxy(WebPageProxy& page, PlaybackSessionManagerProxy& playbackSessionManagerProxy)
     : m_page(page)
     , m_playbackSessionManagerProxy(playbackSessionManagerProxy)
+#if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)
+    , m_updateVideoLayerIsVisibleTimer(RunLoop::mainSingleton(), "VideoPresentationManagerProxy::UpdateVideoLayerIsVisibleTimer"_s, this, &VideoPresentationManagerProxy::updateVideoLayerIsVisibleTimerFired)
+#endif
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     RefPtr protectedPage = m_page.get();
@@ -1023,8 +1032,137 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
 
 void VideoPresentationManagerProxy::willRemoveLayerForID(PlaybackSessionContextIdentifier contextId)
 {
+    // With the layer gone there is nothing left to measure, so retract what we last said rather
+    // than leave it standing: the decision has to fall back to the page and the viewport, or a
+    // video whose layer was torn down could never be told that it is on screen again.
+    if (m_videoLayerIsVisible.remove(contextId))
+        sendToWebProcess(contextId, Messages::VideoPresentationManager::SetVideoLayerIsVisible(contextId.object(), std::nullopt));
+
     removeClientForContext(contextId);
 }
+
+#if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)
+
+void VideoPresentationManagerProxy::videoLayerTreeDidChange()
+{
+    if (m_updateVideoLayerIsVisibleTimer.isActive())
+        return;
+
+    // Answer straight away if we have not looked recently, so that a video scrolled back into
+    // view gets its renderer without waiting; otherwise coalesce until the interval is up.
+    auto elapsed = MonotonicTime::now() - m_lastVideoLayerIsVisibleUpdate;
+    if (elapsed >= updateVideoLayerIsVisibleInterval) {
+        updateVideoLayerIsVisibleForAllContexts("layerTreeCommit"_s);
+        return;
+    }
+
+    m_updateVideoLayerIsVisibleTimer.startOneShot(updateVideoLayerIsVisibleInterval - elapsed);
+}
+
+void VideoPresentationManagerProxy::applicationDidEnterBackground()
+{
+    // Nothing can be seen of a video whose application has been put away.
+    updateVideoLayerIsVisibleForAllContexts("applicationDidEnterBackground"_s);
+}
+
+void VideoPresentationManagerProxy::applicationWillEnterForeground()
+{
+    // Look now, and again once the view hierarchy has had a chance to settle. Coming back to
+    // the foreground rebuilds views, so this first answer can be wrong in ways we cannot
+    // detect - a layer not yet back in a window, or still clipped away by a view about to be
+    // removed - and a page with nothing animating produces no commit to correct it by.
+    updateVideoLayerIsVisibleForAllContexts("applicationWillEnterForeground"_s);
+    if (!m_updateVideoLayerIsVisibleTimer.isActive())
+        m_updateVideoLayerIsVisibleTimer.startOneShot(updateVideoLayerIsVisibleInterval);
+}
+
+void VideoPresentationManagerProxy::updateVideoLayerIsVisibleTimerFired()
+{
+    updateVideoLayerIsVisibleForAllContexts("coalescedUpdate"_s);
+}
+
+void VideoPresentationManagerProxy::updateVideoLayerIsVisibleForAllContexts(ASCIILiteral reason)
+{
+    // Recorded here rather than in the callers so that a pass triggered by an application
+    // state change also holds off the next commit driven one.
+    m_lastVideoLayerIsVisibleUpdate = MonotonicTime::now();
+    for (auto& contextId : copyToVector(m_contextMap.keys()))
+        updateVideoLayerIsVisible(contextId, reason);
+}
+
+void VideoPresentationManagerProxy::updateVideoLayerIsVisible(PlaybackSessionContextIdentifier contextId, ASCIILiteral reason)
+{
+    RefPtr interface = findInterface(contextId);
+    RetainPtr playerLayerView = interface ? interface->playerLayerView() : nil;
+    if (!playerLayerView)
+        return;
+
+    // A view with no window or no size cannot be seen, but it may also merely be part-way
+    // through being set up or torn down. Report it as invisible either way and let the delay
+    // before the renderer is released cover the transient case, but ask again shortly: a
+    // settled page produces no further commits, so otherwise this answer would stand for good.
+    RetainPtr window = [playerLayerView window];
+    bool canBeMeasured = window && !CGRectIsEmpty([playerLayerView bounds]);
+    if (!canBeMeasured && !m_updateVideoLayerIsVisibleTimer.isActive())
+        m_updateVideoLayerIsVisibleTimer.startOneShot(updateVideoLayerIsVisibleInterval);
+
+    // Neither -isHidden, -alpha nor being in a window tell the interesting cases apart: a
+    // video a client hosts outside of the web view and one that has been scrolled far away
+    // read alike for all three. Where the layer ends up does distinguish them, so intersect
+    // its frame with the window and with every clipping ancestor and see what survives.
+    CGRect visibleRect = CGRectNull;
+    if (canBeMeasured) {
+        visibleRect = CGRectIntersection([playerLayerView convertRect:[playerLayerView bounds] toView:nil], [window bounds]);
+        for (RetainPtr<UIView> view = [playerLayerView superview]; view && !CGRectIsEmpty(visibleRect); view = [view superview]) {
+            if ([view clipsToBounds] || [[view layer] masksToBounds])
+                visibleRect = CGRectIntersection(visibleRect, [view convertRect:[view bounds] toView:nil]);
+        }
+    }
+    // Geometry only tells us where the layer sits within our own window, so also require that
+    // the application has not been put away entirely. This is deliberately the application's
+    // own state and not the page's or the view's: a client may take the layer out of the web
+    // view and display it itself, in which case neither knows that it is still on screen.
+    // Occlusion by another application's window is not covered, only full minimisation.
+    // Picture-in-picture is exempt, as the whole point of it is that the system keeps the
+    // video on screen after the application it came from has gone away.
+    RefPtr page = m_page.get();
+    bool applicationCanShowIt = interface->inPictureInPicture() || (page && !page->lastObservedStateWasBackground());
+    bool isVisible = !CGRectIsEmpty(visibleRect) && applicationCanShowIt;
+
+    auto addResult = m_videoLayerIsVisible.add(contextId, isVisible);
+    if (!addResult.isNewEntry) {
+        if (addResult.iterator->value == isVisible)
+            return;
+        addResult.iterator->value = isVisible;
+    }
+
+    ALWAYS_LOG(LOGIDENTIFIER, contextId.object().toUInt64(), ", isVisible: ", isVisible, ", reason: ", reason, ", visibleRect: ", FloatRect { visibleRect });
+    sendToWebProcess(contextId, Messages::VideoPresentationManager::SetVideoLayerIsVisible(contextId.object(), isVisible));
+}
+
+#else
+
+void VideoPresentationManagerProxy::videoLayerTreeDidChange()
+{
+}
+
+void VideoPresentationManagerProxy::applicationDidEnterBackground()
+{
+}
+
+void VideoPresentationManagerProxy::applicationWillEnterForeground()
+{
+}
+
+void VideoPresentationManagerProxy::updateVideoLayerIsVisibleForAllContexts(ASCIILiteral)
+{
+}
+
+void VideoPresentationManagerProxy::updateVideoLayerIsVisible(PlaybackSessionContextIdentifier, ASCIILiteral)
+{
+}
+
+#endif
 
 std::optional<SharedPreferencesForWebProcess> VideoPresentationManagerProxy::sharedPreferencesForWebProcess(IPC::Connection& connection) const
 {
@@ -1596,6 +1734,9 @@ void VideoPresentationManagerProxy::setVideoLayerFrame(PlaybackSessionContextIde
 
     auto [model, interface] = ensureModelAndInterface(contextId);
     interface->setCaptionsFrame(CGRectMake(0, 0, frame.width(), frame.height()));
+
+    // A client moving the video layer around drives this; re-check whether it can be seen.
+    updateVideoLayerIsVisible(contextId, "setVideoLayerFrame"_s);
     WTF::MachSendRightAnnotated sendRightAnnotated;
 #if PLATFORM(IOS_FAMILY)
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -144,6 +144,21 @@ bool RemoteLayerTreeHost::updateBannerLayers(const std::optional<MainFrameData>&
 }
 #endif
 
+// A commit that only carries new backing store cannot have moved or clipped anything, and a
+// page playing a video produces those constantly. Only a change to geometry can alter what is
+// on screen, so only those are worth re-measuring a video layer for.
+static constexpr OptionSet<LayerChange> layerChangesAffectingGeometry {
+    LayerChange::TransformChanged,
+    LayerChange::SublayerTransformChanged,
+    LayerChange::ChildrenChanged,
+    LayerChange::PositionChanged,
+    LayerChange::AnchorPointChanged,
+    LayerChange::BoundsChanged,
+    LayerChange::HiddenChanged,
+    LayerChange::MasksToBoundsChanged,
+    LayerChange::AnimationsChanged,
+};
+
 bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, const RemoteLayerTreeTransaction& transaction, const std::optional<MainFrameData>& mainFrameData, float indicatorScaleFactor)
 {
     if (!m_drawingArea)
@@ -206,9 +221,12 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
         protect(*m_drawingArea)->updateTimelinesRegistration(processIdentifier, transaction.timelinesUpdate(), MonotonicTime::now());
 #endif
 
+    bool geometryChanged = false;
     for (auto& changedLayer : transaction.changedLayerProperties()) {
         auto layerID = changedLayer.key;
         const auto& properties = changedLayer.value.get();
+
+        geometryChanged |= properties.changedProperties.containsAny(layerChangesAffectingGeometry);
 
         RefPtr node = nodeForID(layerID);
         ASSERT(node);
@@ -237,6 +255,16 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
 
     for (auto& destroyedLayer : transaction.destroyedLayers())
         layerWillBeRemoved(processIdentifier, destroyedLayer);
+
+#if HAVE(AVKIT)
+    // Anything that moves, resizes or clips a video layer reaches us here, so let the manager
+    // work out whether the videos it vended layers for are still on screen.
+    if (geometryChanged && !m_videoLayers.isEmpty()) {
+        RefPtr page = drawingArea().page();
+        if (RefPtr videoManager = page ? page->videoPresentationManager() : nullptr)
+            videoManager->videoLayerTreeDidChange();
+    }
+#endif
 
     // Drop the contents of any layers which were unparented; the Web process will re-send
     // the backing store in the commit that reparents them.

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -591,6 +591,11 @@ void WebPageProxy::applicationDidEnterBackground()
 {
     m_lastObservedStateWasBackground = true;
 
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    if (RefPtr videoPresentationManager = m_videoPresentationManager)
+        videoPresentationManager->applicationDidEnterBackground();
+#endif
+
     bool isSuspendedUnderLock = UIApplication.sharedApplication.isSuspendedUnderLock;
     
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "applicationDidEnterBackground: isSuspendedUnderLock? %d", isSuspendedUnderLock);
@@ -616,6 +621,11 @@ void WebPageProxy::applicationDidFinishSnapshottingAfterEnteringBackground()
 void WebPageProxy::applicationWillEnterForeground()
 {
     m_lastObservedStateWasBackground = false;
+
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    if (RefPtr videoPresentationManager = m_videoPresentationManager)
+        videoPresentationManager->applicationWillEnterForeground();
+#endif
 
     bool isSuspendedUnderLock = UIApplication.sharedApplication.isSuspendedUnderLock;
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "applicationWillEnterForeground: isSuspendedUnderLock? %d", isSuspendedUnderLock);

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -669,15 +669,15 @@ void MediaPlayerPrivateRemote::prepareForRendering()
     protect(connection())->send(Messages::RemoteMediaPlayerProxy::PrepareForRendering(), m_id);
 }
 
-void MediaPlayerPrivateRemote::setPageIsVisible(bool visible)
+void MediaPlayerPrivateRemote::setIsVisible(bool visible)
 {
-    if (m_pageIsVisible == visible)
+    if (m_isVisible == visible)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, visible);
 
-    m_pageIsVisible = visible;
-    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetPageIsVisible(visible), m_id);
+    m_isVisible = visible;
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetIsVisible(visible), m_id);
 }
 
 void MediaPlayerPrivateRemote::setViewportVisibility(ViewportVisibility visibility)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -305,7 +305,7 @@ private:
     bool hasVideo() const final;
     bool hasAudio() const final;
 
-    void setPageIsVisible(bool) final;
+    void setIsVisible(bool) final;
     void setViewportVisibility(ViewportVisibility) final;
 
     MediaTime getStartDate() const final;
@@ -537,7 +537,7 @@ private:
     bool m_isCurrentPlaybackTargetWireless { false };
     bool m_waitingForKey { false };
     std::optional<bool> m_shouldMaintainAspectRatio;
-    std::optional<bool> m_pageIsVisible;
+    std::optional<bool> m_isVisible;
     ViewportVisibility m_viewportVisibility { ViewportVisibility::NotVisible };
     RefPtr<RemoteVideoFrameProxy> m_videoFrameForCurrentTime;
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -224,6 +224,7 @@ protected:
     void ensureUpdatedVideoDimensions(WebCore::MediaPlayerClientIdentifier, WebCore::FloatSize existingVideoDimensions);
 
     void NODELETE setCurrentVideoFullscreenMode(VideoPresentationInterfaceContext&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
+    void setVideoLayerIsVisible(WebCore::MediaPlayerClientIdentifier, std::optional<bool>);
     void setRequiresTextTrackRepresentation(WebCore::MediaPlayerClientIdentifier, bool);
     void setTextTrackRepresentationBounds(WebCore::MediaPlayerClientIdentifier, const WebCore::IntRect&);
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
@@ -49,6 +49,7 @@ messages -> VideoPresentationManager {
     FullscreenMayReturnToInline(WebCore::MediaPlayerClientIdentifier contextId, bool isPageVisible)
     RequestRouteSharingPolicyAndContextUID(WebCore::MediaPlayerClientIdentifier contextId) -> (enum:uint8_t WebCore::RouteSharingPolicy routeSharingPolicy, String routingContextUID)
     EnsureUpdatedVideoDimensions(WebCore::MediaPlayerClientIdentifier contextId, WebCore::FloatSize existingVideoDimensions)
+    SetVideoLayerIsVisible(WebCore::MediaPlayerClientIdentifier contextId, std::optional<bool> isVisible)
     SetRequiresTextTrackRepresentation(WebCore::MediaPlayerClientIdentifier contextId, bool requiresTextTrackRepresentation)
     SetTextTrackRepresentationBounds(WebCore::MediaPlayerClientIdentifier contextId, WebCore::IntRect bounds)
 }

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -982,6 +982,15 @@ void VideoPresentationManager::setTextTrackRepresentationIsHiddenForVideoElement
 
 }
 
+void VideoPresentationManager::setVideoLayerIsVisible(WebCore::MediaPlayerClientIdentifier contextId, std::optional<bool> isVisible)
+{
+    RefPtr videoElement = ensureModel(contextId)->videoElement();
+    if (!videoElement)
+        return;
+
+    videoElement->setVideoLayerIsVisible(isVisible);
+}
+
 void VideoPresentationManager::setRequiresTextTrackRepresentation(WebCore::MediaPlayerClientIdentifier contextId, bool requiresTextTrackRepresentation)
 {
     ensureModel(contextId)->setRequiresTextTrackRepresentation(requiresTextTrackRepresentation);


### PR DESCRIPTION
#### 2a64892a84766ed7ddcd698716ab76054a0b3e4f
<pre>
Track if a video layer is visible rather than only relying on player&apos;s viewport position
<a href="https://bugs.webkit.org/show_bug.cgi?id=320726">https://bugs.webkit.org/show_bug.cgi?id=320726</a>
<a href="https://rdar.apple.com/183711482">rdar://183711482</a>

Reviewed by NOBODY (OOPS!).

Moon Player displays web video in its own interface. It takes the WebAVPlayerLayerView
that VideoPresentationManagerProxy::createViewWithID vends for a video element,
reparents it into a view of its own in another window, and then hides its WKWebView.
The video is still on screen, hosted by the client, but as far as the page is concerned it is
neither visible nor anywhere in the viewport.

&quot;[Cocoa] Inifite scrolling video websites can cause window server jetsams&quot; taught the media
players to give up their video renderer once the element could no longer be seen, which is a
worthwhile saving: a page with many videos scrolled far away no longer holds a renderer for
each. Whether the video could be seen was answered from the element&apos;s position in the
viewport and from the page&apos;s visibility, and neither survives a client hosting the layer
elsewhere. Moon&apos;s video therefore went black while its audio kept playing.

That was first addressed with a quirk that switched the teardown off for the application
entirely, which gave Moon back a working video at the cost of the saving, for every video in
that application, and only for applications we know to name. Two earlier fixes had the same
shape: fullscreen and picture-in-picture were each in turn found to be on screen while the
element&apos;s box was not, and each was patched by adding a value to the viewport enumeration.
Moon cannot be patched that way, as no description of the box says &quot;a client took the layer&quot;.

So stop asking where the box is. Where a video has a layer, that layer&apos;s own visibility is
the answer, and the UI process is the only place that can see it: it intersects the layer&apos;s
frame with its window and with every clipping ancestor, and reports the result to the web
process. MediaPlayer resolves that against the page and the viewport in one place,
computeIsVisible(), and passes only the answer down to the MediaPlayerPrivate. The layer wins
whenever it has an answer; std::nullopt means there is no layer to ask - audio only, a port
that reports none, or a layer since torn down - and the page and the box are then all there
is, which is what every platform other than iOS family continues to use. The privates lose
their own copies of the viewport state, so a decision about keeping a renderer can no longer
be made from the box: MediaPlayerPrivateAVFoundationObjC::shouldAttachLayerToPlayer and the
MediaStream player&apos;s frame gate both consult the resolved answer instead.

Anything that moves, resizes or clips a video layer arrives in the UI process as a layer tree
commit, so a commit is what tells us the answer may have changed - but measuring it walks a
superview chain per video, and most commits cannot have changed the answer at all: a page
playing a video sends new backing store constantly, and content has no bearing on where a
layer sits. Only a commit carrying a change to geometry is worth measuring for, and those
measurements are coalesced to at most one per 100ms.

Becoming visible is acted on at once, but becoming invisible waits, by default 10s. A video
that is briefly hidden should not lose its renderer and have to build a new one before it can
show a frame: on visionOS the layer was seen reporting a momentarily empty size while its
views were rebuilt, and a fast scroll down and back up crosses in and out of view several
times in well under a second. The delay absorbs both. It is carried on
MediaPlayerLoadOptions, so the GPU process&apos;s player holds the same value, and comes from a
new setting so that a test can ask for the teardown to happen at once.

Two further inputs are folded into the same decision. A video whose layer the system keeps on
screen after the application is put away - picture-in-picture - stays visible, while one whose
application is fully backgrounded does not, which does mean a scene going to the background
releases a renderer whose layer may still be positioned on screen.

MediaPlayerPrivateInterface::setPageIsVisible and MediaPlayer::pageIsVisible are renamed to
setIsVisible and isVisible, along with the SetPageIsVisible message. They were named after one
of the inputs, but what reaches a private is the resolved answer to whether the video can be
seen at all, which the page&apos;s visibility is only one part of; the old name described neither
the scope of the method nor what acting on it does. MediaPlayer::setPageIsVisible keeps its
name, as that one really is the page and really is an input.

MediaPlayer is also where the teardown is timed. No private carries its own notion of how long
to wait: MediaPlayer holds the timer, arms it when the answer turns to invisible, drops it
again if the video comes back inside the window, and only tells the private once the whole
delay has passed. Becoming visible is passed on immediately, as the renderer has to exist
before a frame can be shown. A player that is handed the answer rather than the inputs, as in
the GPU process, applies it as it stands and does not start a second timer, so the wait
happens once and in one place.

As a fly-by, setVisibleForCanvas is fixed. It was a channel of its own: it told the private
directly and took no part in the decision, so the resolved answer could contradict it and win,
releasing the renderer of a video that a page was still drawing into a canvas. It is now an
input like the others and outranks all of them - a video being drawn into a canvas keeps its
renderer regardless of what the layer, the page or the viewport say - and setting it
re-evaluates rather than waiting for some other input to change.

* LayoutTests/media/media-visible-in-viewport-in-fullscreen-expected.txt:
* LayoutTests/media/media-visible-in-viewport-in-fullscreen.html: Assert the resolved
visibility alongside the viewport state, with the teardown delay set to zero. The test
previously checked only the enumeration, which would not have caught fullscreen video being
released.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource): Fill in the teardown delay from the setting when
building the load options.
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::computeAcceleratedRenderingStateAndUpdateMediaPlayer): Answers
only whether a layer could be composited. It also required the element to intersect the
viewport, which was a way to force the renderer away and is now the visibility path&apos;s job.
(WebCore::HTMLVideoElement::setVideoLayerIsVisible): Receives the layer&apos;s visibility, or
std::nullopt once there is no layer to report.
(WebCore::HTMLVideoElement::mediaPlayerEngineUpdated): Re-seed a new player.
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/page/Settings.yaml: VideoLayerVisibilityDelay.
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::MediaPlayer):
(WebCore::MediaPlayer::loadWithNextMediaEngine):
(WebCore::MediaPlayer::isVisible const):
(WebCore::MediaPlayer::isVisibleForCanvas const):
(WebCore::MediaPlayer::viewportVisibility const): Out-of-line, as the class is exported.
(WebCore::MediaPlayer::setPageIsVisible):
(WebCore::MediaPlayer::setVideoLayerIsVisible):
(WebCore::MediaPlayer::computeIsVisible const): Resolves canvas, layer, page and viewport.
(WebCore::MediaPlayer::updateVisibility): Immediate when becoming visible, delayed otherwise.
(WebCore::MediaPlayer::setIsVisible): Was setPageIsVisible. For a player told the answer
rather than the inputs, as in the GPU process; latches so it does not also derive one.
(WebCore::MediaPlayer::visibilityTimerFired):
(WebCore::MediaPlayer::setVisibleForCanvas): Likewise.
(WebCore::MediaPlayer::setViewportVisibility): Re-evaluates rather than only forwarding.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h: Document what each of the two
visibility entry points answers, and that the box is an input rather than a substitute.
(WebCore::MediaPlayerPrivateInterface::setVisibleForCanvas):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::setIsVisible):
(WebCore::AudioVideoRendererAVFObjC::shouldEnsureLayerOrVideoRenderer const): The renderer
decides whether it needs to exist, from its own visibility and whether it can render
accelerated.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::MediaPlayerPrivateAVFoundation):
(WebCore::MediaPlayerPrivateAVFoundation::isReadyForVideoSetup const):
(WebCore::MediaPlayerPrivateAVFoundation::setIsVisible):
(WebCore::MediaPlayerPrivateAVFoundation::setPageIsVisible): Deleted.
(WebCore::MediaPlayerPrivateAVFoundation::setViewportVisibility): Deleted.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
(WebCore::MediaPlayerPrivateAVFoundation::isVisible const):
(WebCore::MediaPlayerPrivateAVFoundation::pageIsVisible const): Deleted.
(WebCore::MediaPlayerPrivateAVFoundation::viewportVisibility const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::platformIsVisibleChanged):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldAttachLayerToPlayer): The resolved
visibility alone. It also consulted the viewport state, which the player no longer keeps.
(WebCore::MediaPlayerPrivateAVFoundationObjC::platformPageIsVisibleChanged): Deleted.
(WebCore::MediaPlayerPrivateAVFoundationObjC::platformViewportVisibilityChanged): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::WTF_GUARDED_BY_CAPABILITY):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setIsVisible):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateRendererVisibility):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setViewportVisibility): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::enqueueVideoFrame): Gated on the resolved
visibility, in place of a page-visible and an in-viewport flag.
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setIsVisible):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setPageIsVisible): Deleted.
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setViewportVisibility): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::setIsVisible):
(WebCore::MediaPlayerPrivateWebM::setPageIsVisible): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::paint):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h: Keeps the viewport
state, whose use there is a decision about the box rather than about visibility.
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h:
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp:
(WebCore::MediaPlayerPrivateMediaFoundation::setIsVisible):
(WebCore::MediaPlayerPrivateMediaFoundation::setPageIsVisible): Deleted.
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::setIsVisible):
(WebCore::MockMediaPlayerMediaSource::setPageIsVisible): Deleted.
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isVideoVisible const): The resolved answer, as opposed to
isPlayerVisibleInViewport() which reports where the element&apos;s box sits.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::setIsVisible): Applies the answer resolved in the web content
process as it stands.
(WebKit::RemoteMediaPlayerProxy::setPageIsVisible): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::didEnterPictureInPicture):
(WebKit::VideoPresentationModelContext::didExitPictureInPicture):
(WebKit::VideoPresentationManagerProxy::VideoPresentationManagerProxy):
(WebKit::VideoPresentationManagerProxy::willRemoveLayerForID): Retracts what was last
reported, so that the decision falls back rather than standing on a layer that is gone.
(WebKit::VideoPresentationManagerProxy::videoLayerTreeDidChange): Coalesces those
measurements.
(WebKit::VideoPresentationManagerProxy::applicationDidEnterBackground):
(WebKit::VideoPresentationManagerProxy::applicationWillEnterForeground): Measures again, and
once more after the view hierarchy has had a chance to settle.
(WebKit::VideoPresentationManagerProxy::updateVideoLayerIsVisibleTimerFired):
(WebKit::VideoPresentationManagerProxy::updateVideoLayerIsVisibleForAllContexts):
(WebKit::VideoPresentationManagerProxy::updateVideoLayerIsVisible): Measures the layer against
its window and its clipping ancestors, and reports to the web process on change.
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree): Tell the video presentation manager that
something in the layer tree changed, so that it can work out whether the videos it vended
layers for are still on screen.
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::applicationDidEnterBackground):
(WebKit::WebPageProxy::applicationWillEnterForeground):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::setIsVisible):
(WebKit::MediaPlayerPrivateRemote::setPageIsVisible): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::setVideoLayerIsVisible):
</pre>
----------------------------------------------------------------------
#### 3855ef76b857775f701c01bf60aef68c8bae0b92
<pre>
revert moon quirk
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a64892a84766ed7ddcd698716ab76054a0b3e4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187709 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141343 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c085d675-c64f-41b6-933c-0c21d13d47d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179959 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138834 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96410 "1 flakes 4 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b796903-4c99-4c74-a26d-ebdec2601b6d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119290 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f63c7fb7-272c-4118-b376-4975c2dfe1da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41043 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39394 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1259 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8074 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39082 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36167 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39369 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44633 "Build is in progress. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Found 27313 issues") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190137 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147978 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52384 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147750 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42459 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124647 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119126 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50902 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14054 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50287 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50527 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50349 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->