### PR TITLE
XMLHttpRequest.send(URLSearchParams) sets a Content-Type request header on GET and HEAD requests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-usp.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-usp.any-expected.txt
@@ -128,4 +128,10 @@ PASS XMLHttpRequest.send(URLSearchParams) (124)
 PASS XMLHttpRequest.send(URLSearchParams) (125)
 PASS XMLHttpRequest.send(URLSearchParams) (126)
 PASS XMLHttpRequest.send(URLSearchParams) (127)
+PASS XMLHttpRequest.send(URLSearchParams): POST uses the URLSearchParams MIME type when no Content-Type was set
+PASS XMLHttpRequest.send(URLSearchParams): POST keeps an author-set Content-Type
+PASS XMLHttpRequest.send(URLSearchParams): POST replaces the charset parameter of an author-set Content-Type
+PASS XMLHttpRequest.send(URLSearchParams): GET sends neither a body nor a Content-Type
+PASS XMLHttpRequest.send(URLSearchParams): HEAD sends neither a body nor a Content-Type
+PASS XMLHttpRequest.send(URLSearchParams): GET keeps an author-set Content-Type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-usp.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-usp.any.js
@@ -43,4 +43,72 @@ function encode(n) {
   for (var i = 0; i < NUM_TESTS; i++) {
     usp.append("a" + i, String.fromCharCode(i));
   }
-  x.send(usp)
+  x.send(usp);
+
+// Content-Type and request body handling for send(URLSearchParams).
+// https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send
+[
+  {
+    method: "POST",
+    authorContentType: null,
+    expectedContentType: "application/x-www-form-urlencoded;charset=UTF-8",
+    expectedBody: "a=b",
+    description: "POST uses the URLSearchParams MIME type when no Content-Type was set"
+  },
+  {
+    method: "POST",
+    authorContentType: "text/plain",
+    expectedContentType: "text/plain",
+    expectedBody: "a=b",
+    description: "POST keeps an author-set Content-Type"
+  },
+  {
+    // The spec only reconciles the charset parameter when the body is a Document or a string, but
+    // Blink, Gecko and WebKit all do it for URLSearchParams too, and the body is always UTF-8 here.
+    method: "POST",
+    authorContentType: "text/plain;charset=windows-1252",
+    expectedContentType: "text/plain;charset=UTF-8",
+    expectedBody: "a=b",
+    description: "POST replaces the charset parameter of an author-set Content-Type"
+  },
+  {
+    method: "GET",
+    authorContentType: null,
+    expectedContentType: "NO",
+    expectedBody: "",
+    description: "GET sends neither a body nor a Content-Type"
+  },
+  {
+    method: "HEAD",
+    authorContentType: null,
+    expectedContentType: "NO",
+    expectedBody: null,
+    description: "HEAD sends neither a body nor a Content-Type"
+  },
+  {
+    method: "GET",
+    authorContentType: "text/plain",
+    expectedContentType: "text/plain",
+    expectedBody: "",
+    description: "GET keeps an author-set Content-Type"
+  }
+].forEach(({ method, authorContentType, expectedContentType, expectedBody, description }) => {
+  promise_test(t => {
+    const client = new XMLHttpRequest();
+    client.open(method, "resources/content.py");
+    if (authorContentType !== null)
+      client.setRequestHeader("Content-Type", authorContentType);
+    client.send(new URLSearchParams("a=b"));
+    return new Promise((resolve, reject) => {
+      client.onload = resolve;
+      client.onerror = () => reject(new Error("Network error"));
+    }).then(() => {
+      assert_equals(client.getResponseHeader("X-Request-Method"), method, "request method");
+      assert_equals(client.getResponseHeader("X-Request-Content-Type"), expectedContentType, "Content-Type request header");
+      if (expectedBody !== null)
+        assert_equals(client.response, expectedBody, "request body");
+      if (expectedBody === "")
+        assert_equals(client.getResponseHeader("X-Request-Content-Length"), "NO", "Content-Length request header");
+    });
+  }, `XMLHttpRequest.send(URLSearchParams): ${description}`);
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-usp.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-usp.any.worker-expected.txt
@@ -128,4 +128,10 @@ PASS XMLHttpRequest.send(URLSearchParams) (124)
 PASS XMLHttpRequest.send(URLSearchParams) (125)
 PASS XMLHttpRequest.send(URLSearchParams) (126)
 PASS XMLHttpRequest.send(URLSearchParams) (127)
+PASS XMLHttpRequest.send(URLSearchParams): POST uses the URLSearchParams MIME type when no Content-Type was set
+PASS XMLHttpRequest.send(URLSearchParams): POST keeps an author-set Content-Type
+PASS XMLHttpRequest.send(URLSearchParams): POST replaces the charset parameter of an author-set Content-Type
+PASS XMLHttpRequest.send(URLSearchParams): GET sends neither a body nor a Content-Type
+PASS XMLHttpRequest.send(URLSearchParams): HEAD sends neither a body nor a Content-Type
+PASS XMLHttpRequest.send(URLSearchParams): GET keeps an author-set Content-Type
 

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -498,22 +498,10 @@ ExceptionOr<void> XMLHttpRequest::send(String&& body)
     if (auto result = prepareToSend())
         return WTF::move(result.value());
 
-    if (!body.isNull() && m_method != "GET"_s && m_method != "HEAD"_s) {
-        String contentType = m_requestHeaders.get(HTTPHeaderName::ContentType);
-        if (contentType.isNull()) {
-            m_requestHeaders.set(HTTPHeaderName::ContentType, HTTPHeaderValues::textPlainContentType());
-        } else {
-            replaceCharsetInMediaTypeIfNeeded(contentType);
-            m_requestHeaders.set(HTTPHeaderName::ContentType, contentType);
-        }
+    if (body.isNull())
+        return createRequest();
 
-        m_requestEntityBody = FormData::create(PAL::TextCodecUTF8::encodeUTF8(body));
-        Locker locker { m_gcLock };
-        if (m_upload)
-            m_requestEntityBody->setAlwaysStream(true);
-    }
-
-    return createRequest();
+    return sendStringData(WTF::move(body), HTTPHeaderValues::textPlainContentType());
 }
 
 ExceptionOr<void> XMLHttpRequest::send(Ref<Blob>&& body)
@@ -547,9 +535,31 @@ ExceptionOr<void> XMLHttpRequest::send(Ref<Blob>&& body)
 
 ExceptionOr<void> XMLHttpRequest::send(Ref<URLSearchParams>&& params)
 {
-    if (!m_requestHeaders.contains(HTTPHeaderName::ContentType))
-        m_requestHeaders.set(HTTPHeaderName::ContentType, "application/x-www-form-urlencoded;charset=UTF-8"_s);
-    return send(params->toString());
+    if (auto result = prepareToSend())
+        return WTF::move(result.value());
+
+    return sendStringData(params->toString(), HTTPHeaderValues::formURLEncodedContentType());
+}
+
+// https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send steps 3 and 4, for bodies that are serialized to a UTF-8 string.
+ExceptionOr<void> XMLHttpRequest::sendStringData(String&& body, const String& defaultContentType)
+{
+    if (m_method != "GET"_s && m_method != "HEAD"_s) {
+        String contentType = m_requestHeaders.get(HTTPHeaderName::ContentType);
+        if (contentType.isNull())
+            m_requestHeaders.set(HTTPHeaderName::ContentType, defaultContentType);
+        else {
+            replaceCharsetInMediaTypeIfNeeded(contentType);
+            m_requestHeaders.set(HTTPHeaderName::ContentType, contentType);
+        }
+
+        m_requestEntityBody = FormData::create(PAL::TextCodecUTF8::encodeUTF8(body));
+        Locker locker { m_gcLock };
+        if (m_upload)
+            m_requestEntityBody->setAlwaysStream(true);
+    }
+
+    return createRequest();
 }
 
 ExceptionOr<void> XMLHttpRequest::send(Ref<DOMFormData>&& body)

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -183,6 +183,7 @@ private:
     ExceptionOr<void> send(Ref<DOMFormData>&&);
     ExceptionOr<void> send(Ref<JSC::ArrayBuffer>&&);
     ExceptionOr<void> send(Ref<JSC::ArrayBufferView>&&);
+    ExceptionOr<void> sendStringData(String&&, const String& defaultContentType);
     ExceptionOr<void> sendBytesData(std::span<const uint8_t>);
 
     void changeState(State);


### PR DESCRIPTION
#### 24b2504818089f0c82eb3c4e3a235a6805464194
<pre>
XMLHttpRequest.send(URLSearchParams) sets a Content-Type request header on GET and HEAD requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=320791">https://bugs.webkit.org/show_bug.cgi?id=320791</a>
<a href="https://rdar.apple.com/183801778">rdar://183801778</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

send(URLSearchParams) set `Content-Type: application/x-www-form-urlencoded;charset=UTF-8`
before doing anything else, and without the `m_method != GET/HEAD` check that every
sibling send() overload has. Per step 3 of the send() algorithm the body is set to null
for GET and HEAD, so step 4 — which is what sets Content-Type — never runs for those
methods. We sent the header on a request that carries no body, which Blink and Gecko
both get right.

Setting the header ahead of prepareToSend() also meant it was set even when send()
went on to throw InvalidStateError or hit a CSP failure.

Route send(URLSearchParams) through prepareToSend() first and then through a new
sendStringData() helper factored out of send(String&amp;&amp;), so both string-serialized
bodies share one copy of the method guard, the author-supplied Content-Type charset
reconciliation, and the m_upload streaming path. Only the default MIME type differs.

Extends the imported send-usp.any.js with Content-Type and request-body coverage for
POST (with and without an author-set Content-Type), GET and HEAD; previously it only
covered POST. The charset-reconciliation subtest asserts what Blink, Gecko and WebKit
all do rather than what the spec literally says, since the spec restricts that step to
Document and string bodies but no engine implements it that way.

* LayoutTests/imported/w3c/web-platform-tests/xhr/send-usp.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/send-usp.any.js:
(x.send):
(forEach):
* LayoutTests/imported/w3c/web-platform-tests/xhr/send-usp.any.worker-expected.txt:
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::send):
(WebCore::XMLHttpRequest::sendStringData):
* Source/WebCore/xml/XMLHttpRequest.h:

Canonical link: <a href="https://commits.webkit.org/318424@main">https://commits.webkit.org/318424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7665cf7c42368b135b51a03f9b023132346f8731

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141376 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d9e1a21-f19b-4c35-87fa-af84c7dd68dd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138859 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ded9e6c8-cbe2-4480-83d6-794cdbaa0faf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119315 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d047ce4-cbec-4a92-b671-4a2174839481) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41072 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39424 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39111 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36200 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190170 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51735 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39776 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52417 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147776 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42489 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124681 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119179 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50935 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14086 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50320 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50382 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->