### PR TITLE
[GTK][WPE] Fix more issues caught by -Wthread-safety

### DIFF
--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -143,8 +143,8 @@ public:
 private:
     void open(bool overwrite)
     {
+        assertIsHeld(m_clientsLock);
         ASSERT(!m_logFile);
-        ASSERT(m_clientsLock.isHeld());
 
         m_logFile = FilePrintStream::open(m_path.utf8().data(), overwrite ? "w" : "a");
 

--- a/Source/WebCore/platform/RunLoopObserver.cpp
+++ b/Source/WebCore/platform/RunLoopObserver.cpp
@@ -38,13 +38,18 @@ RunLoopObserver::~RunLoopObserver()
 
 void RunLoopObserver::runLoopObserverFired()
 {
-#if USE(CF) || USE(GLIB)
+#if USE(CF)
     ASSERT(m_runLoopObserver);
+#elif USE(GLIB_EVENT_LOOP)
+    if (ASSERT_ENABLED) {
+        Locker locker { m_runLoopObserverLock };
+        ASSERT(m_runLoopObserver);
+    }
 #endif
     m_callback();
 }
 
-#if !USE(CF) && !USE(GLIB)
+#if !USE(CF) && !USE(GLIB_EVENT_LOOP)
 
 void RunLoopObserver::schedule(PlatformRunLoop, OptionSet<Activity>)
 {
@@ -59,6 +64,6 @@ bool RunLoopObserver::isScheduled() const
     return false;
 }
 
-#endif // !USE(CF)
+#endif // !USE(CF) && !USE(GLIB_EVENT_LOOP)
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3870,7 +3870,10 @@ void MediaPlayerPrivateGStreamer::pushTextureToCompositor(bool isDuplicateSample
 
 void MediaPlayerPrivateGStreamer::repaint()
 {
-    ASSERT(m_sample);
+    if (ASSERT_ENABLED) {
+        Locker sampleLocker { m_sampleMutex };
+        ASSERT(m_sample);
+    }
     ASSERT(isMainThread());
 
     if (RefPtr player = m_player.get())


### PR DESCRIPTION
#### bd37677064a8766c131e7918b00311c542236676
<pre>
[GTK][WPE] Fix more issues caught by -Wthread-safety
<a href="https://bugs.webkit.org/show_bug.cgi?id=320741">https://bugs.webkit.org/show_bug.cgi?id=320741</a>

Reviewed by Philippe Normand.

* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::JSONFileHandler::open):
* Source/WebCore/platform/RunLoopObserver.cpp:
(WebCore::RunLoopObserver::runLoopObserverFired):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::repaint):

Canonical link: <a href="https://commits.webkit.org/318316@main">https://commits.webkit.org/318316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0130039b8d47b0229a935e1d3ecc00b53b7abd97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187576 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138720 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42263 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119183 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40926 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39284 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151331 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38968 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36037 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190005 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51571 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147854 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52253 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147635 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26984 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42346 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124506 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118974 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50761 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13948 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50219 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->