### PR TITLE
Web Inspector: Canvas: support WebGPU content previews

### DIFF
--- a/LayoutTests/inspector/canvas/requestContent-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/requestContent-webgpu-expected.txt
@@ -1,0 +1,17 @@
+Test that Canvas.requestContent can retrieve the presented content of a WebGPU canvas.
+
+
+== Running test suite: Canvas.requestContent.WebGPU
+-- Running test case: Canvas.requestContent.WebGPU.HTMLCanvasElement
+PASS: Content should match the presented HTML canvas.
+PASS: Repeated content should match the same presented HTML canvas.
+
+-- Running test case: Canvas.requestContent.WebGPU.OffscreenCanvas
+PASS: Content should match the presented OffscreenCanvas.
+
+-- Running test case: Canvas.requestContent.WebGPU.MultipleCanvases
+PASS: Requesting content with multiple configured canvases should return an error.
+
+-- Running test case: Canvas.requestContent.WebGPU.NoCanvases
+PASS: Requesting content without a configured canvas should return an error.
+

--- a/LayoutTests/inspector/canvas/requestContent-webgpu.html
+++ b/LayoutTests/inspector/canvas/requestContent-webgpu.html
@@ -1,0 +1,152 @@
+<!-- webkit-test-runner [ WebGPUEnabled=true OffscreenCanvasEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+let adapter = null;
+let device = null;
+let htmlCanvasContext = null;
+let offscreenCanvas = null;
+let offscreenCanvasContext = null;
+let expectedOffscreenCanvasContent = null;
+
+async function render(context, clearValue) {
+    let commandEncoder = device.createCommandEncoder();
+    let renderPassEncoder = commandEncoder.beginRenderPass({
+        colorAttachments: [{
+            view: context.getCurrentTexture().createView(),
+            clearValue,
+            loadOp: "clear",
+            storeOp: "store",
+        }],
+    });
+    renderPassEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+}
+
+async function configureHTMLCanvas() {
+    htmlCanvasContext.configure({
+        device,
+        format: navigator.gpu.getPreferredCanvasFormat(),
+    });
+    await render(htmlCanvasContext, {r: 1, g: 0, b: 0, a: 1});
+}
+
+function expectedHTMLCanvasContent() {
+    let canvas = document.createElement("canvas");
+    canvas.width = 4;
+    canvas.height = 4;
+    let context = canvas.getContext("2d");
+    context.fillStyle = "red";
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    return canvas.toDataURL();
+}
+
+async function useOffscreenCanvasOnly() {
+    htmlCanvasContext.unconfigure();
+
+    offscreenCanvas = new OffscreenCanvas(4, 4);
+    offscreenCanvasContext = offscreenCanvas.getContext("webgpu");
+    offscreenCanvasContext.configure({
+        device,
+        format: navigator.gpu.getPreferredCanvasFormat(),
+    });
+    await render(offscreenCanvasContext, {r: 0, g: 1, b: 0, a: 1});
+
+    let blob = await offscreenCanvas.convertToBlob();
+    expectedOffscreenCanvasContent = await new Promise((resolve) => {
+        let reader = new FileReader;
+        reader.addEventListener("load", () => { resolve(reader.result); });
+        reader.readAsDataURL(blob);
+    });
+    TestPage.dispatchEventToFrontend("OffscreenCanvasReady");
+}
+
+async function useMultipleCanvases() {
+    await configureHTMLCanvas();
+    TestPage.dispatchEventToFrontend("MultipleCanvasesReady");
+}
+
+function unconfigureCanvases() {
+    htmlCanvasContext.unconfigure();
+    offscreenCanvasContext.unconfigure();
+}
+
+async function load() {
+    adapter = await navigator.gpu.requestAdapter();
+    device = await adapter.requestDevice();
+
+    let htmlCanvas = document.getElementById("webgpu-canvas");
+    htmlCanvasContext = htmlCanvas.getContext("webgpu");
+    await configureHTMLCanvas();
+
+    runTest();
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("Canvas.requestContent.WebGPU");
+    let canvas = Array.from(WI.canvasManager.canvasCollection).find((canvas) => canvas.contextType === WI.Canvas.ContextType.WebGPU);
+    InspectorTest.assert(canvas, "There should be a WebGPU Canvas.");
+
+    suite.addTestCase({
+        name: "Canvas.requestContent.WebGPU.HTMLCanvasElement",
+        description: "Check that requestContent returns the presented content of an HTML canvas configured with the GPUDevice.",
+        async test() {
+            let content = await canvas.requestContent();
+            let expectedContent = await InspectorTest.evaluateInPage(`expectedHTMLCanvasContent()`);
+            InspectorTest.expectEqual(content, expectedContent, "Content should match the presented HTML canvas.");
+
+            content = await canvas.requestContent();
+            InspectorTest.expectEqual(content, expectedContent, "Repeated content should match the same presented HTML canvas.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.requestContent.WebGPU.OffscreenCanvas",
+        description: "Check that requestContent returns the presented content of an OffscreenCanvas configured with the GPUDevice.",
+        async test() {
+            let readyPromise = InspectorTest.awaitEvent("OffscreenCanvasReady");
+            InspectorTest.evaluateInPage(`void useOffscreenCanvasOnly()`);
+            await readyPromise;
+
+            let content = await canvas.requestContent();
+            let expectedContent = await InspectorTest.evaluateInPage(`expectedOffscreenCanvasContent`);
+            InspectorTest.expectEqual(content, expectedContent, "Content should match the presented OffscreenCanvas.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.requestContent.WebGPU.MultipleCanvases",
+        description: "Check that requestContent rejects a GPUDevice shared by multiple configured canvases instead of choosing an arbitrary canvas.",
+        async test() {
+            let readyPromise = InspectorTest.awaitEvent("MultipleCanvasesReady");
+            InspectorTest.evaluateInPage(`void useMultipleCanvases()`);
+            await readyPromise;
+
+            let error = await canvas.target.CanvasAgent.requestContent(canvas.identifier).then(() => null, (error) => error);
+            InspectorTest.expectTrue(!!error, "Requesting content with multiple configured canvases should return an error.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.requestContent.WebGPU.NoCanvases",
+        description: "Check that requestContent rejects a GPUDevice without a configured canvas.",
+        async test() {
+            await InspectorTest.evaluateInPage(`unconfigureCanvases()`);
+
+            let error = await canvas.target.CanvasAgent.requestContent(canvas.identifier).then(() => null, (error) => error);
+            InspectorTest.expectTrue(!!error, "Requesting content without a configured canvas should return an error.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="window.testRunner?.waitUntilDone(); load()">
+    <canvas id="webgpu-canvas" width="4" height="4"></canvas>
+    <p>Test that Canvas.requestContent can retrieve the presented content of a WebGPU canvas.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/canvas/worker-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/worker-webgpu-expected.txt
@@ -8,6 +8,7 @@ PASS: WebGPU Canvas should belong to the Worker target.
 PASS: Payload should have type "object".
 PASS: Payload should have className "GPUDevice".
 PASS: Worker GPUDevice should have no DOM client nodes.
+PASS: Worker WebGPU Canvas content should not be empty.
 
 -- Running test case: Canvas.WebGPU.Worker.Terminate
 PASS: Removed the expected Worker target.

--- a/LayoutTests/inspector/canvas/worker-webgpu.html
+++ b/LayoutTests/inspector/canvas/worker-webgpu.html
@@ -44,6 +44,9 @@ async function test() {
 
             let clientNodes = await new Promise((resolve) => canvas.requestClientNodes(resolve));
             InspectorTest.expectEqual(clientNodes.length, 0, "Worker GPUDevice should have no DOM client nodes.");
+
+            let content = await canvas.requestContent();
+            InspectorTest.expectGreaterThan(content.length, "data:image/png;base64,".length, "Worker WebGPU Canvas content should not be empty.");
         },
     });
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4246,6 +4246,7 @@ fast/webgpu [ Skip ]
 http/tests/webgpu/webgpu/api/operation/memory_sync/buffer/multiple_buffers.html [ Skip ]
 inspector/canvas/create-context-webgpu.html [ Skip ]
 inspector/canvas/requestClientNodes-webgpu.html [ Skip ]
+inspector/canvas/requestContent-webgpu.html [ Skip ]
 inspector/canvas/resolveContext-webgpu.html [ Skip ]
 inspector/canvas/worker-webgpu.html [ Skip ]
 

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -114,6 +114,7 @@ http/tests/webgpu [ Skip ]
 fast/webgpu [ Skip ]
 inspector/canvas/create-context-webgpu.html [ Skip ]
 inspector/canvas/requestClientNodes-webgpu.html [ Skip ]
+inspector/canvas/requestContent-webgpu.html [ Skip ]
 inspector/canvas/resolveContext-webgpu.html [ Skip ]
 inspector/canvas/worker-webgpu.html [ Skip ]
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -91,7 +91,8 @@ public:
     // Web Inspector and similar reads from the engine reads both.
     enum class SurfaceBuffer : uint8_t {
         DrawingBuffer,
-        DisplayBuffer
+        DisplayBuffer,
+        DisplayBufferForInspector,
     };
 
     // Draws the source buffer to the canvasBase().buffer().

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -111,6 +111,7 @@ private:
         GPUCanvasAlphaMode compositingAlphaMode { GPUCanvasAlphaMode::Opaque };
         Vector<MachSendRight> renderBuffers;
         unsigned frameCount { 0 };
+        std::optional<unsigned> lastPresentedFrameIndex;
     };
     std::optional<Configuration> m_configuration;
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -362,7 +362,7 @@ void GPUCanvasContextCocoa::didUpdateCanvasSizeProperties(bool)
     }
 }
 
-RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuffer)
+RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuffer sourceBuffer)
 {
     RefPtr scriptExecutionContext = protect(canvasBase())->scriptExecutionContext();
     if (!scriptExecutionContext)
@@ -376,7 +376,6 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
     }
     RefPtr<ImageBuffer> buffer = m_readDisplayBuffer;
 
-    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=263957): WebGPU should support obtaining drawing buffer for Web Inspector.
     if (!m_configuration)
         return buffer;
 
@@ -384,6 +383,14 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
 #if HAVE(SUPPORT_HDR_DISPLAY)
     updateScreenHeadroomFromScreenPropertiesIfNeeded();
 #endif
+
+    if (sourceBuffer == SurfaceBuffer::DisplayBufferForInspector && m_configuration->lastPresentedFrameIndex) {
+        if (buffer) {
+            buffer->flushDrawingContext();
+            m_compositorIntegration->paintCompositedResultsToCanvas(*buffer, *m_configuration->lastPresentedFrameIndex);
+        }
+        return buffer;
+    }
 
     auto frameCount = m_configuration->frameCount;
     m_compositorIntegration->prepareForDisplay(frameCount, [weakThis = WeakPtr { *this }, frameCount, buffer] {
@@ -418,6 +425,9 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::transferToImageBuffer()
         m_compositorIntegration->paintCompositedResultsToCanvas(bufferRef, m_configuration->frameCount);
         m_currentTexture = nullptr;
         m_presentationContext->present(m_configuration->frameCount, true);
+        m_configuration->lastPresentedFrameIndex = std::nullopt;
+        m_readDisplayBuffer = nullptr;
+        updateMemoryCost();
     }
     return bufferRef;
 }
@@ -530,6 +540,7 @@ ExceptionOr<void> GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& conf
         configuration.alphaMode,
         WTF::move(renderBuffers),
         0,
+        std::nullopt,
     };
     InspectorInstrumentation::didChangeGPUDeviceClientNodes(m_configuration->device);
     return { };
@@ -621,6 +632,7 @@ void GPUCanvasContextCocoa::present(uint32_t frameIndex)
         return;
 
     m_compositingResultsNeedsUpdating = false;
+    m_configuration->lastPresentedFrameIndex = frameIndex;
     m_configuration->frameCount = (m_configuration->frameCount + 1) % m_configuration->renderBuffers.size();
     if (RefPtr currentTexture = m_currentTexture)
         currentTexture->destroy();

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -612,7 +612,7 @@ Ref<Inspector::Protocol::Recording::Recording> InspectorCanvas::releaseObjectFor
 
 Inspector::Protocol::ErrorStringOr<String> InspectorCanvas::getContentAsDataURL(CanvasRenderingContext& context)
 {
-    auto surfaceBuffer = context.compositingResultsNeedUpdating() ? CanvasRenderingContext::SurfaceBuffer::DrawingBuffer : CanvasRenderingContext::SurfaceBuffer::DisplayBuffer;
+    auto surfaceBuffer = context.compositingResultsNeedUpdating() ? CanvasRenderingContext::SurfaceBuffer::DrawingBuffer : CanvasRenderingContext::SurfaceBuffer::DisplayBufferForInspector;
     return encodeDataURL(context.surfaceBufferToImageBuffer(surfaceBuffer), "image/png"_s);
 }
 
@@ -623,8 +623,24 @@ Inspector::Protocol::ErrorStringOr<String> InspectorCanvas::getContentAsDataURL(
             Ref context = weakContext;
             return getContentAsDataURL(context);
         },
-        [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>&) -> Inspector::Protocol::ErrorStringOr<String> {
-            return makeUnexpected("Canvas content is not available for WebGPU devices"_s);
+        [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>& weakDevice) -> Inspector::Protocol::ErrorStringOr<String> {
+            Ref device = weakDevice;
+            RefPtr<CanvasRenderingContext> context;
+            {
+                Locker locker { CanvasRenderingContext::instancesLock() };
+                for (SUPPRESS_UNCOUNTED_ARG auto* candidate : CanvasRenderingContext::instances()) {
+                    if (!candidate->isContextThread() || !canvasContextMatchesDevice(*candidate, device))
+                        continue;
+                    if (context) {
+                        context = nullptr;
+                        break;
+                    }
+                    context = candidate;
+                }
+            }
+            if (!context)
+                return makeUnexpected("GPUDevice must be configured for one <canvas>."_s);
+            return getContentAsDataURL(*context);
         }
     );
 }

--- a/Source/WebInspectorUI/UserInterface/Models/Canvas.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Canvas.js
@@ -178,15 +178,6 @@ WI.Canvas = class Canvas extends WI.Object
         Canvas._nextDeviceUniqueDisplayNameNumber = 1;
     }
 
-    static supportsRequestContentForContextType(contextType)
-    {
-        switch (contextType) {
-        case Canvas.ContextType.WebGPU:
-            return false;
-        }
-        return true;
-    }
-
     // Public
 
     get target() { return this._target; }
@@ -304,9 +295,6 @@ WI.Canvas = class Canvas extends WI.Object
 
     requestContent()
     {
-        if (!Canvas.supportsRequestContentForContextType(this._contextType))
-            return Promise.resolve(null);
-
         return this._target.CanvasAgent.requestContent(this._identifier).then((result) => result.content).catch((error) => console.error(error));
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js
@@ -254,7 +254,7 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
             this._previewImageElement.remove();
 
         if (!this._errorElement) {
-            let isError = WI.Canvas.supportsRequestContentForContextType(this.representedObject.contextType);
+            const isError = true;
             this._errorElement = WI.createMessageTextView(WI.UIString("No Preview Available"), isError);
         }
 


### PR DESCRIPTION
#### f3e5851b864323666e900682868f4ac22c98b1e6
<pre>
Web Inspector: Canvas: support WebGPU content previews
<a href="https://bugs.webkit.org/show_bug.cgi?id=320702">https://bugs.webkit.org/show_bug.cgi?id=320702</a>

Reviewed by Mike Wyrzykowski.

* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::surfaceBufferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::transferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::configure):
(WebCore::GPUCanvasContextCocoa::present):
Track the last presented buffer so snapshots of WebGPU `&lt;canvas&gt;` read the visible content without advancing the presentation buffer.
Clear the tracked content when it is transferred.

* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::getContentAsDataURL):
Use the configured `&lt;canvas&gt;` for a `GPUDevice` when capturing a snapshot.
Reject `GPUDevice` configured for multiple `&lt;canvas&gt;` since `Canvas.requestContent` only returns one image.

* Source/WebInspectorUI/UserInterface/Models/Canvas.js:
(WI.Canvas.supportsRequestContentForContextType): Deleted.
(WI.Canvas.prototype.requestContent):
* Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js:
(WI.CanvasContentView.prototype._showError):
Remove the now-unnecessary support check since all `&lt;canvas&gt;` context types support snapshotting.

* LayoutTests/inspector/canvas/requestContent-webgpu.html: Added.
* LayoutTests/inspector/canvas/requestContent-webgpu-expected.txt: Added.
* LayoutTests/inspector/canvas/worker-webgpu.html:
* LayoutTests/inspector/canvas/worker-webgpu-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/win/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/318363@main">https://commits.webkit.org/318363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf42439fa91a141400934479ad6445c72eac6063

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187696 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51730 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138815 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42363 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41029 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39066 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36154 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44620 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190124 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159094 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39735 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52371 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147736 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42447 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124634 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119108 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50889 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14038 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50274 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50514 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->