### PR TITLE
corner-shape: adopt the revised contoured-path algorithm

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-bevel-overflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-bevel-overflow.html
@@ -2,7 +2,7 @@
 <title>CSS Borders and Box Decorations 4: 'corner-shape' rendering with overflow</title>
 <link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
 <link rel="match" href="corner-shape-bevel-overflow-ref.html">
-<meta name="fuzzy" content="maxDifference=0-32;totalPixels=0-256">
+<meta name="fuzzy" content="maxDifference=0-36;totalPixels=0-256">
 <style>
     .bevel {
         background: red;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-bevel.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-bevel.html
@@ -3,7 +3,7 @@
 <title>CSS Borders and Box Decorations 4: 'corner-shape: bevel' on all corners</title>
 <link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
 <link rel="match" href="corner-shape-bevel-ref.html">
-<meta name="fuzzy" content="maxDifference=0-13; totalPixels=0-135">
+<meta name="fuzzy" content="maxDifference=0-24; totalPixels=0-135">
 <style>
     .target {
         background: green;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-bevel-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-bevel-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: 'box-shadow' spread with elliptical 'corner-shape: bevel' corners — reference</title>
+<style>
+    body { margin: 0; }
+    .canvas { position: absolute; left: 0; top: 0; width: 160px; height: 160px; }
+    .canvas > div { position: absolute; inset: 0; }
+    .spread {
+        background: green;
+        clip-path: path("\
+            M 123.524 25.000 L 126.494 36.135 L \
+            134.494 66.135 L 135.000 68.034 L 135.000 \
+            91.966 L 134.494 93.865 L 126.494 123.865 \
+            L 123.524 135.000 L 36.476 135.000 L \
+            33.506 123.865 L 25.506 93.865 L 25.000 \
+            91.966 L 25.000 68.034 L 25.506 66.135 \
+            L 33.506 36.135 L 36.476 25.000 Z");
+    }
+    .box {
+        background: red;
+        clip-path: path("\
+            M 112.000 40.000 L 120.000 70.000 L \
+            120.000 90.000 L 112.000 120.000 L 48.000 \
+            120.000 L 40.000 90.000 L 40.000 70.000 \
+            L 48.000 40.000 Z");
+    }
+</style>
+</head>
+<div class=canvas><div class=spread></div><div class=box></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-bevel-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-bevel-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: 'box-shadow' spread with elliptical 'corner-shape: bevel' corners — reference</title>
+<style>
+    body { margin: 0; }
+    .canvas { position: absolute; left: 0; top: 0; width: 160px; height: 160px; }
+    .canvas > div { position: absolute; inset: 0; }
+    .spread {
+        background: green;
+        clip-path: path("\
+            M 123.524 25.000 L 126.494 36.135 L \
+            134.494 66.135 L 135.000 68.034 L 135.000 \
+            91.966 L 134.494 93.865 L 126.494 123.865 \
+            L 123.524 135.000 L 36.476 135.000 L \
+            33.506 123.865 L 25.506 93.865 L 25.000 \
+            91.966 L 25.000 68.034 L 25.506 66.135 \
+            L 33.506 36.135 L 36.476 25.000 Z");
+    }
+    .box {
+        background: red;
+        clip-path: path("\
+            M 112.000 40.000 L 120.000 70.000 L \
+            120.000 90.000 L 112.000 120.000 L 48.000 \
+            120.000 L 40.000 90.000 L 40.000 70.000 \
+            L 48.000 40.000 Z");
+    }
+</style>
+</head>
+<div class=canvas><div class=spread></div><div class=box></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-bevel.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-bevel.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: 'box-shadow' spread with elliptical 'corner-shape: bevel' corners</title>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
+<link rel="match" href="corner-shape-box-shadow-spread-bevel-ref.html">
+<meta name="fuzzy" content="maxDifference=0-64; totalPixels=0-336">
+<style>
+    body { margin: 0; }
+    .target {
+        position: absolute;
+        left: 40px;
+        top: 40px;
+        width: 80px;
+        height: 80px;
+        background: red;
+        box-shadow: 0 0 0 15px green;
+        border-radius: 8px / 30px;
+        corner-shape: bevel;
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-elliptical-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-elliptical-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: 'box-shadow' spread with an elliptical concave 'corner-shape' — reference</title>
+<style>
+    body { margin: 0; }
+    .canvas { position: absolute; left: 0; top: 0; width: 160px; height: 160px; }
+    .canvas > div { position: absolute; inset: 0; }
+    .spread {
+        background: green;
+        clip-path: path("\
+            M 135.000 25.000 L 135.000 135.000 L \
+            25.000 135.000 L 25.000 85.405 L 27.574 \
+            81.599 C 28.031 81.599 29.943 77.656 32.139 \
+            65.138 C 34.335 52.620 35.026 41.723 35.026 \
+            39.114 L 35.861 25.000 Z");
+    }
+    .box {
+        background: red;
+        clip-path: path("\
+            M 120.000 40.000 L 120.000 120.000 L \
+            40.000 120.000 L 40.000 90.000 C 40.614 \
+            90.000 43.179 85.360 46.125 70.627 C 49.072 \
+            55.895 50.000 43.070 50.000 40.000 Z");
+    }
+</style>
+</head>
+<div class=canvas><div class=spread></div><div class=box></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-elliptical-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-elliptical-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: 'box-shadow' spread with an elliptical concave 'corner-shape' — reference</title>
+<style>
+    body { margin: 0; }
+    .canvas { position: absolute; left: 0; top: 0; width: 160px; height: 160px; }
+    .canvas > div { position: absolute; inset: 0; }
+    .spread {
+        background: green;
+        clip-path: path("\
+            M 135.000 25.000 L 135.000 135.000 L \
+            25.000 135.000 L 25.000 85.405 L 27.574 \
+            81.599 C 28.031 81.599 29.943 77.656 32.139 \
+            65.138 C 34.335 52.620 35.026 41.723 35.026 \
+            39.114 L 35.861 25.000 Z");
+    }
+    .box {
+        background: red;
+        clip-path: path("\
+            M 120.000 40.000 L 120.000 120.000 L \
+            40.000 120.000 L 40.000 90.000 C 40.614 \
+            90.000 43.179 85.360 46.125 70.627 C 49.072 \
+            55.895 50.000 43.070 50.000 40.000 Z");
+    }
+</style>
+</head>
+<div class=canvas><div class=spread></div><div class=box></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-elliptical.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-elliptical.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: 'box-shadow' spread with an elliptical concave 'corner-shape'</title>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
+<link rel="match" href="corner-shape-box-shadow-spread-elliptical-ref.html">
+<meta name="fuzzy" content="maxDifference=0-89; totalPixels=0-119">
+<style>
+    body { margin: 0; }
+    .target {
+        position: absolute;
+        left: 40px;
+        top: 40px;
+        width: 80px;
+        height: 80px;
+        background: red;
+        box-shadow: 0 0 0 15px green;
+        border-top-left-radius: 10px 50px;
+        corner-top-left-shape: superellipse(-0.5);
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-bevel-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-bevel-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: 'outline-offset' with elliptical 'corner-shape: bevel' corners — reference</title>
+<style>
+    body { margin: 0; }
+    .canvas { position: absolute; left: 0; top: 0; width: 160px; height: 160px; }
+    .canvas > div { position: absolute; inset: 0; }
+    .box {
+        background: red;
+        clip-path: path("\
+            M 112.000 40.000 L 120.000 70.000 L \
+            120.000 90.000 L 112.000 120.000 L 48.000 \
+            120.000 L 40.000 90.000 L 40.000 70.000 \
+            L 48.000 40.000 Z");
+    }
+    .outline {
+        background: black;
+        clip-path: path(evenodd, "\
+            M 131.207 15.000 L 136.156 33.558 L \
+            144.156 63.558 L 145.000 66.724 L 145.000 \
+            93.276 L 144.156 96.442 L 136.156 126.442 \
+            L 131.207 145.000 L 28.793 145.000 L \
+            23.844 126.442 L 15.844 96.442 L 15.000 \
+            93.276 L 15.000 66.724 L 15.844 63.558 \
+            L 23.844 33.558 L 28.793 15.000 Z \
+            M 127.366 20.000 L 131.325 34.847 L \
+            139.325 64.847 L 140.000 67.379 L 140.000 \
+            92.621 L 139.325 95.153 L 131.325 125.153 \
+            L 127.366 140.000 L 32.634 140.000 L \
+            28.675 125.153 L 20.675 95.153 L 20.000 \
+            92.621 L 20.000 67.379 L 20.675 64.847 \
+            L 28.675 34.847 L 32.634 20.000 Z");
+    }
+</style>
+</head>
+<div class=canvas><div class=box></div><div class=outline></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-bevel-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-bevel-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: 'outline-offset' with elliptical 'corner-shape: bevel' corners — reference</title>
+<style>
+    body { margin: 0; }
+    .canvas { position: absolute; left: 0; top: 0; width: 160px; height: 160px; }
+    .canvas > div { position: absolute; inset: 0; }
+    .box {
+        background: red;
+        clip-path: path("\
+            M 112.000 40.000 L 120.000 70.000 L \
+            120.000 90.000 L 112.000 120.000 L 48.000 \
+            120.000 L 40.000 90.000 L 40.000 70.000 \
+            L 48.000 40.000 Z");
+    }
+    .outline {
+        background: black;
+        clip-path: path(evenodd, "\
+            M 131.207 15.000 L 136.156 33.558 L \
+            144.156 63.558 L 145.000 66.724 L 145.000 \
+            93.276 L 144.156 96.442 L 136.156 126.442 \
+            L 131.207 145.000 L 28.793 145.000 L \
+            23.844 126.442 L 15.844 96.442 L 15.000 \
+            93.276 L 15.000 66.724 L 15.844 63.558 \
+            L 23.844 33.558 L 28.793 15.000 Z \
+            M 127.366 20.000 L 131.325 34.847 L \
+            139.325 64.847 L 140.000 67.379 L 140.000 \
+            92.621 L 139.325 95.153 L 131.325 125.153 \
+            L 127.366 140.000 L 32.634 140.000 L \
+            28.675 125.153 L 20.675 95.153 L 20.000 \
+            92.621 L 20.000 67.379 L 20.675 64.847 \
+            L 28.675 34.847 L 32.634 20.000 Z");
+    }
+</style>
+</head>
+<div class=canvas><div class=box></div><div class=outline></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-bevel.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-bevel.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: 'outline-offset' with elliptical 'corner-shape: bevel' corners</title>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
+<link rel="match" href="corner-shape-outline-offset-bevel-ref.html">
+<meta name="fuzzy" content="maxDifference=0-44; totalPixels=0-458">
+<style>
+    body { margin: 0; }
+    .target {
+        position: absolute;
+        left: 40px;
+        top: 40px;
+        width: 80px;
+        height: 80px;
+        background: red;
+        outline: 5px solid black;
+        outline-offset: 20px;
+        border-radius: 8px / 30px;
+        corner-shape: bevel;
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-elliptical-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-elliptical-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: 'outline-offset' with an elliptical concave 'corner-shape' — reference</title>
+<style>
+    body { margin: 0; }
+    .canvas { position: absolute; left: 0; top: 0; width: 160px; height: 160px; }
+    .canvas > div { position: absolute; inset: 0; }
+    .box {
+        background: red;
+        clip-path: path("\
+            M 120.000 40.000 L 120.000 120.000 L \
+            40.000 120.000 L 40.000 90.000 C 40.614 \
+            90.000 43.179 85.360 46.125 70.627 C 49.072 \
+            55.895 50.000 43.070 50.000 40.000 Z");
+    }
+    .outline {
+        background: black;
+        clip-path: path(evenodd, "\
+            M 145.000 15.000 L 145.000 145.000 L \
+            15.000 145.000 L 15.000 82.342 L 19.289 \
+            75.998 C 19.643 75.998 21.119 72.520 22.814 \
+            61.478 C 24.510 50.436 25.044 40.825 25.044 \
+            38.523 L 26.435 15.000 Z M 140.000 \
+            20.000 L 140.000 140.000 L 20.000 140.000 \
+            L 20.000 83.873 L 23.431 78.798 C \
+            23.837 78.798 25.531 75.088 27.476 63.308 C \
+            29.422 51.528 30.035 41.274 30.035 38.819 L \
+            31.148 20.000 Z");
+    }
+</style>
+</head>
+<div class=canvas><div class=box></div><div class=outline></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-elliptical-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-elliptical-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: 'outline-offset' with an elliptical concave 'corner-shape' — reference</title>
+<style>
+    body { margin: 0; }
+    .canvas { position: absolute; left: 0; top: 0; width: 160px; height: 160px; }
+    .canvas > div { position: absolute; inset: 0; }
+    .box {
+        background: red;
+        clip-path: path("\
+            M 120.000 40.000 L 120.000 120.000 L \
+            40.000 120.000 L 40.000 90.000 C 40.614 \
+            90.000 43.179 85.360 46.125 70.627 C 49.072 \
+            55.895 50.000 43.070 50.000 40.000 Z");
+    }
+    .outline {
+        background: black;
+        clip-path: path(evenodd, "\
+            M 145.000 15.000 L 145.000 145.000 L \
+            15.000 145.000 L 15.000 82.342 L 19.289 \
+            75.998 C 19.643 75.998 21.119 72.520 22.814 \
+            61.478 C 24.510 50.436 25.044 40.825 25.044 \
+            38.523 L 26.435 15.000 Z M 140.000 \
+            20.000 L 140.000 140.000 L 20.000 140.000 \
+            L 20.000 83.873 L 23.431 78.798 C \
+            23.837 78.798 25.531 75.088 27.476 63.308 C \
+            29.422 51.528 30.035 41.274 30.035 38.819 L \
+            31.148 20.000 Z");
+    }
+</style>
+</head>
+<div class=canvas><div class=box></div><div class=outline></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-elliptical.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-elliptical.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: 'outline-offset' with an elliptical concave 'corner-shape'</title>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
+<link rel="match" href="corner-shape-outline-offset-elliptical-ref.html">
+<meta name="fuzzy" content="maxDifference=0-46; totalPixels=0-193">
+<style>
+    body { margin: 0; }
+    .target {
+        position: absolute;
+        left: 40px;
+        top: 40px;
+        width: 80px;
+        height: 80px;
+        background: red;
+        outline: 5px solid black;
+        outline-offset: 20px;
+        border-top-left-radius: 10px 50px;
+        corner-top-left-shape: superellipse(-0.5);
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-squircle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-squircle.html
@@ -3,7 +3,7 @@
 <title>CSS Borders and Box Decorations 4: 'corner-shape: squircle' on all corners</title>
 <link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
 <link rel="match" href="corner-shape-squircle-ref.html">
-<meta name="fuzzy" content="maxDifference=0-93; totalPixels=0-547"/>
+<meta name="fuzzy" content="maxDifference=0-93; totalPixels=0-572"/>
 <style>
     .target {
         background: green;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-bevel.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-bevel.html
@@ -3,7 +3,7 @@
 <title>CSS Borders and Box Decorations 4: 'corner-shape: superellipse(0)' is equivalent to bevel</title>
 <link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
 <link rel="match" href="corner-shape-superellipse-bevel-ref.html">
-<meta name="fuzzy" content="maxDifference=0-13; totalPixels=0-135"/>
+<meta name="fuzzy" content="maxDifference=0-24; totalPixels=0-135"/>
 <style>
     .target {
         background: green;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-convex.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-convex.html
@@ -3,7 +3,7 @@
 <title>CSS Borders and Box Decorations 4: per-corner convex 'corner-shape' superellipse values</title>
 <link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
 <link rel="match" href="corner-shape-superellipse-convex-ref.html">
-<meta name="fuzzy" content="maxDifference=0-70; totalPixels=0-271"/>
+<meta name="fuzzy" content="maxDifference=0-123; totalPixels=0-287"/>
 <style>
     .target {
         background: green;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-squircle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-squircle.html
@@ -3,7 +3,7 @@
 <title>CSS Borders and Box Decorations 4: 'corner-shape: superellipse(2)' on all corners</title>
 <link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
 <link rel="match" href="corner-shape-superellipse-squircle-ref.html">
-<meta name="fuzzy" content="maxDifference=0-93; totalPixels=0-547"/>
+<meta name="fuzzy" content="maxDifference=0-93; totalPixels=0-572"/>
 <style>
     .target {
         background: green;

--- a/Source/WebCore/platform/graphics/BezierUtilities.cpp
+++ b/Source/WebCore/platform/graphics/BezierUtilities.cpp
@@ -310,7 +310,7 @@ Vector<FloatPoint> hermiteInterpolate(const Vector<FloatPoint>& startPoints, con
 }
 
 // Converts each Catmull-Rom span to a cubic Bézier: control points sit 1/6 of the neighbor-to-neighbor tangent out from each endpoint, giving one smooth curve through every knot
-void addCatmullRomBeziers(Path& path, const Vector<FloatPoint>& points, unsigned segmentCount, bool& started)
+void addCatmullRomBeziers(Path& path, const Vector<FloatPoint>& points, unsigned segmentCount, bool& started, std::optional<FloatSize> startTangent, std::optional<FloatSize> endTangent)
 {
     if (points.size() < 2)
         return;
@@ -330,8 +330,8 @@ void addCatmullRomBeziers(Path& path, const Vector<FloatPoint>& points, unsigned
         return knots[std::clamp(index, 0, static_cast<int>(knots.size()) - 1)];
     };
     size_t tail = std::min<size_t>(3, points.size() - 1);
-    auto startTravel = (points[tail] - points[0]).normalized();
-    auto endTravel = (points[points.size() - 1] - points[points.size() - 1 - tail]).normalized();
+    auto startTravel = startTangent.value_or((points[tail] - points[0]).normalized());
+    auto endTravel = endTangent.value_or((points[points.size() - 1] - points[points.size() - 1 - tail]).normalized());
     unsigned lastSpan = knots.size() - 2;
 
     for (unsigned spanIndex = 0; spanIndex + 1 < knots.size(); ++spanIndex) {

--- a/Source/WebCore/platform/graphics/BezierUtilities.h
+++ b/Source/WebCore/platform/graphics/BezierUtilities.h
@@ -27,6 +27,7 @@
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/FloatSize.h>
+#include <optional>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -48,6 +49,6 @@ Vector<FloatPoint> resampleByArcLength(const Vector<FloatPoint>& polyline, unsig
 // fraction between two whole curves, not a position along a single curve.
 Vector<FloatPoint> hermiteInterpolate(const Vector<FloatPoint>& startPoints, const Vector<FloatSize>& startVelocities, const Vector<FloatPoint>& endPoints, const Vector<FloatSize>& endVelocities, double interpolationFraction);
 
-void addCatmullRomBeziers(Path&, const Vector<FloatPoint>& points, unsigned segmentCount, bool& started);
+void addCatmullRomBeziers(Path&, const Vector<FloatPoint>& points, unsigned segmentCount, bool& started, std::optional<FloatSize> startTangent = std::nullopt, std::optional<FloatSize> endTangent = std::nullopt);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
@@ -82,7 +82,6 @@ static std::pair<float, float> edgeBorders(BoxCorner orientation, double startIn
 
 static bool isConcave(const Corner& corner) { return corner.curvature < 0.0; }
 static bool isRound(const Corner& corner) { return corner.curvature == 1.0; }
-static bool isScoop(const Corner& corner) { return corner.curvature == -1.0; }
 static bool isBevel(const Corner& corner) { return corner.curvature == 0.0; }
 static bool isNotch(const Corner& corner) { return std::isinf(corner.curvature) && corner.curvature < 0.0; }
 static bool isSquare(const Corner& corner) { return std::isinf(corner.curvature) && corner.curvature > 0.0; }
@@ -90,10 +89,6 @@ static bool isEmpty(const Corner& corner)
 {
     return (corner.outer - corner.start).diagonalLength() < limit
         || (corner.end - corner.outer).diagonalLength() < limit;
-}
-static bool isSuperellipse(const Corner& corner)
-{
-    return !isBevel(corner) && !isRound(corner) && !isScoop(corner) && !isNotch(corner) && !isSquare(corner) && !isEmpty(corner);
 }
 
 static Corner inverseCorner(const Corner& corner)
@@ -128,136 +123,87 @@ static Corner makeCorner(const CornerInput& input)
     };
 }
 
-static std::pair<FloatPoint, FloatPoint> buildBevelCorners(const Corner& original, double startInset, double endInset)
+// The summed per-endpoint offsets are the start and end normal vectors whose perpendiculars give the outset miter
+// tangents. The radii are carried through for the concave self-intersection test.
+struct CornerAdjustment {
+    Corner corner;
+    FloatSize startNormal;
+    FloatSize endNormal;
+    double startRadius { 0 };
+    double endRadius { 0 };
+    FloatPoint targetCornerOuter;
+    FloatSize unitVectorTowardStart;
+    FloatSize unitVectorTowardEnd;
+};
+
+// Defined in https://drafts.csswg.org/css-borders-4/#corner-shape-interpolation
+static double normalizedSuperellipseHalfCorner(double superellipseParameter)
 {
-    auto strokeDirection = (original.end - original.start).perpendicular().normalized();
-    auto outerToCenter = original.center - original.outer;
-    // Ensure the stroke direction points inward, toward the center of the corner.
-    if (dotProduct(strokeDirection, outerToCenter) < 0)
-        strokeDirection = strokeDirection.scaled(-1);
-    auto adjustedCornerStart = original.start + strokeDirection * float(startInset);
-    auto adjustedCornerEnd = original.end + strokeDirection * float(endInset);
-
-    auto extendStart = (original.center - original.start).directionScaledBy(float(startInset));
-    auto extendEnd = (original.center - original.end).directionScaledBy(float(endInset));
-    auto clipStart = original.start + extendStart;
-    auto clipEnd = original.end + extendEnd;
-    auto clipOuter = original.outer + extendStart + extendEnd;
-
-    auto controlPoint = midPoint(adjustedCornerStart, adjustedCornerEnd);
-    auto axisAlignedCornerStart = findIntersection(adjustedCornerStart, controlPoint, clipStart, clipOuter).value_or(adjustedCornerStart);
-    auto axisAlignedCornerEnd = findIntersection(adjustedCornerEnd, controlPoint, clipEnd, clipOuter).value_or(adjustedCornerEnd);
-
-    return { axisAlignedCornerStart, axisAlignedCornerEnd };
+    if (std::isinf(superellipseParameter))
+        return superellipseParameter < 0.0 ? 0.0 : 1.0;
+    double exponent = std::pow(0.5, std::abs(superellipseParameter));
+    double convexHalfCorner = std::pow(0.5, exponent);
+    return superellipseParameter < 0.0 ? 1.0 - convexHalfCorner : convexHalfCorner;
 }
 
-static Corner buildScoopCorners(const Corner& original, double startInset, double endInset)
+// Offsets both curve endpoints along the corner's two edge vectors, scaling the offset normal per-axis by the two corner radii
+static CornerAdjustment computeCornerAdjustment(const Corner& original, double startInset, double endInset)
 {
-    float outerRadiusX = original.radii.width();
-    float outerRadiusY = original.radii.height();
-
-    auto [verticalEdgeBorder, horizontalEdgeBorder] = edgeBorders(original.orientation, startInset, endInset);
-
-    float radiusX = outerRadiusX + horizontalEdgeBorder;
-    float radiusY = outerRadiusY + verticalEdgeBorder;
-
-    // Endpoints are where the enlarged ellipse (centered on outer) crosses the inset edges
-    auto [directionX, directionY] = inwardDirection(original.orientation);
-
-    // x^2 / a^2 + y^2 / b^2 = 1 => y = b * sqrt(1 - x^2 / a^2)
-    auto ellipseExtent = [](float radius, float ratio) {
-        return radius * std::sqrt(std::max(0.0f, 1.0f - ratio * ratio));
-    };
-
-    FloatPoint sideIntersection {
-        original.outer.x() + directionX * verticalEdgeBorder,
-        original.outer.y() + directionY * ellipseExtent(radiusY, verticalEdgeBorder / radiusX),
-    };
-    FloatPoint topIntersection {
-        original.outer.x() + directionX * ellipseExtent(radiusX, horizontalEdgeBorder / radiusY),
-        original.outer.y() + directionY * horizontalEdgeBorder,
-    };
-
-    auto innerStart = startsOnVerticalEdge(original.orientation) ? sideIntersection : topIntersection;
-    auto innerEnd = startsOnVerticalEdge(original.orientation) ? topIntersection : sideIntersection;
-
-    return { innerStart, original.outer, innerEnd, original.center, FloatSize(radiusX, radiusY), original.curvature, original.orientation };
-}
-
-static Corner buildRoundCorners(const Corner& original, double startInset, double endInset)
-{
-    float outerRadiusX = original.radii.width();
-    float outerRadiusY = original.radii.height();
-
-    auto [verticalEdgeBorder, horizontalEdgeBorder] = edgeBorders(original.orientation, startInset, endInset);
-
-    float radiusX = std::max(0.0f, outerRadiusX - verticalEdgeBorder);
-    float radiusY = std::max(0.0f, outerRadiusY - horizontalEdgeBorder);
-
-    // Endpoints are axis extremes of the ellipse
-    float scaleX = outerRadiusX > limit ? radiusX / outerRadiusX : 0.0f;
-    float scaleY = outerRadiusY > limit ? radiusY / outerRadiusY : 0.0f;
-    auto scaleToCenter = [&](FloatPoint point) {
-        return original.center + FloatSize((point.x() - original.center.x()) * scaleX, (point.y() - original.center.y()) * scaleY);
-    };
-    auto innerStart = scaleToCenter(original.start);
-    auto innerEnd = scaleToCenter(original.end);
-
-    auto [directionX, directionY] = inwardDirection(original.orientation);
-    FloatPoint innerOuter {
-        original.outer.x() + directionX * verticalEdgeBorder,
-        original.outer.y() + directionY * horizontalEdgeBorder,
-    };
-
-    return { innerStart, innerOuter, innerEnd, original.center, FloatSize(radiusX, radiusY), original.curvature, original.orientation };
-}
-
-enum class ForceHullDirection : bool { No, Yes };
-
-static Corner adjustCornerForInset(const Corner& original, double startInset, double endInset, ForceHullDirection forceHullDirection = ForceHullDirection::No)
-{
-    if (isEmpty(original) || (startInset == 0.0 && endInset == 0.0))
-        return original;
-
-    if (forceHullDirection == ForceHullDirection::No) {
-        if (isBevel(original)) {
-            auto [cutStart, cutEnd] = buildBevelCorners(original, startInset, endInset);
-            return { cutStart, original.outer, cutEnd, original.center, cornerRadii(original.center, original.outer), original.curvature, original.orientation };
-        }
-
-        if (isScoop(original))
-            return buildScoopCorners(original, startInset, endInset);
-
-        if (isRound(original))
-            return buildRoundCorners(original, startInset, endInset);
+    auto vectorTowardStart = original.start - original.outer;
+    auto vectorTowardEnd = original.end - original.outer;
+    double endRadius = vectorTowardStart.diagonalLength();
+    double startRadius = vectorTowardEnd.diagonalLength();
+    if (startRadius < limit || endRadius < limit) {
+        CornerAdjustment degenerate;
+        degenerate.corner = original;
+        degenerate.startRadius = startRadius;
+        degenerate.endRadius = endRadius;
+        degenerate.targetCornerOuter = original.outer;
+        return degenerate;
     }
 
-    double strokeA = 0, strokeB = 0;
-    if (isNotch(original)) {
-        strokeA = -1;
-        strokeB = 1;
-    } else if (isSquare(original))
-        strokeB = 1;
-    else {
-        // General: offset each corner vertex inward along the curve's hull direction by the border thickness, keeping the curvature.
-        double clampedCurvature = std::clamp(original.curvature, -1.0, 1.0);
-        double convexHalfCorner = std::pow(0.5, std::exp2(-clampedCurvature));
-        auto hullDirection = FloatSize(float(convexHalfCorner * 2.0 - 0.5), float(1.5 - convexHalfCorner * 2.0)).normalized();
-        strokeA = -hullDirection.height();
-        strokeB = hullDirection.width();
-    }
+    auto unitVectorTowardStart = vectorTowardStart.normalized();
+    auto unitVectorTowardEnd = vectorTowardEnd.normalized();
+    auto targetCornerOuter = original.outer + unitVectorTowardStart * float(endInset) + unitVectorTowardEnd * float(startInset);
 
-    auto offset1 = (original.outer - original.start).directionScaledBy(float(startInset * strokeA));
-    auto offset2 = (original.end - original.outer).directionScaledBy(float(startInset * strokeB));
-    auto offset3 = (original.center - original.end).directionScaledBy(float(endInset * strokeB));
-    auto offset4 = (original.start - original.center).directionScaledBy(float(endInset * strokeA));
+    double clampedHalfCornerX = normalizedSuperellipseHalfCorner(std::clamp(original.curvature, -1.0, 1.0));
+    // Where the endpoint offset directions sit between the corner's two edges: 0 runs along the edge the
+    // endpoint lies on, 1 runs perpendicular to it, and 0.5 is the diagonal between the two, weighted by
+    // the radii
+    double controlPointX = (1.0 / (std::numbers::sqrt2 - 1.0)) * clampedHalfCornerX - 1.0 / std::numbers::sqrt2;
 
-    auto adjustedStart = original.start + offset1 + offset2;
-    auto adjustedOuter = original.outer + offset2 + offset3;
-    auto adjustedEnd = original.end + offset3 + offset4;
-    auto adjustedCenter = original.center + offset4 + offset1;
+    // Bevel corner as the common tangent to two circles centred on corner-start and corner-end with radii the signed insets
+    // negative sign: outward, away from box, postive sign: inward, towards box center
+    double insetDiff = std::clamp(endInset - startInset, -startRadius, endRadius);
+    double root = std::sqrt(std::max(0.0, startRadius * startRadius + endRadius * endRadius - insetDiff * insetDiff));
+    double bevelNormalVectorX = endRadius * insetDiff + startRadius * root;
+    double bevelNormalVectorY = -startRadius * insetDiff + endRadius * root;
+    double bevelDenominator = startRadius * bevelNormalVectorY + endRadius * bevelNormalVectorX;
+    double bevelControlPointX = bevelDenominator != 0.0 ? (startRadius * bevelNormalVectorY) / bevelDenominator : 0.5;
 
-    return {
+    // The two endpoints get separate directions, placed symmetrically either side of controlPointX. How far
+    // apart they land comes from the bevel tangent, which sits at the midpoint unless the two insets differ,
+    // so equal insets give both endpoints the same direction.
+    double startControlPointX = original.curvature < 0.0
+        ? bevelControlPointX * (2.0 * controlPointX)
+        : 1.0 - (1.0 - bevelControlPointX) * (2.0 * (1.0 - controlPointX));
+    double endControlPointX = 2.0 * controlPointX - startControlPointX;
+
+    // Per-axis normal vectors: the corner radii weight each component, so elliptical corners offset correctly.
+    auto startNormal = FloatSize(float((1.0 - startControlPointX) * startRadius), float(startControlPointX * endRadius)).normalized();
+    auto endNormal = FloatSize(float(endControlPointX * startRadius), float((1.0 - endControlPointX) * endRadius)).normalized();
+
+    auto startOffsetTowardStart = vectorTowardStart.directionScaledBy(float(startNormal.width() * startInset));
+    auto startOffsetTowardEnd = vectorTowardEnd.directionScaledBy(float(startNormal.height() * startInset));
+    auto endOffsetTowardStart = vectorTowardStart.directionScaledBy(float(endNormal.width() * endInset));
+    auto endOffsetTowardEnd = vectorTowardEnd.directionScaledBy(float(endNormal.height() * endInset));
+
+    auto adjustedStart = original.start + startOffsetTowardStart + startOffsetTowardEnd;
+    auto adjustedOuter = original.outer + endOffsetTowardStart + startOffsetTowardEnd;
+    auto adjustedEnd = original.end + endOffsetTowardStart + endOffsetTowardEnd;
+    auto adjustedCenter = original.center + startOffsetTowardStart + endOffsetTowardEnd;
+
+    Corner adjusted {
         adjustedStart,
         adjustedOuter,
         adjustedEnd,
@@ -266,6 +212,71 @@ static Corner adjustCornerForInset(const Corner& original, double startInset, do
         original.curvature,
         original.orientation,
     };
+
+    return {
+        .corner = adjusted,
+        .startNormal = startOffsetTowardStart + startOffsetTowardEnd,
+        .endNormal = endOffsetTowardStart + endOffsetTowardEnd,
+        .startRadius = startRadius,
+        .endRadius = endRadius,
+        .targetCornerOuter = targetCornerOuter,
+        .unitVectorTowardStart = unitVectorTowardStart,
+        .unitVectorTowardEnd = unitVectorTowardEnd,
+    };
+}
+
+// Moves the corner's four vertices to where the inset contour needs them. A corner with no radius has no
+// curve to offset, so it collapses to a single point at the inset rect's corner. A corner with no inset is
+// returned unchanged.
+static CornerAdjustment resolveCornerAdjustment(const Corner& original, double startInset, double endInset)
+{
+    auto unchanged = [](const Corner& corner) -> CornerAdjustment {
+        CornerAdjustment adjustment;
+        adjustment.corner = corner;
+        adjustment.targetCornerOuter = corner.outer;
+        return adjustment;
+    };
+
+    if (isEmpty(original)) {
+        if (startInset == 0.0 && endInset == 0.0)
+            return unchanged(original);
+        // Choose a corner position such that the two edges meet on the inset rect rather than on the border
+        // box: the vertical edge's inset moves it horizontally, the horizontal edge's inset vertically.
+        auto [directionX, directionY] = inwardDirection(original.orientation);
+        auto [verticalEdgeBorder, horizontalEdgeBorder] = edgeBorders(original.orientation, startInset, endInset);
+        auto targetCorner = original.outer + FloatSize(directionX * verticalEdgeBorder, directionY * horizontalEdgeBorder);
+        return unchanged({ targetCorner, targetCorner, targetCorner, targetCorner, { }, original.curvature, original.orientation });
+    }
+
+    if (startInset == 0.0 && endInset == 0.0)
+        return unchanged(original);
+
+    if (std::isfinite(original.curvature))
+        return computeCornerAdjustment(original, startInset, endInset);
+
+    double strokeA = isNotch(original) ? -1.0 : 0.0;
+    double strokeB = 1.0;
+
+    auto offset1 = (original.outer - original.start).directionScaledBy(float(startInset * strokeA));
+    auto offset2 = (original.end - original.outer).directionScaledBy(float(startInset * strokeB));
+    auto offset3 = (original.center - original.end).directionScaledBy(float(endInset * strokeB));
+    auto offset4 = (original.start - original.center).directionScaledBy(float(endInset * strokeA));
+
+    auto adjustedOuter = original.outer + offset2 + offset3;
+    auto adjustedCenter = original.center + offset4 + offset1;
+
+    // Notch and square keep the offsets above, but take their miter vectors from the shared construction.
+    auto adjustment = computeCornerAdjustment(original, startInset, endInset);
+    adjustment.corner = {
+        original.start + offset1 + offset2,
+        adjustedOuter,
+        original.end + offset3 + offset4,
+        adjustedCenter,
+        cornerRadii(adjustedCenter, adjustedOuter),
+        original.curvature,
+        original.orientation,
+    };
+    return adjustment;
 }
 
 static bool extendPathForSharpCorner(Path& path, const Corner& corner)
@@ -292,16 +303,6 @@ static void addEllipticalArc(Path& path, const Corner& corner)
     auto direction = delta >= 0.0f ? RotationDirection::Clockwise : RotationDirection::Counterclockwise;
 
     path.addEllipse(corner.center, radiusX, radiusY, 0.0f, startAngle, startAngle + delta, direction);
-}
-
-// Defined in https://drafts.csswg.org/css-borders-4/#corner-shape-interpolation
-static double normalizedSuperellipseHalfCorner(double superellipseParameter)
-{
-    if (std::isinf(superellipseParameter))
-        return superellipseParameter < 0.0 ? 0.0 : 1.0;
-    double exponent = std::pow(0.5, std::abs(superellipseParameter));
-    double convexHalfCorner = std::pow(0.5, exponent);
-    return superellipseParameter < 0.0 ? 1.0 - convexHalfCorner : convexHalfCorner;
 }
 
 struct SuperellipseBezierHandles {
@@ -433,17 +434,62 @@ static void addTrimmedSuperellipseCorner(Path& path, const Corner& corner, const
     }
 }
 
-static void buildCorners(RectCorners<Corner>& corners, const RectCorners<CornerInput>& cornerRects, ForceHullDirection forceHullDirection = ForceHullDirection::No)
+static void buildCorners(RectCorners<Corner>& corners, const RectCorners<CornerInput>& cornerRects)
 {
     for (auto key : { BoxCorner::TopLeft, BoxCorner::TopRight, BoxCorner::BottomLeft, BoxCorner::BottomRight }) {
         auto& input = cornerRects[key];
         auto original = makeCorner(input);
-        auto corner = adjustCornerForInset(original, input.startInset, input.endInset, forceHullDirection);
+        auto corner = resolveCornerAdjustment(original, input.startInset, input.endInset).corner;
         corners[key] = corner;
     }
 }
 
 using ContourEdge = std::pair<FloatPoint, FloatPoint>;
+
+// Outer miters. Convex corners miter along the equivalent-quadratic control point, concave ones
+// along the curve tangent. When the outset exceeds a corner radius the two miters cross and the curve collapses.
+struct OutsetCornerContour {
+    FloatPoint miterStart;
+    FloatPoint miterEnd;
+    bool collapsed { false };
+    FloatPoint collapsePoint;
+};
+
+static std::optional<FloatPoint> findMiterArmCrossing(const FloatPoint& startArmOuter, const FloatPoint& startArmInner, const FloatPoint& endArmOuter, const FloatPoint& endArmInner)
+{
+    if (auto crossing = findSegmentLineIntersection(startArmOuter, startArmInner, endArmOuter, endArmInner))
+        return crossing;
+    return findSegmentLineIntersection(endArmOuter, endArmInner, startArmOuter, startArmInner);
+}
+
+static OutsetCornerContour outsetCornerContour(const Corner& adjusted, const CornerAdjustment& adjustment, double startInset, double endInset)
+{
+    auto clipOuter = adjustment.targetCornerOuter;
+    ContourEdge startLine { clipOuter + adjustment.unitVectorTowardStart, clipOuter };
+    ContourEdge endLine { clipOuter + adjustment.unitVectorTowardEnd, clipOuter };
+
+    OutsetCornerContour contour;
+    if (isConcave(adjusted)) {
+        auto startTangent = adjustment.startNormal.perpendicular().scaled(-1);
+        auto endTangent = adjustment.endNormal.perpendicular();
+        contour.miterStart = findIntersection(startLine.first, startLine.second, adjusted.start, adjusted.start + startTangent).value_or(adjusted.start);
+        contour.miterEnd = findIntersection(endLine.first, endLine.second, adjusted.end, adjusted.end + endTangent).value_or(adjusted.end);
+
+        bool swallowsAnArm = -endInset >= adjustment.startRadius || -startInset >= adjustment.endRadius;
+        if (startInset < 0.0 && endInset < 0.0 && swallowsAnArm) {
+            if (auto crossing = findMiterArmCrossing(contour.miterStart, adjusted.start, contour.miterEnd, adjusted.end)) {
+                contour.collapsed = true;
+                contour.collapsePoint = *crossing;
+            }
+        }
+        return contour;
+    }
+
+    auto controlPoint = quadraticControlPoint(adjusted);
+    contour.miterStart = findIntersection(startLine.first, startLine.second, adjusted.start, controlPoint).value_or(adjusted.start);
+    contour.miterEnd = findIntersection(endLine.first, endLine.second, adjusted.end, controlPoint).value_or(adjusted.end);
+    return contour;
+}
 
 // Flatten the drawn corner curve (start..end) into points, matching addCurvedCorner's geometry.
 static void sampleDrawnCorner(const Corner& corner, unsigned stepsPerHalf, Vector<FloatPoint>& out)
@@ -468,24 +514,59 @@ static void sampleDrawnCorner(const Corner& corner, unsigned stepsPerHalf, Vecto
     }
 }
 
+static std::optional<FloatSize> outsetArmDirection(const FloatPoint& from, const FloatPoint& to)
+{
+    auto direction = to - from;
+    if (direction.diagonalLength() < limit)
+        return std::nullopt;
+    return direction.normalized();
+}
+
+// The outset contour is a straight arm, then the curve, then another straight arm. Fitting the curve with its
+// end tangents forced to the arm directions makes each junction smooth, instead of the crease that shows when
+// the curve and the arm arrive at different angles.
+static void addTangentJoinedCorner(Path& path, const Corner& adjusted, const OutsetCornerContour& contour, float deviceScaleFactor, bool& started)
+{
+    constexpr double flatnessTolerance = 0.25; // device pixels
+    double radius = std::max(adjusted.radii.width(), adjusted.radii.height());
+    double scale = deviceScaleFactor > 0.0f ? deviceScaleFactor : 1.0;
+    double quarterArcChords = std::numbers::pi / 2.0 * std::sqrt(radius * scale / (8.0 * flatnessTolerance));
+    unsigned stepsPerHalf = std::max(2u, static_cast<unsigned>(std::clamp(std::ceil(quarterArcChords / 2.0), 4.0, 64.0)));
+
+    Vector<FloatPoint> samples;
+    sampleDrawnCorner(adjusted, stepsPerHalf, samples);
+    if (samples.size() < 2) {
+        addCurvedCorner(path, adjusted);
+        return;
+    }
+
+    constexpr unsigned bezierSegmentCount = 18;
+    addCatmullRomBeziers(path, samples, bezierSegmentCount, started,
+        outsetArmDirection(contour.miterStart, samples.first()), outsetArmDirection(samples.last(), contour.miterEnd));
+}
+
 // The outset+miter curve for a single corner, flattened from its start miter to its end miter.
-static Vector<FloatPoint> cornerOutsetSamples(const CornerInput& input, double curvature, const ContourEdge& startEdge, const ContourEdge& endEdge, unsigned stepsPerHalf)
+static Vector<FloatPoint> cornerOutsetSamples(const CornerInput& input, double curvature, unsigned stepsPerHalf)
 {
     CornerInput swapped = input;
     swapped.curvature = curvature;
-    auto corner = adjustCornerForInset(makeCorner(swapped), input.startInset, input.endInset, ForceHullDirection::Yes);
-    auto controlPoint = quadraticControlPoint(corner);
-    auto miterStart = findIntersection(startEdge.first, startEdge.second, corner.start, controlPoint).value_or(corner.start);
-    auto miterEnd = findIntersection(endEdge.first, endEdge.second, corner.end, controlPoint).value_or(corner.end);
+    auto adjustment = resolveCornerAdjustment(makeCorner(swapped), input.startInset, input.endInset);
+    auto contour = outsetCornerContour(adjustment.corner, adjustment, input.startInset, input.endInset);
+
     Vector<FloatPoint> points;
-    points.append(miterStart);
-    sampleDrawnCorner(corner, stepsPerHalf, points);
-    points.append(miterEnd);
+    points.append(contour.miterStart);
+    if (contour.collapsed) {
+        // Degenerate concave miter: the curve becomes the crossing of the two arms.
+        points.append(contour.collapsePoint);
+        points.append(contour.collapsePoint);
+    } else
+        sampleDrawnCorner(adjustment.corner, stepsPerHalf, points);
+    points.append(contour.miterEnd);
     return points;
 }
 
-// Cubic Hermite morph of the outset curve at s = -1, 0, +1 for a corner whose curvature is in (-1, 1).
-static void addMorphedOutsetCorner(Path& path, const CornerInput& input, const ContourEdge& startEdge, const ContourEdge& endEdge, float deviceScaleFactor, bool& started)
+// Cubic Hermite morph of the outset curve over s in (0, 1), anchored on the contour that is constructed at s = 0 and s = 1.
+static void addMorphedOutsetCorner(Path& path, const CornerInput& input, float deviceScaleFactor, bool& started)
 {
     constexpr double flatnessTolerance = 0.25; // device pixels
     double radius = std::max(input.width, input.height) + std::max(std::abs(input.startInset), std::abs(input.endInset));
@@ -494,12 +575,10 @@ static void addMorphedOutsetCorner(Path& path, const CornerInput& input, const C
     unsigned stepsPerHalf = std::max(2u, static_cast<unsigned>(std::clamp(std::ceil(quarterArcChords / 2.0), 4.0, 64.0)));
     unsigned sampleCount = 2 * stepsPerHalf + 4;
     constexpr double epsilon = 0.04; // curvature step for the endpoint-velocity finite differences
-    double curvature = input.curvature;
 
     auto anchor = [&](double sampleCurvature) {
-        return resampleByArcLength(cornerOutsetSamples(input, sampleCurvature, startEdge, endEdge, stepsPerHalf), sampleCount);
+        return resampleByArcLength(cornerOutsetSamples(input, sampleCurvature, stepsPerHalf), sampleCount);
     };
-
     auto velocity = [&](const Vector<FloatPoint>& ahead, const Vector<FloatPoint>& behind, double deltaCurvature) {
         Vector<FloatSize> perPointVelocity(sampleCount);
         for (unsigned index = 0; index < sampleCount; ++index)
@@ -507,32 +586,19 @@ static void addMorphedOutsetCorner(Path& path, const CornerInput& input, const C
         return perPointVelocity;
     };
 
-    auto middleAnchor = anchor(0.0);
-    Vector<FloatPoint> startAnchor, endAnchor;
-    Vector<FloatSize> startVelocity, endVelocity;
-    // The morph brackets the curvature s into a sub-interval whose endpoints are anchor curves, then
-    // remaps s onto [0, 1] as hermiteInterpolate's blend fraction
-    double interpolationFraction;
-    if (curvature < 0.0) {
-        startAnchor = anchor(-1.0);
-        endAnchor = middleAnchor;
-        startVelocity = velocity(startAnchor, anchor(-1.0 - epsilon), epsilon); // dPosition/ds at s = -1 (from below)
-        endVelocity = velocity(anchor(epsilon), anchor(-epsilon), 2.0 * epsilon); // dPosition/ds at s = 0 (central)
-        interpolationFraction = curvature + 1.0; // s in [-1, 0] -> [0, 1]
-    } else {
-        startAnchor = middleAnchor;
-        endAnchor = anchor(1.0);
-        startVelocity = velocity(anchor(epsilon), anchor(-epsilon), 2.0 * epsilon); // dPosition/ds at s = 0 (central)
-        endVelocity = velocity(anchor(1.0 + epsilon), endAnchor, epsilon); // dPosition/ds at s = +1 (from above)
-        interpolationFraction = curvature; // s in [0, 1] -> [0, 1]
-    }
+    auto startAnchor = anchor(0.0);
+    auto endAnchor = anchor(1.0);
+    auto startVelocity = velocity(anchor(epsilon), startAnchor, epsilon); // dPosition/ds at s = 0 (from above)
+    auto endVelocity = velocity(anchor(1.0 + epsilon), endAnchor, epsilon); // dPosition/ds at s = +1 (from above)
 
-    auto morphedCorner = hermiteInterpolate(startAnchor, startVelocity, endAnchor, endVelocity, interpolationFraction);
+    auto morphedCorner = hermiteInterpolate(startAnchor, startVelocity, endAnchor, endVelocity, input.curvature);
+    if (morphedCorner.size() < 2)
+        return;
 
-    // Fixed count sized for the worst-case corner (up to ~R = 240) to stay within 0.25px of the true curve
-    // TODO: cache the built path then a Schneider fit could use fewer segments on large corners
     constexpr unsigned bezierSegmentCount = 18;
-    addCatmullRomBeziers(path, morphedCorner, bezierSegmentCount, started);
+    addCatmullRomBeziers(path, morphedCorner, bezierSegmentCount, started,
+        outsetArmDirection(morphedCorner[0], morphedCorner[1]),
+        outsetArmDirection(morphedCorner[morphedCorner.size() - 2], morphedCorner[morphedCorner.size() - 1]));
 }
 
 } // namespace
@@ -541,55 +607,46 @@ static void addMorphedOutsetCorner(Path& path, const CornerInput& input, const C
 void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, const FloatRect* targetRect, OutsetMiter outsetMiter, float deviceScaleFactor)
 {
     RectCorners<Corner> corners;
-    buildCorners(corners, cornerRects, outsetMiter == OutsetMiter::Yes ? ForceHullDirection::Yes : ForceHullDirection::No);
-
-    using Edge = std::pair<FloatPoint, FloatPoint>;
-    auto edges = targetRect ? targetRect->edges() : RectEdges<Edge> { };
-
-    auto edgesForCorner = [&](BoxCorner key) -> std::pair<Edge, Edge> {
-        switch (key) {
-        case BoxCorner::TopRight:
-            return { edges.top(), edges.right() };
-        case BoxCorner::BottomRight:
-            return { edges.right(), edges.bottom() };
-        case BoxCorner::BottomLeft:
-            return { edges.bottom(), edges.left() };
-        case BoxCorner::TopLeft:
-            return { edges.left(), edges.top() };
-        }
-        return { edges.top(), edges.right() };
-    };
-
-    auto miterToEdge = [](const FloatPoint& endpoint, const FloatPoint& tangentControl, const Edge& edge) {
-        return findIntersection(edge.first, edge.second, endpoint, tangentControl).value_or(endpoint);
-    };
+    buildCorners(corners, cornerRects);
 
     bool started = false;
     for (auto key : { BoxCorner::TopRight, BoxCorner::BottomRight, BoxCorner::BottomLeft, BoxCorner::TopLeft }) {
         const auto& corner = corners[key];
+        double startInset = cornerRects[key].startInset;
+        double endInset = cornerRects[key].endInset;
 
-        if (outsetMiter == OutsetMiter::Yes) {
-            auto [startEdge, endEdge] = edgesForCorner(key);
-            double curvature = cornerRects[key].curvature;
-            if (targetRect && curvature > -1.0 && curvature < 1.0) {
-                addMorphedOutsetCorner(path, cornerRects[key], startEdge, endEdge, deviceScaleFactor, started);
-                continue;
-            }
-            auto controlPoint = quadraticControlPoint(corner);
-            auto miterStart = miterToEdge(corner.start, controlPoint, startEdge);
-            auto miterEnd = miterToEdge(corner.end, controlPoint, endEdge);
+        auto addOutsetCorner = [&](const OutsetCornerContour& contour) {
             if (!started) {
-                path.moveTo(miterStart);
+                path.moveTo(contour.miterStart);
                 started = true;
             } else
-                path.addLineTo(miterStart);
-            addCurvedCorner(path, corner);
-            path.addLineTo(miterEnd);
+                path.addLineTo(contour.miterStart);
+            if (contour.collapsed)
+                path.addLineTo(contour.collapsePoint);
+            else
+                addTangentJoinedCorner(path, corner, contour, deviceScaleFactor, started);
+            path.addLineTo(contour.miterEnd);
+        };
+
+        if (outsetMiter == OutsetMiter::Yes) {
+            double curvature = cornerRects[key].curvature;
+            if (targetRect && curvature > 0.0 && curvature < 1.0) {
+                addMorphedOutsetCorner(path, cornerRects[key], deviceScaleFactor, started);
+                continue;
+            }
+            auto adjustment = computeCornerAdjustment(makeCorner(cornerRects[key]), startInset, endInset);
+            addOutsetCorner(outsetCornerContour(corner, adjustment, startInset, endInset));
             continue;
         }
 
+        // An outward offset must still reach the offset rect's edges when no target rect was given
+        if ((startInset < 0.0 || endInset < 0.0) && std::isfinite(corner.curvature) && !isEmpty(corner)) {
+            auto adjustment = computeCornerAdjustment(makeCorner(cornerRects[key]), startInset, endInset);
+            addOutsetCorner(outsetCornerContour(corner, adjustment, startInset, endInset));
+            continue;
+        }
         // Inset: carve the superellipse corner's curve to the target rect.
-        if (targetRect && isSuperellipse(corner)) {
+        if (targetRect && std::isfinite(corner.curvature) && !isEmpty(corner)) {
             addTrimmedSuperellipseCorner(path, corner, *targetRect, started);
             continue;
         }

--- a/Source/WebCore/platform/graphics/GeometryUtilities.cpp
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.cpp
@@ -62,6 +62,23 @@ std::optional<FloatPoint> findIntersection(const FloatPoint& p1, const FloatPoin
     return FloatPoint(p1.x() + param * pxLength, p1.y() + param * pyLength);
 }
 
+std::optional<FloatPoint> findSegmentLineIntersection(const FloatPoint& segmentStart, const FloatPoint& segmentEnd, const FloatPoint& lineA, const FloatPoint& lineB)
+{
+    auto intersection = findIntersection(segmentStart, segmentEnd, lineA, lineB);
+    if (!intersection)
+        return std::nullopt;
+
+    auto segment = segmentEnd - segmentStart;
+    float lengthSquared = segment.diagonalLengthSquared();
+    if (!lengthSquared)
+        return std::nullopt;
+
+    float position = dotProduct(*intersection - segmentStart, segment) / lengthSquared;
+    if (position < 0 || position > 1)
+        return std::nullopt;
+    return intersection;
+}
+
 IntRect unionRect(const Vector<IntRect>& rects)
 {
     IntRect result;

--- a/Source/WebCore/platform/graphics/GeometryUtilities.h
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.h
@@ -43,8 +43,11 @@ float NODELETE dotProduct(const FloatSize&, const FloatSize&);
 // Which side of the directed line lineStart->lineEnd a point lies on: > 0 to the left of the direction, < 0 to the right, 0 on the line.
 float NODELETE signedDistanceToLine(const FloatPoint&, const FloatPoint& lineStart, const FloatPoint& lineEnd);
 
-// Find point where lines through the two pairs of points intersect. Returns std::nullopt if the lines are parallel.
+// Find where two infinite lines intersect, each given by a pair of points lying on it. Returns std::nullopt if the lines are parallel.
 WEBCORE_EXPORT std::optional<FloatPoint> NODELETE findIntersection(const FloatPoint& p1, const FloatPoint& p2, const FloatPoint& d1, const FloatPoint& d2);
+
+// Find where the segment crosses the infinite line through lineA and lineB. Returns std::nullopt if they are parallel or the crossing lies beyond the segment's ends.
+std::optional<FloatPoint> NODELETE findSegmentLineIntersection(const FloatPoint& segmentStart, const FloatPoint& segmentEnd, const FloatPoint& lineA, const FloatPoint& lineB);
 
 WEBCORE_EXPORT IntRect unionRect(const Vector<IntRect>&);
 WEBCORE_EXPORT IntRect unionRectIgnoringZeroRects(const Vector<IntRect>&);

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -114,7 +114,7 @@ BorderShape BorderShape::shapeForBorderRect(const Style::ComputedStyle& style, c
     return BorderShape { borderRect, usedBorderWidths };
 }
 
-BorderShape BorderShape::shapeForOffsetRect(const Style::ComputedStyle& style, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges, ConstantThicknessOffset constantThickness)
+BorderShape BorderShape::shapeForOffsetRect(const Style::ComputedStyle& style, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges)
 {
     auto usedEdgeWidths = applyClosedEdges(edgeWidths, closedEdges);
 
@@ -143,7 +143,6 @@ BorderShape BorderShape::shapeForOffsetRect(const Style::ComputedStyle& style, c
         if (!referenceRadii.areRenderableInRect(borderRect))
             referenceRadii.makeRenderableInRect(borderRect);
         shape.m_offsetReferenceRect = LayoutRoundedRect { borderRect, referenceRadii };
-        shape.m_constantThicknessOffset = constantThickness == ConstantThicknessOffset::Yes;
 
         return shape;
     }
@@ -181,7 +180,6 @@ BorderShape BorderShape::shapeWithBorderWidths(const RectEdges<LayoutUnit>& bord
 {
     auto shape = BorderShape(m_borderRect.rect(), borderWidths, m_borderRect.radii(), m_cornerCurvatures);
     shape.m_offsetReferenceRect = m_offsetReferenceRect;
-    shape.m_constantThicknessOffset = m_constantThicknessOffset;
     return shape;
 }
 
@@ -474,7 +472,7 @@ Path BorderShape::pathForOuterCornerShape(const FloatRoundedRect& outerSnapped, 
     Path path;
     bool useAlignedToCurve = snappedOffsetReference
         && (cornersUseAlignedToCurveOffset(m_cornerCurvatures)
-            || (m_constantThicknessOffset && cornersHaveConvexSuperellipse(m_cornerCurvatures)));
+            || cornersHaveConvexSuperellipse(m_cornerCurvatures));
     if (useAlignedToCurve) {
         addAlignedToCurveOffsetContour(path, *snappedOffsetReference, m_cornerCurvatures, outerSnapped.rect());
         if (!path.isEmpty())
@@ -507,7 +505,7 @@ Path BorderShape::pathForInnerCornerShape(const FloatRoundedRect& outerSnapped, 
     Path path;
     bool useAlignedToCurve = snappedOffsetReference
         && (cornersUseAlignedToCurveOffset(m_cornerCurvatures)
-            || (m_constantThicknessOffset && cornersHaveConvexSuperellipse(m_cornerCurvatures)));
+            || cornersHaveConvexSuperellipse(m_cornerCurvatures));
     if (useAlignedToCurve) {
         addAlignedToCurveOffsetContour(path, *snappedOffsetReference, m_cornerCurvatures, innerSnapped.rect());
         if (!path.isEmpty())

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -48,9 +48,6 @@ namespace Style {
 class ComputedStyle;
 }
 
-// Whether an offset shape keeps constant thickness along the curve (outline) vs. expanding as an area (box-shadow spread).
-enum class ConstantThicknessOffset : bool { No, Yes };
-
 // BorderShape is used to fill and clip to the shape formed by the border and padding boxes with border-radius.
 // In future, this may be a more complex shape than a rounded rect, so accessors that return rounded rects
 // are deprecated.
@@ -63,7 +60,7 @@ public:
     // Create a BorderShape suitable for rendering an outline or shadow. borderRect is provided to
     // allow for scaling the corner radii; radii expand outward or shrink inward based on the offset
     // between borderRect and offsetRect.
-    static BorderShape shapeForOffsetRect(const Style::ComputedStyle&, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges = { true }, ConstantThicknessOffset constantThickness = ConstantThicknessOffset::No);
+    static BorderShape shapeForOffsetRect(const Style::ComputedStyle&, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges = { true });
 
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths);
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const LayoutRoundedRectRadii&);
@@ -158,7 +155,6 @@ private:
     RectCorners<float> m_cornerCurvatures { 1.0f, 1.0f, 1.0f, 1.0f };
 
     std::optional<LayoutRoundedRect> m_offsetReferenceRect;
-    bool m_constantThicknessOffset { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -107,7 +107,7 @@ void OutlinePainter::paintOutline(const RenderElement& renderer, const LayoutRec
     auto closedEdges = RectEdges<bool> { true };
 
     auto outlineEdgeWidths = RectEdges<LayoutUnit> { outlineWidth };
-    auto outlineShape = BorderShape::shapeForOffsetRect(styleToUse.get(), paintRect, outerRect, outlineEdgeWidths, closedEdges, ConstantThicknessOffset::Yes);
+    auto outlineShape = BorderShape::shapeForOffsetRect(styleToUse.get(), paintRect, outerRect, outlineEdgeWidths, closedEdges);
 
     auto bleedAvoidance = BleedAvoidance::ShrinkBackground;
     auto appliedClipAlready = false;
@@ -314,7 +314,7 @@ void OutlinePainter::paintFocusRing(const RenderElement& renderer, const Vector<
         auto borderRect = focusRingRects[0];
         auto outlineRect = borderRect;
         outlineRect.inflate(LayoutUnit(outlineOffset));
-        auto outlineShape = BorderShape::shapeForOffsetRect(style.get(), borderRect, outlineRect, RectEdges<LayoutUnit> { }, RectEdges<bool> { true }, ConstantThicknessOffset::Yes);
+        auto outlineShape = BorderShape::shapeForOffsetRect(style.get(), borderRect, outlineRect, RectEdges<LayoutUnit> { }, RectEdges<bool> { true });
         auto path = outlineShape.pathForOuterShape(deviceScaleFactor);
         drawFocusRing(m_paintInfo.context(), path, style.get(), focusRingColor);
         return;


### PR DESCRIPTION
#### dc1de28bb373793ea1c6540712605960a66ea508
<pre>
corner-shape: adopt the revised contoured-path algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=320753">https://bugs.webkit.org/show_bug.cgi?id=320753</a>
<a href="https://rdar.apple.com/183753095">rdar://183753095</a>

Reviewed by Simon Fraser.

Offsetting a shaped corner outward picked between several constructions
based on the corner&apos;s shape, and they disagreed with one another. They
coincided only for a plain round corner with a single radius, so the damage
showed up on non-round shapes and on elliptical radii

This replaces them with the single construction from the revised algorithm,
which scales the offset normal per-axis by the two corner radii so an
elliptical corner keeps its shape when offset. box-shadow spread now uses
that same construction, so a shadow and an outline at the same distance stay
parallel rather than pinching together at the corners.

Adopted algorithm from <a href="https://github.com/w3c/csswg-drafts/pull/14142">https://github.com/w3c/csswg-drafts/pull/14142</a>

* Source/WebCore/platform/graphics/CornerShapeUtilities.cpp:
(WebCore::borderContourPath):
* Source/WebCore/platform/graphics/GeometryUtilities.cpp:
(WebCore::findSegmentLineIntersection):
* Source/WebCore/platform/graphics/GeometryUtilities.h:
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::shapeForOffsetRect):
(WebCore::buildOutsetCornerInputs):
(WebCore::addAreaExpansionOffsetContour):
(WebCore::BorderShape::pathForOuterCornerShape const):
(WebCore::BorderShape::pathForInnerCornerShape const):
(WebCore::adjustedRadiusDimension):
(WebCore::outsetAdjustedBorderRadius):
(WebCore::expandRadiiForOutset):
(WebCore::BorderShape::shapeWithBorderWidths const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-bevel-overflow.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-convex.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-bevel.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-squircle.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-bevel.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-squircle.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-bevel-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-bevel-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-bevel.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-elliptical-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-elliptical-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-box-shadow-spread-elliptical.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-bevel-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-bevel-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-bevel.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-elliptical-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-elliptical-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outline-offset-elliptical.html: Added.
* Source/WebCore/rendering/BorderShape.h:
(WebCore::BorderShape::shapeForOffsetRect):
* Source/WebCore/rendering/OutlinePainter.cpp:
(WebCore::OutlinePainter::paintOutline const):
(WebCore::OutlinePainter::paintFocusRing const):
* Source/WebCore/platform/graphics/BezierUtilities.cpp:
(WebCore::addCatmullRomBeziers):
* Source/WebCore/platform/graphics/BezierUtilities.h:

Canonical link: <a href="https://commits.webkit.org/318971@main">https://commits.webkit.org/318971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13cffd2803936a137608f6332ccba51b1acea825

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190174 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144281 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140336 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120787 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42669 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40983 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40650 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1331 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192106 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149677 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54261 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149407 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27333 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44053 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126524 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121592 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52778 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15638 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52398 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->