### PR TITLE
Dynamically created cross-site iframe gets stuck on about:blank after a back/forward reload

### DIFF
--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -98,6 +98,17 @@ WebBackForwardListFrameItem* WebBackForwardListFrameItem::childItemAtIndex(uint6
     return m_children[index].ptr();
 }
 
+WebBackForwardListFrameItem* WebBackForwardListFrameItem::childItemForFrameName(const String& frameName)
+{
+    if (frameName.isEmpty())
+        return nullptr;
+    for (auto& child : m_children) {
+        if (child->frameState().target == frameName)
+            return child.ptr();
+    }
+    return nullptr;
+}
+
 WebBackForwardListItem* WebBackForwardListFrameItem::backForwardListItem() const
 {
     return m_backForwardListItem.get();

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -60,6 +60,7 @@ public:
     Ref<WebBackForwardListFrameItem> rootFrame();
     Ref<WebBackForwardListFrameItem> mainFrame();
     WebBackForwardListFrameItem* NODELETE childItemForFrameID(WebCore::FrameIdentifier);
+    WebBackForwardListFrameItem* NODELETE childItemForFrameName(const String& frameName);
     WebBackForwardListFrameItem* NODELETE childItemAtIndex(uint64_t);
     const Vector<Ref<WebBackForwardListFrameItem>>& children() const { return m_children; }
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -953,7 +953,7 @@ void WebBackForwardList::backForwardListCounts(CompletionHandler<void(WebBackFor
     completionHandler(rawCounts());
 }
 
-FrameState* WebBackForwardList::findFrameStateInItem(WebCore::BackForwardItemIdentifier itemID, WebCore::FrameIdentifier parentFrameID, WebCore::FrameIdentifier childFrameID, uint64_t childFrameIndex)
+FrameState* WebBackForwardList::findFrameStateInItem(WebCore::BackForwardItemIdentifier itemID, WebCore::FrameIdentifier parentFrameID, WebCore::FrameIdentifier childFrameID, uint64_t childFrameIndex, const String& childFrameName)
 {
     RefPtr targetItem = itemForID(itemID);
     if (!targetItem)
@@ -971,11 +971,14 @@ FrameState* WebBackForwardList::findFrameStateInItem(WebCore::BackForwardItemIde
 
     RefPtr childFrameItem = parentFrameItem->childItemForFrameID(childFrameID);
     if (!childFrameItem) {
-        // The identifier is absent after session restore or cross-site child-frame recreation; fall back to position.
-        childFrameItem = parentFrameItem->childItemAtIndex(childFrameIndex);
+        // The identifier is absent after session restore or cross-site child-frame recreation
+        if (childFrameName.isEmpty())
+            childFrameItem = parentFrameItem->childItemAtIndex(childFrameIndex);
+        else
+            childFrameItem = parentFrameItem->childItemForFrameName(childFrameName);
+        if (!childFrameItem)
+            return nullptr;
     }
-    if (!childFrameItem)
-        return nullptr;
 
     return &childFrameItem->frameState();
 }

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -102,7 +102,7 @@ public:
     void backForwardAddItemShared(IPC::Connection&, Ref<FrameState>&&, LoadedWebArchive);
     void backForwardGoToItemShared(WebCore::BackForwardItemIdentifier);
 
-    FrameState* findFrameStateInItem(WebCore::BackForwardItemIdentifier, WebCore::FrameIdentifier parentFrameID, WebCore::FrameIdentifier childFrameID, uint64_t childFrameIndex);
+    FrameState* findFrameStateInItem(WebCore::BackForwardItemIdentifier, WebCore::FrameIdentifier parentFrameID, WebCore::FrameIdentifier childFrameID, uint64_t childFrameIndex, const String& childFrameName);
     void updateFrameIdentifier(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
 
     void replaceFrameStateForChild(WebBackForwardListItem&, WebCore::FrameIdentifier, Ref<FrameState>&& newFrameState);

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -896,7 +896,8 @@ final class WebBackForwardList {
         itemID: WebCore.BackForwardItemIdentifier,
         parentFrameID: WebCore.FrameIdentifier,
         childFrameID: WebCore.FrameIdentifier,
-        childFrameIndex: UInt64
+        childFrameIndex: UInt64,
+        childFrameName: WTF.String
     ) -> WebKit.FrameState? {
         guard let targetItem = itemForID(identifier: itemID) else {
             return nil
@@ -909,8 +910,12 @@ final class WebBackForwardList {
         let parentFrameItem = targetItem.mainFrameItem().childItemForFrameID(parentFrameID) ?? targetItem.mainFrameItem()
         var childFrameItem = parentFrameItem.childItemForFrameID(childFrameID)
         if childFrameItem == nil {
-            // The identifier is absent after session restore or cross-site child-frame recreation; fall back to position.
-            childFrameItem = parentFrameItem.childItemAtIndex(childFrameIndex)
+            // The identifier is absent after session restore or cross-site child-frame recreation
+            if childFrameName.isEmpty() {
+                childFrameItem = parentFrameItem.childItemAtIndex(childFrameIndex)
+            } else {
+                childFrameItem = parentFrameItem.childItemForFrameName(childFrameName)
+            }
         }
         guard let childFrameItem else {
             return nil

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9571,7 +9571,7 @@ RefPtr<FrameState> WebPageProxy::frameStateForBackForwardChildFrame(WebFrameProx
     if (!index)
         return nullptr;
 
-    RefPtr frameState = backForwardList().findFrameStateInItem(targetBackForwardItemIdentifier, frame.parentFrame()->frameID(), frame.frameID(), *index);
+    RefPtr frameState = backForwardList().findFrameStateInItem(targetBackForwardItemIdentifier, frame.parentFrame()->frameID(), frame.frameID(), *index, frame.frameName());
     if (!frameState)
         return nullptr;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -5067,6 +5067,37 @@ TEST(SiteIsolation, GoBackToNestedIframeCreatedAfterNavigatingSibling)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "c");
 }
 
+TEST(SiteIsolation, GoBackReloadsDynamicallyCreatedCrossSiteIframe)
+{
+    HTTPServer server({
+        { "/example"_s, { "<body><script>"
+            "var reloaded = sessionStorage.getItem('loaded');"
+            "sessionStorage.setItem('loaded', '1');"
+            "var iframe = document.createElement('iframe');"
+            "iframe.name = reloaded ? 'frame2' : 'frame1';"
+            "iframe.src = reloaded ? 'https://webkit.org/a2' : 'https://webkit.org/a';"
+            "document.body.appendChild(iframe);"
+            "</script></body>"_s } },
+        { "/a"_s, { "<script> alert('a'); </script>"_s } },
+        { "/a2"_s, { "<script> alert('a2'); </script>"_s } },
+        { "/b"_s, { ""_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto *configuration = server.httpsProxyConfiguration();
+    configuration.processPool = processPoolWithBackForwardCacheDisabled().get();
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    EXPECT_WK_STREQ("a", [webView _test_waitForAlert]);
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://apple.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView goBack];
+    EXPECT_WK_STREQ("a2", [webView _test_waitForAlert]);
+    EXPECT_WK_STREQ("https://webkit.org/a2", [webView objectByEvaluatingJavaScript:@"location.href" inFrame:[webView firstChildFrame]]);
+}
+
 TEST(SiteIsolation, AdvancedPrivacyProtectionsHideScreenMetricsFromBindings)
 {
     auto frameHTML = [NSString stringWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"simple" ofType:@"html"] encoding:NSUTF8StringEncoding error:NULL];


### PR DESCRIPTION
#### eb46d8c72c1f3ca11fe79ebeb31bf546bda2daba
<pre>
Dynamically created cross-site iframe gets stuck on about:blank after a back/forward reload
<a href="https://bugs.webkit.org/show_bug.cgi?id=320761">https://bugs.webkit.org/show_bug.cgi?id=320761</a>
<a href="https://rdar.apple.com/184248998">rdar://184248998</a>

Reviewed by Sihui Liu.

When useUIProcessForBackForwardItemLoading is enabled, WebPageProxy::
frameStateForBackForwardChildFrame resolves a child frame&apos;s history
entry by frame identifier, falling back to matching by sibling
position when the identifier isn&apos;t found (e.g. after session restore
or cross-site child-frame recreation). This position-based fallback
didn&apos;t verify that the entry at that position actually corresponded
to the same frame: a frame created fresh by script during a back/
forward-classified reload (e.g. a third-party iframe inserted by an
inline &lt;script&gt; before the page&apos;s load event) could match, by pure
position, a stale entry left behind by an earlier, differently-named
iframe that occupied the same child slot. The new frame was then
misrouted into loading that stale entry&apos;s URL and got stuck instead
of loading its own.

This is fixed by checking the frame name before falling back to
position.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
(TestWebKitAPI::TEST(SiteIsolation, GoBackReloadsDynamicallyCreated-
CrossSiteIframe))

* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::childItemForFrameName):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::findFrameStateInItem):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebBackForwardList.swift:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::frameStateForBackForwardChildFrame):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, GoBackReloadsDynamicallyCreatedCrossSiteIframe)):

Canonical link: <a href="https://commits.webkit.org/318789@main">https://commits.webkit.org/318789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/961ad94a60ba087d1e7fc8ab1ec0bd1dbf76b171

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189220 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b59bca8b-cd61-4c8e-b1d2-7fd0871d9228) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139894 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fd02db6-2e32-4575-bb5b-476175a36cac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120346 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ad3843c-23e9-4b4c-b884-e0b69ed14ec8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40503 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152571 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40149 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/672 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191438 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52997 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149148 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53678 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148890 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27226 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43567 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125950 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120844 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52195 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15136 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51580 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51821 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51641 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->