### PR TITLE
TextEncoderStreamEncoder::flush() does not clear its pending lead surrogate

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1431,6 +1431,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/StyledElement.h
     dom/TaskSource.h
     dom/Text.h
+    dom/TextEncoderStreamEncoder.h
     dom/TextEvent.h
     dom/TextEventInputType.h
     dom/ToggleEvent.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1300,6 +1300,7 @@
 		3227A93028BD744C00BC2697 /* NodeName.h in Headers */ = {isa = PBXBuildFile; fileRef = 3227A92A28BD744B00BC2697 /* NodeName.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3227A93128BD744C00BC2697 /* Namespace.h in Headers */ = {isa = PBXBuildFile; fileRef = 3227A92B28BD744B00BC2697 /* Namespace.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		322B61152C50C26300FB5440 /* ImageBufferResourceLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = 322B61142C50C22D00FB5440 /* ImageBufferResourceLimits.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		323A5DA8F5694FE4BFEC193E /* TextEncoderStreamEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 410A8EF924F8F47B004F9070 /* TextEncoderStreamEncoder.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		325905DC274DE1D8007B7B65 /* FontDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 325905DA274DE1D7007B7B65 /* FontDatabase.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3294ECFA274EFA57006BE8C8 /* FontFamilySpecificationCoreTextCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3294ECF9274EFA57006BE8C8 /* FontFamilySpecificationCoreTextCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		329C0C2328BD96D600F187D2 /* TagName.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3227A92628BD744A00BC2697 /* TagName.cpp */; };
@@ -49587,6 +49588,7 @@
 				97BC84B412371180000C6161 /* TextDocument.h in Headers */,
 				97BC84841236FD93000C6161 /* TextDocumentParser.h in Headers */,
 				448DF9DC2F60EFA700F068C3 /* TextEffectController.h in Headers */,
+				323A5DA8F5694FE4BFEC193E /* TextEncoderStreamEncoder.h in Headers */,
 				933A14300B7D188600A53FFD /* TextEvent.h in Headers */,
 				A77B41A012E675A90054343D /* TextEventInputType.h in Headers */,
 				F457F4C32F156C5D00E97771 /* TextExtraction.h in Headers */,

--- a/Source/WebCore/dom/TextEncoderStreamEncoder.cpp
+++ b/Source/WebCore/dom/TextEncoderStreamEncoder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,7 +74,7 @@ RefPtr<Uint8Array> TextEncoderStreamEncoder::encode(const String& input)
 
 RefPtr<Uint8Array> TextEncoderStreamEncoder::flush()
 {
-    if (!m_pendingLeadSurrogate)
+    if (!std::exchange(m_pendingLeadSurrogate, std::nullopt))
         return nullptr;
 
     constexpr std::array<uint8_t, 3> byteSequence { 0xEF, 0xBF, 0xBD };

--- a/Source/WebCore/dom/TextEncoderStreamEncoder.h
+++ b/Source/WebCore/dom/TextEncoderStreamEncoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,8 +36,8 @@ class TextEncoderStreamEncoder : public RefCounted<TextEncoderStreamEncoder> {
 public:
     static Ref<TextEncoderStreamEncoder> create() { return adoptRef(*new TextEncoderStreamEncoder); }
 
-    RefPtr<Uint8Array> encode(const String&);
-    RefPtr<Uint8Array> flush();
+    WEBCORE_EXPORT RefPtr<Uint8Array> encode(const String&);
+    WEBCORE_EXPORT RefPtr<Uint8Array> flush();
 
 private:
     TextEncoderStreamEncoder() = default;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -265,6 +265,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/SharedBufferTest.cpp
         Tests/WebCore/StyleGradient.cpp
         Tests/WebCore/TestPlatformStrategies.cpp
+        Tests/WebCore/TextEncoderStreamEncoder.cpp
         Tests/WebCore/TextIterator.cpp
         Tests/WebCore/TimeRanges.cpp
         Tests/WebCore/TransformationMatrix.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -816,6 +816,7 @@
 				WebCore/TestPlatformStrategies.cpp,
 				WebCore/TextBoundaries.cpp,
 				WebCore/TextCodec.cpp,
+				WebCore/TextEncoderStreamEncoder.cpp,
 				WebCore/TextIterator.cpp,
 				WebCore/TimeRanges.cpp,
 				WebCore/TransformationMatrix.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/TextEncoderStreamEncoder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TextEncoderStreamEncoder.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Helpers/Test.h"
+#include <JavaScriptCore/GenericTypedArrayViewInlines.h>
+#include <JavaScriptCore/InitializeThreading.h>
+#include <JavaScriptCore/Uint8Array.h>
+#include <WebCore/TextEncoderStreamEncoder.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+// The two halves of U+1F499 BLUE HEART, which is not in the Basic Multilingual Plane.
+constexpr char16_t leadSurrogate = 0xD83D;
+constexpr char16_t trailSurrogate = 0xDC99;
+
+constexpr std::array<uint8_t, 4> astralCharacterEncoded { 0xF0, 0x9F, 0x92, 0x99 };
+constexpr std::array<uint8_t, 3> replacementCharacterEncoded { 0xEF, 0xBF, 0xBD };
+
+static String stringFromCodeUnit(char16_t codeUnit)
+{
+    std::array<char16_t, 1> codeUnits { codeUnit };
+    return String(std::span<const char16_t> { codeUnits });
+}
+
+static Vector<uint8_t> bytes(RefPtr<Uint8Array>&& array)
+{
+    if (!array)
+        return { };
+    return Vector<uint8_t>(array->typedSpan());
+}
+
+static Ref<WebCore::TextEncoderStreamEncoder> createEncoder()
+{
+    JSC::initialize();
+    return WebCore::TextEncoderStreamEncoder::create();
+}
+
+TEST(TextEncoderStreamEncoder, EncodeSurrogatePairSplitAcrossChunks)
+{
+    auto encoder = createEncoder();
+    EXPECT_NULL(encoder->encode(stringFromCodeUnit(leadSurrogate)));
+    EXPECT_EQ(bytes(encoder->encode(stringFromCodeUnit(trailSurrogate))), Vector<uint8_t>(astralCharacterEncoded));
+    EXPECT_NULL(encoder->flush());
+}
+
+TEST(TextEncoderStreamEncoder, FlushEmitsReplacementCharacterForPendingLeadSurrogate)
+{
+    auto encoder = createEncoder();
+    EXPECT_NULL(encoder->encode(stringFromCodeUnit(leadSurrogate)));
+    EXPECT_EQ(bytes(encoder->flush()), Vector<uint8_t>(replacementCharacterEncoded));
+}
+
+TEST(TextEncoderStreamEncoder, FlushClearsPendingLeadSurrogate)
+{
+    auto encoder = createEncoder();
+    EXPECT_NULL(encoder->encode(stringFromCodeUnit(leadSurrogate)));
+    EXPECT_EQ(bytes(encoder->flush()), Vector<uint8_t>(replacementCharacterEncoded));
+
+    // The pending lead surrogate was consumed by the first flush, so flushing
+    // again must not emit a second replacement character.
+    EXPECT_NULL(encoder->flush());
+}
+
+TEST(TextEncoderStreamEncoder, EncodeAfterFlushStartsFromCleanState)
+{
+    auto encoder = createEncoder();
+    EXPECT_NULL(encoder->encode(stringFromCodeUnit(leadSurrogate)));
+    EXPECT_EQ(bytes(encoder->flush()), Vector<uint8_t>(replacementCharacterEncoded));
+
+    // The lead surrogate was already replaced by the flush above, so the trail
+    // surrogate is unpaired and must be replaced too rather than combined into
+    // an astral character.
+    EXPECT_EQ(bytes(encoder->encode(stringFromCodeUnit(trailSurrogate))), Vector<uint8_t>(replacementCharacterEncoded));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### af7b9c7c3e13054c05ed287f97cb48a9091d2cff
<pre>
TextEncoderStreamEncoder::flush() does not clear its pending lead surrogate
<a href="https://bugs.webkit.org/show_bug.cgi?id=320735">https://bugs.webkit.org/show_bug.cgi?id=320735</a>
<a href="https://rdar.apple.com/183719474">rdar://183719474</a>

Reviewed by NOBODY (OOPS!).

TextEncoderStreamEncoder::flush() tests m_pendingLeadSurrogate to decide
whether to emit the U+FFFD byte sequence, but never clears it, so the encoder
is left in a dirty state: a second flush() emits a second replacement
character, and an encode() after a flush() pairs the stale lead surrogate with
a following trail surrogate into an astral character that the input never
contained.

This is not observable from web content today. TextEncoderStreamEncoder is
[PrivateIdentifier], so script can never hold one, and
transformStreamDefaultSinkCloseAlgorithm() calls the flush algorithm exactly
once and then clears it via transformStreamDefaultControllerClearAlgorithms(),
so flush() cannot be reached twice. There is no behavior change for web
content; this makes the encoder&apos;s state consistent with what its single caller
and readers of flush() would expect, and is covered by an API test.

Export encode() and flush() and make the header private so the API test can
drive the encoder directly, since the double-flush path is not reachable from a
layout test; the header is listed in Headers.cmake as well as the Xcode project
so the CMake ports install it into WebCore/PrivateHeaders too. Without the fix,
FlushClearsPendingLeadSurrogate fails on a non-null second flush() and
EncodeAfterFlushStartsFromCleanState gets F0 9F 92 99 (U+1F499) where
EF BF BD is expected; both pass with it.

Test: Tools/TestWebKitAPI/Tests/WebCore/TextEncoderStreamEncoder.cpp

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/TextEncoderStreamEncoder.cpp:
(WebCore::TextEncoderStreamEncoder::flush):
* Source/WebCore/dom/TextEncoderStreamEncoder.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/TextEncoderStreamEncoder.cpp: Added.
(TestWebKitAPI::stringFromCodeUnit):
(TestWebKitAPI::bytes):
(TestWebKitAPI::createEncoder):
(TestWebKitAPI::TEST(TextEncoderStreamEncoder, EncodeSurrogatePairSplitAcrossChunks)):
(TestWebKitAPI::TEST(TextEncoderStreamEncoder, FlushEmitsReplacementCharacterForPendingLeadSurrogate)):
(TestWebKitAPI::TEST(TextEncoderStreamEncoder, FlushClearsPendingLeadSurrogate)):
(TestWebKitAPI::TEST(TextEncoderStreamEncoder, EncodeAfterFlushStartsFromCleanState)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af7b9c7c3e13054c05ed287f97cb48a9091d2cff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187906 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141540 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d40c98c4-0c8a-4e5a-9863-8b1d6120bb7c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138988 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96501 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d22e77de-6126-4ce6-a908-83b4f345c906) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159758 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119443 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/017c6cca-1210-4622-9c96-8da1a50d4a28) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41215 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39569 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39255 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36363 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190334 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51898 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148139 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52580 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147913 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42631 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124844 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119444 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51098 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14230 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50483 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50723 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50545 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->