### PR TITLE
REGRESSION(318122@main): http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html is consistently failing

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8028,8 +8028,6 @@ webkit.org/b/317545 imported/w3c/web-platform-tests/digital-credentials/webdrive
 webkit.org/b/306292 http/wpt/identity/formats/ISO18013/origin-binding.https.html [ Skip ]
 webkit.org/b/317545 imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-openid4vp.https.html [ Skip ]
 
-webkit.org/b/320546 http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html [ Failure ]
-
 # Hits assert in debug, tracked by https://bugs.webkit.org/show_bug.cgi?id=303414
 [ Debug ] fullscreen/fullscreen-grid-item-container-type-crash.html [ Skip ]
 

--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html
@@ -33,7 +33,10 @@
     // With the setting enabled, the OpenID4VP signed/multisigned requests are parsed
     // via convertDictionary() in the web content process, which enforces the required
     // dictionary members. A missing required member makes the whole get() reject.
+    // Note: get() consumes transient activation before serializing requests, so each
+    // test must call test_driver.bless() to provide user activation.
     promise_test(async (t) => {
+        await test_driver.bless("user activation");
         await promise_rejects_js(t, TypeError, navigator.credentials.get({
             digital: { requests: [{ protocol: "openid4vp-v1-signed", data: {} }] },
             mediation: "required",
@@ -41,6 +44,7 @@
     }, "openid4vp-v1-signed missing the required 'request' member rejects with a TypeError");
 
     promise_test(async (t) => {
+        await test_driver.bless("user activation");
         await promise_rejects_js(t, TypeError, navigator.credentials.get({
             digital: { requests: [{ protocol: "openid4vp-v1-multisigned", data: {} }] },
             mediation: "required",
@@ -51,6 +55,7 @@
     // the whole get(), even though a valid mdoc request is also present. (Contrast with
     // the disabled case, where the unsupported request is skipped and the mdoc proceeds.)
     promise_test(async (t) => {
+        await test_driver.bless("user activation");
         await promise_rejects_js(t, TypeError, navigator.credentials.get({
             digital: { requests: [validMDocRequest, { protocol: "openid4vp-v1-signed", data: {} }] },
             mediation: "required",


### PR DESCRIPTION
#### 01f921063def4b0c20a70d8d54d1c207a2311e2e
<pre>
REGRESSION(318122@main): http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html is consistently failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=320546">https://bugs.webkit.org/show_bug.cgi?id=320546</a>
<a href="https://rdar.apple.com/problem/183718878">rdar://problem/183718878</a>

Reviewed by Marcos Caceres.

318122@main moved the transient activation consumption before request
serialization so that a page cannot probe whether its request data is
serializable without spending its user activation.  The OpenID4VP
request-parsing tests relied on the TypeError from malformed dictionary
members firing before the activation gate -- which is no longer the
case.  Provide user activation via test_driver.bless() so the tests
reach the convertDictionary() validation path.

* LayoutTests/TestExpectations:
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html:
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https.html:

Canonical link: <a href="https://commits.webkit.org/318460@main">https://commits.webkit.org/318460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81f0ba3cfa09ad2d2a7bff189ac16a16fd2c2cf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141292 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d831ea8-2a57-4e0e-a878-bcc47b9b255d) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179908 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138785 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce7b04d6-bacb-4674-bb17-70e2f43dfa47) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119241 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b911aa9d-ea86-47e7-9a81-74b4289ca5c1) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/177368 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40994 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39347 "Passed tests") | | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151394 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; 1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39034 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36116 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43588 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/core/f64_bitwise.wast.js.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190085 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/177448 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147926 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39799 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52333 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35658 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147702 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; 1 api test failed or timed out; re-run-api-tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42410 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119066 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50851 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14006 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50236 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50476 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50298 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->