### PR TITLE
Web Inspector: Canvas: support disabling WebGPU render pipelines

### DIFF
--- a/LayoutTests/inspector/canvas/resources/shaderProgram-utilities-webgpu.js
+++ b/LayoutTests/inspector/canvas/resources/shaderProgram-utilities-webgpu.js
@@ -100,6 +100,60 @@ function renderToContext(context) {
     device.queue.submit([commandEncoder.finish()]);
 }
 
+async function renderAndReadPixel(encodeRenderPass) {
+    const bytesPerRow = 256;
+    let texture = device.createTexture({
+        size: [1, 1],
+        format: presentationFormat,
+        usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    let readbackBuffer = device.createBuffer({
+        size: bytesPerRow,
+        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+    });
+
+    let commandEncoder = device.createCommandEncoder();
+    let renderPassEncoder = commandEncoder.beginRenderPass({
+        colorAttachments: [{
+            view: texture.createView(),
+            clearValue: {r: 0, g: 0, b: 0, a: 1},
+            loadOp: "clear",
+            storeOp: "store",
+        }],
+    });
+    encodeRenderPass(renderPassEncoder);
+    renderPassEncoder.end();
+    commandEncoder.copyTextureToBuffer({texture}, {buffer: readbackBuffer, bytesPerRow}, [1, 1]);
+    device.queue.submit([commandEncoder.finish()]);
+
+    await readbackBuffer.mapAsync(GPUMapMode.READ);
+    let pixel = new Uint8Array(readbackBuffer.getMappedRange()).slice(0, 4).join(",");
+    readbackBuffer.unmap();
+    readbackBuffer.destroy();
+    texture.destroy();
+    return pixel;
+}
+
+async function renderWithPipeline(eventName) {
+    let content = await renderAndReadPixel((renderPassEncoder) => {
+        renderPassEncoder.setPipeline(renderPipelines[0]);
+        renderPassEncoder.draw(3);
+    });
+    TestPage.dispatchEventToFrontend(eventName, {content});
+}
+
+async function renderWithRenderBundle(eventName) {
+    let renderBundleEncoder = device.createRenderBundleEncoder({colorFormats: [presentationFormat]});
+    renderBundleEncoder.setPipeline(renderPipelines[0]);
+    renderBundleEncoder.draw(3);
+    let renderBundle = renderBundleEncoder.finish();
+
+    let content = await renderAndReadPixel((renderPassEncoder) => {
+        renderPassEncoder.executeBundles([renderBundle]);
+    });
+    TestPage.dispatchEventToFrontend(eventName, {content});
+}
+
 async function renderWithOffscreenPipeline(eventName) {
     if (!offscreenWebGPUCanvasContext) {
         offscreenWebGPUCanvas = new OffscreenCanvas(4, 4);

--- a/LayoutTests/inspector/canvas/setShaderProgramDisabled-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/setShaderProgramDisabled-webgpu-expected.txt
@@ -1,0 +1,17 @@
+Tests Canvas.setShaderProgramDisabled for a WebGPU render pipeline.
+
+
+== Running test suite: Canvas.setShaderProgramDisabled.WebGPU
+-- Running test case: Canvas.setShaderProgramDisabled.WebGPU.RenderPipeline
+PASS: WebGPU render ShaderProgram should support disabling.
+PASS: Disabling the render pipeline should change render output.
+PASS: Re-enabling the render pipeline should restore render output.
+
+-- Running test case: Canvas.setShaderProgramDisabled.WebGPU.RenderBundlePipeline
+PASS: Disabling the render pipeline should suppress a render bundle draw call.
+PASS: Re-enabling the render pipeline should restore render bundle encoding.
+
+-- Running test case: Canvas.setShaderProgramDisabled.WebGPU.UnsupportedActions
+PASS: There should be a compute ShaderProgram.
+PASS: Disabling a compute pipeline should return an error.
+

--- a/LayoutTests/inspector/canvas/setShaderProgramDisabled-webgpu.html
+++ b/LayoutTests/inspector/canvas/setShaderProgramDisabled-webgpu.html
@@ -1,0 +1,88 @@
+<!-- webkit-test-runner [ WebGPUEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/shaderProgram-utilities-webgpu.js"></script>
+<script>
+async function load() {
+    await initializeWebGPU();
+    runTest();
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("Canvas.setShaderProgramDisabled.WebGPU");
+    let canvas = InspectorTest.WebGPU.canvas();
+    InspectorTest.assert(canvas, "There should be a WebGPU Canvas.");
+    let renderProgram = InspectorTest.WebGPU.shaderProgramForType(canvas, WI.ShaderProgram.ProgramType.Render);
+    InspectorTest.assert(renderProgram, "There should be a render ShaderProgram.");
+
+    async function renderContent() {
+        const eventName = "WebGPUCanvasSnapshot";
+        let snapshotPromise = InspectorTest.awaitEvent(eventName);
+        InspectorTest.evaluateInPage(`void renderWithPipeline("${eventName}")`);
+        let event = await snapshotPromise;
+        return event.data.content;
+    }
+
+    async function renderBundleContent() {
+        const eventName = "WebGPUCanvasRenderBundleSnapshot";
+        let snapshotPromise = InspectorTest.awaitEvent(eventName);
+        InspectorTest.evaluateInPage(`void renderWithRenderBundle("${eventName}")`);
+        let event = await snapshotPromise;
+        return event.data.content;
+    }
+
+    suite.addTestCase({
+        name: "Canvas.setShaderProgramDisabled.WebGPU.RenderPipeline",
+        description: "Check that disabling a render pipeline suppresses its draw calls and re-enabling it restores rendering.",
+        async test() {
+            InspectorTest.expectTrue(renderProgram.supportsDisabling, "WebGPU render ShaderProgram should support disabling.");
+
+            let enabledContent = await renderContent();
+            await renderProgram.target.CanvasAgent.setShaderProgramDisabled(renderProgram.identifier, true);
+            let disabledContent = await renderContent();
+            InspectorTest.expectNotEqual(disabledContent, enabledContent, "Disabling the render pipeline should change render output.");
+
+            await renderProgram.target.CanvasAgent.setShaderProgramDisabled(renderProgram.identifier, false);
+            let reenabledContent = await renderContent();
+            InspectorTest.expectEqual(reenabledContent, enabledContent, "Re-enabling the render pipeline should restore render output.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.setShaderProgramDisabled.WebGPU.RenderBundlePipeline",
+        description: "Check that disabling a render pipeline suppresses draw calls encoded into a render bundle.",
+        async test() {
+            let enabledContent = await renderBundleContent();
+            await renderProgram.target.CanvasAgent.setShaderProgramDisabled(renderProgram.identifier, true);
+            let disabledContent = await renderBundleContent();
+            InspectorTest.expectNotEqual(disabledContent, enabledContent, "Disabling the render pipeline should suppress a render bundle draw call.");
+
+            await renderProgram.target.CanvasAgent.setShaderProgramDisabled(renderProgram.identifier, false);
+            let reenabledContent = await renderBundleContent();
+            InspectorTest.expectEqual(reenabledContent, enabledContent, "Re-enabling the render pipeline should restore render bundle encoding.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.setShaderProgramDisabled.WebGPU.UnsupportedActions",
+        description: "Check that unsupported WebGPU ShaderProgram actions return protocol errors.",
+        async test() {
+            let computeProgram = InspectorTest.WebGPU.shaderProgramForType(canvas, WI.ShaderProgram.ProgramType.Compute);
+            InspectorTest.expectThat(computeProgram instanceof WI.ShaderProgram, "There should be a compute ShaderProgram.");
+
+            let disableError = await computeProgram.target.CanvasAgent.setShaderProgramDisabled(computeProgram.identifier, true).then(() => null, (error) => error);
+            InspectorTest.expectTrue(!!disableError, "Disabling a compute pipeline should return an error.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="load()">
+    <p>Tests Canvas.setShaderProgramDisabled for a WebGPU render pipeline.</p>
+    <canvas id="webgpu-canvas" width="4" height="4"></canvas>
+</body>
+</html>

--- a/LayoutTests/inspector/canvas/shaderProgram-add-remove-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/shaderProgram-add-remove-webgpu-expected.txt
@@ -5,8 +5,10 @@ Test that CanvasManager tracks creation and destruction of WebGPU pipelines.
 -- Running test case: Canvas.ShaderProgram.WebGPU.Existing
 PASS: Found the existing compute ShaderProgram.
 PASS: Compute ShaderProgram should have the WebGPU Canvas as its parent.
+PASS: Compute ShaderProgram should not support disabling.
 PASS: Found the existing render ShaderProgram.
 PASS: Render ShaderProgram should have the WebGPU Canvas as its parent.
+PASS: Render ShaderProgram should support disabling.
 PASS: Canvas should initially have two ShaderPrograms.
 
 -- Running test case: Canvas.ShaderProgram.WebGPU.OffscreenCanvas
@@ -29,6 +31,7 @@ PASS: Added a "vertex" ShaderProgram.
 PASS: ShaderProgram should have the expected type.
 PASS: ShaderProgram should have the WebGPU Canvas as its parent.
 PASS: Fragmentless render ShaderProgram should not report vertex and fragment shader module sharing.
+PASS: Fragmentless render ShaderProgram should support disabling.
 PASS: Fragmentless render ShaderProgram should expose its vertex WGSL source.
 
 -- Running test case: Canvas.ShaderProgram.WebGPU.CreateComputePipelineAsync

--- a/LayoutTests/inspector/canvas/shaderProgram-add-remove-webgpu.html
+++ b/LayoutTests/inspector/canvas/shaderProgram-add-remove-webgpu.html
@@ -37,10 +37,12 @@ function test() {
             let computeProgram = InspectorTest.WebGPU.shaderProgramForType(canvas, WI.ShaderProgram.ProgramType.Compute);
             InspectorTest.expectThat(computeProgram instanceof WI.ShaderProgram, "Found the existing compute ShaderProgram.");
             InspectorTest.expectEqual(computeProgram.canvas, canvas, "Compute ShaderProgram should have the WebGPU Canvas as its parent.");
+            InspectorTest.expectFalse(computeProgram.supportsDisabling, "Compute ShaderProgram should not support disabling.");
 
             let renderProgram = InspectorTest.WebGPU.shaderProgramForType(canvas, WI.ShaderProgram.ProgramType.Render);
             InspectorTest.expectThat(renderProgram instanceof WI.ShaderProgram, "Found the existing render ShaderProgram.");
             InspectorTest.expectEqual(renderProgram.canvas, canvas, "Render ShaderProgram should have the WebGPU Canvas as its parent.");
+            InspectorTest.expectTrue(renderProgram.supportsDisabling, "Render ShaderProgram should support disabling.");
             InspectorTest.expectEqual(canvas.shaderProgramCollection.size, 2, "Canvas should initially have two ShaderPrograms.");
         },
     });
@@ -81,6 +83,7 @@ function test() {
         async test() {
             let shaderProgram = await createAndAwaitProgram(WI.ShaderProgram.ProgramType.Vertex, `void createFragmentlessRenderPipeline()`);
             InspectorTest.expectFalse(shaderProgram.sharesVertexFragmentShader, "Fragmentless render ShaderProgram should not report vertex and fragment shader module sharing.");
+            InspectorTest.expectTrue(shaderProgram.supportsDisabling, "Fragmentless render ShaderProgram should support disabling.");
             let {source} = await shaderProgram.target.CanvasAgent.requestShaderSource(shaderProgram.identifier, WI.ShaderProgram.ShaderType.Vertex);
             InspectorTest.expectTrue(source.includes("@vertex") && source.includes("vertexMain"), "Fragmentless render ShaderProgram should expose its vertex WGSL source.");
         },

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4216,6 +4216,7 @@ inspector/canvas/requestClientNodes-webgpu.html [ Skip ]
 inspector/canvas/requestContent-webgpu.html [ Skip ]
 inspector/canvas/requestShaderSource-webgpu.html [ Skip ]
 inspector/canvas/resolveContext-webgpu.html [ Skip ]
+inspector/canvas/setShaderProgramDisabled-webgpu.html [ Skip ]
 inspector/canvas/shaderProgram-add-remove-webgpu.html [ Skip ]
 inspector/canvas/worker-webgpu.html [ Skip ]
 

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -117,6 +117,7 @@ inspector/canvas/requestClientNodes-webgpu.html [ Skip ]
 inspector/canvas/requestContent-webgpu.html [ Skip ]
 inspector/canvas/requestShaderSource-webgpu.html [ Skip ]
 inspector/canvas/resolveContext-webgpu.html [ Skip ]
+inspector/canvas/setShaderProgramDisabled-webgpu.html [ Skip ]
 inspector/canvas/shaderProgram-add-remove-webgpu.html [ Skip ]
 inspector/canvas/worker-webgpu.html [ Skip ]
 

--- a/Source/JavaScriptCore/inspector/protocol/Canvas.json
+++ b/Source/JavaScriptCore/inspector/protocol/Canvas.json
@@ -187,7 +187,6 @@
         {
             "name": "setShaderProgramDisabled",
             "description": "Enable/disable the visibility of the given shader program.",
-            "condition": "defined(ENABLE_WEBGL) && ENABLE_WEBGL",
             "parameters": [
                 { "name": "programId", "$ref": "ProgramId" },
                 { "name": "disabled", "type": "boolean" }

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp
@@ -31,6 +31,7 @@
 #include "GPUBuffer.h"
 #include "GPURenderBundle.h"
 #include "GPURenderPipeline.h"
+#include "InspectorInstrumentation.h"
 
 namespace WebCore {
 
@@ -46,6 +47,7 @@ void GPURenderBundleEncoder::setLabel(String&& label)
 
 void GPURenderBundleEncoder::setPipeline(const GPURenderPipeline& renderPipeline)
 {
+    m_currentPipeline = renderPipeline;
     m_backing->setPipeline(renderPipeline.backing());
 }
 
@@ -63,6 +65,8 @@ void GPURenderBundleEncoder::draw(GPUSize32 vertexCount,
     GPUSize32 instanceCount,
     GPUSize32 firstVertex, GPUSize32 firstInstance)
 {
+    if (RefPtr pipeline = m_currentPipeline; pipeline && InspectorInstrumentation::isWebGPURenderPipelineDisabled(*pipeline)) [[unlikely]]
+        return;
     m_backing->draw(vertexCount, instanceCount, firstVertex, firstInstance);
 }
 
@@ -72,16 +76,22 @@ void GPURenderBundleEncoder::drawIndexed(GPUSize32 indexCount,
     GPUSignedOffset32 baseVertex,
     GPUSize32 firstInstance)
 {
+    if (RefPtr pipeline = m_currentPipeline; pipeline && InspectorInstrumentation::isWebGPURenderPipelineDisabled(*pipeline)) [[unlikely]]
+        return;
     m_backing->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
 }
 
 void GPURenderBundleEncoder::drawIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset)
 {
+    if (RefPtr pipeline = m_currentPipeline; pipeline && InspectorInstrumentation::isWebGPURenderPipelineDisabled(*pipeline)) [[unlikely]]
+        return;
     m_backing->drawIndirect(indirectBuffer.backing(), indirectOffset);
 }
 
 void GPURenderBundleEncoder::drawIndexedIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset)
 {
+    if (RefPtr pipeline = m_currentPipeline; pipeline && InspectorInstrumentation::isWebGPURenderPipelineDisabled(*pipeline)) [[unlikely]]
+        return;
     m_backing->drawIndexedIndirect(indirectBuffer.backing(), indirectOffset);
 }
 
@@ -129,6 +139,7 @@ static WebGPU::RenderBundleDescriptor NODELETE convertToBacking(const std::optio
 ExceptionOr<Ref<GPURenderBundle>> GPURenderBundleEncoder::finish(const std::optional<GPURenderBundleDescriptor>& renderBundleDescriptor)
 {
     RefPtr bundle = m_backing->finish(convertToBacking(renderBundleDescriptor));
+    m_currentPipeline = nullptr;
     if (!bundle)
         return Exception { ExceptionCode::InvalidStateError, "GPURenderBundleEncoder.finish: Unable to finish."_s };
     return GPURenderBundle::create(bundle.releaseNonNull());

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.h
@@ -34,6 +34,7 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -93,6 +94,7 @@ private:
     }
 
     const Ref<WebGPU::RenderBundleEncoder> m_backing;
+    WeakPtr<GPURenderPipeline> m_currentPipeline;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
@@ -32,6 +32,7 @@
 #include "GPUQuerySet.h"
 #include "GPURenderBundle.h"
 #include "GPURenderPipeline.h"
+#include "InspectorInstrumentation.h"
 #include "WebGPUDevice.h"
 
 namespace WebCore {
@@ -54,6 +55,7 @@ void GPURenderPassEncoder::setLabel(String&& label)
 
 void GPURenderPassEncoder::setPipeline(const GPURenderPipeline& renderPipeline)
 {
+    m_currentPipeline = renderPipeline;
     protect(backing())->setPipeline(renderPipeline.backing());
 }
 
@@ -70,6 +72,8 @@ void GPURenderPassEncoder::setVertexBuffer(GPUIndex32 slot, const GPUBuffer* buf
 void GPURenderPassEncoder::draw(GPUSize32 vertexCount, GPUSize32 instanceCount,
     GPUSize32 firstVertex, GPUSize32 firstInstance)
 {
+    if (RefPtr pipeline = m_currentPipeline; pipeline && InspectorInstrumentation::isWebGPURenderPipelineDisabled(*pipeline)) [[unlikely]]
+        return;
     protect(backing())->draw(vertexCount, instanceCount, firstVertex, firstInstance);
 }
 
@@ -78,16 +82,22 @@ void GPURenderPassEncoder::drawIndexed(GPUSize32 indexCount, GPUSize32 instanceC
     GPUSignedOffset32 baseVertex,
     GPUSize32 firstInstance)
 {
+    if (RefPtr pipeline = m_currentPipeline; pipeline && InspectorInstrumentation::isWebGPURenderPipelineDisabled(*pipeline)) [[unlikely]]
+        return;
     protect(backing())->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
 }
 
 void GPURenderPassEncoder::drawIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset)
 {
+    if (RefPtr pipeline = m_currentPipeline; pipeline && InspectorInstrumentation::isWebGPURenderPipelineDisabled(*pipeline)) [[unlikely]]
+        return;
     protect(backing())->drawIndirect(indirectBuffer.backing(), indirectOffset);
 }
 
 void GPURenderPassEncoder::drawIndexedIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset)
 {
+    if (RefPtr pipeline = m_currentPipeline; pipeline && InspectorInstrumentation::isWebGPURenderPipelineDisabled(*pipeline)) [[unlikely]]
+        return;
     protect(backing())->drawIndexedIndirect(indirectBuffer.backing(), indirectOffset);
 }
 
@@ -164,11 +174,13 @@ void GPURenderPassEncoder::executeBundles(Vector<Ref<GPURenderBundle>>&& bundles
         return bundle->backing();
     });
     protect(backing())->executeBundles(WTF::move(result));
+    m_currentPipeline = nullptr;
 }
 
 void GPURenderPassEncoder::end()
 {
     protect(backing())->end();
+    m_currentPipeline = nullptr;
     if (RefPtr device = m_device) {
         m_overrideLabel = label();
         m_backing = device->invalidRenderPassEncoder();

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
@@ -35,6 +35,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -111,6 +112,7 @@ private:
 
     Ref<WebGPU::RenderPassEncoder> m_backing;
     WeakPtr<WebGPU::Device> m_device;
+    WeakPtr<GPURenderPipeline> m_currentPipeline;
     std::optional<String> m_overrideLabel;
 };
 

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1352,6 +1352,13 @@ void InspectorInstrumentation::willDestroyWebGPURenderPipelineImpl(Instrumenting
         canvasAgent->willDestroyWebGPURenderPipeline(pipeline);
 }
 
+bool InspectorInstrumentation::isWebGPURenderPipelineDisabledImpl(InstrumentingAgents& instrumentingAgents, GPURenderPipeline& pipeline)
+{
+    if (CheckedPtr canvasAgent = instrumentingAgents.enabledCanvasAgent())
+        return canvasAgent->isWebGPURenderPipelineDisabled(pipeline);
+    return false;
+}
+
 void InspectorInstrumentation::willApplyKeyframeEffectImpl(InstrumentingAgents& instrumentingAgents, const Styleable& target, KeyframeEffect& effect, const ComputedEffectTiming& computedTiming)
 {
     if (CheckedPtr animationAgent = instrumentingAgents.trackingAnimationAgent())

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -341,6 +341,7 @@ public:
     static void willDestroyWebGPUComputePipeline(GPUComputePipeline&);
     static void didCreateWebGPURenderPipeline(GPUDevice&, GPURenderPipeline&);
     static void willDestroyWebGPURenderPipeline(GPURenderPipeline&);
+    static bool isWebGPURenderPipelineDisabled(GPURenderPipeline&);
 
     static void willApplyKeyframeEffect(const Styleable&, KeyframeEffect&, const ComputedEffectTiming&);
     static void didChangeWebAnimationName(WebAnimation&);
@@ -555,6 +556,7 @@ private:
     static void willDestroyWebGPUComputePipelineImpl(InstrumentingAgents&, GPUComputePipeline&);
     static void didCreateWebGPURenderPipelineImpl(InstrumentingAgents&, GPUDevice&, GPURenderPipeline&);
     static void willDestroyWebGPURenderPipelineImpl(InstrumentingAgents&, GPURenderPipeline&);
+    static bool isWebGPURenderPipelineDisabledImpl(InstrumentingAgents&, GPURenderPipeline&);
 
     static void willApplyKeyframeEffectImpl(InstrumentingAgents&, const Styleable&, KeyframeEffect&, const ComputedEffectTiming&);
     static void didChangeWebAnimationNameImpl(InstrumentingAgents&, WebAnimation&);
@@ -1579,6 +1581,16 @@ inline void InspectorInstrumentation::willDestroyWebGPURenderPipeline(GPURenderP
         if (RefPtr agents = instrumentingAgents(protect(device->scriptExecutionContext())))
             willDestroyWebGPURenderPipelineImpl(*agents, pipeline);
     }
+}
+
+inline bool InspectorInstrumentation::isWebGPURenderPipelineDisabled(GPURenderPipeline& pipeline)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(false);
+    if (RefPtr device = pipeline.device()) {
+        if (RefPtr agents = instrumentingAgents(protect(device->scriptExecutionContext())))
+            return isWebGPURenderPipelineDisabledImpl(*agents, pipeline);
+    }
+    return false;
 }
 
 inline void InspectorInstrumentation::willApplyKeyframeEffect(const Styleable& target, KeyframeEffect& effect, const ComputedEffectTiming& computedTiming)

--- a/Source/WebCore/inspector/InspectorShaderProgram.cpp
+++ b/Source/WebCore/inspector/InspectorShaderProgram.cpp
@@ -200,6 +200,23 @@ bool InspectorShaderProgram::updateShader(Inspector::Protocol::Canvas::ShaderTyp
     );
 }
 
+bool InspectorShaderProgram::setDisabled(bool disabled)
+{
+    return WTF::switchOn(m_program
+#if ENABLE(WEBGL)
+        , [&](const WeakRef<WebGLProgram>&) {
+            m_disabled = disabled;
+            return true;
+        }
+#endif // ENABLE(WEBGL)
+        , [](const WeakRef<GPUComputePipeline>&) { return false; }
+        , [&](const WeakRef<GPURenderPipeline>&) {
+            m_disabled = disabled;
+            return true;
+        }
+    );
+}
+
 Ref<Inspector::Protocol::Canvas::ShaderProgram> InspectorShaderProgram::buildObjectForShaderProgram()
 {
     auto programType = Inspector::Protocol::Canvas::ProgramType::Render;

--- a/Source/WebCore/inspector/InspectorShaderProgram.h
+++ b/Source/WebCore/inspector/InspectorShaderProgram.h
@@ -61,7 +61,7 @@ public:
     bool updateShader(Inspector::Protocol::Canvas::ShaderType, const String& source);
 
     bool disabled() const { return m_disabled; }
-    void setDisabled(bool disabled) { m_disabled = disabled; }
+    bool setDisabled(bool);
 
     bool highlighted() const { return m_highlighted; }
     void setHighlighted(bool value) { m_highlighted = value; }

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -376,6 +376,8 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::updateShader(cons
     return { };
 }
 
+#endif // ENABLE(WEBGL)
+
 Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::setShaderProgramDisabled(const Inspector::Protocol::Canvas::ProgramId& programId, bool disabled)
 {
     Inspector::Protocol::ErrorString errorString;
@@ -384,10 +386,13 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::setShaderProgramD
     if (!inspectorProgram)
         return makeUnexpected(errorString);
 
-    inspectorProgram->setDisabled(disabled);
+    if (!inspectorProgram->setDisabled(disabled))
+        return makeUnexpected("Failed to disable shader for given programId"_s);
 
     return { };
 }
+
+#if ENABLE(WEBGL)
 
 Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::setShaderProgramHighlighted(const Inspector::Protocol::Canvas::ProgramId& programId, bool highlighted)
 {
@@ -655,6 +660,16 @@ void InspectorCanvasAgent::willDestroyWebGPURenderPipeline(GPURenderPipeline& pi
         return;
 
     unbindProgram(*inspectorProgram);
+}
+
+bool InspectorCanvasAgent::isWebGPURenderPipelineDisabled(GPURenderPipeline& pipeline)
+{
+    RefPtr inspectorProgram = findInspectorProgram(pipeline);
+    ASSERT(inspectorProgram);
+    if (!inspectorProgram)
+        return false;
+
+    return inspectorProgram->disabled();
 }
 
 void InspectorCanvasAgent::recordAction(CanvasRenderingContext& canvasRenderingContext, String&& name, InspectorCanvasProcessedArguments&& arguments)

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -88,7 +88,9 @@ public:
     Inspector::Protocol::ErrorStringOr<String> requestShaderSource(const Inspector::Protocol::Canvas::ProgramId&, Inspector::Protocol::Canvas::ShaderType);
 #if ENABLE(WEBGL)
     Inspector::Protocol::ErrorStringOr<void> updateShader(const Inspector::Protocol::Canvas::ProgramId&, Inspector::Protocol::Canvas::ShaderType, const String& source);
+#endif
     Inspector::Protocol::ErrorStringOr<void> setShaderProgramDisabled(const Inspector::Protocol::Canvas::ProgramId&, bool disabled);
+#if ENABLE(WEBGL)
     Inspector::Protocol::ErrorStringOr<void> setShaderProgramHighlighted(const Inspector::Protocol::Canvas::ProgramId&, bool highlighted);
 #endif // ENABLE(WEBGL)
 
@@ -117,6 +119,7 @@ public:
     void willDestroyWebGPUComputePipeline(GPUComputePipeline&);
     void didCreateWebGPURenderPipeline(GPUDevice&, GPURenderPipeline&);
     void willDestroyWebGPURenderPipeline(GPURenderPipeline&);
+    bool isWebGPURenderPipelineDisabled(GPURenderPipeline&);
 
     void recordAction(CanvasRenderingContext&, String&&, InspectorCanvasProcessedArguments&& = { });
 

--- a/Source/WebInspectorUI/UserInterface/Models/ShaderProgram.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ShaderProgram.js
@@ -94,6 +94,19 @@ WI.ShaderProgram = class ShaderProgram extends WI.Object
     get canvas() { return this._canvas; }
     get sharesVertexFragmentShader() { return this._sharesVertexFragmentShader; }
 
+    get supportsDisabling()
+    {
+        switch (this._programType) {
+        case ShaderProgram.ProgramType.Render:
+        case ShaderProgram.ProgramType.Vertex:
+            return true;
+        case ShaderProgram.ProgramType.Compute:
+            return false;
+        }
+        console.assert(false, this._programType);
+        return false;
+    }
+
     get displayName()
     {
         let format = null;
@@ -131,11 +144,7 @@ WI.ShaderProgram = class ShaderProgram extends WI.Object
 
     set disabled(disabled)
     {
-        console.assert(this._programType === ShaderProgram.ProgramType.Render);
-        console.assert(this._canvas.isWebGL || this._canvas.isWebGL2);
-
-        if (this._canvas.contextType === WI.Canvas.ContextType.WebGPU)
-            return;
+        console.assert(this.supportsDisabling);
 
         if (this._disabled === disabled)
             return;

--- a/Source/WebInspectorUI/UserInterface/Views/ShaderProgramTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ShaderProgramTreeElement.js
@@ -32,8 +32,7 @@ WI.ShaderProgramTreeElement = class ShaderProgramTreeElement extends WI.GeneralT
         const subtitle = null;
         super("shader-program", shaderProgram.displayName, subtitle, shaderProgram);
 
-        // FIXME: add support for disabling/highlighting WebGPU shader pipelines.
-        if (this.representedObject.canvas.isWebGL || this.representedObject.canvas.isWebGL2) {
+        if (this.representedObject.supportsDisabling) {
             this._disabledImageElement = document.createElement("img");
             this._disabledImageElement.title = WI.UIString("Disable Program");
             this._disabledImageElement.addEventListener("click", this._disabledImageElementClicked.bind(this));
@@ -47,10 +46,11 @@ WI.ShaderProgramTreeElement = class ShaderProgramTreeElement extends WI.GeneralT
     {
         super.onattach();
 
-        // FIXME: add support for disabling/highlighting WebGPU shader pipelines.
-        if (this.representedObject.canvas.isWebGL || this.representedObject.canvas.isWebGL2) {
+        if (this.representedObject.supportsDisabling)
             this.representedObject.addEventListener(WI.ShaderProgram.Event.DisabledChanged, this._handleShaderProgramDisabledChanged, this);
 
+        // FIXME: add support for highlighting WebGPU shader pipelines.
+        if (this.representedObject.canvas.isWebGL || this.representedObject.canvas.isWebGL2) {
             this.element.addEventListener("mouseover", this._handleMouseOver.bind(this));
             this.element.addEventListener("mouseout", this._handleMouseOut.bind(this));
         }
@@ -58,8 +58,7 @@ WI.ShaderProgramTreeElement = class ShaderProgramTreeElement extends WI.GeneralT
 
     ondetach()
     {
-        // FIXME: add support for disabling/highlighting WebGPU shader pipelines.
-        if (this.representedObject.canvas.isWebGL || this.representedObject.canvas.isWebGL2)
+        if (this.representedObject.supportsDisabling)
             this.representedObject.removeEventListener(WI.ShaderProgram.Event.DisabledChanged, this._handleShaderProgramDisabledChanged, this);
 
         super.ondetach();
@@ -74,8 +73,7 @@ WI.ShaderProgramTreeElement = class ShaderProgramTreeElement extends WI.GeneralT
 
     populateContextMenu(contextMenu, event)
     {
-        // FIXME: add support for disabling/highlighting WebGPU shader pipelines.
-        if (this.representedObject.canvas.isWebGL || this.representedObject.canvas.isWebGL2) {
+        if (this.representedObject.supportsDisabling) {
             let disabled = this.representedObject.disabled;
             contextMenu.appendItem(disabled ? WI.UIString("Enable Program") : WI.UIString("Disable Program"), () => {
                 this.representedObject.disabled = !disabled;


### PR DESCRIPTION
#### 7be5445e4a22c61e7c197e81bbcb15d965650f7c
<pre>
Web Inspector: Canvas: support disabling WebGPU render pipelines
<a href="https://bugs.webkit.org/show_bug.cgi?id=320700">https://bugs.webkit.org/show_bug.cgi?id=320700</a>

Reviewed by Mike Wyrzykowski.

* Source/JavaScriptCore/inspector/protocol/Canvas.json:
* Source/WebCore/inspector/agents/InspectorCanvasAgent.h:
(WebCore::InspectorCanvasAgent::setShaderProgramDisabled):
(WebCore::InspectorCanvasAgent::isWebGPURenderPipelineDisabled): Added.
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::setShaderProgramDisabled):
(WebCore::InspectorCanvasAgent::isWebGPURenderPipelineDisabled): Added.
* Source/WebCore/inspector/InspectorShaderProgram.h:
* Source/WebCore/inspector/InspectorShaderProgram.cpp:
(WebCore::InspectorShaderProgram::setDisabled):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::isWebGPURenderPipelineDisabled): Added.
(WebCore::InspectorInstrumentation::isWebGPURenderPipelineDisabledImpl): Added.
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::isWebGPURenderPipelineDisabledImpl): Added.
Expose disabling for `GPURenderPipeline` and throw when attempting the same for `GPUComputePipeline`.

* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h:
(WebCore::GPURenderPassEncoder):
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp:
(WebCore::GPURenderPassEncoder::setPipeline):
(WebCore::GPURenderPassEncoder::draw):
(WebCore::GPURenderPassEncoder::drawIndexed):
(WebCore::GPURenderPassEncoder::drawIndirect):
(WebCore::GPURenderPassEncoder::drawIndexedIndirect):
(WebCore::GPURenderPassEncoder::executeBundles):
(WebCore::GPURenderPassEncoder::end):
* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.h:
(WebCore::GPURenderBundleEncoder):
* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp:
(WebCore::GPURenderBundleEncoder::setPipeline):
(WebCore::GPURenderBundleEncoder::draw):
(WebCore::GPURenderBundleEncoder::drawIndexed):
(WebCore::GPURenderBundleEncoder::drawIndirect):
(WebCore::GPURenderBundleEncoder::drawIndexedIndirect):
(WebCore::GPURenderBundleEncoder::finish):
Track the current `GPURenderPipeline` and bail if inspector says it&apos;s disabled.

* Source/WebInspectorUI/UserInterface/Models/ShaderProgram.js:
(WI.ShaderProgram.prototype.get supportsDisabling): Added.
(WI.ShaderProgram.prototype.set disabled):
* Source/WebInspectorUI/UserInterface/Views/ShaderProgramTreeElement.js:
(WI.ShaderProgramTreeElement.prototype.constructor):
(WI.ShaderProgramTreeElement.prototype.onattach):
(WI.ShaderProgramTreeElement.prototype.ondetach):
(WI.ShaderProgramTreeElement.prototype.populateContextMenu):
Also allow disabling for ` WI.Canvas.ContextType.WebGPU` (but not `WI.ShaderProgram.ProgramType.Compute`).

* LayoutTests/inspector/canvas/resources/shaderProgram-utilities-webgpu.js:
* LayoutTests/inspector/canvas/setShaderProgramDisabled-webgpu.html: Added.
* LayoutTests/inspector/canvas/setShaderProgramDisabled-webgpu-expected.txt: Added.
* LayoutTests/inspector/canvas/shaderProgram-add-remove-webgpu.html:
* LayoutTests/inspector/canvas/shaderProgram-add-remove-webgpu-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/win/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/318403@main">https://commits.webkit.org/318403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b22e2f74b1afe99849e0060ec245def5c6561b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187742 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138858 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119314 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41070 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39423 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1283 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8102 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151470 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39110 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36198 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39400 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44665 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190168 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159138 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148003 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39761 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52415 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147775 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42487 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124679 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119178 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50933 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14085 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50318 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50558 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->