### PR TITLE
Validate fingerprints to previous generated offer/answer when apply a local description

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-answer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-answer-expected.txt
@@ -1,7 +1,7 @@
 
 PASS setLocalDescription() with valid answer should succeed
 PASS setLocalDescription() with type answer and null sdp should use lastAnswer generated from createAnswer
-FAIL setLocalDescription() with answer not created by own createAnswer() should reject with InvalidModificationError assert_equals: expected "InvalidModificationError" but got "OperationError"
+PASS setLocalDescription() with answer not created by own createAnswer() should reject with InvalidModificationError
 PASS Calling setLocalDescription(answer) from stable state should reject with InvalidStateError
 PASS Calling setLocalDescription(answer) from have-local-offer state should reject with InvalidStateError
 PASS Setting previously generated answer after a call to createOffer should work

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-offer_interop-2026-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-offer_interop-2026-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL setLocalDescription() with offer not created by own createOffer() should reject with InvalidModificationError assert_equals: expected "InvalidModificationError" but got "OperationError"
+PASS setLocalDescription() with offer not created by own createOffer() should reject with InvalidModificationError
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -351,6 +351,7 @@ void RTCPeerConnection::createOffer(RTCOfferOptions&& options, Ref<DeferredPromi
             }
             // https://w3c.github.io/webrtc-pc/#dfn-final-steps-to-create-an-offer steps 4,5 and 6.
             m_lastCreatedOffer = result.returnValue().sdp;
+            m_isLastCreatedOfferFresh = true;
             promise.resolve(result.releaseReturnValue());
         });
     });
@@ -378,26 +379,51 @@ void RTCPeerConnection::createAnswer(RTCAnswerOptions&& options, Ref<DeferredPro
             }
             // https://w3c.github.io/webrtc-pc/#dfn-final-steps-to-create-an-answer steps 4,5 and 6.
             m_lastCreatedAnswer = result.returnValue().sdp;
+            m_isLastCreatedAnswerFresh = true;
             promise.resolve(result.releaseReturnValue());
         });
     });
 }
 
-static RTCSdpType NODELETE typeForSetLocalDescription(const std::optional<RTCLocalSessionDescriptionInit>& description, RTCSignalingState signalingState)
+static RTCSdpType NODELETE typeForSetLocalDescription(std::optional<RTCSdpType> descriptionType, RTCSignalingState signalingState)
 {
-    std::optional<RTCSdpType> type;
-    if (description)
-        type = description->type;
-
     // https://w3c.github.io/webrtc-pc/#dom-peerconnection-setlocaldescription step 4.1.
-    if (!type) {
+    if (!descriptionType) {
         bool shouldBeOffer = signalingState == RTCSignalingState::Stable || signalingState == RTCSignalingState::HaveLocalOffer || signalingState == RTCSignalingState::HaveRemotePranswer;
         return shouldBeOffer ? RTCSdpType::Offer : RTCSdpType::Answer;
     }
-    return *type;
+    return *descriptionType;
 }
 
-void RTCPeerConnection::setLocalDescription(std::optional<RTCLocalSessionDescriptionInit>&& localDescription, Ref<DeferredPromise>&& promise)
+static bool isSdpFingerprintValid(const String& oldSdp, const String& newSdp)
+{
+    auto newFingerprintPosition = newSdp.find("\na=fingerprint:"_s);
+    if (newFingerprintPosition == notFound) {
+        // Some applications may generate SDP without a fingerprint.
+        return true;
+    }
+
+    auto oldFingerprintPosition = oldSdp.find("\na=fingerprint:"_s);
+    if (oldFingerprintPosition == notFound)
+        return false;
+
+    auto computeFingerprintLength = [](auto& sdp, size_t position) {
+        auto end = sdp.find("\r\n"_s, position + 1);
+        if (end != notFound)
+            return end - position;
+        end = sdp.find('\n', position + 1);
+        if (end != notFound)
+            return end - position;
+        return sdp.length() - position;
+    };
+
+    auto oldLength = computeFingerprintLength(oldSdp, oldFingerprintPosition);
+    auto newLength = computeFingerprintLength(newSdp, newFingerprintPosition);
+
+    return StringView(oldSdp).substring(oldFingerprintPosition, oldLength) == StringView(newSdp).substring(newFingerprintPosition, newLength);
+}
+
+void RTCPeerConnection::setLocalDescription(RTCLocalSessionDescriptionInit&& localDescription, Ref<DeferredPromise>&& promise)
 {
     if (isClosed()) {
         promise->reject(ExceptionCode::InvalidStateError);
@@ -405,20 +431,36 @@ void RTCPeerConnection::setLocalDescription(std::optional<RTCLocalSessionDescrip
     }
 
 #if !RELEASE_LOG_DISABLED
-    String sdp = localDescription.value_or(RTCLocalSessionDescriptionInit { }).sdp;
-    logger().toObservers(LogWebRTC, WTFLogLevel::Always, { }, LOGIDENTIFIER, "Setting local description to:\n", sdp);
-    RELEASE_LOG_FORWARDABLE(WebRTC, RtcPeerConnectionSetLocalDescription, logIdentifier(), sdp.utf8());
+    logger().toObservers(LogWebRTC, WTFLogLevel::Always, { }, LOGIDENTIFIER, "Setting local description to:\n", localDescription.sdp);
+    RELEASE_LOG_FORWARDABLE(WebRTC, RtcPeerConnectionSetLocalDescription, logIdentifier(), localDescription.sdp.utf8());
 #endif
 
     chainOperation(WTF::move(promise), [this, localDescription = WTF::move(localDescription)](Ref<DeferredPromise>&& promise) mutable {
-        auto type = typeForSetLocalDescription(localDescription, m_signalingState);
-        String sdp;
-        if (localDescription)
-            sdp = localDescription->sdp;
-        if (type == RTCSdpType::Offer && sdp.isEmpty())
-            sdp = m_lastCreatedOffer;
-        else if (type == RTCSdpType::Answer && sdp.isEmpty())
-            sdp = m_lastCreatedAnswer;
+        auto type = typeForSetLocalDescription(localDescription.type, m_signalingState);
+        String sdp = localDescription.sdp;
+        if (localDescription.type) {
+            if (type == RTCSdpType::Offer && sdp.isEmpty())
+                sdp = m_lastCreatedOffer;
+            else if (type == RTCSdpType::Answer && sdp.isEmpty())
+                sdp = m_lastCreatedAnswer;
+
+            if (type == RTCSdpType::Offer && sdp != m_lastCreatedOffer && !isSdpFingerprintValid(m_lastCreatedOffer, sdp)) {
+                promise->reject(ExceptionCode::InvalidModificationError, "Local description does not match the last created offer"_s);
+                return;
+            }
+            if ((type == RTCSdpType::Answer || type == RTCSdpType::Pranswer) && sdp != m_lastCreatedAnswer && !isSdpFingerprintValid(m_lastCreatedAnswer, sdp)) {
+                promise->reject(ExceptionCode::InvalidModificationError, "Local description does not match the last created answer"_s);
+                return;
+            }
+        } else {
+            // Parameterless setLocalDescription: reuse the cached last created offer/answer
+            // only when it still represents the current system state, per
+            // https://w3c.github.io/webrtc-pc/#dom-peerconnection-setlocaldescription.
+            if (type == RTCSdpType::Offer && m_isLastCreatedOfferFresh)
+                sdp = m_lastCreatedOffer;
+            else if (type == RTCSdpType::Answer && m_isLastCreatedAnswerFresh)
+                sdp = m_lastCreatedAnswer;
+        }
 
         RefPtr<RTCSessionDescription> description;
         if (!sdp.isEmpty() || (type != RTCSdpType::Offer && type != RTCSdpType::Answer))
@@ -1234,12 +1276,12 @@ void RTCPeerConnection::updateDescriptions(PeerConnectionBackend::DescriptionSta
     updateDescription(m_currentRemoteDescription, states.currentRemoteDescriptionSdpType, WTF::move(states.currentRemoteDescriptionSdp));
     updateDescription(m_pendingRemoteDescription, states.pendingRemoteDescriptionSdpType, WTF::move(states.pendingRemoteDescriptionSdp));
 
-    if (states.signalingState)
+    if (states.signalingState) {
         setSignalingState(*states.signalingState);
 
-    if (!m_pendingRemoteDescription && !m_pendingLocalDescription) {
-        m_lastCreatedOffer = { };
-        m_lastCreatedAnswer = { };
+        // We successfully applied a description, let's not reuse a cached sdp for parameterless setLocalDescription.
+        m_isLastCreatedOfferFresh = false;
+        m_isLastCreatedAnswerFresh = false;
     }
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -118,7 +118,7 @@ public:
     void createOffer(RTCOfferOptions&&, Ref<DeferredPromise>&&);
     void createAnswer(RTCAnswerOptions&&, Ref<DeferredPromise>&&);
 
-    void setLocalDescription(std::optional<RTCLocalSessionDescriptionInit>&&, Ref<DeferredPromise>&&);
+    void setLocalDescription(RTCLocalSessionDescriptionInit&&, Ref<DeferredPromise>&&);
     RefPtr<RTCSessionDescription> localDescription() const { return m_pendingLocalDescription ? m_pendingLocalDescription.get() : m_currentLocalDescription.get(); }
     RefPtr<RTCSessionDescription> currentLocalDescription() const { return m_currentLocalDescription.get(); }
     RefPtr<RTCSessionDescription> pendingLocalDescription() const { return m_pendingLocalDescription.get(); }
@@ -295,6 +295,8 @@ private:
 
     String m_lastCreatedOffer;
     String m_lastCreatedAnswer;
+    bool m_isLastCreatedOfferFresh { false };
+    bool m_isLastCreatedAnswerFresh { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 037843ae12ffcf5071691e3a0ded328179b37a6e
<pre>
Validate fingerprints to previous generated offer/answer when apply a local description
<a href="https://rdar.apple.com/183719203">rdar://183719203</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320733">https://bugs.webkit.org/show_bug.cgi?id=320733</a>

Reviewed by Eric Carlson.

We update setLocalDescription for the non parameter less setLocalDescription.
To validate that applied description comes from the previous generated offer/answer, we validate the fingerprints.
We do not go as far as validating the whole SDP since SDP munging is still a thing.

We also stop resetting last offer/answer in RTCPeerConnection::updateDescriptions as this is not as per spec.
To not change the parameterless setLocalDescription behavior, we introduce booleans to control how much we reuse the last offer/answer.

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-answer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-offer_interop-2026-expected.txt:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::createOffer):
(WebCore::RTCPeerConnection::createAnswer):
(WebCore::typeForSetLocalDescription):
(WebCore::isSdpFingerprintValid):
(WebCore::RTCPeerConnection::setLocalDescription):
(WebCore::RTCPeerConnection::updateDescriptions):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:

Canonical link: <a href="https://commits.webkit.org/319822@main">https://commits.webkit.org/319822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb84478faf8de40933634daa76fa39c835ab8075

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193000 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147071 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c30bab22-a5c4-4576-b006-1f428ad1c0d0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142656 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66f9d2ac-92f8-4164-b81c-cab576dfc447) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123085 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e2da218-8201-4104-8d85-da797b16fb60) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45067 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43317 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42946 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4172 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194941 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56375 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152111 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40774 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57080 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39558 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151808 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46374 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129349 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125396 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55588 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17949 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54959 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55196 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55026 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->