### PR TITLE
Subtitles don't always turn on when selecting "On" in the media controls

### DIFF
--- a/LayoutTests/media/modern-media-controls/tracks-support/on-off-text-track-expected.txt
+++ b/LayoutTests/media/modern-media-controls/tracks-support/on-off-text-track-expected.txt
@@ -32,6 +32,20 @@ EXPECTED (contextMenu[1].checked == 'true') OK
 EXPECTED (contextMenu[2].checked == 'false') OK
 EXPECTED (internals.captionDisplayMode == 'alwayson') OK
 --
+Test On re-enables a track when nothing is showing and the mode is already AlwaysOn
+RUN(for (const track of video.textTracks) track.mode = "disabled")
+EXPECTED (video.textTracks[0].mode == 'disabled') OK
+EXPECTED (video.textTracks[1].mode == 'disabled') OK
+EXPECTED (video.textTracks[2].mode == 'disabled') OK
+EXPECTED (video.textTracks[3].mode == 'disabled') OK
+EXPECTED (internals.captionDisplayMode == 'alwayson') OK
+EXPECTED (contextMenu[4].children[0].checked == 'true') OK
+EXPECTED (contextMenu[4].children[1].checked == 'false') OK
+EXPECTED (contextMenu[4].children[2].checked == 'false') OK
+EXPECTED (contextMenu[4].children[3].checked == 'false') OK
+RUN(controlsHost.setSelectedTextTrack(onItem))
+EXPECTED (video.textTracks[0].mode == 'showing') OK
+--
 Test Off menu item behavior
 RUN(controlsHost.setSelectedTextTrack(offItem))
 EXPECTED (video.textTracks[0].mode == 'disabled') OK

--- a/LayoutTests/media/modern-media-controls/tracks-support/on-off-text-track.html
+++ b/LayoutTests/media/modern-media-controls/tracks-support/on-off-text-track.html
@@ -75,6 +75,26 @@
             testExpected('internals.captionDisplayMode', 'alwayson');
 
             consoleWrite('--');
+            consoleWrite('Test On re-enables a track when nothing is showing and the mode is already AlwaysOn');
+
+            run('for (const track of video.textTracks) track.mode = "disabled"');
+            testExpected('video.textTracks[0].mode', 'disabled');
+            testExpected('video.textTracks[1].mode', 'disabled');
+            testExpected('video.textTracks[2].mode', 'disabled');
+            testExpected('video.textTracks[3].mode', 'disabled');
+            testExpected('internals.captionDisplayMode', 'alwayson');
+
+            // The checked language is the most-preferred track, and pressing On must enable exactly that one.
+            contextMenu = getContextMenuItems();
+            testExpected('contextMenu[4].children[0].checked', true);
+            testExpected('contextMenu[4].children[1].checked', false);
+            testExpected('contextMenu[4].children[2].checked', false);
+            testExpected('contextMenu[4].children[3].checked', false);
+
+            run('controlsHost.setSelectedTextTrack(onItem)');
+            await testExpectedEventually('video.textTracks[0].mode', 'showing', '==', 100);
+
+            consoleWrite('--');
             consoleWrite('Test Off menu item behavior');
 
             run('controlsHost.setSelectedTextTrack(offItem)');

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -644,16 +644,8 @@ auto MediaControlsHost::mediaControlsContextMenuItems(String&& optionsJSONString
                 // captions are "Off" which track would be chosen if
                 // captions are turned on.
                 RefPtr<TextTrack> bestTrackToEnable;
-                if (allTracksDisabled) {
-                    int bestScore = 0;
-                    for (auto& track : sortedTextTracks) {
-                        auto score = captionPreferences->textTrackSelectionScore(track, CaptionUserPreferences::CaptionDisplayMode::AlwaysOn);
-                        if (score <= bestScore)
-                            continue;
-                        bestTrackToEnable = track.ptr();
-                        bestScore = score;
-                    }
-                }
+                if (allTracksDisabled)
+                    bestTrackToEnable = captionPreferences->bestTextTrackToEnable(*textTracks);
 
                 Vector<MenuItem> subtitleMenuItems;
                 subtitleMenuItems.append(createMenuItem(TextTrack::captionMenuOnItemSingleton(), captionPreferences->displayNameForTrack(TextTrack::captionMenuOnItemSingleton()), !allTracksDisabled));
@@ -822,9 +814,11 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
             },
             [&] (Ref<TextTrack>& selectedTextTrack) {
                 protectedThis->savePreviouslySelectedTextTrackIfNecessary();
-                for (auto& track : idMap.values()) {
-                    if (auto* textTrack = std::get_if<Ref<TextTrack>>(&track))
-                        (*textTrack)->setMode(TextTrack::Mode::Disabled);
+                if (selectedTextTrack.ptr() != &TextTrack::captionMenuOnItemSingleton()) {
+                    for (auto& track : idMap.values()) {
+                        if (auto* textTrack = std::get_if<Ref<TextTrack>>(&track))
+                            (*textTrack)->setMode(TextTrack::Mode::Disabled);
+                    }
                 }
                 mediaElement->setSelectedTextTrack(selectedTextTrack.ptr());
             },

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5813,6 +5813,22 @@ void HTMLMediaElement::setSelectedTextTrack(TextTrack* trackToSelect)
         if (captionDisplayMode() != CaptionUserPreferences::CaptionDisplayMode::ForcedOnly && !trackList->isChangeEventScheduled())
             m_textTracks->scheduleChangeEvent();
     } else if (trackToSelect == &TextTrack::captionMenuOnItemSingleton()) {
+        bool hasShowingTrack = false;
+        for (int i = 0, length = trackList->length(); i < length; ++i) {
+            if (RefPtr { trackList->item(i) }->mode() == TextTrack::Mode::Showing) {
+                hasShowingTrack = true;
+                break;
+            }
+        }
+
+        if (!hasShowingTrack) {
+            if (RefPtr page = document().page()) {
+                Ref captionPreferences = protect(page->group())->ensureCaptionPreferences();
+                if (RefPtr trackToEnable = captionPreferences->bestTextTrackToEnable(*trackList))
+                    trackToEnable->setMode(TextTrack::Mode::Showing);
+            }
+        }
+
         if (captionDisplayMode() != CaptionUserPreferences::CaptionDisplayMode::AlwaysOn)
             m_textTracks->scheduleChangeEvent();
     } else {

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -440,6 +440,21 @@ int CaptionUserPreferences::textTrackLanguageSelectionScore(TextTrack& track, co
     return (preferredLanguages.size() + bonus - languageMatchIndex) * 10;
 }
 
+RefPtr<TextTrack> CaptionUserPreferences::bestTextTrackToEnable(const TextTrackList& trackList) const
+{
+    RefPtr<TextTrack> best;
+    int bestScore = 0;
+    for (unsigned i = 0, length = trackList.length(); i < length; ++i) {
+        Ref track = *trackList.item(i);
+        int score = textTrackSelectionScore(track, CaptionDisplayMode::AlwaysOn);
+        if (score > bestScore) {
+            bestScore = score;
+            best = track.ptr();
+        }
+    }
+    return best;
+}
+
 void CaptionUserPreferences::setCaptionsStyleSheetOverride(const String& override)
 {
     if (override == m_captionsStyleSheetOverride)

--- a/Source/WebCore/page/CaptionUserPreferences.h
+++ b/Source/WebCore/page/CaptionUserPreferences.h
@@ -97,6 +97,7 @@ public:
     virtual String displayNameForTrack(const TextTrack&) const;
     MediaSelectionOption mediaSelectionOptionForTrack(const TextTrack&) const;
     virtual Vector<Ref<TextTrack>> sortedTrackListForMenu(TextTrackList*, HashSet<TextTrack::Kind>);
+    RefPtr<TextTrack> bestTextTrackToEnable(const TextTrackList&) const;
 
     virtual String displayNameForTrack(const AudioTrack&) const;
     MediaSelectionOption mediaSelectionOptionForTrack(const AudioTrack&) const;


### PR DESCRIPTION
#### 762e22b2a4d40381bc92f07fb45ccb28fbfe843d
<pre>
Subtitles don&apos;t always turn on when selecting &quot;On&quot; in the media controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=320769">https://bugs.webkit.org/show_bug.cgi?id=320769</a>
<a href="https://rdar.apple.com/183776073">rdar://183776073</a>

Reviewed by Eric Carlson.

Selecting &quot;On&quot; in the media controls captions menu sometimes does nothing and subtitles
never appear. The only way to turn them on is to pick a specific language from the
Languages submenu. Once a language has been chosen, toggling &quot;On&quot; while the subtitles
are active will toggle them Off, and selecting &quot;On&quot; afterwards will do nothing again.

This happens when the caption display mode is already `AlwaysOn` but no text track
is showing. When we make a &quot;On&quot; selection all tracks get disabled and due to the AlwaysOn state
being the same, we never re-run the track configuration that would pick one to display.
Selecting a specific language works because that path enables the chosen track directly.

Selecting &quot;On&quot; now enables the best-matching text track directly, and we no longer
disable all tracks when the selection is &quot;On&quot;, so a track that&apos;s already showing is left alone.

Test: media/modern-media-controls/tracks-support/on-off-text-track.html

Added test case when display mode is already AlwaysOn, that selecting &quot;On&quot; will enable a track

* LayoutTests/media/modern-media-controls/tracks-support/on-off-text-track-expected.txt:
* LayoutTests/media/modern-media-controls/tracks-support/on-off-text-track.html:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::mediaControlsContextMenuItems):
(WebCore::MediaControlsHost::showMediaControlsContextMenu):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setSelectedTextTrack):
* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::CaptionUserPreferences::bestTextTrackToEnable const):
* Source/WebCore/page/CaptionUserPreferences.h:

Canonical link: <a href="https://commits.webkit.org/318468@main">https://commits.webkit.org/318468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce329c69888617be9253525583a7ec4874129c28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187692 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138812 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119268 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41027 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39380 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39067 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36150 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190119 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159095 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147958 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52367 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147730 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27058 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42443 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124630 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119104 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50885 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14065 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50270 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50510 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->