### PR TITLE
Reduce sizeof(ViewportArguments) and stop copying it into computeViewportAttributes()

### DIFF
--- a/Source/WebCore/dom/ViewportArguments.cpp
+++ b/Source/WebCore/dom/ViewportArguments.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  *           (C) 2006 Alexey Proskuryakov (ap@webkit.org)
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
  * Copyright (C) 2012 Intel Corporation. All rights reserved.
@@ -178,7 +178,7 @@ static FloatSize NODELETE convertToUserSpace(const FloatSize& deviceSize, float 
     return result;
 }
 
-ViewportAttributes computeViewportAttributes(ViewportArguments args, int desktopWidth, int deviceWidth, int deviceHeight, float devicePixelRatio, IntSize visibleViewport)
+ViewportAttributes computeViewportAttributes(const ViewportArguments& args, int desktopWidth, int deviceWidth, int deviceHeight, float devicePixelRatio, IntSize visibleViewport)
 {
     FloatSize initialViewportSize = convertToUserSpace(visibleViewport, devicePixelRatio);
     FloatSize deviceSize = convertToUserSpace(FloatSize(deviceWidth, deviceHeight), devicePixelRatio);

--- a/Source/WebCore/dom/ViewportArguments.h
+++ b/Source/WebCore/dom/ViewportArguments.h
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  *           (C) 2006 Alexey Proskuryakov (ap@webkit.org)
- * Copyright (C) 2004, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
  * Copyright (C) 2012 Intel Corporation. All rights reserved.
@@ -80,7 +80,7 @@ struct ViewportArguments {
         ImageDocument,
 #endif
         ViewportMeta,
-    } type;
+    };
 
     static constexpr int ValueAuto = -1;
     static constexpr int ValueDeviceWidth = -2;
@@ -93,9 +93,8 @@ struct ViewportArguments {
     {
     }
 
-    ViewportArguments(Type type, float width, float height, float zoom, float minZoom, float maxZoom, float userZoom, float orientation, float shrinkToFit, ViewportFit viewportFit, bool widthWasExplicit, InteractiveWidget interactiveWidget)
-        : type(type)
-        , width(width)
+    ViewportArguments(float width, float height, float zoom, float minZoom, float maxZoom, float userZoom, float orientation, float shrinkToFit, Type type, ViewportFit viewportFit, bool widthWasExplicit, InteractiveWidget interactiveWidget)
+        : width(width)
         , height(height)
         , zoom(zoom)
         , minZoom(minZoom)
@@ -103,6 +102,7 @@ struct ViewportArguments {
         , userZoom(userZoom)
         , orientation(orientation)
         , shrinkToFit(shrinkToFit)
+        , type(type)
         , viewportFit(viewportFit)
         , widthWasExplicit(widthWasExplicit)
         , interactiveWidget(interactiveWidget)
@@ -120,6 +120,7 @@ struct ViewportArguments {
     float userZoom { ValueAuto };
     float orientation { ValueAuto };
     float shrinkToFit { ValueAuto };
+    Type type { Type::Implicit };
     ViewportFit viewportFit { ViewportFit::Auto };
     bool widthWasExplicit { false };
     InteractiveWidget interactiveWidget { InteractiveWidget::ResizesVisual };
@@ -148,7 +149,7 @@ struct ViewportArguments {
 #endif
 };
 
-WEBCORE_EXPORT ViewportAttributes computeViewportAttributes(ViewportArguments args, int desktopWidth, int deviceWidth, int deviceHeight, float devicePixelRatio, IntSize visibleViewport);
+WEBCORE_EXPORT ViewportAttributes computeViewportAttributes(const ViewportArguments&, int desktopWidth, int deviceWidth, int deviceHeight, float devicePixelRatio, IntSize visibleViewport);
 
 WEBCORE_EXPORT void restrictMinimumScaleFactorToViewportSize(ViewportAttributes& result, IntSize visibleViewport, float devicePixelRatio);
 WEBCORE_EXPORT void NODELETE restrictScaleFactorToInitialScaleIfNotUserScalable(ViewportAttributes& result);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1087,7 +1087,6 @@ header: <WebCore/PlatformPathImpl.h>
 };
 
 struct WebCore::ViewportArguments {
-    WebCore::ViewportArguments::Type type;
     float width;
     float height;
     float zoom;
@@ -1096,6 +1095,7 @@ struct WebCore::ViewportArguments {
     float userZoom;
     float orientation;
     float shrinkToFit;
+    WebCore::ViewportArguments::Type type;
     WebCore::ViewportFit viewportFit;
     bool widthWasExplicit;
     WebCore::InteractiveWidget interactiveWidget;


### PR DESCRIPTION
#### d583cf1b5117746c0c7bbf50169f8679b103f7ea
<pre>
Reduce sizeof(ViewportArguments) and stop copying it into computeViewportAttributes()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320730">https://bugs.webkit.org/show_bug.cgi?id=320730</a>
<a href="https://rdar.apple.com/183715116">rdar://183715116</a>

Reviewed by Jessica Cheung.

ViewportArguments declares its 1-byte Type member ahead of eight floats, so the
compiler inserts 3 bytes of padding after it, and the three trailing 1-byte
members leave another byte of tail padding: sizeof() is 40 where 36 would do.
Move `type` down beside the other small members so all four pack into the final
word.

Two things have to move with it. The generated IPC code asserts that the member
order in the .serialization.in description matches the declaration order -- see
the ShouldBeSameSizeAs and IsIncreasing static_asserts emitted by
Scripts/generate-serializers.py -- so the description is reordered to match. The
generated decoder also constructs the struct positionally, so the 12-argument
constructor, which has no callers other than that decoder, takes `type` in its
new position.

Also stop passing ViewportArguments to computeViewportAttributes() by value. It
is only read there, through the const resolve(), so a const reference is both
cheaper and a more honest signature.

No change in behavior.

* Source/WebCore/dom/ViewportArguments.cpp:
(WebCore::computeViewportAttributes):
* Source/WebCore/dom/ViewportArguments.h:
(WebCore::ViewportArguments::ViewportArguments):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/318335@main">https://commits.webkit.org/318335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/730a03f72e80e5317cd30cf3156bb3351b86622e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187550 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c412806f-d3a4-432b-94fc-1ed0b9e7a6f7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138703 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/30e95514-c34d-4b01-82f6-3346bf71757a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119166 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75309d40-e822-4eef-993b-b6c089e0ec14) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40905 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39262 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151310 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38946 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36011 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189979 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51545 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147833 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39712 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52227 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147614 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42325 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124480 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118929 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50735 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13926 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50131 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50371 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50193 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->