### PR TITLE
Remove big endian support and support for platforms without unaligned loads/stores

### DIFF
--- a/Source/JavaScriptCore/runtime/CloneDeserializerBase.h
+++ b/Source/JavaScriptCore/runtime/CloneDeserializerBase.h
@@ -60,7 +60,6 @@ concept StructuredCloneDeserializerHandler = requires(Derived& d, SerializationT
 
 namespace StructuredCloneInternal {
 
-#if JSC_ASSUME_LITTLE_ENDIAN
 template<typename T> inline bool readLittleEndian(std::span<const uint8_t>& span, T& value)
 {
     if (span.size() < sizeof(value))
@@ -68,23 +67,6 @@ template<typename T> inline bool readLittleEndian(std::span<const uint8_t>& span
     value = consumeAndReinterpretCastTo<const T>(span);
     return true;
 }
-#else
-template<typename T> inline bool readLittleEndian(std::span<const uint8_t>& span, T& value)
-{
-    if (span.size() < sizeof(value))
-        return false;
-
-    if constexpr (sizeof(T) == 1)
-        value = consume(span);
-    else {
-        value = 0;
-        for (size_t i = 0; i < sizeof(T); ++i)
-            value += static_cast<T>(span[i]) << (i * 8);
-        skip(span, sizeof(T));
-    }
-    return true;
-}
-#endif
 
 } // namespace StructuredCloneInternal
 
@@ -269,23 +251,11 @@ protected:
         if (span.size() < size)
             return false;
 
-#if JSC_ASSUME_LITTLE_ENDIAN
         auto stringSpan = consumeSpan(span, size);
         if (shouldAtomize == ShouldAtomize::Yes)
             str = AtomString(spanReinterpretCast<const char16_t>(stringSpan));
         else
             str = String(spanReinterpretCast<const char16_t>(stringSpan));
-#else
-        std::span<char16_t> characters;
-        str = String::createUninitialized(length, characters);
-        for (unsigned i = 0; i < length; ++i) {
-            uint16_t c;
-            StructuredCloneInternal::readLittleEndian(span, c);
-            characters[i] = c;
-        }
-        if (shouldAtomize == ShouldAtomize::Yes)
-            str = AtomString { str };
-#endif
         return true;
     }
 

--- a/Source/JavaScriptCore/runtime/CloneSerializerBase.h
+++ b/Source/JavaScriptCore/runtime/CloneSerializerBase.h
@@ -58,20 +58,10 @@ concept StructuredCloneSerializerHandler = requires(Derived& d, JSObject* obj, S
 
 namespace StructuredCloneInternal {
 
-#if JSC_ASSUME_LITTLE_ENDIAN
 template<typename T> inline void writeLittleEndian(Vector<uint8_t>& buffer, T value)
 {
     buffer.append(asByteSpan(value));
 }
-#else
-template<typename T> inline void writeLittleEndian(Vector<uint8_t>& buffer, T value)
-{
-    for (unsigned i = 0; i < sizeof(T); i++) {
-        buffer.append(value & 0xFF);
-        value >>= 8;
-    }
-}
-#endif
 
 template<> inline void writeLittleEndian<uint8_t>(Vector<uint8_t>& buffer, uint8_t value)
 {
@@ -83,17 +73,7 @@ template<typename T> inline bool writeLittleEndian(Vector<uint8_t>& buffer, std:
     if (values.size() > std::numeric_limits<uint32_t>::max() / sizeof(T))
         return false;
 
-#if JSC_ASSUME_LITTLE_ENDIAN
     buffer.append(asBytes(values));
-#else
-    for (unsigned i = 0; i < values.size(); i++) {
-        T value = values[i];
-        for (unsigned j = 0; j < sizeof(T); j++) {
-            buffer.append(static_cast<uint8_t>(value & 0xFF));
-            value >>= 8;
-        }
-    }
-#endif
     return true;
 }
 

--- a/Source/JavaScriptCore/runtime/StructuredCloneTags.h
+++ b/Source/JavaScriptCore/runtime/StructuredCloneTags.h
@@ -31,16 +31,6 @@
 #include <wtf/text/ASCIILiteral.h>
 #include <wtf/text/StringCommon.h>
 
-// Most CPUs we support are little-endian and accept unaligned loads of the
-// integer widths the wire format uses, so the read/write helpers fast-path
-// to a single load/store. Architectures that need byte-by-byte handling
-// (big-endian, middle-endian, alignment-strict) take the portable path.
-#if CPU(BIG_ENDIAN) || CPU(MIDDLE_ENDIAN) || CPU(NEEDS_ALIGNED_ACCESS)
-#define JSC_ASSUME_LITTLE_ENDIAN 0
-#else
-#define JSC_ASSUME_LITTLE_ENDIAN 1
-#endif
-
 namespace JSC {
 
 /*

--- a/Source/WTF/wtf/ByteOrder.h
+++ b/Source/WTF/wtf/ByteOrder.h
@@ -37,29 +37,11 @@
 #include <arpa/inet.h>
 #endif
 
-namespace WTF {
-
-inline uint32_t wordSwap32(uint32_t x) { return ((x & 0xffff0000) >> 16) | ((x & 0x0000ffff) << 16); }
-
-} // namespace WTF
-
 #if OS(WINDOWS)
 
-#if CPU(BIG_ENDIAN)
-inline uint16_t ntohs(uint16_t x) { return x; }
-inline uint16_t htons(uint16_t x) { return x; }
-inline uint32_t ntohl(uint32_t x) { return x; }
-inline uint32_t htonl(uint32_t x) { return x; }
-#elif CPU(MIDDLE_ENDIAN)
-inline uint16_t ntohs(uint16_t x) { return x; }
-inline uint16_t htons(uint16_t x) { return x; }
-inline uint32_t ntohl(uint32_t x) { return WTF::wordSwap32(x); }
-inline uint32_t htonl(uint32_t x) { return WTF::wordSwap32(x); }
-#else
 inline uint16_t ntohs(uint16_t x) { return std::byteswap(x); }
 inline uint16_t htons(uint16_t x) { return std::byteswap(x); }
 inline uint32_t ntohl(uint32_t x) { return std::byteswap(x); }
 inline uint32_t htonl(uint32_t x) { return std::byteswap(x); }
-#endif
 
 #endif // OS(WINDOWS)

--- a/Source/WTF/wtf/CompactPointerTuple.h
+++ b/Source/WTF/wtf/CompactPointerTuple.h
@@ -61,12 +61,10 @@ public:
     static constexpr unsigned maxNumberOfBitsInPointer = 48;
     static_assert(OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH) <= maxNumberOfBitsInPointer);
 
-#if CPU(LITTLE_ENDIAN)
     static constexpr ptrdiff_t offsetOfType()
     {
         return maxNumberOfBitsInPointer / 8;
     }
-#endif
 
     static constexpr uint64_t pointerMask = (1ULL << maxNumberOfBitsInPointer) - 1;
 

--- a/Source/WTF/wtf/FlipBytes.h
+++ b/Source/WTF/wtf/FlipBytes.h
@@ -36,11 +36,7 @@ namespace WTF {
 
 constexpr bool needToFlipBytesIfLittleEndian(bool littleEndian)
 {
-#if CPU(BIG_ENDIAN)
-    return littleEndian;
-#else
     return !littleEndian;
-#endif
 }
 
 template<typename T>

--- a/Source/WTF/wtf/Int128.h
+++ b/Source/WTF/wtf/Int128.h
@@ -195,15 +195,8 @@ class UInt128Impl {
 
   // TODO(strel) Update implementation to use __int128 once all users of
   // UInt128Impl are fixed to not depend on alignof(UInt128Impl) == 8.
-#if CPU(LITTLE_ENDIAN)
   uint64_t lo_;
   uint64_t hi_;
-#elif CPU(BIG_ENDIAN)
-  uint64_t hi_;
-  uint64_t lo_;
-#else  // byte order
-#error "Unsupported byte order: must be little-endian or big-endian."
-#endif  // byte order
 };
 
 // allow UInt128Impl to be logged
@@ -395,15 +388,8 @@ class Int128Impl {
  private:
   constexpr Int128Impl(int64_t high, uint64_t low);
 
-#if CPU(LITTLE_ENDIAN)
   uint64_t lo_;
   int64_t hi_;
-#elif CPU(BIG_ENDIAN)
-  int64_t hi_;
-  uint64_t lo_;
-#else  // byte order
-#error "Unsupported byte order: must be little-endian or big-endian."
-#endif  // byte order
 };
 
 WTF_EXPORT_PRIVATE std::ostream& operator<<(std::ostream& os, Int128Impl v);
@@ -552,7 +538,6 @@ constexpr uint64_t UInt128High64(UInt128Impl v) { return v.hi_; }
 
 // Constructors from integer types.
 
-#if CPU(LITTLE_ENDIAN)
 
 constexpr UInt128Impl::UInt128Impl(uint64_t high, uint64_t low)
     : lo_{low}, hi_{high} {}
@@ -576,33 +561,6 @@ constexpr UInt128Impl::UInt128Impl(unsigned long long v) : lo_{v}, hi_{0} {}
 constexpr UInt128Impl::UInt128Impl(Int128Impl v)
     : lo_{Int128Low64(v)}, hi_{static_cast<uint64_t>(Int128High64(v))} {}
 
-#elif CPU(BIG_ENDIAN)
-
-constexpr UInt128Impl::UInt128Impl(uint64_t high, uint64_t low)
-    : hi_{high}, lo_{low} {}
-
-constexpr UInt128Impl::UInt128Impl(int v)
-    : hi_{v < 0 ? (std::numeric_limits<uint64_t>::max)() : 0},
-      lo_{static_cast<uint64_t>(v)} {}
-constexpr UInt128Impl::UInt128Impl(long v)  // NOLINT(runtime/int)
-    : hi_{v < 0 ? (std::numeric_limits<uint64_t>::max)() : 0},
-      lo_{static_cast<uint64_t>(v)} {}
-constexpr UInt128Impl::UInt128Impl(long long v)  // NOLINT(runtime/int)
-    : hi_{v < 0 ? (std::numeric_limits<uint64_t>::max)() : 0},
-      lo_{static_cast<uint64_t>(v)} {}
-
-constexpr UInt128Impl::UInt128Impl(unsigned int v) : hi_{0}, lo_{v} {}
-// NOLINTNEXTLINE(runtime/int)
-constexpr UInt128Impl::UInt128Impl(unsigned long v) : hi_{0}, lo_{v} {}
-// NOLINTNEXTLINE(runtime/int)
-constexpr UInt128Impl::UInt128Impl(unsigned long long v) : hi_{0}, lo_{v} {}
-
-constexpr UInt128Impl::UInt128Impl(Int128Impl v)
-    : hi_{static_cast<uint64_t>(Int128High64(v))}, lo_{Int128Low64(v)} {}
-
-#else  // byte order
-#error "Unsupported byte order: must be little-endian or big-endian."
-#endif  // byte order
 
 // Conversion operators to integer types.
 
@@ -952,7 +910,6 @@ constexpr uint64_t Int128Low64(Int128Impl v) { return v.lo_; }
 
 constexpr int64_t Int128High64(Int128Impl v) { return v.hi_; }
 
-#if CPU(LITTLE_ENDIAN)
 
 constexpr Int128Impl::Int128Impl(int64_t high, uint64_t low) :
     lo_(low), hi_(high) {}
@@ -973,30 +930,6 @@ constexpr Int128Impl::Int128Impl(unsigned long long v) : lo_{v}, hi_{0} {}
 constexpr Int128Impl::Int128Impl(UInt128Impl v)
     : lo_{UInt128Low64(v)}, hi_{static_cast<int64_t>(UInt128High64(v))} {}
 
-#elif CPU(BIG_ENDIAN)
-
-constexpr Int128Impl::Int128Impl(int64_t high, uint64_t low) :
-    hi_{high}, lo_{low} {}
-
-constexpr Int128Impl::Int128Impl(int v)
-    : hi_{v < 0 ? ~int64_t{0} : 0}, lo_{static_cast<uint64_t>(v)} {}
-constexpr Int128Impl::Int128Impl(long v)  // NOLINT(runtime/int)
-    : hi_{v < 0 ? ~int64_t{0} : 0}, lo_{static_cast<uint64_t>(v)} {}
-constexpr Int128Impl::Int128Impl(long long v)  // NOLINT(runtime/int)
-    : hi_{v < 0 ? ~int64_t{0} : 0}, lo_{static_cast<uint64_t>(v)} {}
-
-constexpr Int128Impl::Int128Impl(unsigned int v) : hi_{0}, lo_{v} {}
-// NOLINTNEXTLINE(runtime/int)
-constexpr Int128Impl::Int128Impl(unsigned long v) : hi_{0}, lo_{v} {}
-// NOLINTNEXTLINE(runtime/int)
-constexpr Int128Impl::Int128Impl(unsigned long long v) : hi_{0}, lo_{v} {}
-
-constexpr Int128Impl::Int128Impl(UInt128Impl v)
-    : hi_{static_cast<int64_t>(UInt128High64(v))}, lo_{UInt128Low64(v)} {}
-
-#else  // byte order
-#error "Unsupported byte order: must be little-endian or big-endian."
-#endif  // byte order
 
 constexpr Int128Impl::operator bool() const { return lo_ || hi_; }
 

--- a/Source/WTF/wtf/Packed.h
+++ b/Source/WTF/wtf/Packed.h
@@ -145,11 +145,7 @@ public:
         // https://bugs.webkit.org/show_bug.cgi?id=197754
         uintptr_t value = 0;
 
-#if CPU(LITTLE_ENDIAN)
         memcpySpan(asMutableByteSpan(value), std::span { m_storage });
-#else
-        memcpySpan(asMutableByteSpan(value).last(storageSize), std::span { m_storage });
-#endif
 
         if (isAlignmentShiftProfitable)
             value <<= alignmentShiftSize;
@@ -175,11 +171,7 @@ public:
         uintptr_t value = std::bit_cast<uintptr_t>(passedValue);
         if (isAlignmentShiftProfitable)
             value >>= alignmentShiftSize;
-#if CPU(LITTLE_ENDIAN)
         memcpySpan(std::span { m_storage }, asByteSpan(value).first(storageSize));
-#else
-        memcpySpan(std::span { m_storage }, asByteSpan(value).last(storageSize));
-#endif
         ASSERT(get() == passedValue);
     }
 

--- a/Source/WTF/wtf/PlatformCPU.h
+++ b/Source/WTF/wtf/PlatformCPU.h
@@ -332,6 +332,6 @@
 #error "Unknown endian"
 #endif
 
-#if !CPU(LITTLE_ENDIAN) && !CPU(BIG_ENDIAN)
+#if !CPU(LITTLE_ENDIAN)
 #error "Unsupported endian"
 #endif

--- a/Source/WTF/wtf/text/FastCharacterComparison.h
+++ b/Source/WTF/wtf/text/FastCharacterComparison.h
@@ -33,32 +33,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 
-#if CPU(NEEDS_ALIGNED_ACCESS)
-
-#define COMPARE_2CHARS(address, char1, char2) \
-(((address)[0] == char1) && ((address)[1] == char2))
-#define COMPARE_4CHARS(address, char1, char2, char3, char4) \
-    (COMPARE_2CHARS(address, char1, char2) && COMPARE_2CHARS((address) + 2, char3, char4))
-#define COMPARE_2UCHARS(address, char1, char2) \
-    (((address)[0] == char1) && ((address)[1] == char2))
-#define COMPARE_4UCHARS(address, char1, char2, char3, char4) \
-    (COMPARE_2UCHARS(address, char1, char2) && COMPARE_2UCHARS((address) + 2, char3, char4))
-
-#else // CPU(NEEDS_ALIGNED_ACCESS)
-
-#if CPU(BIG_ENDIAN)
-
-#define CHARPAIR_TOUINT16(a, b) \
-((((uint16_t)(a)) << 8) + (uint16_t)(b))
-#define CHARQUAD_TOUINT32(a, b, c, d) \
-    ((((uint32_t)(CHARPAIR_TOUINT16(a, b))) << 16) + CHARPAIR_TOUINT16(c, d))
-#define UCHARPAIR_TOUINT32(a, b) \
-    ((((uint32_t)(a)) << 16) + (uint32_t)(b))
-#define UCHARQUAD_TOUINT64(a, b, c, d) \
-    ((((uint64_t)(UCHARPAIR_TOUINT32(a, b))) << 32) + UCHARPAIR_TOUINT32(c, d))
-
-#else // CPU(BIG_ENDIAN)
-
 #define CHARPAIR_TOUINT16(a, b) \
 ((((uint16_t)(b)) << 8) + (uint16_t)(a))
 #define CHARQUAD_TOUINT32(a, b, c, d) \
@@ -67,9 +41,6 @@ namespace WTF {
     ((((uint32_t)(b)) << 16) + (uint32_t)(a))
 #define UCHARQUAD_TOUINT64(a, b, c, d) \
     ((((uint64_t)(UCHARPAIR_TOUINT32(c, d))) << 32) + UCHARPAIR_TOUINT32(a, b))
-
-#endif // CPU(BIG_ENDIAN)
-
 
 #define COMPARE_2CHARS(address, char1, char2) \
     ((reinterpret_cast_ptr<const uint16_t*>(address))[0] == CHARPAIR_TOUINT16(char1, char2))
@@ -91,8 +62,6 @@ namespace WTF {
     (COMPARE_2UCHARS(address, char1, char2) && COMPARE_2UCHARS((address) + 2, char3, char4))
 
 #endif // CPU(X86_64) || CPU(ARM64)
-
-#endif // CPU(NEEDS_ALIGNED_ACCESS)
 
 #define COMPARE_3CHARS(address, char1, char2, char3) \
     (COMPARE_2CHARS(address, char1, char2) && ((address)[2] == (char3)))

--- a/Source/WTF/wtf/text/RapidHash.h
+++ b/Source/WTF/wtf/text/RapidHash.h
@@ -178,7 +178,6 @@ private:
         };
 
         auto read64 = [&](size_t off) ALWAYS_INLINE_LAMBDA -> uint64_t {
-#if CPU(LITTLE_ENDIAN)
             if (!std::is_constant_evaluated()) {
                 if constexpr (std::is_same_v<Converter, DefaultConverter>) {
                     if constexpr (sizeof(T) == 1)
@@ -196,7 +195,6 @@ private:
                     }
                 }
             }
-#endif
             uint64_t result = 0;
             for (size_t i = 0; i < 8; ++i)
                 result |= static_cast<uint64_t>(foldByte(off + i)) << (i * 8);
@@ -204,7 +202,6 @@ private:
         };
 
         auto read32 = [&](size_t off) ALWAYS_INLINE_LAMBDA -> uint64_t {
-#if CPU(LITTLE_ENDIAN)
             if (!std::is_constant_evaluated()) {
                 if constexpr (std::is_same_v<Converter, DefaultConverter>) {
                     if constexpr (sizeof(T) == 1)
@@ -221,7 +218,6 @@ private:
                     }
                 }
             }
-#endif
             uint64_t result = 0;
             for (size_t i = 0; i < 4; ++i)
                 result |= static_cast<uint64_t>(foldByte(off + i)) << (i * 8);
@@ -250,10 +246,8 @@ private:
         };
 
         auto read64 = [&](size_t byteOff) ALWAYS_INLINE_LAMBDA -> uint64_t {
-#if CPU(LITTLE_ENDIAN)
             if (!std::is_constant_evaluated())
                 return unalignedLoad<uint64_t>(reinterpret_cast<const uint8_t*>(p) + byteOff);
-#endif
             uint64_t r = 0;
             for (size_t i = 0; i < 8; ++i)
                 r |= static_cast<uint64_t>(readByte(byteOff + i)) << (i * 8);
@@ -261,10 +255,8 @@ private:
         };
 
         auto read32 = [&](size_t byteOff) ALWAYS_INLINE_LAMBDA -> uint64_t {
-#if CPU(LITTLE_ENDIAN)
             if (!std::is_constant_evaluated())
                 return static_cast<uint64_t>(unalignedLoad<uint32_t>(reinterpret_cast<const uint8_t*>(p) + byteOff));
-#endif
             uint64_t r = 0;
             for (size_t i = 0; i < 4; ++i)
                 r |= static_cast<uint64_t>(readByte(byteOff + i)) << (i * 8);

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -1592,7 +1592,7 @@ inline void copyElements(std::span<uint8_t> destinationSpan, std::span<const uin
 
     while (destination != end)
         *destination++ = static_cast<uint8_t>(*source++);
-#elif CPU(ARM_NEON) && !(CPU(BIG_ENDIAN) || CPU(MIDDLE_ENDIAN)) && !ASSERT_ENABLED
+#elif CPU(ARM_NEON) && !ASSERT_ENABLED
     const uint8_t* const end = destination + length;
     const uintptr_t memoryAccessSize = 8;
 

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -1571,11 +1571,7 @@ Expected<size_t, UTF8ConversionError> StringImpl::utf8ForCharactersIntoBuffer(st
 {
     ASSERT(bufferVector.size() == span.size() * 3);
 
-#if CPU(BIG_ENDIAN)
-    auto conversionResult = simdutf::convert_utf16be_to_utf8_with_errors(span, bufferVector.mutableSpan());
-#else
     auto conversionResult = simdutf::convert_utf16le_to_utf8_with_errors(span, bufferVector.mutableSpan());
-#endif
 
     if (conversionResult.error == simdutf::error_code::SUCCESS)
         return conversionResult.count;
@@ -1598,20 +1594,12 @@ Expected<size_t, UTF8ConversionError> StringImpl::utf8ForCharactersIntoBuffer(st
 
 size_t StringImpl::utf8LengthFromUTF16(std::span<const char16_t> characters)
 {
-#if CPU(BIG_ENDIAN)
-    return simdutf::utf8_length_from_utf16be(characters);
-#else
     return simdutf::utf8_length_from_utf16le(characters);
-#endif
 }
 
 size_t StringImpl::tryConvertUTF16ToUTF8(std::span<const char16_t> source, std::span<char8_t> destination)
 {
-#if CPU(BIG_ENDIAN)
-    auto result = simdutf::convert_utf16be_to_utf8_with_errors(source, destination);
-#else
     auto result = simdutf::convert_utf16le_to_utf8_with_errors(source, destination);
-#endif
     if (result.error == simdutf::error_code::SUCCESS)
         return result.count;
     return notFound;

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -801,7 +801,7 @@ inline std::strong_ordering codePointCompare(std::span<const CharacterType1> cha
     auto* characters2Ptr = characters2.data();
     size_t position = 0;
 
-#if CPU(REGISTER64) && !CPU(NEEDS_ALIGNED_ACCESS) && CPU(LITTLE_ENDIAN)
+#if CPU(REGISTER64)
     if constexpr (sizeof(CharacterType1) == sizeof(CharacterType2) && (sizeof(CharacterType1) == 1 || sizeof(CharacterType1) == 2)) {
         using ChunkType = std::conditional_t<sizeof(CharacterType1) == 1, uint32_t, uint64_t>;
         constexpr size_t stride = sizeof(ChunkType) / sizeof(CharacterType1);

--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -116,20 +116,12 @@ template<Replacement replacement = Replacement::None, typename SourceCharacterTy
 
 ConversionResult<char8_t> convert(std::span<const char16_t> source, std::span<char8_t> buffer)
 {
-#if CPU(BIG_ENDIAN)
-    size_t requiredLength = simdutf::utf8_length_from_utf16be(source);
-#else
     size_t requiredLength = simdutf::utf8_length_from_utf16le(source);
-#endif
 
     if (buffer.size() < requiredLength)
         return convertInternal(source, buffer);
 
-#if CPU(BIG_ENDIAN)
-    auto result = simdutf::convert_utf16be_to_utf8_with_errors(source, buffer);
-#else
     auto result = simdutf::convert_utf16le_to_utf8_with_errors(source, buffer);
-#endif
 
     if (result.error == simdutf::error_code::SUCCESS) {
         bool isAllASCII = result.count == source.size();

--- a/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
@@ -185,27 +185,6 @@ static SIDBKeyType serializedTypeForKeyType(IndexedDB::KeyType type)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-#if CPU(BIG_ENDIAN) || CPU(MIDDLE_ENDIAN) || CPU(NEEDS_ALIGNED_ACCESS)
-template <typename T> static void writeLittleEndian(Vector<uint8_t>& buffer, T value)
-{
-    for (unsigned i = 0; i < sizeof(T); i++) {
-        buffer.append(value & 0xFF);
-        value >>= 8;
-    }
-}
-
-template <typename T> static bool readLittleEndian(std::span<const uint8_t>& data, T& value)
-{
-    if (data.size() < sizeof(value))
-        return false;
-
-    value = 0;
-    for (size_t i = 0; i < sizeof(T); i++)
-        value += ((T)data[i]) << (i * 8);
-    skip(data, sizeof(T));
-    return true;
-}
-#else
 template <typename T> static void writeLittleEndian(Vector<uint8_t>& buffer, T value)
 {
     buffer.append(asByteSpan(value));
@@ -219,7 +198,6 @@ template <typename T> static bool NODELETE readLittleEndian(std::span<const uint
     value = consumeAndReinterpretCastTo<const T>(data);
     return true;
 }
-#endif
 
 static void writeDouble(Vector<uint8_t>& data, double d)
 {

--- a/Source/WebCore/platform/graphics/FormatConverter.cpp
+++ b/Source/WebCore/platform/graphics/FormatConverter.cpp
@@ -240,13 +240,8 @@ template<> ALWAYS_INLINE void unpack<GraphicsContextGL::DataFormat::BGRA8, uint8
     pixelsPerRow = std::min<unsigned>(destination32.size(), pixelsPerRow);
     for (unsigned i = 0; i < pixelsPerRow; ++i) {
         uint32_t bgra = source32[i];
-#if CPU(BIG_ENDIAN)
-        uint32_t brMask = 0xff00ff00;
-        uint32_t gaMask = 0x00ff00ff;
-#else
         uint32_t brMask = 0x00ff00ff;
         uint32_t gaMask = 0xff00ff00;
-#endif
         uint32_t rgba = (((bgra >> 16) | (bgra << 16)) & brMask) | (bgra & gaMask);
         destination32[i] = rgba;
     }

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1193,17 +1193,12 @@ public:
     static ALWAYS_INLINE bool srcFormatComesFromDOMElementOrImageData(DataFormat SrcFormat)
     {
 #if USE(CG)
-#if CPU(BIG_ENDIAN)
-    return SrcFormat == DataFormat::RGBA8 || SrcFormat == DataFormat::ARGB8 || SrcFormat == DataFormat::RGB8
-        || SrcFormat == DataFormat::RA8 || SrcFormat == DataFormat::AR8 || SrcFormat == DataFormat::R8 || SrcFormat == DataFormat::A8;
-#else
-    // That LITTLE_ENDIAN case has more possible formats than BIG_ENDIAN case is because some decoded image data is actually big endian
+    // This has more possible formats than BIG_ENDIAN case is because some decoded image data is actually big endian
     // even on little endian architectures.
     return SrcFormat == DataFormat::BGRA8 || SrcFormat == DataFormat::ABGR8 || SrcFormat == DataFormat::BGR8
         || SrcFormat == DataFormat::RGBA8 || SrcFormat == DataFormat::ARGB8 || SrcFormat == DataFormat::RGB8
         || SrcFormat == DataFormat::R8 || SrcFormat == DataFormat::A8
         || SrcFormat == DataFormat::RA8 || SrcFormat == DataFormat::AR8;
-#endif
 #else
     return SrcFormat == DataFormat::BGRA8 || SrcFormat == DataFormat::RGBA8;
 #endif

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -580,11 +580,7 @@ OptionSet<TextureMapperFlags> BitmapTexture::colorConvertFlags() const
     // Our GL textures are stored in RGBA format. If we received an update in BGRA format, we write that BGRA data into
     // the RGBA GL texture without pixel format conversions, but instead use a shader program to transparently handle
     // the color conversion on-the-fly, when painting the texture.
-#if CPU(LITTLE_ENDIAN)
     return TextureMapperFlags::ShouldConvertTextureBGRAToRGBA;
-#else
-    return TextureMapperFlags::ShouldConvertTextureARGBToRGBA;
-#endif
 }
 
 #if USE(SKIA)

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
@@ -48,9 +48,6 @@ public:
     {
         uint16_t result;
         memcpySpan(asMutableByteSpan(result), data.span().subspan(offset, 2));
-#if CPU(BIG_ENDIAN)
-        result = ((result & 0xff) << 8) | ((result & 0xff00) >> 8);
-#endif
         return result;
     }
 
@@ -58,9 +55,6 @@ public:
     {
         uint32_t result;
         memcpySpan(asMutableByteSpan(result), data.span().subspan(offset, 4));
-#if CPU(BIG_ENDIAN)
-        result = ((result & 0xff) << 24) | ((result & 0xff00) << 8) | ((result & 0xff0000) >> 8) | ((result & 0xff000000) >> 24);
-#endif
         return result;
     }
 
@@ -207,9 +201,6 @@ private:
             // won't read it.
             uint32_t pixel;
             memcpySpan(asMutableByteSpan(pixel), m_data->span().subspan(m_decodedOffset + offset, 3));
-#if CPU(BIG_ENDIAN)
-            pixel = ((pixel & 0xff00) << 8) | ((pixel & 0xff0000) >> 8) | ((pixel & 0xff000000) >> 24);
-#endif
             return pixel;
         }
 

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -52,13 +52,7 @@ extern "C" {
 #include <setjmp.h>
 }
 
-#if CPU(BIG_ENDIAN) || CPU(MIDDLE_ENDIAN)
-#define ASSUME_LITTLE_ENDIAN 0
-#else
-#define ASSUME_LITTLE_ENDIAN 1
-#endif
-
-#if defined(JCS_ALPHA_EXTENSIONS) && ASSUME_LITTLE_ENDIAN
+#if defined(JCS_ALPHA_EXTENSIONS)
 #define TURBO_JPEG_RGB_SWIZZLE
 inline J_COLOR_SPACE rgbOutputColorSpace() { return JCS_EXT_BGRA; }
 inline bool turboSwizzled(J_COLOR_SPACE colorSpace) { return colorSpace == JCS_EXT_RGBA || colorSpace == JCS_EXT_BGRA; }


### PR DESCRIPTION
#### 232cebabc1f3c9c0e7abfd5bf6a173e5aae8329a
<pre>
Remove big endian support and support for platforms without unaligned loads/stores
<a href="https://bugs.webkit.org/show_bug.cgi?id=320780">https://bugs.webkit.org/show_bug.cgi?id=320780</a>

Reviewed by Yusuke Suzuki.

This streamlines the supported set of builds, and now seems like a good
time since we are also dropping armv7 to cloop.

Canonical link: <a href="https://commits.webkit.org/318379@main">https://commits.webkit.org/318379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7433bce9f12e554edbe21a2c0d9e26172ac9ca96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187716 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138838 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42380 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159591 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119294 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41046 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39400 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1263 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8081 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39089 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36174 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39376 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190144 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51709 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147984 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39747 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52391 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35714 "Found 1 new test failure: scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147756 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42467 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124654 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119134 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50909 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14061 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50294 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50534 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->