### PR TITLE
Simple drive-by safer-cpp fixes

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -32,7 +32,7 @@
 #include "JITStubRoutine.h"
 #include "JSFunctionInlines.h"
 #include "MacroAssembler.h"
-#include "PropertyInlineCacheClearingWatchpoint.h"
+#include "PropertyInlineCache.h"
 #include "ScratchRegisterAllocator.h"
 #include <wtf/Vector.h>
 

--- a/Source/JavaScriptCore/bytecode/InlineCacheHandler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheHandler.cpp
@@ -37,6 +37,7 @@
 #include "JSModuleNamespaceObject.h"
 #include "ModuleNamespaceAccessCase.h"
 #include "PropertyInlineCache.h"
+#include "PropertyInlineCacheClearingWatchpoint.h"
 #include "SharedJITStubSet.h"
 
 namespace JSC {

--- a/Source/JavaScriptCore/bytecode/InlineCacheHandler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheHandler.h
@@ -30,7 +30,6 @@
 #include "AccessCase.h"
 #include "CallLinkInfo.h"
 #include "JITStubRoutine.h"
-#include "PropertyInlineCacheClearingWatchpoint.h"
 #include <wtf/RefCounted.h>
 
 namespace JSC {
@@ -40,6 +39,7 @@ class InlineCacheCompiler;
 class InlineCacheHandlerWithJSCall;
 class PolymorphicAccessJITStubRoutine;
 class PropertyInlineCache;
+class PropertyInlineCacheClearingWatchpoint;
 
 enum class CacheType : int8_t {
     Unset,

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
@@ -42,6 +42,18 @@ static constexpr bool verbose = false;
 
 PropertyInlineCache::~PropertyInlineCache() = default;
 
+RepatchingPropertyInlineCache::RepatchingPropertyInlineCache()
+    : PropertyInlineCache(PropertyInlineCacheType::Repatching)
+{
+}
+
+RepatchingPropertyInlineCache::RepatchingPropertyInlineCache(AccessType accessType, CodeOrigin codeOrigin)
+    : PropertyInlineCache(PropertyInlineCacheType::Repatching, accessType, codeOrigin)
+{
+}
+
+RepatchingPropertyInlineCache::~RepatchingPropertyInlineCache() = default;
+
 void PropertyInlineCache::initGetByIdSelf(const ConcurrentJSLockerBase& locker, CodeBlock* codeBlock, Structure* inlineAccessBaseStructure, PropertyOffset offset)
 {
     ASSERT(m_cacheType == CacheType::Unset);

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
@@ -32,7 +32,6 @@
 #include "JITStubRoutine.h"
 #include "MacroAssembler.h"
 #include "Options.h"
-#include "PropertyInlineCacheClearingWatchpoint.h"
 #include "PropertyInlineCacheSummary.h"
 #include "RegisterSet.h"
 #include "Structure.h"
@@ -685,13 +684,9 @@ public:
 class RepatchingPropertyInlineCache final : public PropertyInlineCache {
     WTF_MAKE_NONCOPYABLE(RepatchingPropertyInlineCache);
 public:
-    RepatchingPropertyInlineCache()
-        : PropertyInlineCache(PropertyInlineCacheType::Repatching)
-    { }
-
-    RepatchingPropertyInlineCache(AccessType accessType, CodeOrigin codeOrigin)
-        : PropertyInlineCache(PropertyInlineCacheType::Repatching, accessType, codeOrigin)
-    { }
+    RepatchingPropertyInlineCache();
+    RepatchingPropertyInlineCache(AccessType, CodeOrigin);
+    ~RepatchingPropertyInlineCache();
 
     // This is either the start of the inline IC for *byId caches, or the location of patchable jump for 'instanceof' caches.
     CodeLocationLabel<JITStubRoutinePtrTag> startLocation;

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCacheClearingWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCacheClearingWatchpoint.h
@@ -32,6 +32,7 @@
 #include "GCAwareJITStubRoutine.h"
 #include "ObjectPropertyCondition.h"
 #include "PackedCellPtr.h"
+#include "PropertyInlineCache.h"
 #include "Watchpoint.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
@@ -40,7 +41,6 @@ namespace JSC {
 
 class CodeBlock;
 class PolymorphicAccessJITStubRoutine;
-class PropertyInlineCache;
 
 class PropertyInlineCacheClearingWatchpoint final : public Watchpoint {
     WTF_MAKE_NONCOPYABLE(PropertyInlineCacheClearingWatchpoint);

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -34,6 +34,7 @@
 #include "VM.h"
 #include "JITStubRoutineSet.h"
 #include "JSCellInlines.h"
+#include "PropertyInlineCacheClearingWatchpoint.h"
 #include "SharedJITStubSet.h"
 #include <wtf/RefPtr.h>
 

--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
@@ -40,7 +40,8 @@ WKTypeID WKBackForwardListGetTypeID()
 
 WKBackForwardListItemRef WKBackForwardListGetCurrentItem(WKBackForwardListRef listRef)
 {
-    return toAPI(protect(toImpl(listRef)->currentItem()).get());
+    RefPtr currentItem = protect(toImpl(listRef))->currentItem();
+    return toAPI(currentItem.get());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetBackItem(WKBackForwardListRef listRef)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
@@ -53,7 +53,8 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKBackForwardListItem *)currentItem
 {
-    return WebKit::wrapper(protect((*_list).currentItem()).get());
+    RefPtr currentItem = protect(*_list)->currentItem();
+    return WebKit::wrapper(currentItem.get());
 }
 
 - (WKBackForwardListItem *)backItem

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -742,7 +742,8 @@ void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::D
             auto clearHandlingProvisionalMessage = makeScopeExit([&] {
                 page->backForwardList().setHandlingProvisionalMessage(false);
             });
-            page->backForwardListMessageReceiver().didReceiveMessage(connection, decoder);
+            Ref backForwardListReceiver = page->backForwardListMessageReceiver();
+            backForwardListReceiver->didReceiveMessage(connection, decoder);
 #else
             page->backForwardList().didReceiveProvisionalMessage(connection, decoder);
 #endif
@@ -882,9 +883,10 @@ void ProvisionalPageProxy::didReceiveSyncMessage(IPC::Connection& connection, IP
 
     RefPtr page = m_page.get();
     if (page) {
-        if (decoder.messageReceiverName() == Messages::WebBackForwardList::messageReceiverName())
-            page->backForwardListMessageReceiver().didReceiveSyncMessage(connection, decoder, replyEncoder);
-        else
+        if (decoder.messageReceiverName() == Messages::WebBackForwardList::messageReceiverName()) {
+            Ref backForwardListReceiver = page->backForwardListMessageReceiver();
+            backForwardListReceiver->didReceiveSyncMessage(connection, decoder, replyEncoder);
+        } else
             page->didReceiveSyncMessage(connection, decoder, replyEncoder);
     }
 }

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -103,10 +103,11 @@ RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, c
     , m_site(site)
     , m_processActivityState(makeUniqueRef<WebProcessActivityState>(*this))
 {
+    Ref backForwardListReceiver = protect(page)->backForwardListMessageReceiver();
     if (registrationToTransfer)
-        m_messageReceiverRegistration.transferMessageReceivingFrom(*registrationToTransfer, *this, page.backForwardListMessageReceiver());
+        m_messageReceiverRegistration.transferMessageReceivingFrom(*registrationToTransfer, *this, backForwardListReceiver);
     else
-        m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, page.backForwardListMessageReceiver());
+        m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, backForwardListReceiver);
 }
 
 void RemotePageProxy::initializeAfterAdoption()
@@ -272,7 +273,8 @@ void RemotePageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decode
         return;
 
     if (decoder.messageReceiverName() == Messages::WebBackForwardList::messageReceiverName()) {
-        page->backForwardListMessageReceiver().didReceiveMessage(connection, decoder);
+        Ref backForwardListReceiver = page->backForwardListMessageReceiver();
+        backForwardListReceiver->didReceiveMessage(connection, decoder);
         return;
     }
     page->didReceiveMessage(connection, decoder);
@@ -281,9 +283,10 @@ void RemotePageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decode
 void RemotePageProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
 {
     if (RefPtr page = m_page.get()) {
-        if (decoder.messageReceiverName() == Messages::WebBackForwardList::messageReceiverName())
-            page->backForwardListMessageReceiver().didReceiveSyncMessage(connection, decoder, encoder);
-        else
+        if (decoder.messageReceiverName() == Messages::WebBackForwardList::messageReceiverName()) {
+            Ref backForwardListReceiver = page->backForwardListMessageReceiver();
+            backForwardListReceiver->didReceiveSyncMessage(connection, decoder, encoder);
+        } else
             page->didReceiveSyncMessage(connection, decoder, encoder);
     }
 }

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -248,7 +248,7 @@ private:
 
 #if PLATFORM(COCOA)
 #if ENABLE(BACK_FORWARD_LIST_SWIFT)
-    std::optional<WebBackForwardList> NODELETE backForwardListForNavigation() const;
+    std::optional<WebBackForwardList> backForwardListForNavigation() const;
 #else
     WebBackForwardList* NODELETE backForwardListForNavigation() const;
 #endif

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -1125,7 +1125,7 @@ void setFrameStateBackForwardItemIdentifier(WebKit::FrameState& frameState, cons
 
 Ref<WebKit::WebBackForwardListItem> createItemFromState(const WebKit::BackForwardListItemState& itemState, WebKit::WebPageProxyIdentifier pageIdentifier)
 {
-    Ref stateCopy = itemState.frameState->copy();
+    Ref stateCopy = protect(itemState.frameState)->copy();
     setBackForwardItemIdentifiers(stateCopy, WebCore::BackForwardItemIdentifier::generate());
     return WebKit::WebBackForwardListItem::create(WTF::move(stateCopy), pageIdentifier, itemState.navigatedFrameID);
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1125,7 +1125,8 @@ WebPageProxy::~WebPageProxy()
 void WebPageProxy::addAllMessageReceivers()
 {
     Ref process = m_legacyMainFrameProcess;
-    internals().messageReceiverRegistration.startReceivingMessages(process, m_webPageID, *this, backForwardListMessageReceiver());
+    Ref backForwardListReceiver = backForwardListMessageReceiver();
+    internals().messageReceiverRegistration.startReceivingMessages(process, m_webPageID, *this, backForwardListReceiver);
     process->addMessageReceiver(Messages::NotificationManagerMessageHandler::messageReceiverName(), m_webPageID, protect(internals().notificationManagerMessageHandler));
 }
 


### PR DESCRIPTION
#### 0d188aac4126a0ef736af8549f967a932e209fa6
<pre>
Simple drive-by safer-cpp fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=320778">https://bugs.webkit.org/show_bug.cgi?id=320778</a>

Reviewed by Yusuke Suzuki.

[armv7] Remove ARMv7 JIT support - #70306 triggers these safer cpp
errors. This patch fixes them so that the other patch stays clean.

Canonical link: <a href="https://commits.webkit.org/318382@main">https://commits.webkit.org/318382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8423c99d58cbadee6a480e277973df39b12ed36f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178149 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187763 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138876 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119332 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41090 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39443 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1301 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8122 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39130 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36220 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39422 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190190 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51755 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148021 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39750 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52437 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147793 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42508 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124701 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119228 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50955 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14105 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50340 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50580 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->