### PR TITLE
Wire the Local Network Access check into NetworkResourceLoader and the navigation preload path

### DIFF
--- a/LayoutTests/http/wpt/fetch/local-network-access/loopback-blocked-without-permission-expected.txt
+++ b/LayoutTests/http/wpt/fetch/local-network-access/loopback-blocked-without-permission-expected.txt
@@ -1,0 +1,4 @@
+
+PASS fetch to a cross-origin loopback address should fail without a Local Network Access permission grant
+PASS fetch to a cross-origin loopback address should succeed once Local Network Access permission is granted
+

--- a/LayoutTests/http/wpt/fetch/local-network-access/loopback-blocked-without-permission.html
+++ b/LayoutTests/http/wpt/fetch/local-network-access/loopback-blocked-without-permission.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<html>
+<body>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+
+// LNA-PROTOTYPE: demonstrates the enforcement path added in NetworkResourceLoader end-to-end,
+// using the Internals stub (Internals::setLocalNetworkAccessPermissionForTesting ->
+// NetworkSession::localNetworkAccessPermission) in place of a real permission prompt, which
+// doesn't exist yet for this feature (see the FIXME in LocalNetworkAccess.cpp).
+//
+// The fetch target is deliberately http://127.0.0.1:8800 rather than location.origin. WebKit's
+// http/wpt/ test harness always navigates this page to http://localhost:8800 (see
+// wpt_webkit_test_path_to_uri in Tools/Scripts/webkitpy/port/driver.py, which hardcodes
+// "localhost" for this subdirectory regardless of the WPT server's configured browser_host) --
+// so location.origin here is http://localhost:8800, not http://127.0.0.1:8800 as an earlier
+// version of this test assumed. "localhost" and "127.0.0.1" are different host strings and
+// therefore different origins per same-origin policy, even though both resolve to the loopback
+// interface and are served by the very same Apache instance. A same-origin loopback fetch would
+// be exempted by performLocalNetworkAccessCheck's Step 1 (same-origin + potentially-trustworthy)
+// regardless of any permission grant, which would defeat the point of this test. mode: 'no-cors'
+// is used so a missing Access-Control-Allow-Origin header (expected, since the target has no CORS
+// setup) isn't a confounding failure reason distinct from the Local Network Access check itself.
+internals.settings.setLocalNetworkAccessEnabled(true);
+
+const crossOriginLoopbackURL = 'http://127.0.0.1:8800/resources/gc.js';
+
+promise_test(async (t) => {
+    await promise_rejects_js(t, TypeError, fetch(crossOriginLoopbackURL, { mode: 'no-cors' }));
+}, 'fetch to a cross-origin loopback address should fail without a Local Network Access permission grant');
+
+promise_test(async (t) => {
+    await internals.setLocalNetworkAccessPermissionForTesting(location.origin, 'loopback', 'granted');
+    await fetch(crossOriginLoopbackURL, { mode: 'no-cors' });
+}, 'fetch to a cross-origin loopback address should succeed once Local Network Access permission is granted');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -422,6 +422,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/fetch/FetchRequestMode.h
     Modules/fetch/FetchResponse.h
     Modules/fetch/IPAddressSpace.h
+    Modules/fetch/LocalNetworkAccess.h
     Modules/fetch/RequestPriority.h
 
     Modules/filesystem/FileSystemDirectoryHandle.h

--- a/Source/WebCore/Modules/fetch/LocalNetworkAccess.cpp
+++ b/Source/WebCore/Modules/fetch/LocalNetworkAccess.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LocalNetworkAccess.h"
+
+#include "IPAddressSpace.h"
+#include "ResourceRequest.h"
+#include "SecurityOrigin.h"
+#include "SecurityOriginData.h"
+
+namespace WebCore {
+
+std::optional<ResourceError> performLocalNetworkAccessCheck(const ResourceRequest& request, IPAddressSpace connectionAddressSpace, IPAddressSpace clientPolicyContainerAddressSpace, bool clientIsSecureContext, const SecurityOriginData& clientOrigin, NOESCAPE const LocalNetworkAccessPermissionCheckFunction& permissionCheck)
+{
+    if (shouldTreatAsPotentiallyTrustworthy(request.url()) && SecurityOriginData::fromURL(request.url()) == clientOrigin)
+        return std::nullopt;
+
+    if (connectionAddressSpace != IPAddressSpace::Unknown) {
+        if (request.targetAddressSpace() != IPAddressSpace::Public && request.targetAddressSpace() != connectionAddressSpace) {
+            return ResourceError { "WebKitErrorDomain"_s, 0, request.url(),
+                "Local Network Access: connection's resolved address space does not match the request's declared targetAddressSpace"_s,
+                ResourceError::Type::AccessControl };
+        }
+
+        if (!isLessPublicThan(connectionAddressSpace, clientPolicyContainerAddressSpace))
+            return std::nullopt;
+    }
+
+    auto error = ResourceError { "WebKitErrorDomain"_s, 0, request.url(),
+        "Local Network Access: connection to a less public address space than the requesting document was blocked"_s,
+        ResourceError::Type::AccessControl };
+
+    if (!clientIsSecureContext)
+        return error;
+
+    // FIXME: Per the spec, the permission check should be keyed on a PermissionName ("local-network" or
+    // "loopback-network" depending on connectionAddressSpace) looked up through PermissionController, not
+    // this bespoke callback. This stub exists because no such permission names are wired up yet.
+    switch (permissionCheck(clientOrigin, connectionAddressSpace)) {
+    case PermissionState::Granted:
+        return std::nullopt;
+    case PermissionState::Denied:
+    case PermissionState::Prompt:
+        return error;
+    }
+    return error;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/fetch/LocalNetworkAccess.h
+++ b/Source/WebCore/Modules/fetch/LocalNetworkAccess.h
@@ -25,53 +25,20 @@
 
 #pragma once
 
-#include <wtf/HashFunctions.h>
-#include <wtf/HashTraits.h>
+#include <WebCore/PermissionState.h>
+#include <WebCore/ResourceError.h>
+#include <optional>
+#include <wtf/Forward.h>
+#include <wtf/Function.h>
 
 namespace WebCore {
 
-class IPAddress;
+enum class IPAddressSpace : uint8_t;
+class ResourceRequest;
+class SecurityOriginData;
 
-class Site;
+using LocalNetworkAccessPermissionCheckFunction = Function<PermissionState(const SecurityOriginData& clientOrigin, IPAddressSpace connectionAddressSpace)>;
 
-enum class IPAddressSpace : uint8_t {
-    Public,
-    Local,
-    Loopback,
-    Unknown
-};
-
-constexpr uint8_t publicnessRank(IPAddressSpace space)
-{
-    switch (space) {
-    case IPAddressSpace::Loopback:
-        return 0;
-    case IPAddressSpace::Local:
-        return 1;
-    case IPAddressSpace::Public:
-        return 2;
-    case IPAddressSpace::Unknown:
-        return 0;
-    }
-    return 2;
-}
-
-inline bool isLessPublicThan(IPAddressSpace a, IPAddressSpace b)
-{
-    return publicnessRank(a) < publicnessRank(b);
-}
-
-WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
-WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const Site&);
-
-WEBCORE_EXPORT IPAddressSpace classifyIPAddressSpace(const IPAddress&);
+WEBCORE_EXPORT std::optional<ResourceError> performLocalNetworkAccessCheck(const ResourceRequest&, IPAddressSpace connectionAddressSpace, IPAddressSpace clientPolicyContainerAddressSpace, bool clientIsSecureContext, const SecurityOriginData& clientOrigin, NOESCAPE const LocalNetworkAccessPermissionCheckFunction&);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct DefaultHash<WebCore::IPAddressSpace> : IntHash<WebCore::IPAddressSpace> { };
-template<> struct HashTraits<WebCore::IPAddressSpace> : StrongEnumHashTraits<WebCore::IPAddressSpace> { };
-
-} // namespace WTF
-

--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
@@ -57,7 +57,7 @@ public:
 
     enum IsolatedCopyTag { IsolatedCopy };
     IDBRequestData(const IDBRequestData&, IsolatedCopyTag);
-    WEBCORE_EXPORT IDBRequestData NODELETE isolatedCopy() const;
+    WEBCORE_EXPORT IDBRequestData isolatedCopy() const;
 
     IDBConnectionIdentifier NODELETE serverConnectionIdentifier() const;
     WEBCORE_EXPORT IDBResourceIdentifier NODELETE requestIdentifier() const;

--- a/Source/WebCore/Modules/permissions/PermissionState.idl
+++ b/Source/WebCore/Modules/permissions/PermissionState.idl
@@ -25,7 +25,9 @@
 
 // https://w3c.github.io/permissions/#enumdef-permissionstate
 
-enum PermissionState {
+[
+    ExportMacro=WEBCORE_EXPORT
+] enum PermissionState {
     "granted",
     "denied",
     "prompt"

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -136,6 +136,7 @@ Modules/fetch/FetchRequest.cpp @cost:3
 Modules/fetch/FetchResponse.cpp @cost:4
 Modules/fetch/FormDataConsumer.cpp
 Modules/fetch/IPAddressSpace.cpp
+Modules/fetch/LocalNetworkAccess.cpp
 Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp @cost:3
 Modules/filesystem/FileSystemDirectoryHandle.cpp
 Modules/filesystem/FileSystemFileHandle.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1380,6 +1380,7 @@
 		3BB6B81122A7D313003A2A69 /* TabSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BB6B80F22A7D311003A2A69 /* TabSize.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3C244FEAA375AC633F88BE6F /* RenderLayerModelObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C244FE4A375AC633F88BE6F /* RenderLayerModelObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3C8D24EE2E25CF1A00D2A929 /* IPAddressSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		58E9CA87641E10563C3CE61C /* LocalNetworkAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = DAE4358201103A6E524EB9AE /* LocalNetworkAccess.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3D42BC4514B0E28F44D62E77 /* UnifiedSource51-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6D90699809046B96AE290168 /* UnifiedSource51-header-RenderStyleGetters.cpp */; };
 		3D4E6A98F12B0C85A2C173D6 /* RenderLayerSVGAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C7B5F48E0A31D9467FB8C52 /* RenderLayerSVGAdditions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F42B31D1881191B00278AAC /* WebVideoFullscreenControllerAVKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F42B31B1881191B00278AAC /* WebVideoFullscreenControllerAVKit.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -10904,6 +10905,8 @@
 		3C6A595F2E4E5D5300A908CC /* IPAddressSpace.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPAddressSpace.cpp; sourceTree = "<group>"; };
 		3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPAddressSpace.h; sourceTree = "<group>"; };
 		3CE7C6702E270278005CDFD8 /* IPAddressSpace.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = IPAddressSpace.idl; sourceTree = "<group>"; };
+		DAE4358201103A6E524EB9AE /* LocalNetworkAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LocalNetworkAccess.h; sourceTree = "<group>"; };
+		DAD333D76403A91488F601D7 /* LocalNetworkAccess.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LocalNetworkAccess.cpp; sourceTree = "<group>"; };
 		3DCCA4B4BF1CEDC0C5E7B3BB /* Airplay.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Airplay.svg; sourceTree = "<group>"; };
 		3EB98985C78E4C2A4C58889D /* UnifiedSource61-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource61-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		3F3BB5821E709EE400C701F2 /* CoreAudioCaptureSource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CoreAudioCaptureSource.cpp; sourceTree = "<group>"; };
@@ -27939,6 +27942,8 @@
 				3C6A595F2E4E5D5300A908CC /* IPAddressSpace.cpp */,
 				3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */,
 				3CE7C6702E270278005CDFD8 /* IPAddressSpace.idl */,
+				DAD333D76403A91488F601D7 /* LocalNetworkAccess.cpp */,
+				DAE4358201103A6E524EB9AE /* LocalNetworkAccess.h */,
 				44CF5098299B906F0038D284 /* RequestPriority.h */,
 				44CF5097299B90600038D284 /* RequestPriority.idl */,
 				7C2E0BD125106AC4005F3C87 /* WindowOrWorkerGlobalScope+Fetch.idl */,
@@ -47301,6 +47306,7 @@
 				E35B907F23F60A50000011FF /* LocalizedDeviceModel.h in Headers */,
 				935207BE09BD410A00F2038D /* LocalizedStrings.h in Headers */,
 				550A0BCC085F6039007353D7 /* LocalNameWithNamespace.h in Headers */,
+				58E9CA87641E10563C3CE61C /* LocalNetworkAccess.h in Headers */,
 				41FCD6BB23CE027700C62567 /* LocalSampleBufferDisplayLayer.h in Headers */,
 				BCE1C41B0D982980003B02F2 /* Location.h in Headers */,
 				E3C788EE2D035C9500D6C13D /* LogClient.h in Headers */,

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1437,7 +1437,7 @@ public:
     bool loadEventFinished() const { return m_loadEventFinished; }
 
     bool isContextThread() const final;
-    bool isSecureContext() const final;
+    WEBCORE_EXPORT bool isSecureContext() const final;
     bool NODELETE crossOriginIsolated() const final;
     bool NODELETE originAgentCluster() const;
     String agentClusterID() const final;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -182,10 +182,12 @@ enum class AXTextChange : uint8_t;
 enum class BroadcastFocusedElement : bool;
 enum class ContentChange : uint8_t;
 enum class DidFilterLinkDecoration : bool { No, Yes };
+enum class IPAddressSpace : uint8_t;
 enum class IsLoggedIn : uint8_t;
 enum class LinkDecorationFilteringTrigger : uint8_t;
 enum class ModalContainerControlType : uint8_t;
 enum class ModalContainerDecision : uint8_t;
+enum class PermissionState : uint8_t;
 enum class PlatformEventModifier : uint8_t;
 enum class PluginUnavailabilityReason : uint8_t;
 enum class PointerLockRequestResult : uint8_t;
@@ -471,6 +473,8 @@ public:
     virtual RefPtr<ShapeDetection::TextDetector> createTextDetector() const;
 
     virtual void registerBlobPathForTesting(const String&, CompletionHandler<void()>&&) { }
+
+    virtual void setLocalNetworkAccessPermissionForTesting(SecurityOriginData&&, IPAddressSpace, PermissionState, CompletionHandler<void()>&& completionHandler) { completionHandler(); }
 
     // Pass nullptr as the GraphicsLayer to detatch the root layer.
     virtual void attachRootGraphicsLayer(LocalFrame&, GraphicsLayer*) = 0;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -131,6 +131,7 @@
 #include "HitTestResult.h"
 #include "IDBRequest.h"
 #include "IDBTransaction.h"
+#include "IPAddressSpace.h"
 #include "ImageData.h"
 #include "ImageOverlay.h"
 #include "ImageOverlayController.h"
@@ -153,6 +154,7 @@
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "LocalNetworkAccess.h"
 #include "LocalizedStrings.h"
 #include "Location.h"
 #include "MallocStatistics.h"
@@ -186,6 +188,7 @@
 #include "PageInspectorController.h"
 #include "PageOverlay.h"
 #include "PathUtilities.h"
+#include "PermissionState.h"
 #include "PictureInPictureSupport.h"
 #include "PlatformKeyboardEvent.h"
 #include "PlatformMediaEngineConfigurationFactory.h"
@@ -231,6 +234,7 @@
 #include "ScrollingCoordinator.h"
 #include "ScrollingMomentumCalculator.h"
 #include "SecurityOrigin.h"
+#include "SecurityOriginData.h"
 #include "SelectorFilter.h"
 #include "SerializedScriptValue.h"
 #include "ServiceWorker.h"
@@ -6174,6 +6178,28 @@ String Internals::createTemporaryFile(const String& name, const String& contents
 
     file.write(byteCast<uint8_t>(contents.utf8().span()));
     return path;
+}
+
+void Internals::setLocalNetworkAccessPermissionForTesting(const String& originURL, IPAddressSpace addressSpace, PermissionState decision, DOMPromiseDeferred<void>&& promise)
+{
+    Document* document = contextDocument();
+    if (!document) {
+        promise.reject(ExceptionCode::InvalidStateError);
+        return;
+    }
+
+    URL url = document->encodingParseURL(originURL);
+    auto origin = SecurityOriginData::fromURL(url);
+
+    RefPtr page = document->page();
+    if (!page) {
+        promise.reject(ExceptionCode::InvalidStateError);
+        return;
+    }
+
+    page->chrome().client().setLocalNetworkAccessPermissionForTesting(WTF::move(origin), addressSpace, decision, [promise = WTF::move(promise)]() mutable {
+        promise.resolve();
+    });
 }
 
 void Internals::queueMicroTask(int testNumber)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -156,6 +156,8 @@ class XMLHttpRequest;
 struct VideoConfiguration;
 
 enum class DocumentMarkerType : uint32_t;
+enum class IPAddressSpace : uint8_t;
+enum class PermissionState : uint8_t;
 
 #if ENABLE(ENCRYPTED_MEDIA)
 class MediaKeys;
@@ -987,6 +989,8 @@ public:
     RefPtr<File> createFile(const String&);
     void asyncCreateFile(const String&, DOMPromiseDeferred<IDLInterface<File>>&&);
     String createTemporaryFile(const String& name, const String& contents);
+
+    void setLocalNetworkAccessPermissionForTesting(const String& originURL, IPAddressSpace, PermissionState, DOMPromiseDeferred<void>&&);
 
     void queueMicroTask(int);
     bool testPreloaderSettingViewport();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1164,6 +1164,8 @@ enum ContentsFormat {
     Promise<File> asyncCreateFile(DOMString url);
     DOMString createTemporaryFile(DOMString name, DOMString contents);
 
+    Promise<undefined> setLocalNetworkAccessPermissionForTesting(DOMString originURL, IPAddressSpace addressSpace, PermissionState decision);
+
     undefined queueMicroTask(long testNumber);
     boolean testPreloaderSettingViewport();
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -82,9 +82,12 @@
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/DocumentStorageAccess.h>
 #include <WebCore/HTTPCookieAcceptPolicy.h>
+#include <WebCore/IPAddressSpace.h>
+#include <WebCore/LocalNetworkAccess.h>
 #include <WebCore/LogInitialization.h>
 #include <WebCore/LoginStatus.h>
 #include <WebCore/NetworkStorageSession.h>
+#include <WebCore/PermissionState.h>
 #include <WebCore/Quirks.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceLoadObserver.h>
@@ -1318,6 +1321,13 @@ void NetworkConnectionToWebProcess::generalStoragePathForTesting(CompletionHandl
     if (!session)
         return completion({ });
     completion(String { session->storageManager().path() });
+}
+
+void NetworkConnectionToWebProcess::setLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData&& origin, WebCore::IPAddressSpace addressSpace, WebCore::PermissionState decision, CompletionHandler<void()>&& completion)
+{
+    if (CheckedPtr session = networkSession())
+        session->setLocalNetworkAccessPermissionForTesting(WTF::move(origin), addressSpace, decision);
+    completion();
 }
 
 void NetworkConnectionToWebProcess::allowAccessToFile(const String& path)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -84,10 +84,13 @@ class LoginStatus;
 class MockContentFilterSettings;
 class ResourceError;
 class ResourceRequest;
+class SecurityOriginData;
 class Site;
 enum class AdvancedPrivacyProtections : uint16_t;
 enum class StorageAccessScope : bool;
 enum class IsLoggedIn : uint8_t;
+enum class IPAddressSpace : uint8_t;
+enum class PermissionState : uint8_t;
 enum class ShouldPartitionCookie : bool;
 struct ClientOrigin;
 struct Cookie;
@@ -342,6 +345,7 @@ private:
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&&)>&&);
     void registerBlobPathForTesting(const String& path, CompletionHandler<void()>&&);
     void generalStoragePathForTesting(CompletionHandler<void(String&&)>&&);
+    void setLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData&&, WebCore::IPAddressSpace, WebCore::PermissionState, CompletionHandler<void()>&&);
     bool isFilePathAllowed(String path);
 
     void registerBlobURLHandle(const URL&, const std::optional<WebCore::SecurityOriginData>& topOrigin);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -77,6 +77,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     UnregisterBlobURLHandle(URL url, std::optional<WebCore::SecurityOriginData> topOrigin);
     RegisterBlobPathForTesting(String path) -> ();
     [EnabledBy=AllowTestOnlyIPC] GeneralStoragePathForTesting() -> (String path);
+    [EnabledBy=AllowTestOnlyIPC] SetLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData origin, enum:uint8_t WebCore::IPAddressSpace addressSpace, enum:uint8_t WebCore::PermissionState decision) -> ();
 
     SetCaptureExtraNetworkLoadMetricsEnabled(bool enabled)
 

--- a/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
@@ -72,6 +72,7 @@ struct NetworkLoadParameters {
     // the WebProcess). We should block storage access cookies on this load's network requests without
     // revoking the frame's storage from JS until the navigation load commits.
     bool navigationLosesFrameSpecificStorageAccess { false };
+    bool localNetworkAccessEnabled { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -94,7 +94,8 @@ NetworkLoadParameters NetworkResourceLoadParameters::networkLoadParameters() con
         advancedPrivacyProtections,
         isInitiatedByDedicatedWorker,
         requiredCookiesVersion,
-        navigationLosesFrameSpecificStorageAccess
+        navigationLosesFrameSpecificStorageAccess,
+        localNetworkAccessEnabled
     };
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -34,6 +34,7 @@
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/FetchOptions.h>
 #include <WebCore/FetchingWorkerIdentifier.h>
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/NavigationRequester.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
@@ -135,6 +136,11 @@ struct NetworkResourceLoadParameters {
     bool globalPrivacyControlEnabled { false };
     bool shouldConsiderEnhancedSecurityForInsecureResponse { false };
     MonotonicTime originalNavigationStartTime { };
+
+    // The resolved connection's address space isn't known at load-schedule time, so it isn't a field here.
+    WebCore::IPAddressSpace clientAddressSpace { WebCore::IPAddressSpace::Public };
+    bool clientIsSecureContext { false };
+    bool localNetworkAccessEnabled { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -112,6 +112,10 @@ enum class WebKit::NavigatingToAppBoundDomain : bool;
     bool globalPrivacyControlEnabled;
     bool shouldConsiderEnhancedSecurityForInsecureResponse;
     MonotonicTime originalNavigationStartTime;
+
+    WebCore::IPAddressSpace clientAddressSpace;
+    bool clientIsSecureContext;
+    bool localNetworkAccessEnabled;
 };
 
 using WebCore::FetchingWorkerIdentifier = Variant<std::monostate, WebCore::SharedWorkerIdentifier, WebCore::ServiceWorkerIdentifier>;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -71,6 +71,7 @@
 #include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/LegacySchemeRegistry.h>
 #include <WebCore/LinkHeader.h>
+#include <WebCore/LocalNetworkAccess.h>
 #include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/OriginAccessPatterns.h>
@@ -80,6 +81,7 @@
 #include <WebCore/SWServer.h>
 #include <WebCore/SameSiteInfo.h>
 #include <WebCore/SecurityOrigin.h>
+#include <WebCore/SecurityOriginData.h>
 #include <WebCore/SecurityPolicy.h>
 #include <WebCore/ShareableResource.h>
 #include <WebCore/SharedBuffer.h>
@@ -867,6 +869,24 @@ std::optional<ResourceError> NetworkResourceLoader::doCrossOriginOpenerHandlingO
     return std::nullopt;
 }
 
+// Skipped for main resources: at this point clientAddressSpace/clientIsSecureContext/sourceOrigin
+// still reflect the previous document, since navigating a frame is what establishes the new one.
+std::optional<ResourceError> NetworkResourceLoader::checkLocalNetworkAccess(const ResourceRequest& request, IPAddressSpace connectionAddressSpace)
+{
+    if (isMainResource() || !m_parameters.localNetworkAccessEnabled)
+        return std::nullopt;
+
+    CheckedPtr networkSession = m_connection->networkSession();
+    if (!networkSession)
+        return std::nullopt;
+
+    auto sourceOrigin = m_parameters.sourceOrigin ? m_parameters.sourceOrigin->data() : SecurityOriginData { };
+    return performLocalNetworkAccessCheck(request, connectionAddressSpace, m_parameters.clientAddressSpace, m_parameters.clientIsSecureContext, sourceOrigin,
+        [networkSession](const SecurityOriginData& origin, IPAddressSpace addressSpace) {
+            return networkSession->localNetworkAccessPermission(origin, addressSpace);
+        });
+}
+
 void NetworkResourceLoader::processClearSiteDataHeader(const WebCore::ResourceResponse& response, CompletionHandler<void()>&& completionHandler)
 {
     if (!m_parameters.isClearSiteDataHeaderEnabled)
@@ -1032,6 +1052,17 @@ void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedRespon
     }
 
     initializeReportingEndpoints(m_response);
+
+    // Skipped for main resources: at this point clientAddressSpace/clientIsSecureContext/sourceOrigin
+    // still reflect the previous document, since navigating a frame is what establishes the new one.
+    if (auto error = checkLocalNetworkAccess(m_parameters.request, m_response.ipAddressSpace())) {
+        LOADER_RELEASE_LOG_ERROR("didReceiveResponse: Blocked by Local Network Access check");
+        RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }, error = WTF::move(*error)] {
+            if (protectedThis->m_networkLoad)
+                protectedThis->didFailLoading(error);
+        });
+        return completionHandler(PolicyAction::Ignore);
+    }
 
     if (isMainResource() && shouldInterruptLoadForCSPFrameAncestorsOrXFrameOptions(m_response)) {
         LOADER_RELEASE_LOG_ERROR("didReceiveResponse: Interrupting main resource load due to CSP frame-ancestors or X-Frame-Options");
@@ -1387,6 +1418,15 @@ void NetworkResourceLoader::continueWillSendRedirectedRequestAfterContentFilteri
     }
 
     if (auto error = doCrossOriginOpenerHandlingOfResponse(redirectResponse)) {
+        didFailLoading(*error);
+        return completionHandler({ });
+    }
+
+    // Redirects don't flow through didReceiveResponse, so this hop needs its own Local Network Access check.
+    //
+    // Skipped for main resources: a redirected top-level navigation has no prior document to check against.
+    if (auto error = checkLocalNetworkAccess(redirectRequest, redirectResponse.ipAddressSpace())) {
+        LOADER_RELEASE_LOG_ERROR("willSendRedirectedRequest: Blocked by Local Network Access check");
         didFailLoading(*error);
         return completionHandler({ });
     }
@@ -1808,6 +1848,15 @@ void NetworkResourceLoader::didRetrieveCacheEntry(std::unique_ptr<NetworkCache::
         didReceiveMainResourceResponse(response);
 
     initializeReportingEndpoints(response);
+
+    // A cache hit still resolved to a real address when the entry was stored, so it needs the same check.
+    //
+    // Skipped for main resources: a cache-served navigation has no prior document to check against.
+    if (auto error = checkLocalNetworkAccess(originalRequest(), response.ipAddressSpace())) {
+        LOADER_RELEASE_LOG_ERROR("didRetrieveCacheEntry: Blocked by Local Network Access check");
+        didFailLoading(*error);
+        return;
+    }
 
     if (isMainResource() && shouldInterruptLoadForCSPFrameAncestorsOrXFrameOptions(response)) {
         LOADER_RELEASE_LOG_ERROR("didRetrieveCacheEntry: Stopping load due to CSP Frame-Ancestors or X-Frame-Options");

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -57,6 +57,7 @@ namespace WebCore {
 class BlobDataFileReference;
 class ContentFilter;
 class FormData;
+enum class IPAddressSpace : uint8_t;
 class LinkHeader;
 class NetworkStorageSession;
 class PendingStreamState;
@@ -188,6 +189,7 @@ public:
     void NODELETE setWorkerFinalRouterSource(WebCore::RouterSourceEnum);
 
     std::optional<WebCore::ResourceError> doCrossOriginOpenerHandlingOfResponse(const WebCore::ResourceResponse&);
+    std::optional<WebCore::ResourceError> checkLocalNetworkAccess(const WebCore::ResourceRequest&, WebCore::IPAddressSpace connectionAddressSpace);
     void sendDidReceiveResponseWithPotentialProcessSwap(const WebCore::ResourceResponse&, PrivateRelayed, bool needsContinueDidReceiveResponseMessage);
 
     bool NODELETE isAppInitiated();

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -54,8 +54,11 @@
 #include "WebSharedWorkerServer.h"
 #include "WebSocketTask.h"
 #include <WebCore/CookieJar.h>
+#include <WebCore/IPAddressSpace.h>
+#include <WebCore/LocalNetworkAccess.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/SWServer.h>
+#include <WebCore/SecurityOriginData.h>
 #include <numeric>
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/StdLibExtras.h>
@@ -439,6 +442,19 @@ std::optional<WebCore::IPAddress> NetworkSession::firstPartyHostIPAddress(const 
         return std::nullopt;
 
     return { iterator->value };
+}
+
+WebCore::PermissionState NetworkSession::localNetworkAccessPermission(const WebCore::SecurityOriginData& origin, WebCore::IPAddressSpace addressSpace) const
+{
+    auto iterator = m_localNetworkAccessPermissions.find({ origin, addressSpace });
+    if (iterator == m_localNetworkAccessPermissions.end())
+        return WebCore::PermissionState::Denied;
+    return iterator->value;
+}
+
+void NetworkSession::setLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData&& origin, WebCore::IPAddressSpace addressSpace, WebCore::PermissionState decision)
+{
+    m_localNetworkAccessPermissions.set({ WTF::move(origin), addressSpace }, decision);
 }
 
 void NetworkSession::storePrivateClickMeasurement(WebCore::PrivateClickMeasurement&& unattributedPrivateClickMeasurement)

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -60,6 +60,7 @@
 
 namespace WebCore {
 class CertificateInfo;
+enum class IPAddressSpace : uint8_t;
 class NetworkStorageSession;
 class ResourceMonitorThrottlerHolder;
 class ResourceRequest;
@@ -68,6 +69,7 @@ class SWServer;
 class SecurityOriginData;
 enum class AdvancedPrivacyProtections : uint16_t;
 enum class IncludeHttpOnlyCookies : bool;
+enum class PermissionState : uint8_t;
 enum class ShouldSample : bool;
 enum class IsInitiatedByDedicatedWorker : bool;
 struct ClientOrigin;
@@ -166,6 +168,11 @@ public:
     std::optional<WebCore::RegistrableDomain> thirdPartyCNAMEDomainForTesting() const { return m_thirdPartyCNAMEDomainForTesting; }
     void resetFirstPartyDNSData();
     void destroyResourceLoadStatistics(CompletionHandler<void()>&&);
+
+    // FIXME: Stub permission decision; replace with a real prompt-mediated check once one exists.
+    // Queried from WebCore::performLocalNetworkAccessCheck()'s callback via NetworkResourceLoader.
+    WebCore::PermissionState localNetworkAccessPermission(const WebCore::SecurityOriginData&, WebCore::IPAddressSpace) const;
+    void setLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData&&, WebCore::IPAddressSpace, WebCore::PermissionState);
     
 #if ENABLE(APP_BOUND_DOMAINS)
     virtual bool hasAppBoundSession() const { return false; }
@@ -350,6 +357,7 @@ protected:
     HashMap<String, WebCore::RegistrableDomain> m_firstPartyHostCNAMEDomains;
     HashMap<String, WebCore::IPAddress> m_firstPartyHostIPAddresses;
     std::optional<WebCore::RegistrableDomain> m_thirdPartyCNAMEDomainForTesting;
+    HashMap<std::pair<WebCore::SecurityOriginData, WebCore::IPAddressSpace>, WebCore::PermissionState> m_localNetworkAccessPermissions;
     bool m_isStaleWhileRevalidateEnabled { false };
     const Ref<PCM::ManagerInterface> m_privateClickMeasurement;
     bool m_privateClickMeasurementDebugModeEnabled { false };

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -578,6 +578,15 @@ void ServiceWorkerFetchTask::processPreloadResponse()
         return;
     }
 
+    // The navigation preload response comes from a real network connection, so it needs the same
+    // Local Network Access check as any other network-resolved response reaching NetworkResourceLoader.
+    if (RefPtr loader = m_loader.get()) {
+        if (auto error = loader->checkLocalNetworkAccess(m_currentRequest, response.ipAddressSpace())) {
+            didFail(*error);
+            return;
+        }
+    }
+
     bool needsContinueDidReceiveResponseMessage = m_currentRequest.requester() == ResourceRequestRequester::Main;
     processResponse(WTF::move(response), needsContinueDidReceiveResponseMessage, ShouldSetSource::No);
     if (needsContinueDidReceiveResponseMessage)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -126,6 +126,7 @@ private:
     bool m_navigationLosesFrameSpecificStorageAccess { false };
     RefPtr<WebCore::SecurityOrigin> m_sourceOrigin;
     uint64_t m_requiredCookiesVersion { 0 };
+    bool m_localNetworkAccessEnabled { false };
 };
 
 WebCore::Credential serverTrustCredential(const WebCore::AuthenticationChallenge&);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -216,6 +216,7 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
     , m_navigationLosesFrameSpecificStorageAccess(parameters.navigationLosesFrameSpecificStorageAccess)
     , m_sourceOrigin(parameters.sourceOrigin)
     , m_requiredCookiesVersion(parameters.requiredCookiesVersion)
+    , m_localNetworkAccessEnabled(parameters.localNetworkAccessEnabled)
 {
     auto request = parameters.request;
     auto url = request.url();
@@ -464,7 +465,7 @@ void NetworkDataTaskCocoa::didReceiveResponse(WebCore::ResourceResponse&& respon
     }
 #endif
     auto resolvedIPAddress = WebCore::IPAddress::fromString(lastRemoteIPAddress(m_task.get()));
-    if (resolvedIPAddress)
+    if (resolvedIPAddress && m_localNetworkAccessEnabled)
         response.setIPAddressSpace(WebCore::classifyIPAddressSpace(*resolvedIPAddress));
     NetworkDataTask::didReceiveResponse(WTF::move(response), negotiatedLegacyTLS, privateRelayed, resolvedIPAddress, WTF::move(completionHandler));
 }
@@ -473,8 +474,10 @@ void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&
 {
     WTFEmitSignpost(m_task.get(), DataTask, "redirect");
 
-    if (auto resolvedIPAddress = WebCore::IPAddress::fromString(lastRemoteIPAddress(m_task.get())))
-        redirectResponse.setIPAddressSpace(WebCore::classifyIPAddressSpace(*resolvedIPAddress));
+    if (auto resolvedIPAddress = WebCore::IPAddress::fromString(lastRemoteIPAddress(m_task.get()))) {
+        if (m_localNetworkAccessEnabled)
+            redirectResponse.setIPAddressSpace(WebCore::classifyIPAddressSpace(*resolvedIPAddress));
+    }
 
     networkLoadMetrics().hasCrossOriginRedirect = networkLoadMetrics().hasCrossOriginRedirect || !WebCore::SecurityOrigin::create(request.url())->canRequest(redirectResponse.url(), WebCore::EmptyOriginAccessPatterns::singleton());
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -404,6 +404,17 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
         parameters.isClearSiteDataExecutionContextEnabled = document->settings().clearSiteDataExecutionContextsSupportEnabled();
         parameters.mayBlockNetworkRequest = !isMainFrameNavigation && document->settings().scriptTrackingPrivacyNetworkRequestBlockingEnabled();
         parameters.globalPrivacyControlEnabled = document->settings().globalPrivacyControlEnabled().value_or(false);
+        // The resolved connection's address space is only known in NetworkProcess once the connection completes, so it can't be precomputed here.
+        //
+        // FIXME: document->ipAddressSpace() is currently dead scaffolding: nothing sets
+        // PolicyContainer::ipAddressSpace from a response's classified address space, so every
+        // document reports Public here regardless of what address space it was actually loaded
+        // from. A document itself loaded from a local/loopback address will incorrectly be
+        // treated as Public, making its own same-space subrequests go through the permission
+        // check unnecessarily instead of being recognized as already-local.
+        parameters.clientAddressSpace = document->ipAddressSpace();
+        parameters.clientIsSecureContext = document->isSecureContext();
+        parameters.localNetworkAccessEnabled = document->settings().localNetworkAccessEnabled();
     }
 
     if (RefPtr page = frame->page()) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -110,11 +110,14 @@
 #include <WebCore/HTMLParserIdioms.h>
 #include <WebCore/HTMLPlugInElement.h>
 #include <WebCore/HTMLVideoElement.h>
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/Icon.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/LocalFrameInlines.h>
 #include <WebCore/LocalFrameView.h>
+#include <WebCore/LocalNetworkAccess.h>
 #include <WebCore/NotImplemented.h>
+#include <WebCore/PermissionState.h>
 #include <WebCore/PointerLockController.h>
 #include <WebCore/PopupMenuClient.h>
 #include <WebCore/RegistrableDomain.h>
@@ -1360,6 +1363,10 @@ void WebChromeClient::registerBlobPathForTesting(const String& path, CompletionH
     WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::RegisterBlobPathForTesting(path), WTF::move(completionHandler));
 }
 
+void WebChromeClient::setLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData&& origin, WebCore::IPAddressSpace addressSpace, WebCore::PermissionState decision, CompletionHandler<void()>&& completionHandler)
+{
+    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::SetLocalNetworkAccessPermissionForTesting(WTF::move(origin), addressSpace, decision), WTF::move(completionHandler));
+}
 
 void WebChromeClient::contentRuleListNotification(const URL& url, const ContentRuleListResults& results)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -250,6 +250,7 @@ private:
     void renderingUpdateFramesPerSecondChanged() final;
     unsigned remoteImagesCountForTesting() const final;
     void registerBlobPathForTesting(const String& path, CompletionHandler<void()>&&) final;
+    void setLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData&&, WebCore::IPAddressSpace, WebCore::PermissionState, CompletionHandler<void()>&&) final;
 
     void contentRuleListNotification(const URL&, const WebCore::ContentRuleListResults&) final;
     void contentRuleListMatchedRule(const WebCore::ContentRuleListMatchedRule&) final;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -243,6 +243,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/KeyedCoding.cpp
         Tests/WebCore/LayoutRoundedRectTests.cpp
         Tests/WebCore/LayoutUnitTests.cpp
+        Tests/WebCore/LocalNetworkAccess.cpp
         Tests/WebCore/MIMESniffer.cpp
         Tests/WebCore/MIMETypeRegistry.cpp
         Tests/WebCore/MediaConstraintsTests.cpp

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -195,6 +195,7 @@ Tests/WebKit/WKWebView/LoadFileThenReload.mm @nonARC
 Tests/WebKit/WKWebView/LoadFileURL.mm @nonARC
 Tests/WebKit/WKWebView/LoadInvalidURLRequest.mm @nonARC
 Tests/WebKit/WKWebView/Loading.mm @nonARC
+Tests/WebKit/WKWebView/LocalNetworkAccessTests.mm @nonARC
 Tests/WebKit/WKWebView/LocalStorageClear.mm @nonARC
 Tests/WebKit/WKWebView/LocalStorageDatabaseTracker.mm @nonARC
 Tests/WebKit/WKWebView/LocalStorageNullEntries.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -772,6 +772,7 @@
 				WebCore/KeyedCoding.cpp,
 				WebCore/LayoutRoundedRectTests.cpp,
 				WebCore/LayoutUnitTests.cpp,
+				WebCore/LocalNetworkAccess.cpp,
 				WebCore/Logging.cpp,
 				WebCore/LoginStatus.cpp,
 				WebCore/MarkedText.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/LocalNetworkAccess.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/LocalNetworkAccess.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/IPAddressSpace.h>
+#include <WebCore/LocalNetworkAccess.h>
+#include <WebCore/PermissionState.h>
+#include <WebCore/ResourceRequest.h>
+#include <WebCore/SecurityOriginData.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+static LocalNetworkAccessPermissionCheckFunction permissionCheckReturning(PermissionState decision)
+{
+    return [decision](const SecurityOriginData&, IPAddressSpace) {
+        return decision;
+    };
+}
+
+TEST(LocalNetworkAccess, SameOriginTrustworthyExemption)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://example.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, SameOriginButNotTrustworthyIsNotExempt)
+{
+    ResourceRequest request { URL { "http://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "http://example.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, CrossOriginIsNotExempt)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, MatchingTargetAddressSpaceStillRequiresPermission)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    request.setTargetAddressSpace(IPAddressSpace::Loopback);
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, MatchingTargetAddressSpaceAllowedWithGrant)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    request.setTargetAddressSpace(IPAddressSpace::Loopback);
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Granted));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, MismatchedTargetAddressSpaceIsBlocked)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    request.setTargetAddressSpace(IPAddressSpace::Local);
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, false, clientOrigin, permissionCheckReturning(PermissionState::Granted));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, MorePublicConnectionIsAllowed)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Public, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, LoopbackToLoopbackIsAllowedWithoutExplicitTargetAddressSpace)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Loopback, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, NonSecureContextIsBlockedWithoutConsultingPermissionStub)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, false, clientOrigin, permissionCheckReturning(PermissionState::Granted));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, SecureContextGrantedByPermissionStub)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Granted));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, SecureContextDeniedByPermissionStub)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, SecureContextPromptIsTreatedAsDenied)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Prompt));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, UndeterminedConnectionSpaceInNonSecureContextIsBlocked)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Unknown, IPAddressSpace::Public, false, clientOrigin, permissionCheckReturning(PermissionState::Granted));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, UndeterminedConnectionSpaceIsBlockedByDefaultPermission)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Unknown, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, UndeterminedConnectionSpaceCanStillBeGranted)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Unknown, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Granted));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, UndeterminedConnectionSpaceStillHonorsSameOriginTrustworthyExemption)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://example.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Unknown, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    EXPECT_FALSE(error.has_value());
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LocalNetworkAccessTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LocalNetworkAccessTests.mm
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "Helpers/cocoa/HTTPServer.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import "Helpers/cocoa/WKWebViewConfigurationExtras.h"
+#import "PlatformUtilities.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/_WKFeature.h>
+
+namespace TestWebKitAPI {
+
+// LocalNetworkAccessEnabled has no dedicated Obj-C setter, so flip it via the generic _WKFeature list.
+static void setLocalNetworkAccessEnabledForConfiguration(WKWebViewConfiguration *configuration, BOOL enabled)
+{
+    for (_WKFeature *feature in WKPreferences._features) {
+        if ([feature.key isEqualToString:@"LocalNetworkAccessEnabled"])
+            [configuration.preferences _setEnabled:enabled forFeature:feature];
+    }
+}
+
+static RetainPtr<TestWKWebView> createWebViewForLocalNetworkAccessTesting(BOOL localNetworkAccessEnabled)
+{
+    // WebProcessPlugInWithInternals is what makes `window.internals` available to page script here.
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    setLocalNetworkAccessEnabledForConfiguration(configuration.get(), localNetworkAccessEnabled);
+    // Without _allowTestOnlyIPC, NetworkProcess treats SetLocalNetworkAccessPermissionForTesting as
+    // an invalid message and terminates the WebContent process instead of servicing it.
+    configuration.get()._allowTestOnlyIPC = YES;
+    return adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+}
+
+static constexpr auto crossOriginLoopbackFetchPageBytes = R"HTMLRESOURCE(
+<script>
+async function doFetch(targetOrigin)
+{
+    await fetch(targetOrigin + "/target.txt", { mode: "no-cors" })
+        .then(() => window.fetchResult = "success")
+        .catch(e => window.fetchResult = "error: " + e.message);
+}
+</script>
+)HTMLRESOURCE"_s;
+
+static String waitForFetchResult(TestWKWebView *webView)
+{
+    Util::waitForConditionWithLogging([&] -> bool {
+        return [[webView stringByEvaluatingJavaScript:@"window.fetchResult || ''"] length] > 0;
+    }, 10, @"Timed out waiting for fetch result.");
+    return String { [webView stringByEvaluatingJavaScript:@"window.fetchResult"] };
+}
+
+TEST(LocalNetworkAccessTests, DisabledFeatureAllowsLoopbackFetchUnconditionally)
+{
+    auto server = HTTPServer({
+        { "/index.html"_s, { crossOriginLoopbackFetchPageBytes } },
+        { "/target.txt"_s, { "hello"_s } },
+    });
+
+    auto webView = createWebViewForLocalNetworkAccessTesting(NO);
+    [webView synchronouslyLoadRequest:server.requestWithLocalhost("/index.html"_s)];
+
+    RetainPtr targetOrigin = server.origin().createNSString();
+    [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"doFetch('%@'); undefined", targetOrigin.get()]];
+
+    EXPECT_WK_STREQ(waitForFetchResult(webView.get()), "success");
+}
+
+TEST(LocalNetworkAccessTests, CrossOriginLoopbackFetchBlockedWithoutGrant)
+{
+    // The page is loaded via requestWithLocalhost so its origin (http://localhost:<port>) differs
+    // from the fetch target (http://127.0.0.1:<port>), even though both resolve to the loopback
+    // interface -- otherwise the same-origin exemption would trivially allow the request.
+    auto server = HTTPServer({
+        { "/index.html"_s, { crossOriginLoopbackFetchPageBytes } },
+        { "/target.txt"_s, { "hello"_s } },
+    });
+
+    auto webView = createWebViewForLocalNetworkAccessTesting(YES);
+    [webView synchronouslyLoadRequest:server.requestWithLocalhost("/index.html"_s)];
+
+    RetainPtr targetOrigin = server.origin().createNSString();
+    [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"doFetch('%@'); undefined", targetOrigin.get()]];
+
+    EXPECT_TRUE(waitForFetchResult(webView.get()).startsWith("error:"_s));
+}
+
+TEST(LocalNetworkAccessTests, CrossOriginLoopbackFetchSucceedsWithGrant)
+{
+    auto server = HTTPServer({
+        { "/index.html"_s, { crossOriginLoopbackFetchPageBytes } },
+        { "/target.txt"_s, { "hello"_s } },
+    });
+
+    auto webView = createWebViewForLocalNetworkAccessTesting(YES);
+    [webView synchronouslyLoadRequest:server.requestWithLocalhost("/index.html"_s)];
+
+    NSString *pageOrigin = [webView stringByEvaluatingJavaScript:@"location.origin"];
+    NSString *grantScript = [NSString stringWithFormat:@"(async () => { await internals.setLocalNetworkAccessPermissionForTesting('%@', 'loopback', 'granted'); window.grantComplete = true; })(); undefined", pageOrigin];
+    [webView objectByEvaluatingJavaScript:grantScript];
+    Util::waitForConditionWithLogging([&] -> bool {
+        return [[webView objectByEvaluatingJavaScript:@"window.grantComplete || false"] boolValue];
+    }, 10, @"Timed out waiting for permission grant.");
+
+    RetainPtr targetOrigin = server.origin().createNSString();
+    [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"doFetch('%@'); undefined", targetOrigin.get()]];
+
+    EXPECT_WK_STREQ(waitForFetchResult(webView.get()), "success");
+}
+
+TEST(LocalNetworkAccessTests, SameOriginTargetAddressSpaceFetchSucceedsWithoutGrant)
+{
+    // This exemption is unconditional and doesn't consult the permission stub, unlike the
+    // cross-origin permission-gated path covered by the two tests above.
+    auto server = HTTPServer({
+        { "/index.html"_s, { "<script>window.pageLoaded = true;</script>"_s } },
+        { "/target.txt"_s, { "hello"_s } },
+    });
+
+    auto webView = createWebViewForLocalNetworkAccessTesting(YES);
+    [webView synchronouslyLoadRequest:server.request("/index.html"_s)];
+
+    NSString *fetchScript =
+        @"(async () => {"
+        "  try {"
+        "    await fetch(location.origin + '/target.txt', { targetAddressSpace: 'loopback' });"
+        "    window.fetchResult = 'success';"
+        "  } catch (e) {"
+        "    window.fetchResult = 'error: ' + e.message;"
+        "  }"
+        "})(); undefined";
+    [webView objectByEvaluatingJavaScript:fetchScript];
+
+    EXPECT_WK_STREQ(waitForFetchResult(webView.get()), "success");
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 98fd7710de9a4dad311a49e0ef8796b4f537c0a3
<pre>
Wire the Local Network Access check into NetworkResourceLoader and the navigation preload path
<a href="https://bugs.webkit.org/show_bug.cgi?id=319908">https://bugs.webkit.org/show_bug.cgi?id=319908</a>
<a href="https://rdar.apple.com/182830246">rdar://182830246</a>

Reviewed by NOBODY (OOPS!).

Makes the Local Network Access check added in bug 319907 actually enforce: a cross-origin subresource
fetch that resolves to a less-public address space than the requesting document is now blocked unless
permission has been granted. Gated on the LocalNetworkAccessEnabled feature flag, which is off by
default.

Threads the requesting document&apos;s address space and secure-context status from WebProcess into
NetworkProcess and invokes WebCore::performLocalNetworkAccessCheck() at the three points where a
load&apos;s resolved-connection address space becomes known: the final response in
NetworkResourceLoader::didReceiveResponse, each redirect hop in
NetworkResourceLoader::continueWillSendRedirectedRequestAfterContentFiltering (redirects do not flow
through didReceiveResponse, so without a separate check there, a local/loopback-hosted redirect
chain could otherwise bypass Local Network Access entirely), and a cache hit in
NetworkResourceLoader::didRetrieveCacheEntry (a cache entry still resolved to a real address when it
was stored, so a cache-served load needs the same check). All three sites are collapsed into a single
NetworkResourceLoader::checkLocalNetworkAccess helper, following the existing
doCrossOriginOpenerHandlingOfResponse precedent for a check invoked from every response-delivery path,
so the guard/lookup logic isn&apos;t triplicated. All three are skipped for main resources, since
clientAddressSpace/clientIsSecureContext/sourceOrigin still reflect the previous document at that
point (navigating a frame is what establishes the new one). The same helper is also called from
ServiceWorkerFetchTask::processPreloadResponse, since a navigation preload response is a real network
fetch with a real resolved connection; the service worker&apos;s own respondWith()-synthesized response and
its DOM Cache API read path are not checked, since neither involves an external network connection to
classify.

Since no native permission prompt exists yet, this also adds the permission store the check consults:
NetworkSession keeps a per-session (origin, address space) -&gt; PermissionState map, settable via a new
AllowTestOnlyIPC-gated message reachable from Internals so the enforcement paths above can be tested
in both the granted and denied states. Prompt is treated as Denied for now. PermissionState.idl gains
[ExportMacro=WEBCORE_EXPORT] so its generated enum conversions link into WebCoreTestSupport for the
new Internals entry point.

WebLoaderStrategy::addParametersShared snapshots document-&gt;ipAddressSpace() and
document-&gt;isSecureContext() into NetworkResourceLoadParameters at load-schedule time, the same way
other per-load document state (e.g. CrossOriginEmbedderPolicy) is captured there today. Since this is
the first call to Document::isSecureContext() from outside WebCore, it now needs WEBCORE_EXPORT.
NetworkResourceLoadParameters gained clientAddressSpace/clientIsSecureContext/localNetworkAccessEnabled
fields and a corresponding IPC serialization entry; localNetworkAccessEnabled also flows through to
NetworkDataTaskCocoa, gating its response/redirect IP classification on the feature flag rather than
running unconditionally. Computing the resolved IP address itself stays unconditional in
NetworkDataTaskCocoa, since NetworkDataTask::didReceiveResponse&apos;s pre-existing check for mixed-content
loads from localhost resolving to a non-loopback address (bug 272955) also depends on it, and gating
that computation behind the (currently off-by-default) Local Network Access flag would have silently
disabled that unrelated, already-shipped protection.

Also adds a WebKitCocoa API test exercising the enforcement path against the real Cocoa network
stack (HTTPServer bound to loopback, not a mock), and a WebKit-authored layout test demonstrating
block-without-grant / allow-with-grant using the Internals permission stub.

* LayoutTests/http/wpt/fetch/local-network-access/loopback-blocked-without-permission-expected.txt: Added.
* LayoutTests/http/wpt/fetch/local-network-access/loopback-blocked-without-permission.html: Added.
* Source/WebCore/Modules/permissions/PermissionState.idl:
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setLocalNetworkAccessPermissionForTesting):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::setLocalNetworkAccessPermissionForTesting):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::checkLocalNetworkAccess): Added.
(WebKit::NetworkResourceLoader::didReceiveResponse):
(WebKit::NetworkResourceLoader::continueWillSendRedirectedRequestAfterContentFiltering):
(WebKit::NetworkResourceLoader::didRetrieveCacheEntry):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::setLocalNetworkAccessPermissionForTesting):
(WebKit::NetworkSession::localNetworkAccessPermission):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::processPreloadResponse):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
(WebKit::NetworkDataTaskCocoa::didReceiveResponse):
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::setLocalNetworkAccessPermissionForTesting):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LocalNetworkAccessTests.mm: Added.
</pre>
----------------------------------------------------------------------
#### 8fd2cf727f53a99f2cd45d8d23858ce45d6d4ff1
<pre>
Add the Local Network Access check algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=319907">https://bugs.webkit.org/show_bug.cgi?id=319907</a>
<a href="https://rdar.apple.com/182830329">rdar://182830329</a>

Reviewed by NOBODY (OOPS!).

Adds WebCore::performLocalNetworkAccessCheck(), implementing the algorithm from the WICG Local
Network Access spec (<a href="https://wicg.github.io/local-network-access/#fetching)">https://wicg.github.io/local-network-access/#fetching)</a>: a same-origin/trustworthy
exemption, a targetAddressSpace mismatch check, a publicness comparison via isLessPublicThan(), and a
fail-closed result for non-secure contexts.

The permission decision is not looked up directly. WebCore can&apos;t link against a NetworkProcess-resident
permission store, and no native Local Network Access prompt exists yet, so the function takes the
decision as a NOESCAPE callback returning WebCore::PermissionState (the existing Permissions API
decision type, rather than a bespoke duplicate). This keeps the algorithm a pure, self-contained
function: the caller supplies the lookup, and this patch&apos;s unit tests supply it directly. The
NetworkProcess-side permission store, its test-only IPC plumbing, and the enforcement call sites that
consume this function all land in the follow-up patch for bug 319908, which is what makes the check
observable to a browser user.

Also drops an incorrect NODELETE annotation on IDBRequestData::isolatedCopy() const, caught by
mac/ios-safer-cpp EWS and unrelated to the above.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/fetch/IPAddressSpace.h:
* Source/WebCore/Modules/fetch/LocalNetworkAccess.cpp: Added.
(WebCore::performLocalNetworkAccessCheck):
* Source/WebCore/Modules/fetch/LocalNetworkAccess.h: Added.
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/LocalNetworkAccess.cpp: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98fd7710de9a4dad311a49e0ef8796b4f537c0a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187675 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141309 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51709 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138817 "Found 1 new test failure: http/wpt/fetch/local-network-access/loopback-blocked-without-permission.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96405 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181019 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42349 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159561 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119273 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41015 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39370 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151415 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39059 "344 new passes 6 flakes") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36133 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44599 "Found 2 new failures in NetworkProcess/NetworkResourceLoader.cpp") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43613 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190102 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51668 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159087 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147950 "Found 1 new test failure: http/wpt/fetch/local-network-access/loopback-blocked-without-permission.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52350 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35684 "344 new passes 8 flakes 2 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147723 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42433 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124613 "Found 2 new failures in NetworkProcess/NetworkResourceLoader.cpp") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119087 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50868 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14031 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50493 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50315 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->