### PR TITLE
[Wasm] Optimize JITCallee publication

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -3973,21 +3973,41 @@ public:
     // and jump patching as they're modifying existing (linked) code,
     // so the address being provided is correct for relative address
     // computation.
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush>
     static void relinkJump(void* from, void* to)
     {
-        relinkJumpOrCall<BranchType_JMP>(reinterpret_cast<int*>(from), reinterpret_cast<const int*>(from), to);
-        cacheFlush(from, sizeof(int));
+        relinkJumpOrCall<BranchType_JMP, noFlush(repatch)>(reinterpret_cast<int*>(from), reinterpret_cast<const int*>(from), to);
+        if constexpr ((*repatch).contains(RepatchingFlag::Flush))
+            flushJump(from);
     }
-    
+
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush>
     static void relinkCall(void* from, void* to)
     {
-        relinkJumpOrCall<BranchType_CALL>(reinterpret_cast<int*>(from) - 1, reinterpret_cast<const int*>(from) - 1, to);
+        relinkJumpOrCall<BranchType_CALL, noFlush(repatch)>(reinterpret_cast<int*>(from) - 1, reinterpret_cast<const int*>(from) - 1, to);
+        if constexpr ((*repatch).contains(RepatchingFlag::Flush))
+            flushCall(from);
+    }
+
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush>
+    static void relinkTailCall(void* from, void* to)
+    {
+        relinkJump<repatch>(from, to);
+    }
+
+    static void flushJump(void* from)
+    {
+        cacheFlush(from, sizeof(int));
+    }
+
+    static void flushCall(void* from)
+    {
         cacheFlush(reinterpret_cast<int*>(from) - 1, sizeof(int));
     }
 
-    static void relinkTailCall(void* from, void* to)
+    static void flushTailCall(void* from)
     {
-        relinkJump(from, to);
+        flushJump(from);
     }
 
 #if ENABLE(JUMP_ISLANDS)
@@ -4336,7 +4356,7 @@ protected:
         }
     }
 
-    template<BranchType type>
+    template<BranchType type, RepatchingInfo repatch = jitMemcpyRepatch>
     static void relinkJumpOrCall(int* from, const int* fromInstruction, void* to)
     {
         static_assert(type == BranchType_JMP || type == BranchType_CALL);
@@ -4353,7 +4373,7 @@ protected:
                 if (imm19 == 8)
                     condition = invert(condition);
 
-                linkConditionalBranch<IndirectBranch>(condition, from - 1, fromInstruction - 1, to);
+                linkConditionalBranch<IndirectBranch, repatch>(condition, from - 1, fromInstruction - 1, to);
                 return;
             }
 
@@ -4366,7 +4386,7 @@ protected:
                 if (imm19 == 8)
                     op = !op;
 
-                linkCompareAndBranch<IndirectBranch>(op ? ConditionNE : ConditionEQ, opSize == Datasize_64, rt, from - 1, fromInstruction - 1, to);
+                linkCompareAndBranch<IndirectBranch, repatch>(op ? ConditionNE : ConditionEQ, opSize == Datasize_64, rt, from - 1, fromInstruction - 1, to);
                 return;
             }
 
@@ -4378,12 +4398,12 @@ protected:
                 if (imm14 == 8)
                     op = !op;
 
-                linkTestAndBranch<IndirectBranch>(op ? ConditionNE : ConditionEQ, bitNumber, rt, from - 1, fromInstruction - 1, to);
+                linkTestAndBranch<IndirectBranch, repatch>(op ? ConditionNE : ConditionEQ, bitNumber, rt, from - 1, fromInstruction - 1, to);
                 return;
             }
         }
 
-        linkJumpOrCall<type>(from, fromInstruction, to);
+        linkJumpOrCall<type, repatch>(from, fromInstruction, to);
     }
 
     static int* addressOf(void* code, AssemblerLabel label)

--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -2730,6 +2730,7 @@ public:
     // the write and executable address for call and jump patching
     // as they're modifying existing (linked) code, so the address being
     // provided is correct for relative address computation.
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush>
     static void relinkJump(void* from, void* to)
     {
         ASSERT(!(reinterpret_cast<intptr_t>(from) & 1));
@@ -2737,9 +2738,11 @@ public:
 
         linkJumpAbsolute(reinterpret_cast<uint16_t*>(from), reinterpret_cast<uint16_t*>(from), to);
 
-        cacheFlush(reinterpret_cast<uint16_t*>(from) - 5, 5 * sizeof(uint16_t));
+        if constexpr ((*repatch).contains(RepatchingFlag::Flush))
+            flushJump(from);
     }
 
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush>
     static void relinkCall(void* from, void* to)
     {
         ASSERT(isEven(from));
@@ -2747,19 +2750,46 @@ public:
         uint16_t* location = reinterpret_cast<uint16_t*>(from);
         if (isBL(location - 2)) {
             linkBranch(location, location, makeEven(to), BranchWithLink::Yes);
-            cacheFlush(location - 2, 2 * sizeof(uint16_t));
+            if constexpr ((*repatch).contains(RepatchingFlag::Flush))
+                cacheFlush(location - 2, 2 * sizeof(uint16_t));
             return;
         }
 
-        setPointer<jitMemcpyRepatchFlush>(location - 1, to);
+        setPointer<repatch>(location - 1, to);
     }
 
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush>
     static void relinkTailCall(void* from, void* to)
     {
         ASSERT(isEven(from));
 
         uint16_t* location = reinterpret_cast<uint16_t*>(from);
         linkBranch(location, location, to, BranchWithLink::No);
+        if constexpr ((*repatch).contains(RepatchingFlag::Flush))
+            flushTailCall(from);
+    }
+
+    // Unlike the other ports, relinkTailCall here writes a direct branch rather than
+    // delegating to relinkJump's absolute jump sequence, so flushJump and flushTailCall
+    // cover different ranges.
+    static void flushJump(void* from)
+    {
+        cacheFlush(reinterpret_cast<uint16_t*>(from) - 5, 5 * sizeof(uint16_t));
+    }
+
+    static void flushCall(void* from)
+    {
+        uint16_t* location = reinterpret_cast<uint16_t*>(from);
+        if (isBL(location - 2)) {
+            cacheFlush(location - 2, 2 * sizeof(uint16_t));
+            return;
+        }
+        cacheFlush(location - 5, 4 * sizeof(uint16_t));
+    }
+
+    static void flushTailCall(void* from)
+    {
+        uint16_t* location = reinterpret_cast<uint16_t*>(from);
         cacheFlush(location - 2, 2 * sizeof(uint16_t));
     }
 

--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -1021,15 +1021,29 @@ public:
         AssemblerType::relinkJump(jump.dataLocation(), destination.dataLocation());
     }
     
-    template<PtrTag callTag, PtrTag destTag>
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush, PtrTag callTag, PtrTag destTag>
     static void repatchNearCall(CodeLocationNearCall<callTag> nearCall, CodeLocationLabel<destTag> destination)
     {
         switch (nearCall.callMode()) {
         case NearCallMode::Tail:
-            AssemblerType::relinkTailCall(nearCall.dataLocation(), destination.dataLocation());
+            AssemblerType::template relinkTailCall<repatch>(nearCall.dataLocation(), destination.dataLocation());
             return;
         case NearCallMode::Regular:
-            AssemblerType::relinkCall(nearCall.dataLocation(), destination.untaggedPtr());
+            AssemblerType::template relinkCall<repatch>(nearCall.dataLocation(), destination.untaggedPtr());
+            return;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    template<PtrTag callTag>
+    static void flushNearCall(CodeLocationNearCall<callTag> nearCall)
+    {
+        switch (nearCall.callMode()) {
+        case NearCallMode::Tail:
+            AssemblerType::flushTailCall(nearCall.dataLocation());
+            return;
+        case NearCallMode::Regular:
+            AssemblerType::flushCall(nearCall.dataLocation());
             return;
         }
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -578,7 +578,8 @@ void LinkBuffer::performFinalization()
     
     s_profileCummulativeLinkedSizes[static_cast<unsigned>(m_profile)] += m_size;
     s_profileCummulativeLinkedCounts[static_cast<unsigned>(m_profile)]++;
-    MacroAssembler::cacheFlush(code(), m_size);
+    if (m_cacheFlushOnFinalize == CacheFlushOnFinalize::Yes)
+        MacroAssembler::cacheFlush(code(), m_size);
 }
 
 #if DUMP_LINK_STATISTICS

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -165,8 +165,11 @@ public:
 #undef COUNT_LINKBUFFER_PROFILE
     static constexpr unsigned numberOfProfilesExcludingTotal = numberOfProfiles - 1;
 
-    LinkBuffer(MacroAssembler& macroAssembler, void* ownerUID, Profile profile = Profile::Uncategorized, JITCompilationEffort effort = JITCompilationMustSucceed)
+    enum class CacheFlushOnFinalize : bool { No, Yes };
+
+    LinkBuffer(MacroAssembler& macroAssembler, void* ownerUID, Profile profile = Profile::Uncategorized, JITCompilationEffort effort = JITCompilationMustSucceed, CacheFlushOnFinalize cacheFlushOnFinalize = CacheFlushOnFinalize::Yes)
         : m_ownerUID(ownerUID)
+        , m_cacheFlushOnFinalize(cacheFlushOnFinalize)
         , m_profile(profile)
     {
         linkCode(macroAssembler, effort);
@@ -465,6 +468,7 @@ private:
 #endif
     bool m_alreadyDisassembled { false };
     bool m_isThunk { false };
+    CacheFlushOnFinalize m_cacheFlushOnFinalize { CacheFlushOnFinalize::Yes };
     bool m_isRewriting { false };
     Profile m_profile { Profile::Uncategorized };
     CodePtr<LinkBufferPtrTag> m_code;

--- a/Source/JavaScriptCore/assembler/RISCV64Assembler.h
+++ b/Source/JavaScriptCore/assembler/RISCV64Assembler.h
@@ -1632,23 +1632,43 @@ public:
         cacheFlush(location, sizeof(uint32_t) * 8);
     }
 
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush>
     static void relinkJump(void* from, void* to)
     {
         uint32_t* location = static_cast<uint32_t*>(from);
         LinkJumpImpl::apply(location, to);
-        cacheFlush(location, sizeof(uint32_t) * 2);
+        if constexpr ((*repatch).contains(RepatchingFlag::Flush))
+            flushJump(from);
     }
 
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush>
     static void relinkCall(void* from, void* to)
     {
         uint32_t* location = static_cast<uint32_t*>(from);
         LinkCallImpl::apply(location, to);
-        cacheFlush(location, sizeof(uint32_t) * 2);
+        if constexpr ((*repatch).contains(RepatchingFlag::Flush))
+            flushCall(from);
     }
 
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush>
     static void relinkTailCall(void* from, void* to)
     {
-        relinkJump(from, to);
+        relinkJump<repatch>(from, to);
+    }
+
+    static void flushJump(void* from)
+    {
+        cacheFlush(static_cast<uint32_t*>(from), sizeof(uint32_t) * 2);
+    }
+
+    static void flushCall(void* from)
+    {
+        cacheFlush(static_cast<uint32_t*>(from), sizeof(uint32_t) * 2);
+    }
+
+    static void flushTailCall(void* from)
+    {
+        flushJump(from);
     }
 
     static void replaceWithVMHalt(void* where)

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -6407,20 +6407,29 @@ public:
         setPointer(static_cast<char*>(code) + where.offset(), value);
     }
 
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush>
     static void relinkJump(void* from, void* to)
     {
         setRel32(from, to);
     }
-    
+
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush>
     static void relinkCall(void* from, void* to)
     {
         setRel32(from, to);
     }
 
+    template<RepatchingInfo repatch = jitMemcpyRepatchFlush>
     static void relinkTailCall(void* from, void* to)
     {
-        relinkJump(from, to);
+        relinkJump<repatch>(from, to);
     }
+
+    // Flushing is a no-op on x86: instruction fetch is coherent with data writes, so the relink
+    // functions above never flush either.
+    static void flushJump(void*) { }
+    static void flushCall(void*) { }
+    static void flushTailCall(void*) { }
 
     static void repatchPointer(void* where, void* value)
     {

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -99,7 +99,9 @@ void BBQPlan::work()
     Ref<BBQCallee> callee = BBQCallee::create(functionIndexSpace, m_moduleInformation->nameSection().get(functionIndexSpace), Ref { m_profiledCallee });
     std::unique_ptr<InternalFunction> function = compileFunction(m_functionIndex, callee.get(), context, unlinkedWasmToWasmCalls);
 
-    LinkBuffer linkBuffer(*context.wasmEntrypointJIT, callee.ptr(), LinkBuffer::Profile::WasmBBQ, JITCompilationCanFail);
+    // The finished code is patched further (wasm call-site linking in installOptimizedCallee) and
+    // flushed once afterward, so skip LinkBuffer's finalize instruction-cache flush.
+    LinkBuffer linkBuffer(*context.wasmEntrypointJIT, callee.ptr(), LinkBuffer::Profile::WasmBBQ, JITCompilationCanFail, LinkBuffer::CacheFlushOnFinalize::No);
     if (linkBuffer.didFailToAllocate()) [[unlikely]] {
         fail(makeString("Out of executable memory while tiering up function at index "_s, m_functionIndex.rawIndex()), CompilationError::OutOfMemory);
         return;
@@ -131,10 +133,13 @@ void BBQPlan::work()
             callee->setPCToCodeOriginMap(WTF::move(context.pcToCodeOriginMap));
         }
 
+        CalleeGroup::CallerCallsiteFlushes deferredFlushes;
         {
             Locker locker { m_calleeGroup->m_lock };
-            m_calleeGroup->installOptimizedCallee(locker, m_moduleInformation, m_functionIndex, callee.copyRef(), function->outgoingJITDirectCallees);
+            m_calleeGroup->installOptimizedCallee(locker, m_moduleInformation, m_functionIndex, callee.copyRef(), function->outgoingJITDirectCallees, deferredFlushes);
         }
+        // Flush the repatched callsites now that m_lock is released, keeping the icache flushes out of the critical section.
+        deferredFlushes.flush();
         {
             Locker locker { m_profiledCallee->tierUpCounter().m_lock };
             m_profiledCallee->tierUpCounter().setCompilationStatus(mode(), IPIntTierUpCounter::CompilationStatus::Compiled);

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -160,40 +160,17 @@ void CalleeGroup::compileAsync(VM& vm, AsyncCompilationCallback&& task)
     task->run(Ref { *this }, isAsync);
 }
 
-RefPtr<JITCallee> CalleeGroup::tryGetReplacementConcurrently(FunctionCodeIndex functionIndex) const
-{
-    if (m_optimizedCallees.isEmpty())
-        return nullptr;
-
-    // Do not use optimizedCalleesTuple. optimizedCalleesTuple handles currently-installing Callee. But we do not want to handle it actually.
-    // We would like to peek the callee when it is stored into m_optimizedCallees without taking a lock.
-    auto* tuple = &m_optimizedCallees[functionIndex];
-    UNUSED_PARAM(tuple);
-#if ENABLE(WEBASSEMBLY_OMGJIT)
-    if (RefPtr callee = tuple->m_omgCallee)
-        return callee;
-#endif
-#if ENABLE(WEBASSEMBLY_BBQJIT)
-    {
-        Locker locker { tuple->m_bbqCalleeLock };
-        if (RefPtr callee = tuple->m_bbqCallee.get())
-            return callee;
-    }
-#endif
-    return nullptr;
-}
-
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 RefPtr<BBQCallee> CalleeGroup::tryGetBBQCalleeForLoopOSRConcurrently(VM& vm, FunctionCodeIndex functionIndex)
 {
     if (m_optimizedCallees.isEmpty())
         return nullptr;
 
-    // Do not use optimizedCalleesTuple. optimizedCalleesTuple adjusts the result with currently-installing Callee. But we do not want to handle it actually.
-    // We would like to peek the callee when it is stored into m_optimizedCallees without taking a lock.
     auto* tuple = &m_optimizedCallees[functionIndex];
     RefPtr<BBQCallee> bbqCallee;
     {
+        // get() and isStrong() must be read as one atomic pair: split, we could see a strong callee
+        // and then miss that it was retired, skipping the report below.
         Locker bbqLocker { tuple->m_bbqCalleeLock };
         bbqCallee = tuple->m_bbqCallee.get();
         if (!bbqCallee)
@@ -231,6 +208,8 @@ void CalleeGroup::releaseBBQCallee(const AbstractLocker& locker, FunctionCodeInd
             return;
         bbqCallee = tuple->m_bbqCallee.convertToWeak();
     }
+    // Reported outside m_bbqCalleeLock: this takes the heap's own lock, and nothing in the heap
+    // reaches back into CalleeGroup.
     bbqCallee->reportToVMsForDestruction();
 }
 #endif
@@ -238,18 +217,81 @@ void CalleeGroup::releaseBBQCallee(const AbstractLocker& locker, FunctionCodeInd
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 RefPtr<OMGCallee> CalleeGroup::tryGetOMGCalleeConcurrently(FunctionCodeIndex functionIndex)
 {
+    // See tryGetBBQCalleeForLoopOSRConcurrently for why reading m_optimizedCallees without m_lock is
+    // safe. m_omgCallee itself is written once and never cleared, so the worst case is that we miss
+    // a tier-up that just landed.
     if (m_optimizedCallees.isEmpty())
         return nullptr;
 
-    // Do not use optimizedCalleesTuple. optimizedCalleesTuple handles currently-installing Callee. But we do not want to handle it actually.
-    // We would like to peek the callee when it is stored into m_optimizedCallees without taking a lock.
-    auto* tuple = &m_optimizedCallees[functionIndex];
-    return tuple->m_omgCallee;
+    return m_optimizedCallees[functionIndex].m_omgCallee;
 }
 #endif
 
 #if ENABLE(WEBASSEMBLY_OMGJIT) || ENABLE(WEBASSEMBLY_BBQJIT)
-bool CalleeGroup::startInstallingCallee(const AbstractLocker& locker, FunctionCodeIndex functionIndex, OptimizingJITCallee& callee)
+void CalleeGroup::CallerCallsiteFlushes::flush()
+{
+    // This only invalidates the caller's instruction cache; it does not context-synchronize the
+    // threads executing those callers. So a core that already prefetched the old branch target may
+    // keep calling the previous callee for an architecturally unbounded time after this returns.
+    // That is safe because retired code is not freed until Heap::finalizeWasmCalleeCleanup() runs
+    // with the world stopped in every VM that could be running it, and stopping a thread is itself a
+    // context-synchronizing event. Anything that shortens a retired callee's lifetime must preserve
+    // that property.
+
+    // FIXME: Maybe it's worth doing a cpuid here on X86_64. We don't do any earlier in the callee
+    // publication process as it's not strictly necessary.
+    for (auto& callsite : callsites)
+        MacroAssembler::flushNearCall(callsite.callLocation);
+}
+
+// Reserves this callee's place before any of its code is linked, so a competing install for the same
+// function loses here rather than part-way through publication. Must run before reportCallees, or a
+// loser would leave itself permanently recorded as a caller of everything it calls.
+bool CalleeGroup::tryReserveCalleeForInstall(const AbstractLocker& locker, FunctionCodeIndex functionIndex, OptimizingJITCallee& callee)
+{
+    switch (callee.compilationMode()) {
+#if ENABLE(WEBASSEMBLY_OMGJIT)
+    case CompilationMode::OMGMode: {
+        // Why does it happen? It is possible that some code is still running IPIntCallee, and OMGCallee is installed and BBQCallee gets retired.
+        // But since IPIntCallee can only tier up to BBQCallee, it may spin up BBQCallee again.
+        // And because of BBQCallee's new TierUpCounter, we may start introducing OMGCallee again.
+        // For now, we make this defensive: making installation failed when OMGCallee is already installed.
+        // This is only a reservation; publishing happens after the code is flushed, so it is rechecked
+        // there too.
+        auto* slot = optimizedCalleesTuple(locker, functionIndex);
+        ASSERT(slot);
+        if (slot->m_omgCallee) [[unlikely]]
+            return false;
+
+        for (auto& pending : m_pendingPublishCallees) {
+            if (toCodeIndex(pending->index()) == functionIndex && pending->compilationMode() == CompilationMode::OMGMode) [[unlikely]]
+                return false;
+        }
+        break;
+    }
+
+    case CompilationMode::OMGForOSREntryMode:
+        // This only reserves/registers the callee, OMGOSREntryCallee's are only reachable via the
+        // BBQCallee (after BBQCallee::setOSREntryCallee is called).
+        if (!m_osrEntryCallees.add(functionIndex, ThreadSafeWeakPtr<OMGOSREntryCallee> { downcast<OMGOSREntryCallee>(callee) }).isNewEntry)
+            return false;
+        break;
+#endif
+#if ENABLE(WEBASSEMBLY_BBQJIT)
+    case CompilationMode::BBQMode:
+        // The IPInt tier-up counter's compilation status already serializes BBQ plans for a function.
+        break;
+#endif
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    addPendingPublishCallee(locker, callee);
+    return true;
+
+}
+
+bool CalleeGroup::installOptimizedCallee(Locker<Lock>& locker, const ModuleInformation& info, FunctionCodeIndex functionIndex, Ref<OptimizingJITCallee>&& callee, const FixedBitVector& outgoingJITDirectCallees, CallerCallsiteFlushes& deferred)
 {
     auto* slot = optimizedCalleesTuple(locker, functionIndex);
     if (!slot) [[unlikely]] {
@@ -258,102 +300,111 @@ bool CalleeGroup::startInstallingCallee(const AbstractLocker& locker, FunctionCo
     }
     ASSERT(slot);
 
-#if ENABLE(WEBASSEMBLY_OMGJIT)
-    if (callee.compilationMode() == CompilationMode::OMGMode) {
-        // Why does it happen? It is possible that some code is still running IPIntCallee, and OMGCallee is installed and BBQCallee gets retired.
-        // But since IPIntCallee can only tier up to BBQCallee, it may spin up BBQCallee again.
-        // And because of BBQCallee's new TierUpCounter, we may start introducing OMGCallee again.
-        // For now, we make this defensive: making installation failed when OMGCallee is already installed.
-        if (slot->m_omgCallee) [[unlikely]]
-            return false;
-        m_currentlyInstallingOptimizedCallees.m_omgCallee = Ref { uncheckedDowncast<OMGCallee>(callee) };
-    } else
-        m_currentlyInstallingOptimizedCallees.m_omgCallee = slot->m_omgCallee;
-#endif // ENABLE(WEBASSEMBLY_OMGJIT)
-    {
-        Locker replacerLocker { m_currentlyInstallingOptimizedCallees.m_bbqCalleeLock };
-        Locker locker { slot->m_bbqCalleeLock };
-        if (callee.compilationMode() == CompilationMode::BBQMode)
-            m_currentlyInstallingOptimizedCallees.m_bbqCallee = Ref { uncheckedDowncast<BBQCallee>(callee) };
-        else
-            m_currentlyInstallingOptimizedCallees.m_bbqCallee = slot->m_bbqCallee;
-    }
-    m_currentlyInstallingOptimizedCalleesIndex = functionIndex;
-    return true;
-}
-
-void CalleeGroup::finalizeInstallingCallee(const AbstractLocker&, FunctionCodeIndex functionIndex)
-{
-    RELEASE_ASSERT(m_currentlyInstallingOptimizedCalleesIndex == functionIndex);
-    auto* slot = &m_optimizedCallees[functionIndex];
-    {
-        Locker replacerLocker { m_currentlyInstallingOptimizedCallees.m_bbqCalleeLock };
-        Locker locker { slot->m_bbqCalleeLock };
-        slot->m_bbqCallee = m_currentlyInstallingOptimizedCallees.m_bbqCallee;
-        m_currentlyInstallingOptimizedCallees.m_bbqCallee = nullptr;
-    }
-#if ENABLE(WEBASSEMBLY_OMGJIT)
-    slot->m_omgCallee = std::exchange(m_currentlyInstallingOptimizedCallees.m_omgCallee, nullptr);
-#endif
-    m_currentlyInstallingOptimizedCalleesIndex = { };
-}
-
-bool CalleeGroup::installOptimizedCallee(const AbstractLocker& locker, const ModuleInformation& info, FunctionCodeIndex functionIndex, Ref<OptimizingJITCallee>&& callee, const FixedBitVector& outgoingJITDirectCallees)
-{
-    // We want to make sure we publish our callee at the same time as we link our callsites. This enables us to ensure we
-    // always call the fastest code. Any function linked after us will see our new code and the new callsites, which they
-    // will update. It's also ok if they publish their code before we reset the instruction caches because after we release
-    // the lock our code is ready to be published too.
-
-    if (!startInstallingCallee(locker, functionIndex, callee.get()))
+    // Tracking callees in the process of getting published is required for correctness. It avoids the
+    // race of callee A (which calls B) dropping the lock below, B's OMGCallee going through the whole
+    // process and never updating A. A would be stuck linking calls to the now retired BBQCallee and
+    // could end up calling released code.
+    if (!tryReserveCalleeForInstall(locker, functionIndex, callee.get())) [[unlikely]]
         return false;
+
+    // OSREntryCallees are only valid for the specific loop they were compiled for and can't be used as
+    // a general entrypoint.
+    const bool weAreTheEntrypoint = callee->compilationMode() != CompilationMode::OMGForOSREntryMode;
+
+    // Record who we call before dropping the lock below. This is what lets another thread that
+    // retires one of our callees find us and relink our callsites while we are unpublished.
     reportCallees(locker, callee.ptr(), outgoingJITDirectCallees);
 
+    auto ourEntrypoint = CodeLocationLabel<WasmEntryPtrTag>(callee->entrypoint().retagged<WasmEntryPtrTag>());
+    auto ourSpaceIndex = callee->index();
     for (auto& call : callee->wasmToWasmCallsites()) {
         CodePtr<WasmEntryPtrTag> entrypoint;
         if (call.functionIndexSpace < info.importFunctionCount())
             entrypoint = m_wasmToWasmExitStubs[call.functionIndexSpace].code();
-        else {
+        else if (weAreTheEntrypoint && call.functionIndexSpace == ourSpaceIndex) {
+            // Recursive call. We are deliberately not in m_optimizedCallees yet, so resolve it against
+            // ourselves rather than looking it up. An OSR entry callee shares this index but is not the
+            // function's entrypoint, so a recursive call from it resolves like any other call.
+            entrypoint = ourEntrypoint;
+        } else {
             Ref calleeCallee = wasmEntrypointCalleeFromFunctionIndexSpace(locker, call.functionIndexSpace);
             entrypoint = calleeCallee->entrypoint().retagged<WasmEntryPtrTag>();
         }
 
-        // FIXME: This does an icache flush for each of these... which doesn't make any sense since this code isn't runnable here
-        // and any stale cache will be evicted when updateCallsitesToCallUs is called.
-        MacroAssembler::repatchNearCall(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(entrypoint));
+        // Link the call site without flushing. LinkBuffer skipped its finalize instruction-cache
+        // flush for this code, and the whole function is flushed once below, after every outgoing
+        // call is linked. A per-site flush would be wasteful; relying on the finalize flush would be
+        // unsafe, because these targets are written after it and an adjacent live instruction sharing
+        // a cache line with a call site could pull the stale pre-link bytes into the instruction cache.
+        MacroAssembler::repatchNearCall<jitMemcpyRepatchAtomic>(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(entrypoint));
     }
+
     {
-        Ref calleeCallee = wasmEntrypointCalleeFromFunctionIndexSpace(locker, callee->index());
-        if (calleeCallee == callee) [[likely]] {
-            auto entrypoint = calleeCallee->entrypoint().retagged<WasmEntryPtrTag>();
-            updateCallsitesToCallUs(locker, CodeLocationLabel<WasmEntryPtrTag>(entrypoint), functionIndex);
-        } else
-            resetInstructionCacheOnAllThreads();
+        // Flushing the instruction cache and synchronizing every wasm thread is pure cache maintenance:
+        // it touches no CalleeGroup state, so it does not need m_lock, and it is far too slow to hold
+        // the lock across. Our code stays unreachable to execution threads while the lock is dropped,
+        // so it is safe to publish it only after this completes.
+        // FIXME: Maybe we shouldn't drop the lock on X86_64. The stuff below is essentially a no-op there.
+        DropLockForScope unlocked(locker);
+
+        // Every outgoing call is linked, so flush the finished function before it is published. This is
+        // the single instruction-cache flush that makes this code coherent. It must cover the whole
+        // range, not just the call sites as the LinkBuffer didn't do it.
+        auto [start, end] = callee->range();
+        MacroAssembler::cacheFlush(start, static_cast<size_t>(static_cast<char*>(end) - static_cast<char*>(start)));
+
+        barrierInstructionCacheOnAllThreads();
     }
-    WTF::storeStoreFence();
-    finalizeInstallingCallee(locker, functionIndex);
+
+    // At this point the callee is ready to be published.
+    removePendingPublishCallee(locker, callee.get());
+
+    if (!weAreTheEntrypoint)
+        return true;
+
+    // Another callee for this index may have been installed while the lock was dropped, so re-read
+    // the slot before deciding what to publish.
+    slot = optimizedCalleesTuple(locker, functionIndex);
+    ASSERT(slot);
+
+    // FIXME: We should do a better job ensuring that we don't compile callees while they're already tiering up.
+#if ENABLE(WEBASSEMBLY_OMGJIT)
+    if (callee->compilationMode() == CompilationMode::OMGMode) {
+        RELEASE_ASSERT(!slot->m_omgCallee);
+        slot->m_omgCallee = Ref { uncheckedDowncast<OMGCallee>(callee.get()) };
+    }
+#endif
+#if ENABLE(WEBASSEMBLY_BBQJIT)
+    if (callee->compilationMode() == CompilationMode::BBQMode) {
+        Locker bbqLocker { slot->m_bbqCalleeLock };
+        // A retired BBQCallee may still be here: releaseBBQCallee re-arms IPInt's tier-up counter, so
+        // a function can be compiled to BBQ again before the previous callee is destroyed. Overwriting
+        // that weak reference is fine, it does not own the callee. Overwriting a strong one would drop
+        // the last reference to code that may still be executing.
+        RELEASE_ASSERT(!slot->m_bbqCallee.isStrong() || !slot->m_bbqCallee.get());
+        slot->m_bbqCallee = Ref { uncheckedDowncast<BBQCallee>(callee.get()) };
+    }
+#endif
+
+    // We dropped the lock so a higher tier callee could have installed in that time frame.
+    Ref currentCallee = wasmEntrypointCalleeFromFunctionIndexSpace(locker, ourSpaceIndex);
+    if (currentCallee.ptr() == callee.ptr()) [[likely]]
+        updateCallsitesToCallUs(locker, ourEntrypoint, functionIndex, deferred);
+
     return true;
 }
 
-void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLocationLabel<WasmEntryPtrTag> entrypoint, FunctionCodeIndex functionIndex)
+void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLocationLabel<WasmEntryPtrTag> entrypoint, FunctionCodeIndex functionIndex, CallerCallsiteFlushes& deferred)
 {
     constexpr bool verbose = false;
     dataLogLnIf(verbose, "Updating callsites for ", functionIndex, " to target ", RawPointer(entrypoint.taggedPtr()));
-    struct Callsite {
-        CodeLocationNearCall<WasmEntryPtrTag> callLocation;
-        CodeLocationLabel<WasmEntryPtrTag> target;
-    };
 
     // This is necessary since Callees are released under `Heap::stopThePeriphery()`, but that only stops JS compiler
     // threads and not wasm ones. So a weakly held BBQCallee and its OMGOSREntryCallee could die between the time we
-    // collect the callsites and when we actually repatch its callsites. Additionally, after a re-tier (where a fresh
+    // collect the callsites and when we flush them. Additionally, after a re-tier (where a fresh
     // BBQCallee replaces a retired one), m_osrEntryCallees may hold a stale weak ref to an OMGOSREntryCallee not
-    // owned by the current BBQCallee, so we always keep it alive unconditionally.
-
-    // FIXME: These inline capacities were picked semi-randomly. We should figure out if there's a better number.
-    Vector<Ref<BBQCallee>, 4> keepAliveBBQCallees;
-    Vector<Ref<OMGOSREntryCallee>, 4> keepAliveOSREntryCallees;
-    Vector<Callsite, 16> callsites;
+    // owned by the current BBQCallee, so we always keep it alive unconditionally. These references live in `deferred`
+    // so the caller code backing each callsite stays alive until the deferred flush runs after m_lock is released.
 
     auto functionSpaceIndex = toSpaceIndex(functionIndex);
     auto collectCallsites = [&](JITCallee* caller) {
@@ -361,13 +412,18 @@ void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLoca
             return;
 
         // FIXME: This should probably be a variant of FixedVector<UnlinkedWasmToWasmCall> and UncheckedKeyHashMap<FunctionIndex, FixedVector<UnlinkedWasmToWasmCall>> for big functions.
+        bool hadCall = false;
         for (UnlinkedWasmToWasmCall& callsite : caller->wasmToWasmCallsites()) {
             if (callsite.functionIndexSpace == functionSpaceIndex) {
                 dataLogLnIf(verbose, "Repatching call [", toCodeIndex(caller->index()), "] at: ", RawPointer(callsite.callLocation.dataLocation()), " to ", RawPointer(entrypoint.taggedPtr()));
                 CodeLocationLabel<WasmEntryPtrTag> target = MacroAssembler::prepareForAtomicRepatchNearCallConcurrently(callsite.callLocation, entrypoint);
-                callsites.append({ callsite.callLocation, target });
+                deferred.callsites.append({ callsite.callLocation, target });
+                hadCall = true;
             }
         }
+
+        if (hadCall)
+            deferred.keepAliveCallees.append(*caller);
     };
 
     auto handleCallerIndex = [&](size_t caller) {
@@ -382,13 +438,12 @@ void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLoca
         // that we're going to want to destroy.
         RefPtr<BBQCallee> bbqCallee;
         {
-            Locker locker { tuple->m_bbqCalleeLock };
+            Locker bbqLocker { tuple->m_bbqCalleeLock };
             bbqCallee = tuple->m_bbqCallee.get();
         }
         if (bbqCallee) {
             collectCallsites(bbqCallee.get());
             ASSERT(!bbqCallee->osrEntryCallee() || m_osrEntryCallees.find(callerIndex) != m_osrEntryCallees.end());
-            keepAliveBBQCallees.append(bbqCallee.releaseNonNull());
         }
 #endif
 #if ENABLE(WEBASSEMBLY_OMGJIT)
@@ -397,7 +452,6 @@ void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLoca
             if (RefPtr callee = iter->value.get()) {
                 // Since there is a OMGOSREntryCallee, we need to collect all the callsites there and also keep it alive until we patch it.
                 collectCallsites(callee.get());
-                keepAliveOSREntryCallees.append(callee.releaseNonNull());
             } else
                 m_osrEntryCallees.remove(iter);
         }
@@ -406,31 +460,34 @@ void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLoca
 
     WTF::switchOn(m_callers[functionIndex],
         [&](SparseCallers& callers) {
-            callsites.reserveInitialCapacity(callers.size());
+            deferred.callsites.reserveInitialCapacity(callers.size());
             for (uint32_t caller : callers)
                 handleCallerIndex(caller);
         },
         [&](DenseCallers& callers) {
-            callsites.reserveInitialCapacity(callers.bitCount());
+            deferred.callsites.reserveInitialCapacity(callers.bitCount());
             for (uint32_t caller : callers)
                 handleCallerIndex(caller);
         }
     );
 
-    // It's important to make sure we do this before we make any of the code we just compiled visible. If we didn't, we could end up
-    // where we are tiering up some function A to A' and we repatch some function B to call A' instead of A. Another CPU could see
-    // the updates to B but still not have reset its cache of A', which would lead to all kinds of badness.
-    resetInstructionCacheOnAllThreads();
+    // Callees that are linked but not yet published are not reachable through m_optimizedCallees, yet
+    // they may already hold direct calls to us. If we are being retired they must be relinked too, or
+    // they would call code that is about to be freed once they publish.
+    for (auto& pending : m_pendingPublishCallees)
+        collectCallsites(pending.ptr());
+
     WTF::storeStoreFence(); // This probably isn't necessary but it's good to be paranoid.
 
     m_wasmIndirectCallEntrypoints[functionIndex] = entrypoint;
 
-    // FIXME: This does an icache flush for each repatch but we
-    // 1) only need one at the end.
-    // 2) probably don't need one at all because we don't compile wasm on mutator threads so we don't have to worry about cache coherency.
-    for (auto& callsite : callsites) {
+    // Store the new call targets now (a single atomic instruction each, no flush), but defer the
+    // instruction-cache flush until m_lock is released, via `deferred`. The previous callee stays
+    // valid, so a caller that has not yet observed the new target simply keeps calling it until the
+    // deferred flush makes the store visible.
+    for (auto& callsite : deferred.callsites) {
         dataLogLnIf(verbose, "Repatching call at: ", RawPointer(callsite.callLocation.dataLocation()), " to ", RawPointer(entrypoint.taggedPtr()));
-        MacroAssembler::repatchNearCall(callsite.callLocation, callsite.target);
+        MacroAssembler::repatchNearCall<jitMemcpyRepatchAtomic>(callsite.callLocation, callsite.target);
     }
 }
 
@@ -503,7 +560,7 @@ TriState CalleeGroup::calleeIsReferenced(const AbstractLocker& locker, Wasm::Cal
             if (!tuple)
                 return TriState::Indeterminate;
 
-            Locker locker { tuple->m_bbqCalleeLock };
+            Locker bbqLocker { tuple->m_bbqCalleeLock };
             if (tuple->m_bbqCallee.get())
                 return TriState::True;
             return TriState::Indeterminate;

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -59,6 +59,11 @@ public:
 
     struct OptimizedCallees {
 #if ENABLE(WEBASSEMBLY_BBQJIT)
+        // ThreadSafeWeakOrStrongPtr is a tagged union of RefPtr and ThreadSafeWeakPtr whose
+        // transitions are not atomic, so every access needs this lock: readers that peek callees
+        // without m_lock (tryGetBBQCalleeForLoopOSRConcurrently) would otherwise race the
+        // strong->weak conversion in releaseBBQCallee and the assignment in installOptimizedCallee.
+        // The lock is per function index, so it is effectively uncontended.
         mutable Lock m_bbqCalleeLock;
         ThreadSafeWeakOrStrongPtr<BBQCallee> m_bbqCallee WTF_GUARDED_BY_LOCK(m_bbqCalleeLock);
 #endif
@@ -115,7 +120,7 @@ public:
 #endif
 #if ENABLE(WEBASSEMBLY_BBQJIT)
             {
-                Locker locker { tuple->m_bbqCalleeLock };
+                Locker bbqLocker { tuple->m_bbqCalleeLock };
                 if (RefPtr callee = tuple->m_bbqCallee.get())
                     return callee;
             }
@@ -124,12 +129,16 @@ public:
         return nullptr;
     }
 
-    RefPtr<JITCallee> tryGetReplacementConcurrently(FunctionCodeIndex functionIndex) const WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
 #if ENABLE(WEBASSEMBLY_BBQJIT)
+    // Tier-up peeks that run on execution threads and deliberately skip m_lock, whose critical
+    // section they would otherwise contend with every compiler thread for. They are sound because a
+    // callee is only reachable through m_optimizedCallees once its code is linked, flushed, and
+    // published; m_bbqCalleeLock covers the pointer itself. Thread safety analysis cannot express
+    // this, hence WTF_IGNORES_THREAD_SAFETY_ANALYSIS.
     RefPtr<BBQCallee> tryGetBBQCalleeForLoopOSRConcurrently(VM&, FunctionCodeIndex) WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
 #endif
 #if ENABLE(WEBASSEMBLY_OMGJIT)
-    RefPtr<OMGCallee> NODELETE tryGetOMGCalleeConcurrently(FunctionCodeIndex) WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
+    RefPtr<OMGCallee> tryGetOMGCalleeConcurrently(FunctionCodeIndex) WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
 #endif
 
     Ref<Callee> wasmEntrypointCalleeFromFunctionIndexSpace(const AbstractLocker& locker, FunctionSpaceIndex functionIndexSpace) WTF_REQUIRES_LOCK(m_lock)
@@ -149,14 +158,30 @@ public:
     }
 
 #if ENABLE(WEBASSEMBLY_BBQJIT) || ENABLE(WEBASSEMBLY_OMGJIT)
-    bool installOptimizedCallee(const AbstractLocker&, const ModuleInformation&, FunctionCodeIndex, Ref<OptimizingJITCallee>&&, const FixedBitVector& outgoingJITDirectCallees) WTF_REQUIRES_LOCK(m_lock);
+    struct CallerCallsiteFlushes {
+        void flush();
+
+        struct Callsite {
+            CodeLocationNearCall<WasmEntryPtrTag> callLocation;
+            CodeLocationLabel<WasmEntryPtrTag> target;
+        };
+
+        // FIXME: These inline capacities were picked semi-randomly. We should figure out if there's a better number.
+        Vector<Callsite, 16> callsites;
+        // The keep-alive references ensure the caller code backing each callsite stays live until flush() runs.
+        // Note: We don't need OMGCallees since their lifetime is equivalent to the CalleeGroup's but it simplifies
+        // the code to do so anyway.
+        Vector<Ref<JITCallee>, 8> keepAliveCallees;
+    };
+
+    bool installOptimizedCallee(Locker<Lock>&, const ModuleInformation&, FunctionCodeIndex, Ref<OptimizingJITCallee>&&, const FixedBitVector& outgoingJITDirectCallees, CallerCallsiteFlushes&) WTF_REQUIRES_LOCK(m_lock);
 #endif
 
 #if ENABLE(WEBASSEMBLY_BBQJIT)
     RefPtr<BBQCallee> bbqCallee(const AbstractLocker& locker, FunctionCodeIndex functionIndex) WTF_REQUIRES_LOCK(m_lock)
     {
         if (auto* tuple = optimizedCalleesTuple(locker, functionIndex)) {
-            Locker locker { tuple->m_bbqCalleeLock };
+            Locker bbqLocker { tuple->m_bbqCalleeLock };
             return tuple->m_bbqCallee.get();
         }
         return nullptr;
@@ -164,20 +189,6 @@ public:
 
 
     void releaseBBQCallee(const AbstractLocker&, FunctionCodeIndex) WTF_REQUIRES_LOCK(m_lock);
-#endif
-
-#if ENABLE(WEBASSEMBLY_OMGJIT)
-    OMGCallee* omgCallee(const AbstractLocker& locker, FunctionCodeIndex functionIndex) WTF_REQUIRES_LOCK(m_lock)
-    {
-        if (auto* tuple = optimizedCalleesTuple(locker, functionIndex))
-            return tuple->m_omgCallee.get();
-        return nullptr;
-    }
-
-    bool recordOMGOSREntryCallee(const AbstractLocker&, FunctionCodeIndex functionIndex, OMGOSREntryCallee& callee) WTF_REQUIRES_LOCK(m_lock)
-    {
-        return m_osrEntryCallees.add(functionIndex, callee).isNewEntry;
-    }
 #endif
 
     CodePtr<WasmEntryPtrTag>* entrypointLoadLocationFromFunctionIndexSpace(FunctionSpaceIndex functionIndexSpace)
@@ -214,7 +225,6 @@ private:
 #endif
 #if ENABLE(WEBASSEMBLY_OMGJIT)
     friend class OMGPlan;
-    friend class OSREntryPlan;
 #endif
 
     CalleeGroup(VM&, MemoryMode, ModuleInformation&, Ref<IPIntCallees>&&);
@@ -223,8 +233,6 @@ private:
 
     OptimizedCallees* optimizedCalleesTuple(const AbstractLocker&, FunctionCodeIndex index) WTF_REQUIRES_LOCK(m_lock)
     {
-        if (m_currentlyInstallingOptimizedCalleesIndex == index)
-            return &m_currentlyInstallingOptimizedCallees;
         if (m_optimizedCallees.isEmpty())
             return nullptr;
         return &m_optimizedCallees[index];
@@ -232,8 +240,6 @@ private:
 
     const OptimizedCallees* optimizedCalleesTuple(const AbstractLocker&, FunctionCodeIndex index) const WTF_REQUIRES_LOCK(m_lock)
     {
-        if (m_currentlyInstallingOptimizedCalleesIndex == index)
-            return &m_currentlyInstallingOptimizedCallees;
         if (m_optimizedCallees.isEmpty())
             return nullptr;
         return &m_optimizedCallees[index];
@@ -242,18 +248,38 @@ private:
     void ensureOptimizedCalleesSlow(const AbstractLocker&) WTF_REQUIRES_LOCK(m_lock);
 
 #if ENABLE(WEBASSEMBLY_OMGJIT) || ENABLE(WEBASSEMBLY_BBQJIT)
-    bool startInstallingCallee(const AbstractLocker&, FunctionCodeIndex, OptimizingJITCallee&) WTF_REQUIRES_LOCK(m_lock);
-    void finalizeInstallingCallee(const AbstractLocker&, FunctionCodeIndex) WTF_REQUIRES_LOCK(m_lock);
-    void updateCallsitesToCallUs(const AbstractLocker&, CodeLocationLabel<WasmEntryPtrTag> entrypoint, FunctionCodeIndex functionIndex) WTF_REQUIRES_LOCK(m_lock);
+    bool tryReserveCalleeForInstall(const AbstractLocker&, FunctionCodeIndex, OptimizingJITCallee&) WTF_REQUIRES_LOCK(m_lock);
+
+    // Callees are added here for as long as their code is linked but not yet flushed, i.e. across the
+    // window where installOptimizedCallee drops m_lock. Both bookends must run under one lock hold, so
+    // only installOptimizedCallee may call them.
+    void addPendingPublishCallee(const AbstractLocker&, OptimizingJITCallee& callee) WTF_REQUIRES_LOCK(m_lock)
+    {
+        m_pendingPublishCallees.append(callee);
+    }
+
+    void removePendingPublishCallee(const AbstractLocker&, OptimizingJITCallee& callee) WTF_REQUIRES_LOCK(m_lock)
+    {
+        m_pendingPublishCallees.removeFirst(&callee);
+    }
+
+    void updateCallsitesToCallUs(const AbstractLocker&, CodeLocationLabel<WasmEntryPtrTag> entrypoint, FunctionCodeIndex functionIndex, CallerCallsiteFlushes&) WTF_REQUIRES_LOCK(m_lock);
     void reportCallees(const AbstractLocker&, JITCallee* caller, const FixedBitVector& callees) WTF_REQUIRES_LOCK(m_lock);
 #endif
 
     unsigned m_calleeCount;
     MemoryMode m_mode;
 
-    FunctionCodeIndex m_currentlyInstallingOptimizedCalleesIndex WTF_GUARDED_BY_LOCK(m_lock) { };
-    OptimizedCallees m_currentlyInstallingOptimizedCallees WTF_GUARDED_BY_LOCK(m_lock) { };
     FixedVector<OptimizedCallees> m_optimizedCallees WTF_GUARDED_BY_LOCK(m_lock);
+
+#if ENABLE(WEBASSEMBLY_OMGJIT) || ENABLE(WEBASSEMBLY_BBQJIT)
+    // Callees whose code is fully linked but not yet published, i.e. their owner has dropped m_lock to
+    // flush the instruction cache. They are deliberately absent from m_optimizedCallees so execution
+    // threads cannot reach code that has not been flushed yet. They must still be discoverable as
+    // direct-call targets: an installer that links a call to one of these must be able to find the
+    // callee here so it can be relinked (and kept alive) if that callee is retired before we publish.
+    Vector<Ref<OptimizingJITCallee>, 4> m_pendingPublishCallees WTF_GUARDED_BY_LOCK(m_lock);
+#endif
     const Ref<IPIntCallees> m_ipintCallees;
     UncheckedKeyHashMap<uint32_t, RefPtr<JSToWasmCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsToWasmCallees WTF_GUARDED_BY_LOCK(m_jsToWasmCalleesLock);
     mutable Lock m_jsToWasmCalleesLock;

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -122,10 +122,6 @@ void EntryPlan::prepare()
         return;
     if (!tryReserveCapacity(m_wasmToJSExitStubs, importFunctionCount, " WebAssembly to JavaScript stubs"_s))
         return;
-    if (!tryReserveCapacity(m_unlinkedWasmToWasmCalls, functions.size(), " unlinked WebAssembly to WebAssembly calls"_s))
-        return;
-
-    m_unlinkedWasmToWasmCalls.resize(functions.size());
 
     for (const auto& exp : m_moduleInformation->exports) {
         if (exp.kindIndex >= importFunctionCount)

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -78,12 +78,6 @@ public:
         return WTF::move(m_wasmToWasmExitStubs);
     }
 
-    Vector<Vector<UnlinkedWasmToWasmCall>> takeWasmToWasmCallsites()
-    {
-        RELEASE_ASSERT(!failed() && !hasWork());
-        return WTF::move(m_unlinkedWasmToWasmCalls);
-    }
-
     Vector<MacroAssemblerCodeRef<WasmEntryPtrTag>> takeWasmToJSExitStubs()
     {
         RELEASE_ASSERT(!failed() && !hasWork());
@@ -150,7 +144,6 @@ protected:
     Vector<MacroAssemblerCodeRef<WasmEntryPtrTag>> m_wasmToJSExitStubs;
     UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_exportedFunctionIndices;
 
-    Vector<Vector<UnlinkedWasmToWasmCall>> m_unlinkedWasmToWasmCalls;
     StreamingParser m_streamingParser;
     State m_state;
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -92,7 +92,6 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
     ASSERT_UNUSED(functionIndexSpace, &m_moduleInformation->rtt(functionIndexSpace) == &m_moduleInformation->rtt(typeSignatureIndex));
 
     beginCompilerSignpost(CompilationMode::IPIntMode, functionIndexSpace);
-    m_unlinkedWasmToWasmCalls[functionIndex] = Vector<UnlinkedWasmToWasmCall>();
     auto parseAndCompileResult = parseAndCompileMetadata(function.data, signature, m_moduleInformation.get(), functionIndex);
     endCompilerSignpost(CompilationMode::IPIntMode, functionIndexSpace);
 
@@ -150,22 +149,6 @@ void IPIntPlan::didCompleteCompilation()
         NativeCalleeRegistry::singleton().registerCallees(*m_ipintCallees);
         if (Options::useWasmTailCalls())
             RestoreFrameCallee::singleton();
-    }
-
-    if (m_compilerMode == CompilerMode::Validation)
-        return;
-
-    for (auto& unlinked : m_unlinkedWasmToWasmCalls) {
-        for (auto& call : unlinked) {
-            CodePtr<WasmEntryPtrTag> executableAddress;
-            if (m_moduleInformation->isImportedFunctionFromFunctionIndexSpace(call.functionIndexSpace)) {
-                // FIXME: imports could have been linked in B3, instead of generating a patchpoint. This condition should be replaced by a RELEASE_ASSERT.
-                // https://bugs.webkit.org/show_bug.cgi?id=166462
-                executableAddress = m_wasmToWasmExitStubs.at(call.functionIndexSpace).code();
-            } else
-                executableAddress = m_ipintCallees->at(call.functionIndexSpace - m_moduleInformation->importFunctionCount())->entrypoint();
-            MacroAssembler::repatchNearCall(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(executableAddress));
-        }
     }
 }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -184,8 +184,14 @@ static inline RefPtr<Wasm::JITCallee> jitCompileAndSetHeuristics(Wasm::IPIntCall
     auto getReplacement = [&] () -> RefPtr<Wasm::JITCallee> {
         switch (osrFor) {
         case OSRFor::Prologue: {
-            if (!Options::useWasmIPInt() || needsSIMDReplacement) [[unlikely]]
-                return calleeGroup.tryGetReplacementConcurrently(functionIndex);
+            if (!Options::useWasmIPInt() || needsSIMDReplacement) [[unlikely]] {
+                // Deliberately not the lock-free peek used for loops: needsSIMDReplacement means
+                // IPInt cannot interpret this function at all, so we must find the JIT callee that
+                // IPIntPlan forced to be compiled, whether it is BBQ or OMG. This path is disabled
+                // in the default configuration, so it is not worth optimizing for contention.
+                Locker locker { calleeGroup.m_lock };
+                return calleeGroup.replacement(locker, callee.index());
+            }
             return nullptr;
         }
         case OSRFor::Epilogue: {

--- a/Source/JavaScriptCore/wasm/WasmMachineThreads.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMachineThreads.cpp
@@ -30,7 +30,6 @@
 
 #include "MachineStackMarker.h"
 #include <wtf/NeverDestroyed.h>
-#include <wtf/ThreadMessage.h>
 
 namespace JSC { namespace Wasm {
 
@@ -51,16 +50,16 @@ void startTrackingCurrentThread()
     wasmThreads().addCurrentThread();
 }
 
-void resetInstructionCacheOnAllThreads()
+// FIXME: Use Linux's membarrier(MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE) here.
+void barrierInstructionCacheOnAllThreads()
 {
+#if CPU(X86_64)
+    return;
+#else
     Locker locker { wasmThreads().getLock() };
-    ThreadSuspendLocker threadSuspendLocker;
-    for (auto& thread : wasmThreads().threads(locker)) {
-        sendMessage(threadSuspendLocker, thread.get(), [] (const PlatformRegisters&) {
-            // It's likely that the signal handler will already reset the instruction cache but we might as well be sure.
-            WTF::crossModifyingCodeFence();
-        });
-    }
+    for (auto& thread : wasmThreads().threads(locker))
+        thread->barrierInstructionCache();
+#endif
 }
 
     

--- a/Source/JavaScriptCore/wasm/WasmMachineThreads.h
+++ b/Source/JavaScriptCore/wasm/WasmMachineThreads.h
@@ -38,7 +38,7 @@ namespace JSC { namespace Wasm {
 
 void startTrackingCurrentThread();
 
-void resetInstructionCacheOnAllThreads();
+void barrierInstructionCacheOnAllThreads();
     
 } } // namespace JSC::Wasm
 
@@ -47,7 +47,7 @@ void resetInstructionCacheOnAllThreads();
 namespace JSC { namespace Wasm {
 
 inline void startTrackingCurrentThread() { }
-inline void resetInstructionCacheOnAllThreads() { }
+inline void barrierInstructionCacheOnAllThreads() { }
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -146,7 +146,9 @@ void OMGPlan::work()
     }
 
     Entrypoint omgEntrypoint;
-    LinkBuffer linkBuffer(*context.wasmEntrypointJIT, callee.ptr(), LinkBuffer::Profile::WasmOMG, JITCompilationCanFail);
+    // The finished code is patched further (wasm call-site linking in installOptimizedCallee) and
+    // flushed once afterward, so skip LinkBuffer's finalize instruction-cache flush.
+    LinkBuffer linkBuffer(*context.wasmEntrypointJIT, callee.ptr(), LinkBuffer::Profile::WasmOMG, JITCompilationCanFail, LinkBuffer::CacheFlushOnFinalize::No);
     if (linkBuffer.didFailToAllocate()) [[unlikely]] {
         Locker locker { m_lock };
         Base::fail(makeString("Out of executable memory while tiering up function at index "_s, m_functionIndex.rawIndex()), CompilationError::OutOfMemory);
@@ -169,6 +171,7 @@ void OMGPlan::work()
     omgEntrypoint.calleeSaveRegisters = WTF::move(internalFunction->entrypoint.calleeSaveRegisters);
 
     bool newlyInstalled = false;
+    CalleeGroup::CallerCallsiteFlushes deferredFlushes;
     CodePtr<WasmEntryPtrTag> entrypoint;
     {
         ASSERT(m_calleeGroup.ptr() == m_module->calleeGroupFor(mode()));
@@ -181,7 +184,7 @@ void OMGPlan::work()
         }
 
         Locker locker { m_calleeGroup->m_lock };
-        newlyInstalled = m_calleeGroup->installOptimizedCallee(locker, m_moduleInformation, m_functionIndex, callee.copyRef(), internalFunction->outgoingJITDirectCallees);
+        newlyInstalled = m_calleeGroup->installOptimizedCallee(locker, m_moduleInformation, m_functionIndex, callee.copyRef(), internalFunction->outgoingJITDirectCallees, deferredFlushes);
 
         if (newlyInstalled) {
             if (RefPtr bbqCallee = m_calleeGroup->bbqCallee(locker, m_functionIndex)) {
@@ -193,6 +196,9 @@ void OMGPlan::work()
             ipintCallee.tierUpCounter().setCompilationStatus(mode(), IPIntTierUpCounter::CompilationStatus::Compiled);
         }
     }
+
+    // Flush the repatched callsites now that m_lock is released, keeping the icache flushes out of the critical section.
+    deferredFlushes.flush();
 
     if (newlyInstalled) {
         if (Options::freeRetiredWasmCode()) {

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -34,7 +34,6 @@
 #include "WasmCallee.h"
 #include "WasmFaultSignalHandler.h"
 #include "WasmIRGeneratorHelpers.h"
-#include "WasmMachineThreads.h"
 #include "WasmNameSection.h"
 #include "WasmOMGIRGenerator.h"
 #include "WasmTypeDefinitionInlines.h"
@@ -49,7 +48,7 @@ namespace WasmOSREntryPlanInternal {
 static constexpr bool verbose = false;
 }
 
-OSREntryPlan::OSREntryPlan(VM& vm, Ref<Module>&& module, Ref<Callee>&& callee, FunctionCodeIndex functionIndex, uint32_t loopIndex, MemoryMode mode, CompletionTask&& task)
+OSREntryPlan::OSREntryPlan(VM& vm, Ref<Module>&& module, Ref<BBQCallee>&& callee, FunctionCodeIndex functionIndex, uint32_t loopIndex, MemoryMode mode, CompletionTask&& task)
     : Base(vm, const_cast<ModuleInformation&>(module->moduleInformation()), WTF::move(task))
     , m_module(WTF::move(module))
     , m_calleeGroup(*m_module->calleeGroupFor(mode))
@@ -121,7 +120,9 @@ void OSREntryPlan::work()
     }
 
     Entrypoint omgEntrypoint;
-    LinkBuffer linkBuffer(*context.wasmEntrypointJIT, callee.ptr(), LinkBuffer::Profile::WasmOMG, JITCompilationCanFail);
+    // The finished code is patched further (wasm call-site linking in installOptimizedCallee) and
+    // flushed once afterward, so skip LinkBuffer's finalize instruction-cache flush.
+    LinkBuffer linkBuffer(*context.wasmEntrypointJIT, callee.ptr(), LinkBuffer::Profile::WasmOMG, JITCompilationCanFail, LinkBuffer::CacheFlushOnFinalize::No);
     if (linkBuffer.didFailToAllocate()) [[unlikely]] {
         Locker locker { m_lock };
         Base::fail(makeString("Out of executable memory while tiering up function at index "_s, m_functionIndex.rawIndex()));
@@ -149,42 +150,23 @@ void OSREntryPlan::work()
         callee->setPCToCodeOriginMap(WTF::move(samplingProfilerMap));
     }
 
+    bool newlyInstalled = false;
+    CalleeGroup::CallerCallsiteFlushes deferredFlushes;
     {
         Locker locker { m_calleeGroup->m_lock };
-        bool newlyInstalled = m_calleeGroup->recordOMGOSREntryCallee(locker, m_functionIndex, callee.get());
-        if (newlyInstalled) {
-            m_calleeGroup->reportCallees(locker, callee.ptr(), internalFunction->outgoingJITDirectCallees);
+        newlyInstalled = m_calleeGroup->installOptimizedCallee(locker, m_module->moduleInformation(), m_functionIndex, callee.copyRef(), internalFunction->outgoingJITDirectCallees, deferredFlushes);
+    }
+    // Nothing holds a direct call to an OSR entry callee, so there should be no callsites to flush.
+    ASSERT(deferredFlushes.callsites.isEmpty());
+    deferredFlushes.flush();
 
-            for (auto& call : callee->wasmToWasmCallsites()) {
-                CodePtr<WasmEntryPtrTag> entrypoint;
-                if (call.functionIndexSpace < m_module->moduleInformation().importFunctionCount())
-                    entrypoint = m_calleeGroup->m_wasmToWasmExitStubs[call.functionIndexSpace].code();
-                else {
-                    Ref wasmCallee = m_calleeGroup->wasmEntrypointCalleeFromFunctionIndexSpace(locker, call.functionIndexSpace);
-                    entrypoint = wasmCallee->entrypoint().retagged<WasmEntryPtrTag>();
-                }
+    if (newlyInstalled) {
+        WTF::storeStoreFence();
 
-                MacroAssembler::repatchNearCall(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(entrypoint));
-            }
-
-            resetInstructionCacheOnAllThreads();
-            WTF::storeStoreFence();
-
-            {
-                switch (m_callee->compilationMode()) {
-                case CompilationMode::BBQMode: {
-                    BBQCallee* bbqCallee = uncheckedDowncast<BBQCallee>(m_callee.ptr());
-                    Locker locker { bbqCallee->tierUpCounter().getLock() };
-                    bbqCallee->setOSREntryCallee(callee.copyRef(), mode());
-                    bbqCallee->tierUpCounter().osrEntryTriggers()[m_loopIndex] = TierUpCount::TriggerReason::CompilationDone;
-                    bbqCallee->tierUpCounter().setCompilationStatusForOMGForOSREntry(mode(), TierUpCount::CompilationStatus::Compiled);
-                    break;
-                }
-                default:
-                    RELEASE_ASSERT_NOT_REACHED();
-                }
-            }
-        }
+        Locker locker { m_callee->tierUpCounter().getLock() };
+        m_callee->setOSREntryCallee(callee.copyRef(), mode());
+        m_callee->tierUpCounter().osrEntryTriggers()[m_loopIndex] = TierUpCount::TriggerReason::CompilationDone;
+        m_callee->tierUpCounter().setCompilationStatusForOMGForOSREntry(mode(), TierUpCount::CompilationStatus::Compiled);
     }
 
     // We don't register our BBQCallee for deletion because this entrypoint isn't a general one and is only used for loop OSR.

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.h
@@ -48,7 +48,7 @@ public:
     bool multiThreaded() const final { return false; }
 
     // Note: CompletionTask should not hold a reference to the Plan otherwise there will be a reference cycle.
-    OSREntryPlan(VM&, Ref<Module>&&, Ref<Callee>&&, FunctionCodeIndex functionIndex, uint32_t loopIndex, MemoryMode, CompletionTask&&);
+    OSREntryPlan(VM&, Ref<Module>&&, Ref<BBQCallee>&&, FunctionCodeIndex functionIndex, uint32_t loopIndex, MemoryMode, CompletionTask&&);
 
 private:
     // For some reason friendship doesn't extend to parent classes...
@@ -64,7 +64,8 @@ private:
 
     const Ref<Module> m_module;
     const Ref<CalleeGroup> m_calleeGroup;
-    const Ref<Callee> m_callee;
+    // The callee whose loop we are compiling an OSR entry for.
+    const Ref<BBQCallee> m_callee;
     bool m_completed { false };
     FunctionCodeIndex m_functionIndex;
     uint32_t m_loopIndex;

--- a/Source/WTF/wtf/ThreadMessage.h
+++ b/Source/WTF/wtf/ThreadMessage.h
@@ -37,9 +37,12 @@ enum class MessageStatus {
     ThreadExited,
 };
 
-// This method allows us to send a message which will be run in a signal handler on the desired thread.
-// There are several caveates to this method however, This function uses signals so your message should
-// be sync signal safe.
+// Suspends targetThread, snapshots its register state, and runs func on the calling thread with
+// that snapshot while the target remains suspended; targetThread is resumed before returning. func
+// does not run on targetThread -- it runs on the caller and can inspect the suspended thread (its
+// registers, stack, and the code it is stopped in). Because the target is frozen, func must not
+// block on any resource (e.g. a lock) that the suspended thread might currently hold, or it will
+// deadlock. Returns ThreadExited if targetThread had already exited.
 WTF_EXPORT_PRIVATE MessageStatus sendMessageScoped(const ThreadSuspendLocker&, Thread&, const ThreadMessage&);
 
 template<typename Functor>

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -189,6 +189,12 @@ public:
     WTF_EXPORT_PRIVATE void resume(const ThreadSuspendLocker&);
     WTF_EXPORT_PRIVATE size_t getRegisters(const ThreadSuspendLocker&, PlatformRegisters&);
 
+    // Forces this thread through a context-synchronizing event so it re-fetches instructions that
+    // were modified by another thread (the caller must have already flushed the modified code from
+    // the instruction cache). This does not read or modify the thread's state; it only publishes the
+    // change to it.
+    WTF_EXPORT_PRIVATE void barrierInstructionCache();
+
 #if USE(PTHREADS)
 #if OS(LINUX)
     WTF_EXPORT_PRIVATE static ThreadIdentifier currentID();

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -580,6 +580,51 @@ size_t Thread::getRegisters(const ThreadSuspendLocker&, PlatformRegisters& regis
 #endif
 }
 
+void Thread::barrierInstructionCache()
+{
+#if CPU(X86_64)
+    // x86-64 has a coherent instruction cache: instruction fetches on every core observe stores to
+    // code without any explicit synchronization, so there is nothing to publish.
+    return;
+#else
+    RELEASE_ASSERT_WITH_MESSAGE(this != &Thread::currentSingleton(), "We do not support synchronizing the current thread itself.");
+    // Every mechanism below synchronizes the core the target thread is running on at the time. It is
+    // therefore only sufficient because the kernel is responsible for instruction-cache maintenance
+    // when it migrates a thread to another core; nothing here can cover a core the thread has not run
+    // on yet.
+#if OS(DARWIN) && CPU(ARM64)
+    // Reading a thread's register state forces it through a context-synchronizing kernel round-trip
+    // (the ERET on the way back to user code is an ISB), so it re-fetches modified instructions
+    // without taking the thread-suspend lock. thread_get_state's count is an in/out argument, so
+    // restore the buffer capacity before each attempt.
+    auto metadata = threadStateMetadata();
+    const unsigned stateCapacity = metadata.userCount;
+    PlatformRegisters registers;
+    kern_return_t result;
+    do {
+        metadata.userCount = stateCapacity;
+        result = thread_get_state(m_platformThread, metadata.flavor, (thread_state_t)&registers, &metadata.userCount);
+    } while (result == KERN_ABORTED);
+    ASSERT(result == KERN_SUCCESS);
+#elif CPU(RISCV64)
+    // Not implemented on RISC-V, which means the wasm JITs cannot publish code there. Instruction
+    // fetch coherence on RISC-V requires FENCE.I to execute on the hart that will run the modified
+    // code, and neither suspend/resume nor returning from a signal is architecturally guaranteed to
+    // imply one. Publishing needs an explicit remote fence — on Linux,
+    // membarrier(MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE) — rather than the mechanism below.
+    // Failing loudly is preferable to silently letting a hart execute stale instructions.
+    RELEASE_ASSERT_NOT_REACHED();
+#else
+    // Suspending and then resuming the thread makes the OS run a context-synchronizing exception
+    // return on it as it resumes, so it re-fetches modified instructions.
+    ThreadSuspendLocker locker;
+    if (!suspend(locker))
+        return;
+    resume(locker);
+#endif
+#endif
+}
+
 void Thread::establishPlatformSpecificHandle(pthread_t handle)
 {
     Locker locker { m_mutex };

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -246,6 +246,23 @@ size_t Thread::getRegisters(const ThreadSuspendLocker&, PlatformRegisters& regis
     return sizeof(CONTEXT);
 }
 
+void Thread::barrierInstructionCache()
+{
+#if CPU(X86_64)
+    // x86-64 has a coherent instruction cache, so there is nothing to publish.
+    return;
+#else
+    RELEASE_ASSERT_WITH_MESSAGE(this != &Thread::currentSingleton(), "We do not support synchronizing the current thread itself.");
+    // Suspending and then resuming the thread makes the OS run a context-synchronizing return on it
+    // as it resumes, so it re-fetches modified instructions. suspend()/resume() need the
+    // thread-suspend lock, so take it here rather than requiring it from the caller.
+    ThreadSuspendLocker locker;
+    if (!suspend(locker))
+        return;
+    resume(locker);
+#endif
+}
+
 Thread& Thread::initializeCurrentTLS()
 {
     // Not a WTF-created thread, ThreadIdentifier is not established yet.


### PR DESCRIPTION
#### 24527bbb9ac882ec69bbb900711d5ca479d12316
<pre>
[Wasm] Optimize JITCallee publication
<a href="https://bugs.webkit.org/show_bug.cgi?id=320747">https://bugs.webkit.org/show_bug.cgi?id=320747</a>
<a href="https://rdar.apple.com/183747593">rdar://183747593</a>

Reviewed by Yusuke Suzuki.

Publishing a freshly compiled wasm function held CalleeGroup::m_lock across the two most
expensive steps in the sequence: a per-callsite icache flush for every outgoing call, and
barrierCacheOnAllThreads(), which forces a kernel round-trip per tracked wasm thread.
Neither reads nor mutates CalleeGroup state, yet every other compiler thread blocked
behind them.

This does three things.

First, correctness: Relying on LinkBuffer&apos;s finalize flush to cover a function&apos;s outgoing
call sites is unsafe: those targets are written after finalization, so an adjacent live
instruction sharing a cache line with a call site can pull the stale pre-link bytes into
the instruction cache. relink{Jump,Call,TailCall} and repatchNearCall gain a
RepatchingInfo template parameter so a repatch can skip its flush, with
flush{Jump,Call,TailCall} counterparts to perform it later, and wasm&apos;s LinkBuffers are
constructed with CacheFlushOnFinalize::No. A single whole-range cacheFlush then runs after
every outgoing call is linked. machineCodeCopy already static_asserts that a memcpy
repatch carries no Flush bit, so the split cannot be quietly broken.

Second, the critical section: installOptimizedCallee now links outgoing calls under the
lock, drops it via DropLockForScope to flush and synchronize, then re-acquires to publish
and relink callers. The window is safe because the callee is not yet in m_optimizedCallees,
so no execution thread can reach unflushed code. It is not, however, undiscoverable:
m_pendingPublishCallees keeps it findable as a direct-call target, so a thread that retires
one of its callees during the window still relinks it rather than leaving it calling code
that is about to be freed. Since an OMG install for the same index can land mid-window,
the decision to redirect callers is recomputed after re-acquiring; acting on the stale one
would relink callers to BBQ over a newer OMG and tier the function back down.

Third, the readers: Maintains the lock-free tier-up peeks from 299970@main for the two hot
paths — the IPInt loop back-edge and the BBQ loop&apos;s OMG check — now that the critical
section they contended with is short. Both are sound because a callee only appears in
m_optimizedCallees after its code is flushed and published. The staging slot that commit
needed is gone: m_pendingPublishCallees subsumes it, and more cleanly, since an unpublished
callee is simply absent rather than visible-but-half-baked. m_bbqCalleeLock has to stay
because ThreadSafeWeakOrStrongPtr is a tagged union whose strong-&gt;weak transition and
assignment are both non-atomic. The IPInt prologue reader deliberately stays on m_lock: it
is only reached when IPInt cannot interpret the function at all, so it must find whichever
JIT callee exists, and it is disabled in the default configuration.

barrierCacheOnAllThreads() no longer &quot;claims&quot; to invalidate any instruction cache, only
context-synchronizes, and is rewritten on top of a new Thread::barrierInstructionCache().
The old implementation passed crossModifyingCodeFence() to sendMessage, which runs the functor
on the calling thread, not the target, so it only ever worked via the suspend/resume the
message mechanism performs incidentally. On ARM64 Darwin the new primitive reads the target&apos;s
register state instead, whose returning ERET is the context-synchronizing event. Elsewhere it
stays as a thread suspend/resume sequence.

OSR entry installation shares all of this rather than duplicating it, as it did before. An
OMGOSREntryCallee is not the function&apos;s entrypoint even though it shares its index, so one
predicate gates both the recursive-call resolution and the caller relinking; its reservation
in m_osrEntryCallees also registers it, which is safe because that map is relinking
bookkeeping and only BBQCallee::setOSREntryCallee, after the flush, makes the code enterable.

Also removes EntryPlan::m_unlinkedWasmToWasmCalls and IPIntPlan&apos;s relink loop over it,
which were dead (parseAndCompileMetadata never populated the vector).

No new tests, no behavior change. Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/318386@main">https://commits.webkit.org/318386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a79937c7e7da2879293e73cbc44c02be58983e90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52108 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39ba82ae-86f2-477e-a95e-ed12506c81f5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51817 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/187784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ac96fe0-6b07-4f93-806b-899a7ea1a259) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181127 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/42440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2008e3a4-15bb-4a05-84bc-62e7bed4eba7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/8142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/36241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39443 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44708 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190211 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51776 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/159178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52458 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/147811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27018 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/42526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119266 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50976 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/14125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50361 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50423 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->