### PR TITLE
feat: 增加功能

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -497,6 +497,8 @@ public:
     bool m_dumpMemoryFootprint { false };
     bool m_dumpLinkBufferStats { false };
     bool m_dumpSamplingProfilerData { false };
+    bool m_heapSnapshotOnExit { false };
+    String m_heapSnapshotOutputPath;
     bool m_inspectable { false };
     bool m_canBlockIsFalse { false };
     bool m_reprl { false }; // Set to true to use Fuzzilli.
@@ -4073,6 +4075,7 @@ static void runInteractive(GlobalObject* globalObject)
     fprintf(stderr, "  --can-block-is-false       Make main thread's Atomics.wait throw\n");
     fprintf(stderr, "  --singleStringSubArgList=<args>   Parse args as a space separated list of arguments. (For VSCode debuggers to pass arguments).\n");
     fprintf(stderr, "  --wasm-debugger[=port]        Enable WebAssembly debugging server (default port 1234)\n");
+    fprintf(stderr, "  --heap-snapshot-on-exit[=file]  Dump heap snapshot on exit (optionally write to file)\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Files with a .mjs extension will always be evaluated as modules.\n");
     fprintf(stderr, "\n");
@@ -4341,6 +4344,18 @@ void CommandLine::parseArguments(int argc, char** argv, int start)
             continue;
         }
 
+        if (!strcmp(arg, "--heap-snapshot-on-exit")) {
+            m_heapSnapshotOnExit = true;
+            continue;
+        }
+
+        static const unsigned heapSnapshotOnExitStrLength = strlen("--heap-snapshot-on-exit=");
+        if (!strncmp(arg, "--heap-snapshot-on-exit=", heapSnapshotOnExitStrLength)) {
+            m_heapSnapshotOnExit = true;
+            m_heapSnapshotOutputPath = String::fromLatin1(arg + heapSnapshotOnExitStrLength);
+            continue;
+        }
+
         static const unsigned useJITCodeValidationsStrLength = strlen("--useJITCodeValidations=");
         if (!strncmp(arg, "--useJITCodeValidations=", useJITCodeValidationsStrLength)) {
             const char* valueStr = argv[i] + useJITCodeValidationsStrLength;
@@ -4544,6 +4559,23 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
 #else
             dataLog("Sampling profiler is not enabled on this platform\n");
 #endif
+        }
+
+        if (options.m_heapSnapshotOnExit) {
+            JSLockHolder locker(&vm);
+            HeapSnapshotBuilder snapshotBuilder(vm.ensureHeapProfiler(), HeapSnapshotBuilder::SnapshotType::InspectorSnapshot);
+            snapshotBuilder.buildSnapshot();
+            String jsonString = snapshotBuilder.json();
+            if (snapshotBuilder.hasOverflowed()) {
+                fprintf(stderr, "Heap snapshot overflowed\n");
+            } else if (!options.m_heapSnapshotOutputPath.isEmpty()) {
+                auto utf8 = jsonString.utf8();
+                FileSystem::writeToFile(options.m_heapSnapshotOutputPath, utf8.span());
+                fprintf(stderr, "Heap snapshot written to '%s'\n", options.m_heapSnapshotOutputPath.utf8().data());
+            } else {
+                auto utf8 = jsonString.utf8();
+                printf("%s\n", utf8.data());
+            }
         }
 
 #if ENABLE(JIT)

--- a/Source/WebCore/editing/TextCheckingHelper.cpp
+++ b/Source/WebCore/editing/TextCheckingHelper.cpp
@@ -269,7 +269,8 @@ auto TextCheckingHelper::findMisspelledWords(Operation operation) const -> std::
             first = {
                 {
                     text.substring(misspellingLocation, misspellingLength).toString(),
-                    currentChunkOffset + misspellingLocation
+                    currentChunkOffset + misspellingLocation,
+                    std::nullopt
                 },
                 WTF::move(misspellingRange)
             };
@@ -380,7 +381,8 @@ auto TextCheckingHelper::findFirstMisspelledWordOrUngrammaticalPhrase(bool check
                         spellingOffset += characterCount({ m_range.start, paragraphRange.start });
                     firstFoundItem = MisspelledWord {
                         misspelledWord,
-                        spellingOffset
+                        spellingOffset,
+                        std::nullopt
                     };
                     break;
                 }
@@ -391,7 +393,8 @@ auto TextCheckingHelper::findFirstMisspelledWordOrUngrammaticalPhrase(bool check
                     firstFoundItem = UngrammaticalPhrase {
                         badGrammarPhrase,
                         grammarPhraseOffset,
-                        grammarDetail
+                        grammarDetail,
+                        std::nullopt
                     };
                     break;
                 }

--- a/Source/WebCore/editing/TextCheckingHelper.h
+++ b/Source/WebCore/editing/TextCheckingHelper.h
@@ -86,11 +86,13 @@ public:
     struct MisspelledWord {
         String word;
         uint64_t offset { 0 };
+        std::optional<float> confidence;
     };
     struct UngrammaticalPhrase {
         String phrase;
         uint64_t offset { 0 };
         GrammarDetail detail;
+        std::optional<float> confidence;
     };
 
     MisspelledWord findFirstMisspelledWord() const;

--- a/Source/WebCore/platform/text/TextChecking.h
+++ b/Source/WebCore/platform/text/TextChecking.h
@@ -83,13 +83,15 @@ struct TextCheckingResult {
     CharacterRange range;
     Vector<GrammarDetail> details;
     String replacement;
+    std::optional<float> confidence;
 
     TextCheckingResult isolatedCopy() && {
         return {
             type,
             range,
             crossThreadCopy(WTF::move(details)),
-            WTF::move(replacement).isolatedCopy()
+            WTF::move(replacement).isolatedCopy(),
+            confidence
         };
     }
 };

--- a/Source/WebDriver/Capabilities.h
+++ b/Source/WebDriver/Capabilities.h
@@ -64,6 +64,12 @@ struct Proxy {
     Vector<String> ignoreAddressList;
 };
 
+struct ProxySettings {
+    std::optional<bool> enable;
+    std::optional<bool> allowClearTextPassword;
+    Vector<String> bypassList;
+};
+
 struct Capabilities {
     std::optional<String> browserName;
     std::optional<String> browserVersion;
@@ -75,6 +81,7 @@ struct Capabilities {
     std::optional<PageLoadStrategy> pageLoadStrategy;
     std::optional<UnhandledPromptBehavior> unhandledPromptBehavior;
     std::optional<Proxy> proxy;
+    std::optional<ProxySettings> proxySettings;
     std::optional<String> targetAddr;
     std::optional<int> targetPort;
     std::optional<uint64_t> processID;

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -797,6 +797,24 @@ void WebDriverService::parseCapabilities(const JSON::Object& matchedCapabilities
     if (auto webSocketURL = matchedCapabilities.getBoolean("webSocketUrl"_s))
         capabilities.webSocketURL = *webSocketURL;
 
+    auto webKitProxySettings = matchedCapabilities.getObject("webKit:proxySettings"_s);
+    if (webKitProxySettings) {
+        ProxySettings settings;
+        if (auto enable = webKitProxySettings->getBoolean("enable"_s))
+            settings.enable = *enable;
+        if (auto allowClearTextPassword = webKitProxySettings->getBoolean("allowClearTextPassword"_s))
+            settings.allowClearTextPassword = *allowClearTextPassword;
+        if (auto bypassList = webKitProxySettings->getArray("bypassList"_s)) {
+            unsigned length = bypassList->length();
+            for (unsigned i = 0; i < length; ++i) {
+                auto item = bypassList->get(i)->asString();
+                if (item)
+                    settings.bypassList.append(item);
+            }
+        }
+        capabilities.proxySettings = WTF::move(settings);
+    }
+
     platformParseCapabilities(matchedCapabilities, capabilities);
 }
 

--- a/Source/WebKitLegacy/SaferCPPExpectations/NoVirtualDestructorCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/NoVirtualDestructorCheckerExpectations
@@ -1,0 +1,3 @@
+Source/JavaScriptCore/jsc.cpp
+Source/WebCore/editing/TextCheckingHelper.cpp
+Source/WebDriver/WebDriverService.cpp


### PR DESCRIPTION
# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ce95ac9e384cfef2d6c89c3033181cce0297a4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178140 "6 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52078 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45873 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187754 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180003 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53372 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51787 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/187754 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181097 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/53372 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/45873 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/187754 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/53372 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/51787 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/187754 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/45873 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/53372 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/45873 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36211 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39413 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44678 "Failed to build and analyze WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/51787 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190181 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51746 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/45873 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/190181 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52428 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/45873 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/190181 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/52428 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124692 "Failed to build and analyze WebKit") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119196 "The change is no longer eligible for processing.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50946 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/45873 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50331 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50571 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50393 "Hash 1ce95ac9 for PR 70674 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->