### PR TITLE
Cherry-pick 318362@main (db4f6aa69ab2). https://bugs.webkit.org/show_bug.cgi?id=320756

### DIFF
--- a/JSTests/stress/many-substrings-of-rope-shouldnt-use-excessive-memory-2.js
+++ b/JSTests/stress/many-substrings-of-rope-shouldnt-use-excessive-memory-2.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture == "x86_64" and $hostOS == "linux"
+//@ skip if $hostOS == "linux"
 //@ runDefault
 
 let total_slice_call_count = 0;

--- a/JSTests/wasm/js-api/Instance.imports.exports.unicode.js
+++ b/JSTests/wasm/js-api/Instance.imports.exports.unicode.js
@@ -81,14 +81,17 @@ b = b.End();
 
 const module = new WebAssembly.Module(b.WebAssembly().get());
 
-for (let idxModule = 0; idxModule < names.length; ++idxModule)   
+const imports = WebAssembly.Module.imports(module);
+for (let idxModule = 0; idxModule < names.length; ++idxModule)
     for (let idxField = 0; idxField < names.length; ++idxField) {
-        assert.eq(WebAssembly.Module.imports(module)[idxModule * names.length + idxField].module, names[idxModule]);
-        assert.eq(WebAssembly.Module.imports(module)[idxModule * names.length + idxField].name, names[idxField]);
+        const reflectedImport = imports[idxModule * names.length + idxField];
+        assert.eq(reflectedImport.module, names[idxModule]);
+        assert.eq(reflectedImport.name, names[idxField]);
     }
 
+const exports = WebAssembly.Module.exports(module);
 for (let idx = 0; idx < names.length; ++idx)
-    assert.eq(WebAssembly.Module.exports(module)[idx].name, names[idx]);
+    assert.eq(exports[idx].name, names[idx]);
 
 const instance = new WebAssembly.Instance(module, importObject);
 


### PR DESCRIPTION
#### 31cfb645ecfb9f198a99d8b6b7bf931c413095bd
<pre>
Cherry-pick 318362@main (db4f6aa69ab2). <a href="https://bugs.webkit.org/show_bug.cgi?id=320756">https://bugs.webkit.org/show_bug.cgi?id=320756</a>

    [JSC] wasm/js-api/Instance.imports.exports.unicode.js: reuse the import and export descriptor arrays instead of rebuilding them for every check
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320756">https://bugs.webkit.org/show_bug.cgi?id=320756</a>

    Reviewed by Yusuke Suzuki.

    Cache the import and export descriptor arrays before checking their contents.
    Calling WebAssembly.Module.imports() for every imported name rebuilt the
    import descriptor around ~961 times and the export one around 31 times,
    causing excessive allocation and garbage collection without adding test
    coverage.

    This was causing this test to be very slow on Release+Asserts for WPE ARM64,
    usually timing out.
    After this fix the total time to run it went from several minutes to less
    than 2 seconds

    * JSTests/wasm/js-api/Instance.imports.exports.unicode.js:
    (idxModule):

    Canonical link: <a href="https://commits.webkit.org/318362@main">https://commits.webkit.org/318362@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.22@webkitglib/2.54">https://commits.webkit.org/317695.22@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### cf0a318ae633c008406dfb4b4e4512309925036f
<pre>
Cherry-pick 318329@main (18b5fd469877). <a href="https://bugs.webkit.org/show_bug.cgi?id=306952">https://bugs.webkit.org/show_bug.cgi?id=306952</a>

    [JSC] many-substrings-of-rope-shouldnt-use-excessive-memory-2.js.default fails on WPE
    <a href="https://bugs.webkit.org/show_bug.cgi?id=306952">https://bugs.webkit.org/show_bug.cgi?id=306952</a>

    Unreviewed test gardening.

    This test was skipped for WPE/x86_64 on 306795@main but it is also failing for
    WPE/ARM64, so make the skip more generic.

    * JSTests/stress/many-substrings-of-rope-shouldnt-use-excessive-memory-2.js:

    Canonical link: <a href="https://commits.webkit.org/318329@main">https://commits.webkit.org/318329@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.21@webkitglib/2.54">https://commits.webkit.org/317695.21@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c87b3ad2ed0148b710f2b3cf93712099de65a3cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178095 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52033 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45828 "The change is no longer eligible for processing.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141342 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53327 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51742 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/187708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141342 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181052 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53327 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/45828 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53327 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51742 "The change is no longer eligible for processing.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/45828 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53327 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45828 "The change is no longer eligible for processing.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36166 "Failed to checkout and rebase branch from PR 70652") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/39368 "The change is no longer eligible for processing.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/51742 "The change is no longer eligible for processing.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190136 "Failed to checkout and rebase branch from PR 70652") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51701 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/45828 "The change is no longer eligible for processing.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/190136 "Failed to checkout and rebase branch from PR 70652") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/52383 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45828 "The change is no longer eligible for processing.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/190136 "Failed to checkout and rebase branch from PR 70652") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27008 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/52383 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119120 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/50901 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/45828 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50286 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50526 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50348 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->