### PR TITLE
[Text Extraction] Treat small, visually-distinct elements as clickable for the purpose of simulating clicks

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-button-like-div-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-button-like-div-expected.txt
@@ -1,0 +1,12 @@
+PASS continueHasUID is true
+PASS continueIsClickable is true
+PASS tallHasUID is false
+PASS plainHasUID is false
+PASS inertHasUID is false
+PASS wrapperHasUID is false
+PASS linkHasUID is true
+PASS pointerHasUID is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-button-like-div.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-button-like-div.html
@@ -1,0 +1,90 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+#scratch > * {
+    width: 220px;
+    margin: 8px;
+}
+
+.pill {
+    background-color: rgb(212, 212, 212);
+    border-radius: 9999px;
+    height: 48px;
+    box-sizing: border-box;
+    text-align: center;
+}
+
+.tall {
+    height: 120px;
+}
+
+.plain {
+    height: 48px;
+    box-sizing: border-box;
+}
+
+.pointer-cursor {
+    cursor: pointer;
+}
+
+.inert {
+    pointer-events: none;
+}
+</style>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div id="scratch">
+    <div class="pill">ContinueButton</div>
+    <div class="pill tall">TallDistinctBox</div>
+    <div class="plain">PlainUnstyledBox</div>
+    <div class="pill inert">NoPointerEventsBox</div>
+    <div class="pill">WrapsInteractiveBox<a href="https://webkit.org/">InnerLink</a></div>
+    <div class="pill pointer-cursor">PointerCursorBox</div>
+</div>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    const debugText = await UIHelper.requestDebugText({
+        nodeIdentifierInclusion: "interactive",
+    });
+
+    const hasUID = label => UIHelper.nodeIdentifierFromDebugText(debugText, label) !== null;
+    const isClickable = label => debugText.split("\n").some(line => line.includes(label) && line.includes("clickable"));
+
+    continueHasUID = hasUID("ContinueButton");
+    continueIsClickable = isClickable("ContinueButton");
+
+    tallHasUID = hasUID("TallDistinctBox");
+    plainHasUID = hasUID("PlainUnstyledBox");
+    inertHasUID = hasUID("NoPointerEventsBox");
+    wrapperHasUID = hasUID("WrapsInteractiveBox");
+
+    linkHasUID = hasUID("InnerLink");
+
+    pointerHasUID = hasUID("PointerCursorBox");
+
+    shouldBeTrue("continueHasUID");
+    shouldBeTrue("continueIsClickable");
+    shouldBeFalse("tallHasUID");
+    shouldBeFalse("plainHasUID");
+    shouldBeFalse("inertHasUID");
+    shouldBeFalse("wrapperHasUID");
+    shouldBeTrue("linkHasUID");
+    shouldBeTrue("pointerHasUID");
+
+    document.getElementById("scratch").remove();
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -945,14 +945,59 @@ static bool isVisuallyDistinctContainer(const Style::ComputedStyle& style, const
     return rect.width() >= minimumWidth && rect.height() >= minimumHeight;
 }
 
+static bool containsInteractiveDescendant(const Element& element)
+{
+    for (Ref descendant : descendantsOfType<Element>(element)) {
+        if (descendant->isLink())
+            return true;
+
+        if (is<HTMLButtonElement>(descendant) || is<HTMLTextFormControlElement>(descendant) || is<HTMLSelectElement>(descendant))
+            return true;
+
+        auto role = descendant->attributeWithoutSynchronization(HTMLNames::roleAttr);
+        if (equalLettersIgnoringASCIICase(role, "button"_s) || equalLettersIgnoringASCIICase(role, "link"_s))
+            return true;
+    }
+    return false;
+}
+
+static bool looksLikeButton(const RenderObject& renderer)
+{
+    CheckedRef style = renderer.style();
+    if (!hasVisuallyDistinctStyling(protect(style)))
+        return false;
+
+    CheckedPtr box = dynamicDowncast<RenderBox>(renderer);
+    if (!box)
+        return false;
+
+    static constexpr auto minButtonHeight = 16;
+    static constexpr auto maxButtonHeight = 64;
+    auto height = box->borderBoxHeight().toFloat();
+    if (height < minButtonHeight || height > maxButtonHeight)
+        return false;
+
+    RefPtr element = dynamicDowncast<Element>(renderer.node());
+    if (!element)
+        return false;
+
+    static constexpr auto maxButtonLabelLength = 64;
+    auto text = element->textContent();
+    if (text.isEmpty() || text.length() > maxButtonLabelLength || text.containsOnly<isASCIIWhitespace>())
+        return false;
+
+    return !containsInteractiveDescendant(*element);
+}
+
 static bool looksVisuallyClickable(const RenderObject& renderer)
 {
     CheckedRef style = renderer.style();
-    if (style->cursorType() != CursorType::Pointer)
-        return false;
 
     if (style->pointerEvents() == PointerEvents::None)
         return false;
+
+    if (style->cursorType() != CursorType::Pointer)
+        return looksLikeButton(renderer);
 
     if (!hasVisuallyDistinctStyling(protect(style)) && !renderer.isRenderReplaced())
         return false;

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -1425,6 +1425,11 @@ static String quoteValue(const String& value, bool conditionalQuoting)
     return value;
 }
 
+static bool shouldEmitClickableToken(const TextExtraction::Item& item)
+{
+    return item.isVisuallyClickable && item.accessibilityRole != "button"_s && item.accessibilityRole != "link"_s;
+}
+
 enum class IncludeRectForParentItem : bool { No, Yes };
 
 static String lineWithoutNodeIdentifier(const String& line, const std::optional<String>& identifier)
@@ -1647,7 +1652,7 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
 
                 parts.appendVector(partsForItem(item, aggregator, includeRectForParentItem));
 
-                if (isGenericContainer && item.isVisuallyClickable)
+                if (isGenericContainer && shouldEmitClickableToken(item))
                     parts.append("clickable"_s);
             }
             aggregator.addResult(line, WTF::move(parts));
@@ -1987,7 +1992,7 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
                 if (!imageData.altText.isEmpty())
                     parts.append(makeString("alt="_s, quoteValue(escapeString(imageData.altText), streamlined)));
 
-                if (item.isVisuallyClickable)
+                if (shouldEmitClickableToken(item))
                     parts.append("clickable"_s);
             }
 


### PR DESCRIPTION
#### 777dd2c83c0ea4748670a4ab0a06bef0581f1a4a
<pre>
[Text Extraction] Treat small, visually-distinct elements as clickable for the purpose of simulating clicks
<a href="https://bugs.webkit.org/show_bug.cgi?id=320777">https://bugs.webkit.org/show_bug.cgi?id=320777</a>
<a href="https://rdar.apple.com/183765548">rdar://183765548</a>

Reviewed by Abrar Rahman Protyasha.

Adjust the text extraction `looksVisuallyClickable` heuristic, to not require potential targets to
have `cursor: pointer;` as long as:

- The target is short
- The target contains a small amount of rendered text
- The target passes the `hasVisuallyDistinctStyling` check.

Test: fast/text-extraction/debug-text-extraction-button-like-div.html

* LayoutTests/fast/text-extraction/debug-text-extraction-button-like-div-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-button-like-div.html: Added.
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::containsInteractiveDescendant):
(WebCore::TextExtraction::looksLikeButton):
(WebCore::TextExtraction::looksVisuallyClickable):
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::shouldEmitClickableToken):
(WebKit::addPartsForItem):

Also make a slight adjustment here, to avoid emitting `clickable` for visually-clickable elements if
they already have an accessibility role that clearly suggests it&apos;s clickable.

Canonical link: <a href="https://commits.webkit.org/318473@main">https://commits.webkit.org/318473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9f1f83ac5de83ab2ddb62109b329a62f9c95aa3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141364 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fdedccaa-0c1c-4b90-a363-c6f51680dbe9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138846 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43525761-3e8c-423f-8c41-77b59958e2aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119302 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca4d1646-7b1b-40b1-8dfd-90cc8dbed940) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41061 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39414 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1271 "Build is in progress. Recent messages:") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151461 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39099 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36188 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190158 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147993 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39804 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52405 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35724 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147765 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42478 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124669 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119153 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50923 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14073 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50308 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50548 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50370 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->