### PR TITLE
SpaceSplitStringData::create() leaks a table entry for every distinct whitespace-only class attribute value

### DIFF
--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -63,18 +63,15 @@ static inline void tokenizeSpaceSplitString(TokenProcessor& tokenProcessor, Stri
         tokenizeSpaceSplitString(tokenProcessor, string.span16());
 }
 
-bool SpaceSplitStringData::containsAll(SpaceSplitStringData& other)
+bool SpaceSplitStringData::containsAll(const SpaceSplitStringData& other) const
 {
     if (this == &other)
         return true;
 
-    unsigned otherSize = other.m_size;
-    unsigned i = 0;
-    do {
-        if (!contains(other[i]))
+    for (auto& token : other) {
+        if (!contains(token))
             return false;
-        ++i;
-    } while (i < otherSize);
+    }
     return true;
 }
 
@@ -224,8 +221,12 @@ RefPtr<SpaceSplitStringData> SpaceSplitStringData::create(const AtomString& keyS
     tokenizeSpaceSplitString(tokenCounter, keyString);
     unsigned tokenCount = tokenCounter.tokenCount();
 
-    if (!tokenCount)
+    if (!tokenCount) {
+        // The input was whitespace-only, so there is nothing to cache. Remove the entry we just
+        // added, otherwise the table would retain the key string for the lifetime of the process.
+        spaceSplitStringTable().remove(addResult.iterator);
         return nullptr;
+    }
 
     RefPtr<SpaceSplitStringData> spaceSplitStringData = create(keyString, tokenCount);
     addResult.iterator->value = spaceSplitStringData.get();

--- a/Source/WebCore/dom/SpaceSplitString.h
+++ b/Source/WebCore/dom/SpaceSplitString.h
@@ -39,13 +39,13 @@ public:
     auto begin() LIFETIME_BOUND { return std::to_address(tokenArray().begin()); }
     auto end() LIFETIME_BOUND { return std::to_address(tokenArray().end()); }
 
-    bool contains(const AtomString& string)
+    bool contains(const AtomString& string) const
     {
         auto tokens = tokenArray();
         return std::ranges::find(tokens, string) != tokens.end();
     }
 
-    bool NODELETE containsAll(SpaceSplitStringData&);
+    bool NODELETE containsAll(const SpaceSplitStringData&) const;
 
     unsigned size() const { return m_size; }
     static constexpr ptrdiff_t sizeMemoryOffset() { return OBJECT_OFFSETOF(SpaceSplitStringData, m_size); }


### PR DESCRIPTION
#### 1bbc068de5dae4fa194a1c705aeada4d4641baa6
<pre>
SpaceSplitStringData::create() leaks a table entry for every distinct whitespace-only class attribute value
<a href="https://bugs.webkit.org/show_bug.cgi?id=320752">https://bugs.webkit.org/show_bug.cgi?id=320752</a>
<a href="https://rdar.apple.com/183751460">rdar://183751460</a>

Reviewed by Chris Dumez.

create() adds to spaceSplitStringTable() before it knows the token count, then
returns nullptr for whitespace-only input, leaving an entry that is never filled in.
destroy() only removes keys that got a SpaceSplitStringData, so nothing reclaims
these, and the table is a NeverDestroyed. Since the constructor filters empty
strings but not whitespace-only ones, script grows it for the lifetime of the
process, retaining one AtomString per entry:

    for (let i = 1; i &lt; 100000; ++i)
        element.className = &quot; &quot;.repeat(i);

Remove the entry before returning nullptr. No behavior change: a cached null was
already the right answer for such a key, it just could not be freed.

No test, because the table is a file-local NeverDestroyed with no size accessor and
the leaked entries are unreachable from any existing testing hook. A regression test
would need a SpaceSplitStringData size accessor plus an Internals counter, as
memoryCacheSize() has.

Also replace containsAll()&apos;s do/while, which read other[0] before testing
other.m_size, with a range-based for; zero-token instances are ruled out by both the
constructor and create(), so this is hardening, not a fix. While here, make
containsAll() and contains() const.

* Source/WebCore/dom/SpaceSplitString.cpp:
(WebCore::SpaceSplitStringData::containsAll const):
(WebCore::SpaceSplitStringData::create):
(WebCore::SpaceSplitStringData::containsAll): Deleted.
* Source/WebCore/dom/SpaceSplitString.h:
(WebCore::SpaceSplitStringData::contains const):
(WebCore::SpaceSplitStringData::contains): Deleted.

Canonical link: <a href="https://commits.webkit.org/318427@main">https://commits.webkit.org/318427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6fe5bac44beb7991a38fe6303f18763a52b7f32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141242 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ecf1688-8d43-4b36-ae26-973b651fcf70) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138754 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2bd727cb-7bcc-4530-b2ab-3ba79e35693d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119210 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f439e0ce-2429-47b0-a6e9-e38569c3255e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40957 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39308 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39002 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36066 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190035 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51601 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147885 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39778 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52283 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147664 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42377 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124546 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119012 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50790 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13974 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50186 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50426 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50248 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->