### PR TITLE
Web Inspector: Timelines Tab: incrementally update rendering frame graph height

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/RenderingFrameTimelineOverviewGraph.js
+++ b/Source/WebInspectorUI/UserInterface/Views/RenderingFrameTimelineOverviewGraph.js
@@ -40,7 +40,8 @@ WI.RenderingFrameTimelineOverviewGraph = class RenderingFrameTimelineOverviewGra
 
         this._timelineRecordFrames = [];
         this._selectedTimelineRecordFrame = null;
-        this._graphHeightSeconds = NaN;
+        this._maximumFrameDuration = 0;
+        this._graphHeightSeconds = WI.RenderingFrameTimelineOverviewGraph._minimumGraphHeightSeconds;
         this._framesPerSecondDividerMap = new Map;
 
         this.reset();
@@ -50,16 +51,6 @@ WI.RenderingFrameTimelineOverviewGraph = class RenderingFrameTimelineOverviewGra
 
     get graphHeightSeconds()
     {
-        if (!isNaN(this._graphHeightSeconds))
-            return this._graphHeightSeconds;
-
-        var maximumFrameDuration = this._renderingFrameTimeline.records.reduce(function(previousValue, currentValue) {
-            return Math.max(previousValue, currentValue.duration);
-        }, 0);
-
-        this._graphHeightSeconds = maximumFrameDuration * 1.1; // Add 10% margin above frames.
-        this._graphHeightSeconds = Math.min(this._graphHeightSeconds, WI.RenderingFrameTimelineOverviewGraph.MaximumGraphHeightSeconds);
-        this._graphHeightSeconds = Math.max(this._graphHeightSeconds, WI.RenderingFrameTimelineOverviewGraph.MinimumGraphHeightSeconds);
         return this._graphHeightSeconds;
     }
 
@@ -70,6 +61,11 @@ WI.RenderingFrameTimelineOverviewGraph = class RenderingFrameTimelineOverviewGra
         this.element.removeChildren();
 
         this.selectedRecord = null;
+
+        this._maximumFrameDuration = 0;
+        for (let record of this._renderingFrameTimeline.records)
+            this._maximumFrameDuration = Math.max(this._maximumFrameDuration, record.duration);
+        this._updateGraphHeightSeconds();
 
         this._framesPerSecondDividerMap.clear();
     }
@@ -170,9 +166,17 @@ WI.RenderingFrameTimelineOverviewGraph = class RenderingFrameTimelineOverviewGra
 
     _timelineRecordAdded(event)
     {
-        this._graphHeightSeconds = NaN;
+        this._maximumFrameDuration = Math.max(this._maximumFrameDuration, event.data.record.duration);
+        this._updateGraphHeightSeconds();
 
         this.needsLayout();
+    }
+
+    _updateGraphHeightSeconds()
+    {
+        this._graphHeightSeconds = this._maximumFrameDuration * 1.1; // Add 10% margin above frames.
+        this._graphHeightSeconds = Math.min(this._graphHeightSeconds, WI.RenderingFrameTimelineOverviewGraph._maximumGraphHeightSeconds);
+        this._graphHeightSeconds = Math.max(this._graphHeightSeconds, WI.RenderingFrameTimelineOverviewGraph._minimumGraphHeightSeconds);
     }
 
     _updateDividers()
@@ -283,5 +287,5 @@ WI.RenderingFrameTimelineOverviewGraph = class RenderingFrameTimelineOverviewGra
 
 WI.RenderingFrameTimelineOverviewGraph.RecordWasFilteredSymbol = Symbol("rendering-frame-overview-graph-record-was-filtered");
 
-WI.RenderingFrameTimelineOverviewGraph.MaximumGraphHeightSeconds = 0.037;
-WI.RenderingFrameTimelineOverviewGraph.MinimumGraphHeightSeconds = 0.0185;
+WI.RenderingFrameTimelineOverviewGraph._maximumGraphHeightSeconds = 0.037;
+WI.RenderingFrameTimelineOverviewGraph._minimumGraphHeightSeconds = 0.0185;


### PR DESCRIPTION
#### 9f548d5dacb904f07472237ea3ea4fdffda811eb
<pre>
Web Inspector: Timelines Tab: incrementally update rendering frame graph height
<a href="https://bugs.webkit.org/show_bug.cgi?id=320658">https://bugs.webkit.org/show_bug.cgi?id=320658</a>

Reviewed by NOBODY (OOPS!).

* Source/WebInspectorUI/UserInterface/Views/RenderingFrameTimelineOverviewGraph.js:
(WI.RenderingFrameTimelineOverviewGraph.prototype.constructor):
(WI.RenderingFrameTimelineOverviewGraph.prototype.get graphHeightSeconds):
(WI.RenderingFrameTimelineOverviewGraph.prototype.reset):
(WI.RenderingFrameTimelineOverviewGraph.prototype._timelineRecordAdded):
(WI.RenderingFrameTimelineOverviewGraph.prototype._updateGraphHeightSeconds): Added.
Track the maximum frame duration as records are added instead of scanning the entire timeline whenever graph height is queried.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f548d5dacb904f07472237ea3ea4fdffda811eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45883 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51797 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/187764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181107 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/42425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36221 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44688 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/190191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51756 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/159159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/190191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52438 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/190191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/42509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124702 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119229 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50956 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/14106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50581 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->