### PR TITLE
Web Inspector: remove all references to WebMetal

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -2038,8 +2038,6 @@ localizedStrings["WebGL2 @ Offscreen Canvas Context Type"] = "WebGL2 (Offscreen)
 /* WebGPU is a type of rendering context associated with a <canvas> element. */
 localizedStrings["WebGPU @ Canvas Context Type"] = "WebGPU";
 localizedStrings["WebKit Threads"] = "WebKit Threads";
-/* WebMetal is a type of rendering context associated with a <canvas> element. */
-localizedStrings["WebMetal @ Canvas Context Type"] = "WebMetal";
 localizedStrings["WebP"] = "WebP";
 localizedStrings["WebRTC"] = "WebRTC";
 localizedStrings["WebRTC Logging:"] = "WebRTC Logging:";

--- a/Source/WebInspectorUI/UserInterface/Models/Canvas.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Canvas.js
@@ -105,9 +105,6 @@ WI.Canvas = class Canvas extends WI.Object
         case InspectorBackend.Enum.Canvas.ContextType.WebGPU:
             contextType = WI.Canvas.ContextType.WebGPU;
             break;
-        case InspectorBackend.Enum.Canvas.ContextType.WebMetal:
-            contextType = WI.Canvas.ContextType.WebMetal;
-            break;
         default:
             console.error("Invalid canvas context type", payload.contextType);
         }
@@ -150,8 +147,6 @@ WI.Canvas = class Canvas extends WI.Object
             return WI.UIString("WebGL2 (Offscreen)", "WebGL2 @ Offscreen Canvas Context Type", "WebGL2 is a type of rendering context associated with a OffscreenCanvas.");
         case WI.Canvas.ContextType.WebGPU:
             return WI.UIString("WebGPU", "WebGPU @ Canvas Context Type", "WebGPU is a type of rendering context associated with a <canvas> element.");
-        case WI.Canvas.ContextType.WebMetal:
-            return WI.UIString("WebMetal", "WebMetal @ Canvas Context Type", "WebMetal is a type of rendering context associated with a <canvas> element.");
         }
 
         console.assert(false, "Unknown canvas context type", contextType);
@@ -185,7 +180,6 @@ WI.Canvas = class Canvas extends WI.Object
     {
         switch (contextType) {
         case Canvas.ContextType.WebGPU:
-        case Canvas.ContextType.WebMetal:
             return false;
         }
         return true;
@@ -221,7 +215,6 @@ WI.Canvas = class Canvas extends WI.Object
             return true;
 
         case WI.Canvas.ContextType.WebGPU:
-        case WI.Canvas.ContextType.WebMetal:
             return false;
         }
 
@@ -522,7 +515,6 @@ WI.Canvas.ContextType = {
     WebGL2: "webgl2",
     OffscreenWebGL2: "offscreen-webgl2",
     WebGPU: "webgpu",
-    WebMetal: "webmetal",
 };
 
 WI.Canvas.ColorSpace = {

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasSidebarPanel.css
@@ -47,7 +47,7 @@
     content: url(../Images/Canvas2D.svg);
 }
 
-.sidebar > .panel.navigation.canvas > .content > .tree-outline .item.canvas:is(.webgl, .webgl2, .webgpu, .webmetal) .icon {
+.sidebar > .panel.navigation.canvas > .content > .tree-outline .item.canvas:is(.webgl, .webgl2, .webgpu) .icon {
     content: url(../Images/Canvas3D.svg);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/GraphicsTabContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/GraphicsTabContentView.css
@@ -31,7 +31,7 @@
     content: url(../Images/Canvas2D.svg);
 }
 
-.content-view.tab.graphics .navigation-bar > .item .canvas:is(.webgl, .webgl2, .webgpu, .webmetal) .icon {
+.content-view.tab.graphics .navigation-bar > .item .canvas:is(.webgl, .webgl2, .webgpu) .icon {
     content: url(../Images/Canvas3D.svg);
 }
 


### PR DESCRIPTION
#### 31e173570f49e460387cabab18aa15dcb403954c
<pre>
Web Inspector: remove all references to WebMetal
<a href="https://bugs.webkit.org/show_bug.cgi?id=320743">https://bugs.webkit.org/show_bug.cgi?id=320743</a>

Reviewed by Simon Fraser.

This should have been done when support for iOS 12.2 was removed.

* Source/WebInspectorUI/UserInterface/Models/Canvas.js:
(WI.Canvas.fromPayload):
(WI.Canvas.displayNameForContextType):
(WI.Canvas.supportsRequestContentForContextType):
(WI.Canvas.prototype.get supportsRecording):
* Source/WebInspectorUI/UserInterface/Views/CanvasSidebarPanel.css:
(.sidebar &gt; .panel.navigation.canvas &gt; .content &gt; .tree-outline .item.canvas:is(.webgl, .webgl2, .webgpu) .icon): Renamed from `.sidebar &gt; .panel.navigation.canvas &gt; .content &gt; .tree-outline .item.canvas:is(.webgl, .webgl2, .webgpu, .webmetal) .icon`.
* Source/WebInspectorUI/UserInterface/Views/GraphicsTabContentView.css:
(.content-view.tab.graphics .navigation-bar &gt; .item .canvas:is(.webgl, .webgl2, .webgpu) .icon): Renamed from `.content-view.tab.graphics .navigation-bar &gt; .item .canvas:is(.webgl, .webgl2, .webgpu, .webmetal) .icon`.
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

Canonical link: <a href="https://commits.webkit.org/318322@main">https://commits.webkit.org/318322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9c1ccef5fe1f9d22a5bb03853fa2ba0a3b79a3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187578 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53199 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51615 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138721 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159475 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40928 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39287 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38967 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36039 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190007 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51573 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147856 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39708 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52255 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147637 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42347 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124508 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118976 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50763 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13947 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50159 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50399 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50221 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->