### PR TITLE
Use char16_t instead of UChar in MathMLOperatorElement

### DIFF
--- a/Source/WebCore/mathml/MathMLOperatorElement.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorElement.cpp
@@ -59,7 +59,7 @@ Ref<MathMLOperatorElement> MathMLOperatorElement::create(const QualifiedName& ta
 MathMLOperatorElement::OperatorChar MathMLOperatorElement::parseOperatorChar(StringView string)
 {
     OperatorChar operatorChar;
-    auto trimmed = string.trim(isASCIIWhitespaceWithoutFF<UChar>);
+    auto trimmed = string.trim(isASCIIWhitespaceWithoutFF<char16_t>);
     if (trimmed.isEmpty())
         return operatorChar;
 
@@ -90,9 +90,9 @@ MathMLOperatorElement::OperatorChar MathMLOperatorElement::parseOperatorChar(Str
         // Base character followed by U+0338 COMBINING LONG SOLIDUS OVERLAY
         // or U+20D2 COMBINING LONG VERTICAL LINE OVERLAY. The base character
         // is used for dictionary lookup and must not be substituted.
-        constexpr UChar combiningLongSolidusOverlay = 0x0338;
-        constexpr UChar combiningLongVerticalLineOverlay = 0x20D2;
-        UChar second = trimmed[1];
+        constexpr char16_t combiningLongSolidusOverlay = 0x0338;
+        constexpr char16_t combiningLongVerticalLineOverlay = 0x20D2;
+        char16_t second = trimmed[1];
         if (second == combiningLongSolidusOverlay || second == combiningLongVerticalLineOverlay) {
             setOperatorChar(trimmed[0]);
             return operatorChar;


### PR DESCRIPTION
#### 518a15be844d0a2179f0fbf8403db9b106e15550
<pre>
Use char16_t instead of UChar in MathMLOperatorElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=320783">https://bugs.webkit.org/show_bug.cgi?id=320783</a>
<a href="https://rdar.apple.com/183793101">rdar://183793101</a>

Reviewed by Frédéric Wang Nélar.

UChar is an ICU typedef for char16_t and WebKit has been migrating to spelling
the underlying type directly: only two files in Source/WebCore still used the
old spelling. MathMLOperatorElement.h already declares
OperatorChar::characters as std::array&lt;char16_t, 2&gt;, so the four UChar uses in
the implementation file were the last ones in Source/WebCore/mathml/.

No change in behavior.

* Source/WebCore/mathml/MathMLOperatorElement.cpp:
(WebCore::MathMLOperatorElement::parseOperatorChar):

Canonical link: <a href="https://commits.webkit.org/318376@main">https://commits.webkit.org/318376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/134ac3c1c31057a31cd699a0d2c8fcc220a980f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187724 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0dbf256b-9947-4ed3-9b23-6e0bcca22a3f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138840 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9bf83c7-8294-4b18-9484-971267b804f6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119296 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c491f379-a066-46f0-805f-5b491e9fb50e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41057 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39408 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39096 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36182 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190152 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51717 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147988 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39746 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52399 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147760 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42474 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124663 "Build is in progress. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Found 27164 issues") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119145 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50917 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14070 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50302 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50542 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50364 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->