### PR TITLE
Site-isolated iframe processes keep a page load assertion after a cross-site navigation

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -175,6 +175,11 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 
 @property (nonatomic, readonly) BOOL _hasAccessibilityActivityForTesting;
 
+// Number of remote pages belonging to a back/forward cached version of this web view's page that
+// still hold a ProcessThrottler activity. Nothing can release these once the page is suspended, so
+// this must be zero.
+@property (nonatomic, readonly) NSUInteger _suspendedRemotePageActivityCountForTesting;
+
 - (void)_setMediaVolumeForTesting:(float)volume;
 
 - (void)_textFragmentRangesWithCompletionHandlerForTesting:(void(^)(NSArray<NSValue *> *fragmentRanges))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -1035,6 +1035,11 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 #endif
 }
 
+- (NSUInteger)_suspendedRemotePageActivityCountForTesting
+{
+    return _page ? _page->suspendedRemotePageActivityCountForTesting() : 0;
+}
+
 - (BOOL)_hasAccessibilityActivityForTesting
 {
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -43,6 +43,7 @@
 #include "WebPageMessages.h"
 #include "WebPageProxy.h"
 #include "WebPageProxyMessages.h"
+#include "WebProcessActivityState.h"
 #include "WebProcessMessages.h"
 #include "WebProcessPool.h"
 #include <wtf/CallbackAggregator.h>
@@ -57,6 +58,11 @@ using namespace WebCore;
 
 static const Seconds suspensionTimeout { 10_s };
 
+static void dropActivitiesOnRemotePage(RemotePageProxy& remotePage)
+{
+    remotePage.processActivityState().dropAllActivities();
+}
+
 static WeakHashSet<SuspendedPageProxy>& NODELETE allSuspendedPages()
 {
     static NeverDestroyed<WeakHashSet<SuspendedPageProxy>> map;
@@ -64,6 +70,20 @@ static WeakHashSet<SuspendedPageProxy>& NODELETE allSuspendedPages()
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SuspendedPageProxy);
+
+unsigned SuspendedPageProxy::remotePagesHoldingActivityCountForTesting(const WebPageProxy& page)
+{
+    unsigned count = 0;
+    for (Ref suspendedPage : allSuspendedPages()) {
+        if (suspendedPage->page() != &page)
+            continue;
+        suspendedPage->m_browsingContextGroup->forEachRemotePage(page, [&count](auto& remotePage) {
+            if (remotePage.processActivityState().hasAnyActivityForTesting())
+                ++count;
+        });
+    }
+    return count;
+}
 
 RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(WebProcessPool& processPool, const RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
 {
@@ -166,8 +186,12 @@ void SuspendedPageProxy::startSuspension(std::optional<BackForwardFrameItemIdent
     if (mainFrameItemID) {
         m_suspendedFrameItemID = *mainFrameItemID;
         suspendSubframeProcesses(*mainFrameItemID);
-    } else
+    } else {
         m_allSubframesSuspended = true;
+        // No subframe suspension handshake will happen, so no remote page process has anything left
+        // to do on behalf of this page.
+        dropActivitiesOnAllRemotePages();
+    }
 
     m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, *this);
     m_suspensionTimeoutTimer.startOneShot(suspensionTimeout);
@@ -373,6 +397,16 @@ void SuspendedPageProxy::suspensionTimedOut()
     protect(backForwardCache())->removeEntry(*this); // Will destroy |this|.
 }
 
+void SuspendedPageProxy::dropActivitiesOnAllRemotePages()
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    m_browsingContextGroup->forEachRemotePage(*page, [](auto& remotePage) {
+        dropActivitiesOnRemotePage(remotePage);
+    });
+}
+
 void SuspendedPageProxy::suspendSubframeProcesses(BackForwardFrameItemIdentifier mainFrameItemID)
 {
     ASSERT(!m_allSubframesSuspended);
@@ -409,13 +443,24 @@ void SuspendedPageProxy::suspendSubframeProcesses(BackForwardFrameItemIdentifier
 
     m_browsingContextGroup->forEachRemotePage(*page, [suspendedPage = Ref { *this }, &aggregator, mainFrameItemID](auto& remotePage) {
         Ref process = remotePage.siteIsolatedProcess();
-        if (!suspendedPage->hasSubframeInProcess(process->coreProcessIdentifier()))
+        if (!suspendedPage->hasSubframeInProcess(process->coreProcessIdentifier())) {
+            // This process hosts no subframe of the page being suspended, so it receives no
+            // SuspendWithFrameItem and has nothing left to do for this page.
+            dropActivitiesOnRemotePage(remotePage);
             return;
+        }
         process->addSuspendedPageProxy(suspendedPage);
 
         RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::suspendSubframeProcesses: Sending SuspendWithFrameItem to pid %i", &suspendedPage, process->processID());
 
-        process->sendWithAsyncReply(Messages::WebPage::SuspendWithFrameItem(mainFrameItemID), aggregator->chain(), remotePage.identifierInSiteIsolatedProcess());
+        process->sendWithAsyncReply(Messages::WebPage::SuspendWithFrameItem(mainFrameItemID), [
+            chain = aggregator->chain(),
+            weakRemotePage = WeakPtr<RemotePageProxy> { remotePage }
+        ](bool success) mutable {
+            if (RefPtr protectedRemotePage = weakRemotePage.get())
+                dropActivitiesOnRemotePage(*protectedRemotePage);
+            chain(success);
+        }, remotePage.identifierInSiteIsolatedProcess());
     });
 }
 

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -89,6 +89,11 @@ public:
 
     bool hasSubframeInProcess(WebCore::ProcessIdentifier) const;
 
+    // Number of remote pages of `page` that are held by a suspended page and still hold an activity.
+    // Should be zero once the page has been suspended: nothing can reach them after
+    // suspendCurrentPageIfPossible() replaces the page's BrowsingContextGroup.
+    static unsigned remotePagesHoldingActivityCountForTesting(const WebPageProxy&);
+
     std::optional<WebCore::BackForwardFrameItemIdentifier> suspendedFrameItemID() const { return m_suspendedFrameItemID; }
     HashSet<Ref<WebProcessProxy>> iframeProcesses() const;
 
@@ -114,6 +119,7 @@ private:
     void didProcessRequestToSuspend(SuspensionState);
     void suspensionTimedOut();
     void suspendSubframeProcesses(WebCore::BackForwardFrameItemIdentifier);
+    void dropActivitiesOnAllRemotePages();
     void maybeCompleteSuspension();
 
     void close();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -754,6 +754,11 @@ bool WebPageProxy::hasValidNetworkActivity() const
     return hasValidNetworkActivity;
 }
 
+unsigned WebPageProxy::suspendedRemotePageActivityCountForTesting() const
+{
+    return SuspendedPageProxy::remotePagesHoldingActivityCountForTesting(*this);
+}
+
 bool WebPageProxy::hasValidMainFrameVisibleActivity() const
 {
     return m_mainFrameProcessActivityState->hasValidVisibleActivity();
@@ -9367,9 +9372,12 @@ void WebPageProxy::processIsNoLongerAssociatedWithPage(WebProcessProxy& process)
     m_navigationState->clearNavigationsFromProcess(process.coreProcessIdentifier());
 }
 
-void WebPageProxy::isNoLongerAssociatedWithRemotePage(RemotePageProxy&)
+void WebPageProxy::isNoLongerAssociatedWithRemotePage(RemotePageProxy& page)
 {
     internals().updatePlayingMediaDidChangeTimer.startOneShot(0_s);
+
+    // XXX: rename reset and explain why we don't reset network activity state here.
+    page.processActivityState().reset();
 }
 
 bool WebPageProxy::hasAllowedToRunInTheBackgroundActivity() const

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3009,6 +3009,8 @@ public:
 
     void takeActivitiesOnRemotePage(RemotePageProxy&);
 
+    unsigned suspendedRemotePageActivityCountForTesting() const;
+
     void didCreateRemotePage(RemotePageProxy&);
     void willDestroyRemotePage(RemotePageProxy&);
 

--- a/Source/WebKit/UIProcess/WebProcessActivityState.cpp
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.cpp
@@ -156,6 +156,27 @@ void WebProcessActivityState::reset()
 #endif
 }
 
+void WebProcessActivityState::dropAllActivities()
+{
+    reset();
+    m_networkActivity = nullptr;
+}
+
+bool WebProcessActivityState::hasAnyActivityForTesting() const
+{
+    return m_isVisibleActivity
+#if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
+        || m_wasRecentlyVisibleActivity->activity()
+#endif
+        || m_isAudibleActivity
+        || m_isCapturingActivity
+        || m_isMutedCaptureAssertion
+#if PLATFORM(IOS_FAMILY)
+        || m_openingAppLinkActivity
+#endif
+        || m_networkActivity;
+}
+
 void WebProcessActivityState::dropVisibleActivity()
 {
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/WebProcessActivityState.h
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.h
@@ -50,6 +50,8 @@ public:
     void takeTextExtractionAssertion();
 
     void reset();
+
+    void dropAllActivities();
     void dropVisibleActivity();
     void dropAudibleActivity();
     void dropCapturingActivity();
@@ -62,6 +64,9 @@ public:
     bool NODELETE hasValidCapturingActivity() const;
     bool NODELETE hasValidMutedCaptureAssertion() const;
     bool NODELETE hasValidNetworkActivity() const;
+
+    // True if any of the activities that dropAllActivities() releases is still held.
+    bool NODELETE hasAnyActivityForTesting() const;
 
 #if PLATFORM(IOS_FAMILY)
     void takeOpeningAppLinkActivity();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8043,6 +8043,82 @@ TEST(SiteIsolation, SharedProcessInProcessCacheAfterNavigation)
     }
 }
 
+// A RemotePageProxy mirrors the activity state of its WebPageProxy, and those activities can only be
+// released by a drop that reaches that particular remote page. suspendCurrentPageIfPossible()
+// replaces the page's BrowsingContextGroup and hands the old one to the SuspendedPageProxy, so once
+// the previous page is in the back/forward cache the drop paths can no longer reach its remote pages.
+// Anything left on them is held for the whole life of the cache entry, keeping the iframe process
+// runnable long after the navigation completed.
+TEST(SiteIsolation, SharedProcessDropsActivitiesWhenPageIsSuspended)
+{
+    HTTPServer server({
+        { "/example"_s, { "<!DOCTYPE html><iframe src='https://webkit.org/webkit'></iframe>"_s } },
+        { "/webkit"_s, { "webkit"_s } },
+        { "/plain"_s, { "<!DOCTYPE html><p>plain"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewWithSharedProcess(server, EnableProcessCache::No, nil, nil, nil, EnableBackForwardCache::Yes);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        {
+            "https://example.com"_s,
+            { { RemoteFrame } }
+        },
+        {
+            RemoteFrame,
+            { { "https://webkit.org"_s } }
+        },
+    });
+    auto sharedProcess = [webView mainFrame].childFrames[0].info._processIdentifier;
+    EXPECT_NE(sharedProcess, [webView mainFrame].info._processIdentifier);
+
+    // The example.com page enters the back/forward cache, taking its BrowsingContextGroup and its
+    // webkit.org remote page with it.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://other.com/plain"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // The process is deliberately kept alive so the cached page can be restored. That is exactly why
+    // the activities have to be dropped explicitly rather than by process teardown.
+    EXPECT_TRUE(processStillRunning(sharedProcess));
+    EXPECT_TRUE(TestWebKitAPI::Util::waitFor([&] {
+        return ![webView _suspendedRemotePageActivityCountForTesting];
+    }));
+}
+
+// Same as above, except the shared process has already lost its frame before the cross-site
+// navigation: a same-site navigation to a page with no cross-site iframe destroys the frame but
+// leaves the RemotePageProxy behind. Such a remote page receives no SuspendWithFrameItem, so
+// suspendSubframeProcesses() has to release its activities directly.
+TEST(SiteIsolation, SharedProcessDropsActivitiesForStaleRemotePageWhenPageIsSuspended)
+{
+    HTTPServer server({
+        { "/example"_s, { "<!DOCTYPE html><iframe src='https://webkit.org/webkit'></iframe>"_s } },
+        { "/webkit"_s, { "webkit"_s } },
+        { "/no-iframe"_s, { "<!DOCTYPE html><p>no iframe"_s } },
+        { "/plain"_s, { "<!DOCTYPE html><p>plain"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewWithSharedProcess(server, EnableProcessCache::No, nil, nil, nil, EnableBackForwardCache::Yes);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_EQ([webView mainFrame].childFrames.count, 1u);
+
+    // Same-site, same-process navigation. The webkit.org frame in the shared process is destroyed.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/no-iframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_EQ([webView mainFrame].childFrames.count, 0u);
+
+    // Cross-site navigation, which suspends the example.com page.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://other.com/plain"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(TestWebKitAPI::Util::waitFor([&] {
+        return ![webView _suspendedRemotePageActivityCountForTesting];
+    }));
+}
+
 TEST(SiteIsolation, WebProcessCacheCrashWithZeroSharedProcess)
 {
     HTTPServer server({


### PR DESCRIPTION
#### d88f5b6f04baceabd52c8ad46e5af29163885c2d
<pre>
Site-isolated iframe processes keep a page load assertion after a cross-site navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=320790">https://bugs.webkit.org/show_bug.cgi?id=320790</a>
<a href="https://rdar.apple.com/183676310">rdar://183676310</a>

Reviewed by NOBODY (OOPS!).

Reset the activity state for a RemotePageProxy when it disconnects or enters the B/F
cache. Previously we weren&apos;t doing this, which was leading to remote frame processes sometimes
holding on to activities (and continuing to run) even after the main WebPageProxy already completed
a top-level navigation.

More explanation to come...

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _suspendedRemotePageActivityCountForTesting]):
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::dropActivitiesOnRemotePage):
(WebKit::SuspendedPageProxy::remotePagesHoldingActivityCountForTesting):
(WebKit::SuspendedPageProxy::startSuspension):
(WebKit::SuspendedPageProxy::dropActivitiesOnAllRemotePages):
(WebKit::SuspendedPageProxy::suspendSubframeProcesses):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::suspendedRemotePageActivityCountForTesting const):
(WebKit::WebPageProxy::isNoLongerAssociatedWithRemotePage):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::WebProcessActivityState::dropAllActivities):
(WebKit::WebProcessActivityState::hasAnyActivityForTesting const):
* Source/WebKit/UIProcess/WebProcessActivityState.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, SharedProcessDropsActivitiesWhenPageIsSuspended)):
(TestWebKitAPI::(SiteIsolation, SharedProcessDropsActivitiesForStaleRemotePageWhenPageIsSuspended)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d88f5b6f04baceabd52c8ad46e5af29163885c2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178207 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141454 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a79bc4c-538c-4c16-9607-a19b95548b4e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180070 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138921 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4be8d30b-1a53-4d81-a559-b55d72da81b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42479 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119377 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71293161-a5e2-4c73-83ea-2c89aa85612c) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/177530 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41145 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39499 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1346 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8177 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151545 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39185 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36278 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39480 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190248 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/177610 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159213 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148072 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52495 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147845 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42562 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124759 "Found 1 new failure in UIProcess/WebProcessActivityState.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119315 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51013 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14161 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50398 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50638 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50460 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->