### PR TITLE
[Memory64] Add SIMD support

### DIFF
--- a/JSTests/wasm/stress/memory64-simd.js
+++ b/JSTests/wasm/stress/memory64-simd.js
@@ -1,0 +1,284 @@
+//@ skip if !$isSIMDPlatform
+//@ skip if $addressBits <= 32
+
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+const pageSize = 65536n;
+const initialPages = 2n;
+const maximumPages = 3n;
+const memorySize = initialPages * pageSize;
+
+// 2^32. Only meaningful in a 64-bit address computation: every access using it is out
+// of bounds here, so an implementation that truncated the offset would wrongly succeed.
+const hugeOffset = 4294967296n;
+
+const zeroVector = "(v128.const i64x2 0 0)";
+const dataVector = "(v128.const i64x2 0x7766554433221100 0xFFEEDDCCBBAA9988)";
+
+// Instructions reading from $src. `width` is the number of bytes touched at $src.
+const loadOps = [
+    { name: "v128_load",        width: 16n, body: memarg => `(v128.load ${memarg} (local.get $src))` },
+    { name: "v128_load8x8_s",   width:  8n, body: memarg => `(v128.load8x8_s ${memarg} (local.get $src))` },
+    { name: "v128_load8x8_u",   width:  8n, body: memarg => `(v128.load8x8_u ${memarg} (local.get $src))` },
+    { name: "v128_load16x4_s",  width:  8n, body: memarg => `(v128.load16x4_s ${memarg} (local.get $src))` },
+    { name: "v128_load16x4_u",  width:  8n, body: memarg => `(v128.load16x4_u ${memarg} (local.get $src))` },
+    { name: "v128_load32x2_s",  width:  8n, body: memarg => `(v128.load32x2_s ${memarg} (local.get $src))` },
+    { name: "v128_load32x2_u",  width:  8n, body: memarg => `(v128.load32x2_u ${memarg} (local.get $src))` },
+    { name: "v128_load8_splat", width:  1n, body: memarg => `(v128.load8_splat ${memarg} (local.get $src))` },
+    { name: "v128_load16_splat", width: 2n, body: memarg => `(v128.load16_splat ${memarg} (local.get $src))` },
+    { name: "v128_load32_splat", width: 4n, body: memarg => `(v128.load32_splat ${memarg} (local.get $src))` },
+    { name: "v128_load64_splat", width: 8n, body: memarg => `(v128.load64_splat ${memarg} (local.get $src))` },
+    { name: "v128_load8_lane",  width:  1n, body: memarg => `(v128.load8_lane ${memarg} 13 (local.get $src) ${zeroVector})` },
+    { name: "v128_load16_lane", width:  2n, body: memarg => `(v128.load16_lane ${memarg} 6 (local.get $src) ${zeroVector})` },
+    { name: "v128_load32_lane", width:  4n, body: memarg => `(v128.load32_lane ${memarg} 3 (local.get $src) ${zeroVector})` },
+    { name: "v128_load64_lane", width:  8n, body: memarg => `(v128.load64_lane ${memarg} 0 (local.get $src) ${zeroVector})` },
+    { name: "v128_load32_zero", width:  4n, body: memarg => `(v128.load32_zero ${memarg} (local.get $src))` },
+    { name: "v128_load64_zero", width:  8n, body: memarg => `(v128.load64_zero ${memarg} (local.get $src))` },
+];
+
+// Instructions writing to $addr. `width` is the number of bytes touched at $addr.
+const storeOps = [
+    { name: "v128_store",        width: 16n, body: memarg => `(v128.store ${memarg} (local.get $addr) ${dataVector})` },
+    { name: "v128_store8_lane",  width:  1n, body: memarg => `(v128.store8_lane ${memarg} 8 (local.get $addr) ${dataVector})` },
+    { name: "v128_store16_lane", width:  2n, body: memarg => `(v128.store16_lane ${memarg} 4 (local.get $addr) ${dataVector})` },
+    { name: "v128_store32_lane", width:  4n, body: memarg => `(v128.store32_lane ${memarg} 2 (local.get $addr) ${dataVector})` },
+    { name: "v128_store64_lane", width:  8n, body: memarg => `(v128.store64_lane ${memarg} 1 (local.get $addr) ${dataVector})` },
+];
+
+let wat = `
+(module
+    (memory i64 ${initialPages} ${maximumPages})
+
+    (func (export "i64_store") (param $addr i64) (param $value i64)
+        (i64.store (local.get $addr) (local.get $value))
+    )
+
+    (func (export "i64_load") (param $addr i64) (result i64)
+        (i64.load (local.get $addr))
+    )
+
+    (func (export "grow") (param $delta i64) (result i64)
+        (memory.grow (local.get $delta))
+    )
+    ${
+      // Each load-like instruction, wrapped so the loaded vector is written back to
+      // memory at $dst: v128 cannot cross the JS boundary, so results are read back
+      // through i64.load.
+      loadOps.map(({ name, body }) =>
+        `(func (export "${name}") (param $src i64) (param $dst i64)
+            (v128.store (local.get $dst) ${body("")})
+        )
+        (func (export "${name}_huge_offset") (param $src i64) (param $dst i64)
+            (v128.store (local.get $dst) ${body(`offset=${hugeOffset}`)})
+        )`).join("\n    ")
+    }
+    ${
+      storeOps.map(({ name, body }) =>
+        `(func (export "${name}") (param $addr i64)
+            ${body("")}
+        )
+        (func (export "${name}_huge_offset") (param $addr i64)
+            ${body(`offset=${hugeOffset}`)}
+        )`).join("\n    ")
+    }
+
+    ;; A static offset that does not fit in 16 bits, exercised against an i64 base.
+    (func (export "v128_load_page_offset") (param $src i64) (param $dst i64)
+        (v128.store (local.get $dst) (v128.load offset=${pageSize} (local.get $src)))
+    )
+
+    (func (export "v128_store_page_offset") (param $addr i64)
+        (v128.store offset=${pageSize} (local.get $addr) ${dataVector})
+    )
+)
+`;
+
+const instance = await instantiate(wat, {}, { memory64: true, simd: true });
+const exports = instance.exports;
+const { i64_load, i64_store, grow } = exports;
+
+// i64 results come back sign-extended; the expectations below are written unsigned.
+const asI64 = value => BigInt.asIntN(64, value);
+
+const outOfBounds = (fn) =>
+    assert.throws(fn, WebAssembly.RuntimeError, "Out of bounds memory access");
+
+function testAt(base) {
+    const src = base;
+    const dst = base + 16n;
+
+    const check = (lo, hi) => {
+        assert.eq(i64_load(dst), asI64(lo));
+        assert.eq(i64_load(dst + 8n), asI64(hi));
+    };
+
+    i64_store(src, 0x7766554433221100n);
+    i64_store(src + 8n, 0xFFEEDDCCBBAA9988n);
+
+    exports.v128_load(src, dst);
+    check(0x7766554433221100n, 0xFFEEDDCCBBAA9988n);
+
+    exports.v128_load8x8_s(src + 8n, dst);
+    check(0xFFBBFFAAFF99FF88n, 0xFFFFFFEEFFDDFFCCn);
+
+    exports.v128_load8x8_u(src + 8n, dst);
+    check(0x00BB00AA00990088n, 0x00FF00EE00DD00CCn);
+
+    exports.v128_load16x4_s(src + 8n, dst);
+    check(0xFFFFBBAAFFFF9988n, 0xFFFFFFEEFFFFDDCCn);
+
+    exports.v128_load16x4_u(src + 8n, dst);
+    check(0x0000BBAA00009988n, 0x0000FFEE0000DDCCn);
+
+    exports.v128_load32x2_s(src + 8n, dst);
+    check(0xFFFFFFFFBBAA9988n, 0xFFFFFFFFFFEEDDCCn);
+
+    exports.v128_load32x2_u(src + 8n, dst);
+    check(0x00000000BBAA9988n, 0x00000000FFEEDDCCn);
+
+    exports.v128_load8_splat(src + 1n, dst);
+    check(0x1111111111111111n, 0x1111111111111111n);
+
+    exports.v128_load16_splat(src, dst);
+    check(0x1100110011001100n, 0x1100110011001100n);
+
+    exports.v128_load32_splat(src, dst);
+    check(0x3322110033221100n, 0x3322110033221100n);
+
+    exports.v128_load64_splat(src, dst);
+    check(0x7766554433221100n, 0x7766554433221100n);
+
+    // Lane loads replace one lane of an all-zero vector.
+    exports.v128_load8_lane(src + 8n, dst);
+    check(0n, 0x0000880000000000n);
+
+    exports.v128_load16_lane(src + 8n, dst);
+    check(0n, 0x0000998800000000n);
+
+    exports.v128_load32_lane(src + 8n, dst);
+    check(0n, 0xBBAA998800000000n);
+
+    exports.v128_load64_lane(src, dst);
+    check(0x7766554433221100n, 0n);
+
+    exports.v128_load32_zero(src, dst);
+    check(0x33221100n, 0n);
+
+    exports.v128_load64_zero(src, dst);
+    check(0x7766554433221100n, 0n);
+
+    exports.v128_store(dst);
+    check(0x7766554433221100n, 0xFFEEDDCCBBAA9988n);
+
+    // Lane stores must write only their own lane.
+    i64_store(dst, 0n);
+    exports.v128_store8_lane(dst);
+    assert.eq(i64_load(dst), 0x88n);
+
+    i64_store(dst, 0n);
+    exports.v128_store16_lane(dst);
+    assert.eq(i64_load(dst), 0x9988n);
+
+    i64_store(dst, 0n);
+    exports.v128_store32_lane(dst);
+    assert.eq(i64_load(dst), 0xBBAA9988n);
+
+    i64_store(dst, 0n);
+    exports.v128_store64_lane(dst);
+    assert.eq(i64_load(dst), asI64(0xFFEEDDCCBBAA9988n));
+}
+
+function testPageOffset() {
+    // Write a vector one page up, then read it back through the same static offset.
+    i64_store(pageSize, 0n);
+    i64_store(pageSize + 8n, 0n);
+    exports.v128_store_page_offset(0n);
+    assert.eq(i64_load(pageSize), 0x7766554433221100n);
+    assert.eq(i64_load(pageSize + 8n), asI64(0xFFEEDDCCBBAA9988n));
+
+    exports.v128_load_page_offset(0n, 0n);
+    assert.eq(i64_load(0n), 0x7766554433221100n);
+    assert.eq(i64_load(8n), asI64(0xFFEEDDCCBBAA9988n));
+}
+
+// An address whose low 32 bits are in bounds still traps: the high bits must not be
+// dropped. 2^32 and 2^32 + 8 alias to 0 and 8 when truncated to 32 bits.
+function testAddressAboveFourGigs() {
+    for (const address of [hugeOffset, hugeOffset + 8n, 0xFFFFFFFF00000000n, 0x0000000100000010n]) {
+        for (const { name } of loadOps)
+            outOfBounds(() => exports[name](address, 0n));
+
+        for (const { name } of storeOps)
+            outOfBounds(() => exports[name](address));
+    }
+}
+
+// The same requirement for the static offset, which memory64 encodes as a u64.
+function testOffsetAboveFourGigs() {
+    for (const { name } of loadOps)
+        outOfBounds(() => exports[`${name}_huge_offset`](0n, 0n));
+
+    for (const { name } of storeOps)
+        outOfBounds(() => exports[`${name}_huge_offset`](0n));
+}
+
+// address + width must be computed without wrapping: 2^64 - 8 plus a 16-byte access
+// wraps to 8, which is in bounds.
+function testOverflow() {
+    for (const { name, width } of loadOps) {
+        outOfBounds(() => exports[name](0xFFFFFFFFFFFFFFFFn, 0n));
+        outOfBounds(() => exports[name](-width, 0n));
+    }
+
+    for (const { name, width } of storeOps) {
+        outOfBounds(() => exports[name](0xFFFFFFFFFFFFFFFFn));
+        outOfBounds(() => exports[name](-width));
+    }
+}
+
+// An access ending exactly at the memory bound is in bounds; one byte further is not.
+function testBoundary() {
+    for (const { name, width } of loadOps) {
+        exports[name](memorySize - width, 0n);
+        outOfBounds(() => exports[name](memorySize - width + 1n, 0n));
+    }
+
+    for (const { name, width } of storeOps) {
+        exports[name](memorySize - width);
+        outOfBounds(() => exports[name](memorySize - width + 1n));
+    }
+}
+
+for (let i = 0; i < wasmTestLoopCount; i++) {
+    testAt(0n);
+    testAt(pageSize);
+    testPageOffset();
+    testAddressAboveFourGigs();
+    testOffsetAboveFourGigs();
+    testOverflow();
+    testBoundary();
+}
+
+// memory.grow takes and returns an i64 page count for memory64; SIMD accesses must
+// see the new bound afterwards. Run last: it changes what is in bounds above.
+function testGrow() {
+    const grownBase = initialPages * pageSize;
+
+    outOfBounds(() => exports.v128_load(grownBase, 0n));
+    outOfBounds(() => exports.v128_store(grownBase));
+
+    assert.eq(grow(1n), initialPages);
+
+    i64_store(grownBase, 0x7766554433221100n);
+    i64_store(grownBase + 8n, 0xFFEEDDCCBBAA9988n);
+    exports.v128_load(grownBase, grownBase + 16n);
+    assert.eq(i64_load(grownBase + 16n), 0x7766554433221100n);
+    assert.eq(i64_load(grownBase + 24n), asI64(0xFFEEDDCCBBAA9988n));
+
+    const grownSize = maximumPages * pageSize;
+    exports.v128_store(grownSize - 16n);
+    outOfBounds(() => exports.v128_store(grownSize - 15n));
+}
+
+testGrow();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -2128,9 +2128,9 @@ public:
 
     void NODELETE notifyFunctionUsesSIMD();
 
-    PartialResult addSIMDLoad(ExpressionType, uint32_t, ExpressionType&, uint8_t);
+    PartialResult addSIMDLoad(ExpressionType, uint64_t, ExpressionType&, uint8_t);
 
-    PartialResult addSIMDStore(ExpressionType, ExpressionType, uint32_t, uint8_t);
+    PartialResult addSIMDStore(ExpressionType, ExpressionType, uint64_t, uint8_t);
 
     PartialResult addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&);
 
@@ -2140,15 +2140,15 @@ public:
 
     PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
 
-    PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&, uint8_t);
+    PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint64_t, ExpressionType&, uint8_t);
 
-    PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&, uint8_t);
+    PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint64_t, uint8_t, ExpressionType&, uint8_t);
 
-    PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, uint8_t);
+    PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint64_t, uint8_t, uint8_t);
 
-    PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&, uint8_t);
+    PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint64_t, ExpressionType&, uint8_t);
 
-    PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&, uint8_t);
+    PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint64_t, ExpressionType&, uint8_t);
 
     void materializeVectorConstant(v128_t, Location);
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -3546,7 +3546,7 @@ void NODELETE BBQJIT::notifyFunctionUsesSIMD()
     m_usesSIMD = true;
 }
 
-[[nodiscard]] PartialResult BBQJIT::addSIMDLoad(ExpressionType pointer, uint32_t uoffset, ExpressionType& result, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoad(ExpressionType pointer, uint64_t uoffset, ExpressionType& result, uint8_t memoryIndex)
 {
     result = emitCheckAndPrepareAndMaterializePointerApply(pointer, uoffset, bytesForWidth(Width::Width128), memoryIndex, [&](auto location) -> Value {
         consume(pointer);
@@ -3559,7 +3559,7 @@ void NODELETE BBQJIT::notifyFunctionUsesSIMD()
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t uoffset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::addSIMDStore(ExpressionType value, ExpressionType pointer, uint64_t uoffset, uint8_t memoryIndex)
 {
     emitCheckAndPrepareAndMaterializePointerApply(pointer, uoffset, bytesForWidth(Width::Width128), memoryIndex, [&](auto location) -> void {
         Location valueLocation = loadIfNecessary(value);
@@ -3819,7 +3819,7 @@ void NODELETE BBQJIT::notifyFunctionUsesSIMD()
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addSIMDLoadSplat(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoadSplat(SIMDLaneOperation op, ExpressionType pointer, uint64_t uoffset, ExpressionType& result, uint8_t memoryIndex)
 {
     Width width;
     switch (op) {
@@ -3872,7 +3872,7 @@ void NODELETE BBQJIT::notifyFunctionUsesSIMD()
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addSIMDLoadLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint32_t uoffset, uint8_t lane, ExpressionType& result, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoadLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint64_t uoffset, uint8_t lane, ExpressionType& result, uint8_t memoryIndex)
 {
     Width width;
     switch (op) {
@@ -3923,7 +3923,7 @@ void NODELETE BBQJIT::notifyFunctionUsesSIMD()
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addSIMDStoreLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint32_t uoffset, uint8_t lane, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::addSIMDStoreLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint64_t uoffset, uint8_t lane, uint8_t memoryIndex)
 {
     Width width;
     switch (op) {
@@ -3970,7 +3970,7 @@ void NODELETE BBQJIT::notifyFunctionUsesSIMD()
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addSIMDLoadExtend(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoadExtend(SIMDLaneOperation op, ExpressionType pointer, uint64_t uoffset, ExpressionType& result, uint8_t memoryIndex)
 {
     SIMDLane lane;
     SIMDSignMode signMode;
@@ -4019,7 +4019,7 @@ void NODELETE BBQJIT::notifyFunctionUsesSIMD()
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addSIMDLoadPad(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoadPad(SIMDLaneOperation op, ExpressionType pointer, uint64_t uoffset, ExpressionType& result, uint8_t memoryIndex)
 {
     result = emitCheckAndPrepareAndMaterializePointerApply(pointer, uoffset, op == SIMDLaneOperation::LoadPad32 ? sizeof(float) : sizeof(double), memoryIndex, [&](auto location) -> Value {
         consume(pointer);

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -691,17 +691,17 @@ public:
     [[nodiscard]] PartialResult addCrash() CONST_EXPR_STUB
     bool NODELETE usesSIMD() { return false; }
     void NODELETE notifyFunctionUsesSIMD() { }
-    [[nodiscard]] PartialResult addSIMDLoad(ExpressionType, uint32_t, ExpressionType&, uint8_t) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addSIMDStore(ExpressionType, ExpressionType, uint32_t, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDLoad(ExpressionType, uint64_t, ExpressionType&, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDStore(ExpressionType, ExpressionType, uint64_t, uint8_t) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&, uint8_t) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&, uint8_t) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, uint8_t) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&, uint8_t) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint64_t, ExpressionType&, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint64_t, uint8_t, ExpressionType&, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint64_t, uint8_t, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint64_t, ExpressionType&, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint64_t, ExpressionType&, uint8_t) CONST_EXPR_STUB
     [[nodiscard]] ExpressionType NODELETE addSIMDConstant(v128_t vector)
     {
         RELEASE_ASSERT(Options::useWasmSIMD());

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -1050,7 +1050,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
     UNUSED_VARIABLE(pushUnreachable);
     UNUSED_PARAM(optionalRelation);
 
-    auto parseMemOp = [&] (uint32_t& offset, TypedExpression& pointer, uint8_t& memoryIndex) -> PartialResult {
+    auto parseMemOp = [&] (uint64_t& offset, TypedExpression& pointer, uint8_t& memoryIndex) -> PartialResult {
         uint32_t maxAlignment;
         switch (op) {
         case SIMDLaneOperation::LoadLane8:
@@ -1093,7 +1093,13 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         uint32_t alignment;
         WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get simd memory op alignment"_s);
         WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get simd memory index"_s);
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get simd memory op offset"_s);
+        if (m_info.memory(memoryIndex).isMemory64())
+            WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get simd memory op offset"_s);
+        else {
+            uint32_t offset32;
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get simd memory op offset"_s);
+            offset = offset32;
+        }
 
         WASM_VALIDATOR_FAIL_IF(alignment > maxAlignment, "alignment: "_s, alignment, " can't be larger than max alignment for simd operation: "_s, maxAlignment);
 
@@ -1101,7 +1107,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
             return { };
 
         WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "simd memory op pointer"_s);
-        WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), "pointer must be i32"_s);
+        WASM_VALIDATOR_FAIL_IF(pointer.type().kind() != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), "pointer type mismatch"_s);
 
         return { };
     };
@@ -1208,7 +1214,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
     case SIMDLaneOperation::LoadSplat32:
     case SIMDLaneOperation::LoadSplat64:
     case SIMDLaneOperation::Load: {
-        uint32_t offset;
+        uint64_t offset;
         TypedExpression pointer;
         uint8_t memoryIndex;
         WASM_FAIL_IF_HELPER_FAILS(parseMemOp(offset, pointer, memoryIndex));
@@ -1235,7 +1241,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
             WASM_VALIDATOR_FAIL_IF(!val.type().isV128(), "store vector must be v128"_s);
         }
 
-        uint32_t offset;
+        uint64_t offset;
         TypedExpression pointer;
         uint8_t memoryIndex;
         WASM_FAIL_IF_HELPER_FAILS(parseMemOp(offset, pointer, memoryIndex));
@@ -1251,7 +1257,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
     case SIMDLaneOperation::LoadLane16:
     case SIMDLaneOperation::LoadLane32:
     case SIMDLaneOperation::LoadLane64: {
-        uint32_t offset;
+        uint64_t offset;
         TypedExpression pointer;
         TypedExpression vector;
         uint8_t laneIndex;
@@ -1294,7 +1300,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
     case SIMDLaneOperation::StoreLane16:
     case SIMDLaneOperation::StoreLane32:
     case SIMDLaneOperation::StoreLane64: {
-        uint32_t offset;
+        uint64_t offset;
         TypedExpression pointer;
         TypedExpression vector;
         uint8_t laneIndex;
@@ -1335,7 +1341,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
     case SIMDLaneOperation::LoadExtend16S:
     case SIMDLaneOperation::LoadExtend32U:
     case SIMDLaneOperation::LoadExtend32S: {
-        uint32_t offset;
+        uint64_t offset;
         TypedExpression pointer;
         uint8_t memoryIndex;
 
@@ -1354,7 +1360,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
     }
     case SIMDLaneOperation::LoadPad32:
     case SIMDLaneOperation::LoadPad64: {
-        uint32_t offset;
+        uint64_t offset;
         TypedExpression pointer;
         uint8_t memoryIndex;
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -244,17 +244,17 @@ public:
 
     bool NODELETE usesSIMD() { return m_usesSIMD; }
     void NODELETE notifyFunctionUsesSIMD() { ASSERT(Options::useWasmSIMD()); m_usesSIMD = true; }
-    [[nodiscard]] PartialResult addSIMDLoad(ExpressionType, uint32_t, ExpressionType&, uint8_t);
-    [[nodiscard]] PartialResult addSIMDStore(ExpressionType, ExpressionType, uint32_t, uint8_t);
+    [[nodiscard]] PartialResult addSIMDLoad(ExpressionType, uint64_t, ExpressionType&, uint8_t);
+    [[nodiscard]] PartialResult addSIMDStore(ExpressionType, ExpressionType, uint64_t, uint8_t);
     [[nodiscard]] PartialResult addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&);
     [[nodiscard]] PartialResult addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&);
     [[nodiscard]] PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
     [[nodiscard]] PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
-    [[nodiscard]] PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&, uint8_t);
-    [[nodiscard]] PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&, uint8_t);
-    [[nodiscard]] PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, uint8_t);
-    [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&, uint8_t);
-    [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&, uint8_t);
+    [[nodiscard]] PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint64_t, ExpressionType&, uint8_t);
+    [[nodiscard]] PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint64_t, uint8_t, ExpressionType&, uint8_t);
+    [[nodiscard]] PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint64_t, uint8_t, uint8_t);
+    [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint64_t, ExpressionType&, uint8_t);
+    [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint64_t, ExpressionType&, uint8_t);
 
     ExpressionType addSIMDConstant(v128_t);
 
@@ -716,13 +716,13 @@ IPIntValue IPIntGenerator::addConstant(Type, uint64_t)
 
 // SIMD
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoad(ExpressionType, uint32_t, ExpressionType&, uint8_t)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoad(ExpressionType, uint64_t, ExpressionType&, uint8_t)
 {
     changeStackSize(0); // Pop address, push v128 value (net change = 0)
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDStore(ExpressionType, ExpressionType, uint32_t, uint8_t)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDStore(ExpressionType, ExpressionType, uint64_t, uint8_t)
 {
     changeStackSize(-2); // Pop address and v128 value
     return { };
@@ -751,29 +751,29 @@ IPIntValue IPIntGenerator::addConstant(Type, uint64_t)
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint64_t offset, ExpressionType& result, uint8_t memoryIndex)
 {
     return addSIMDLoad(pointer, offset, result, memoryIndex);
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&, uint8_t)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint64_t, uint8_t, ExpressionType&, uint8_t)
 {
     changeStackSize(-1);
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, uint8_t)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint64_t, uint8_t, uint8_t)
 {
     changeStackSize(-2);
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint64_t offset, ExpressionType& result, uint8_t memoryIndex)
 {
     return addSIMDLoad(pointer, offset, result, memoryIndex);
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint64_t offset, ExpressionType& result, uint8_t memoryIndex)
 {
     return addSIMDLoad(pointer, offset, result, memoryIndex);
 }

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -487,17 +487,17 @@ public:
 
     // SIMD
     void NODELETE notifyFunctionUsesSIMD() { ASSERT(m_info.usesSIMD(m_functionIndex)); }
-    [[nodiscard]] PartialResult addSIMDLoad(ExpressionType pointer, uint32_t offset, ExpressionType& result, uint8_t memoryIndex);
-    [[nodiscard]] PartialResult addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t offset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult addSIMDLoad(ExpressionType pointer, uint64_t offset, ExpressionType& result, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult addSIMDStore(ExpressionType value, ExpressionType pointer, uint64_t offset, uint8_t memoryIndex);
     [[nodiscard]] PartialResult addSIMDSplat(SIMDLane, ExpressionType scalar, ExpressionType& result);
     [[nodiscard]] PartialResult addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result);
     [[nodiscard]] PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType v, ExpressionType shift, ExpressionType& result);
     [[nodiscard]] PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType lhs, ExpressionType rhs, ExpressionType& result);
-    [[nodiscard]] PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result, uint8_t memoryIndex);
-    [[nodiscard]] PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex, ExpressionType& result, uint8_t memoryIndex);
-    [[nodiscard]] PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex, uint8_t memoryIndex);
-    [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result, uint8_t memoryIndex);
-    [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint64_t offset, ExpressionType& result, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint64_t offset, uint8_t laneIndex, ExpressionType& result, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint64_t offset, uint8_t laneIndex, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint64_t offset, ExpressionType& result, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint64_t offset, ExpressionType& result, uint8_t memoryIndex);
 
     [[nodiscard]] ExpressionType addSIMDConstant(v128_t value)
     {
@@ -1020,7 +1020,7 @@ private:
 
     void emitChecksForModOrDiv(B3::Opcode, Value* left, Value* right);
 
-    [[nodiscard]] int32_t fixupPointerPlusOffset(Value*&, uint32_t);
+    [[nodiscard]] int32_t fixupPointerPlusOffset(Value*&, uint64_t);
     [[nodiscard]] Value* fixupPointerPlusOffsetForAtomicOps(ExtAtomicOpType, Value*, uint64_t);
 
     void restoreWasmContextInstance(BasicBlock*, Value*);
@@ -1179,10 +1179,10 @@ private:
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(OMGIRGenerator);
 
-// Memory accesses in WebAssembly have unsigned 32-bit offsets, whereas they have signed 32-bit offsets in B3.
-int32_t OMGIRGenerator::fixupPointerPlusOffset(Value*& ptr, uint32_t offset)
+// Memory accesses in WebAssembly have unsigned 32-bit offsets (unsigned 64-bit offsets in memory64), whereas they have signed 32-bit offsets in B3.
+int32_t OMGIRGenerator::fixupPointerPlusOffset(Value*& ptr, uint64_t offset)
 {
-    if (static_cast<uint64_t>(offset) > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+    if (offset > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
         ptr = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), ptr, m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), offset));
         return 0;
     }
@@ -4304,7 +4304,7 @@ auto OMGIRGenerator::addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType
     return { };
 }
 
-auto OMGIRGenerator::addSIMDLoad(ExpressionType pointerVariable, uint32_t uoffset, ExpressionType& result, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::addSIMDLoad(ExpressionType pointerVariable, uint64_t uoffset, ExpressionType& result, uint8_t memoryIndex) -> PartialResult
 {
     Value* ptr = emitCheckAndPreparePointer(get(pointerVariable), uoffset, 16, memoryIndex);
     int32_t offset = fixupPointerPlusOffset(ptr, uoffset);
@@ -4315,7 +4315,7 @@ auto OMGIRGenerator::addSIMDLoad(ExpressionType pointerVariable, uint32_t uoffse
     return { };
 }
 
-auto OMGIRGenerator::addSIMDStore(ExpressionType value, ExpressionType pointerVariable, uint32_t uoffset, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::addSIMDStore(ExpressionType value, ExpressionType pointerVariable, uint64_t uoffset, uint8_t memoryIndex) -> PartialResult
 {
     Value* ptr = emitCheckAndPreparePointer(get(pointerVariable), uoffset, 16, memoryIndex);
     int32_t offset = fixupPointerPlusOffset(ptr, uoffset);
@@ -4325,7 +4325,7 @@ auto OMGIRGenerator::addSIMDStore(ExpressionType value, ExpressionType pointerVa
     return { };
 }
 
-auto OMGIRGenerator::addSIMDLoadSplat(SIMDLaneOperation op, ExpressionType pointerVariable, uint32_t uoffset, ExpressionType& result, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::addSIMDLoadSplat(SIMDLaneOperation op, ExpressionType pointerVariable, uint64_t uoffset, ExpressionType& result, uint8_t memoryIndex) -> PartialResult
 {
     size_t byteSize;
 
@@ -4370,7 +4370,7 @@ auto OMGIRGenerator::addSIMDLoadSplat(SIMDLaneOperation op, ExpressionType point
     return { };
 }
 
-auto OMGIRGenerator::addSIMDLoadLane(SIMDLaneOperation op, ExpressionType pointerVariable, ExpressionType vectorVariable, uint32_t uoffset, uint8_t laneIndex, ExpressionType& result, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::addSIMDLoadLane(SIMDLaneOperation op, ExpressionType pointerVariable, ExpressionType vectorVariable, uint64_t uoffset, uint8_t laneIndex, ExpressionType& result, uint8_t memoryIndex) -> PartialResult
 {
     size_t byteSize;
     B3::Opcode loadOp;
@@ -4414,7 +4414,7 @@ auto OMGIRGenerator::addSIMDLoadLane(SIMDLaneOperation op, ExpressionType pointe
     return { };
 }
 
-auto OMGIRGenerator::addSIMDStoreLane(SIMDLaneOperation op, ExpressionType pointerVariable, ExpressionType vectorVariable, uint32_t uoffset, uint8_t laneIndex, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::addSIMDStoreLane(SIMDLaneOperation op, ExpressionType pointerVariable, ExpressionType vectorVariable, uint64_t uoffset, uint8_t laneIndex, uint8_t memoryIndex) -> PartialResult
 {
     size_t byteSize;
     B3::Opcode storeOp;
@@ -4458,7 +4458,7 @@ auto OMGIRGenerator::addSIMDStoreLane(SIMDLaneOperation op, ExpressionType point
     return { };
 }
 
-auto OMGIRGenerator::addSIMDLoadExtend(SIMDLaneOperation op, ExpressionType pointerVariable, uint32_t uoffset, ExpressionType& result, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::addSIMDLoadExtend(SIMDLaneOperation op, ExpressionType pointerVariable, uint64_t uoffset, ExpressionType& result, uint8_t memoryIndex) -> PartialResult
 {
     B3::Opcode loadOp = Load;
     size_t byteSize = 8;
@@ -4502,7 +4502,7 @@ auto OMGIRGenerator::addSIMDLoadExtend(SIMDLaneOperation op, ExpressionType poin
     return { };
 }
 
-auto OMGIRGenerator::addSIMDLoadPad(SIMDLaneOperation op, ExpressionType pointerVariable, uint32_t uoffset, ExpressionType& result, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::addSIMDLoadPad(SIMDLaneOperation op, ExpressionType pointerVariable, uint64_t uoffset, ExpressionType& result, uint8_t memoryIndex) -> PartialResult
 {
     B3::Type loadType;
     unsigned byteSize;


### PR DESCRIPTION
#### 15aa6fad53e3f14050c4e361c0fe777d5e4f0ee1
<pre>
[Memory64] Add SIMD support
<a href="https://bugs.webkit.org/show_bug.cgi?id=320755">https://bugs.webkit.org/show_bug.cgi?id=320755</a>
<a href="https://rdar.apple.com/183755031">rdar://183755031</a>

Reviewed by Keith Miller.

Add SIMD support in memory64

* JSTests/wasm/stress/memory64-simd.js: Added.
(13):
(3):
(8):
(2):
(func.export.string_appeared_here.param.addr.i64.param.value.i64.i64.store.local.addr.local.value.func.export.string_appeared_here.param.addr.i64.result.i64.i64.load.local.addr.func.export.string_appeared_here.param.delta.i64.result.i64.memory.grow):
(join):
(testAt):
(testPageOffset):
(testAddressAboveFourGigs):
(testGrow):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoad):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDStore):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadSplat):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDStoreLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadExtend):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadPad):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::simd):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addSIMDLoad):
(JSC::Wasm::IPIntGenerator::addSIMDStore):
(JSC::Wasm::IPIntGenerator::addSIMDLoadSplat):
(JSC::Wasm::IPIntGenerator::addSIMDLoadLane):
(JSC::Wasm::IPIntGenerator::addSIMDStoreLane):
(JSC::Wasm::IPIntGenerator::addSIMDLoadExtend):
(JSC::Wasm::IPIntGenerator::addSIMDLoadPad):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::fixupPointerPlusOffset):
(JSC::Wasm::OMGIRGenerator::addSIMDLoad):
(JSC::Wasm::OMGIRGenerator::addSIMDStore):
(JSC::Wasm::OMGIRGenerator::addSIMDLoadSplat):
(JSC::Wasm::OMGIRGenerator::addSIMDLoadLane):
(JSC::Wasm::OMGIRGenerator::addSIMDStoreLane):
(JSC::Wasm::OMGIRGenerator::addSIMDLoadExtend):
(JSC::Wasm::OMGIRGenerator::addSIMDLoadPad):

Canonical link: <a href="https://commits.webkit.org/318352@main">https://commits.webkit.org/318352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03f0dee413a1db3a71b319788fd7e9e52a2c3d15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187642 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9d79d352-daba-4e6a-bbff-836e3b306fc5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138773 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119229 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1dc1888-2d38-4dff-89fa-8801c0dd3838) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40981 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39334 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1198 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8013 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39021 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36100 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39301 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44565 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43575 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; 339 new passes 9 flakes 16 failures; Uploaded test results; 339 new passes 11 flakes 16 failures; Compiled WebKit (warnings); layout-tests; Passed layout tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190069 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51635 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147913 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39727 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52317 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147690 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42397 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124580 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119050 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50833 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13993 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50220 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->