### PR TITLE
Address inconsistencies with the browser.alarms API

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIAlarms.cpp
+++ b/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIAlarms.cpp
@@ -39,11 +39,13 @@ bool WebExtensionContext::isAlarmsMessageAllowed(IPC::Decoder& message)
     return isLoadedAndPrivilegedMessage(message) && hasPermission(WebExtensionPermission::alarms());
 }
 
-void WebExtensionContext::alarmsCreate(const String& name, Seconds initialInterval, Seconds repeatInterval)
+void WebExtensionContext::alarmsCreate(const String& name, Seconds initialInterval, Seconds repeatInterval, CompletionHandler<void()>&& completionHandler)
 {
     m_alarmMap.set(name, WebExtensionAlarm::create(name, initialInterval, repeatInterval, [this, protectedThis = Ref { *this }](const WebExtensionAlarm& alarm) {
         fireAlarmsEventIfNeeded(alarm);
     }));
+
+    completionHandler();
 }
 
 void WebExtensionContext::alarmsGet(const String& name, CompletionHandler<void(std::optional<WebExtensionAlarmParameters>&&)>&& completionHandler)
@@ -54,11 +56,11 @@ void WebExtensionContext::alarmsGet(const String& name, CompletionHandler<void(s
         completionHandler(std::nullopt);
 }
 
-void WebExtensionContext::alarmsClear(const String& name, CompletionHandler<void()>&& completionHandler)
+void WebExtensionContext::alarmsClear(const String& name, CompletionHandler<void(bool)>&& completionHandler)
 {
-    m_alarmMap.remove(name);
+    bool success = m_alarmMap.remove(name);
 
-    completionHandler();
+    completionHandler(success);
 }
 
 void WebExtensionContext::alarmsGetAll(CompletionHandler<void(Vector<WebExtensionAlarmParameters>&&)>&& completionHandler)
@@ -70,11 +72,14 @@ void WebExtensionContext::alarmsGetAll(CompletionHandler<void(Vector<WebExtensio
     completionHandler(WTF::move(alarms));
 }
 
-void WebExtensionContext::alarmsClearAll(CompletionHandler<void()>&& completionHandler)
+void WebExtensionContext::alarmsClearAll(CompletionHandler<void(bool)>&& completionHandler)
 {
+    // Per MDN, only return true if there are alarms to clear.
+    bool success = !m_alarmMap.isEmpty();
+
     m_alarmMap.clear();
 
-    completionHandler();
+    completionHandler(success);
 }
 
 void WebExtensionContext::fireAlarmsEventIfNeeded(const WebExtensionAlarm& alarm)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -823,11 +823,11 @@ private:
 
     // Alarms APIs
     bool isAlarmsMessageAllowed(IPC::Decoder&);
-    void alarmsCreate(const String& name, Seconds initialInterval, Seconds repeatInterval);
+    void alarmsCreate(const String& name, Seconds initialInterval, Seconds repeatInterval, CompletionHandler<void()>&&);
     void alarmsGet(const String& name, CompletionHandler<void(std::optional<WebExtensionAlarmParameters>&&)>&&);
-    void alarmsClear(const String& name, CompletionHandler<void()>&&);
+    void alarmsClear(const String& name, CompletionHandler<void(bool)>&&);
     void alarmsGetAll(CompletionHandler<void(Vector<WebExtensionAlarmParameters>&&)>&&);
-    void alarmsClearAll(CompletionHandler<void()>&&);
+    void alarmsClearAll(CompletionHandler<void(bool)>&&);
     void fireAlarmsEventIfNeeded(const WebExtensionAlarm&);
 
     // Bookmarks APIs

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -47,11 +47,11 @@ messages -> WebExtensionContext {
     [Validator=isActionMessageAllowed] ActionSetEnabled(std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, bool enabled) -> (Expected<void, WebKit::WebExtensionError> result)
 
     // Alarms APIs
-    [Validator=isAlarmsMessageAllowed] AlarmsCreate(String name, Seconds initialInterval, Seconds repeatInterval)
+    [Validator=isAlarmsMessageAllowed] AlarmsCreate(String name, Seconds initialInterval, Seconds repeatInterval) -> ()
     [Validator=isAlarmsMessageAllowed] AlarmsGet(String name) -> (struct std::optional<WebKit::WebExtensionAlarmParameters> alarmInfo)
-    [Validator=isAlarmsMessageAllowed] AlarmsClear(String name) -> ()
+    [Validator=isAlarmsMessageAllowed] AlarmsClear(String name) -> (bool success)
     [Validator=isAlarmsMessageAllowed] AlarmsGetAll() -> (Vector<WebKit::WebExtensionAlarmParameters> alarms)
-    [Validator=isAlarmsMessageAllowed] AlarmsClearAll() -> ()
+    [Validator=isAlarmsMessageAllowed] AlarmsClearAll() -> (bool success)
 
 #if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
     // Bookmarks APIs

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.cpp
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.cpp
@@ -57,11 +57,12 @@ static inline JSValueRef toWebAPI(JSContextRef context, const WebExtensionAlarmP
     return result;
 }
 
-void WebExtensionAPIAlarms::createAlarm(const String& name, RefPtr<JSON::Value> alarmInfo, String& outExceptionString)
+void WebExtensionAPIAlarms::createAlarm(const String& name, RefPtr<JSON::Value> alarmInfo, Ref<WebExtensionCallbackHandler>&& callback, String& outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/create
 
     if (!validateDictionary(alarmInfo, "info"_s, { }, {
+        { nameKey, JSON::Value::Type::String },
         { whenKey, JSON::Value::Type::Double },
         { delayInMinutesKey, JSON::Value::Type::Double },
         { periodInMinutesKey, JSON::Value::Type::Double },
@@ -71,6 +72,13 @@ void WebExtensionAPIAlarms::createAlarm(const String& name, RefPtr<JSON::Value> 
     auto alarmObject = alarmInfo->asObject();
     if (!alarmObject)
         return;
+
+    auto infoName = alarmObject->getString(nameKey);
+
+    if (!name.isEmpty() && !infoName.isNull()) {
+        callback->reportError(toErrorString("alarms.create()"_s, "info"_s, "it cannot specify 'name' when a name is also passed as an argument"_s));
+        return;
+    }
 
     auto whenNumber = alarmObject->getDouble(whenKey);
     auto delayNumber = alarmObject->getDouble(delayInMinutesKey);
@@ -107,7 +115,11 @@ void WebExtensionAPIAlarms::createAlarm(const String& name, RefPtr<JSON::Value> 
         repeatInterval = repeatInterval ? std::max(repeatInterval, webExtensionMinimumAlarmInterval) : 0_s;
     }
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::AlarmsCreate(!name.isEmpty() ? name : emptyAlarmName, initialInterval, repeatInterval), extensionContext().identifier());
+    String alarmName = !name.isEmpty() ? name : infoName;
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsCreate(!alarmName.isEmpty() ? alarmName : emptyAlarmName, initialInterval, repeatInterval), [protectedThis = Ref { *this }, callback = WTF::move(callback)]() {
+        callback->call();
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIAlarms::get(const String& name, Ref<WebExtensionCallbackHandler>&& callback)
@@ -115,7 +127,7 @@ void WebExtensionAPIAlarms::get(const String& name, Ref<WebExtensionCallbackHand
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/get
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsGet(!name.isEmpty() ? name : emptyAlarmName), [protectedThis = Ref { *this }, callback = WTF::move(callback)](std::optional<WebExtensionAlarmParameters>&& alarm) {
-        callback->call(toWebAPI(callback->globalContext(), alarm));
+        callback->call(toWebAPI(callback->globalContext(), alarm, UseNullValue::No));
     }, extensionContext().identifier());
 }
 
@@ -132,8 +144,8 @@ void WebExtensionAPIAlarms::clear(const String& name, Ref<WebExtensionCallbackHa
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clear
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsClear(!name.isEmpty() ? name : emptyAlarmName), [protectedThis = Ref { *this }, callback = WTF::move(callback)]() {
-        callback->call();
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsClear(!name.isEmpty() ? name : emptyAlarmName), [protectedThis = Ref { *this }, callback = WTF::move(callback)](bool success) {
+        callback->call(JSValueMakeBoolean(callback->globalContext(), success));
     }, extensionContext().identifier());
 }
 
@@ -141,8 +153,8 @@ void WebExtensionAPIAlarms::clearAll(Ref<WebExtensionCallbackHandler>&& callback
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsClearAll(), [protectedThis = Ref { *this }, callback = WTF::move(callback)]() {
-        callback->call();
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsClearAll(), [protectedThis = Ref { *this }, callback = WTF::move(callback)](bool success) {
+        callback->call(JSValueMakeBoolean(callback->globalContext(), success));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h
@@ -37,7 +37,7 @@ class WebExtensionAPIAlarms : public WebExtensionAPIObject, public JSWebExtensio
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIAlarms, alarms, alarms);
 
 public:
-    void createAlarm(const String& name, RefPtr<JSON::Value> alarmInfo, String& outExceptionString);
+    void createAlarm(const String& name, RefPtr<JSON::Value> alarmInfo, Ref<WebExtensionCallbackHandler>&&, String& outExceptionString);
 
     void get(const String& name, Ref<WebExtensionCallbackHandler>&&);
     void getAll(Ref<WebExtensionCallbackHandler>&&);

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl
@@ -29,7 +29,7 @@
     ReturnsPromiseWhenCallbackIsOmitted,
     UseCPPAPI
 ] interface WebExtensionAPIAlarms {
-    [RaisesStringException, ImplementedAs=createAlarm] void create([Optional] DOMString name, [JSONValue] any info);
+    [RaisesStringException, ImplementedAs=createAlarm] void create([Optional] DOMString name, [JSONValue] any info, [Optional, CallbackHandler] function callback);
 
     void get([Optional] DOMString name, [Optional, CallbackHandler] function callback);
     void getAll([Optional, CallbackHandler] function callback);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIAlarms.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIAlarms.mm
@@ -71,6 +71,8 @@ TEST(WKWebExtensionAPIAlarms, Errors)
 
         @"browser.test.assertThrows(() => browser.alarms.create({ delayInMinutes: 1, when: Date.now() + 60000 }), /cannot specify both 'delayInMinutes' and 'when'/i)",
 
+        @"await browser.test.assertRejects(browser.alarms.create('one', { name: 'one', delayInMinutes: 1 }), /cannot specify 'name' when a name is also passed as an argument/i)",
+
         @"browser.test.notifyPass()",
     ]);
 
@@ -259,7 +261,9 @@ TEST(WKWebExtensionAPIAlarms, ClearSingleAlarm)
         @"browser.alarms.create('one', { delayInMinutes: 0.01 })",
         @"browser.alarms.create('two', { delayInMinutes: 0.1 })",
 
-        @"browser.alarms.clear('one')",
+        @"browser.test.assertTrue(await browser.alarms.clear('one'), 'Should return true when an alarm was cleared.')",
+        @"browser.test.assertFalse(await browser.alarms.clear('one'), 'Should return false when no alarm matched.')",
+        @"browser.test.assertFalse(await browser.alarms.clear('missing'), 'Should return false for an unknown alarm.')",
 
         // The listener firing will indicate that the test passed.
     ]);
@@ -287,6 +291,9 @@ TEST(WKWebExtensionAPIAlarms, GetSingleAlarm)
         @"browser.test.assertEq(typeof result.periodInMinutes, 'number')",
         @"browser.test.assertEq(result.periodInMinutes, 1)",
 
+        @"result = await browser.alarms.get('missing')",
+        @"browser.test.assertEq(result, undefined, 'Should be undefined for an unknown alarm.')",
+
         @"browser.test.notifyPass()",
     ]);
 
@@ -304,10 +311,13 @@ TEST(WKWebExtensionAPIAlarms, ClearAllAlarms)
         // Test
         @"browser.alarms.onAlarm.addListener(listener)",
 
+        @"browser.test.assertFalse(await browser.alarms.clearAll(), 'Should return false when there are no alarms.')",
+
         @"browser.alarms.create('one', { delayInMinutes: 0.01 })",
         @"browser.alarms.create('two', { delayInMinutes: 0.1 })",
 
-        @"await browser.alarms.clearAll()",
+        @"browser.test.assertTrue(await browser.alarms.clearAll(), 'Should return true when alarms were cleared.')",
+        @"browser.test.assertFalse(await browser.alarms.clearAll(), 'Should return false once all alarms are gone.')",
 
         @"setTimeout(() => {",
         @"  browser.test.notifyPass()",
@@ -363,6 +373,27 @@ TEST(WKWebExtensionAPIAlarms, UnnamedAlarm)
         @"browser.alarms.create({ delayInMinutes: 0.01 })",
 
         // The listener firing will indicate that the test passed.
+    ]);
+
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIAlarms, CreateAlarms)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.alarms.create({ name: 'one', periodInMinutes: 1 })",
+        @"let result = await browser.alarms.get('one')",
+        @"browser.test.assertEq(result.name, 'one', 'Should create the alarm with the name from the info object')",
+        @"browser.test.assertEq(result.periodInMinutes, 1)",
+        @"browser.test.assertEq(result.delayInMinutes, undefined)",
+
+        @"browser.alarms.create('two', { periodInMinutes: 1 })",
+        @"result = await browser.alarms.get('two')",
+        @"browser.test.assertEq(result.name, 'two', 'Should create the alarm with the name passed as an argument.')",
+        @"browser.test.assertEq(result.periodInMinutes, 1)",
+        @"browser.test.assertEq(result.delayInMinutes, undefined)",
+
+        @"browser.test.notifyPass()",
     ]);
 
     Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });


### PR DESCRIPTION
#### 07565287df4a952e02a052d06125123d24ffcebd
<pre>
Address inconsistencies with the browser.alarms API
<a href="https://bugs.webkit.org/show_bug.cgi?id=320767">https://bugs.webkit.org/show_bug.cgi?id=320767</a>
<a href="https://rdar.apple.com/183770530">rdar://183770530</a>

Reviewed by Timothy Hatcher.

This patch addresses a few of inconsistencies with the browser.alarms API:
- alarms.create() should return a promise as specified in the MDN documentation.
- alarms.create() should allow for a &quot;name&quot; key to be specified in the info options. <a href="https://github.com/w3c/webextensions/issues/999">https://github.com/w3c/webextensions/issues/999</a>
- alarms.get() for an unknown alarm should return undefined, not nil.
- alarms.clear() and alarms.clearAll() should return a promise that resolves with a boolean.

Note: Chrome returns true always for clearAll() whereas Firefox only returns true if an alarm was
actually cleared. This patch matches Firefox&apos;s behavior since this implementation follows the MDN
documentation. I filed <a href="https://github.com/w3c/webextensions/issues/1055">https://github.com/w3c/webextensions/issues/1055</a> to address this in the WECG.

With these changes, all of the currently running WPT tests for browser.alarms pass.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIAlarms.mm

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm:
(WebKit::WebExtensionContext::alarmsCreate):
(WebKit::WebExtensionContext::alarmsClear):
(WebKit::WebExtensionContext::alarmsClearAll):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm:
(WebKit::WebExtensionAPIAlarms::createAlarm):
(WebKit::WebExtensionAPIAlarms::get):
(WebKit::WebExtensionAPIAlarms::clear):
(WebKit::WebExtensionAPIAlarms::clearAll):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIAlarms.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIAlarms, Errors)):
(TestWebKitAPI::TEST(WKWebExtensionAPIAlarms, ClearSingleAlarm)):
(TestWebKitAPI::TEST(WKWebExtensionAPIAlarms, GetSingleAlarm)):
(TestWebKitAPI::TEST(WKWebExtensionAPIAlarms, ClearAllAlarms)):
(TestWebKitAPI::TEST(WKWebExtensionAPIAlarms, CreateAlarms)):

Canonical link: <a href="https://commits.webkit.org/318493@main">https://commits.webkit.org/318493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee14d17331c92f4600ddef2aea1fde1a5d3c13ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178430 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188046 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141678 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db87110e-0c1d-4d3e-bb98-2335e9692f72) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139104 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef747737-58d4-479a-bef9-2f9e9ca4d82e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159865 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119558 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7df7a6cf-d214-461f-b219-2f93444157bf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41335 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39684 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39364 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36501 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190473 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52037 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148262 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39815 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52718 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148034 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42748 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124984 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119621 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51236 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14339 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50621 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50861 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50683 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->