### PR TITLE
[SwiftUI WebKit API] Expose _editable on WebPage

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage+SPI.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+SPI.swift
@@ -1,0 +1,179 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI
+
+import Observation
+import WebKit_Private
+import WebKit_Internal
+
+// MARK: CrossImportOverlay SPI
+
+extension WebPage {
+    #if os(macOS)
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(CrossImportOverlay)
+    public func setMenuBuilder(_ menuBuilder: ((WKContextMenuElementInfoAdapter) -> NSMenu)?) {
+        backingUIDelegate.menuBuilder = menuBuilder
+    }
+
+    // SPI for testing.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(Testing)
+    public var smartListsEnabled: Bool {
+        get { backingWebView._isSmartListsEnabled() }
+        set { backingWebView._setSmartListsEnabled(newValue) }
+    }
+    #endif // os(macOS)
+
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(CrossImportOverlay)
+    public func backingProperty<Value, BackingValue>(
+        _ keyPath: KeyPath<WebPage, Value>,
+        backedBy backingKeyPath: KeyPath<WebPageWebView, BackingValue>,
+        _ transform: (BackingValue) -> Value
+    ) -> Value {
+        if observations.contents[keyPath] == nil {
+            observations.contents[keyPath] = createObservation(for: keyPath, backedBy: backingKeyPath)
+        }
+
+        self.access(keyPath: keyPath)
+
+        let backingValue = backingWebView[keyPath: backingKeyPath]
+        return transform(backingValue)
+    }
+
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(CrossImportOverlay)
+    public func backingProperty<Value>(_ keyPath: KeyPath<WebPage, Value>, backedBy backingKeyPath: KeyPath<WebPageWebView, Value>) -> Value
+    {
+        backingProperty(keyPath, backedBy: backingKeyPath) { $0 }
+    }
+}
+
+// MARK: Testing SPI
+
+extension WebPage {
+    /// Represents details about the current editor state.
+    @_spi(Testing)
+    public struct EditorStateSnapshot: Sendable, Equatable {
+        /// The post-layout data associated with an editor state.
+        @_spi(Testing)
+        public struct PostLayoutData: Sendable, Equatable {
+            /// The current selection is bold.
+            @_spi(Testing)
+            public let bold: Bool
+
+            /// The current selection is italic.
+            @_spi(Testing)
+            public let italic: Bool
+
+            /// The current selection is underlined.
+            @_spi(Testing)
+            public let underline: Bool
+
+            /// The text alignment of the current selection.
+            @_spi(Testing)
+            public let textAlignment: NSTextAlignment
+
+            /// The CSS color string of the current selection.
+            @_spi(Testing)
+            public let textColor: Swift.String
+        }
+
+        /// A type of selection.
+        @_spi(Testing)
+        public enum SelectionType: Int, Sendable, Equatable {
+            /// No selection.
+            case none
+
+            /// A caret selection.
+            case caret
+
+            /// A range selection.
+            case range
+        }
+
+        /// The current type of selection.
+        @_spi(Testing)
+        public let selectionType: SelectionType
+
+        /// The post-layout data of the editor state, if any.
+        @_spi(Testing)
+        public let postLayoutData: PostLayoutData?
+    }
+
+    // SPI for testing.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(Testing)
+    public func terminateWebContentProcess() {
+        backingWebView._killWebContentProcess()
+    }
+
+    /// An indefinite sequence of editor state snapshot changes for this page.
+    @_spi(Testing)
+    public func editorStateSnapshots() -> some AsyncSequence<EditorStateSnapshot, Never> & Sendable {
+        let id = UUID()
+
+        let (stream, continuation) = AsyncStream.makeStream(of: EditorStateSnapshot.self)
+        continuation.onTermination = { [weak self] termination in
+            guard let self else {
+                return
+            }
+            Task { @MainActor in
+                editorStateSnapshotsContinuations[id] = nil
+            }
+        }
+
+        editorStateSnapshotsContinuations[id] = continuation
+        return stream
+    }
+}
+
+extension WebPage.EditorStateSnapshot {
+    init(_ dictionary: [AnyHashable: Any]) {
+        // The Objective-C interface this is converting from is not able to express at compile-time that this is guaranteed.
+        // swift-format-ignore: NeverForceUnwrap
+        self.selectionType = SelectionType(rawValue: dictionary["selection-type"] as! SelectionType.RawValue)!
+
+        guard let postLayoutData = dictionary["post-layout-data"] as? Bool, postLayoutData else {
+            self.postLayoutData = nil
+            return
+        }
+
+        // The Objective-C interface this is converting from is not able to express at compile-time that these are guaranteed.
+        // swift-format-ignore: NeverForceUnwrap
+        self.postLayoutData = .init(
+            bold: dictionary["bold"] as! Bool,
+            italic: dictionary["italic"] as! Bool,
+            underline: dictionary["underline"] as! Bool,
+            textAlignment: NSTextAlignment(rawValue: dictionary["text-alignment"] as! Int)!,
+            textColor: dictionary["text-color"] as! String
+        )
+    }
+}
+
+#endif // ENABLE_SWIFTUI

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -362,17 +362,8 @@ final public class WebPage {
     let backingUIDelegate: WKUIDelegateAdapter
     private let backingNavigationDelegate: WKNavigationDelegateAdapter
 
-    #if os(macOS)
-    // SPI for the cross-import overlay.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    @_spi(CrossImportOverlay)
-    public func setMenuBuilder(_ menuBuilder: ((WKContextMenuElementInfoAdapter) -> NSMenu)?) {
-        backingUIDelegate.menuBuilder = menuBuilder
-    }
-    #endif
-
     @ObservationIgnored
-    private var observations = KeyValueObservations()
+    var observations = KeyValueObservations()
 
     // SPI for the cross-import overlay.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -398,16 +389,6 @@ final public class WebPage {
         return webView
     }()
 
-    #if os(macOS)
-    // SPI for testing.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    @_spi(Testing)
-    public var smartListsEnabled: Bool {
-        get { backingWebView._isSmartListsEnabled() }
-        set { backingWebView._setSmartListsEnabled(newValue) }
-    }
-    #endif
-
     // MARK: Loading functions
 
     @ObservationIgnored
@@ -420,7 +401,7 @@ final public class WebPage {
     private var indefiniteNavigations: [UUID: AsyncThrowingStream<NavigationEvent, any Error>.Continuation] = [:]
 
     @ObservationIgnored
-    private var editorStateSnapshotsContinuations: [UUID: AsyncStream<EditorStateSnapshot>.Continuation] = [:]
+    var editorStateSnapshotsContinuations: [UUID: AsyncStream<EditorStateSnapshot>.Continuation] = [:]
 
     /// Loads the web content that the specified URL references and navigates to that content.
     ///
@@ -682,7 +663,7 @@ final public class WebPage {
 // MARK: Helper functions
 
 extension WebPage {
-    private struct KeyValueObservations: ~Copyable {
+    struct KeyValueObservations: ~Copyable {
         var contents: [PartialKeyPath<WebPage>: NSKeyValueObservation] = [:]
 
         deinit {
@@ -763,7 +744,7 @@ extension WebPage {
         return stream
     }
 
-    private func createObservation<Value, BackingValue>(
+    func createObservation<Value, BackingValue>(
         for keyPath: KeyPath<WebPage, Value>,
         backedBy backingKeyPath: KeyPath<WebPageWebView, BackingValue>
     ) -> NSKeyValueObservation {
@@ -779,32 +760,6 @@ extension WebPage {
             }
         }
     }
-
-    // SPI for the cross-import overlay.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    @_spi(CrossImportOverlay)
-    public func backingProperty<Value, BackingValue>(
-        _ keyPath: KeyPath<WebPage, Value>,
-        backedBy backingKeyPath: KeyPath<WebPageWebView, BackingValue>,
-        _ transform: (BackingValue) -> Value
-    ) -> Value {
-        if observations.contents[keyPath] == nil {
-            observations.contents[keyPath] = createObservation(for: keyPath, backedBy: backingKeyPath)
-        }
-
-        self.access(keyPath: keyPath)
-
-        let backingValue = backingWebView[keyPath: backingKeyPath]
-        return transform(backingValue)
-    }
-
-    // SPI for the cross-import overlay.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    @_spi(CrossImportOverlay)
-    public func backingProperty<Value>(_ keyPath: KeyPath<WebPage, Value>, backedBy backingKeyPath: KeyPath<WebPageWebView, Value>) -> Value
-    {
-        backingProperty(keyPath, backedBy: backingKeyPath) { $0 }
-    }
 }
 
 extension WebPage.FullscreenState {
@@ -818,108 +773,6 @@ extension WebPage.FullscreenState {
             @unknown default:
                 fatalError()
             }
-    }
-}
-
-// MARK: Testing
-
-extension WebPage {
-    /// Represents details about the current editor state.
-    @_spi(Testing)
-    public struct EditorStateSnapshot: Sendable, Equatable {
-        /// The post-layout data associated with an editor state.
-        @_spi(Testing)
-        public struct PostLayoutData: Sendable, Equatable {
-            /// The current selection is bold.
-            @_spi(Testing)
-            public let bold: Bool
-
-            /// The current selection is italic.
-            @_spi(Testing)
-            public let italic: Bool
-
-            /// The current selection is underlined.
-            @_spi(Testing)
-            public let underline: Bool
-
-            /// The text alignment of the current selection.
-            @_spi(Testing)
-            public let textAlignment: NSTextAlignment
-
-            /// The CSS color string of the current selection.
-            @_spi(Testing)
-            public let textColor: Swift.String
-        }
-
-        /// A type of selection.
-        @_spi(Testing)
-        public enum SelectionType: Int, Sendable, Equatable {
-            /// No selection.
-            case none
-
-            /// A caret selection.
-            case caret
-
-            /// A range selection.
-            case range
-        }
-
-        /// The current type of selection.
-        @_spi(Testing)
-        public let selectionType: SelectionType
-
-        /// The post-layout data of the editor state, if any.
-        @_spi(Testing)
-        public let postLayoutData: PostLayoutData?
-    }
-
-    // SPI for testing.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    @_spi(Testing)
-    public func terminateWebContentProcess() {
-        backingWebView._killWebContentProcess()
-    }
-
-    /// An indefinite sequence of editor state snapshot changes for this page.
-    @_spi(Testing)
-    public func editorStateSnapshots() -> some AsyncSequence<EditorStateSnapshot, Never> & Sendable {
-        let id = UUID()
-
-        let (stream, continuation) = AsyncStream.makeStream(of: EditorStateSnapshot.self)
-        continuation.onTermination = { [weak self] termination in
-            guard let self else {
-                return
-            }
-            Task { @MainActor in
-                editorStateSnapshotsContinuations[id] = nil
-            }
-        }
-
-        editorStateSnapshotsContinuations[id] = continuation
-        return stream
-    }
-}
-
-extension WebPage.EditorStateSnapshot {
-    init(_ dictionary: [AnyHashable: Any]) {
-        // The Objective-C interface this is converting from is not able to express at compile-time that this is guaranteed.
-        // swift-format-ignore: NeverForceUnwrap
-        self.selectionType = SelectionType(rawValue: dictionary["selection-type"] as! SelectionType.RawValue)!
-
-        guard let postLayoutData = dictionary["post-layout-data"] as? Bool, postLayoutData else {
-            self.postLayoutData = nil
-            return
-        }
-
-        // The Objective-C interface this is converting from is not able to express at compile-time that these are guaranteed.
-        // swift-format-ignore: NeverForceUnwrap
-        self.postLayoutData = .init(
-            bold: dictionary["bold"] as! Bool,
-            italic: dictionary["italic"] as! Bool,
-            underline: dictionary["underline"] as! Bool,
-            textAlignment: NSTextAlignment(rawValue: dictionary["text-alignment"] as! Int)!,
-            textColor: dictionary["text-color"] as! String
-        )
     }
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		07275C8F2D011396002315A5 /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07275C8E2D011396002315A5 /* Empty.swift */; };
 		07297F9F1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 07297F9D1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.h */; };
 		07297F9F1C17BBEA015F0735 /* DeviceIdHashSaltStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 07297F9D1C17BBEA223F0735 /* DeviceIdHashSaltStorage.h */; };
+		0732D6EB301D645100C2BFE7 /* WebPage+SPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0732D6EA301D645100C2BFE7 /* WebPage+SPI.swift */; };
 		0735F31C2D3760AA0003D029 /* IntelligenceTextEffectViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0735F31B2D3760AA0003D029 /* IntelligenceTextEffectViewManager.swift */; };
 		0735F31E2D3760BC0003D029 /* IntelligenceTextEffectChunk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0735F31D2D3760BC0003D029 /* IntelligenceTextEffectChunk.swift */; };
 		0735F3202D3761A10003D029 /* WKIntelligenceReplacementTextEffectCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0735F31F2D3761A10003D029 /* WKIntelligenceReplacementTextEffectCoordinator.h */; };
@@ -3465,6 +3466,7 @@
 		07297F9C1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserMediaPermissionCheckProxy.cpp; sourceTree = "<group>"; };
 		07297F9D1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserMediaPermissionCheckProxy.h; sourceTree = "<group>"; };
 		07297F9D1C17BBEA223F0735 /* DeviceIdHashSaltStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceIdHashSaltStorage.h; sourceTree = "<group>"; };
+		0732D6EA301D645100C2BFE7 /* WebPage+SPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+SPI.swift"; sourceTree = "<group>"; };
 		0735F31B2D3760AA0003D029 /* IntelligenceTextEffectViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntelligenceTextEffectViewManager.swift; sourceTree = "<group>"; };
 		0735F31D2D3760BC0003D029 /* IntelligenceTextEffectChunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntelligenceTextEffectChunk.swift; sourceTree = "<group>"; };
 		0735F31F2D3761A10003D029 /* WKIntelligenceReplacementTextEffectCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKIntelligenceReplacementTextEffectCoordinator.h; sourceTree = "<group>"; };
@@ -9853,6 +9855,7 @@
 				07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */,
 				074E87E02CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift */,
 				078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */,
+				0732D6EA301D645100C2BFE7 /* WebPage+SPI.swift */,
 				071467772DFE84E500F77867 /* WebPage+Transferable.swift */,
 				07CB79952CE9435700199C49 /* WebPage.swift */,
 			);
@@ -22515,6 +22518,7 @@
 				07FAA74B2CE947AA00128360 /* WebPage+Navigation.swift in Sources */,
 				074E87E12CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift in Sources */,
 				078B04A02CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift in Sources */,
+				0732D6EB301D645100C2BFE7 /* WebPage+SPI.swift in Sources */,
 				071467782DFE84E500F77867 /* WebPage+Transferable.swift in Sources */,
 				07CB79962CE9435700199C49 /* WebPage.swift in Sources */,
 				0715310F2F3037C100B56C0E /* WebPageProxy.swift in Sources */,

--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -217,6 +217,15 @@ extension View {
         return self
         #endif
     }
+
+    /// The semantic environment describing how the contents of the web view will be used in.
+    ///
+    /// - Parameter value: The kind of environment.
+    /// - Returns: A view with the specified content environment configured.
+    @_spi(Experimental)
+    public nonisolated func webViewContentEnvironmentV0(_ value: WebView.ContentEnvironment_v0) -> some View {
+        environment(\.webViewContentEnvironment, value)
+    }
 }
 
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
@@ -246,6 +246,27 @@ extension WebView {
         /// The URL of the link that the user clicked.
         public let linkURL: URL?
     }
+
+    /// Defines a specific set of semantics representing how the webpage contents are used.
+    @_spi(Experimental)
+    public struct ContentEnvironment_v0: Sendable {
+        enum Storage: Sendable {
+            case standard
+            case editable
+        }
+
+        /// The standard environment with no specialized behavior changes.
+        @_spi(Experimental)
+        public static let standard = Self(storage: .standard)
+
+        /// An environment suitable for editable contents.
+        ///
+        /// This environment imbues `contenteditable` and other affordances that are designed for editable use cases.
+        @_spi(Experimental)
+        public static let editable = Self(storage: .editable)
+
+        let storage: Storage
+    }
 }
 
 extension WebView {

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
@@ -67,6 +67,9 @@ extension EnvironmentValues {
     @Entry
     var webViewImmersiveEnvironmentRequestContext: ImmersiveEnvironmentRequestContext? = nil
     #endif
+
+    @Entry
+    var webViewContentEnvironment = WebView.ContentEnvironment_v0.standard
 }
 
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -139,6 +139,8 @@ struct WebViewRepresentable {
         webView.configuration.preferences.isTextInteractionEnabled = environment.webViewTextSelection
         webView.configuration.preferences.isElementFullscreenEnabled = environment.webViewElementFullscreenBehavior.value == .enabled
 
+        webView._isEditable = environment.webViewContentEnvironment.storage == .editable
+
         platformView.onScrollGeometryChange = environment.webViewOnScrollGeometryChange
 
         #if ENABLE_MODEL_ELEMENT_IMMERSIVE

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -570,6 +570,7 @@
 				WebKit/WebPage/WebPageScrollbarTests.swift,
 				WebKit/WebPage/WebPageTests.swift,
 				WebKit/WebPage/WebPageTransferableTests.swift,
+				WebKit/WebPage/WebViewTests.swift,
 				WebKit/WKWebView/CodingTests.swift,
 				WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift,
 			);
@@ -1361,6 +1362,7 @@
 				WebKit/WebPage/WebPageScrollbarTests.swift,
 				WebKit/WebPage/WebPageTests.swift,
 				WebKit/WebPage/WebPageTransferableTests.swift,
+				WebKit/WebPage/WebViewTests.swift,
 				WebKit/WKWebView/CodingTests.swift,
 				WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift,
 				WTF/cocoa/SwiftCxxInteropTestbed.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift
@@ -1,0 +1,112 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && !os(watchOS) && !os(tvOS)
+
+import Observation
+import SwiftUI
+import Testing
+import WebKit
+@_spi(Experimental) import _WebKit_SwiftUI
+private import TestWebKitAPILibrary
+import struct _Concurrency.Task
+#if WTF_PLATFORM_MAC
+import AppKit
+#else
+import UIKit
+#endif
+
+@Observable
+@MainActor
+private final class ViewModel {
+    let page = WebPage()
+
+    var isEditable: Bool = false
+}
+
+@MainActor
+struct WebViewTests {
+    @Test
+    func applyingContentEnvironmentAffectsPageSemantics() async throws {
+        struct TestView: View {
+            @Environment(ViewModel.self)
+            var model
+
+            var body: some View {
+                WebView(model.page)
+                    .webViewContentEnvironmentV0(model.isEditable ? .editable : .standard)
+            }
+        }
+
+        func isContentEditable() async throws -> Bool {
+            try await model.page.callJavaScript(returning: Bool.self) {
+                """
+                const element = document.getElementById("div");
+                return element.isContentEditable;
+                """
+            }
+        }
+
+        let model = ViewModel()
+
+        render(observing: model) {
+            TestView()
+                .environment(model)
+        }
+
+        model.isEditable = true
+
+        try await model.page.load(html: #"<div id="div">hello</div>"#).wait()
+        await model.page.waitForNextPresentationUpdate()
+
+        try await #expect(isContentEditable())
+
+        model.isEditable = false
+
+        await model.page.waitForNextPresentationUpdate()
+
+        try await #expect(!isContentEditable())
+    }
+}
+
+@MainActor
+func render(
+    observing observable: @escaping @isolated(any) @autoclosure @Sendable () -> some Observable & Sendable,
+    @ViewBuilder rootView: () -> some View
+) {
+    let resolvedView = rootView()
+
+    #if WTF_PLATFORM_MAC
+    let viewController = NSHostingController(rootView: resolvedView)
+    #else
+    let viewController = UIHostingController(rootView: resolvedView)
+    #endif
+
+    Task.immediate {
+        for await _ in Observations(observable) {
+            viewController._render(seconds: 1.0 / 60.0)
+        }
+    }
+}
+
+#endif // ENABLE_SWIFTUI && !os(watchOS) && !os(tvOS)


### PR DESCRIPTION
#### 88df87f94496dffe265df6d5281c7043cf7becbc
<pre>
[SwiftUI WebKit API] Expose _editable on WebPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=320772">https://bugs.webkit.org/show_bug.cgi?id=320772</a>
<a href="https://rdar.apple.com/183774945">rdar://183774945</a>

Reviewed by Aditya Keerthi.

Expose SPI to define the content environment of a page, a more flexible version of the existing `_editable` WKWebView SPI.

Also refactor WebPage to have a dedicated SPI file.

* Source/WebKit/UIProcess/API/Swift/WebPage+SPI.swift: Added.
(WebPage.setMenuBuilder(_:)):
(WebPage.smartListsEnabled):
(terminateWebContentProcess):
(editorStateSnapshots):
(contentEnvironment):
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(editorStateSnapshotsContinuations):
(setMenuBuilder(_:)): Deleted.
(smartListsEnabled): Deleted.
(terminateWebContentProcess): Deleted.
(editorStateSnapshots): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/318398@main">https://commits.webkit.org/318398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02bff05c9397f6dfcc109fafb0b02a764906e079

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187815 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d32aa62e-df83-45c2-97b0-154e5b14b344) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138915 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a85bdec-ae2c-4c3f-a09c-7cd80aed8624) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119371 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c91866c0-e844-4d7f-b5ff-b2ddaf9cd2e8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41138 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39493 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39179 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36272 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44739 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190242 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51807 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148067 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39759 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/multipart-three-part.py (failure)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52489 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35804 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147840 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27026 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42554 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124753 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119307 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51007 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14155 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50392 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50632 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50454 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->