### PR TITLE
[JSC] Implement Crandall reduction

### DIFF
--- a/JSTests/stress/bigint-fold-mod.js
+++ b/JSTests/stress/bigint-fold-mod.js
@@ -1,0 +1,203 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+// Divisors close to a power of the digit base reduce by folding the high half of the dividend down
+// with a single-digit multiply instead of using the cached multiplicative inverse. Only divisors
+// whose reduction factor is a single digit and whose quotient into that power of two is small
+// qualify, so cover both sides of that gate and confirm the answers agree with a reference path.
+//
+// The cache is only armed after 100 uses of the same divisor, so each case loops past that
+// threshold to exercise the pre-arming and post-arming paths.
+//
+// A Digit is a CPU register, so it is 64 bits on 64-bit targets and 32 bits on 32-bit ones. Cases
+// built from a digit width run at both so the qualifying shape is hit either way.
+const digitWidths = [32, 64];
+
+// Reference modulo that does not go through the cached path.
+function refMod(a, b) {
+    return a - (a / b) * b;
+}
+
+function checkRepeated(divisor, dividend) {
+    const divisorMagnitude = divisor < 0n ? -divisor : divisor;
+    for (let i = 0; i < 150; i++) {
+        const actual = dividend % divisor;
+        shouldBe(actual, refMod(dividend, divisor));
+        // BigInt % is truncated, so the result takes the sign of the dividend.
+        const magnitude = actual < 0n ? -actual : actual;
+        if (magnitude >= divisorMagnitude)
+            throw new Error(`${actual} out of range for divisor ${divisor}`);
+    }
+}
+
+// Sweep dividends of n through 2n digits, both signs, for one divisor.
+function checkAllDividendSizes(divisor, width, n) {
+    for (let size = n; size <= 2 * n; size++) {
+        const top = 1n << BigInt(size * width);
+        for (const dividend of [top - 1n, top - 12345n, top >> 1n, (top >> 1n) | 1n]) {
+            checkRepeated(divisor, dividend);
+            checkRepeated(divisor, -dividend);
+        }
+    }
+}
+
+// Qualifying divisors: 2^k - c with a small c, so the reduction factor stays a single digit.
+for (const width of digitWidths) {
+    for (const n of [2, 3, 4, 5, 6, 8]) {
+        const bits = n * width;
+        for (const c of [1n, 19n, 977n, 4294968273n]) {
+            const divisor = (1n << BigInt(bits)) - c;
+            if (divisor <= 0n)
+                continue;
+            checkAllDividendSizes(divisor, width, n);
+        }
+        // Not filling the top digit still qualifies: the ed25519 prime is 2^255 - 19 on a 4-digit
+        // 64-bit layout, so the factor is 2 * 19 rather than 19.
+        const shortDivisor = (1n << BigInt(bits - 1)) - 19n;
+        if (shortDivisor > 0n)
+            checkAllDividendSizes(shortDivisor, width, n);
+    }
+}
+
+// The real curve primes this path exists for.
+const ed25519P = (1n << 255n) - 19n;
+const secp256k1P = (1n << 256n) - (1n << 32n) - 977n;
+const mersenne127 = (1n << 127n) - 1n;
+const mersenne521 = (1n << 521n) - 1n;
+for (const p of [ed25519P, secp256k1P, mersenne127, mersenne521]) {
+    checkRepeated(p, p - 1n);
+    checkRepeated(p, p);
+    checkRepeated(p, p + 1n);
+    checkRepeated(p, p * 2n - 1n);
+    checkRepeated(p, p * p - 1n);
+    let x = 123456789n;
+    for (let i = 0; i < 200; i++) {
+        // Reduce the unreduced square, not the already-reduced result: comparing x against
+        // refMod(x, p) would be comparing x against itself, since x is below p by construction.
+        const square = x * x;
+        x = square % p;
+        if (x >= p)
+            throw new Error(`squaring escaped the modulus: ${x}`);
+        shouldBe(x, refMod(square, p));
+    }
+}
+
+// The quotient cap is maxFoldQuotient = 4, and q alone sets how many times the corrective loop
+// subtracts, so cover the q = 3 and q = 4 qualifying boundary as well as q = 5, which must not
+// qualify and falls back to the inverse path. Each divisor is built from T = q * B + C with a
+// single-digit C:
+//   2^256 = 3 * ((2^256 - 4) / 3) + 4            (q = 3)
+//   2^256 = 4 * (2^254 - 1) + 4                  (q = 4, the largest admitted quotient)
+//   2^128 = 4 * (2^126 - 2^62 + 1) + (2^64 - 4)  (q = 4 with C near the top of a 64-bit digit;
+//                                                on 32-bit targets C spans two digits, so this
+//                                                exercises the inverse path there instead)
+//   2^256 = 5 * ((2^256 - 1) / 5) + 1            (q = 5, rejected by the cap)
+for (const width of digitWidths) {
+    const n256 = 256 / width;
+    const n128 = 128 / width;
+    checkAllDividendSizes(((1n << 256n) - 4n) / 3n, width, n256);
+    checkAllDividendSizes((1n << 254n) - 1n, width, n256);
+    checkAllDividendSizes((1n << 126n) - (1n << 62n) + 1n, width, n128);
+    checkAllDividendSizes(((1n << 256n) - 1n) / 5n, width, n256);
+}
+
+// Negative divisors take the same cached paths; only the result sign differs.
+for (const p of [ed25519P, secp256k1P]) {
+    checkRepeated(-p, p * p - 1n);
+    checkRepeated(-p, -(p * 2n + 12345n));
+}
+
+// Non-qualifying divisors must keep using the multiplicative inverse and still be correct. These
+// are the standard curve moduli whose reduction factor spans more than one digit.
+const nonQualifying = [
+    // ed25519 group order.
+    (1n << 252n) + 27742317777372353535851937790883648493n,
+    // secp256k1 group order.
+    0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141n,
+    // NIST P-256 and P-384.
+    (1n << 256n) - (1n << 224n) + (1n << 192n) + (1n << 96n) - 1n,
+    (1n << 384n) - (1n << 128n) - (1n << 96n) + (1n << 32n) - 1n,
+    // bls12-381 base field.
+    0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaabn,
+];
+for (const m of nonQualifying) {
+    checkRepeated(m, m - 1n);
+    checkRepeated(m, m * m - 1n);
+    checkRepeated(m, (m << 1n) + 12345n);
+    let x = 987654321n;
+    for (let i = 0; i < 200; i++) {
+        const square = x * x;
+        x = square % m;
+        if (x >= m)
+            throw new Error(`squaring escaped the modulus: ${x}`);
+        shouldBe(x, refMod(square, m));
+    }
+}
+
+// Switching between divisors of the same digit count: the reduction factor belongs to whichever
+// divisor is armed, so a stale one must never be applied. Arming takes 100 consecutive uses of one
+// divisor, and while neither divisor is armed a strictly alternating loop puts each call in the
+// third branch of the cache and resets the counter, so nothing is ever armed and none of this code
+// runs. Each divisor therefore gets a run of its own past the threshold first; the run right after
+// a switch is what would expose a factor or inverse left behind by the previous divisor.
+function runOfOneDivisor(divisor, dividendAt) {
+    for (let i = 0; i < 150; i++) {
+        const dividend = dividendAt(i);
+        shouldBe(dividend % divisor, refMod(dividend, divisor));
+    }
+}
+
+// A qualifying divisor against a non-qualifying one of the same size, so arming has to swap between
+// the fold factor and the multiplicative inverse in both directions.
+{
+    const qualifying = ed25519P;
+    const other = (1n << 256n) - (1n << 224n) + (1n << 192n) + (1n << 96n) - 1n;
+    const dividendAt = i => (1n << 500n) - BigInt(i) * 7919n;
+    runOfOneDivisor(qualifying, dividendAt);
+    runOfOneDivisor(other, dividendAt);
+    runOfOneDivisor(qualifying, dividendAt);
+    for (let i = 0; i < 400; i++) {
+        const dividend = dividendAt(i);
+        shouldBe(dividend % qualifying, refMod(dividend, qualifying));
+        shouldBe(dividend % other, refMod(dividend, other));
+    }
+}
+
+// Two qualifying divisors of the same size, so each must use its own factor.
+{
+    const a = ed25519P;
+    const b = secp256k1P;
+    const dividendAt = i => (1n << 480n) + BigInt(i) * 104729n;
+    runOfOneDivisor(a, dividendAt);
+    runOfOneDivisor(b, dividendAt);
+    runOfOneDivisor(a, dividendAt);
+    for (let i = 0; i < 400; i++) {
+        const dividend = dividendAt(i);
+        shouldBe(dividend % a, refMod(dividend, a));
+        shouldBe(dividend % b, refMod(dividend, b));
+    }
+}
+
+// Divisors of more than maxInPlaceCachedModSize digits (8 at a 64-bit digit width) return their
+// remainder through the out-of-line result path. That is the only fold path where an all-zero
+// result has to normalize to 0n, and the only one where a negative dividend could otherwise
+// produce a negative zero.
+for (const bits of [640n, 1280n]) {
+    const divisor = (1n << bits) - 19n;
+    checkAllDividendSizes(divisor, 64, Number(bits) / 64);
+    checkRepeated(divisor, divisor);
+    checkRepeated(divisor, -divisor);
+    checkRepeated(divisor, divisor * 3n);
+    checkRepeated(divisor, -(divisor * 3n));
+}
+
+// Powers of two have a zero reduction factor, which the factor check rejects, so they keep using
+// the multiplicative inverse; make sure they stay correct.
+for (const bits of [128n, 192n, 256n, 320n]) {
+    const divisor = 1n << bits;
+    checkRepeated(divisor, divisor - 1n);
+    checkRepeated(divisor, divisor * divisor - 1n);
+    checkRepeated(divisor, (divisor << 1n) | 1n);
+}

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -1989,6 +1989,147 @@ void JSBigInt::cachedModMakeInverse(VM& vm, std::span<const Digit> b)
     }
 }
 
+// Reduction factor for divisors close to a power of the digit base. With n = b.size() and
+// T = 2^(n * digitBits), returns C = T mod B when T = q * B + C has a single-digit C and
+// q <= maxFoldQuotient, and 0 otherwise.
+JSBigInt::Digit JSBigInt::cachedModFoldFactor(std::span<const Digit> b)
+{
+    // We would like to prepare for Crandall reduction, which is efficient when the divisor `b` is a
+    // pseudo-Mersenne number 2^k - c with a small c. A Mersenne number is 2^k - 1, like 0xff.
+    // Note the fold factor returned here is c << (n * digitBits - k) rather than c itself, since T
+    // sits at the next whole digit boundary at or above b.
+    // Efficiency needs the factor to be a single digit, which keeps each fold one multiply, and q
+    // to be small, which is what bounds the corrective loop.
+    size_t n = b.size();
+    RELEASE_ASSERT(n >= 2 && n <= maxCachedModDivisorSize);
+
+    // T is 1 followed by n zero digits, so it needs n + 1 digits. The quotient of an (n + 1)-digit
+    // value by an n-digit one needs at most two digits, and the remainder at most n.
+    std::array<Digit, maxCachedModDivisorSize + 1> t;
+    for (size_t i = 0; i < n; ++i)
+        t[i] = 0;
+    t[n] = 1;
+
+    std::array<Digit, 2> q;
+    std::array<Digit, maxCachedModDivisorSize> r;
+    // Only the returned spans are meaningful, and neither is guaranteed to have its leading zero
+    // digits trimmed, so normalize before judging their widths.
+    auto [qSpanRaw, rSpanRaw] = divideSchoolbook(std::span { q }, std::span { r }.first(n), std::span { t }.first(n + 1), b);
+    auto qSpan = normalize(qSpanRaw);
+    auto rSpan = normalize(rSpanRaw);
+
+    // A divisor B of n digits qualifies for the folding reduction when T = 2^(n * digitBits)
+    // satisfies T = q * B + C with C a single digit and q no larger than this bound.
+    //
+    // The two conditions do different jobs. C fitting one digit is what keeps each fold a
+    // single-digit multiply and caps the carry out of a fold at one digit, which is what makes two
+    // folds always sufficient. q is independent of that and sets how far the twice-folded value can
+    // still exceed B, so it alone decides how many times the corrective loop subtracts.
+    //
+    // Cost is therefore flat in C but linear in q, and it crosses the multiplicative inverse path
+    // it replaces at roughly q = 12 for a 4-digit divisor. Divisors with a single-digit C and a
+    // large q do exist (2^(n * digitBits - k) - 1 has C = 2^k and q = 2^k), so the bound is real
+    // rather than defensive. It sits well below the crossover because the moduli this path exists
+    // for cluster at the bottom of the range: the ed25519 and secp256k1 field primes give q of 2
+    // and 1, and nothing observed needs more.
+    constexpr Digit maxFoldQuotient = 4;
+    if (qSpan.size() != 1 || qSpan[0] > maxFoldQuotient)
+        return 0;
+
+    // The fold stays a single-digit multiply only when the remainder is one digit. An empty
+    // remainder would mean B divides T exactly, so B is a power of two, which the shift paths
+    // handle and which would collide with the not-qualifying sentinel anyway.
+    if (rSpan.size() != 1)
+        return 0;
+
+    return rSpan[0];
+}
+
+// This is Crandall reduction implementation. When factor is not appropriate for efficiency, we use
+// Barrett reduction instead.
+//
+// R = A mod B for a divisor whose reduction factor C = 2^(n * digitBits) mod B is a single digit.
+//
+// Splitting A into low and high halves of n digits gives A = lo + hi * 2^(n * digitBits), and
+// since 2^(n * digitBits) is congruent to C, that is congruent to lo + hi * C. Each such fold is a
+// row of single-digit multiplies.
+//
+// Two folds always suffice. Write D for the digit base. The first fold's running carry never
+// exceeds C: a column computes a[i] + a[n + i] * C + carry, so if the incoming carry is at most C
+// the total is at most (D - 1) + (D - 1) * C + C = C * D + D - 1, whose high half is again at most
+// C. The carry starts at zero, so one digit above the low n always holds it. Folding that digit
+// back multiplies it by C once more, adding less than D^2 to a value below D^n, so with n >= 2 the
+// final carry out is at most 1 and the residue stays below 2 * D^n. Since B = (D^n - C) / q, that
+// is roughly 2 * q * B, so the corrective loop runs a bounded number of times given the q cap the
+// factor check enforces.
+//
+// This wants a single-digit C, which is the Pseudo-Mersenne shape 2^k - c for a small c.
+//
+// The span extents are template parameters so that one body serves both the size-specialized and
+// the size-agnostic callers. When they are static the sizes are compile-time constants, so the fold
+// loop unrolls and the per-column bound arithmetic folds away; when they are dynamic the same source
+// keeps its loops.
+template<typename RSpan, typename ASpan, typename BSpan>
+ALWAYS_INLINE void JSBigInt::cachedModFoldImpl(RSpan r, ASpan a, BSpan b, Digit c)
+{
+    size_t n = b.size();
+
+    // First fold: r = a[0..n-1] + a[n..a.size()-1] * c, keeping the carry out separately.
+    Digit carry = 0;
+    for (size_t i = 0; i < n; ++i) {
+        Digit high = 0;
+        Digit low = a[i];
+        if (n + i < a.size()) {
+            auto [productLow, productHigh] = digitMul(a[n + i], c);
+            high = productHigh;
+            Digit addCarry = 0;
+            low = digitAdd(low, productLow, addCarry);
+            high += addCarry;
+        }
+        Digit sumCarry = 0;
+        r[i] = digitAdd(low, carry, sumCarry);
+        carry = high + sumCarry;
+    }
+
+    // Second fold: the single digit above the low n is worth c times its value.
+    if (carry) {
+        auto [productLow, productHigh] = digitMul(carry, c);
+        Digit addCarry = 0;
+        r[0] = digitAdd(r[0], productLow, addCarry);
+        Digit propagate = productHigh + addCarry;
+        for (size_t i = 1; i < n && propagate; ++i) {
+            Digit nextCarry = 0;
+            r[i] = digitAdd(r[i], propagate, nextCarry);
+            propagate = nextCarry;
+        }
+        carry = propagate;
+    }
+
+    while (carry || greaterThanOrEqual(r, b))
+        carry -= inplaceSub(r, b);
+}
+
+template<size_t N, size_t ASize>
+ALWAYS_INLINE void JSBigInt::cachedModFoldFixed(std::span<Digit, N> r, std::span<const Digit, ASize> a, std::span<const Digit, N> b, Digit c)
+{
+    static_assert(N >= 2);
+    static_assert(ASize >= N && ASize <= 2 * N);
+
+    cachedModFoldImpl(r, a, b, c);
+}
+
+void JSBigInt::cachedModFold(std::span<Digit> r, std::span<const Digit> a, std::span<const Digit> b, Digit c)
+{
+    size_t n = b.size();
+    // A one-digit divisor would leave the second fold's carry unpropagated and turn the corrective
+    // loop into a walk over the whole digit range, so fail here rather than spin.
+    RELEASE_ASSERT(n >= 2);
+    RELEASE_ASSERT(r.size() == n);
+    RELEASE_ASSERT(a.size() >= n && a.size() <= 2 * n);
+
+    cachedModFoldImpl(r, a, b, c);
+}
+
 // Compile-time-specialized form of cachedMod for a divisor of exactly N digits and a dividend of
 // exactly ASize digits. Every span size is static, so the special multiplies unroll and the
 // scratch buffer becomes a stack array with no zeroing. The arithmetic is identical to cachedMod;
@@ -2063,6 +2204,35 @@ std::span<const JSBigInt::Digit> JSBigInt::cachedMod(VM& vm, std::span<Digit> r,
     ASSERT(r.size() >= n);
 
     r = r.first(n);
+
+    // Divisors close to a power of the digit base reduce by folding the high half down with a single-digit multiply.
+    if (Digit foldFactor = vm.m_bigIntFoldFactor) {
+        if (n <= maxFixedCachedModDivisorSize) {
+            auto dispatchDividend = [&]<size_t N, size_t ASize>(auto&& self) ALWAYS_INLINE_LAMBDA -> bool {
+                if constexpr (ASize <= 2 * N) {
+                    if (a.size() == ASize) {
+                        cachedModFoldFixed<N, ASize>(r.first<N>(), a.first<ASize>(), b.first<N>(), foldFactor);
+                        return true;
+                    }
+                    return self.template operator()<N, ASize + 1>(self);
+                } else
+                    return false;
+            };
+            auto dispatchDivisor = [&]<size_t N>(auto&& self) ALWAYS_INLINE_LAMBDA -> bool {
+                if constexpr (N >= 2) {
+                    if (b.size() == N)
+                        return dispatchDividend.template operator()<N, N>(dispatchDividend);
+                    return self.template operator()<N - 1>(self);
+                } else
+                    return false;
+            };
+            if (dispatchDivisor.template operator()<maxFixedCachedModDivisorSize>(dispatchDivisor))
+                return r;
+        }
+        cachedModFold(r, a, b, foldFactor);
+        return r;
+    }
+
     // cachedModFixed reads the inverse through a static-extent span, which has no bounds check of
     // its own, and the size-agnostic path below indexes it up to n. Both rely on the inverse having
     // been rebuilt for this divisor, which happens in cachedModMakeInverse when the divisor is
@@ -2276,7 +2446,9 @@ JSBigInt::ImplResult JSBigInt::remainderImpl(JSGlobalObject* globalObject, BigIn
         } else if (vm.m_nextCachedBigIntDivisor.get() == y.toHeapBigInt(globalObject)) {
             if (++vm.m_bigIntDivisorCount >= 100) {
                 vm.m_cachedBigIntDivisor.setWithoutWriteBarrier(y.toHeapBigInt(globalObject));
-                cachedModMakeInverse(vm, ySpan);
+                vm.m_bigIntFoldFactor = cachedModFoldFactor(ySpan);
+                if (!vm.m_bigIntFoldFactor)
+                    cachedModMakeInverse(vm, ySpan); // Compute inverse when appropriate fold-factor is not found.
             }
         } else if (ySpan.size() >= 2 && ySpan.size() <= maxCachedModDivisorSize) {
             vm.m_nextCachedBigIntDivisor.setWithoutWriteBarrier(y.toHeapBigInt(globalObject));

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -599,9 +599,15 @@ private:
     // inverse through a span whose extent is fixed at compile time.
     static_assert(maxFixedCachedModDivisorSize <= maxCachedModDivisorSize);
     static void cachedModMakeInverse(VM&, std::span<const Digit> b);
+    static Digit cachedModFoldFactor(std::span<const Digit> b);
     static std::span<const Digit> cachedMod(VM&, std::span<Digit> r, std::span<const Digit>, std::span<const Digit>);
     template<size_t N, size_t ASize>
     static void cachedModFixed(VM&, std::span<Digit, N> r, std::span<const Digit, ASize>, std::span<const Digit, N> b);
+    template<typename RSpan, typename ASpan, typename BSpan>
+    static void cachedModFoldImpl(RSpan r, ASpan, BSpan b, Digit c);
+    template<size_t N, size_t ASize>
+    static void cachedModFoldFixed(std::span<Digit, N> r, std::span<const Digit, ASize>, std::span<const Digit, N> b, Digit c);
+    static void cachedModFold(std::span<Digit> r, std::span<const Digit>, std::span<const Digit> b, Digit c);
     static bool NODELETE greaterThanOrEqual(std::span<const Digit>, std::span<const Digit>);
 
     static std::span<Digit> rightShift(std::span<Digit> z, std::span<const Digit> x, unsigned);

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -642,6 +642,7 @@ public:
     WriteBarrier<JSBigInt> m_nextCachedBigIntDivisor;
     Vector<UCPURegister> m_bigIntCachedInverse;
     int m_bigIntDivisorCount { 0 };
+    UCPURegister m_bigIntFoldFactor { 0 };
 
     JSCell* orderedHashTableDeletedValue()
     {


### PR DESCRIPTION
#### 2eb77e9c947382dbf8bca4a61c0e794bb5524136
<pre>
[JSC] Implement Crandall reduction
<a href="https://bugs.webkit.org/show_bug.cgi?id=320763">https://bugs.webkit.org/show_bug.cgi?id=320763</a>
<a href="https://rdar.apple.com/183764395">rdar://183764395</a>

Reviewed by Justin Michaud.

This patch implements Crandall reduction for fast modulo calculation.
When you have

    R = A mod B
    R ≡ A (mod B)

If B is Pseudo-Mersenne (2^k - C, where C is small), then you can
decompose A into,

    R ≡ X * 2^k + Y (mod B)
    R ≡ X * C + Y (mod B)

Since X * C + Y result needs to be handled in the same way again as
X * C + Y would exceeds B again, but at most 2 times is enough. Then we
can convert mod into much cheaper computation. For example, if C is one
digit, X * C becomes multiplication with one digit, so O(N) instead of
O(N^2).

Test: JSTests/stress/bigint-fold-mod.js

* JSTests/stress/bigint-fold-mod.js: Added.
(shouldBe):
(refMod):
(checkRepeated):
(checkAllDividendSizes):
(runOfOneDivisor):
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::cachedModFoldFactor):
(JSC::JSBigInt::cachedModFoldImpl):
(JSC::JSBigInt::cachedModFoldFixed):
(JSC::JSBigInt::cachedModFold):
(JSC::JSBigInt::cachedMod):
(JSC::JSBigInt::remainderImpl):
* Source/JavaScriptCore/runtime/JSBigInt.h:
* Source/JavaScriptCore/runtime/VM.h:

Canonical link: <a href="https://commits.webkit.org/318364@main">https://commits.webkit.org/318364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95c9d40a5135d90587d7330574c1631165af68a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178072 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187685 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58461ce4-401b-4886-8547-04b43f863c5c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51719 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138822 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77e7f657-760d-45f8-b01e-5178fc6fd6d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42362 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119278 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1f12d29-17f9-4467-bc2d-5db3e8124e77) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41028 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/1247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8062 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151428 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36143 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39345 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44609 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190112 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51678 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147954 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52360 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147726 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27007 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42446 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124623 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119097 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50878 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14042 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50263 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50503 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50325 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->