### PR TITLE
Add logging in logUserInteractionWithReducedTimeResolution method for diagnostics purposes

### DIFF
--- a/Source/WebKit/Platform/LogMessages.in
+++ b/Source/WebKit/Platform/LogMessages.in
@@ -59,6 +59,7 @@ WebProcessFreezeAllLayerTrees, "[sessionID=%" PRIu64 "] WebProcess::freezeAllLay
 WebProcessMarkAllLayersVolatile, "[sessionID=%" PRIu64 "] WebProcess::markAllLayersVolatile:", (uint64_t), DEFAULT, ProcessSuspension
 WebProcessPrepareToSuspend, "[sessionID=%" PRIu64 "] WebProcess::prepareToSuspend: isSuspensionImminent=%d, remainingRunTime=%fs", (uint64_t, int, double), DEFAULT, ProcessSuspension
 WebProcessReadyToSuspend, "[sessionID=%" PRIu64 "] WebProcess::prepareToSuspend: Process is ready to suspend", (uint64_t), DEFAULT, ProcessSuspension
+WebResourceLoadObserverLogUserInteractionWithReducedTimeResolutionWithRemoteFrame, "WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution; opener is remote frame with page ID = %" PRIu64, (uint64_t), DEFAULT, SiteIsolation
 WebResourceLoaderConstructor, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::WebResourceLoader", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
 WebResourceLoaderDidBlockAuthenticationChallenge, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didBlockAuthenticationChallenge", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
 WebResourceLoaderDidFailResourceLoad, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didFailResourceLoad", (uint64_t, uint64_t, uint64_t), DEFAULT, Network

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
@@ -401,13 +401,15 @@ void WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution(const 
             if (RefPtr openerCorePage = frame->opener()->page()) {
                 RefPtr openerWebPage = WebPage::fromCorePage(*openerCorePage);
                 RefPtr webPage = WebPage::fromCorePage(*protect(protect(mainFrameDocument)->page()));
+                RELEASE_LOG_FORWARDABLE(SiteIsolation, WebResourceLoadObserverLogUserInteractionWithReducedTimeResolutionWithRemoteFrame, openerWebPage ? openerWebPage->identifier().toUInt64() : 0);
                 if (webPage && openerWebPage) {
                     if (auto openerURL = webPage->mainFrameOpenerURL(); !openerURL.isEmpty()) {
                         RegistrableDomain openerDomain { openerURL };
                         if (topFrameDomain != openerDomain && !mainFrameDocument->hasRequestedPageSpecificStorageAccessWithUserInteraction(topFrameDomain)) {
                             openerWebPage->addDomainWithPageLevelStorageAccess(openerDomain, topFrameDomain);
-                            Ref { WebProcess::singleton().ensureNetworkProcessConnection().connection() }->send(
-                                Messages::NetworkConnectionToWebProcess::RequestStorageAccessUnderOpener(topFrameDomain, openerWebPage->identifier(), openerDomain), 0);
+                            // FIXME: this message and the message in requestStorageAccessUnderOpener should instead be sent from the UI process. See rdar://183732418.
+                            Ref connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+                            connection->send(Messages::NetworkConnectionToWebProcess::RequestStorageAccessUnderOpener(topFrameDomain, openerWebPage->identifier(), openerDomain), 0);
                             mainFrameDocument->setHasRequestedPageSpecificStorageAccessWithUserInteraction(topFrameDomain);
                         }
                     }


### PR DESCRIPTION
#### 737d57033aaebca28e8033822e64142f80548348
<pre>
Add logging in logUserInteractionWithReducedTimeResolution method for diagnostics purposes
<a href="https://bugs.webkit.org/show_bug.cgi?id=320740">https://bugs.webkit.org/show_bug.cgi?id=320740</a>
<a href="https://rdar.apple.com/183734309">rdar://183734309</a>

Reviewed by Sihui Liu.

Log page identifier when opener is a remote frame. This can be useful information when diagnosing login
issues with Site Isolation enabled.

* Source/WebKit/Platform/LogMessages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp:
(WebKit::WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution):

Canonical link: <a href="https://commits.webkit.org/318327@main">https://commits.webkit.org/318327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f3530eb307b7764e5995edf234a721eca70c4e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187580 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b58b92f-0131-41c5-8fdf-8b5f9432631e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138724 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6370dd78-a846-4660-8992-71dfe83b7da6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119187 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90d15d7f-e18e-4562-bf70-28692b2172c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40931 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39289 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38973 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36041 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190009 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51575 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147858 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52257 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35602 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147639 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26991 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42351 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124510 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118980 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50765 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13952 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50161 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50401 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50223 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->