### PR TITLE
[JSC] wasm/js-api/Instance.imports.exports.unicode.js: reuse the import and export descriptor arrays instead of rebuilding them for every check

### DIFF
--- a/JSTests/wasm/js-api/Instance.imports.exports.unicode.js
+++ b/JSTests/wasm/js-api/Instance.imports.exports.unicode.js
@@ -81,14 +81,17 @@ b = b.End();
 
 const module = new WebAssembly.Module(b.WebAssembly().get());
 
-for (let idxModule = 0; idxModule < names.length; ++idxModule)   
+const imports = WebAssembly.Module.imports(module);
+for (let idxModule = 0; idxModule < names.length; ++idxModule)
     for (let idxField = 0; idxField < names.length; ++idxField) {
-        assert.eq(WebAssembly.Module.imports(module)[idxModule * names.length + idxField].module, names[idxModule]);
-        assert.eq(WebAssembly.Module.imports(module)[idxModule * names.length + idxField].name, names[idxField]);
+        const reflectedImport = imports[idxModule * names.length + idxField];
+        assert.eq(reflectedImport.module, names[idxModule]);
+        assert.eq(reflectedImport.name, names[idxField]);
     }
 
+const exports = WebAssembly.Module.exports(module);
 for (let idx = 0; idx < names.length; ++idx)
-    assert.eq(WebAssembly.Module.exports(module)[idx].name, names[idx]);
+    assert.eq(exports[idx].name, names[idx]);
 
 const instance = new WebAssembly.Instance(module, importObject);
 


### PR DESCRIPTION
#### db4f6aa69ab27ed7346a92cbaffccbfdb25eee67
<pre>
[JSC] wasm/js-api/Instance.imports.exports.unicode.js: reuse the import and export descriptor arrays instead of rebuilding them for every check
<a href="https://bugs.webkit.org/show_bug.cgi?id=320756">https://bugs.webkit.org/show_bug.cgi?id=320756</a>

Reviewed by Yusuke Suzuki.

Cache the import and export descriptor arrays before checking their contents.
Calling WebAssembly.Module.imports() for every imported name rebuilt the
import descriptor around ~961 times and the export one around 31 times,
causing excessive allocation and garbage collection without adding test
coverage.

This was causing this test to be very slow on Release+Asserts for WPE ARM64,
usually timing out.
After this fix the total time to run it went from several minutes to less
than 2 seconds

* JSTests/wasm/js-api/Instance.imports.exports.unicode.js:
(idxModule):

Canonical link: <a href="https://commits.webkit.org/318362@main">https://commits.webkit.org/318362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53835c9d13551883bdf38fbff95766e1699e2b1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187622 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51658 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138755 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; 8 flakes 1 failures; Uploaded test results; layout-tests; Passed layout tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119211 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40966 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39320 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1180 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8000 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39008 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36082 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39282 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190051 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51617 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147891 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52299 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147670 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42383 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119032 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50806 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13980 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50202 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50442 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->