### PR TITLE
NEW TEST(317936@main): TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting is a flaky failure on macOS Sequoia bots

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -265,6 +265,7 @@ public:
     virtual void zoomIn() = 0;
     virtual void zoomOut() = 0;
     void save(CompletionHandler<void(const String&, const URL&, std::span<const uint8_t>)>&&);
+    void updateHUDLocation();
 #endif
 
     void openWithPreview(CompletionHandler<void(const String&, std::optional<FrameInfoData>&&, std::span<const uint8_t>)>&&);
@@ -451,7 +452,6 @@ protected:
     virtual void incrementalLoadingDidFinish() { }
 
 #if ENABLE(PDF_HUD)
-    void updateHUDLocation();
     WebCore::IntRect frameForHUDInRootViewCoordinates() const;
     bool NODELETE hudEnabled() const;
     bool shouldShowHUD() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1418,28 +1418,42 @@ void WebPage::frameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameID, 
         return;
 
     RefPtr coreFrame = frame->coreFrame();
-    if (coreFrame) {
-        coreFrame->updateFrameTreeSyncData(data);
+    if (!coreFrame)
+        return;
 
-        switch (static_cast<FrameTreeSyncDataType>(data.value.index())) {
-        case FrameTreeSyncDataType::FrameRect:
-            frame->updateFrameRectFromRemote(coreFrame->frameTreeSyncData().frameRect);
-            break;
+    coreFrame->updateFrameTreeSyncData(data);
+    auto dataType = static_cast<FrameTreeSyncDataType>(data.value.index());
 
-        case FrameTreeSyncDataType::FrameScrollPosition:
-            if (RefPtr view = coreFrame->virtualView())
-                view->scrollTo(coreFrame->frameTreeSyncData().frameScrollPosition);
+    switch (dataType) {
+    case FrameTreeSyncDataType::FrameRect:
+        frame->updateFrameRectFromRemote(coreFrame->frameTreeSyncData().frameRect);
+        break;
 
-            break;
+    case FrameTreeSyncDataType::FrameScrollPosition:
+        if (RefPtr view = coreFrame->virtualView())
+            view->scrollTo(coreFrame->frameTreeSyncData().frameScrollPosition);
+        break;
 
-        case FrameTreeSyncDataType::ChildrenFrameLayoutInfo:
-            updateExposedRectFromParent(*coreFrame);
-            break;
+    case FrameTreeSyncDataType::ChildrenFrameLayoutInfo:
+        updateExposedRectFromParent(*coreFrame);
+        break;
 
-        default:
-            break;
-        }
+    default:
+        break;
     }
+
+#if ENABLE(PDF_HUD)
+    switch (dataType) {
+    case FrameTreeSyncDataType::FrameRect:
+    case FrameTreeSyncDataType::FrameScrollPosition:
+    case FrameTreeSyncDataType::FrameLayoutViewportRect:
+    case FrameTreeSyncDataType::ChildrenFrameLayoutInfo:
+        updatePDFHUDLocationsAfterRemoteFrameGeometryChange();
+        break;
+    default:
+        break;
+    }
+#endif
 }
 
 void WebPage::allFrameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameID, Ref<WebCore::FrameTreeSyncData>&& data)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -663,6 +663,7 @@ public:
     void updatePDFHUDLocation(PDFPluginBase&, const WebCore::IntRect&);
     void removePDFHUD(PDFPluginBase&);
     void showPDFHUD(PDFPluginBase&);
+    void updatePDFHUDLocationsAfterRemoteFrameGeometryChange();
 #endif
 
 #if ENABLE(PDF_PAGE_NUMBER_INDICATOR)

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -1145,6 +1145,18 @@ void WebPage::showPDFHUD(PDFPluginBase& plugin)
         send(Messages::WebPageProxy::ShowPDFHUD(plugin.identifier()));
 }
 
+void WebPage::updatePDFHUDLocationsAfterRemoteFrameGeometryChange()
+{
+    // A remote parent's geometry changes but a cross-origin <iframe> plugin's
+    // local root view transform stays unchanged, so we ask the plugin to re-report
+    // its HUD location to the UI process, which runs the main frame conversion
+    // with newer geometry.
+    for (WeakPtr weakPlugin : m_pdfPlugInsWithHUD.values()) {
+        if (RefPtr plugin = weakPlugin.get())
+            plugin->updateHUDLocation();
+    }
+}
+
 #endif // ENABLE(PDF_PLUGIN)
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -518,9 +518,19 @@ UNIFIED_PDF_TEST(PDFHUDMultiplePluginsDoNotInterceptHitTesting)
     [webView waitForNextPresentationUpdate];
 
     // HUDs for <embed> plugins are created asynchronously after navigation, so wait for both to appear.
-    TestWebKitAPI::Util::waitFor([webView] {
-        return [webView _pdfHUDs].count >= 2;
+    bool hudsReady = TestWebKitAPI::Util::waitFor([webView] {
+        [webView waitForNextPresentationUpdate];
+        RetainPtr currentHUDs = [[webView _pdfHUDs] allObjects];
+        if ([currentHUDs count] < 2)
+            return false;
+        for (NSView *hud in currentHUDs.get()) {
+            RetainPtr bar = [[hud subviews] firstObject];
+            if (!bar || NSIsEmptyRect([bar frame]))
+                return false;
+        }
+        return true;
     });
+    EXPECT_TRUE(hudsReady);
 
     RetainPtr huds = [[webView _pdfHUDs] allObjects];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -785,6 +785,53 @@ public:
         return { };
     }
 
+    String scrollableMainHTML() const
+    {
+        // Same embedded PDF, but tall enough that the main frame actually scrolls.
+        return makeString(mainHTML(), "<div style='height:2000px'></div>"_s);
+    }
+
+    void SetUp() override
+    {
+        server = makeUnique<HTTPServer>(std::initializer_list<std::pair<String, HTTPResponse>> {
+            { "/main"_s, HTTPResponse { { { "Content-Type"_s, "text/html"_s } }, mainHTML() } },
+            { "/test.pdf"_s, HTTPResponse { { { "Content-Type"_s, "application/pdf"_s } }, testPDFData() } },
+        }, HTTPServer::Protocol::HttpsProxy);
+
+        configuration = server->httpsProxyConfiguration();
+        for (_WKFeature *feature in [WKPreferences _features]) {
+            NSString *key = feature.key;
+            if ([key isEqualToString:@"UnifiedPDFEnabled"] || [key isEqualToString:@"PDFPluginHUDEnabled"])
+                [[configuration preferences] _setEnabled:YES forFeature:feature];
+            else if ([key isEqualToString:@"SiteIsolationEnabled"])
+                [[configuration preferences] _setEnabled:siteIsolationEnabled() forFeature:feature];
+            else if ([key isEqualToString:@"SiteIsolationSharedProcessEnabled"])
+                [[configuration preferences] _setEnabled:siteIsolationSharedProcessEnabled() forFeature:feature];
+        }
+
+        navigationDelegate = adoptNS([TestNavigationDelegate new]);
+        [navigationDelegate allowAnyTLSCertificate];
+        webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+        [webView _setWindowOcclusionDetectionEnabled:NO];
+        [[webView window] makeKeyAndOrderFront:nil];
+        [[webView window] orderFrontRegardless];
+        [webView setNavigationDelegate:navigationDelegate];
+    }
+
+    RetainPtr<NSView> loadAndWaitForHUD()
+    {
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+        [navigationDelegate waitForDidFinishNavigation];
+        TestWebKitAPI::Util::waitFor([this] {
+            return [webView _pdfHUDs].count;
+        });
+        RetainPtr<NSView> hud = [webView _pdfHUDs].anyObject;
+        TestWebKitAPI::Util::waitFor([hud] {
+            return !NSEqualPoints([hud frame].origin, NSZeroPoint);
+        });
+        return hud;
+    }
+
     static std::string testNameGenerator(testing::TestParamInfo<EmbeddedPDFHUDSiteIsolationParams> info)
     {
         std::string element = [embedElement = std::get<0>(info.param)] {
@@ -804,47 +851,39 @@ public:
             + "_SiteIsolation" + (std::get<2>(info.param) ? "Enabled" : "Disabled")
             + "_SiteIsolationSharedProcess" + (std::get<3>(info.param) ? "Enabled" : "Disabled");
     }
+
+    std::unique_ptr<HTTPServer> server;
+    RetainPtr<WKWebViewConfiguration> configuration;
+    RetainPtr<TestNavigationDelegate> navigationDelegate;
+    RetainPtr<TestWKWebView> webView;
 };
 
 TEST_P(EmbeddedPDFHUDSiteIsolation, HUDMatchesOffset)
 {
-    HTTPServer server { {
-        { "/main"_s, HTTPResponse { { { "Content-Type"_s, "text/html"_s } }, mainHTML() } },
-        { "/test.pdf"_s, HTTPResponse { { { "Content-Type"_s, "application/pdf"_s } }, testPDFData() } },
-    }, HTTPServer::Protocol::HttpsProxy };
+    RetainPtr hud = loadAndWaitForHUD();
+    checkFrame([hud frame], 10, 28, 300, 150);
+}
 
-    RetainPtr configuration = server.httpsProxyConfiguration();
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        NSString *key = feature.key;
-        if ([key isEqualToString:@"UnifiedPDFEnabled"] || [key isEqualToString:@"PDFPluginHUDEnabled"])
-            [[configuration preferences] _setEnabled:YES forFeature:feature];
-        else if ([key isEqualToString:@"SiteIsolationEnabled"])
-            [[configuration preferences] _setEnabled:siteIsolationEnabled() forFeature:feature];
-        else if ([key isEqualToString:@"SiteIsolationSharedProcessEnabled"])
-            [[configuration preferences] _setEnabled:siteIsolationSharedProcessEnabled() forFeature:feature];
-    }
+TEST_P(EmbeddedPDFHUDSiteIsolation, HUDTracksMainFrameScroll)
+{
+    server->setResponse("/main"_s, HTTPResponse { { { "Content-Type"_s, "text/html"_s } }, scrollableMainHTML() });
 
-    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
-    [navigationDelegate allowAnyTLSCertificate];
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
-    [webView _setWindowOcclusionDetectionEnabled:NO];
-    [[webView window] makeKeyAndOrderFront:nil];
-    [[webView window] orderFrontRegardless];
-    [webView setNavigationDelegate:navigationDelegate];
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
-    [navigationDelegate waitForDidFinishNavigation];
-
-    TestWebKitAPI::Util::waitFor([webView] {
-        return [webView _pdfHUDs].count;
-    });
-
-    RetainPtr<NSView> hud = [webView _pdfHUDs].anyObject;
-
-    TestWebKitAPI::Util::waitFor([hud] {
-        return !NSEqualPoints([hud frame].origin, NSZeroPoint);
-    });
+    RetainPtr hud = loadAndWaitForHUD();
 
     checkFrame([hud frame], 10, 28, 300, 150);
+
+    bool scrolled = TestWebKitAPI::Util::waitFor([this] {
+        [webView objectByEvaluatingJavaScript:@"window.scrollTo(0, 20)"];
+        return [[webView objectByEvaluatingJavaScript:@"window.scrollY"] integerValue] == 20;
+    });
+    EXPECT_TRUE(scrolled);
+
+    TestWebKitAPI::Util::waitFor([this] {
+        [webView waitForNextPresentationUpdate];
+        RetainPtr<NSView> currentHUD = [webView _pdfHUDs].anyObject;
+        return currentHUD && [currentHUD frame].origin.y < 10;
+    });
+    checkFrame([webView _pdfHUDs].anyObject.frame, 10, 8, 300, 150, 1);
 }
 
 INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFHUDSiteIsolation, testing::Combine(testing::Values(PDFEmbedElement::IFrame, PDFEmbedElement::Embed, PDFEmbedElement::Object), testing::Bool(), testing::Bool(), testing::Bool()), &EmbeddedPDFHUDSiteIsolation::testNameGenerator);


### PR DESCRIPTION
#### 344ea423b5e9061fd9139085676365fa717350ff
<pre>
NEW TEST(<a href="https://commits.webkit.org/317936@main">317936@main</a>): TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting is a flaky failure on macOS Sequoia bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=320732">https://bugs.webkit.org/show_bug.cgi?id=320732</a>
<a href="https://rdar.apple.com/183717723">rdar://183717723</a>

Reviewed by NOBODY (OOPS!).

In this test, failing results suggests that `barCenter` was computed
before the HUD bar subview was not fully laid out, which produced a bad
hit test. This patch attempts to make the test more robust by not only
waiting for a &gt;=2 HUD count, but also waiting a non-empty bar frame.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):
</pre>
----------------------------------------------------------------------
#### 20dda6bd1dbfd6a6697ef58930a6d2ed9f6296f6
<pre>
[Site Isolation] PDF HUD of cross-origin &lt;iframe src=pdf&gt; gets displaced by main frame scroll offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=320592">https://bugs.webkit.org/show_bug.cgi?id=320592</a>
<a href="https://rdar.apple.com/183356213">rdar://183356213</a>

Reviewed by NOBODY (OOPS!).

With site isolation enabled, if a remote parent&apos;s geometry changes (say,
the frame scroll position), that does not actually modify the
cross-origin &lt;iframe&gt; plugin&apos;s local root view transform. As such, we
need to ask the plugin to re-report its HUD location to the UI process,
which runs the main frame conversion with newer geometry. Otherwise,
when the top-level page scrolls the HUD stays where it was first placed
and drifts out of the iframe.

We hook up this &quot;ask the plugin&quot; part by keying off frame tree sync data
and calling WebPage::updatePDFHUDLocationsAfterRemoteFrameGeometryChange,
which enumerates through the tracked PDF plugins and asks them to
produce HUD location updates.

Test: TestWebKitAPI.UnifiedPDF/EmbeddedPDFHUDSiteIsolation.HUDTracksMainFrameScroll

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::frameTreeSyncDataChangedInAnotherProcess):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::updatePDFHUDLocationsAfterRemoteFrameGeometryChange):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::scrollableMainHTML const):
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::loadAndWaitForHUD):
(TestWebKitAPI::TEST_P):

We hoist the shared test setup into SetUp() (the gtest sanctioned test
class initializer), which makes the main test logic easier to read.
</pre>