### PR TITLE
[GLib] Fix looking up the size of various website data types

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteData.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteData.cpp
@@ -227,8 +227,9 @@ WebKitWebsiteDataTypes webkit_website_data_get_types(WebKitWebsiteData* websiteD
  *
  * Gets the size of the data of types @types in a #WebKitWebsiteData.
  *
- * Note that currently the data size is only known for %WEBKIT_WEBSITE_DATA_DISK_CACHE data type
- * so for all other types 0 will be returned.
+ * Note that currently the data size is only known for the %WEBKIT_WEBSITE_DATA_DISK_CACHE,
+ * %WEBKIT_WEBSITE_DATA_LOCAL_STORAGE, %WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES and
+ * %WEBKIT_WEBSITE_DATA_DOM_CACHE data types, so for all other types 0 will be returned.
  *
  * Returns: the size of @website_data for the given @types.
  *
@@ -242,9 +243,9 @@ guint64 webkit_website_data_get_size(WebKitWebsiteData* websiteData, WebKitWebsi
         return 0;
 
     guint64 totalSize = 0;
-    for (auto type : websiteData->record.size->typeSizes.keys()) {
-        if (type & types)
-            totalSize += websiteData->record.size->typeSizes.get(type);
+    for (auto [type, size] : websiteData->record.size->typeSizes) {
+        if (toWebKitWebsiteDataTypes(static_cast<WebsiteDataType>(type)) & types)
+            totalSize += size;
     }
 
     return totalSize;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebsiteData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebsiteData.cpp
@@ -502,9 +502,9 @@ static void testWebsiteDataStorage(WebsiteDataTest* test, gconstpointer)
     g_assert_cmpstr(webkit_website_data_get_name(data), ==, webkit_security_origin_get_host(origin));
     webkit_security_origin_unref(origin);
     g_assert_cmpuint(webkit_website_data_get_types(data), ==, storageTypes);
-    // Storage sizes are unknown.
+    // Session storage is only kept in memory, so its size is unknown.
     g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_SESSION_STORAGE), ==, 0);
-    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_LOCAL_STORAGE), ==, 0);
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_LOCAL_STORAGE), >, 0);
 
     // Get also cached data, and clear it.
     static const WebKitWebsiteDataTypes cacheAndStorageTypes = static_cast<WebKitWebsiteDataTypes>(storageTypes | WEBKIT_WEBSITE_DATA_MEMORY_CACHE | WEBKIT_WEBSITE_DATA_DISK_CACHE);
@@ -548,8 +548,10 @@ static void testWebsiteDataDatabases(WebsiteDataTest* test, gconstpointer)
 
     test->loadURI(kServer->getURIForPath("/empty").data());
     test->waitUntilLoadFinished();
-    test->runJavaScriptAndWaitUntilFinished("window.indexedDB.open('TestDatabase');", nullptr);
+    test->runJavaScriptAndWaitUntilFinished("let idbOpened = false; window.indexedDB.open('TestDatabase').onsuccess = () => { idbOpened = true; };", nullptr);
 
+    // Wait for the database to be created on disk, so that its size can be computed.
+    test->assertJavaScriptBecomesTrue("idbOpened");
     test->wait(1);
 
     dataList = test->fetch(databaseTypes);
@@ -561,8 +563,7 @@ static void testWebsiteDataDatabases(WebsiteDataTest* test, gconstpointer)
     g_assert_cmpstr(webkit_website_data_get_name(data), ==, webkit_security_origin_get_host(origin));
     webkit_security_origin_unref(origin);
     g_assert_cmpuint(webkit_website_data_get_types(data), ==, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES);
-    // Database sizes are unknown.
-    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES), ==, 0);
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES), >, 0);
 
     test->runJavaScriptAndWaitUntilFinished("db = openDatabase(\"TestDatabase\", \"1.0\", \"TestDatabase\", 1);", nullptr);
     dataList = test->fetch(databaseTypes);
@@ -571,8 +572,7 @@ static void testWebsiteDataDatabases(WebsiteDataTest* test, gconstpointer)
     data = static_cast<WebKitWebsiteData*>(dataList->data);
     g_assert_nonnull(data);
     g_assert_cmpuint(webkit_website_data_get_types(data), ==, databaseTypes);
-    // Database sizes are unknown.
-    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES), ==, 0);
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES), >, 0);
 
     // Remove all databases at once.
     GList removeList = { data, nullptr, nullptr };
@@ -834,7 +834,7 @@ static void testWebsiteDataDOMCache(WebsiteDataTest* test, gconstpointer)
     g_assert_nonnull(dataList);
     g_assert_cmpuint(g_list_length(dataList), ==, 1);
     auto* data = static_cast<WebKitWebsiteData*>(dataList->data);
-g_assert_nonnull(data);
+    g_assert_nonnull(data);
     WebKitSecurityOrigin* origin = webkit_security_origin_new_for_uri(kServer->getURIForPath("/").data());
     g_assert_cmpstr(webkit_website_data_get_name(data), ==, webkit_security_origin_get_host(origin));
     webkit_security_origin_unref(origin);
@@ -849,6 +849,66 @@ g_assert_nonnull(data);
     static const WebKitWebsiteDataTypes caches = static_cast<WebKitWebsiteDataTypes>(WEBKIT_WEBSITE_DATA_DOM_CACHE | WEBKIT_WEBSITE_DATA_MEMORY_CACHE | WEBKIT_WEBSITE_DATA_DISK_CACHE);
     test->clear(caches, 0);
     dataList = test->fetch(caches);
+    g_assert_null(dataList);
+}
+
+static void testWebsiteDataSizes(WebsiteDataTest* test, gconstpointer)
+{
+    static const WebKitWebsiteDataTypes sizeTypes = static_cast<WebKitWebsiteDataTypes>(WEBKIT_WEBSITE_DATA_LOCAL_STORAGE | WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES | WEBKIT_WEBSITE_DATA_DOM_CACHE);
+
+    test->clear(sizeTypes, 0);
+    GList* dataList = test->fetch(sizeTypes);
+    g_assert_null(dataList);
+
+    test->loadURI(kServer->getURIForPath("/localstorage").data());
+    test->waitUntilLoadFinished();
+
+    // Local storage uses a 1 second timer to update the database.
+    test->wait(1);
+
+    dataList = test->fetch(sizeTypes);
+    g_assert_nonnull(dataList);
+    g_assert_cmpuint(g_list_length(dataList), ==, 1);
+    auto* data = static_cast<WebKitWebsiteData*>(dataList->data);
+    g_assert_nonnull(data);
+    g_assert_cmpuint(webkit_website_data_get_types(data), ==, WEBKIT_WEBSITE_DATA_LOCAL_STORAGE);
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_LOCAL_STORAGE), >, 0);
+
+    // Only the types actually present in the record contribute to the size, so the size of a
+    // type that has no data must never be reported as the size of a different type.
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES), ==, 0);
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_DOM_CACHE), ==, 0);
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_DISK_CACHE), ==, 0);
+
+    // Now add IndexedDB and DOM cache data for the same origin.
+    test->runJavaScriptAndWaitUntilFinished("let idbOpened = false; window.indexedDB.open('TestDatabase').onsuccess = () => { idbOpened = true; };", nullptr);
+    test->assertJavaScriptBecomesTrue("idbOpened");
+
+    test->runJavaScriptAndWaitUntilFinished("let domCacheFilled = false; window.caches.open('TestDOMCache').then(cache => cache.put('/domcache-entry', new Response('x'.repeat(1024)))).then(() => { domCacheFilled = true; });", nullptr);
+    test->assertJavaScriptBecomesTrue("domCacheFilled");
+
+    dataList = test->fetch(sizeTypes);
+    g_assert_nonnull(dataList);
+    g_assert_cmpuint(g_list_length(dataList), ==, 1);
+    data = static_cast<WebKitWebsiteData*>(dataList->data);
+    g_assert_nonnull(data);
+    g_assert_cmpuint(webkit_website_data_get_types(data), ==, sizeTypes);
+
+    auto localStorageSize = webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_LOCAL_STORAGE);
+    auto indexedDBSize = webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES);
+    auto domCacheSize = webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_DOM_CACHE);
+    g_assert_cmpuint(localStorageSize, >, 0);
+    g_assert_cmpuint(indexedDBSize, >, 0);
+    g_assert_cmpuint(domCacheSize, >, 0);
+
+    // Querying several types at once returns the sum of the individual sizes.
+    g_assert_cmpuint(webkit_website_data_get_size(data, sizeTypes), ==, localStorageSize + indexedDBSize + domCacheSize);
+
+    // Session storage is only kept in memory, so it never reports a size.
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_SESSION_STORAGE), ==, 0);
+
+    test->clear(sizeTypes, 0);
+    dataList = test->fetch(sizeTypes);
     g_assert_null(dataList);
 }
 
@@ -907,6 +967,7 @@ void beforeAll()
     WebsiteDataTest::add("WebKitWebsiteData", "itp", testWebsiteDataITP);
     WebsiteDataTest::add("WebKitWebsiteData", "service-worker-registrations", testWebsiteDataServiceWorkerRegistrations);
     WebsiteDataTest::add("WebKitWebsiteData", "dom-cache", testWebsiteDataDOMCache);
+    WebsiteDataTest::add("WebKitWebsiteData", "sizes", testWebsiteDataSizes);
     WebsiteDataTest::add("WebKitWebsiteData", "handle-corrupted-local-storage", testWebViewHandleCorruptedLocalStorage);
     WebsiteDataTest::add("WebKitWebsiteData", "origin-and-total-storage-ratio", testWebsiteDataOriginAndTotalStorageRatio);
 }


### PR DESCRIPTION
#### 31a2484dd863a7a449323c3c222b47e028c2acf1
<pre>
[GLib] Fix looking up the size of various website data types
<a href="https://bugs.webkit.org/show_bug.cgi?id=320784">https://bugs.webkit.org/show_bug.cgi?id=320784</a>

Reviewed by Adrian Perez de Castro and Carlos Garcia Campos.

This was using the wrong flags to match types. Update docs
and add tests for more types.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebsiteData.cpp

* Source/WebKit/UIProcess/API/glib/WebKitWebsiteData.cpp:
(webkit_website_data_get_size):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebsiteData.cpp:
(testWebsiteDataStorage):
(testWebsiteDataDatabases):
(testWebsiteDataDOMCache):
(testWebsiteDataSizes):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/318404@main">https://commits.webkit.org/318404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b2acce41d178a533db758f2c6c5b07222bd164c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138842 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119298 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41056 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39410 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39097 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36184 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190154 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51719 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147989 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52401 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35722 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147761 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27030 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42475 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124665 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119148 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50919 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14071 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->