### PR TITLE
requestIdleCallback timeout is dropped if the request was already moved to the list of runnable idle callbacks

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-timeout-runnable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-timeout-runnable-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A requestIdleCallback timeout is honored for a callback already moved to the list of runnable idle callbacks
+

--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-timeout-runnable.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-timeout-runnable.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html><!-- webkit-test-runner [ RequestIdleCallbackEnabled=true ] -->
+<meta charset="utf-8">
+<title>requestIdleCallback: timeout must be honored for a callback in the list of runnable idle callbacks</title>
+<link rel="help" href="https://w3c.github.io/requestidlecallback/#dfn-invoke-idle-callback-timeout-algorithm">
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<div id="log"></div>
+<script>
+function busyWait(milliseconds) {
+    const end = performance.now() + milliseconds;
+    while (performance.now() < end) { }
+}
+
+async_test(t => {
+    const order = [];
+
+    // This callback runs well past the idle deadline, so the callbacks requested below are
+    // moved into the list of runnable idle callbacks by the same "start an idle period" run,
+    // but are left there un-invoked when the idle period ends.
+    requestIdleCallback(t.step_func(() => {
+        order.push("first");
+        busyWait(200);
+    }));
+
+    // Long callbacks sitting ahead of the timed-out one in the list of runnable idle callbacks.
+    for (let i = 0; i < 3; ++i) {
+        requestIdleCallback(t.step_func(() => {
+            order.push("filler");
+            busyWait(45);
+        }));
+    }
+
+    // This timeout expires while "first" is still running. The invoke idle callback timeout
+    // algorithm has to find the entry in the list of runnable idle callbacks as well as in the
+    // list of idle request callbacks, so this callback must run ahead of the filler callbacks.
+    requestIdleCallback(t.step_func_done(deadline => {
+        order.push("timed out");
+        assert_true(deadline.didTimeout, "didTimeout must be true when the callback ran because its timeout expired");
+        assert_equals(deadline.timeRemaining(), 0, "timeRemaining() must be 0 when the callback ran because its timeout expired");
+        assert_array_equals(order, ["first", "timed out"], "the timed-out callback must run before the idle callbacks queued ahead of it");
+    }), { timeout: 10 });
+}, "A requestIdleCallback timeout is honored for a callback already moved to the list of runnable idle callbacks");
+</script>
+</body>

--- a/Source/WebCore/dom/IdleCallbackController.cpp
+++ b/Source/WebCore/dom/IdleCallbackController.cpp
@@ -141,16 +141,26 @@ void IdleCallbackController::invokeIdleCallbackTimeout(unsigned identifier)
     if (!m_document)
         return;
 
-    auto it = m_idleRequestCallbacks.findIf([identifier](auto& request) {
-        return request.identifier == identifier;
-    });
+    // The request may already have been moved to m_runnableIdleCallbacks by startIdlePeriod
+    // without having been invoked yet, so both lists have to be searched.
+    auto takeCallback = [identifier](Deque<IdleRequest>& requests) -> RefPtr<IdleRequestCallback> {
+        auto it = requests.findIf([identifier](auto& request) {
+            return request.identifier == identifier;
+        });
+        if (it == requests.end())
+            return nullptr;
+        RefPtr callback = WTF::move(it->callback);
+        requests.remove(it);
+        return callback;
+    };
 
-    if (it == m_idleRequestCallbacks.end())
+    RefPtr callback = takeCallback(m_idleRequestCallbacks);
+    if (!callback)
+        callback = takeCallback(m_runnableIdleCallbacks);
+    if (!callback)
         return;
 
     auto idleDeadline = IdleDeadline::create(IdleDeadline::DidTimeout::Yes);
-    auto callback = WTF::move(it->callback);
-    m_idleRequestCallbacks.remove(it);
     callback->invoke(idleDeadline.get());
 }
 


### PR DESCRIPTION
#### 8b9359f4828555ec1e734b8e8777c97e0e588962
<pre>
requestIdleCallback timeout is dropped if the request was already moved to the list of runnable idle callbacks
<a href="https://bugs.webkit.org/show_bug.cgi?id=320787">https://bugs.webkit.org/show_bug.cgi?id=320787</a>
<a href="https://rdar.apple.com/183796796">rdar://183796796</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

IdleCallbackController::invokeIdleCallbackTimeout searched only
m_idleRequestCallbacks, but startIdlePeriod moves every pending request into
m_runnableIdleCallbacks and invokeIdleCallbacks stops once the idle deadline is
exceeded, so a request can be sitting there un-invoked. A timeout expiring at
that point found nothing and returned, and the callback ran only when a later
idle period reached it, in FIFO order behind the other runnable callbacks --
defeating the purpose of the timeout argument.

Step 1 of the invoke idle callback timeout algorithm finds the entry in &quot;the list
of idle request callbacks or the list of runnable idle callbacks&quot;, and step 2.1
removes it from both:
<a href="https://w3c.github.io/requestidlecallback/#dfn-invoke-idle-callback-timeout-algorithm">https://w3c.github.io/requestidlecallback/#dfn-invoke-idle-callback-timeout-algorithm</a>

The runnable list is reachable at timeout time because step 4 of &quot;start an idle
period&quot; appends every pending entry to it:
<a href="https://w3c.github.io/requestidlecallback/#start-an-idle-period-algorithm">https://w3c.github.io/requestidlecallback/#start-an-idle-period-algorithm</a>

cancelIdleCallback is specified with the same both-lists phrasing and
removeIdleCallback already implements it correctly, so this was an oversight in
one of the two lookups:
<a href="https://w3c.github.io/requestidlecallback/#the-cancelidlecallback-method">https://w3c.github.io/requestidlecallback/#the-cancelidlecallback-method</a>

Search both lists.

The test blocks a whole idle period with a 200ms callback so the callbacks
requested after it strand in the runnable list, then checks the one requested
with { timeout: 10 } runs ahead of the three 45ms callbacks queued in front of
it. Before this change the order was [&quot;first&quot;, &quot;filler&quot;, &quot;filler&quot;, &quot;filler&quot;,
&quot;timed out&quot;]; Firefox and Chrome both pass.

Test: imported/w3c/web-platform-tests/requestidlecallback/callback-timeout-runnable.html

* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-timeout-runnable-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-timeout-runnable.html: Added.
* Source/WebCore/dom/IdleCallbackController.cpp:
(WebCore::IdleCallbackController::invokeIdleCallbackTimeout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b9359f4828555ec1e734b8e8777c97e0e588962

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141365 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8e9798d9-2b9e-4d92-b223-a2570513affe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138848 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96413 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8316d3d3-510b-4fcd-81f0-21cd5a97b349) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181075 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42397 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119304 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b33b7ce-99a5-4796-b5e7-6fd6f1431342) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41063 "Exiting early after 10 failures. 11 tests run. 1 flakes") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39415 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39101 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36189 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44656 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43658 "339 new passes 10 flakes 16 failures") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190159 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51724 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159129 "Exiting early after 10 failures. 16 tests run. 1 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147995 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52406 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35726 "Found 1 new test failure: imported/w3c/web-platform-tests/requestidlecallback/callback-timeout-runnable.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147767 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42479 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124670 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119158 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50924 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14075 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50309 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50549 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50371 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->