### PR TITLE
getUserMedia audio permanently fails with NotAllowedError: No AVAudioSessionCaptureDevice after an audiomxd media‑services reset on iOS 26

### DIFF
--- a/Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureSource.cpp
@@ -88,8 +88,10 @@ CaptureSourceOrError CoreAudioCaptureSource::create(const CaptureDevice& device,
     auto source = adoptRef(*new CoreAudioCaptureSource(device, coreAudioDevice->deviceID(), WTF::move(hashSalts), pageIdentifier));
 #elif PLATFORM(IOS_FAMILY)
     auto coreAudioDevice = AVAudioSessionCaptureDeviceManager::singleton().audioSessionDeviceWithUID(device.persistentId());
-    if (!coreAudioDevice)
+    if (!coreAudioDevice && !device.isDefault()) {
+        AVAudioSessionCaptureDeviceManager::singleton().scheduleUpdateCaptureDevices();
         return CaptureSourceOrError({ "No AVAudioSessionCaptureDevice device"_s, MediaAccessDenialReason::PermissionDenied });
+    }
 
     auto source = adoptRef(*new CoreAudioCaptureSource(device, 0, WTF::move(hashSalts), pageIdentifier));
 #endif

--- a/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h
@@ -55,6 +55,7 @@ public:
     std::optional<AVAudioSessionCaptureDevice> audioSessionDeviceWithUID(const String&);
     
     void scheduleUpdateCaptureDevices();
+    void scheduleMediaServicesWereReset();
 
     void enableAllDevicesQuery();
     void disableAllDevicesQuery();

--- a/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
@@ -60,6 +60,7 @@
         return nil;
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(routeDidChange:) name:PAL::get_AVFoundation_AVAudioSessionRouteChangeNotificationSingleton() object:session];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionMediaServicesWereReset:) name:AVAudioSessionMediaServicesWereResetNotification object:session];
 
     _callback = callback;
 
@@ -80,6 +81,17 @@
     callOnWebThreadOrDispatchAsyncOnMainThread([protectedSelf = retainPtr(self)]() mutable {
         if (auto* callback = protectedSelf->_callback)
             callback->scheduleUpdateCaptureDevices();
+    });
+}
+
+- (void)sessionMediaServicesWereReset:(NSNotification *)notification
+{
+    if (!_callback)
+        return;
+
+    callOnWebThreadOrDispatchAsyncOnMainThread([protectedSelf = retainPtr(self)]() mutable {
+        if (auto* callback = protectedSelf->_callback)
+            callback->scheduleMediaServicesWereReset();
     });
 }
 
@@ -221,6 +233,15 @@ bool AVAudioSessionCaptureDeviceManager::setPreferredAudioSessionDeviceIDs()
 void AVAudioSessionCaptureDeviceManager::scheduleUpdateCaptureDevices()
 {
     computeCaptureDevices([] { });
+}
+
+void AVAudioSessionCaptureDeviceManager::scheduleMediaServicesWereReset()
+{
+    m_captureDevices = { };
+    m_dispatchQueue->dispatch([this] {
+        createAudioSession();
+    });
+    scheduleUpdateCaptureDevices();
 }
 
 void AVAudioSessionCaptureDeviceManager::refreshAudioCaptureDevices()


### PR DESCRIPTION
#### d2277d7a18372283b1e3dab710ccbd196cf91659
<pre>
getUserMedia audio permanently fails with NotAllowedError: No AVAudioSessionCaptureDevice after an audiomxd media‑services reset on iOS 26
<a href="https://rdar.apple.com/183164001">rdar://183164001</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319706">https://bugs.webkit.org/show_bug.cgi?id=319706</a>

Reviewed by Eric Carlson.

We react to audio services crash via a listener to recompute the list of devices.
This ensures that if AVAudioSessionCaptureDeviceManager ever gets an empty availableInputs due to a crash of audio services close to the availableInputs crash, we can recover from this.

Also, in CoreAudioCaptureSource::create, we are no longer returning an error if we do not find the device, if the device is the default.
In that case, later when starting capture, we anyway check whether the device is empty and if so, we set preferred device to the empty string.
We also enforce refresh of capture devices if we enter in the No AVAudioSessionCaptureDevice error as a further improvement.

* Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::create):
* Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm:
(-[WebAVAudioSessionAvailableInputsListener initWithCallback:audioSession:]):
(-[WebAVAudioSessionAvailableInputsListener sessionMediaServicesWereReset:]):
(WebCore::AVAudioSessionCaptureDeviceManager::scheduleMediaServicesWereReset):

Canonical link: <a href="https://commits.webkit.org/318349@main">https://commits.webkit.org/318349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a303e834162b848fe90208b2e345859f106c902

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187659 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51693 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181003 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/42336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119242 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39033 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36117 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44583 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190086 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51652 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39723 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52334 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147704 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42411 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124597 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119067 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50852 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14005 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50237 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50477 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50299 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->