### PR TITLE
[LBSE] Skip the outline paint pass for outline-free SVG renderers

### DIFF
--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
@@ -675,6 +675,8 @@ void RenderLayer::paintChildrenInDOMOrderForSVG(GraphicsContext& context, const 
         }
 
         for (auto phase : childToPaint.phasesToPaint) {
+            if ((phase == PaintPhase::Outline || phase == PaintPhase::SelfOutline) && !childRenderer->hasOutline())
+                continue;
             paintNonLayerChildForFragmentsForSVG(childRenderer.get(), childToPaint.accumulatedAncestorOffset,
                 phase, layerFragments, context, paintingInfo, paintBehavior, subtreePaintRootForRenderer, containerBaseOffset, isSVGRoot, sharedClipSaver.has_value());
         }
@@ -810,10 +812,12 @@ void RenderLayer::paintRendererByApplyingTransformForSVG(GraphicsContext& contex
                 } else if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(rendererToPaint.get()))
                     recursionBase = svgModel->nominalSVGLayoutLocation();
                 paintSubtreeWithinTransformScopeForSVG(context, rendererToPaint.get(), recursionBase, transformedPaintingInfo, adjustedPaintFlags, paintBehavior, subtreePaintRoot);
-                paintInScope(PaintPhase::SelfOutline, selfPaintOffset);
+                if (rendererToPaint->hasOutline())
+                    paintInScope(PaintPhase::SelfOutline, selfPaintOffset);
             } else {
                 paintInScope(PaintPhase::Foreground, selfPaintOffset);
-                paintInScope(PaintPhase::Outline, selfPaintOffset);
+                if (rendererToPaint->hasOutline())
+                    paintInScope(PaintPhase::Outline, selfPaintOffset);
             }
         }
     }

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -189,7 +189,7 @@ void RenderSVGContainer::paint(PaintInfo& paintInfo, const LayoutPoint& paintOff
 
         child->paint(childPaintInfo, adjustedPaintOffset);
 
-        if (paintInfo.phase == PaintPhase::Foreground) {
+        if (paintInfo.phase == PaintPhase::Foreground && child->hasOutline()) {
             // Paint each child's outline immediately so later DOM siblings paint on top of it.
             PaintInfo outlinePaintInfo(childPaintInfo);
             outlinePaintInfo.phase = PaintPhase::Outline;


### PR DESCRIPTION
#### 94caace776745ba04ac48a565b3f43145a33cd06
<pre>
[LBSE] Skip the outline paint pass for outline-free SVG renderers
<a href="https://bugs.webkit.org/show_bug.cgi?id=320813">https://bugs.webkit.org/show_bug.cgi?id=320813</a>

Reviewed by Rob Buis.

Every SVG child was painted twice per frame: once for the foreground and
once for the outline phase, the latter constructing a PaintInfo and
calling paint() even when the renderer has no outline (the common case!).
The outline phase is a no-op without an outline, so the extra pass
was wasted work on every shape.

Guard the outline/self-outline pass behind hasOutline() in the three
places that drive it: paintChildrenInDOMOrderForSVG() and
paintRendererByApplyingTransformForSVG() for layer-painted children, and
RenderSVGContainer::paint() for the non-layer child walk.

Covered by existing tests.

* Source/WebCore/rendering/RenderLayerSVGAdditions.cpp:
(WebCore::RenderLayer::paintChildrenInDOMOrderForSVG):
(WebCore::RenderLayer::paintRendererByApplyingTransformForSVG):
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::paint):

Canonical link: <a href="https://commits.webkit.org/318410@main">https://commits.webkit.org/318410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25f85afb87039bd7a4a2d9125d19197df5ef4117

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187786 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180035 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138891 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119347 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41112 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39464 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39155 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36243 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190213 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51778 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148038 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39767 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52460 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147812 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42529 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124724 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119270 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50978 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14131 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50363 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->