### PR TITLE
[CoordinatedGraphics] Remove unused m_transformedVisibleRect from CoordinatedPlatformLayer

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -317,14 +317,13 @@ const FloatRect& CoordinatedPlatformLayer::visibleRect() const
     return m_visibleRect;
 }
 
-void CoordinatedPlatformLayer::setTransformedVisibleRect(IntRect&& transformedVisibleRect, IntRect&& transformedVisibleRectIncludingFuture)
+void CoordinatedPlatformLayer::setTransformedVisibleRect(IntRect&& transformedVisibleRect)
 {
     assertIsHeld(m_lock);
-    if (m_transformedVisibleRect == transformedVisibleRect && m_transformedVisibleRectIncludingFuture == transformedVisibleRectIncludingFuture)
+    if (m_transformedVisibleRect == transformedVisibleRect)
         return;
 
     m_transformedVisibleRect = WTF::move(transformedVisibleRect);
-    m_transformedVisibleRectIncludingFuture = WTF::move(transformedVisibleRectIncludingFuture);
     m_needsTilesUpdate = true;
 }
 
@@ -816,7 +815,7 @@ void CoordinatedPlatformLayer::updateBackingStore()
 
     Damage damage(m_size, Damage::Mode::Rectangles);
     IntRect contentsRect(IntPoint::zero(), IntSize(m_size));
-    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRectIncludingFuture, contentsRect, m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
+    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRect, contentsRect, m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
     m_needsTilesUpdate = false;
 #if ENABLE(DAMAGE_TRACKING)
     addDamage(WTF::move(damage));

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -137,7 +137,7 @@ public:
 
     void setVisibleRect(const FloatRect&) WTF_REQUIRES_LOCK(m_lock);
     const FloatRect& visibleRect() const WTF_REQUIRES_LOCK(m_lock);
-    void setTransformedVisibleRect(IntRect&& visibleRect, IntRect&& visibleRectIncludingFuture) WTF_REQUIRES_LOCK(m_lock);
+    void setTransformedVisibleRect(IntRect&&) WTF_REQUIRES_LOCK(m_lock);
 
 #if ENABLE(SCROLLING_THREAD)
     void setScrollingNodeID(std::optional<ScrollingNodeID>) WTF_REQUIRES_LOCK(m_lock);
@@ -300,7 +300,6 @@ private:
     TransformationMatrix m_childrenTransform WTF_GUARDED_BY_LOCK(m_lock);
     FloatRect m_visibleRect WTF_GUARDED_BY_LOCK(m_lock);
     IntRect m_transformedVisibleRect WTF_GUARDED_BY_LOCK(m_lock);
-    IntRect m_transformedVisibleRectIncludingFuture WTF_GUARDED_BY_LOCK(m_lock);
     bool m_drawsContent WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_masksToBounds WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_preserves3D WTF_GUARDED_BY_LOCK(m_lock) { false };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -921,17 +921,16 @@ void GraphicsLayerCoordinated::computeLayerTransformIfNeeded(bool affectedByTran
     m_layerTransform.current.setChildrenTransform(childrenTransform());
     m_layerTransform.current.combineTransforms(parent() ? downcast<GraphicsLayerCoordinated>(*parent()).m_layerTransform.current.combinedForChildren() : TransformationMatrix());
 
-    m_layerTransform.cachedCombined = m_layerTransform.current.combined();
-    m_layerTransform.cachedInverse = m_layerTransform.cachedCombined.inverse().value_or(TransformationMatrix());
-
     m_layerTransform.future = m_layerTransform.current;
+
+    m_layerTransform.cachedInverse = m_layerTransform.current.combined().inverse();
     m_layerTransform.cachedFutureInverse = m_layerTransform.cachedInverse;
 
     auto* parentLayer = downcast<GraphicsLayerCoordinated>(parent());
     if (currentTransform != futureTransform || (parentLayer && parentLayer->m_layerTransform.current.combinedForChildren() != parentLayer->m_layerTransform.future.combinedForChildren())) {
         m_layerTransform.future.setLocalTransform(futureTransform);
         m_layerTransform.future.combineTransforms(parentLayer ? parentLayer->m_layerTransform.future.combinedForChildren() : TransformationMatrix());
-        m_layerTransform.cachedFutureInverse = m_layerTransform.future.combined().inverse().value_or(TransformationMatrix());
+        m_layerTransform.cachedFutureInverse = m_layerTransform.future.combined().inverse();
     }
 
     m_platformLayer->didUpdateLayerTransform();
@@ -955,28 +954,25 @@ void GraphicsLayerCoordinated::updateVisibleRect(const FloatRect& rect)
     assertIsHeld(m_platformLayer->lock());
     m_platformLayer->setVisibleRect(rect);
 
-    IntRect visibleRect;
-    IntRect visibleRectFuture;
     // Non-invertible layers are not visible.
-    if (!m_layerTransform.current.combined().isInvertible()) {
-        m_platformLayer->setTransformedVisibleRect(WTF::move(visibleRect), WTF::move(visibleRect));
+    if (!m_layerTransform.cachedInverse) {
+        m_platformLayer->setTransformedVisibleRect({ });
         return;
     }
 
     // Return a projection of the rect (surface coordinates) onto the layer's plane (layer coordinates).
     // The resulting quad might be squewed and the result is the bounding box of this quad,
     // so it might spread further than the real visible area (and then even more amplified by the cover rect multiplier).
-    ASSERT(m_layerTransform.cachedInverse == m_layerTransform.current.combined().inverse().value_or(TransformationMatrix()));
+    ASSERT(m_layerTransform.cachedInverse == m_layerTransform.current.combined().inverse());
     auto transformedRect = [&](const TransformationMatrix& matrix) -> IntRect {
         FloatRect result = matrix.clampedBoundsOfProjectedQuad(FloatQuad(rect));
         clampToSizeIfRectIsInfinite(result, m_size);
         return enclosingIntRect(result);
     };
-    visibleRect = transformedRect(m_layerTransform.cachedInverse);
-    visibleRectFuture = visibleRect;
-    if (m_layerTransform.cachedInverse != m_layerTransform.cachedFutureInverse)
-        visibleRectFuture.unite(transformedRect(m_layerTransform.cachedFutureInverse));
-    m_platformLayer->setTransformedVisibleRect(WTF::move(visibleRect), WTF::move(visibleRectFuture));
+    auto visibleRect = transformedRect(*m_layerTransform.cachedInverse);
+    if (m_layerTransform.cachedFutureInverse && m_layerTransform.cachedInverse != m_layerTransform.cachedFutureInverse)
+        visibleRect.unite(transformedRect(*m_layerTransform.cachedFutureInverse));
+    m_platformLayer->setTransformedVisibleRect(WTF::move(visibleRect));
 }
 
 void GraphicsLayerCoordinated::updateBackdropFilters()

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -215,9 +215,8 @@ private:
     struct {
         GraphicsLayerTransform current;
         GraphicsLayerTransform future;
-        TransformationMatrix cachedInverse;
-        TransformationMatrix cachedFutureInverse;
-        TransformationMatrix cachedCombined;
+        std::optional<TransformationMatrix> cachedInverse;
+        std::optional<TransformationMatrix> cachedFutureInverse;
     } m_layerTransform;
     bool m_needsUpdateLayerTransform { false };
     bool m_shouldUpdateRootRelativeScaleFactor : 1 { false };


### PR DESCRIPTION
#### 715e928122550027230c5aff497c31fe60d0c04b
<pre>
[CoordinatedGraphics] Remove unused m_transformedVisibleRect from CoordinatedPlatformLayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=320738">https://bugs.webkit.org/show_bug.cgi?id=320738</a>

Reviewed by Fujii Hironori.

Only the one including future is used, so we can keep that one as just
m_transformedVisibleRect. We can also simplify GraphicsLayerCoordinated,
m_layerTransform.cachedCombined is only used inside computeLayerTransformIfNeeded()
so it can be a local variable.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setTransformedVisibleRect):
(WebCore::CoordinatedPlatformLayer::updateBackingStore):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::computeLayerTransformIfNeeded):
(WebCore::GraphicsLayerCoordinated::updateVisibleRect):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:

Canonical link: <a href="https://commits.webkit.org/318313@main">https://commits.webkit.org/318313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2d856ff9508aa31629e60874bb3648de676ae9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187566 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138714 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119177 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40919 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39276 "Passed tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38960 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36027 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44486 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43512 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189995 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51561 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147847 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52243 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147628 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26981 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Reviewed by Fujii Hironori; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42339 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124496 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118954 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50751 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13940 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50147 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->