### PR TITLE
[Site Isolation] Activate the audio session per web process

### DIFF
--- a/LayoutTests/http/tests/site-isolation/audio-session-active-capture-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-capture-expected.txt
@@ -1,0 +1,11 @@
+Under site isolation, capturing microphone audio activates the audio session, and stopping capture deactivates it. The UI process drives capture activation from each web process's capture-source count.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS the audio session is active once microphone capture starts
+PASS the audio session is inactive once microphone capture stops
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-capture.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-capture.html
@@ -1,0 +1,27 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/media-resources/utilities.js"></script>
+<script>
+description("Under site isolation, capturing microphone audio activates the audio session, and stopping capture deactivates it. The UI process drives capture activation from each web process's capture-source count.");
+jsTestIsAsync = true;
+
+let stream;
+
+onload = async () => {
+    internals.settings.setShouldDeactivateAudioSession(true);
+
+    try {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        await waitForAudioSessionActiveState(true);
+        testPassed("the audio session is active once microphone capture starts");
+
+        stream.getTracks().forEach(track => track.stop());
+        await waitForAudioSessionActiveState(false);
+        testPassed("the audio session is inactive once microphone capture stops");
+    } catch (e) {
+        testFailed(e.message);
+    }
+
+    finishJSTest();
+};
+</script>

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-in-cross-site-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-in-cross-site-iframe-expected.txt
@@ -1,0 +1,12 @@
+Under site isolation, audio played in a cross-site iframe activates the audio session in the iframe's own process. The main frame runs in a separate process that produced no audio, so it does not observe the session as active (own-process attribution).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS frameResult is "active"
+PASS event.origin is "http://localhost:8000"
+PASS internals.audioSessionActive() is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-in-cross-site-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-in-cross-site-iframe.html
@@ -1,0 +1,27 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Under site isolation, audio played in a cross-site iframe activates the audio session in the iframe's own process. The main frame runs in a separate process that produced no audio, so it does not observe the session as active (own-process attribution).");
+jsTestIsAsync = true;
+
+onload = () => {
+    window.onmessage = (event) => {
+        frameResult = event.data;
+        shouldBeEqualToString("frameResult", "active");
+        shouldBeEqualToString("event.origin", "http://localhost:8000");
+        shouldBeFalse("internals.audioSessionActive()");
+        finishJSTest();
+    };
+    // localhost and 127.0.0.1 are different sites, so the iframe runs in a different process.
+    const iframe = document.createElement("iframe");
+    iframe.src = "http://localhost:8000/site-isolation/resources/audio-session-active-frame.html";
+    document.body.appendChild(iframe);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-in-same-site-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-in-same-site-iframe-expected.txt
@@ -1,0 +1,11 @@
+Under site isolation, audio played in a same-site iframe activates the audio session; because the iframe shares the main frame's process, the main frame observes the session as active too.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS frameResult is "active"
+PASS internals.audioSessionActive() is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-in-same-site-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-in-same-site-iframe.html
@@ -1,0 +1,25 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Under site isolation, audio played in a same-site iframe activates the audio session; because the iframe shares the main frame's process, the main frame observes the session as active too.");
+jsTestIsAsync = true;
+
+onload = () => {
+    window.onmessage = (event) => {
+        frameResult = event.data;
+        shouldBeEqualToString("frameResult", "active");
+        shouldBeTrue("internals.audioSessionActive()");
+        finishJSTest();
+    };
+    const iframe = document.createElement("iframe");
+    iframe.src = "http://127.0.0.1:8000/site-isolation/resources/audio-session-active-frame.html";
+    document.body.appendChild(iframe);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-replay-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-replay-expected.txt
@@ -1,0 +1,11 @@
+Under site isolation, stopping audio and immediately starting it again re-activates the audio session, without racing the stale in-flight deactivation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS the audio session is active
+PASS the audio session is active after replay
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-replay.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-replay.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/media-resources/utilities.js"></script>
+<script>
+description("Under site isolation, stopping audio and immediately starting it again re-activates the audio session, without racing the stale in-flight deactivation.");
+jsTestIsAsync = true;
+
+let context;
+
+onload = async () => {
+    try {
+        context = await startNearSilentAudioContext();
+        await waitForAudioSessionActiveState(true);
+        testPassed("the audio session is active");
+
+        // Stop, then immediately replay. close()'s deactivation is still in flight when the new context
+        // starts; the replay must still leave the audio session active rather than have the late
+        // deactivation win.
+        await context.close();
+        context = await startNearSilentAudioContext();
+        await waitForAudioSessionActiveState(true);
+        testPassed("the audio session is active after replay");
+
+        await context.close();
+    } catch (e) {
+        testFailed(e.message);
+    }
+    finishJSTest();
+};
+</script>

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-two-pages-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-two-pages-expected.txt
@@ -1,0 +1,12 @@
+Under site isolation, two pages in different processes each activate their own audio session; one page being active must not deny the other activation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS the audio session is active in this page
+PASS messageType is "audioSessionActive"
+PASS openedPageAudioSessionActive is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-two-pages.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-two-pages.html
@@ -1,0 +1,46 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/media-resources/utilities.js"></script>
+</head>
+<body>
+<script>
+description("Under site isolation, two pages in different processes each activate their own audio session; one page being active must not deny the other activation.");
+jsTestIsAsync = true;
+
+let context;
+
+onload = async () => {
+    if (!window.internals) {
+        testFailed("This test requires the Internals API");
+        finishJSTest();
+        return;
+    }
+
+    try {
+        context = await startNearSilentAudioContext();
+        await waitForAudioSessionActiveState(true);
+        testPassed("the audio session is active in this page");
+    } catch (e) {
+        testFailed(e.message);
+        finishJSTest();
+        return;
+    }
+
+    window.addEventListener("message", (event) => {
+        messageType = event.data.type;
+        openedPageAudioSessionActive = event.data.active;
+        shouldBeEqualToString("messageType", "audioSessionActive");
+        shouldBeTrue("openedPageAudioSessionActive");
+        openedWindow.close();
+        finishJSTest();
+    }, { once: true });
+
+    // localhost and 127.0.0.1 are different sites, so the opened page runs in a different process.
+    openedWindow = window.open("http://localhost:8000/site-isolation/resources/report-audio-session-active.html");
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-video-element-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-video-element-expected.txt
@@ -1,4 +1,4 @@
-Under site isolation, audio played in the main frame activates the audio session, and the web process observes it via AudioSession::isActive().
+Under site isolation, a video element playing audio in the main frame activates the audio session, and the web process observes it via AudioSession::isActive().
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-video-element-replay-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-video-element-replay-expected.txt
@@ -1,0 +1,11 @@
+Under site isolation, pausing a video element and immediately playing it again re-activates the audio session, without racing the stale in-flight deactivation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS the audio session is active
+PASS the audio session is active after replay
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-video-element-replay.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-video-element-replay.html
@@ -1,0 +1,47 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/media-resources/utilities.js"></script>
+</head>
+<body>
+<video></video>
+<script>
+description("Under site isolation, pausing a video element and immediately playing it again re-activates the audio session, without racing the stale in-flight deactivation.");
+jsTestIsAsync = true;
+
+let video;
+
+onload = async () => {
+    if (!window.internals) {
+        testFailed("This test requires the Internals API");
+        finishJSTest();
+        return;
+    }
+
+    video = document.querySelector("video");
+    video.src = "/media/resources/test.mp4";
+    video.volume = 0.001;
+
+    playIgnoringAbort(video);
+    try {
+        await waitForAudioSessionActiveState(true);
+        testPassed("the audio session is active");
+
+        // Stop, then immediately replay. Any deactivation triggered by the pause is still in flight when
+        // the new playback starts; the replay must still leave the audio session active.
+        video.pause();
+        playIgnoringAbort(video);
+        await waitForAudioSessionActiveState(true);
+        testPassed("the audio session is active after replay");
+    } catch (e) {
+        testFailed(e.message);
+    }
+
+    video.pause();
+    finishJSTest();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-video-element-two-pages-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-video-element-two-pages-expected.txt
@@ -1,0 +1,12 @@
+Under site isolation, two pages in different processes each playing a video element activate their own audio session; one page being active must not deny the other activation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS the audio session is active in this page
+PASS messageType is "audioSessionActive"
+PASS openedPageAudioSessionActive is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-video-element-two-pages.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-video-element-two-pages.html
@@ -1,0 +1,50 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/media-resources/utilities.js"></script>
+</head>
+<body>
+<video></video>
+<script>
+description("Under site isolation, two pages in different processes each playing a video element activate their own audio session; one page being active must not deny the other activation.");
+jsTestIsAsync = true;
+
+let video;
+
+onload = async () => {
+    if (!window.internals) {
+        testFailed("This test requires the Internals API");
+        finishJSTest();
+        return;
+    }
+
+    video = document.querySelector("video");
+    video.src = "/media/resources/test.mp4";
+    video.volume = 0.001;
+    playIgnoringAbort(video);
+    try {
+        await waitForAudioSessionActiveState(true);
+        testPassed("the audio session is active in this page");
+    } catch (e) {
+        testFailed(e.message);
+        finishJSTest();
+        return;
+    }
+
+    window.addEventListener("message", (event) => {
+        messageType = event.data.type;
+        openedPageAudioSessionActive = event.data.active;
+        shouldBeEqualToString("messageType", "audioSessionActive");
+        shouldBeTrue("openedPageAudioSessionActive");
+        openedWindow.close();
+        finishJSTest();
+    }, { once: true });
+
+    // localhost and 127.0.0.1 are different sites, so the opened page runs in a different process.
+    openedWindow = window.open("http://localhost:8000/site-isolation/resources/report-video-element-audio-session-active.html");
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/audio-session-active-video-element.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active-video-element.html
@@ -1,0 +1,42 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/media-resources/utilities.js"></script>
+</head>
+<body>
+<video></video>
+<script>
+description("Under site isolation, a video element playing audio in the main frame activates the audio session, and the web process observes it via AudioSession::isActive().");
+jsTestIsAsync = true;
+
+let video;
+
+onload = async () => {
+    if (!window.internals) {
+        testFailed("This test requires the Internals API");
+        finishJSTest();
+        return;
+    }
+
+    video = document.querySelector("video");
+    // test.mp4 has an audio track; keep it near-silent so the test is quiet at a desk, but not
+    // muted (a muted element can't produce audio and wouldn't activate the session).
+    video.src = "/media/resources/test.mp4";
+    video.volume = 0.001;
+    playIgnoringAbort(video);
+
+    try {
+        await waitForAudioSessionActiveState(true);
+        testPassed("the audio session is active");
+    } catch (e) {
+        testFailed(e.message);
+    }
+
+    video.pause();
+    finishJSTest();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/audio-session-active.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-active.html
@@ -1,52 +1,21 @@
 <!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
 <script src="/js-test-resources/js-test.js"></script>
+<script src="/media-resources/utilities.js"></script>
 <script>
 description("Under site isolation, audio played in the main frame activates the audio session, and the web process observes it via AudioSession::isActive().");
 jsTestIsAsync = true;
 
 let context;
 
-async function waitForActiveAudioSession()
-{
-    for (let i = 0; i < 200; ++i) {
-        if (internals.audioSessionActive())
-            return true;
-        await new Promise(resolve => setTimeout(resolve, 10));
-    }
-    return false;
-}
-
-async function waitForInactiveAudioSession()
-{
-    for (let i = 0; i < 200; ++i) {
-        if (!internals.audioSessionActive())
-            return;
-        await new Promise(resolve => setTimeout(resolve, 10));
-    }
-}
-
 onload = async () => {
-    internals.withUserGesture(() => {
-        context = new AudioContext();
-        const oscillator = context.createOscillator();
-        // Keep the tone inaudible for anyone running the tests at their desk: route the oscillator
-        // through a near-silent gain node. The context still renders audio (so it activates the
-        // audio session), but at 0.1% amplitude the output is effectively silent.
-        const gain = context.createGain();
-        gain.gain.value = 0.001;
-        oscillator.connect(gain);
-        gain.connect(context.destination);
-        oscillator.start();
-        context.resume();
-    });
-    audioSessionActive = await waitForActiveAudioSession();
-    shouldBeTrue("audioSessionActive");
-    await context.close();
-    // The audio-session manager is a process-wide singleton under site isolation, so its "became
-    // active" state leaks across repeated runs in one WebKitTestRunner (the stress bots). Wait for
-    // deactivation to land so the next run starts clean. Remove once the per-page audio-session
-    // activation follow-up makes this state per-page.
-    await waitForInactiveAudioSession();
+    try {
+        context = await startNearSilentAudioContext();
+        await waitForAudioSessionActiveState(true);
+        testPassed("the audio session is active");
+        await context.close();
+    } catch (e) {
+        testFailed(e.message);
+    }
     finishJSTest();
 };
 </script>

--- a/LayoutTests/http/tests/site-isolation/resources/audio-session-active-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/audio-session-active-frame.html
@@ -1,0 +1,20 @@
+<script src="/media-resources/utilities.js"></script>
+<script>
+// Plays a near-silent WebAudio tone, then reports to its parent whether its own process's audio
+// session became active. Used by the same-site and cross-site iframe activation tests.
+let context;
+
+async function startAudioAndReport()
+{
+    context = await startNearSilentAudioContext();
+    let active = true;
+    try {
+        await waitForAudioSessionActiveState(true);
+    } catch (e) {
+        active = false;
+    }
+    window.parent.postMessage(active ? "active" : "inactive", "*");
+}
+
+startAudioAndReport();
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/report-audio-session-active.html
+++ b/LayoutTests/http/tests/site-isolation/resources/report-audio-session-active.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/media-resources/utilities.js"></script>
+<script>
+let context;
+
+window.addEventListener("load", async () => {
+    if (!window.opener || !window.internals)
+        return;
+
+    context = await startNearSilentAudioContext();
+
+    let active = true;
+    try {
+        await waitForAudioSessionActiveState(true);
+    } catch (e) {
+        active = false;
+    }
+    window.opener.postMessage({ type: "audioSessionActive", active }, "*");
+});
+</script>
+</head>
+<body>
+This page plays near-silent audio and reports whether its own process's audio session is active to its opener.
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/report-video-element-audio-session-active.html
+++ b/LayoutTests/http/tests/site-isolation/resources/report-video-element-audio-session-active.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/media-resources/utilities.js"></script>
+<script>
+let video;
+
+window.addEventListener("load", async () => {
+    if (!window.opener || !window.internals)
+        return;
+
+    video = document.querySelector("video");
+    video.src = "/media/resources/test.mp4";
+    video.volume = 0.001;
+    playIgnoringAbort(video);
+
+    let active = true;
+    try {
+        await waitForAudioSessionActiveState(true);
+    } catch (e) {
+        active = false;
+    }
+    window.opener.postMessage({ type: "audioSessionActive", active }, "*");
+});
+</script>
+</head>
+<body>
+<video></video>
+This page plays a near-silent &lt;video&gt; and reports whether its own process's audio session is active to its opener.
+</body>
+</html>

--- a/LayoutTests/media/utilities.js
+++ b/LayoutTests/media/utilities.js
@@ -110,3 +110,57 @@ function timeRangesToString(timeRanges) {
     }
     return ranges.toString();
 }
+
+// Play a media element inside a user gesture, ignoring the AbortError that play() rejects with when
+// a still-pending play() is interrupted by a later pause() or by teardown (spec behavior, not a
+// failure). Any other rejection is rethrown so a genuine play() failure still surfaces. Requires the
+// Internals API.
+function playIgnoringAbort(mediaElement) {
+    internals.withUserGesture(() => {
+        mediaElement.play().catch(error => {
+            if (error.name !== "AbortError")
+                throw error;
+        });
+    });
+}
+
+// Create a near-silent AudioContext under a user gesture and wait until it is actually running before
+// returning it, so a caller polling internals.audioSessionActive() is timing the audio-session
+// activation and not WebAudio context startup. The tone renders (activating the audio session) but is
+// routed through a 0.001 gain so it is inaudible at a desk. Requires the Internals API. The caller owns
+// the returned context and should close() it when done.
+async function startNearSilentAudioContext() {
+    let context;
+    let resumePromise;
+    internals.withUserGesture(() => {
+        context = new AudioContext();
+        const oscillator = context.createOscillator();
+        const gain = context.createGain();
+        gain.gain.value = 0.001;
+        oscillator.connect(gain);
+        gain.connect(context.destination);
+        oscillator.start();
+        resumePromise = context.resume();
+    });
+    await resumePromise;
+    return context;
+}
+
+function waitForAudioSessionActiveState(active) {
+    return new Promise((resolve, reject) => {
+        if (!window.internals) {
+            reject(new Error("waitForAudioSessionActiveState requires window.internals"));
+            return;
+        }
+        let tries = 0;
+        const check = () => {
+            if (internals.audioSessionActive() === active)
+                resolve();
+            else if (++tries >= 200)
+                reject(new Error(`audio session did not reach active=${active}`));
+            else
+                setTimeout(check, 10);
+        };
+        check();
+    });
+}

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6787,7 +6787,7 @@ bool HTMLMediaElement::couldPlayIfEnoughData() const
         return false;
 
     RefPtr manager = sessionManager();
-    if (!canProduceAudio() || (manager && manager->hasActiveAudioSession()))
+    if (!canProduceAudio() || (manager && manager->hasActiveAudioSession(mediaSession())))
         return true;
 
     Ref mediaSession = this->mediaSession();

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -175,6 +175,24 @@ void MediaSessionManagerInterface::resetRestrictions()
     m_restrictions[indexFromMediaType(PlatformMediaSession::MediaType::DOMMediaSession)] = MediaSessionRestriction::NoRestrictions;
 }
 
+void MediaSessionManagerInterface::resetToConsistentStateForTesting()
+{
+#if ENABLE(VIDEO)
+    resetHaveEverRegisteredAsNowPlayingApplicationForTesting();
+    resetRestrictions();
+    resetSessionState();
+    setWillIgnoreSystemInterruptions(true);
+    applicationWillEnterForeground(false);
+#endif
+    setIsPlayingToAutomotiveHeadUnit(false);
+
+#if USE(AUDIO_SESSION)
+    AudioSession::singleton().setCategoryOverride(AudioSessionCategory::None);
+    AudioSession::singleton().tryToSetActive(false)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
+    AudioSession::singleton().endInterruptionForTesting();
+#endif
+}
+
 bool MediaSessionManagerInterface::isMediaSessionManagerGLib() const
 {
     return false;
@@ -201,7 +219,7 @@ bool MediaSessionManagerInterface::activeAudioSessionRequired() const
 #endif
 }
 
-bool MediaSessionManagerInterface::hasActiveAudioSession() const
+bool MediaSessionManagerInterface::hasActiveAudioSession(PlatformMediaSessionInterface&) const
 {
 #if USE(AUDIO_SESSION)
     return m_becameActive;
@@ -561,7 +579,7 @@ void MediaSessionManagerInterface::sessionWillBeginPlayback(PlatformMediaSession
     }
 #endif
 
-    if (!activeAudioSessionRequired() || m_becameActive) {
+    if (!activeAudioSessionRequired() || hasActiveAudioSession(session)) {
         completeWillBeginPlayback(true);
         return;
     }

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -72,7 +72,7 @@ public:
     virtual bool hasNoSession() const;
 
     virtual bool activeAudioSessionRequired() const;
-    virtual bool hasActiveAudioSession() const;
+    virtual bool hasActiveAudioSession(PlatformMediaSessionInterface&) const;
     virtual bool canProduceAudio() const;
 
     virtual void setShouldDeactivateAudioSession(bool should) { m_shouldDeactivateAudioSession = should; };
@@ -96,6 +96,7 @@ public:
     virtual bool registeredAsNowPlayingApplication() const { return false; }
     virtual bool haveEverRegisteredAsNowPlayingApplication() const { return false; }
     virtual void resetHaveEverRegisteredAsNowPlayingApplicationForTesting() { };
+    virtual void resetToConsistentStateForTesting();
 
     virtual bool willIgnoreSystemInterruptions() const { return m_willIgnoreSystemInterruptions; }
     virtual void setWillIgnoreSystemInterruptions(bool ignore) { m_willIgnoreSystemInterruptions = ignore; }
@@ -253,7 +254,9 @@ private:
     bool m_alreadyScheduledSessionStatedUpdate { false };
     bool m_hasScheduledSessionStateUpdate { false };
     mutable bool m_isApplicationInBackground { false };
+#if USE(AUDIO_SESSION)
     bool m_becameActive { false };
+#endif
 };
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
@@ -140,6 +140,12 @@ MediaSessionManagerGLib::MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&& mprisI
 
 MediaSessionManagerGLib::~MediaSessionManagerGLib() = default;
 
+void MediaSessionManagerGLib::resetToConsistentStateForTesting()
+{
+    PlatformMediaSessionManager::resetToConsistentStateForTesting();
+    setDBusNotificationsEnabled(false);
+}
+
 void MediaSessionManagerGLib::beginInterruption(PlatformMediaSession::InterruptionType type)
 {
     if (type == PlatformMediaSession::InterruptionType::SystemInterruption) {

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
@@ -90,6 +90,7 @@ protected:
     RemoteCommandListener::RemoteCommandsSet supportedCommands() const final;
 
     void resetHaveEverRegisteredAsNowPlayingApplicationForTesting() final { m_haveEverRegisteredAsNowPlayingApplication = false; };
+    void resetToConsistentStateForTesting() final;
 
 private:
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -433,10 +433,6 @@
 #include "NavigatorMediaSession.h"
 #endif
 
-#if ENABLE(MEDIA_SESSION) && USE(GLIB)
-#include "MediaSessionManagerGLib.h"
-#endif
-
 #if ENABLE(IMAGE_ANALYSIS)
 #include "TextRecognitionResult.h"
 #endif
@@ -671,22 +667,17 @@ void Internals::resetToConsistentState(Page& page)
         localMainFrame->editor().toggleOverwriteModeEnabled();
     localMainFrame->loader().clearTestingOverrides();
 
-    RefPtr sessionManager = page.mediaSessionManager();
 #if ENABLE(VIDEO)
     page.group().ensureCaptionPreferences().setCaptionDisplayMode(CaptionUserPreferences::CaptionDisplayMode::ForcedOnly);
     page.group().ensureCaptionPreferences().setCaptionsStyleSheetOverride(emptyString());
     page.group().ensureCaptionPreferences().setPreferredLanguage(emptyString());
 
-    sessionManager->resetHaveEverRegisteredAsNowPlayingApplicationForTesting();
-    sessionManager->resetRestrictions();
-    sessionManager->resetSessionState();
-    sessionManager->setWillIgnoreSystemInterruptions(true);
-    sessionManager->applicationWillEnterForeground(false);
     if (page.mediaPlaybackIsSuspended())
         page.resumeAllMediaPlayback();
 #endif
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    sessionManager->setIsPlayingToAutomotiveHeadUnit(false);
+    if (RefPtr sessionManager = page.mediaSessionManager())
+        sessionManager->resetToConsistentStateForTesting();
 #endif
     AXObjectCache::setEnhancedUserInterfaceAccessibility(false);
     AXObjectCache::disableAccessibilityForTesting();
@@ -765,22 +756,11 @@ void Internals::resetToConsistentState(Page& page)
     WebCore::setContentSizeCategory(kCTFontContentSizeCategoryL);
 #endif
 
-#if ENABLE(MEDIA_SESSION) && USE(GLIB)
-    if (auto* glibSessionManager = dynamicDowncast<MediaSessionManagerGLib>(sessionManager.get()))
-        glibSessionManager->setDBusNotificationsEnabled(false);
-#endif
-
 #if PLATFORM(COCOA)
     setOverrideEnhanceTextLegibility(false);
 #endif
 
     TextPainter::setForceUseGlyphDisplayListForTesting(false);
-
-#if USE(AUDIO_SESSION)
-    AudioSession::singleton().setCategoryOverride(AudioSessionCategory::None);
-    AudioSession::singleton().tryToSetActive(false)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
-    AudioSession::singleton().endInterruptionForTesting();
-#endif
 
 #if ENABLE(DAMAGE_TRACKING)
     page.chrome().client().resetDamageHistoryForTesting();

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -30,6 +30,7 @@
 
 #include "GPUConnectionToWebProcess.h"
 #include "GPUProcess.h"
+#include "GPUProcessProxyMessages.h"
 #include "Logging.h"
 #include "RemoteAudioSessionMessages.h"
 #include "RemoteAudioSessionProxyManager.h"
@@ -124,8 +125,16 @@ void RemoteAudioSessionProxy::tryToSetActive(bool active, SetActiveCompletion&& 
 #endif
             }
             completion(success);
-            if (hasActiveChanged && m_gpuConnection.get())
+            if (hasActiveChanged && m_gpuConnection.get()) {
                 configurationChanged();
+                // Also tell the UI-process RemoteMediaSessionManagerProxy singleton (the audio-session
+                // authority under site isolation) this process's active state, so its activation gate uses
+                // the value the GPU process owns rather than one relayed by the untrusted WebContent
+                // process. Guarded by the connection being live: processIdentifier() dereferences it, and
+                // when the process is gone the UI process cleans up via webProcessWillShutDown anyway.
+                if (RefPtr parentConnection = GPUProcess::singleton().parentProcessConnection())
+                    parentConnection->send(Messages::GPUProcessProxy::AudioSessionActiveStateChangedForProcess(processIdentifier(), m_active), 0);
+            }
             manager->updatePresentingProcesses();
             manager->updateSpatialExperience();
         });

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -39,6 +39,7 @@
 #include "OverrideLanguages.h"
 #include "ProcessTerminationReason.h"
 #include "ProvisionalPageProxy.h"
+#include "RemoteMediaSessionManagerProxy.h"
 #include "SharedFileHandle.h"
 #include "WebKitServiceNames.h"
 #include "WebPageGroup.h"
@@ -894,6 +895,22 @@ void GPUProcessProxy::statusBarWasTapped(CompletionHandler<void()>&& completionH
 }
 #endif
 #endif // ENABLE(MEDIA_STREAM)
+
+#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
+void GPUProcessProxy::audioSessionActiveStateChangedForProcess(WebCore::ProcessIdentifier webProcessIdentifier, bool active)
+{
+    // The GPU process owns each web process's real audio-session active state; forward it to the
+    // UI-process RemoteMediaSessionManagerProxy singleton, which uses it at its activation gate instead
+    // of a value relayed by the (untrusted) WebContent process.
+#if USE(AUDIO_SESSION)
+    if (RefPtr manager = RemoteMediaSessionManagerProxy::singletonIfCreated())
+        manager->setAudioSessionActiveForProcess(webProcessIdentifier, active);
+#else
+    UNUSED_PARAM(webProcessIdentifier);
+    UNUSED_PARAM(active);
+#endif
+}
+#endif
 
 #if HAVE(AUDIT_TOKEN)
 void GPUProcessProxy::setPresentingApplicationAuditToken(WebCore::ProcessIdentifier processIdentifier, WebCore::PageIdentifier pageIdentifier, std::optional<CoreIPCAuditToken> auditToken)

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -235,6 +235,10 @@ private:
 #endif
 #endif // ENABLE(MEDIA_STREAM)
 
+#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
+    void audioSessionActiveStateChangedForProcess(WebCore::ProcessIdentifier, bool active);
+#endif
+
     GPUProcessCreationParameters processCreationParameters();
     void platformInitializeGPUProcessParameters(GPUProcessCreationParameters&);
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
@@ -45,6 +45,10 @@ messages -> GPUProcessProxy {
 #endif
 #endif
 
+#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
+    AudioSessionActiveStateChangedForProcess(WebCore::ProcessIdentifier webProcessIdentifier, bool active)
+#endif
+
     ProcessIsReadyToExit()
     TerminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier, enum:uint16_t IPC::MessageName invalidMessageName)
 }

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -106,44 +106,22 @@ private:
         if (!manager)
             return GenericPromise::createAndReject();
 
-        RefPtr gpuProcess = GPUProcessProxy::singletonIfCreated();
-        if (!gpuProcess)
-            return GenericPromise::createAndReject();
-
-        std::optional<WebCore::ProcessIdentifier> target;
-        if (active) {
-            // Activate the audio session for the process that owns the triggering session.
-            if (!session)
-                return GenericPromise::createAndReject();
-
-            for (auto& entry : manager->m_sessionProxies) {
-                if (entry.value.ptr() == session) {
-                    target = entry.key.processIdentifier();
-                    break;
-                }
-            }
-            if (!target)
-                return GenericPromise::createAndReject();
-
-        } else {
-            // Deactivate the same process we activated, so the GPU's per-process aggregation stays
-            // balanced regardless of which session is current now. Nothing activated is a no-op.
-            target = std::exchange(manager->m_activatedTargetProcess, std::nullopt);
-            if (!target)
-                return GenericPromise::createAndResolve();
+        if (!active) {
+            // The base class only asks to deactivate once no session needs the audio session anymore
+            // (hasNoSession), so drop activation for every web process we activated.
+            manager->deactivateAllAudioSessions();
+            return GenericPromise::createAndResolve();
         }
 
-        return gpuProcess->tryToSetAudioSessionActiveForProcess(*target, active)->whenSettled(RunLoop::mainSingleton(), [protectedManager = Ref { *manager }, active, target](auto&& result) -> Ref<GenericPromise> {
-            bool succeeded = result.has_value();
-            if (active && succeeded)
-                protectedManager->m_activatedTargetProcess = target;
-
-            // A failed deactivation means the target proxy is already gone: treat as a no-op success.
-            if (succeeded || !active)
-                return GenericPromise::createAndResolve();
-
+        // Activate the audio session for the web process that owns the triggering session.
+        if (!session)
             return GenericPromise::createAndReject();
-        });
+
+        auto target = manager->processForSession(*session);
+        if (!target)
+            return GenericPromise::createAndReject();
+
+        return manager->enqueueAudioSessionActivation(*target, true);
     }
 
     void hasActiveNowPlayingSessionChanged(WebCore::PlatformMediaSessionInterface*) final
@@ -225,9 +203,30 @@ void RemoteMediaSessionManagerProxy::addMediaSession(IPC::Connection& connection
 
 void RemoteMediaSessionManagerProxy::removeMediaSession(IPC::Connection& connection, RemoteMediaSessionState&& state)
 {
+    auto processIdentifier = WebProcessProxy::fromConnection(connection)->coreProcessIdentifier();
     if (RefPtr session = findAndUpdateSession(connection, state))
         removeSession(*session);
-    m_sessionProxies.remove({ state.sessionIdentifier, WebProcessProxy::fromConnection(connection)->coreProcessIdentifier() });
+    m_sessionProxies.remove({ state.sessionIdentifier, processIdentifier });
+
+#if USE(AUDIO_SESSION)
+    // If that was the process's last session and it is not still capturing audio, drive its audio session
+    // inactive and clear the per-process activation state now -- decoupled from the global
+    // maybeDeactivateAudioSession() path (gated on m_becameActive, which can't track per-process state).
+    // Otherwise a reused process (same-origin navigation) keeps a stale "active" flag and the next document's
+    // sessionWillBeginPlayback skips activation even though the process's audio session was reset.
+    bool processStillHasSession = false;
+    for (auto& key : m_sessionProxies.keys()) {
+        if (key.processIdentifier() == processIdentifier) {
+            processStillHasSession = true;
+            break;
+        }
+    }
+    if (!processStillHasSession && !processRequiresAudioSession(processIdentifier)) {
+        auto it = m_activationByProcess.find(processIdentifier);
+        if (it != m_activationByProcess.end() && it->value.active)
+            enqueueAudioSessionActivation(processIdentifier, false)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
+    }
+#endif
 }
 
 void RemoteMediaSessionManagerProxy::webProcessWillShutDown(WebCore::ProcessIdentifier processIdentifier)
@@ -259,12 +258,11 @@ void RemoteMediaSessionManagerProxy::webProcessWillShutDown(WebCore::ProcessIden
     }))
         updateSessionState();
 
-    // If we had activated the audio session on behalf of this now-gone process, forget it: its GPU
-    // audio-session proxy was torn down with the process, and removeSession() above already drives the
-    // shared session inactive once nothing else needs it. This keeps a later deactivation from being
-    // misattributed to a dead process.
-    if (m_activatedTargetProcess == processIdentifier)
-        m_activatedTargetProcess = std::nullopt;
+    // The process is gone; drop the activation state we tracked for it (keyed by ProcessIdentifier, so a
+    // reused process starts clean). The pending activations' waiters are AutoRejectProducers, so removing the
+    // entry rejects any still-pending promises as it is destroyed. setAudioSessionActiveForProcess() relies on
+    // this removal (it uses find(), not ensure(), so it never resurrects a departed process's entry).
+    m_activationByProcess.remove(processIdentifier);
 #endif
 }
 
@@ -287,7 +285,11 @@ void RemoteMediaSessionManagerProxy::updateMediaSessionStates(IPC::Connection& c
 {
     refreshSessionStates(connection, sessions);
 
-    WebCore::ProcessQualified<WebCore::PageIdentifier> key { WTF::move(pageIdentifier), WebProcessProxy::fromConnection(connection)->coreProcessIdentifier() };
+    auto process = WebProcessProxy::fromConnection(connection)->coreProcessIdentifier();
+    WebCore::ProcessQualified<WebCore::PageIdentifier> key { WTF::move(pageIdentifier), process };
+#if USE(AUDIO_SESSION)
+    uint64_t previousPageCaptureCount = m_audioCaptureSourceCountsByPage.get(key);
+#endif
     if (!audioCaptureSourceCount)
         m_audioCaptureSourceCountsByPage.remove(key);
     else
@@ -305,7 +307,16 @@ void RemoteMediaSessionManagerProxy::updateMediaSessionStates(IPC::Connection& c
 #endif
 
     updateSessionState();
+
 #if USE(AUDIO_SESSION)
+    // Drive audio-session activation for this process's audio capture: activeAudioSessionRequired() can't see
+    // capture from the UI process (only the count is forwarded, not the AudioCaptureSource objects), so key off
+    // the capture-count transition -- activate when it starts, deactivate when it stops and nothing else needs it.
+    if (audioCaptureSourceCount && !previousPageCaptureCount)
+        enqueueAudioSessionActivation(process, true)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
+    else if (!audioCaptureSourceCount && previousPageCaptureCount && !processRequiresAudioSession(process))
+        enqueueAudioSessionActivation(process, false)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
+
     completionHandler(m_category, m_mode, m_routeSharingPolicy);
 #else
     completionHandler(WebCore::AudioSessionCategory::None, WebCore::AudioSessionMode::Default, WebCore::RouteSharingPolicy::Default);
@@ -336,7 +347,11 @@ void RemoteMediaSessionManagerProxy::setCurrentSession(WebCore::PlatformMediaSes
         }
     }
 
-    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::addSession(session);
+    // Make this the current session (moves it to the front) so currentSession() returns it, rather
+    // than addSession() which moves it to the back and leaves a stale session current -- which would
+    // make tryToSetActiveInternal activate the wrong web process. PlatformMediaSessionManager's
+    // implementation only reorders the list; NowPlaying routing is a separate follow-up.
+    WebCore::PlatformMediaSessionManager::setCurrentSession(session);
 }
 
 void RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback(IPC::Connection& connection, RemoteMediaSessionState&& state, CompletionHandler<void(bool, WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&& completionHandler)
@@ -357,6 +372,19 @@ void RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback(IPC::Connecti
         reply(false);
         return;
     }
+
+#if USE(AUDIO_SESSION)
+    // Mirror this process's real audio-session active state onto the shared session's active flag (which
+    // the base sessionWillBeginPlayback reads via AudioSession::singleton().isActive() on its fast-activation
+    // path) before the base activation gate, so the gate decides on this process's reality. The value is the
+    // authoritative per-process state the GPU process reports (via setAudioSessionActiveForProcess()) plus the
+    // activation chain (NOT a WebContent-supplied bool); the per-process entry the base reads via hasActiveAudioSession()
+    // is already up to date. Key by the connection's process (trusted), not by any value the web process
+    // sent. setActive() only sets the flag; it fires no observers.
+    auto processIdentifier = WebProcessProxy::fromConnection(connection)->coreProcessIdentifier();
+    auto it = m_activationByProcess.find(processIdentifier);
+    AudioSession::setActive(it != m_activationByProcess.end() && it->value.active);
+#endif
 
     REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::sessionWillBeginPlayback(*session, WTF::move(reply));
 }
@@ -389,7 +417,31 @@ WebCore::AudioSessionCategory RemoteMediaSessionManagerProxy::categoryOverride()
 
 void RemoteMediaSessionManagerProxy::remoteAudioConfigurationChanged(RemoteAudioSessionConfiguration&& configuration)
 {
+    // configuration.isActive is NOT trusted for the activation gate: it is relayed by the (untrusted)
+    // WebContent process. Each process's active state is derived from the GPU process via
+    // setAudioSessionActiveForProcess(); this message carries only the descriptive configuration
+    // (category, sample rate, buffer size, routing, ...).
     m_audioConfiguration = WTF::move(configuration);
+}
+
+void RemoteMediaSessionManagerProxy::setAudioSessionActiveForProcess(WebCore::ProcessIdentifier process, bool active)
+{
+    // Correct the cached active state of a process the UI process is already tracking, pushed by the GPU
+    // process (see GPUProcessProxy::audioSessionActiveStateChangedForProcess). Use find(), NOT ensure():
+    // creating an entry here could resurrect one that webProcessWillShutDown() removed while an activation
+    // IPC was still in flight, and the stale reply would then crash sendNextActivationIPC()'s completion on
+    // an empty chain. A process we aren't tracking has no cache to correct -- its next gate just activates.
+    auto it = m_activationByProcess.find(process);
+    if (it == m_activationByProcess.end())
+        return;
+    // Don't clobber an in-flight UI-driven activation/deactivation: while its chain is pending the
+    // optimistic state governs (that is what lets stop->replay re-activate), and the chain reverts on
+    // failure / otherwise converges to what the GPU process reports. Adopt the GPU process's value only
+    // when the process's chain is quiescent.
+    auto& state = it->value;
+    if (state.ipcInFlight || !state.pendingChain.isEmpty())
+        return;
+    state.active = active;
 }
 
 void RemoteMediaSessionManagerProxy::setCategory(CategoryType type, Mode mode, WebCore::RouteSharingPolicy policy)
@@ -416,6 +468,172 @@ Ref<WebCore::AudioSession::SetActivePromise> RemoteMediaSessionManagerProxy::try
         return SetActivePromise::createAndReject();
 
     return client().tryToSetAudioSessionActive(active, currentSession().get());
+}
+
+void RemoteMediaSessionManagerProxy::reevaluateAudioSessionActivation(WebCore::PlatformMediaSessionInterface& session)
+{
+    scheduleUpdateSessionState();
+
+    auto process = processForSession(session);
+    if (!process)
+        return;
+
+    // Gate on the session's own process, not the manager-wide activeAudioSessionRequired(): otherwise an
+    // unrelated process holding an audible session would let this process -- driven by its own untrusted
+    // state update -- activate the shared session and cache active=true for itself, short-circuiting its
+    // later playback-activation gate. Mirrors remoteProcessDidResume().
+    if (!processRequiresAudioSession(*process))
+        return;
+
+    enqueueAudioSessionActivation(*process, true);
+}
+
+void RemoteMediaSessionManagerProxy::remoteProcessWillSuspend(IPC::Connection& connection)
+{
+    // The content process is suspending and no longer drives the shared audio session, so release it here;
+    // otherwise a suspended process would keep the system session active (matching the pre-site-isolation
+    // behavior where the web process released it on suspend).
+    auto process = WebProcessProxy::fromConnection(connection)->coreProcessIdentifier();
+    enqueueAudioSessionActivation(process, false);
+}
+
+void RemoteMediaSessionManagerProxy::remoteProcessDidResume(IPC::Connection& connection)
+{
+    auto process = WebProcessProxy::fromConnection(connection)->coreProcessIdentifier();
+    if (processRequiresAudioSession(process))
+        enqueueAudioSessionActivation(process, true);
+}
+
+bool RemoteMediaSessionManagerProxy::hasActiveAudioSession(WebCore::PlatformMediaSessionInterface& session) const
+{
+    // Track activation per web process instead of with the base class's single flag: under site
+    // isolation one manager serves every process, so a session in one process must not make
+    // sessionWillBeginPlayback treat a session in another process as already active (which would skip
+    // activating the latter). Emulates the non-site-isolation model where each process has its own manager.
+    auto process = processForSession(session);
+    if (!process)
+        return false;
+    auto it = m_activationByProcess.find(*process);
+    return it != m_activationByProcess.end() && it->value.active;
+}
+
+std::optional<WebCore::ProcessIdentifier> RemoteMediaSessionManagerProxy::processForSession(const WebCore::PlatformMediaSessionInterface& session) const
+{
+    for (auto& entry : m_sessionProxies) {
+        if (entry.value.ptr() == &session)
+            return entry.key.processIdentifier();
+    }
+    return std::nullopt;
+}
+
+bool RemoteMediaSessionManagerProxy::processRequiresAudioSession(WebCore::ProcessIdentifier process) const
+{
+    for (auto& entry : m_audioCaptureSourceCountsByPage) {
+        if (entry.key.processIdentifier() == process && entry.value)
+            return true;
+    }
+    for (auto& entry : m_sessionProxies) {
+        if (entry.key.processIdentifier() != process)
+            continue;
+        Ref session = entry.value;
+        if (session->activeAudioSessionRequired())
+            return true;
+    }
+    return false;
+}
+
+Ref<WebCore::AudioSession::SetActivePromise> RemoteMediaSessionManagerProxy::enqueueAudioSessionActivation(WebCore::ProcessIdentifier process, bool active)
+{
+    auto& state = m_activationByProcess.ensure(process, [] {
+        return ProcessActivationState { };
+    }).iterator->value;
+
+    SetActivePromise::AutoRejectProducer producer;
+    Ref promise = producer.promise();
+
+    // Optimistically reflect the requested state so hasActiveAudioSession() sees it without waiting
+    // for the GPU process round-trip. This is what lets a stop->replay re-activate: the replay's gate sees the
+    // process as inactive (set when the deactivation was enqueued) even while that deactivation IPC is
+    // still in flight. Mirrors RemoteAudioSession's optimistic setActive.
+    state.active = active;
+
+    // Keep at most one activation IPC per process in flight, coalescing consecutive same-state requests
+    // against the tail; a different-state request appends a new entry dispatched when the previous reply
+    // arrives. This serializes an in-flight deactivation and a following activation so the last state wins.
+    if (!state.pendingChain.isEmpty() && state.pendingChain.last().active == active) {
+        state.pendingChain.last().waiters.append(WTF::move(producer));
+        return promise;
+    }
+
+    PendingActivation entry { active, { } };
+    entry.waiters.append(WTF::move(producer));
+    state.pendingChain.append(WTF::move(entry));
+
+    sendNextActivationIPC(process);
+    return promise;
+}
+
+void RemoteMediaSessionManagerProxy::deactivateAllAudioSessions()
+{
+    Vector<WebCore::ProcessIdentifier> processes;
+    for (auto& entry : m_activationByProcess) {
+        if (entry.value.active)
+            processes.append(entry.key);
+    }
+    for (auto process : processes)
+        enqueueAudioSessionActivation(process, false);
+}
+
+void RemoteMediaSessionManagerProxy::sendNextActivationIPC(WebCore::ProcessIdentifier process)
+{
+    auto it = m_activationByProcess.find(process);
+    if (it == m_activationByProcess.end() || it->value.ipcInFlight || it->value.pendingChain.isEmpty())
+        return;
+
+    bool active = it->value.pendingChain.first().active;
+    it->value.ipcInFlight = true;
+
+    auto processResult = [protectedThis = Ref { *this }, process, active](bool succeeded) mutable {
+        auto it = protectedThis->m_activationByProcess.find(process);
+        if (it == protectedThis->m_activationByProcess.end())
+            return;
+
+        // The chain should be non-empty while an IPC we sent is outstanding. An empty chain here means a
+        // stale reply for an entry that was reset (e.g. removed at process shutdown then re-created) --
+        // unexpected, so ASSERT to catch it in debug (this assert is what surfaced the ensure()-resurrection
+        // bug on the bots), but tolerate it in release rather than take from an empty chain.
+        ASSERT(!it->value.pendingChain.isEmpty());
+        if (it->value.pendingChain.isEmpty())
+            return;
+
+        ASSERT(it->value.pendingChain.first().active == active);
+        auto pending = it->value.pendingChain.takeFirst();
+        it->value.ipcInFlight = false;
+
+        // If the request failed and nothing newer superseded it, revert the optimistic state.
+        if (!succeeded && it->value.pendingChain.isEmpty())
+            it->value.active = !active;
+
+        protectedThis->sendNextActivationIPC(process);
+
+        for (auto& waiter : pending.waiters) {
+            if (succeeded)
+                waiter.resolve();
+            else
+                waiter.reject();
+        }
+    };
+
+    RefPtr gpuProcess = GPUProcessProxy::singletonIfCreated();
+    if (!gpuProcess) {
+        processResult(false);
+        return;
+    }
+
+    gpuProcess->tryToSetAudioSessionActiveForProcess(process, active)->whenSettled(RunLoop::mainSingleton(),
+        [processResult = WTF::move(processResult)](auto&& result) mutable {
+            processResult(result.has_value());
+        });
 }
 
 void RemoteMediaSessionManagerProxy::setPreferredBufferSize(size_t size)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -34,7 +34,9 @@
 #include <WebCore/MediaSessionIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ProcessQualified.h>
+#include <wtf/Deque.h>
 #include <wtf/HashMap.h>
+#include <wtf/NativePromise.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -84,6 +86,19 @@ public:
 
     void webProcessWillShutDown(WebCore::ProcessIdentifier);
 
+#if USE(AUDIO_SESSION)
+    // Called by a RemoteMediaSessionProxy when its session's state changes. Under site isolation the content
+    // process keeps only an optimistic local audio-session state and does not drive the GPU (see
+    // RemoteAudioSession::sendNextActivationIPC); the UI process is the sole activation driver, so it activates
+    // the given session's process here when the session requires an active audio session (e.g. WebAudio, which
+    // becomes audible only after begin).
+    void reevaluateAudioSessionActivation(WebCore::PlatformMediaSessionInterface&);
+
+    // Called by GPUProcessProxy with the GPU-authoritative per-process audio-session active state (the
+    // trusted source), so the activation gate never depends on a value sent by the WebContent process.
+    void setAudioSessionActiveForProcess(WebCore::ProcessIdentifier, bool active);
+#endif
+
     // IPC::MessageReceiver, WebCore::AudioSession.
     void ref() const final { WebCore::REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::ref(); }
     void deref() const final { WebCore::REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::deref(); }
@@ -123,6 +138,8 @@ private:
 
 #if USE(AUDIO_SESSION)
     void remoteAudioConfigurationChanged(RemoteAudioSessionConfiguration&&);
+    void remoteProcessWillSuspend(IPC::Connection&);
+    void remoteProcessDidResume(IPC::Connection&);
 
     // AudioSession
     void setCategory(CategoryType, Mode, WebCore::RouteSharingPolicy) final;
@@ -139,6 +156,12 @@ private:
     size_t outputLatency() const final { return m_audioConfiguration.outputLatency; }
 
     Ref<SetActivePromise> tryToSetActiveInternal(bool) final;
+    bool hasActiveAudioSession(WebCore::PlatformMediaSessionInterface&) const final;
+    std::optional<WebCore::ProcessIdentifier> processForSession(const WebCore::PlatformMediaSessionInterface&) const;
+    bool processRequiresAudioSession(WebCore::ProcessIdentifier) const;
+    Ref<SetActivePromise> enqueueAudioSessionActivation(WebCore::ProcessIdentifier, bool active);
+    void deactivateAllAudioSessions();
+    void sendNextActivationIPC(WebCore::ProcessIdentifier);
 
     size_t preferredBufferSize() const final { return m_audioConfiguration.preferredBufferSize; }
     void setPreferredBufferSize(size_t) final;
@@ -171,7 +194,17 @@ private:
     Mode m_mode { Mode::Default };
     WebCore::RouteSharingPolicy m_routeSharingPolicy { WebCore::RouteSharingPolicy::Default };
     mutable RemoteAudioSessionConfiguration m_audioConfiguration;
-    std::optional<WebCore::ProcessIdentifier> m_activatedTargetProcess;
+
+    struct PendingActivation {
+        bool active;
+        Vector<WebCore::AudioSession::SetActivePromise::AutoRejectProducer> waiters;
+    };
+    struct ProcessActivationState {
+        bool active { false };
+        Deque<PendingActivation> pendingChain;
+        bool ipcInFlight { false };
+    };
+    HashMap<WebCore::ProcessIdentifier, ProcessActivationState> m_activationByProcess;
 #endif
 
     bool m_isInterruptedForTesting { false };

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
@@ -49,6 +49,8 @@ messages -> RemoteMediaSessionManagerProxy {
 
 #if USE(AUDIO_SESSION)
     void RemoteAudioConfigurationChanged(struct WebKit::RemoteAudioSessionConfiguration configuration);
+    void RemoteProcessWillSuspend();
+    void RemoteProcessDidResume();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
@@ -69,6 +69,12 @@ void RemoteMediaSessionProxy::updateState(const RemoteMediaSessionState& remoteS
     m_sessionState = remoteState;
     downcast<RemoteMediaSessionClientProxy>(protect(client())).updateState(remoteState);
 
+#if USE(AUDIO_SESSION)
+    // Re-evaluate activation for this session when its state changes: WebAudio becomes audible (canProduceAudio)
+    // only after sessionWillBeginPlayback, so the begin-time activation gate can't catch it.
+    if (RefPtr manager = RemoteMediaSessionManagerProxy::singletonIfCreated())
+        manager->reevaluateAudioSessionActivation(*this);
+#endif
 }
 
 void RemoteMediaSessionProxy::setState(WebCore::PlatformMediaSessionState state)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -168,6 +168,19 @@ void RemoteAudioSession::sendNextActivationIPC()
     if (m_activationIPCInFlight || m_pendingActivationChain.isEmpty())
         return;
 
+    // Under site isolation the UI process is the sole driver of the shared audio session; the content
+    // process keeps only an optimistic local view (set in tryToSetActiveInternal) and must not send
+    // TryToSetActive to the GPU, or it would race the UI process. Resolve the pending waiters and let the
+    // GPU push the authoritative state back via configurationChanged.
+    if (WebProcess::singleton().sharedPreferencesForWebProcessValue().remoteMediaSessionManagerEnabled) {
+        while (!m_pendingActivationChain.isEmpty()) {
+            auto pending = m_pendingActivationChain.takeFirst();
+            for (auto& waiter : pending.waiters)
+                waiter.resolve();
+        }
+        return;
+    }
+
     bool active = m_pendingActivationChain.first().active;
     m_activationIPCInFlight = true;
 
@@ -262,7 +275,13 @@ void RemoteAudioSession::configurationChanged(RemoteAudioSessionConfiguration&& 
             observer.routingContextUIDDidChange(*this);
     });
 
-    if (!mutedStateChanged && !bufferSizeChanged && !sampleRateChanged && !routingContextUIDChanged)
+    // Forward the configuration to the UI process on an active-state change too (not only on
+    // muted/buffer/sampleRate/routing changes) so the RemoteMediaSessionManagerProxy singleton's
+    // per-process activation state mirrors this web process's real audio session state. Under site
+    // isolation the UI process has no other signal for a GPU-driven active-state change (e.g. after a
+    // same-origin navigation reuses the process), so without this its cached state drifts and it can
+    // wrongly skip activating the reused process.
+    if (!mutedStateChanged && !bufferSizeChanged && !sampleRateChanged && !routingContextUIDChanged && !activeChanged)
         return;
 
     RefPtr protectedProcess = m_webProcess.get();

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
@@ -73,6 +73,7 @@ RemoteMediaSessionManager::RemoteMediaSessionManager(WebPage& webPage)
         sharedSession->sceneIdentifier(),
         sharedSession->soundStageSize(),
         sharedSession->categoryOverride(),
+        sharedSession->isActive(),
     };
     send(Messages::RemoteMediaSessionManagerProxy::RemoteAudioConfigurationChanged(WTF::move(configuration)));
 #endif
@@ -128,6 +129,9 @@ void RemoteMediaSessionManager::sessionWillBeginPlayback(WebCore::PlatformMediaS
     // the interruption the session was under has to happen here, where the interrupted sessions are.
     bool sessionWasAlreadyInterrupted = session.state() == WebCore::PlatformMediaSessionState::Interrupted;
 
+    // The UI-process proxy decides activation using each process's audio-session active state as reported
+    // by the GPU process (the source of truth); this process does not send its own view, which the proxy
+    // could not trust.
     sendWithAsyncReply(Messages::RemoteMediaSessionManagerProxy::MediaSessionWillBeginPlayback(currentSessionState(session)),
         [protectedThis = Ref { *this }, sessionWasAlreadyInterrupted, completionHandler = WTF::move(completionHandler)](bool granted, WebCore::AudioSessionCategory category, WebCore::AudioSessionMode mode, WebCore::RouteSharingPolicy policy) mutable {
 #if USE(AUDIO_SESSION)
@@ -195,6 +199,24 @@ void RemoteMediaSessionManager::sessionStateChanged(WebCore::PlatformMediaSessio
 {
     send(Messages::RemoteMediaSessionManagerProxy::MediaSessionStateChanged(currentSessionState(session)));
     REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::sessionStateChanged(session);
+}
+
+void RemoteMediaSessionManager::processWillSuspend()
+{
+    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::processWillSuspend();
+#if USE(AUDIO_SESSION)
+    // The base class only updated this process's optimistic local state; under site isolation the UI process
+    // owns the shared audio session, so ask it to release this process's session on suspend.
+    send(Messages::RemoteMediaSessionManagerProxy::RemoteProcessWillSuspend());
+#endif
+}
+
+void RemoteMediaSessionManager::processDidResume()
+{
+    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::processDidResume();
+#if USE(AUDIO_SESSION)
+    send(Messages::RemoteMediaSessionManagerProxy::RemoteProcessDidResume());
+#endif
 }
 
 RefPtr<WebCore::PlatformMediaSessionInterface> RemoteMediaSessionManager::sessionWithIdentifier(WebCore::MediaSessionIdentifier identifier)
@@ -285,11 +307,6 @@ void RemoteMediaSessionManager::setAudioSessionCategory(WebCore::AudioSessionCat
 void RemoteMediaSessionManager::setAudioSessionPreferredBufferSize(uint64_t preferredBufferSize)
 {
     WebCore::AudioSession::singleton().setPreferredBufferSize(preferredBufferSize);
-}
-
-void RemoteMediaSessionManager::tryToSetAudioSessionActive(bool active)
-{
-    WebCore::AudioSession::singleton().tryToSetActive(active)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
 }
 #endif
 

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h
@@ -78,7 +78,6 @@ protected:
 #if USE(AUDIO_SESSION)
     void setAudioSessionCategory(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy);
     void setAudioSessionPreferredBufferSize(uint64_t);
-    void tryToSetAudioSessionActive(bool);
 #endif
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
@@ -100,6 +99,8 @@ private:
     void sessionWillBeginPlayback(WebCore::PlatformMediaSessionInterface&, CompletionHandler<void(bool)>&&) final;
     Ref<GenericPromise> updateSessionState() final;
     void sessionStateChanged(WebCore::PlatformMediaSessionInterface&) final;
+    void processWillSuspend() final;
+    void processDidResume() final;
 
     void addRestriction(WebCore::PlatformMediaSessionMediaType, WebCore::MediaSessionRestrictions) final;
     void removeRestriction(WebCore::PlatformMediaSessionMediaType, WebCore::MediaSessionRestrictions) final;


### PR DESCRIPTION
#### 267cd2e8c7072fd01bfe053e05c171a4ddbd1e60
<pre>
[Site Isolation] Activate the audio session per web process
<a href="https://bugs.webkit.org/show_bug.cgi?id=320600">https://bugs.webkit.org/show_bug.cgi?id=320600</a>
<a href="https://rdar.apple.com/183573361">rdar://183573361</a>

Reviewed by Jean-Yves Avenard.

Under site isolation one process-wide RemoteMediaSessionManagerProxy serves every web
process, but it controlled audio-session activation with a single global AudioSession. A
second page was denied activation once any page was active, a stop + play raced the async
deactivation, and a reused web process (same-origin navigation, or a lingering/stopped
session) kept a stale &quot;active&quot; session so sessionWillBeginPlayback skipped activating it
even though its real audio session was inactive.

Track activation per web process, and source each web process&apos;s real audio-session state
from the GPU process, which owns it. When a process&apos;s audio session becomes active or
inactive the GPU process pushes that state to the UI process via
GPUProcessProxy::AudioSessionActiveStateChangedForProcess and the proxy applies it to the
per-process activation entry and to the shared session&apos;s active flag before the activation,
so the decision reflects each process&apos;s reality and is never taken from data an untrusted
web process supplied. Per-process activate/deactivate is serialized, the forwarded
configuration is completed, a process is deactivated on its last session removal, and its
per-process activation state is dropped on web-process shutdown (rejecting any pending
activations).

Make the UI process the single GPU-side activation driver without disabling the web
process&apos;s local activation. The web process still activates its own AudioSession
optimistically -- so getUserMedia&apos;s activation wait, the DOM audio-session state, and
process-suspend deactivation keep working -- but under site isolation RemoteAudioSession no
longer sends TryToSetActive to the GPU process: it resolves the request locally and the
UI-process proxy owns the GPU-side decision, so the two never race. RemoteMediaSessionProxy::updateState
re-evaluates activation for a session when its state changes (WebAudio becomes audible only
after playback begins, so the begin-time gate can&apos;t catch it), targeting that session&apos;s
process, and updateMediaSessionStates activates a process while it has active audio-capture
sources -- the UI process can&apos;t use activeAudioSessionRequired() for capture, since the
capture sources live in the web process and only their count is forwarded.

When a web process suspends it can no longer release the shared session through the GPU
itself, so RemoteMediaSessionManager forwards processWillSuspend/processDidResume to the
proxy, which releases that process&apos;s GPU session on suspend and re-acquires it on resume
when the process still requires it.

Route the tests&apos; reset-to-consistent-state through the manager too. Internals reached past
the MediaSessionManager to deactivate AudioSession directly between tests; under site
isolation that made the web process yet another uncoordinated driver, racing the per-process
activation chain across iterations and flaking the stress tests. Move that logic into
MediaSessionManagerInterface::resetToConsistentStateForTesting() -- with the GPU-side gate
now in RemoteAudioSession, that reset no longer reaches the GPU under site isolation. The
now-unused RemoteMediaSessionManager::tryToSetAudioSessionActive is removed.

Tests: http/tests/site-isolation/audio-session-active-capture.html
     http/tests/site-isolation/audio-session-active-in-cross-site-iframe.html
     http/tests/site-isolation/audio-session-active-in-same-site-iframe.html
     http/tests/site-isolation/audio-session-active-replay.html
     http/tests/site-isolation/audio-session-active-two-pages.html
     http/tests/site-isolation/audio-session-active-video-element-replay.html
     http/tests/site-isolation/audio-session-active-video-element-two-pages.html
     http/tests/site-isolation/audio-session-active-video-element.html

* LayoutTests/http/tests/site-isolation/audio-session-active-in-cross-site-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-in-cross-site-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-in-same-site-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-in-same-site-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-replay-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-replay.html: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-two-pages-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-two-pages.html: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-video-element-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-video-element-replay-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-video-element-replay.html: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-video-element-two-pages-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-video-element-two-pages.html: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-video-element.html: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active.html:
* LayoutTests/http/tests/site-isolation/resources/audio-session-active-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/report-audio-session-active.html: Added.
* LayoutTests/http/tests/site-isolation/resources/report-video-element-audio-session-active.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::couldPlayIfEnoughData const):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::hasActiveAudioSession const):
(WebCore::MediaSessionManagerInterface::sessionWillBeginPlayback):
(WebCore::MediaSessionManagerInterface::maybeDeactivateAudioSession):
(WebCore::MediaSessionManagerInterface::removeSession):
(WebCore::MediaSessionManagerInterface::maybeActivateAudioSession):
(WebCore::MediaSessionManagerInterface::managesAudioSessionActivation):
(WebCore::MediaSessionManagerInterface::audioCaptureSourceStateChanged):
(WebCore::MediaSessionManagerInterface::resetToConsistentStateForTesting):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::RemoteMediaSessionManagerProxy::removeMediaSession):
(WebKit::RemoteMediaSessionManagerProxy::webProcessWillShutDown):
(WebKit::RemoteMediaSessionManagerProxy::setCurrentSession):
(WebKit::RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback):
(WebKit::RemoteMediaSessionManagerProxy::remoteAudioConfigurationChanged):
(WebKit::RemoteMediaSessionManagerProxy::hasActiveAudioSession const):
(WebKit::RemoteMediaSessionManagerProxy::processForSession const):
(WebKit::RemoteMediaSessionManagerProxy::enqueueAudioSessionActivation):
(WebKit::RemoteMediaSessionManagerProxy::deactivateAllAudioSessions):
(WebKit::RemoteMediaSessionManagerProxy::sendNextActivationIPC):
(WebKit::RemoteMediaSessionManagerProxy::setAudioSessionActiveForProcess):
(WebKit::RemoteMediaSessionManagerProxy::reevaluateAudioSessionActivation):
(WebKit::RemoteMediaSessionManagerProxy::updateMediaSessionStates):
(WebKit::RemoteMediaSessionManagerProxy::processRequiresAudioSession const):
(WebKit::RemoteMediaSessionManagerProxy::remoteProcessWillSuspend):
(WebKit::RemoteMediaSessionManagerProxy::remoteProcessDidResume):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::configurationChanged):
(WebKit::RemoteAudioSession::sendNextActivationIPC):
(WebKit::RemoteAudioSession::tryToSetActiveInternal):
(WebKit::RemoteAudioSession::gpuProcessConnectionDidClose):
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp:
(WebKit::RemoteMediaSessionManager::RemoteMediaSessionManager):
(WebKit::RemoteMediaSessionManager::sessionWillBeginPlayback):
(WebKit::RemoteMediaSessionManager::setAudioSessionPreferredBufferSize):
(WebKit::RemoteMediaSessionManager::tryToSetAudioSessionActive): Deleted.
(WebKit::RemoteMediaSessionManager::processWillSuspend):
(WebKit::RemoteMediaSessionManager::processDidResume):
* LayoutTests/media/utilities.js:
(playIgnoringAbort):
(async startNearSilentAudioContext):
(async waitForAudioSessionActiveState):
(waitForAudioSessionActiveState):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::tryToSetActive):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::audioSessionActiveStateChangedForProcess):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp:
(WebKit::RemoteMediaSessionProxy::updateState):
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h:
* LayoutTests/http/tests/site-isolation/audio-session-active-capture-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/audio-session-active-capture.html: Added.
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp:
(WebCore::MediaSessionManagerGLib::resetToConsistentStateForTesting):
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
* LayoutTests/http/tests/site-isolation/audio-session-active-expected.txt:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in:

Canonical link: <a href="https://commits.webkit.org/319006@main">https://commits.webkit.org/319006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdec456947bb4a19143db5ff2bc1c7efebe87bc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47848 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190317 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144424 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e24e3dbd-2d05-413a-b306-a37264af7b7b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140468 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/134d6785-fb7f-4bbe-95e9-d3c251a5579d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120920 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce21d069-6a30-4e4f-8e60-2d203741e441) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41101 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40777 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1476 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46650 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192250 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53717 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160766 "Failed to checkout and rebase branch from PR 70634") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149811 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40125 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54405 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37390 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149537 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44175 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126668 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121782 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52922 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15764 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52304 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52541 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52369 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->