### PR TITLE
[LBSE] Support external and data: URL clip-path, marker and paint-server references

### DIFF
--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -327,12 +327,31 @@ RefPtr<SVGClipPathElement> ReferencedSVGResources::referencedClipPathElement(Tre
     if (clipPath.fragment().isEmpty())
         return nullptr;
 
+    Ref document = treeScope.documentScope();
+    CheckedRef extensions = document->svgExtensions();
+    if (auto externalDocument = extensions->externalResourceDocument(clipPath.url().resolved)) {
+        RefPtr resolvedDocument = *externalDocument;
+        if (!resolvedDocument)
+            return nullptr;
+        return downcast<SVGClipPathElement>(elementForResourceID(*resolvedDocument, clipPath.fragment(), SVGNames::clipPathTag));
+    }
+
     return downcast<SVGClipPathElement>(elementForResourceID(treeScope, clipPath.fragment(), SVGNames::clipPathTag));
 }
 
 RefPtr<SVGMarkerElement> ReferencedSVGResources::referencedMarkerElement(TreeScope& treeScope, const Style::URL& markerResource)
 {
-    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(markerResource, protect(treeScope.documentScope()));
+    Ref document = treeScope.documentScope();
+    CheckedRef extensions = document->svgExtensions();
+    if (auto externalDocument = extensions->externalResourceDocument(markerResource.resolved)) {
+        RefPtr resolvedDocument = *externalDocument;
+        auto resourceID = markerResource.resolved.fragmentIdentifier().toAtomString();
+        if (resourceID.isEmpty() || !resolvedDocument)
+            return nullptr;
+        return downcast<SVGMarkerElement>(elementForResourceID(*resolvedDocument, resourceID, SVGNames::markerTag));
+    }
+
+    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(markerResource, protect(document));
     if (resourceID.isEmpty())
         return nullptr;
 
@@ -355,7 +374,17 @@ RefPtr<SVGMaskElement> ReferencedSVGResources::referencedMaskElement(TreeScope& 
 
 RefPtr<SVGElement> ReferencedSVGResources::referencedPaintServerElement(TreeScope& treeScope, const Style::URL& uri)
 {
-    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(uri, protect(treeScope.documentScope()));
+    Ref document = treeScope.documentScope();
+    CheckedRef extensions = document->svgExtensions();
+    if (auto externalDocument = extensions->externalResourceDocument(uri.resolved)) {
+        RefPtr resolvedDocument = *externalDocument;
+        auto resourceID = uri.resolved.fragmentIdentifier().toAtomString();
+        if (resourceID.isEmpty() || !resolvedDocument)
+            return nullptr;
+        return elementForResourceIDs(*resolvedDocument, resourceID, { SVGNames::linearGradientTag, SVGNames::radialGradientTag, SVGNames::patternTag });
+    }
+
+    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(uri, protect(document));
     if (resourceID.isEmpty())
         return nullptr;
 


### PR DESCRIPTION
#### 8c5024f26d63d29271869b2a0833832a95eb452f
<pre>
[LBSE] Support external and data: URL clip-path, marker and paint-server references
<a href="https://bugs.webkit.org/show_bug.cgi?id=320796">https://bugs.webkit.org/show_bug.cgi?id=320796</a>

Reviewed by Rob Buis.

The LBSE resource resolvers in ReferencedSVGResources only looked up the
fragment in the local document, so external (url(file.svg#id)) and data:
URL references to clip-paths, markers and paint servers never resolved.
The legacy engine already handles these through externalResourceDocument()
in SVGResources.cpp, and referencedFilterElement already did the same here.

This forward-ports to LBSE the external/data: URL resolution the legacy
engine gained in:

  <a href="https://commits.webkit.org/317649@main">https://commits.webkit.org/317649@main</a> Support external and data: URL clip-path references on SVG elements
  <a href="https://commits.webkit.org/317774@main">https://commits.webkit.org/317774@main</a> Support external and data: URL clip-path references on HTML elements
  <a href="https://commits.webkit.org/317614@main">https://commits.webkit.org/317614@main</a> Support external and data: URL marker references on SVG elements
  <a href="https://commits.webkit.org/317199@main">https://commits.webkit.org/317199@main</a> Introduce IsolatedSVGDocumentContext

Following tests are now fixed:

  svg/clip-path/clip-path-invalid-reference-002.svg
  svg/paint-servers/external-paint-server-css.html
  svg/paint-servers/external-paint-server-gradient.html
  svg/paint-servers/external-paint-server-pattern.html
  imported/w3c/web-platform-tests/svg/painting/reftests/marker-external-reference.svg
  imported/w3c/web-platform-tests/svg/painting/reftests/marker-data-uri-reference.svg
  imported/w3c/web-platform-tests/svg/painting/reftests/pattern-external-reference.svg

* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::referencedClipPathElement):
(WebCore::ReferencedSVGResources::referencedMarkerElement):
(WebCore::ReferencedSVGResources::referencedPaintServerElement):

Canonical link: <a href="https://commits.webkit.org/318412@main">https://commits.webkit.org/318412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6754b150769a1f60dbab9450e19722d2686e6286

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141382 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179998 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138865 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119321 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41078 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39430 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39117 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36206 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190176 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51741 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148010 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39770 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52423 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147782 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42495 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124687 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119185 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50941 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14126 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50326 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50566 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50388 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->