### PR TITLE
Fix imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resource-popup.https.html to have correct certificate info

### DIFF
--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -370,9 +370,6 @@ public:
 
     void flushNetworkProcessIPC(CompletionHandler<void()>&&);
 
-    bool isWaitingForCertificateInfo() const { return m_isWaitingForCertificateInfo; }
-    void setIsWaitingForCertificateInfo(bool waiting) { m_isWaitingForCertificateInfo = waiting; }
-
 private:
     explicit NetworkProcessProxy();
 
@@ -507,7 +504,6 @@ private:
     RetainPtr<id> m_backgroundObserver;
     RetainPtr<id> m_foregroundObserver;
 #endif
-    bool m_isWaitingForCertificateInfo { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -142,6 +142,9 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
         previousMainFrame->transferNavigationCallbackToFrame(mainFrame);
     }
 
+    if (isProcessSwappingOnNavigationResponse && previousMainFrame)
+        protect(m_mainFrame)->copyCertificateInfoForProcessSwapOnNavigationResponse(m_provisionalLoadURL, *previousMainFrame);
+
     // Normally, notification of a server redirect comes from the WebContent process.
     // If we are process swapping in response to a server redirect then that notification will not come from the new WebContent process.
     // In this case we have the UIProcess synthesize the redirect notification at the appropriate time.

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -1230,50 +1230,39 @@ void WebFrameProxy::updateDocumentSecurityOrigin(WebFrameProxy* creator, ForInit
     m_documentSecurityOrigin = SecurityOrigin::create(url());
 }
 
-void WebFrameProxy::waitForCertificateInfoFromNetworkProcess(const String& hostAndPort)
+WebCore::CertificateInfo WebFrameProxy::certificateInfoFromNetworkProcess(const URL& url) const
 {
+    String hostAndPort = url.hostAndPort();
+    if (!decltype(m_hostAndPortToCertificateInfo)::isValidKey(hostAndPort))
+        return { };
+
+    if (!url.protocolIsSecure())
+        return { };
+
+    if (CertificateInfo certificateInfo = m_hostAndPortToCertificateInfo.get(hostAndPort); !certificateInfo.isEmpty())
+        return certificateInfo;
+
     RefPtr page = m_page.get();
     if (!page)
-        return;
+        return { };
     RefPtr networkProcess = page->websiteDataStore().networkProcessIfExists();
     if (!networkProcess)
-        return;
+        return { };
     RefPtr connection = networkProcess->connection();
     if (!connection)
-        return;
+        return { };
 
-    // waitForAndDispatchImmediately dispatches messages besides the one being waited for.
-    // If another Messages::WebPageProxy::DidCommitLoadForFrame is received, we can get Error::MultipleWaitingClients.
-    // To prevent this, only be in one waitForAndDispatchImmediately call at a time per connection for this.
-    // If the next frame commit is also missing certificate info after this, then it will wait too.
-    if (networkProcess->isWaitingForCertificateInfo())
-        return;
-    networkProcess->setIsWaitingForCertificateInfo(true);
-    if (connection->waitForAndDispatchImmediately<Messages::WebFrameProxyFromNetworkProcess::ReceivedMainResourceResponseWithCertificateInfo>(frameID(), 0_s) != IPC::Error::NoError) {
-        RELEASE_LOG_ERROR(Network, "Unexpectedly missing certificate info from IPC");
-    }
-    networkProcess->setIsWaitingForCertificateInfo(false);
+    connection->waitForAndDispatchImmediately<Messages::WebFrameProxyFromNetworkProcess::ReceivedMainResourceResponseWithCertificateInfo>(frameID(), 0_s);
+
+    CertificateInfo certificateInfo = m_hostAndPortToCertificateInfo.get(hostAndPort);
+    if (certificateInfo.isEmpty())
+        RELEASE_LOG_ERROR(Network, "Unexpectedly missing certificate info");
+    return certificateInfo;
 }
 
 void WebFrameProxy::commitCertificateInfo(const URL& url)
 {
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    String hostAndPort = url.hostAndPort();
-    CertificateInfo certificateInfo;
-    if (decltype(m_hostAndPortToCertificateInfo)::isValidKey(hostAndPort)) {
-        certificateInfo = m_hostAndPortToCertificateInfo.get(hostAndPort);
-        if (certificateInfo.isEmpty() && url.protocolIsSecure()) {
-            waitForCertificateInfoFromNetworkProcess(hostAndPort);
-            certificateInfo = m_hostAndPortToCertificateInfo.get(hostAndPort);
-            if (certificateInfo.isEmpty())
-                RELEASE_LOG_ERROR(Network, "Unexpectedly missing certificate info");
-        }
-    }
-
-    m_certificateInfo = WTF::move(certificateInfo);
+    m_certificateInfo = certificateInfoFromNetworkProcess(url);
 }
 
 void WebFrameProxy::receivedMainResourceResponseWithCertificateInfo(String&& hostAndPort, WebCore::CertificateInfo&& certificateInfo)
@@ -1283,6 +1272,15 @@ void WebFrameProxy::receivedMainResourceResponseWithCertificateInfo(String&& hos
     // multiple hosts, this would only affect iframes that navigate to many hosts.
     if (decltype(m_hostAndPortToCertificateInfo)::isValidKey(hostAndPort))
         m_hostAndPortToCertificateInfo.set(WTF::move(hostAndPort), WTF::move(certificateInfo));
+}
+
+void WebFrameProxy::copyCertificateInfoForProcessSwapOnNavigationResponse(const URL& url, const WebFrameProxy& oldMainFrame)
+{
+    ASSERT(isMainFrame());
+    ASSERT(oldMainFrame.isMainFrame());
+    ASSERT(m_hostAndPortToCertificateInfo.isEmpty());
+
+    m_hostAndPortToCertificateInfo.set(url.hostAndPort(), oldMainFrame.certificateInfoFromNetworkProcess(url));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -186,6 +186,7 @@ public:
 
     void commitCertificateInfo(const URL&);
     void receivedMainResourceResponseWithCertificateInfo(String&&, WebCore::CertificateInfo&&);
+    void copyCertificateInfoForProcessSwapOnNavigationResponse(const URL&, const WebFrameProxy&);
 
     bool canProvideSource() const;
 
@@ -340,7 +341,7 @@ private:
     WebFrameProxy(WebPageProxy&, FrameProcess&, WebCore::FrameIdentifier, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode, WebFrameProxy*, WebFrameProxy*, IsMainFrame, std::optional<URL>&&);
 
     std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
-    void waitForCertificateInfoFromNetworkProcess(const String& hostAndPort);
+    WebCore::CertificateInfo certificateInfoFromNetworkProcess(const URL&) const;
 
     std::optional<WebCore::PageIdentifier> NODELETE pageIdentifier() const;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm
@@ -30,6 +30,7 @@
 #import "Helpers/Utilities.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
+#import "Helpers/cocoa/TestUIDelegate.h"
 #import <wtf/RetainPtr.h>
 
 @interface TrustObserver : NSObject
@@ -91,4 +92,39 @@ TEST(WKWebView, ServerTrustKVC)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
     [observer waitUntilServerTrustChanged];
     EXPECT_NULL([webView serverTrust]);
+}
+
+TEST(WKWebView, ServerTrustKVCWithCOOP)
+{
+    using namespace TestWebKitAPI;
+    HTTPServer server({
+        { "/path1"_s, { "hi"_s } },
+        { "/path2"_s, { { { "Cross-Origin-Opener-Policy"_s, "same-origin"_s } }, "hi"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:server.httpsProxyConfiguration()]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    webView.get().UIDelegate = uiDelegate.get();
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    RetainPtr observer = adoptNS([TrustObserver new]);
+    __block RetainPtr<WKWebView> opened;
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
+        opened = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        opened.get().navigationDelegate = navigationDelegate.get();
+        [opened addObserver:observer.get() forKeyPath:@"serverTrust" options:NSKeyValueObservingOptionNew context:nil];
+        return opened.get();
+    };
+    [webView loadURL:[NSURL URLWithString:@"https://webkit.org/path1"]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView evaluateJavaScript:@"window.open('https://webkit.org/path2')" completionHandler:nil];
+    [observer waitUntilServerTrustChanged];
+
+    // FIXME: This should be null. The web process should say whether to include a cert,
+    // it just shouldn't provide the cert.
+    [webView loadHTMLString:@"<script>alert('loaded')</script>" baseURL:[NSURL URLWithString:@"https://webkit.org/path1"]];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "loaded");
+    EXPECT_NOT_NULL(webView.get().serverTrust);
 }


### PR DESCRIPTION
#### 702c6b7899c5c83843ec2df1dc9531e0e32130e1
<pre>
Fix imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resource-popup.https.html to have correct certificate info
<a href="https://bugs.webkit.org/show_bug.cgi?id=320765">https://bugs.webkit.org/show_bug.cgi?id=320765</a>
<a href="https://rdar.apple.com/183768315">rdar://183768315</a>

Reviewed by Chris Dumez.

317375@main had a few issues.

It introduced a bool to prevent waitForAndDispatchImmediately re-entry,
but at the cost of sometimes not having the correct certificate info.
The real bug was that after a COOP-initiated process swap, we weren&apos;t
taking the certificate info received by the old main frame and giving
it to the new main frame.

I added a unit test that times out waiting for a server trust that
never appears before this fix, showing clearly the functional regression
from 316854@main that this PR fixes and 317375@main did not.

* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::certificateInfoFromNetworkProcess const):
(WebKit::WebFrameProxy::commitCertificateInfo):
(WebKit::WebFrameProxy::copyCertificateInfoForProcessSwapOnNavigationResponse):
(WebKit::WebFrameProxy::waitForCertificateInfoFromNetworkProcess):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm:
(TEST(WKWebView, ServerTrustKVCWithCOOP)):

Canonical link: <a href="https://commits.webkit.org/318495@main">https://commits.webkit.org/318495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f1658079a9f1c452037f21f26e0eb8668520c01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188066 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139124 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42680 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159878 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119578 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41346 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151746 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39377 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36521 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44988 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43938 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190493 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52057 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148279 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52738 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148050 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27071 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42761 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125004 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119641 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51256 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14352 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50641 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50881 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50703 "Hash 6f165807 for PR 70645 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->