### PR TITLE
[interactive-widget] Make overlays-content layout tests device-agnostic

### DIFF
--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll-expected.txt
@@ -1,17 +1,16 @@
-Scrolled to 40, 1048
-PASS document.scrollingElement.scrollTop is 1048
-PASS document.scrollingElement.scrollLeft is 40
-PASS window.visualViewport.pageTop is not 0
-PASS window.visualViewport.scale is 1
-PASS window.visualViewport.width is 390
-PASS window.visualViewport.height is 797
+PASS document.scrollingElement.scrollTop == window.targetScrollTop is true
+PASS document.scrollingElement.scrollLeft == 40 is true
+PASS window.visualViewport.pageTop != 0 is true
+PASS window.visualViewport.scale == 1 is true
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
 Scrolled to 0, 0
-PASS document.scrollingElement.scrollTop is 0
-PASS document.scrollingElement.scrollLeft is 0
-PASS window.visualViewport.pageTop is 0
-PASS window.visualViewport.scale is 1
-PASS window.visualViewport.width is 390
-PASS window.visualViewport.height is 797
+PASS document.scrollingElement.scrollTop == 0 is true
+PASS document.scrollingElement.scrollLeft == 0 is true
+PASS window.visualViewport.pageTop == 0 is true
+PASS window.visualViewport.scale == 1 is true
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll.html
@@ -24,25 +24,25 @@
             await UIHelper.activateElement(textField);
             await UIHelper.waitForKeyboardToShow();
 
-            window.scrollTo(40, 1048);
-            debug('Scrolled to ' + window.scrollX + ', ' + window.scrollY);
+            window.targetScrollTop = Math.floor((document.scrollingElement.scrollHeight - document.scrollingElement.clientHeight) / 2);
+            window.scrollTo(40, window.targetScrollTop);
 
-            shouldBe('document.scrollingElement.scrollTop', '1048');
-            shouldBe('document.scrollingElement.scrollLeft', '40');
-            shouldNotBe('window.visualViewport.pageTop', '0');
-            shouldBe('window.visualViewport.scale', '1');
-            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
-            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+            shouldBeTrue('document.scrollingElement.scrollTop == window.targetScrollTop');
+            shouldBeTrue('document.scrollingElement.scrollLeft == 40');
+            shouldBeTrue('window.visualViewport.pageTop != 0');
+            shouldBeTrue('window.visualViewport.scale == 1');
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
 
             window.scrollTo(0, 0);
             debug('Scrolled to ' + window.scrollX + ', ' + window.scrollY);
 
-            shouldBe('document.scrollingElement.scrollTop', '0');
-            shouldBe('document.scrollingElement.scrollLeft', '0');
-            shouldBe('window.visualViewport.pageTop', '0');
-            shouldBe('window.visualViewport.scale', '1');
-            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
-            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+            shouldBeTrue('document.scrollingElement.scrollTop == 0');
+            shouldBeTrue('document.scrollingElement.scrollLeft == 0');
+            shouldBeTrue('window.visualViewport.pageTop == 0');
+            shouldBeTrue('window.visualViewport.scale == 1');
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
 
             finishJSTest();
         });

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets-expected.txt
@@ -1,21 +1,13 @@
-layoutViewport: {"x":0,"y":0,"width":390,"height":747,"top":0,"right":390,"bottom":747,"left":0}
-visualViewportRect: {"x":0,"y":0,"width":390,"height":747,"top":0,"right":390,"bottom":747,"left":0}
-PASS window.visualViewport.pageTop is 0
-PASS window.visualViewport.scale is 1
-PASS window.visualViewport.width is 390
-PASS window.visualViewport.height is 747
-layoutViewport: {"x":0,"y":0,"width":390,"height":697,"top":0,"right":390,"bottom":697,"left":0}
-visualViewportRect: {"x":0,"y":0,"width":390,"height":697,"top":0,"right":390,"bottom":697,"left":0}
-PASS window.visualViewport.pageTop is 0
-PASS window.visualViewport.scale is 1
-PASS window.visualViewport.width is 390
-PASS window.visualViewport.height is 697
-layoutViewport: {"x":0,"y":0,"width":390,"height":729,"top":0,"right":390,"bottom":729,"left":0}
-visualViewportRect: {"x":0,"y":0,"width":390,"height":729,"top":0,"right":390,"bottom":729,"left":0}
-PASS window.visualViewport.pageTop is 0
-PASS window.visualViewport.scale is 1
-PASS window.visualViewport.width is 390
-PASS window.visualViewport.height is 729
+PASS window.visualViewport.pageTop == 0 is true
+PASS window.visualViewport.scale == 1 is true
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
+PASS internals.layoutViewportRect().height == window.initialLayoutViewportHeight - window.smallerInset is true
+PASS window.visualViewport.pageTop == 0 is true
+PASS window.visualViewport.scale == 1 is true
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
+PASS internals.layoutViewportRect().height == window.initialLayoutViewportHeight - window.biggerInset is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets.html
@@ -20,48 +20,34 @@
         jsTestIsAsync = true;
         addEventListener("load", async () => {
             let textField = document.querySelector("input");
+            window.initialLayoutViewportHeight = internals.layoutViewportRect().height;
+            window.smallerInset = 50;
+            window.biggerInset = 100;
 
             // Test the bottom inset being smaller than the input accessory view.
-            await UIHelper.setObscuredInsets(0, 0, 50, 0);
+            await UIHelper.setObscuredInsets(0, 0, window.smallerInset, 0);
             await UIHelper.renderingUpdate();
             await UIHelper.activateElement(textField);
             await UIHelper.waitForKeyboardToShow();
 
-            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
-            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
+            shouldBeTrue('window.visualViewport.pageTop == 0');
+            shouldBeTrue('window.visualViewport.scale == 1');
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
+            shouldBeTrue('internals.layoutViewportRect().height == window.initialLayoutViewportHeight - window.smallerInset');
 
-            shouldBe('window.visualViewport.pageTop', '0');
-            shouldBe('window.visualViewport.scale', '1');
-            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
-            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
 
             // Test the bottom inset being bigger than the input accessory view.
-            await UIHelper.setObscuredInsets(0, 0, 100, 0);
+            await UIHelper.setObscuredInsets(0, 0, window.biggerInset, 0);
             await UIHelper.renderingUpdate();
             await UIHelper.activateElement(textField);
             await UIHelper.waitForKeyboardToShow();
 
-            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
-            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
-
-            shouldBe('window.visualViewport.pageTop', '0');
-            shouldBe('window.visualViewport.scale', '1');
-            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
-            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
-
-            // Test the bottom inset being equal to the input accessory view.
-            await UIHelper.setObscuredInsets(0, 0, 68, 0);
-            await UIHelper.renderingUpdate();
-            await UIHelper.activateElement(textField);
-            await UIHelper.waitForKeyboardToShow();
-
-            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
-            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
-
-            shouldBe('window.visualViewport.pageTop', '0');
-            shouldBe('window.visualViewport.scale', '1');
-            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
-            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+            shouldBeTrue('window.visualViewport.pageTop == 0');
+            shouldBeTrue('window.visualViewport.scale == 1');
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
+            shouldBeTrue('internals.layoutViewportRect().height == window.initialLayoutViewportHeight - window.biggerInset');
 
             finishJSTest();
         });

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled-expected.txt
@@ -1,9 +1,8 @@
-layoutViewport: {"x":0,"y":0,"width":390,"height":797,"top":0,"right":390,"bottom":797,"left":0}
-visualViewportRect: {"x":0,"y":0,"width":390,"height":797,"top":0,"right":390,"bottom":797,"left":0}
-PASS window.visualViewport.pageTop is 0
-PASS window.visualViewport.scale is 1
-PASS window.visualViewport.width is 390
-PASS window.visualViewport.height is 797
+PASS window.visualViewport.pageTop == 0 is true
+PASS window.visualViewport.scale == 1 is true
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
+PASS window.initialLayoutViewportHeight == internals.layoutViewportRect().height is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled.html
@@ -18,16 +18,16 @@
         jsTestIsAsync = true;
         addEventListener("load", async () => {
             let textField = document.querySelector("input");
+            window.initialLayoutViewportHeight = internals.layoutViewportRect().height;
+
             await UIHelper.activateElement(textField);
             await UIHelper.waitForKeyboardToShow();
 
-            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
-            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
-
-            shouldBe('window.visualViewport.pageTop', '0');
-            shouldBe('window.visualViewport.scale', '1');
-            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
-            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+            shouldBeTrue('window.visualViewport.pageTop == 0');
+            shouldBeTrue('window.visualViewport.scale == 1');
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
+            shouldBeTrue('window.initialLayoutViewportHeight == internals.layoutViewportRect().height');
 
             finishJSTest();
         });

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled-expected.txt
@@ -1,11 +1,7 @@
-layoutViewport: {"x":0,"y":0,"width":390,"height":797,"top":0,"right":390,"bottom":797,"left":0}
-visualViewportRect: {"x":0,"y":0,"width":268,"height":548,"top":0,"right":268,"bottom":548,"left":0}
-PASS window.visualViewport.pageTop is 0
-PASS window.visualViewport.scale is not 1
+PASS window.visualViewport.scale != 1 is true
+PASS internals.layoutViewportRect().height == window.initialLayoutViewportHeight is true
+PASS Math.abs(internals.visualViewportRect().height * window.visualViewport.scale - window.initialVisualViewportHeight) <= 1 is true
 PASS successfullyParsed is true
 
 TEST COMPLETE
-Layout viewport: {"x":0,"y":0,"width":390,"height":797,"top":0,"right":390,"bottom":797,"left":0}
-Visual viewport: {"x":0,"y":0,"width":268,"height":548,"top":0,"right":268,"bottom":548,"left":0}
-
 

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled.html
@@ -12,24 +12,24 @@
     <script src="../../../resources/ui-helper.js"></script>
 </head>
 <body>
-    <p id="results"></p>
     <input id="input" type="text">
 
     <script>
         jsTestIsAsync = true;
         addEventListener("load", async () => {
             let textField = document.querySelector("input");
+            window.initialLayoutViewportHeight = internals.layoutViewportRect().height;
+            window.initialVisualViewportHeight = internals.visualViewportRect().height;
+
             await UIHelper.activateElement(textField);
             await UIHelper.waitForKeyboardToShow();
 
-            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
-            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
+            await UIHelper.zoomToScale(2);
+            await UIHelper.ensureStablePresentationUpdate();
 
-            shouldBe('window.visualViewport.pageTop', '0');
-            shouldNotBe('window.visualViewport.scale', '1');
-            var output = 'Layout viewport: ' + JSON.stringify(internals.layoutViewportRect()) + '\nVisual viewport: ' + JSON.stringify(internals.visualViewportRect()) + '\n';
-            document.getElementById('results').innerText = output;
-
+            shouldBeTrue('window.visualViewport.scale != 1');
+            shouldBeTrue('internals.layoutViewportRect().height == window.initialLayoutViewportHeight');
+            shouldBeTrue('Math.abs(internals.visualViewportRect().height * window.visualViewport.scale - window.initialVisualViewportHeight) <= 1');
             finishJSTest();
         });
     </script>


### PR DESCRIPTION
#### d150a7efa62948e9d501603e0f52b5225e14da90
<pre>
[interactive-widget] Make overlays-content layout tests device-agnostic
<a href="https://bugs.webkit.org/show_bug.cgi?id=320582">https://bugs.webkit.org/show_bug.cgi?id=320582</a>
<a href="https://rdar.apple.com/183559055">rdar://183559055</a>

Reviewed by Aditya Keerthi.

Currently, overlays-content layout tests are not device-agnostic (they
will fail on an iPad simulator). Rewrite the tests in such a way that it
still tests the functionality of overlays-content while being device-agnostic.

* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll-expected.txt:
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll.html:
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets-expected.txt:
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets.html:
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled-expected.txt:
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled.html:
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled-expected.txt:
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled.html:

Canonical link: <a href="https://commits.webkit.org/318369@main">https://commits.webkit.org/318369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53bad5f1cf3bf2179b7f059547d6ef261180398b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187680 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bd0b162c-2dc5-439e-9f4a-5e8e2164e542) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138801 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/83769d7b-73b0-4890-93f3-f44fc17d9246) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119257 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74346047-43f1-4c94-80a2-1406cdbc837a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41014 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39367 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39052 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36138 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190121 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147959 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52355 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147731 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27010 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42430 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119092 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50873 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14024 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50258 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50498 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50320 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->