### PR TITLE
[JSC] Deply add / sub / mul tightening to JSBigInt

### DIFF
--- a/JSTests/stress/bigint-add-sub-fixed-size.js
+++ b/JSTests/stress/bigint-add-sub-fixed-size.js
@@ -1,0 +1,86 @@
+// Equal-width BigInt addition and subtraction take kernels that are unrolled onto a static extent
+// for narrow operands. They must agree with the size-agnostic path for every width and sign
+// combination, including the carry-out and full-borrow-cascade cases.
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: expected ${expected} but got ${actual}`);
+}
+
+let seed = 0x9e3779b9n;
+function nextDigit() {
+    seed = (seed * 6364136223846793005n + 1442695040888963407n) & 0xffffffffffffffffn;
+    return seed;
+}
+
+function fromDigits(digits) {
+    let result = 0n;
+    for (let i = digits.length - 1; i >= 0; --i)
+        result = (result << 64n) | digits[i];
+    return result;
+}
+
+function randomOfLength(length) {
+    let digits = [];
+    for (let i = 0; i < length; ++i)
+        digits.push(nextDigit());
+    digits[length - 1] |= 1n; // Keep the value exactly {length} digits wide.
+    return fromDigits(digits);
+}
+
+// Addition and subtraction are checked against each other and against a shift-free reconstruction,
+// so a wrong kernel cannot be masked by the path it is being compared with.
+function check(a, b, label) {
+    let sum = a + b;
+    shouldBe(sum - b, a, `${label}: (a + b) - b`);
+    shouldBe(sum - a, b, `${label}: (a + b) - a`);
+    shouldBe(a - b, -(b - a), `${label}: a - b == -(b - a)`);
+    shouldBe(a + b, b + a, `${label}: commutative`);
+    shouldBe((-a) + (-b), -sum, `${label}: (-a) + (-b)`);
+    shouldBe((-a) - (-b), b - a, `${label}: (-a) - (-b)`);
+    shouldBe(a - (-b), sum, `${label}: a - (-b)`);
+    shouldBe((-a) + b, b - a, `${label}: (-a) + b`);
+    shouldBe(a - a, 0n, `${label}: a - a`);
+    // A + B == (A ^ B) + 2 * (A & B) for non-negative operands: no reliance on the add path.
+    if (a >= 0n && b >= 0n)
+        shouldBe(sum, (a ^ b) + 2n * (a & b), `${label}: xor/and identity`);
+}
+
+// Widths 1..6 span the unrolled kernels (1..4) and the sizes just above them.
+for (let length = 1; length <= 6; ++length) {
+    let allOnes = (1n << BigInt(64 * length)) - 1n;
+    let one = 1n;
+
+    // Carry out of the top digit, and a borrow cascading through every digit.
+    check(allOnes, allOnes, `all ones + all ones, ${length} digits`);
+    check(allOnes, one, `all ones + 1, ${length} digits`);
+    check(1n << BigInt(64 * length - 1), 1n << BigInt(64 * length - 1), `top bits, ${length} digits`);
+    check(1n << BigInt(64 * (length - 1)), one, `borrow cascade, ${length} digits`);
+    check(allOnes - 1n, one, `no carry out, ${length} digits`);
+    check(0n, allOnes, `zero and all ones, ${length} digits`);
+
+    for (let round = 0; round < 8; ++round) {
+        let a = randomOfLength(length);
+        let b = randomOfLength(length);
+        check(a, b, `random equal width ${length}, round ${round}`);
+    }
+
+    // Mixed widths keep using the size-agnostic path, which must still be reachable.
+    for (let other = 1; other <= 6; ++other) {
+        let a = randomOfLength(length);
+        let b = randomOfLength(other);
+        check(a, b, `mixed widths ${length}/${other}`);
+    }
+}
+
+// Repeated add/subtract cycles must return to the starting value.
+{
+    let value = randomOfLength(4);
+    let step = randomOfLength(4);
+    let running = value;
+    for (let i = 0; i < 1000; ++i)
+        running = running + step;
+    for (let i = 0; i < 1000; ++i)
+        running = running - step;
+    shouldBe(running, value, "add/subtract round trip");
+}

--- a/JSTests/stress/bigint-square-comba.js
+++ b/JSTests/stress/bigint-square-comba.js
@@ -1,0 +1,101 @@
+// Squaring a BigInt by itself takes a dedicated Comba path that accumulates each off-diagonal
+// product once at twice the weight. Its result must match the general multiply for every operand
+// width, including the widths that have a fully unrolled kernel (1, 2, 4, 8 and 16 digits).
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: expected ${expected} but got ${actual}`);
+}
+
+// A distinct BigInt cell holding the same value, so that x * copy(x) cannot take the squaring path.
+function copy(x) {
+    return BigInt(x.toString());
+}
+
+function checkSquare(x, label) {
+    let expected = x * copy(x);
+    shouldBe(x * x, expected, `${label}: x * x`);
+    shouldBe((-x) * (-x), expected, `${label}: (-x) * (-x)`);
+    shouldBe(x * (-x), -expected, `${label}: x * (-x)`);
+    shouldBe((-x) * x, -expected, `${label}: (-x) * x`);
+    // Independent of the multiply path: x^2 == x * (x - 1) + x.
+    shouldBe(expected, x * copy(x - 1n) + x, `${label}: x * (x - 1) + x`);
+    shouldBe(x ** 2n, expected, `${label}: x ** 2n`);
+}
+
+let seed = 0x12345678n;
+function nextDigit() {
+    // 64-bit LCG, so the test data is fixed but exercises every digit position.
+    seed = (seed * 6364136223846793005n + 1442695040888963407n) & 0xffffffffffffffffn;
+    return seed;
+}
+
+function fromDigits(digits) {
+    let result = 0n;
+    for (let i = digits.length - 1; i >= 0; --i)
+        result = (result << 64n) | digits[i];
+    return result;
+}
+
+// Widths 1..17 digits cover both the unrolled kernels and the size-agnostic fallbacks, plus the
+// boundaries just above each of them.
+for (let length = 1; length <= 17; ++length) {
+    let allOnes = (1n << BigInt(64 * length)) - 1n;
+    checkSquare(allOnes, `all ones, ${length} digits`);
+
+    checkSquare(1n << BigInt(64 * length - 1), `top bit only, ${length} digits`);
+    checkSquare((1n << BigInt(64 * (length - 1))) + 1n, `lowest and highest digit, ${length} digits`);
+
+    // Small top digit: the product is one digit shorter than length * 2, so the caller has to trim.
+    let digits = [];
+    for (let i = 0; i < length; ++i)
+        digits.push(nextDigit());
+    digits[length - 1] = 1n;
+    checkSquare(fromDigits(digits), `small top digit, ${length} digits`);
+
+    // Zero digits in the middle must not disturb the carry chain.
+    digits = [];
+    for (let i = 0; i < length; ++i)
+        digits.push(i % 2 ? 0n : nextDigit() | 1n);
+    checkSquare(fromDigits(digits), `alternating zero digits, ${length} digits`);
+
+    for (let round = 0; round < 4; ++round) {
+        digits = [];
+        for (let i = 0; i < length; ++i)
+            digits.push(nextDigit());
+        digits[length - 1] |= 1n << 63n;
+        checkSquare(fromDigits(digits), `random, ${length} digits, round ${round}`);
+    }
+}
+
+checkSquare(0n, "zero");
+checkSquare(1n, "one");
+checkSquare(0xffffffffffffffffn, "one all-ones digit");
+
+// (a + b)^2 == a^2 + 2ab + b^2 ties the squaring path back to addition and the general multiply.
+for (let length = 1; length <= 9; ++length) {
+    let a = fromDigits(Array.from({ length }, () => nextDigit()));
+    let b = fromDigits(Array.from({ length }, () => nextDigit()));
+    let sum = a + b;
+    shouldBe(sum * sum, a * a + 2n * (a * copy(b)) + b * b, `binomial, ${length} digits`);
+}
+
+// Modular exponentiation squares the same cell repeatedly, which is the shape this path exists for.
+{
+    let base = 0xdeadbeefcafebabe0123456789abcdefn;
+    let modulus = (1n << 255n) - 19n;
+    let expected = 1n;
+    for (let i = 0; i < 64; ++i)
+        expected = (expected * copy(base)) % modulus;
+    let actual = 1n;
+    let running = base;
+    let exponent = 64n;
+    // Square-and-multiply, so every step squares one cell.
+    while (exponent > 0n) {
+        if (exponent & 1n)
+            actual = (actual * running) % modulus;
+        running = (running * running) % modulus;
+        exponent >>= 1n;
+    }
+    shouldBe(actual, expected, "modular exponentiation");
+}

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -702,17 +702,52 @@ using TwoDigit = UInt128;
 using TwoDigit = uint64_t;
 #endif
 
+// Where a column's carry lives between the three accumulator digits. Keeping it in the condition
+// flags is the shortest instruction sequence, but there is only one flag register, so a scheduler
+// interleaving several accumulations has to save and restore it. Materializing the carry as a value
+// costs an instruction per term and lets those accumulations overlap freely.
+enum class CarryForm : uint8_t { Flags, Value };
+
+template<CarryForm carryForm>
 class DigitColumnAccumulator {
     using Digit = JSBigInt::Digit;
 public:
     ALWAYS_INLINE void mac(Digit a, Digit b)
     {
         TwoDigit prod = static_cast<TwoDigit>(a) * b;
+        if constexpr (carryForm == CarryForm::Value) {
+            Digit carry = 0;
+            t0 = addCarrying(t0, static_cast<Digit>(prod), 0, carry);
+            t1 = addCarrying(t1, static_cast<Digit>(prod >> JSBigInt::digitBits), carry, carry);
+            t2 += carry;
+            return;
+        }
         TwoDigit sum0 = static_cast<TwoDigit>(t0) + static_cast<Digit>(prod);
         t0 = static_cast<Digit>(sum0);
         TwoDigit sum1 = static_cast<TwoDigit>(t1) + static_cast<Digit>(prod >> JSBigInt::digitBits) + static_cast<Digit>(sum0 >> JSBigInt::digitBits);
         t1 = static_cast<Digit>(sum1);
         t2 += static_cast<Digit>(sum1 >> JSBigInt::digitBits);
+    }
+
+    // Accumulates 2 * a * b. The doubled product needs one bit more than the two digits prod
+    // occupies, and that bit lands in t2, the digit above the pair.
+    ALWAYS_INLINE void macDoubled(Digit a, Digit b)
+    {
+        TwoDigit prod = static_cast<TwoDigit>(a) * b;
+        Digit high = static_cast<Digit>(prod >> (JSBigInt::digitBits * 2 - 1));
+        TwoDigit doubled = prod << 1;
+        if constexpr (carryForm == CarryForm::Value) {
+            Digit carry = 0;
+            t0 = addCarrying(t0, static_cast<Digit>(doubled), 0, carry);
+            t1 = addCarrying(t1, static_cast<Digit>(doubled >> JSBigInt::digitBits), carry, carry);
+            t2 += carry + high;
+            return;
+        }
+        TwoDigit sum0 = static_cast<TwoDigit>(t0) + static_cast<Digit>(doubled);
+        t0 = static_cast<Digit>(sum0);
+        TwoDigit sum1 = static_cast<TwoDigit>(t1) + static_cast<Digit>(doubled >> JSBigInt::digitBits) + static_cast<Digit>(sum0 >> JSBigInt::digitBits);
+        t1 = static_cast<Digit>(sum1);
+        t2 += static_cast<Digit>(sum1 >> JSBigInt::digitBits) + high;
     }
 
     ALWAYS_INLINE Digit storeAndShift()
@@ -731,6 +766,21 @@ public:
     ALWAYS_INLINE bool fitsInLow() const { return !t1 && !t2; }
 
 private:
+    ALWAYS_INLINE static Digit addCarrying(Digit a, Digit b, Digit carryIn, Digit& carryOut)
+    {
+        if constexpr (sizeof(Digit) == sizeof(unsigned long long)) {
+            unsigned long long out = 0;
+            Digit result = __builtin_addcll(a, b, carryIn, &out);
+            carryOut = static_cast<Digit>(out);
+            return result;
+        } else {
+            unsigned out = 0;
+            Digit result = __builtin_addc(a, b, carryIn, &out);
+            carryOut = static_cast<Digit>(out);
+            return result;
+        }
+    }
+
     Digit t0 { 0 };
     Digit t1 { 0 };
     Digit t2 { 0 };
@@ -764,8 +814,38 @@ public:
         }
     }
 
+    // Column K of a * a. The pairs (I, J) and (J, I) contribute the same product, so it is
+    // accumulated once at twice the weight, halving the digit multiplies to N * (N + 1) / 2.
+    template<size_t K, size_t I = 0>
+    ALWAYS_INLINE void computeSquareColumn(std::span<const Digit, N> a)
+    {
+        if constexpr (I < N) {
+            constexpr int J = static_cast<int>(K) - static_cast<int>(I);
+            if constexpr (J >= static_cast<int>(I) && J < static_cast<int>(N)) {
+                if constexpr (J == static_cast<int>(I))
+                    m_accumulator.mac(a[I], a[I]);
+                else
+                    m_accumulator.macDoubled(a[I], a[J]);
+            }
+            computeSquareColumn<K, I + 1>(a);
+        }
+    }
+
+    template<size_t K = 0>
+    ALWAYS_INLINE void squarePass(std::span<Digit, N * 2> r, std::span<const Digit, N> a)
+    {
+        if constexpr (K < 2 * N - 1) {
+            computeSquareColumn<K>(a);
+            r[K] = m_accumulator.storeAndShift();
+            squarePass<K + 1>(r, a);
+        } else {
+            ASSERT(m_accumulator.fitsInLow());
+            r[N * 2 - 1] = m_accumulator.low();
+        }
+    }
+
 private:
-    DigitColumnAccumulator m_accumulator;
+    DigitColumnAccumulator<CarryForm::Value> m_accumulator;
 };
 
 template<size_t N>
@@ -783,6 +863,21 @@ std::span<JSBigInt::Digit, N * 2> JSBigInt::multiplyCombaFixed(std::span<const D
 
     CombaAccumulator<N> acc;
     acc.template pass<>(result, a, b);
+    return result;
+}
+
+template<size_t N>
+std::span<JSBigInt::Digit, N * 2> JSBigInt::squareCombaFixed(std::span<const Digit, N> x, std::span<Digit, N * 2> result)
+{
+    static_assert(N == 1 || N == 2 || N == 4 || N == 8 || N == maxCombaFixedSize);
+    std::array<Digit, N> a;
+
+    // Ensure that all loads are done before entering to computation. This allows compiler to use registers for all elements.
+    for (size_t i = 0; i < N; ++i)
+        a[i] = x[i];
+
+    CombaAccumulator<N> acc;
+    acc.template squarePass<>(result, a);
     return result;
 }
 
@@ -894,7 +989,7 @@ void JSBigInt::multiplySpecialLow(std::span<const Digit> xSpan, std::span<const 
     const auto* y = ySpan.data();
     auto* result = resultSpan.data();
 
-    DigitColumnAccumulator accumulator;
+    DigitColumnAccumulator<CarryForm::Flags> accumulator;
     size_t lastColumn = resultSpan.size() - 1;
     size_t mainEnd = std::min({ xSpan.size(), ySpan.size(), lastColumn });
     size_t column = 0;
@@ -934,7 +1029,7 @@ void JSBigInt::multiplySpecialHigh(std::span<const Digit> xSpan, std::span<const
     const auto* y = ySpan.data();
     auto* result = resultSpan.data();
 
-    DigitColumnAccumulator accumulator;
+    DigitColumnAccumulator<CarryForm::Flags> accumulator;
     size_t column = startPosition;
 
     // Expanding phase: column < ySpan.size(), so the term range starts at 0.
@@ -999,7 +1094,7 @@ std::span<JSBigInt::Digit> JSBigInt::multiplyComba(std::span<const Digit> xSpan,
     const size_t xSize = xSpan.size();
     const size_t ySize = ySpan.size();
 
-    DigitColumnAccumulator accumulator;
+    DigitColumnAccumulator<CarryForm::Flags> accumulator;
     for (size_t i = 0; i < ySize; ++i) {
         for (size_t j = 0; j <= i; ++j)
             accumulator.mac(x[j], y[i - j]);
@@ -1029,7 +1124,7 @@ std::span<JSBigInt::Digit> JSBigInt::multiplyComba(std::span<const Digit> xSpan,
 // error bound that cachedMod's corrective loop relies on depends on that accumulation order.
 
 // Accumulates x[j] * y[i - j] for j in [min, max] into acc.
-ALWAYS_INLINE static void multiplySpecialColumn(const JSBigInt::Digit* x, const JSBigInt::Digit* y, size_t i, size_t min, size_t max, DigitColumnAccumulator& acc)
+ALWAYS_INLINE static void multiplySpecialColumn(const JSBigInt::Digit* x, const JSBigInt::Digit* y, size_t i, size_t min, size_t max, DigitColumnAccumulator<CarryForm::Flags>& acc)
 {
     for (size_t j = min; j <= max; ++j)
         acc.mac(x[j], y[i - j]);
@@ -1046,7 +1141,7 @@ ALWAYS_INLINE void JSBigInt::multiplySpecialHighFixed(std::span<const Digit, XSi
     const auto* y = ySpan.data();
     auto* result = resultSpan.data();
 
-    DigitColumnAccumulator acc;
+    DigitColumnAccumulator<CarryForm::Flags> acc;
     for (size_t i = StartPosition; i <= loopEnd; ++i) {
         size_t minXIndex = i < YSize ? 0 : i - (YSize - 1);
         multiplySpecialColumn(x, y, i, minXIndex, std::min(i, XSize - 1), acc);
@@ -1069,7 +1164,7 @@ ALWAYS_INLINE void JSBigInt::multiplySpecialLowFixed(std::span<const Digit, XSiz
     const auto* y = ySpan.data();
     auto* result = resultSpan.data();
 
-    DigitColumnAccumulator acc;
+    DigitColumnAccumulator<CarryForm::Flags> acc;
     size_t i = 0;
 
     // Expanding phase: both operands still cover the whole column, so the term range is exactly
@@ -1085,6 +1180,45 @@ ALWAYS_INLINE void JSBigInt::multiplySpecialLowFixed(std::span<const Digit, XSiz
         multiplySpecialColumn(x, y, i, i - maxYIndex, std::min(i, XSize - 1), acc);
         result[i] = acc.storeAndShift();
     }
+}
+
+ALWAYS_INLINE std::span<JSBigInt::Digit> JSBigInt::multiplyDigitsInto(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
+{
+    ASSERT(!y.empty());
+    ASSERT(x.size() >= y.size());
+    ASSERT(result.size() >= x.size() + y.size());
+
+    if (x.size() == y.size()) {
+        // Aliased operands mean squaring, which needs only half of the digit multiplies.
+        bool isSquare = x.data() == y.data();
+        switch (y.size()) {
+        case 1:
+            if (isSquare)
+                return squareCombaFixed<1>(x.first<1>(), result.first<2>());
+            return multiplyCombaFixed<1>(x.first<1>(), y.first<1>(), result.first<2>());
+        case 2:
+            if (isSquare)
+                return squareCombaFixed<2>(x.first<2>(), result.first<4>());
+            return multiplyCombaFixed<2>(x.first<2>(), y.first<2>(), result.first<4>());
+        case 4:
+            if (isSquare)
+                return squareCombaFixed<4>(x.first<4>(), result.first<8>());
+            return multiplyCombaFixed<4>(x.first<4>(), y.first<4>(), result.first<8>());
+        case 8:
+            if (isSquare)
+                return squareCombaFixed<8>(x.first<8>(), result.first<16>());
+            return multiplyCombaFixed<8>(x.first<8>(), y.first<8>(), result.first<16>());
+        case 16:
+            if (isSquare)
+                return squareCombaFixed<16>(x.first<16>(), result.first<32>());
+            return multiplyCombaFixed<16>(x.first<16>(), y.first<16>(), result.first<32>());
+        }
+    }
+    if (y.size() == 1)
+        return multiplySingle(x, y[0], result);
+    if (shouldUseComba(x.size(), y.size()))
+        return multiplyComba(x, y, result);
+    return multiplySchoolbook(x, y, result);
 }
 
 template <typename BigIntImpl1, typename BigIntImpl2>
@@ -1137,27 +1271,7 @@ JSBigInt::ImplResult JSBigInt::multiplyImpl(JSGlobalObject* globalObject, BigInt
     bigInt->finishCreation(vm);
     bigInt->setSign(resultSign);
 
-    std::span<Digit> result = ([](std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> span) -> std::span<Digit> {
-        if (x.size() == y.size()) {
-            switch (y.size()) {
-            case 1:
-                return multiplyCombaFixed<1>(x.template first<1>(), y.template first<1>(), span.first<2>());
-            case 2:
-                return multiplyCombaFixed<2>(x.template first<2>(), y.template first<2>(), span.first<4>());
-            case 4:
-                return multiplyCombaFixed<4>(x.template first<4>(), y.template first<4>(), span.first<8>());
-            case 8:
-                return multiplyCombaFixed<8>(x.template first<8>(), y.template first<8>(), span.first<16>());
-            case 16:
-                return multiplyCombaFixed<16>(x.template first<16>(), y.template first<16>(), span.first<32>());
-            }
-        }
-        if (y.size() == 1)
-            return multiplySingle(x, y[0], span);
-        if (shouldUseComba(x.size(), y.size()))
-            return multiplyComba(x, y, span);
-        return multiplySchoolbook(x, y, span);
-    }(xSpan, ySpan, bigInt->digits()));
+    std::span<Digit> result = multiplyDigitsInto(xSpan, ySpan, bigInt->digits());
     ASSERT(!result.empty());
     if (!result.back())
         result = result.first(result.size() - 1);
@@ -1798,7 +1912,7 @@ std::span<JSBigInt::Digit> JSBigInt::addDigits(std::span<const Digit> x, std::sp
     if (x.size() < y.size())
         std::swap(x, y);
     RELEASE_ASSERT(result.size() >= x.size() + 1);
-    return normalize(addSchoolbook(x, y, result));
+    return normalize(addDigitsInto(x, y, result));
 }
 
 std::span<JSBigInt::Digit> JSBigInt::multiplyDigits(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
@@ -1810,11 +1924,7 @@ std::span<JSBigInt::Digit> JSBigInt::multiplyDigits(std::span<const Digit> x, st
     if (x.size() < y.size())
         std::swap(x, y);
     RELEASE_ASSERT(result.size() >= x.size() + y.size());
-    if (y.size() == 1)
-        return normalize(multiplySingle(x, y[0], result));
-    if (shouldUseComba(x.size(), y.size()))
-        return normalize(multiplyComba(x, y, result));
-    return normalize(multiplySchoolbook(x, y, result));
+    return normalize(multiplyDigitsInto(x, y, result));
 }
 
 std::span<JSBigInt::Digit> JSBigInt::divideDigits(std::span<Digit> quotient, std::span<const Digit> x, std::span<const Digit> y)
@@ -2584,7 +2694,9 @@ JSBigInt::ImplResult JSBigInt::addImpl(JSGlobalObject* globalObject, BigIntImpl1
     // x + -y == x - y == -(y - x)
     // -x + y == y - x == -(x - y)
     ComparisonResult comparisonResult = absoluteCompare(x, y);
-    if (comparisonResult == ComparisonResult::GreaterThan || comparisonResult == ComparisonResult::Equal)
+    if (comparisonResult == ComparisonResult::Equal)
+        return zeroImpl(globalObject->vm());
+    if (comparisonResult == ComparisonResult::GreaterThan)
         return absoluteSub(globalObject, x, y, xSign);
 
     return absoluteSub(globalObject, y, x, !xSign);
@@ -2616,7 +2728,9 @@ JSBigInt::ImplResult JSBigInt::subImpl(JSGlobalObject* globalObject, BigIntImpl1
     // x - y == -(y - x)
     // (-x) - (-y) == y - x == -(x - y)
     ComparisonResult comparisonResult = absoluteCompare(x, y);
-    if (comparisonResult == ComparisonResult::GreaterThan || comparisonResult == ComparisonResult::Equal)
+    if (comparisonResult == ComparisonResult::Equal)
+        return zeroImpl(globalObject->vm());
+    if (comparisonResult == ComparisonResult::GreaterThan)
         return absoluteSub(globalObject, x, y, xSign);
 
     return absoluteSub(globalObject, y, x, !xSign);
@@ -3250,6 +3364,39 @@ std::span<JSBigInt::Digit> JSBigInt::addSchoolbook(std::span<const Digit> x, std
     return result.first(i);
 }
 
+template<size_t N>
+ALWAYS_INLINE std::span<JSBigInt::Digit, N + 1> JSBigInt::addSchoolbookFixed(std::span<const Digit, N> x, std::span<const Digit, N> y, std::span<Digit, N + 1> result)
+{
+    Digit carry = 0;
+    for (size_t i = 0; i < N; ++i) {
+        Digit newCarry = 0;
+        result[i] = digitAdd3(x[i], y[i], carry, newCarry);
+        carry = newCarry;
+    }
+    result[N] = carry;
+    return result;
+}
+
+ALWAYS_INLINE std::span<JSBigInt::Digit> JSBigInt::addDigitsInto(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
+{
+    ASSERT(x.size() >= y.size());
+    ASSERT(result.size() >= x.size() + 1);
+
+    if (x.size() == y.size()) {
+        switch (x.size()) {
+        case 1:
+            return addSchoolbookFixed<1>(x.first<1>(), y.first<1>(), result.first<2>());
+        case 2:
+            return addSchoolbookFixed<2>(x.first<2>(), y.first<2>(), result.first<3>());
+        case 3:
+            return addSchoolbookFixed<3>(x.first<3>(), y.first<3>(), result.first<4>());
+        case 4:
+            return addSchoolbookFixed<4>(x.first<4>(), y.first<4>(), result.first<5>());
+        }
+    }
+    return addSchoolbook(x, y, result);
+}
+
 template <typename BigIntImpl1, typename BigIntImpl2>
 JSBigInt::ImplResult JSBigInt::absoluteAdd(JSGlobalObject* globalObject, BigIntImpl1 x, BigIntImpl2 y, bool resultSign)
 {
@@ -3287,7 +3434,7 @@ JSBigInt::ImplResult JSBigInt::absoluteAdd(JSGlobalObject* globalObject, BigIntI
     bigInt->finishCreation(vm);
     bigInt->setSign(resultSign);
 
-    auto span = addSchoolbook(x.digits(), y.digits(), bigInt->digits());
+    auto span = addDigitsInto(x.digits(), y.digits(), bigInt->digits());
     ASSERT(!span.empty());
     if (!span.back())
         bigInt->setLength(span.size() - 1);
@@ -3317,29 +3464,56 @@ std::span<JSBigInt::Digit> JSBigInt::subSchoolbook(std::span<const Digit> x, std
     return result.first(x.size());
 }
 
+template<size_t N>
+ALWAYS_INLINE std::span<JSBigInt::Digit, N> JSBigInt::subSchoolbookFixed(std::span<const Digit, N> x, std::span<const Digit, N> y, std::span<Digit, N> result)
+{
+    Digit borrow = 0;
+    for (size_t i = 0; i < N; ++i) {
+        Digit newBorrow = 0;
+        result[i] = digitSub2(x[i], y[i], borrow, newBorrow);
+        borrow = newBorrow;
+    }
+    ASSERT(!borrow);
+    return result;
+}
+
+ALWAYS_INLINE std::span<JSBigInt::Digit> JSBigInt::subDigitsInto(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
+{
+    ASSERT(x.size() >= y.size());
+    ASSERT(compareDigits(x, y) != ComparisonResult::LessThan);
+    ASSERT(result.size() >= x.size());
+
+    if (x.size() == y.size()) {
+        switch (x.size()) {
+        case 1:
+            return subSchoolbookFixed<1>(x.first<1>(), y.first<1>(), result.first<1>());
+        case 2:
+            return subSchoolbookFixed<2>(x.first<2>(), y.first<2>(), result.first<2>());
+        case 3:
+            return subSchoolbookFixed<3>(x.first<3>(), y.first<3>(), result.first<3>());
+        case 4:
+            return subSchoolbookFixed<4>(x.first<4>(), y.first<4>(), result.first<4>());
+        }
+    }
+    return subSchoolbook(x, y, result);
+}
+
 template <typename BigIntImpl1, typename BigIntImpl2>
 JSBigInt::ImplResult JSBigInt::absoluteSub(JSGlobalObject* globalObject, BigIntImpl1 x, BigIntImpl2 y, bool resultSign)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ComparisonResult comparisonResult = absoluteCompare(x, y);
-    ASSERT(x.length() >= y.length());
-    ASSERT(comparisonResult == ComparisonResult::GreaterThan || comparisonResult == ComparisonResult::Equal);
-
-    if (x.isZero()) {
-        ASSERT(y.isZero());
-        return { x };
-    }
+    // Callers fold the equal case into zero, so |x| > |y| here and neither x nor the difference is
+    // zero.
+    ASSERT(absoluteCompare(x, y) == ComparisonResult::GreaterThan);
+    ASSERT(!x.isZero());
 
     if (y.isZero()) {
         if (resultSign == x.sign())
             return ImplResult { x };
         RELEASE_AND_RETURN(scope, JSBigInt::unaryMinusImpl(globalObject, x));
     }
-
-    if (comparisonResult == ComparisonResult::Equal)
-        RELEASE_AND_RETURN(scope, zeroImpl(vm));
 
     unsigned resultLength = x.length();
     if (resultLength > maxInPlaceSubSize) [[unlikely]] {
@@ -3358,9 +3532,8 @@ JSBigInt::ImplResult JSBigInt::absoluteSub(JSGlobalObject* globalObject, BigIntI
     bigInt->finishCreation(vm);
     bigInt->setSign(resultSign);
 
-    auto span = normalize(subSchoolbook(x.digits(), y.digits(), bigInt->digits()));
-    if (span.empty())
-        RELEASE_AND_RETURN(scope, zeroImpl(vm));
+    auto span = normalize(subDigitsInto(x.digits(), y.digits(), bigInt->digits()));
+    ASSERT(!span.empty());
     bigInt->setLength(span.size());
     return bigInt;
 }

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -540,6 +540,9 @@ private:
     static void multiplySpecialLowFixed(std::span<const Digit, XSize>, std::span<const Digit, YSize>, std::span<Digit, RSize> result);
     template<size_t N>
     static std::span<Digit, N * 2> multiplyCombaFixed(std::span<const Digit, N> x, std::span<const Digit, N> y, std::span<Digit, N * 2> result);
+    template<size_t N>
+    static std::span<Digit, N * 2> squareCombaFixed(std::span<const Digit, N> x, std::span<Digit, N * 2> result);
+    static std::span<Digit> multiplyDigitsInto(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
 
     static std::span<Digit> NODELETE divideSingle(std::span<Digit> q, Digit& remainder, std::span<const Digit>, Digit);
     static std::tuple<std::span<Digit>, std::span<Digit>> divideSchoolbook(std::span<Digit> q, std::span<Digit> r, std::span<const Digit>, std::span<const Digit>);
@@ -548,6 +551,12 @@ private:
 
     static std::span<Digit> NODELETE addSchoolbook(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
     static std::span<Digit> NODELETE subSchoolbook(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
+    template<size_t N>
+    static std::span<Digit, N + 1> addSchoolbookFixed(std::span<const Digit, N> x, std::span<const Digit, N> y, std::span<Digit, N + 1> result);
+    template<size_t N>
+    static std::span<Digit, N> subSchoolbookFixed(std::span<const Digit, N> x, std::span<const Digit, N> y, std::span<Digit, N> result);
+    static std::span<Digit> addDigitsInto(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
+    static std::span<Digit> subDigitsInto(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
 
     static ComparisonResult NODELETE compareDigits(std::span<const Digit> x, std::span<const Digit> y);
     static std::span<Digit> NODELETE addDigits(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);


### PR DESCRIPTION
#### deb0d2fa4be6ecd15bf67bf44613db50820999d7
<pre>
[JSC] Deply add / sub / mul tightening to JSBigInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=320806">https://bugs.webkit.org/show_bug.cgi?id=320806</a>
<a href="https://rdar.apple.com/183823079">rdar://183823079</a>

Reviewed by Yijia Huang.

This patch tightening JSBigInt add / sub / mul.

1. We add size-fixed streamlined implementations to add and sub as the
   same to mul.
2. Removed unnecessary absoluteCompare for sub. Before doing sub, we
   already did absoluteCompare.
3. Multiply streamlined implementations should have square optimization.
4. DigitColumnAccumulator now picks where a column&apos;s carry lives per
   consumer. Keeping it in the condition flags is the shortest sequence, but
   there is only one flag register, so in the fully unrolled Comba kernels,
   where two mac chains end up interleaved, the compiler spilled it with
   mrs / msr NZCV: 6 times in multiplyCombaFixed&lt;4&gt; and 14 times in &lt;8&gt;.
   CombaAccumulator now materializes the carry as a value with
   __builtin_addcll, which removes those spills and 6 instructions per
   4-digit multiply. The Barrett / folding helpers keep the flag form on
   purpose: switching them over too pushes 8 flag spills into cachedMod,
   which is three times hotter, and cancels the win.

In squire multiplication, Comba multiplication can leverage the fact
that the same value multiplication is happening. a[i] * b[j] and
a[j] * b[i] will be the same since a[i] == b[i] in squire case.

          a0      a1      a2      a3
    a0  [0,0]   (0,1)   (0,2)   (0,3)
    a1  (1,0)   [1,1]   (1,2)   (1,3)      [i,i] diagonal - counted once
    a2  (2,0)   (2,1)   [2,2]   (2,3)      (i,j) off-diagonal - equal in pairs
    a3  (3,0)   (3,1)   (3,2)   [3,3]

So, half of multilication is not necessary. So then in the Comba multiplication,

                                  a6   a5   a4   a3   a2   a1   a0
                            x     a6   a5   a4   a3   a2   a1   a0
                            --------------------------------------
                                a6a0 a5a0 a4a0 a3a0 a2a0 a1a0 a0a0
                           a6a1 a5a1 a4a1 a3a1 a2a1 a1a1 a0a1
                      a6a2 a5a2 a4a2 a3a2 a2a2 a1a2 a0a2
                 a6a3 a5a3 a4a3 a3a3 a2a3 a1a3 a0a3
            a6a4 a5a4 a4a4 a3a4 a2a4 a1a4 a0a4
       a6a5 a5a5 a4a5 a3a5 a2a5 a1a5 a0a5
  a6a6 a5a6 a4a6 a3a6 a2a6 a1a6 a0a6
 -----------------------------------------------------------------

Now we can find that, in each column (that&apos;s how Comba multiplication computes),
basically you only need to compute the half way. And you can double the
result and that&apos;s what you need. Like, a6a0 == a0a6, so only diagonal
case, a3a3, needs to be additionally done. But other ones should just
use a6a0 * 2, and then, you do not need to compute a0a6.

Tests: JSTests/stress/bigint-add-sub-fixed-size.js
       JSTests/stress/bigint-square-comba.js

* JSTests/stress/bigint-add-sub-fixed-size.js: Added.
(shouldBe):
(nextDigit):
(fromDigits):
(randomOfLength):
(check):
* JSTests/stress/bigint-square-comba.js: Added.
(shouldBe):
(checkSquare):
(nextDigit):
(fromDigits):
(a.a.2n.a.copy):
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::DigitColumnAccumulator::mac):
(JSC::DigitColumnAccumulator::macDoubled):
(JSC::DigitColumnAccumulator::addCarrying):
(JSC::CombaAccumulator::computeSquareColumn):
(JSC::CombaAccumulator::squarePass):
(JSC::JSBigInt::squareCombaFixed):
(JSC::JSBigInt::multiplySpecialLow):
(JSC::JSBigInt::multiplySpecialHigh):
(JSC::JSBigInt::multiplyComba):
(JSC::multiplySpecialColumn):
(JSC::JSBigInt::multiplySpecialHighFixed):
(JSC::JSBigInt::multiplySpecialLowFixed):
(JSC::JSBigInt::multiplyDigitsInto):
(JSC::JSBigInt::multiplyImpl):
(JSC::JSBigInt::addDigits):
(JSC::JSBigInt::multiplyDigits):
(JSC::JSBigInt::addImpl):
(JSC::JSBigInt::subImpl):
(JSC::JSBigInt::addSchoolbookFixed):
(JSC::JSBigInt::addDigitsInto):
(JSC::JSBigInt::absoluteAdd):
(JSC::JSBigInt::subSchoolbookFixed):
(JSC::JSBigInt::subDigitsInto):
(JSC::JSBigInt::absoluteSub):
* Source/JavaScriptCore/runtime/JSBigInt.h:

Canonical link: <a href="https://commits.webkit.org/318413@main">https://commits.webkit.org/318413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/636050dfb6e0073d6e49322f04599158c67d28f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141418 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138892 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6944b97a-f32b-49b0-a1a7-1ceba4f4f486) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119348 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6904748-2122-468c-8614-3084235453bc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41110 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39465 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1317 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8145 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39153 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36242 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39444 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190212 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51777 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148039 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52459 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147813 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27034 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42528 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124723 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119267 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50977 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14129 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50362 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50602 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50424 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->