### PR TITLE
Remove 32-bit libpas support

### DIFF
--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -27,7 +27,6 @@
 #include <wtf/Threading.h>
 
 #include <bmalloc/BPlatform.h>
-#include <bmalloc/pas_process.h>
 #include <cstring>
 #include <wtf/DateMath.h>
 #include <wtf/FastMalloc.h>
@@ -301,9 +300,16 @@ Ref<Thread> Thread::create(ASCIILiteral name, Function<void()>&& entryPoint, Thr
     return thread;
 }
 
+#if !OS(WINDOWS)
+bool processIsShuttingDown()
+{
+    return false;
+}
+#endif
+
 void Thread::didExit()
 {
-    if (pas_process_is_shutting_down())
+    if (processIsShuttingDown())
         return;
 
     allThreads().remove(*this);

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -86,6 +86,8 @@ class PrintStream;
 
 WTF_EXPORT_PRIVATE void initialize();
 
+WTF_EXPORT_PRIVATE bool processIsShuttingDown();
+
 class ThreadSuspendLocker {
     WTF_MAKE_NONCOPYABLE(ThreadSuspendLocker);
 public:

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -87,7 +87,6 @@
 #include <wtf/Threading.h>
 
 #include <bmalloc/BPlatform.h>
-#include <bmalloc/pas_process.h>
 #include <errno.h>
 #include <process.h>
 #include <windows.h>
@@ -98,6 +97,21 @@
 #include <wtf/ThreadingPrimitives.h>
 
 namespace WTF {
+
+bool processIsShuttingDown()
+{
+    using RtlDllShutdownInProgressPtr = BOOLEAN (WINAPI *)();
+    static RtlDllShutdownInProgressPtr resolved;
+    static bool didResolve;
+
+    if (!didResolve) {
+        if (HMODULE ntdll = GetModuleHandleW(L"ntdll.dll"))
+            resolved = reinterpret_cast<RtlDllShutdownInProgressPtr>(GetProcAddress(ntdll, "RtlDllShutdownInProgress"));
+        didResolve = true;
+    }
+
+    return resolved && resolved();
+}
 
 Thread::~Thread()
 {
@@ -264,7 +278,7 @@ void Thread::establishPlatformSpecificHandle(HANDLE handle, ThreadIdentifier thr
 struct Thread::ThreadHolder {
     ~ThreadHolder()
     {
-        if (pas_process_is_shutting_down())
+        if (processIsShuttingDown())
             return;
 
         if (thread) {

--- a/Source/bmalloc/libpas/src/libpas/pas_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_config.h
@@ -67,6 +67,10 @@
 #undef LIBPAS_ENABLED
 #define LIBPAS_ENABLED 0
 #endif
+
+#if BENABLE(LIBPAS) && !PAS_CPU(ADDRESS64)
+#error "libpas requires a 64-bit address space"
+#endif
 #endif
 
 #if ((PAS_OS(DARWIN) && __PAS_ARM64 && !__PAS_ARM64E) || PAS_PLATFORM(PLAYSTATION)) && defined(NDEBUG)
@@ -81,7 +85,6 @@
 #endif
 
 #define PAS_ARM64 __PAS_ARM64
-#define PAS_ARM32 __PAS_ARM32
 
 #define PAS_ARM __PAS_ARM
 
@@ -177,4 +180,3 @@
 #endif
 
 #endif /* PAS_CONFIG_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_config_prefix.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_config_prefix.h
@@ -45,19 +45,7 @@
 #define __PAS_ARM64E 0
 #endif
 
-#if (defined(arm) || defined(__arm__) || defined(ARM) || defined(_ARM_)) && !__PAS_ARM64
-#define __PAS_ARM32 1
-#else
-#define __PAS_ARM32 0
-#endif
-
-#define __PAS_ARM (!!__PAS_ARM64 || !!__PAS_ARM32)
-
-#if defined(__i386__) || defined(i386) || defined(_M_IX86) || defined(_X86_) || defined(__THW_INTEL)
-#define __PAS_X86 1
-#else
-#define __PAS_X86 0
-#endif
+#define __PAS_ARM (!!__PAS_ARM64)
 
 #if defined(__x86_64__) || defined(_M_X64)
 #define __PAS_X86_64 1

--- a/Source/bmalloc/libpas/src/libpas/pas_mar_registry.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mar_registry.c
@@ -54,8 +54,6 @@ struct pas_mar_registry* pas_mar_registry_for_crash_reporter_enumeration = NULL;
 
 // Backtrace hashing
 
-#if PAS_CPU(ADDRESS64)
-
 static uint32_t hash_backtrace(unsigned num_stack_frames, void** backtrace)
 {
     // This implements Murmur hash on the low 32b of each backtrace
@@ -102,7 +100,6 @@ unsigned pas_mar_insert_backtrace(pas_mar_registry* registry, unsigned num_stack
     return index;
 }
 
-#endif /* PAS_CPU(ADDRESS64) */
 
 // MAR Registry
 

--- a/Source/bmalloc/libpas/src/libpas/pas_platform.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_platform.h
@@ -202,9 +202,7 @@
 /* __LP64__ is not defined on 64bit Windows since it uses LLP64. Using __SIZEOF_POINTER__ is simpler. */
 #if __SIZEOF_POINTER__ == 8
 #define PAS_CPU_ADDRESS64 1
-#elif __SIZEOF_POINTER__ == 4
-#define PAS_CPU_ADDRESS32 1
-#else
+#elif __SIZEOF_POINTER__ != 4
 #error "Unsupported pointer width"
 #endif
 #elif PAS_COMPILER(MSVC)

--- a/Source/bmalloc/libpas/src/libpas/pas_process.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_process.c
@@ -23,6 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "pas_config.h"
+
+#if LIBPAS_ENABLED
+
 #include "pas_process.h"
 
 #if PAS_OS(WINDOWS)
@@ -58,3 +62,5 @@ bool pas_process_is_shutting_down(void)
 }
 
 #endif /* PAS_OS(WINDOWS) */
+
+#endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/pas_root.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.c
@@ -457,8 +457,6 @@ kern_return_t pas_root_visit_conservative_candidate_pointers_in_address_range(ta
         if (!candidate_pointer)
             continue;
 
-#if PAS_CPU(ADDRESS64)
-
 #if PAS_ARM
         if (candidate_pointer > MACH_VM_MAX_ADDRESS_RAW)
             continue;
@@ -475,7 +473,6 @@ kern_return_t pas_root_visit_conservative_candidate_pointers_in_address_range(ta
         /* First page on x64 process is unmapped. */
         if (candidate_pointer < (4ULL << 10))
             continue;
-#endif
 #endif
 
         /* FIXME: We can add more filtering via pas_root information later. */

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_directory.c
@@ -24,10 +24,10 @@
  */
 
 #include "pas_config.h"
-#include "pas_segregated_view_kind.h"
 
 #if LIBPAS_ENABLED
 
+#include "pas_segregated_view_kind.h"
 #include "pas_segregated_directory.h"
 
 #include "pas_heap_lock.h"

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.c
@@ -67,18 +67,6 @@
 #define CRASH_GPR5 "x22"
 #define CRASH_GPR6 "x23"
 
-#elif PAS_ARM32
-
-#define PAS_FATAL_CRASH_INST "bkpt #0"
-
-#define CRASH_GPR0 "r4"
-#define CRASH_GPR1 "r5"
-#define CRASH_GPR2 "r6"
-#define CRASH_GPR3 "r8"
-#define CRASH_GPR4 "r9"
-#define CRASH_GPR5 "r10"
-#define CRASH_GPR6 "r11"
-
 #endif
 
 #if defined(PAS_BMALLOC) && PAS_BMALLOC
@@ -89,7 +77,7 @@
 #endif // defined(__has_include)
 #endif // defined(PAS_BMALLOC) && PAS_BMALLOC
 
-#if PAS_X86_64 || PAS_ARM64 || PAS_ARM32
+#if PAS_X86_64 || PAS_ARM64
 
 #if (PAS_OS(DARWIN) || PAS_OS(LINUX)) && PAS_VA_OPT_SUPPORTED
 

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -122,11 +122,9 @@ PAS_BEGIN_EXTERN_C;
 
 #define PAS_ARM64 __PAS_ARM64
 #define PAS_ARM64E __PAS_ARM64E
-#define PAS_ARM32 __PAS_ARM32
 
 #define PAS_ARM __PAS_ARM
 
-#define PAS_X86 __PAS_X86
 #define PAS_X86_64 __PAS_X86_64
 
 #define PAS_RISCV __PAS_RISCV
@@ -867,20 +865,12 @@ static inline bool pas_compare_and_swap_bool_strong(bool* ptr, bool old_value, b
 
 static inline bool pas_compare_and_swap_uintptr_weak(uintptr_t* ptr, uintptr_t old_value, uintptr_t new_value)
 {
-#if PAS_CPU(ADDRESS64)
     return pas_compare_and_swap_uint64_weak((uint64_t*)ptr, (uint64_t)old_value, (uint64_t)new_value);
-#else
-    return pas_compare_and_swap_uint32_weak((uint32_t*)ptr, (uint32_t)old_value, (uint32_t)new_value);
-#endif
 }
 
 static inline uintptr_t pas_compare_and_swap_uintptr_strong(uintptr_t* ptr, uintptr_t old_value, uintptr_t new_value)
 {
-#if PAS_CPU(ADDRESS64)
     return (uintptr_t)pas_compare_and_swap_uint64_strong((uint64_t*)ptr, (uint64_t)old_value, (uint64_t)new_value);
-#else
-    return (uintptr_t)pas_compare_and_swap_uint32_strong((uint32_t*)ptr, (uint32_t)old_value, (uint32_t)new_value);
-#endif
 }
 
 static inline bool pas_compare_and_swap_ptr_weak(void* ptr, const void* old_value, const void* new_value)
@@ -921,7 +911,7 @@ static PAS_ALWAYS_INLINE uintptr_t pas_opaque(uintptr_t value)
     return value;
 }
 
-#if PAS_COMPILER(CLANG) || PAS_ARM32
+#if PAS_COMPILER(CLANG)
 
 struct pas_pair;
 typedef struct pas_pair pas_pair;
@@ -1007,17 +997,9 @@ static inline bool pas_compare_and_swap_pair_weak(void* raw_ptr,
     return cond;
 #elif PAS_COMPILER(CLANG)
 PAS_IGNORE_WARNINGS_BEGIN("atomic-alignment")
-#if PAS_CPU(ADDRESS64)
     PAS_TESTING_ASSERT(!((uintptr_t)raw_ptr % 16)); // CMPXCHG16B requires destination be 16-byte aligned
-#endif
     return __c11_atomic_compare_exchange_weak((_Atomic pas_pair*)raw_ptr, &old_value, new_value, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 PAS_IGNORE_WARNINGS_END
-#elif PAS_ARM32
-    PAS_ASSERT_IF(true, !"Should not be reached");
-    PAS_UNUSED_PARAM(raw_ptr);
-    PAS_UNUSED_PARAM(old_value);
-    PAS_UNUSED_PARAM(new_value);
-    return false;
 #else
     return __atomic_compare_exchange_n((pas_pair*)raw_ptr, &old_value, new_value, true, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 #endif
@@ -1056,16 +1038,9 @@ static inline pas_pair pas_compare_and_swap_pair_strong(void* raw_ptr,
     return pas_pair_create(low, high);
 #elif PAS_COMPILER(CLANG)
 PAS_IGNORE_WARNINGS_BEGIN("atomic-alignment")
-#if PAS_CPU(ADDRESS64)
     PAS_TESTING_ASSERT(!((uintptr_t)raw_ptr % 16)); // CMPXCHG16B requires destination be 16-byte aligned
-#endif
     __c11_atomic_compare_exchange_strong((_Atomic pas_pair*)raw_ptr, &old_value, new_value, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 PAS_IGNORE_WARNINGS_END
-    return old_value;
-#elif PAS_ARM32
-    PAS_ASSERT_IF(true, !"Should not be reached");
-    PAS_UNUSED_PARAM(raw_ptr);
-    PAS_UNUSED_PARAM(new_value);
     return old_value;
 #else
     __atomic_compare_exchange_n((pas_pair*)raw_ptr, &old_value, new_value, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
@@ -1090,10 +1065,6 @@ static inline pas_pair pas_atomic_load_pair_relaxed(void* raw_ptr)
 PAS_IGNORE_WARNINGS_BEGIN("atomic-alignment")
     return __c11_atomic_load((_Atomic pas_pair*)raw_ptr, __ATOMIC_RELAXED);
 PAS_IGNORE_WARNINGS_END
-#elif PAS_ARM32
-    PAS_ASSERT_IF(true, !"Should not be reached");
-    PAS_UNUSED_PARAM(raw_ptr);
-    return *(pas_pair*)raw_ptr;
 #else
     return __atomic_load_n((pas_pair*)raw_ptr, __ATOMIC_RELAXED);
 #endif
@@ -1119,10 +1090,6 @@ static inline void pas_atomic_store_pair(void* raw_ptr, pas_pair value)
 PAS_IGNORE_WARNINGS_BEGIN("atomic-alignment")
     __c11_atomic_store((_Atomic pas_pair*)raw_ptr, value, __ATOMIC_SEQ_CST);
 PAS_IGNORE_WARNINGS_END
-#elif PAS_ARM32
-    PAS_ASSERT_IF(true, !"Should not be reached");
-    PAS_UNUSED_PARAM(raw_ptr);
-    PAS_UNUSED_PARAM(value);
 #else
     __atomic_store_n((pas_pair*)raw_ptr, value, __ATOMIC_SEQ_CST);
 #endif
@@ -1135,10 +1102,6 @@ static inline void pas_atomic_store_pair_relaxed(void* raw_ptr, pas_pair value)
 PAS_IGNORE_WARNINGS_BEGIN("atomic-alignment")
     __c11_atomic_store((_Atomic pas_pair*)raw_ptr, value, __ATOMIC_RELAXED);
 PAS_IGNORE_WARNINGS_END
-#elif PAS_ARM32
-    PAS_ASSERT_IF(true, !"Should not be reached");
-    PAS_UNUSED_PARAM(raw_ptr);
-    PAS_UNUSED_PARAM(value);
 #else
     __atomic_store_n((pas_pair*)raw_ptr, value, __ATOMIC_RELAXED);
 #endif


### PR DESCRIPTION
#### 6eaa5ac1f65dd2fd749e637265e96717e900bf4a
<pre>
Remove 32-bit libpas support
<a href="https://bugs.webkit.org/show_bug.cgi?id=320779">https://bugs.webkit.org/show_bug.cgi?id=320779</a>

Reviewed by Yusuke Suzuki.

First, remove 32-bit predicates from libpas. Then, add a #error if you
try to build libpas for a 32-bit target. Finally, move one windows
helper from libpas out to WTF so that libpas doesn&apos;t get #included on
32-bit cloop builds.

Canonical link: <a href="https://commits.webkit.org/318383@main">https://commits.webkit.org/318383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8c21a8ebe39aed1fdf0125e75c392a040d3bf15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178151 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187765 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138878 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119334 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41092 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39445 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1303 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8124 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39132 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36222 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39424 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190192 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51757 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148020 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39751 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52439 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35757 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147792 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42510 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124703 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119230 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50957 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14107 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50342 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->