### PR TITLE
[JSC] Avoid ensureArrayStorage transition on Wasm GC objects

### DIFF
--- a/JSTests/wasm/gc/no-gc-structure-transition.js
+++ b/JSTests/wasm/gc/no-gc-structure-transition.js
@@ -680,6 +680,45 @@ function testPropertyEnumeration() {
     verifyStructIntact(m, obj);
 }
 
+// https://bugs.webkit.org/show_bug.cgi?id=319087
+function testEnsureArrayStorage() {
+    const ms = makeStruct();
+    const s = ms.exports.make();
+    ensureArrayStorage(s);
+    verifyStructIntact(ms, s);
+
+    const ma = makeArray();
+    const a = ma.exports.make();
+    ensureArrayStorage(a);
+    verifyArrayIntact(ma, a);
+}
+
+function testEnsureArrayStorageViaWasmImport() {
+    const m = instantiate(`
+        (module
+            (type $s (struct (field i32)))
+            (import "imports" "ensure" (func $ensure (param (ref $s)) (result i32)))
+            (func (export "make") (result (ref $s))
+                (struct.new $s (i32.const 42)))
+            (func (export "run") (param (ref $s)) (result i32)
+                (call $ensure (local.get 0)))
+            (func (export "get") (param (ref $s)) (result i32)
+                (struct.get $s 0 (local.get 0)))
+        )
+    `, {
+        imports: {
+            ensure(obj) {
+                ensureArrayStorage(obj);
+                return 1;
+            }
+        }
+    });
+
+    const obj = m.exports.make();
+    assert.eq(m.exports.run(obj), 1);
+    assert.eq(m.exports.get(obj), 42);
+}
+
 // Run all tests
 testPropertyAdditionNamed();
 testPropertyAdditionIndexed();
@@ -714,3 +753,5 @@ testPrototypeReplacement();
 testDeepPrototypeChain();
 testIsExtensible();
 testPropertyEnumeration();
+testEnsureArrayStorage();
+testEnsureArrayStorageViaWasmImport();

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3257,7 +3257,7 @@ JSC_DEFINE_HOST_FUNCTION(functionEnsureArrayStorage, (JSGlobalObject* globalObje
 {
     VM& vm = globalObject->vm();
     for (unsigned i = 0; i < callFrame->argumentCount(); ++i) {
-        if (JSObject* object = dynamicDowncast<JSObject>(callFrame->argument(i)))
+        if (auto* object = dynamicDowncast<JSObjectWithButterfly>(callFrame->argument(i)))
             object->ensureArrayStorage(vm);
     }
     return JSValue::encode(jsUndefined());

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -4372,8 +4372,8 @@ JSC_DEFINE_HOST_FUNCTION(functionEnsureArrayStorage, (JSGlobalObject* globalObje
     VM& vm = globalObject->vm();
 
     JSValue arg = callFrame->argument(0);
-    if (arg.isObject())
-        asObject(arg)->ensureArrayStorage(vm);
+    if (auto* object = dynamicDowncast<JSObjectWithButterfly>(arg))
+        object->ensureArrayStorage(vm);
     return JSValue::encode(jsUndefined());
 }
 


### PR DESCRIPTION
#### 13ada10535a452a15c0734938f3c3e5eb1390a0e
<pre>
[JSC] Avoid ensureArrayStorage transition on Wasm GC objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=319087">https://bugs.webkit.org/show_bug.cgi?id=319087</a>

Reviewed by Keith Miller.

The jsc and $vm ensureArrayStorage test helpers passed any object to
ensureArrayStorage. Wasm GC objects have no butterfly, so that path
transitioned Structure and hit RELEASE_ASSERT on WebAssemblyGCStructure.
Only call it for JSObjectWithButterfly.

* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* JSTests/wasm/gc/no-gc-structure-transition.js:
(testEnsureArrayStorage):
(testEnsureArrayStorageViaWasmImport):

Canonical link: <a href="https://commits.webkit.org/318462@main">https://commits.webkit.org/318462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2055462b641d6d5e2e04fa56dca35ba41576920

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187634 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138764 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42305 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159519 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119220 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40971 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39327 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1189 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8009 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39017 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36092 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39293 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190061 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51627 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147902 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52309 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147681 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27055 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42393 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124572 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119042 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50821 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13989 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50212 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->