### PR TITLE
[ANGLE] Metal read of a re-specified color attachment crashes

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
@@ -1855,7 +1855,11 @@ angle::Result FramebufferMtl::readPixelsToBuffer(const gl::Context *context,
     const mtl::Format &readFormat        = renderTarget->getFormat();
     const angle::Format &readAngleFormat = readFormat.actualAngleFormat();
 
+    // The render target holds a weak reference to its texture, so the texture can be gone if the
+    // attachment was re-specified after being attached. readPixelsImpl performs the same check on
+    // the path that reads into client memory.
     mtl::TextureRef texture = renderTarget->getTexture();
+    ANGLE_CHECK(contextMtl, texture, gl::err::kInternalError, GL_INVALID_OPERATION);
 
     const mtl::BufferRef &dstBuffer = *pDstBuffer;
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
@@ -1280,7 +1280,11 @@ angle::Result ColorBlitUtils::getColorBlitRenderPipelineState(
 
     pipelineDesc.setInputPrimitiveTopology(MTLPrimitiveTopologyClassTriangle);
 
-    ShaderKey key(GetShaderTextureType(params.src), renderPassDesc.numColorAttachments,
+    const int sourceTextureType = GetShaderTextureType(params.src);
+    ANGLE_CHECK(contextMtl, sourceTextureType >= 0, gl::err::kInternalError,
+                GL_INVALID_OPERATION);
+
+    ShaderKey key(sourceTextureType, renderPassDesc.numColorAttachments,
                   params.unpackUnmultiplyAlpha, params.unpackPremultiplyAlpha,
                   params.transformLinearToSrgb);
 
@@ -1413,6 +1417,8 @@ angle::Result DepthStencilBlitUtils::getStencilToBufferComputePipelineState(
     angle::ObjCPtr<id<MTLComputePipelineState>> *outComputePipelineState)
 {
     int sourceStencilTextureType = GetShaderTextureType(params.srcStencil);
+    ANGLE_CHECK(contextMtl, sourceStencilTextureType >= 0, gl::err::kInternalError,
+                GL_INVALID_OPERATION);
     angle::ObjCPtr<id<MTLFunction>> &shader =
         mStencilBlitToBufferComputeShaders[sourceStencilTextureType];
     if (!shader)
@@ -1459,6 +1465,10 @@ angle::Result DepthStencilBlitUtils::getDepthStencilBlitRenderPipelineState(
     angle::ObjCPtr<id<MTLFunction>> *fragmentShader = nullptr;
     int depthTextureType                            = GetShaderTextureType(params.src);
     int stencilTextureType                          = GetShaderTextureType(params.srcStencil);
+    ANGLE_CHECK(contextMtl,
+                (params.src || params.srcStencil) && (!params.src || depthTextureType >= 0) &&
+                    (!params.srcStencil || stencilTextureType >= 0),
+                gl::err::kInternalError, GL_INVALID_OPERATION);
     if (params.src && params.srcStencil)
     {
         fragmentShader = &mDepthStencilBlitFragmentShaders[depthTextureType][stencilTextureType];
@@ -2398,6 +2408,8 @@ angle::Result CopyPixelsUtils::getT2BComputePipeline(
 {
     int formatIDValue     = static_cast<int>(angleFormat.id);
     int shaderTextureType = GetShaderTextureType(texture);
+    ANGLE_CHECK(contextMtl, shaderTextureType >= 0, gl::err::kInternalError,
+                GL_INVALID_OPERATION);
 
     auto &shader = mT2BComputeShaders[formatIDValue][shaderTextureType];
 

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/ReadPixelsTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/ReadPixelsTest.cpp
@@ -1768,6 +1768,106 @@ TEST_P(ReadPixelsWebGLErrorTest, FormatIsDepthComponent)
     EXPECT_GL_ERROR(GL_INVALID_ENUM);
 }
 
+class ReadPixelsPBOMetalTest : public ReadPixelsTest
+{};
+
+// Reading into a PBO from a colour attachment whose texture was re-specified after being
+// attached. The Metal render target's texture is null in that state, so the texture-to-buffer
+// compute path has no shader texture type to select and must reject the read rather than index
+// its shader cache with -1. Regression test for rdar://183915520.
+TEST_P(ReadPixelsPBOMetalTest, ReadPixelsToPBOWithRespecifiedReadAttachment)
+{
+    GLTexture firstTexture;
+    glBindTexture(GL_TEXTURE_2D, firstTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, 2, 1, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
+
+    GLBuffer unpackBuffer;
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, unpackBuffer);
+    glBufferData(GL_PIXEL_UNPACK_BUFFER, 210, nullptr, GL_STATIC_READ);
+
+    GLTexture secondTexture;
+    glBindTexture(GL_TEXTURE_2D, secondTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA4, 2, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+    GLBuffer packBuffer;
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, packBuffer);
+    glBufferData(GL_PIXEL_PACK_BUFFER, 28568, nullptr, GL_DYNAMIC_DRAW);
+
+    GLFramebuffer fbo;
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, secondTexture,
+                           0);
+    const GLfloat clearColor[4] = {1.0f, 0.6f, 1.0f, 0.79f};
+    glClearBufferfv(GL_COLOR, 0, clearColor);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, firstTexture, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT4, GL_TEXTURE_2D, secondTexture, 0);
+    glReadBuffer(GL_COLOR_ATTACHMENT4);
+    ASSERT_GL_NO_ERROR();
+
+    // Re-specify the read attachment. This is what leaves the render target without a texture.
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA4, 2, 1, 0, GL_RGBA, GL_UNSIGNED_SHORT_4_4_4_4, nullptr);
+    ASSERT_GL_NO_ERROR();
+
+    // The read format differs from the attachment format, so this takes the compute path.
+    glReadPixels(-822, 0, 1052, 1, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+    // The read must be rejected. GL_NO_ERROR here means the compute path was not reached and
+    // this test has stopped covering the shader-texture-type check.
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+}
+
+// As above, but the read format matches the attachment format, which selects the blit path
+// instead of the texture-to-buffer compute path. The null render target texture is then
+// dereferenced while evaluating the branch condition itself, before any shader texture type is
+// looked up, so the shader-texture-type check cannot reject this read.
+TEST_P(ReadPixelsPBOMetalTest, ReadPixelsToPBOWithRespecifiedReadAttachmentMatchingFormat)
+{
+    GLTexture firstTexture;
+    glBindTexture(GL_TEXTURE_2D, firstTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, 2, 1, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
+
+    GLBuffer unpackBuffer;
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, unpackBuffer);
+    glBufferData(GL_PIXEL_UNPACK_BUFFER, 210, nullptr, GL_STATIC_READ);
+
+    // RGBA8 resolves to the same angle::Format as a GL_RGBA/GL_UNSIGNED_BYTE read, which is what
+    // makes this test take the other branch.
+    GLTexture secondTexture;
+    glBindTexture(GL_TEXTURE_2D, secondTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 2, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+    GLBuffer packBuffer;
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, packBuffer);
+    glBufferData(GL_PIXEL_PACK_BUFFER, 28568, nullptr, GL_DYNAMIC_DRAW);
+
+    GLFramebuffer fbo;
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, secondTexture,
+                           0);
+    const GLfloat clearColor[4] = {1.0f, 0.6f, 1.0f, 0.79f};
+    glClearBufferfv(GL_COLOR, 0, clearColor);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, firstTexture, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT4, GL_TEXTURE_2D, secondTexture, 0);
+    glReadBuffer(GL_COLOR_ATTACHMENT4);
+    ASSERT_GL_NO_ERROR();
+
+    // Re-specify the read attachment with the same internal format and size, so the redefinition
+    // discards the image definition without reallocating storage. This is what leaves the render
+    // target without a texture.
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 2, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    ASSERT_GL_NO_ERROR();
+
+    // Read the whole attachment so nothing is clipped away, with a format that matches it.
+    glReadPixels(0, 0, 2, 1, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+    // The read must be rejected. Without the render target texture check this dereferences a null
+    // texture while choosing between the blit and compute paths, before any shader texture type
+    // is looked up.
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+}
+
 }  // anonymous namespace
 
 // Use this to select which configurations (e.g. which renderer, which GLES major version) these
@@ -1801,3 +1901,6 @@ ANGLE_INSTANTIATE_TEST_ES3(ReadPixelsErrorTest);
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(ReadPixelsWebGLErrorTest);
 ANGLE_INSTANTIATE_TEST_ES3(ReadPixelsWebGLErrorTest);
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(ReadPixelsPBOMetalTest);
+ANGLE_INSTANTIATE_TEST(ReadPixelsPBOMetalTest, ES3_METAL());


### PR DESCRIPTION
#### 6788dffd9d3580bb90b089bb0997a37d000becd2
<pre>
[ANGLE] Metal read of a re-specified color attachment crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=320737">https://bugs.webkit.org/show_bug.cgi?id=320737</a>
<a href="https://rdar.apple.com/180731265">rdar://180731265</a>

Reviewed by NOBODY (OOPS!).

Re-specifying a texture level with the same format and size discards the level&apos;s image,
but leaves the render targets that point at it. A render target holds only a weak
reference, and the framebuffer&apos;s cached render pass keeps the discarded image alive, so
the next framebuffer sync does not rebuild the render target. The framebuffer then
releases the image when it prepares the read, and glReadPixels reads a render target with
no texture. The texture-to-buffer read traps on a -1 shader index, and the blit read
dereferences null.

Clear the render targets for the image that redefineImage discards. The next use rebuilds
them from the new image, and the read returns the re-specified contents.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm:
(rx::TextureMtl::redefineImage):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/ReadPixelsTest.cpp:
(ReadPixelsPBOTest::testReadFromRespecifiedAttachment):
(TEST_P(ReadPixelsPBOTest, ReadFromRespecifiedAttachment)):
(TEST_P(ReadPixelsPBOTest, ReadFromRespecifiedAttachmentWithMatchingFormat)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6788dffd9d3580bb90b089bb0997a37d000becd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197597 "Built successfully") | [⏳ 🛠 win](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/atp/15d8a7f0-b1c5-11f1-b023-4f064a49eb02) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146335 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65df8a2e-bf5d-428e-a9c0-e969d84f01a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126827 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41963c18-e861-4b28-8ba5-31ea9b3b9c68) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48768 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46640 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/159080 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46411 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8690 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199624 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60838 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155993 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61551 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155645 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49969 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/131232 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59941 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21400 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59369 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59551 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59484 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->