### PR TITLE
(Site isolation) Fix WKURLSchemeHandler process confusion

### DIFF
--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -137,8 +137,12 @@ void RemotePageProxy::disconnect()
     RefPtr page = m_page;
     if (page)
         page->isNoLongerAssociatedWithRemotePage(*this);
-    if (m_drawingArea)
+    if (m_drawingArea) {
+        // The process's own stop messages would arrive after stopReceivingMessages() below, so stop its tasks here.
+        if (page)
+            page->stopAllURLSchemeTasks(m_process.ptr());
         m_process->sendPageCloseMessage(page ? std::optional { page->identifier() } : std::nullopt, m_webPageID);
+    }
     m_process->removeRemotePageProxy(*this);
 
     m_drawingArea = nullptr;
@@ -220,6 +224,7 @@ void RemotePageProxy::processDidTerminate(WebProcessProxy& process, ProcessTermi
     RefPtr page = m_page.get();
     if (!page)
         return;
+    page->stopAllURLSchemeTasks(&process);
     if (RefPtr drawingArea = page->drawingArea())
         drawingArea->remotePageProcessDidTerminate(process.coreProcessIdentifier());
     if (RefPtr mainFrame = page->mainFrame())

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -17286,7 +17286,7 @@ void WebPageProxy::stopURLSchemeTask(IPC::Connection& connection, WebURLSchemeHa
     auto iterator = internals().urlSchemeHandlersByIdentifier.find(handlerIdentifier);
     MESSAGE_CHECK_BASE(iterator != internals().urlSchemeHandlersByIdentifier.end(), connection);
 
-    protect(iterator->value)->stopTask(*this, taskIdentifier);
+    protect(iterator->value)->stopTask(*this, { taskIdentifier, WebProcessProxy::fromConnection(connection)->coreProcessIdentifier() });
 }
 
 void WebPageProxy::loadSynchronousURLSchemeTask(IPC::Connection& connection, URLSchemeTaskParameters&& parameters, CompletionHandler<void(const WebCore::ResourceResponse&, const WebCore::ResourceError&, Vector<uint8_t>&&)>&& reply)
@@ -17295,7 +17295,9 @@ void WebPageProxy::loadSynchronousURLSchemeTask(IPC::Connection& connection, URL
     auto iterator = internals().urlSchemeHandlersByIdentifier.find(parameters.handlerIdentifier);
     MESSAGE_CHECK_COMPLETION_BASE(iterator != internals().urlSchemeHandlersByIdentifier.end(), connection, reply({ }, { }, { }));
 
-    protect(iterator->value)->startTask(*this, m_legacyMainFrameProcess, m_webPageID, WTF::move(parameters), WTF::move(reply));
+    Ref process = WebProcessProxy::fromConnection(connection);
+    auto webPageID = webPageIDInProcess(process);
+    protect(iterator->value)->startTask(*this, process, webPageID, WTF::move(parameters), WTF::move(reply));
 }
 
 void WebPageProxy::requestStorageAccessConfirm(const RegistrableDomain& subFrameDomain, const RegistrableDomain& topFrameDomain, FrameIdentifier frameID, std::optional<OrganizationStorageAccessPromptQuirk>&& organizationStorageAccessPromptQuirk, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3012,6 +3012,8 @@ public:
     void didCreateRemotePage(RemotePageProxy&);
     void willDestroyRemotePage(RemotePageProxy&);
 
+    void stopAllURLSchemeTasks(WebProcessProxy* = nullptr);
+
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
     RefPtr<WebDeviceOrientationUpdateProviderProxy> NODELETE webDeviceOrientationUpdateProviderProxy();
 #endif
@@ -3528,8 +3530,6 @@ private:
 
     void viewIsBecomingVisible();
     void viewIsBecomingInvisible();
-
-    void stopAllURLSchemeTasks(WebProcessProxy* = nullptr);
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     void registerAttachmentIdentifierFromData(IPC::Connection&, const String&, const String& contentType, const String& preferredFileName, const IPC::SharedBufferReference&);

--- a/Source/WebKit/UIProcess/WebURLSchemeHandler.cpp
+++ b/Source/WebKit/UIProcess/WebURLSchemeHandler.cpp
@@ -28,6 +28,7 @@
 
 #include "URLSchemeTaskParameters.h"
 #include "WebPageProxy.h"
+#include "WebProcessProxy.h"
 #include "WebURLSchemeTask.h"
 
 namespace WebKit {
@@ -42,26 +43,15 @@ WebURLSchemeHandler::~WebURLSchemeHandler()
 
 void WebURLSchemeHandler::startTask(WebPageProxy& page, WebProcessProxy& process, PageIdentifier webPageID, URLSchemeTaskParameters&& parameters, SyncLoadCompletionHandler&& completionHandler)
 {
-    auto taskIdentifier = parameters.taskIdentifier;
+    ScopedResourceLoaderIdentifier taskIdentifier { parameters.taskIdentifier, process.coreProcessIdentifier() };
     auto result = m_tasks.add({ taskIdentifier, page.identifier() }, WebURLSchemeTask::create(*this, page, process, webPageID, WTF::move(parameters), WTF::move(completionHandler)));
     ASSERT(result.isNewEntry);
 
-    auto pageEntry = m_tasksByPageIdentifier.add(page.identifier(), HashSet<WebCore::ResourceLoaderIdentifier>());
+    auto pageEntry = m_tasksByPageIdentifier.add(page.identifier(), HashSet<WebCore::ScopedResourceLoaderIdentifier>());
     ASSERT(!pageEntry.iterator->value.contains(taskIdentifier));
     pageEntry.iterator->value.add(taskIdentifier);
 
     platformStartTask(page, result.iterator->value);
-}
-
-WebProcessProxy* WebURLSchemeHandler::processForTaskIdentifier(WebPageProxy& page, WebCore::ResourceLoaderIdentifier taskIdentifier) const
-{
-    auto key = std::make_pair(taskIdentifier, page.identifier());
-    if (!decltype(m_tasks)::isValidKey(key))
-        return nullptr;
-    auto iterator = m_tasks.find(key);
-    if (iterator == m_tasks.end())
-        return nullptr;
-    return &iterator->value->process();
 }
 
 void WebURLSchemeHandler::stopAllTasksForPage(WebPageProxy& page, WebProcessProxy* process)
@@ -71,18 +61,17 @@ void WebURLSchemeHandler::stopAllTasksForPage(WebPageProxy& page, WebProcessProx
         return;
 
     auto& tasksByPage = iterator->value;
-    auto taskIdentifiersToStop = WTF::compactMap(tasksByPage, [&](auto& taskIdentifier) -> std::optional<WebCore::ResourceLoaderIdentifier> {
-        if (!process || processForTaskIdentifier(page, taskIdentifier) == process)
+    auto taskIdentifiersToStop = WTF::compactMap(tasksByPage, [&](auto& taskIdentifier) -> std::optional<WebCore::ScopedResourceLoaderIdentifier> {
+        if (!process || taskIdentifier.processIdentifier() == process->coreProcessIdentifier())
             return taskIdentifier;
         return std::nullopt;
     });
 
     for (auto& taskIdentifier : taskIdentifiersToStop)
         stopTask(page, taskIdentifier);
-
 }
 
-void WebURLSchemeHandler::stopTask(WebPageProxy& page, WebCore::ResourceLoaderIdentifier taskIdentifier)
+void WebURLSchemeHandler::stopTask(WebPageProxy& page, WebCore::ScopedResourceLoaderIdentifier taskIdentifier)
 {
     auto key = std::make_pair(taskIdentifier, page.identifier());
     if (!decltype(m_tasks)::isValidKey(key))
@@ -101,14 +90,15 @@ void WebURLSchemeHandler::stopTask(WebPageProxy& page, WebCore::ResourceLoaderId
 
 void WebURLSchemeHandler::taskCompleted(WebPageProxyIdentifier pageID, WebURLSchemeTask& task)
 {
-    auto takenTask = m_tasks.take({ task.resourceLoaderID(), pageID });
+    ScopedResourceLoaderIdentifier taskIdentifier { task.resourceLoaderID(), task.process().coreProcessIdentifier() };
+    auto takenTask = m_tasks.take({ taskIdentifier, pageID });
     ASSERT_UNUSED(takenTask, takenTask == &task);
-    removeTaskFromPageMap(*task.pageProxyID(), task.resourceLoaderID());
+    removeTaskFromPageMap(*task.pageProxyID(), taskIdentifier);
 
     platformTaskCompleted(task);
 }
 
-void WebURLSchemeHandler::removeTaskFromPageMap(WebPageProxyIdentifier pageID, WebCore::ResourceLoaderIdentifier taskID)
+void WebURLSchemeHandler::removeTaskFromPageMap(WebPageProxyIdentifier pageID, WebCore::ScopedResourceLoaderIdentifier taskID)
 {
     auto iterator = m_tasksByPageIdentifier.find(pageID);
     ASSERT(iterator != m_tasksByPageIdentifier.end());

--- a/Source/WebKit/UIProcess/WebURLSchemeHandler.h
+++ b/Source/WebKit/UIProcess/WebURLSchemeHandler.h
@@ -27,6 +27,7 @@
 
 #include "WebURLSchemeHandlerIdentifier.h"
 #include "WebURLSchemeTask.h"
+#include <WebCore/ProcessQualified.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
@@ -52,7 +53,7 @@ public:
     virtual ~WebURLSchemeHandler();
 
     void startTask(WebPageProxy&, WebProcessProxy&, WebCore::PageIdentifier, URLSchemeTaskParameters&&, SyncLoadCompletionHandler&&);
-    void stopTask(WebPageProxy&, WebCore::ResourceLoaderIdentifier taskIdentifier);
+    void stopTask(WebPageProxy&, WebCore::ScopedResourceLoaderIdentifier taskIdentifier);
     void stopAllTasksForPage(WebPageProxy&, WebProcessProxy*);
     void taskCompleted(WebPageProxyIdentifier, WebURLSchemeTask&);
 
@@ -67,11 +68,10 @@ private:
     virtual void platformStopTask(WebPageProxy&, WebURLSchemeTask&) = 0;
     virtual void platformTaskCompleted(WebURLSchemeTask&) { };
 
-    void removeTaskFromPageMap(WebPageProxyIdentifier, WebCore::ResourceLoaderIdentifier);
-    WebProcessProxy* NODELETE processForTaskIdentifier(WebPageProxy&, WebCore::ResourceLoaderIdentifier) const;
+    void removeTaskFromPageMap(WebPageProxyIdentifier, WebCore::ScopedResourceLoaderIdentifier);
 
-    HashMap<std::pair<WebCore::ResourceLoaderIdentifier, WebPageProxyIdentifier>, Ref<WebURLSchemeTask>> m_tasks;
-    HashMap<WebPageProxyIdentifier, HashSet<WebCore::ResourceLoaderIdentifier>> m_tasksByPageIdentifier;
+    HashMap<std::pair<WebCore::ScopedResourceLoaderIdentifier, WebPageProxyIdentifier>, Ref<WebURLSchemeTask>> m_tasks;
+    HashMap<WebPageProxyIdentifier, HashSet<WebCore::ScopedResourceLoaderIdentifier>> m_tasksByPageIdentifier;
     
     SyncLoadCompletionHandler m_syncLoadCompletionHandler;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -267,6 +267,151 @@ std::pair<std::unique_ptr<InstanceMethodSwizzler>, std::unique_ptr<InstanceMetho
 
 #endif // ENABLE(IMAGE_ANALYSIS)
 
+@interface TrackingURLSchemeHandler : NSObject <WKURLSchemeHandler>
+@property (nonatomic, copy) void (^startURLSchemeTaskHandler)(TrackingURLSchemeHandler *, id<WKURLSchemeTask>);
+- (BOOL)deliveredSameTaskTwice;
+- (BOOL)raisedException;
+- (NSUInteger)stopCountForURLPathPrefix:(NSString *)prefix;
+- (void)park:(id<WKURLSchemeTask>)task;
+- (NSUInteger)parkedCountForURLPathPrefix:(NSString *)prefix;
+- (void)respond:(id<WKURLSchemeTask>)task text:(const char *)text mimeType:(NSString *)mimeType;
+- (void)respondToParkedTasksWithURLPathPrefix:(NSString *)prefix text:(const char *)text;
+@end
+
+@implementation TrackingURLSchemeHandler {
+    BlockPtr<void(TrackingURLSchemeHandler *, id<WKURLSchemeTask>)> _startURLSchemeTaskHandler;
+    RetainPtr<NSMutableArray> _liveTasks;
+    RetainPtr<NSMutableArray> _parkedTasks;
+    RetainPtr<NSMutableArray<NSString *>> _stoppedURLStrings;
+    BOOL _deliveredSameTaskTwice;
+    BOOL _raisedException;
+}
+
+- (instancetype)init
+{
+    if (!(self = [super init]))
+        return nil;
+    _liveTasks = adoptNS([NSMutableArray new]);
+    _parkedTasks = adoptNS([NSMutableArray new]);
+    _stoppedURLStrings = adoptNS([NSMutableArray new]);
+    return self;
+}
+
+- (void)setStartURLSchemeTaskHandler:(void (^)(TrackingURLSchemeHandler *, id<WKURLSchemeTask>))block
+{
+    _startURLSchemeTaskHandler = makeBlockPtr(block);
+}
+
+- (void (^)(TrackingURLSchemeHandler *, id<WKURLSchemeTask>))startURLSchemeTaskHandler
+{
+    return _startURLSchemeTaskHandler.get();
+}
+
+- (void)webView:(WKWebView *)webView startURLSchemeTask:(id<WKURLSchemeTask>)task
+{
+    if ([_liveTasks indexOfObjectIdenticalTo:task] != NSNotFound) {
+        _deliveredSameTaskTwice = YES;
+        return;
+    }
+    [_liveTasks addObject:task];
+
+    if (_startURLSchemeTaskHandler)
+        _startURLSchemeTaskHandler(self, task);
+}
+
+- (void)webView:(WKWebView *)webView stopURLSchemeTask:(id<WKURLSchemeTask>)task
+{
+    [_stoppedURLStrings addObject:task.request.URL.absoluteString];
+    [_liveTasks removeObjectIdenticalTo:task];
+    [_parkedTasks removeObjectIdenticalTo:task];
+}
+
+- (BOOL)deliveredSameTaskTwice
+{
+    return _deliveredSameTaskTwice;
+}
+
+- (BOOL)raisedException
+{
+    return _raisedException;
+}
+
+- (NSUInteger)stopCountForURLPathPrefix:(NSString *)prefix
+{
+    NSUInteger count = 0;
+    for (NSString *urlString in _stoppedURLStrings.get()) {
+        if ([[NSURL URLWithString:urlString].path hasPrefix:prefix])
+            ++count;
+    }
+    return count;
+}
+
+- (void)park:(id<WKURLSchemeTask>)task
+{
+    [_parkedTasks addObject:task];
+}
+
+- (NSUInteger)parkedCountForURLPathPrefix:(NSString *)prefix
+{
+    NSUInteger count = 0;
+    for (id<WKURLSchemeTask> task in _parkedTasks.get()) {
+        if ([task.request.URL.path hasPrefix:prefix])
+            ++count;
+    }
+    return count;
+}
+
+- (void)respond:(id<WKURLSchemeTask>)task text:(const char *)text mimeType:(NSString *)mimeType
+{
+    RetainPtr data = [NSData dataWithBytes:text length:strlen(text)];
+    RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:[data length] textEncodingName:nil]);
+    @try {
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:data.get()];
+        [task didFinish];
+    } @catch (NSException *exception) {
+        _raisedException = YES;
+    }
+    [_liveTasks removeObjectIdenticalTo:task];
+    [_parkedTasks removeObjectIdenticalTo:task];
+}
+
+- (void)respondToParkedTasksWithURLPathPrefix:(NSString *)prefix text:(const char *)text
+{
+    RetainPtr<NSArray> tasks = [NSArray arrayWithArray:_parkedTasks.get()];
+    for (id<WKURLSchemeTask> task in tasks.get()) {
+        if ([task.request.URL.path hasPrefix:prefix])
+            [self respond:task text:text mimeType:@"text/plain"];
+    }
+}
+
+@end
+
+// Unlike -_test_waitForAlert, this waits with a bound, so a wedged load fails the test instead of hanging it.
+@interface BoundedAlertRecorder : NSObject <WKUIDelegate>
+- (NSString *)waitForAlert;
+@end
+
+@implementation BoundedAlertRecorder {
+    RetainPtr<NSString> _message;
+}
+
+- (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler
+{
+    _message = message;
+    completionHandler();
+}
+
+- (NSString *)waitForAlert
+{
+    EXPECT_TRUE(TestWebKitAPI::Util::waitFor([&] {
+        return !!_message;
+    }));
+    return _message.get();
+}
+
+@end
+
 namespace TestWebKitAPI {
 
 static void enableFeature(WKWebViewConfiguration *configuration, NSString *featureName)
@@ -5025,6 +5170,285 @@ TEST(SiteIsolation, URLSchemeTask)
             { { "customscheme://webkit.org"_s } }
         },
     });
+}
+
+// Wide enough that two processes parking a block each are practically guaranteed overlapping identifier ranges.
+constexpr NSUInteger parkedLoadsPerFrame = 20;
+
+static NSString *loadParkingHTML(NSString *pathPrefix, NSUInteger count)
+{
+    return [NSString stringWithFormat:@"<body><script>"
+        "window.results = { };"
+        "for (let i = 0; i < %lu; ++i) {"
+            "let path = '%@' + i;"
+            "let xhr = new XMLHttpRequest();"
+            "xhr.open('GET', path);"
+            "xhr.onload = function () { window.results[path] = xhr.responseText; };"
+            "xhr.send();"
+        "}"
+        "</script>", static_cast<unsigned long>(count), pathPrefix];
+}
+
+// A nil frame targets the main frame without -mainFrame, which needs a reply from every process in the tree.
+static NSUInteger resultCount(TestWKWebView *webView, WKFrameInfo *frame)
+{
+    if (!frame)
+        return [[webView objectByEvaluatingJavaScript:@"Object.keys(window.results).length"] unsignedLongValue];
+    return [[webView objectByEvaluatingJavaScript:@"Object.keys(window.results).length" inFrame:frame] unsignedLongValue];
+}
+
+static bool waitForParkedLoads(TrackingURLSchemeHandler *handler, NSString *pathPrefix, NSUInteger count)
+{
+    return Util::waitFor([&] {
+        return [handler parkedCountForURLPathPrefix:pathPrefix] >= count;
+    });
+}
+
+static bool waitForParkedLoadsOrDuplicateTask(TrackingURLSchemeHandler *handler, NSString *pathPrefix, NSUInteger count)
+{
+    return Util::waitFor([&] {
+        return [handler parkedCountForURLPathPrefix:pathPrefix] >= count || [handler deliveredSameTaskTwice];
+    });
+}
+
+static bool waitForStoppedLoads(TrackingURLSchemeHandler *handler, NSString *pathPrefix, NSUInteger count)
+{
+    return Util::waitFor([&] {
+        return [handler stopCountForURLPathPrefix:pathPrefix] >= count;
+    });
+}
+
+static bool waitForResults(TestWKWebView *webView, WKFrameInfo *frame, NSUInteger count)
+{
+    return Util::waitFor([&] {
+        return resultCount(webView, frame) >= count;
+    });
+}
+
+static void addCrossSiteIframe(TestWKWebView *webView, NSString *url)
+{
+    [webView evaluateJavaScript:[NSString stringWithFormat:@"const f = document.createElement('iframe'); f.id = 'child'; f.src = '%@'; document.body.appendChild(f)", url] completionHandler:nil];
+}
+
+static RetainPtr<TrackingURLSchemeHandler> parkingSchemeHandler()
+{
+    RetainPtr handler = adoptNS([TrackingURLSchemeHandler new]);
+    handler.get().startURLSchemeTaskHandler = ^(TrackingURLSchemeHandler *trackingHandler, id<WKURLSchemeTask> task) {
+        NSString *path = task.request.URL.path;
+        if ([path isEqualToString:@"/main"])
+            [trackingHandler respond:task text:loadParkingHTML(@"/aparked", parkedLoadsPerFrame).UTF8String mimeType:@"text/html"];
+        else if ([path isEqualToString:@"/iframe"])
+            [trackingHandler respond:task text:loadParkingHTML(@"/bparked", parkedLoadsPerFrame).UTF8String mimeType:@"text/html"];
+        else if ([path hasPrefix:@"/aparked"] || [path hasPrefix:@"/bparked"])
+            [trackingHandler park:task];
+        else
+            EXPECT_TRUE(false);
+    };
+    return handler;
+}
+
+static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> viewAndDelegateWithSchemeHandler(TrackingURLSchemeHandler *handler, bool siteIsolationEnabled)
+{
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration setURLSchemeHandler:handler forURLScheme:@"customscheme"];
+    return siteIsolatedViewAndDelegate(configuration, CGRectZero, siteIsolationEnabled);
+}
+
+TEST(SiteIsolation, URLSchemeTaskIdentifierCollisionAcrossProcesses)
+{
+    RetainPtr handler = parkingSchemeHandler();
+    auto [webView, navigationDelegate] = viewAndDelegateWithSchemeHandler(handler.get(), true);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"customscheme://example.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(waitForParkedLoads(handler.get(), @"/aparked", parkedLoadsPerFrame));
+
+    addCrossSiteIframe(webView.get(), @"customscheme://webkit.org/iframe");
+    EXPECT_TRUE(waitForParkedLoadsOrDuplicateTask(handler.get(), @"/bparked", parkedLoadsPerFrame));
+
+    EXPECT_FALSE([handler deliveredSameTaskTwice]);
+    EXPECT_EQ([handler parkedCountForURLPathPrefix:@"/bparked"], parkedLoadsPerFrame);
+    EXPECT_NE([webView mainFrame].info._processIdentifier, [webView firstChildFrame]._processIdentifier);
+
+    [handler respondToParkedTasksWithURLPathPrefix:@"/aparked" text:"a-data"];
+    [handler respondToParkedTasksWithURLPathPrefix:@"/bparked" text:"b-data"];
+    EXPECT_FALSE([handler raisedException]);
+
+    EXPECT_TRUE(waitForResults(webView.get(), nil, parkedLoadsPerFrame));
+    EXPECT_TRUE(waitForResults(webView.get(), [webView firstChildFrame], parkedLoadsPerFrame));
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"window.results['/aparked0']"], "a-data");
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"window.results['/bparked0']" inFrame:[webView firstChildFrame]], "b-data");
+}
+
+TEST(SiteIsolation, URLSchemeTaskIdentifierCollisionWithoutSiteIsolation)
+{
+    RetainPtr handler = parkingSchemeHandler();
+    auto [webView, navigationDelegate] = viewAndDelegateWithSchemeHandler(handler.get(), false);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"customscheme://example.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_TRUE(waitForParkedLoads(handler.get(), @"/aparked", parkedLoadsPerFrame));
+
+    addCrossSiteIframe(webView.get(), @"customscheme://webkit.org/iframe");
+    EXPECT_TRUE(waitForParkedLoadsOrDuplicateTask(handler.get(), @"/bparked", parkedLoadsPerFrame));
+
+    EXPECT_FALSE([handler deliveredSameTaskTwice]);
+    EXPECT_EQ([handler parkedCountForURLPathPrefix:@"/bparked"], parkedLoadsPerFrame);
+
+    [handler respondToParkedTasksWithURLPathPrefix:@"/aparked" text:"a-data"];
+    [handler respondToParkedTasksWithURLPathPrefix:@"/bparked" text:"b-data"];
+    EXPECT_FALSE([handler raisedException]);
+    EXPECT_TRUE(waitForResults(webView.get(), nil, parkedLoadsPerFrame));
+}
+
+TEST(SiteIsolation, URLSchemeTaskCancellationDoesNotCrossProcesses)
+{
+    RetainPtr handler = parkingSchemeHandler();
+    auto [webView, navigationDelegate] = viewAndDelegateWithSchemeHandler(handler.get(), true);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"customscheme://example.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_TRUE(waitForParkedLoads(handler.get(), @"/aparked", parkedLoadsPerFrame));
+
+    addCrossSiteIframe(webView.get(), @"customscheme://webkit.org/iframe");
+    EXPECT_TRUE(waitForParkedLoadsOrDuplicateTask(handler.get(), @"/bparked", parkedLoadsPerFrame));
+    EXPECT_FALSE([handler deliveredSameTaskTwice]);
+
+    [webView objectByEvaluatingJavaScript:@"document.getElementById('child').remove()"];
+    EXPECT_TRUE(waitForStoppedLoads(handler.get(), @"/bparked", parkedLoadsPerFrame));
+
+    EXPECT_EQ([handler stopCountForURLPathPrefix:@"/aparked"], 0u);
+    EXPECT_EQ([handler parkedCountForURLPathPrefix:@"/aparked"], parkedLoadsPerFrame);
+
+    [handler respondToParkedTasksWithURLPathPrefix:@"/aparked" text:"a-data"];
+    EXPECT_FALSE([handler raisedException]);
+    EXPECT_TRUE(waitForResults(webView.get(), nil, parkedLoadsPerFrame));
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"window.results['/aparked0']"], "a-data");
+}
+
+TEST(SiteIsolation, SynchronousURLSchemeTaskFromCrossSiteIframe)
+{
+    RetainPtr handler = adoptNS([TrackingURLSchemeHandler new]);
+    handler.get().startURLSchemeTaskHandler = ^(TrackingURLSchemeHandler *trackingHandler, id<WKURLSchemeTask> task) {
+        NSString *path = task.request.URL.path;
+        if ([path isEqualToString:@"/main"])
+            [trackingHandler respond:task text:loadParkingHTML(@"/aparked", parkedLoadsPerFrame).UTF8String mimeType:@"text/html"];
+        else if ([path isEqualToString:@"/iframe"]) {
+            [trackingHandler respond:task text:"<script>"
+                "let xhr = new XMLHttpRequest();"
+                "xhr.open('GET', '/syncsubresource', false);"
+                "try { xhr.send(null); alert('sync:' + xhr.responseText); }"
+                "catch (e) { alert('sync-failed:' + e); }"
+                "</script>" mimeType:@"text/html"];
+        } else if ([path isEqualToString:@"/syncsubresource"])
+            [trackingHandler respond:task text:"sync-data" mimeType:@"text/plain"];
+        else if ([path hasPrefix:@"/aparked"])
+            [trackingHandler park:task];
+        else
+            EXPECT_TRUE(false);
+    };
+    auto [webView, navigationDelegate] = viewAndDelegateWithSchemeHandler(handler.get(), true);
+    RetainPtr alertRecorder = adoptNS([BoundedAlertRecorder new]);
+    webView.get().UIDelegate = alertRecorder.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"customscheme://example.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_TRUE(waitForParkedLoads(handler.get(), @"/aparked", parkedLoadsPerFrame));
+
+    addCrossSiteIframe(webView.get(), @"customscheme://webkit.org/iframe");
+
+    EXPECT_WK_STREQ([alertRecorder waitForAlert], "sync:sync-data");
+    EXPECT_FALSE([handler deliveredSameTaskTwice]);
+    EXPECT_FALSE([handler raisedException]);
+    EXPECT_EQ([handler stopCountForURLPathPrefix:@"/aparked"], 0u);
+    EXPECT_EQ([handler parkedCountForURLPathPrefix:@"/aparked"], parkedLoadsPerFrame);
+
+    [handler respondToParkedTasksWithURLPathPrefix:@"/aparked" text:"a-data"];
+    EXPECT_FALSE([handler raisedException]);
+    EXPECT_TRUE(waitForResults(webView.get(), nil, parkedLoadsPerFrame));
+    for (NSUInteger i = 0; i < parkedLoadsPerFrame; ++i) {
+        NSString *script = [NSString stringWithFormat:@"window.results['/aparked%lu']", static_cast<unsigned long>(i)];
+        EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:script], "a-data");
+    }
+}
+
+TEST(SiteIsolation, URLSchemeTasksStoppedWhenIframeProcessTerminates)
+{
+    RetainPtr handler = adoptNS([TrackingURLSchemeHandler new]);
+    handler.get().startURLSchemeTaskHandler = ^(TrackingURLSchemeHandler *trackingHandler, id<WKURLSchemeTask> task) {
+        NSString *path = task.request.URL.path;
+        if ([path isEqualToString:@"/main"])
+            [trackingHandler respond:task text:loadParkingHTML(@"/aparked", 1).UTF8String mimeType:@"text/html"];
+        else if ([path isEqualToString:@"/iframe"])
+            [trackingHandler respond:task text:loadParkingHTML(@"/bparked", 1).UTF8String mimeType:@"text/html"];
+        else if ([path hasPrefix:@"/aparked"] || [path hasPrefix:@"/bparked"])
+            [trackingHandler park:task];
+        else
+            EXPECT_TRUE(false);
+    };
+    auto [webView, navigationDelegate] = viewAndDelegateWithSchemeHandler(handler.get(), true);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"customscheme://example.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_TRUE(waitForParkedLoads(handler.get(), @"/aparked", 1));
+
+    addCrossSiteIframe(webView.get(), @"customscheme://webkit.org/iframe");
+    EXPECT_TRUE(waitForParkedLoads(handler.get(), @"/bparked", 1));
+
+    // Query the frame tree before the kill; -mainFrame waits for a reply from every process with no timeout.
+    pid_t mainFramePID = [webView mainFrame].info._processIdentifier;
+    pid_t iframePID = [webView firstChildFrame]._processIdentifier;
+    ASSERT_NE(iframePID, 0);
+    ASSERT_NE(iframePID, mainFramePID);
+
+    kill(iframePID, 9);
+
+    EXPECT_TRUE(waitForStoppedLoads(handler.get(), @"/bparked", 1));
+
+    EXPECT_EQ([handler stopCountForURLPathPrefix:@"/aparked"], 0u);
+    EXPECT_EQ([handler parkedCountForURLPathPrefix:@"/aparked"], 1u);
+    [handler respondToParkedTasksWithURLPathPrefix:@"/aparked" text:"a-data"];
+    EXPECT_FALSE([handler raisedException]);
+}
+
+TEST(SiteIsolation, URLSchemeTaskRedirectFromCrossSiteIframeWithCollidingIdentifiers)
+{
+    RetainPtr handler = adoptNS([TrackingURLSchemeHandler new]);
+    handler.get().startURLSchemeTaskHandler = ^(TrackingURLSchemeHandler *trackingHandler, id<WKURLSchemeTask> task) {
+        NSString *path = task.request.URL.path;
+        if ([path isEqualToString:@"/main"])
+            [trackingHandler respond:task text:loadParkingHTML(@"/aparked", parkedLoadsPerFrame).UTF8String mimeType:@"text/html"];
+        else if ([path isEqualToString:@"/iframe"]) {
+            [trackingHandler respond:task text:"<script>"
+                "let xhr = new XMLHttpRequest();"
+                "xhr.open('GET', '/beforeredirect');"
+                "xhr.onload = function () { alert(xhr.responseURL + ' ' + xhr.responseText); };"
+                "xhr.send();"
+                "</script>" mimeType:@"text/html"];
+        } else if ([path isEqualToString:@"/beforeredirect"]) {
+            RetainPtr newRequest = adoptNS([[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"customscheme://webkit.org/afterredirect"]]);
+            [(id<WKURLSchemeTaskPrivate>)task _willPerformRedirection:adoptNS([NSURLResponse new]).get() newRequest:newRequest.get() completionHandler:^(NSURLRequest *) {
+                [trackingHandler respond:task text:"redirected-data" mimeType:@"text/plain"];
+            }];
+        } else if ([path hasPrefix:@"/aparked"])
+            [trackingHandler park:task];
+        else
+            EXPECT_TRUE(false);
+    };
+    auto [webView, navigationDelegate] = viewAndDelegateWithSchemeHandler(handler.get(), true);
+    RetainPtr alertRecorder = adoptNS([BoundedAlertRecorder new]);
+    webView.get().UIDelegate = alertRecorder.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"customscheme://example.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_TRUE(waitForParkedLoads(handler.get(), @"/aparked", parkedLoadsPerFrame));
+
+    addCrossSiteIframe(webView.get(), @"customscheme://webkit.org/iframe");
+
+    EXPECT_WK_STREQ([alertRecorder waitForAlert], "customscheme://webkit.org/afterredirect redirected-data");
+    EXPECT_FALSE([handler deliveredSameTaskTwice]);
+    EXPECT_FALSE([handler raisedException]);
 }
 
 TEST(SiteIsolation, StorageSiteValidationCustomScheme)


### PR DESCRIPTION
#### 0c10d5c89c06a1886d19bf347d2fd457aca70988
<pre>
(Site isolation) Fix WKURLSchemeHandler process confusion
<a href="https://rdar.apple.com/183779751">rdar://183779751</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320774">https://bugs.webkit.org/show_bug.cgi?id=320774</a>

Reviewed by Alex Christensen.

URL scheme handlers were built on an assumption of tasks always coming from &quot;the one&quot;
web content process backing the WKWebView.

With site isolation, confusion occurred.

Changing their identifiers to include a process component fixes things right up.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::disconnect):
(WebKit::RemotePageProxy::processDidTerminate):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::stopURLSchemeTask):
(WebKit::WebPageProxy::loadSynchronousURLSchemeTask):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebURLSchemeHandler.cpp:
(WebKit::WebURLSchemeHandler::startTask):
(WebKit::WebURLSchemeHandler::stopAllTasksForPage):
(WebKit::WebURLSchemeHandler::stopTask):
(WebKit::WebURLSchemeHandler::taskCompleted):
(WebKit::WebURLSchemeHandler::removeTaskFromPageMap):
(WebKit::WebURLSchemeHandler::processForTaskIdentifier const): Deleted.
* Source/WebKit/UIProcess/WebURLSchemeHandler.h:

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(-[TrackingURLSchemeHandler init]):
(-[TrackingURLSchemeHandler setStartURLSchemeTaskHandler:]):
(-[TrackingURLSchemeHandler startURLSchemeTaskHandler]):
(-[TrackingURLSchemeHandler webView:startURLSchemeTask:]):
(-[TrackingURLSchemeHandler webView:stopURLSchemeTask:]):
(-[TrackingURLSchemeHandler deliveredSameTaskTwice]):
(-[TrackingURLSchemeHandler raisedException]):
(-[TrackingURLSchemeHandler stopCountForURLPathPrefix:]):
(-[TrackingURLSchemeHandler park:]):
(-[TrackingURLSchemeHandler parkedCountForURLPathPrefix:]):
(-[TrackingURLSchemeHandler respond:text:mimeType:]):
(-[TrackingURLSchemeHandler respondToParkedTasksWithURLPathPrefix:text:]):
(-[BoundedAlertRecorder webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:]):
(-[BoundedAlertRecorder waitForAlert]):
(TestWebKitAPI::loadParkingHTML):
(TestWebKitAPI::resultCount):
(TestWebKitAPI::waitForParkedLoads):
(TestWebKitAPI::waitForParkedLoadsOrDuplicateTask):
(TestWebKitAPI::waitForStoppedLoads):
(TestWebKitAPI::waitForResults):
(TestWebKitAPI::addCrossSiteIframe):
(TestWebKitAPI::parkingSchemeHandler):
(TestWebKitAPI::viewAndDelegateWithSchemeHandler):
(TestWebKitAPI::TEST(SiteIsolation, URLSchemeTaskIdentifierCollisionAcrossProcesses)):
(TestWebKitAPI::TEST(SiteIsolation, URLSchemeTaskIdentifierCollisionWithoutSiteIsolation)):
(TestWebKitAPI::TEST(SiteIsolation, URLSchemeTaskCancellationDoesNotCrossProcesses)):
(TestWebKitAPI::TEST(SiteIsolation, SynchronousURLSchemeTaskFromCrossSiteIframe)):
(TestWebKitAPI::TEST(SiteIsolation, URLSchemeTasksStoppedWhenIframeProcessTerminates)):
(TestWebKitAPI::TEST(SiteIsolation, URLSchemeTaskRedirectFromCrossSiteIframeWithCollidingIdentifiers)):

Canonical link: <a href="https://commits.webkit.org/318370@main">https://commits.webkit.org/318370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e057e2a53fd3a378a8b6914fdd496efed77b47d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187717 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/61cb929d-cd09-4d44-8c33-3eb0bfdf9f2b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138832 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7f9e24a7-c56a-40a0-91c9-86051c01065c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119288 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79d3fb81-161a-4e68-8bb2-9ec9c69201d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41047 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39401 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39088 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36175 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190145 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51710 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147981 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39741 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52392 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147753 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42462 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124655 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119135 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50910 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14060 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50295 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50535 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50357 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->