### PR TITLE
REGRESSION(318202@main): Win-Build-EWS -  failing compile-webkit

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -29,23 +29,6 @@
 
 #if ENABLE(B3_JIT)
 
-// On Windows, there's macros for these which interfere with the opcodes
-#pragma push_macro("RotateLeft32")
-#pragma push_macro("RotateLeft64")
-#pragma push_macro("RotateRight32")
-#pragma push_macro("RotateRight64")
-#pragma push_macro("StoreFence")
-#pragma push_macro("LoadFence")
-#pragma push_macro("MemoryFence")
-
-#undef RotateLeft32
-#undef RotateLeft64
-#undef RotateRight32
-#undef RotateRight64
-#undef StoreFence
-#undef LoadFence
-#undef MemoryFence
-
 #if USE(JSVALUE64)
 #include "AirBlockInsertionSet.h"
 #include "AirCCallSpecial.h"
@@ -83,6 +66,25 @@
 #include <wtf/IndexMap.h>
 #include <wtf/IndexSet.h>
 #include <wtf/StdLibExtras.h>
+
+// On Windows, there's macros for these which interfere with the opcodes. The
+// undefs have to follow every #include: <windows.h> defines them, so anything
+// that pulls it in later would put them back.
+#pragma push_macro("RotateLeft32")
+#pragma push_macro("RotateLeft64")
+#pragma push_macro("RotateRight32")
+#pragma push_macro("RotateRight64")
+#pragma push_macro("StoreFence")
+#pragma push_macro("LoadFence")
+#pragma push_macro("MemoryFence")
+
+#undef RotateLeft32
+#undef RotateLeft64
+#undef RotateRight32
+#undef RotateRight64
+#undef StoreFence
+#undef LoadFence
+#undef MemoryFence
 
 #if !ASSERT_ENABLED
 IGNORE_RETURN_TYPE_WARNINGS_BEGIN
@@ -6846,8 +6848,6 @@ IGNORE_RETURN_TYPE_WARNINGS_END
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-#endif // USE(JSVALUE64)
-
 #pragma pop_macro("RotateLeft32")
 #pragma pop_macro("RotateLeft64")
 #pragma pop_macro("RotateRight32")
@@ -6855,5 +6855,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #pragma pop_macro("StoreFence")
 #pragma pop_macro("LoadFence")
 #pragma pop_macro("MemoryFence")
+
+#endif // USE(JSVALUE64)
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -750,6 +750,12 @@ writeH("OpcodeUtils") {
     outp.puts ""
     outp.puts "#if ENABLE(B3_JIT)"
 
+    outp.puts "#include \"AirCustom.h\""
+    outp.puts "#include \"AirInst.h\""
+    outp.puts "#include \"AirFormTable.h\""
+
+    # The undefs have to follow every #include: <windows.h> defines macros named
+    # after some opcodes, so anything that pulls it in later would put them back.
     outp.puts "#pragma push_macro(\"RotateLeft32\")"
     outp.puts "#pragma push_macro(\"RotateLeft64\")"
     outp.puts "#pragma push_macro(\"RotateRight32\")"
@@ -765,9 +771,6 @@ writeH("OpcodeUtils") {
     outp.puts "#undef LoadFence"
     outp.puts "#undef MemoryFence"
 
-    outp.puts "#include \"AirCustom.h\""
-    outp.puts "#include \"AirInst.h\""
-    outp.puts "#include \"AirFormTable.h\""
     outp.puts "namespace JSC { namespace B3 { namespace Air {"
     
     outp.puts "inline bool opgenHiddenTruth() { return true; }"
@@ -922,6 +925,13 @@ writeH("OpcodeGenerated") {
     outp.puts ""
     outp.puts "#if ENABLE(B3_JIT)"
 
+    outp.puts "#include \"AirInstInlines.h\""
+    outp.puts "#include \"B3ProcedureInlines.h\""
+    outp.puts "#include \"CCallHelpers.h\""
+    outp.puts "#include \"wtf/PrintStream.h\""
+
+    # The undefs have to follow every #include: <windows.h> defines macros named
+    # after some opcodes, so anything that pulls it in later would put them back.
     outp.puts "#pragma push_macro(\"RotateLeft32\")"
     outp.puts "#pragma push_macro(\"RotateLeft64\")"
     outp.puts "#pragma push_macro(\"RotateRight32\")"
@@ -937,10 +947,6 @@ writeH("OpcodeGenerated") {
     outp.puts "#undef LoadFence"
     outp.puts "#undef MemoryFence"
 
-    outp.puts "#include \"AirInstInlines.h\""
-    outp.puts "#include \"B3ProcedureInlines.h\""
-    outp.puts "#include \"CCallHelpers.h\""
-    outp.puts "#include \"wtf/PrintStream.h\""
     outp.puts "namespace WTF {"
     outp.puts "void printInternal(PrintStream& out, JSC::B3::Air::Opcode opcode)"
     outp.puts "{"


### PR DESCRIPTION
#### 3108e0a68c0ea7f887716cdb73cbd3f9109ddc78
<pre>
REGRESSION(318202@main): Win-Build-EWS -  failing compile-webkit
<a href="https://bugs.webkit.org/show_bug.cgi?id=320754">https://bugs.webkit.org/show_bug.cgi?id=320754</a>
<a href="https://rdar.apple.com/183756146">rdar://183756146</a>

Reviewed by Yusuke Suzuki and Ian Grunert.

The generated AirOpcodeUtils.h and AirOpcodeGenerated.h #undef the &lt;windows.h&gt;
macros that collide with Air opcode names (RotateRight32, MemoryFence, and
friends) and then #include AirInstInlines.h, CCallHelpers.h, and others. Those
includes reach &lt;windows.h&gt;, which re-defines the macros, so the references that
follow expand to garbage: &quot;no member named &apos;_rotr&apos; in &apos;JSC::B3::Air::Opcode&apos;&quot;
for case Opcode::RotateRight32. The headers only compiled because something had
already pulled &lt;windows.h&gt; into the translation unit ahead of the undefs, either
via JavaScriptCorePrefix.h (286296@main) or via an earlier file in the same
unified source bundle. 318202@main dropped a file from Sources.txt, which
shifted the b3 bundles so that AirGenerated.cpp became the first file in
UnifiedSource-b3-15.cpp, leaving nothing ahead of it.

Emit the #includes before the #pragma push_macro/#undef block, so no header is
read while the macros are undefined and none of them can re-define the names.
This makes the generated headers independent of bundle order and of whether the
prefix header reaches the translation unit. B3LowerToAir.cpp had the same
ordering, so it gets the same treatment; its #pragma pop_macro block moves
inside #if USE(JSVALUE64) to stay balanced with the pushes.

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/air/opcode_generator.rb:

Canonical link: <a href="https://commits.webkit.org/318381@main">https://commits.webkit.org/318381@main</a>
</pre>
