### PR TITLE
[JSC] Object-literal shorthand in an arrow function should not force the enclosing function to capture arguments

### DIFF
--- a/JSTests/stress/arrow-function-object-literal-shorthand-should-not-capture-arguments.js
+++ b/JSTests/stress/arrow-function-object-literal-shorthand-should-not-capture-arguments.js
@@ -1,0 +1,65 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual);
+}
+
+// An object-literal shorthand property inside an arrow function must not force the
+// enclosing function to capture its `arguments`. Otherwise the arguments passed to `make`
+// are retained by the closures it returns.
+function make(opts) {
+    const host = {};
+    const worker = (r) => ({ r });
+    return { worker, inner };
+    function inner() { return host; }
+}
+noInline(make);
+
+const refs = [];
+let cur = make({ previous: null });
+for (let i = 0; i < 128; i++) {
+    const opts = { previous: cur, payload: new Uint8Array(1024) };
+    refs.push(new WeakRef(opts));
+    cur = make(opts);
+}
+
+// `{ eval }` and `{ arguments }` shorthands inside arrow functions still resolve to the
+// enclosing function's bindings.
+function shorthandEvalAndArguments(a, b, c) {
+    const f = () => ({ eval, arguments, len: arguments.length });
+    return f();
+}
+noInline(shorthandEvalAndArguments);
+for (let i = 0; i < 100; i++) {
+    const result = shorthandEvalAndArguments(1, 2, 3);
+    shouldBe(result.eval, eval);
+    shouldBe(result.arguments[1], 2);
+    shouldBe(result.len, 3);
+}
+
+// Direct eval next to a shorthand property inside an arrow function still sees the
+// enclosing function's variables.
+function shorthandWithDirectEval(code) {
+    const x = 42;
+    const f = (s) => ({ x, v: eval(s) });
+    return f(code);
+}
+noInline(shorthandWithDirectEval);
+for (let i = 0; i < 100; i++) {
+    const result = shorthandWithDirectEval("arguments[0].length");
+    shouldBe(result.x, 42);
+    shouldBe(result.v, "arguments[0].length".length);
+}
+
+// WeakRef targets are kept alive until the end of the current job, so check liveness
+// from a later task.
+setTimeout(() => {
+    gc();
+    gc();
+    let alive = 0;
+    for (const ref of refs) {
+        if (ref.deref())
+            alive++;
+    }
+    if (alive > refs.length / 4)
+        throw new Error("Too many option objects are retained: " + alive + " / " + refs.length);
+}, 0);

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -4708,8 +4708,6 @@ namedProperty:
             JSTextPosition start = tokenStartPosition();
             JSTokenLocation location(tokenLocation());
             currentScope()->useVariable(ident, m_vm.propertyNames->eval == *ident);
-            if (currentScope()->isArrowFunction())
-                currentScope()->setInnerArrowFunctionUsesEval();
             TreeExpression node = context.createResolve(location, *ident, start, lastTokenEndPosition());
             return context.createProperty(ident, node, static_cast<PropertyNode::Type>(PropertyNode::Constant | PropertyNode::Shorthand), SuperBinding::NotNeeded, InferName::Allowed, ClassElementTag::No);
         }


### PR DESCRIPTION
#### 5d6747ef60d4327f25547d55277cb7735a623854
<pre>
[JSC] Object-literal shorthand in an arrow function should not force the enclosing function to capture arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=320789">https://bugs.webkit.org/show_bug.cgi?id=320789</a>

Reviewed by Yusuke Suzuki.

Since 172894@main, parseProperty calls setInnerArrowFunctionUsesEval() for every
shorthand property inside an arrow function, so the enclosing function materializes
`arguments` into its lexical environment and closures returned from it retain all
call arguments.

    function make(opts) {
        const worker = (r) =&gt; ({ r });
        return { worker };
    }
    // `make` emits create_direct_arguments + put_to_scope; `opts` stays alive

useVariable() already sets m_usesEval for `{ eval }`, which
setInnerArrowFunctionUsesEvalAndUseArgumentsIfNeeded() propagates at scope pop,
so drop the unconditional call.

Test: JSTests/stress/arrow-function-object-literal-shorthand-should-not-capture-arguments.js

* JSTests/stress/arrow-function-object-literal-shorthand-should-not-capture-arguments.js: Added.
(shouldBe):
(make.inner):
(make):
(shorthandEvalAndArguments):
(shorthandWithDirectEval):
(setTimeout):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseProperty):

Canonical link: <a href="https://commits.webkit.org/318431@main">https://commits.webkit.org/318431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/158b3414b466d93dfc380d70942c5a64ed85110f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141515 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138968 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119423 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41193 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39546 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1392 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8223 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39232 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36338 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39540 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190308 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51873 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148119 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39780 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52555 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147892 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42609 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124819 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119407 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51073 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14207 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50458 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->