### PR TITLE
[LBSE] Invert the 2D affine transform when mapping the paint dirty rect

### DIFF
--- a/Source/WebCore/rendering/TransformPaintScope.h
+++ b/Source/WebCore/rendering/TransformPaintScope.h
@@ -43,8 +43,15 @@ public:
         if (newRootLayer)
             m_transformedPaintingInfo.rootLayer = newRootLayer.get();
 
-        if (!m_transformedPaintingInfo.paintDirtyRect.isInfinite())
-            m_transformedPaintingInfo.paintDirtyRect = LayoutRect(encloseRectToDevicePixels(valueOrDefault(transform.inverse()).mapRect(paintingInfo.paintDirtyRect), deviceScaleFactor));
+        if (!m_transformedPaintingInfo.paintDirtyRect.isInfinite()) {
+            // Map the dirty rect back through the inverse transform. For a 2D affine transform (the
+            // common SVG case, e.g. translate/rotate/scale) invert the 2x3 AffineTransform we
+            // already computed rather than doing a full 4x4 TransformationMatrix inverse per paint.
+            auto mappedDirtyRect = transform.isAffine()
+                ? valueOrDefault(m_affineTransform.inverse()).mapRect(paintingInfo.paintDirtyRect)
+                : valueOrDefault(transform.inverse()).mapRect(paintingInfo.paintDirtyRect);
+            m_transformedPaintingInfo.paintDirtyRect = LayoutRect(encloseRectToDevicePixels(mappedDirtyRect, deviceScaleFactor));
+        }
 
         m_transformedPaintingInfo.subpixelOffset = adjustedSubpixelOffset;
     }


### PR DESCRIPTION
#### 5132ac6063434aa89f46175a9872c60f2ecc9dd4
<pre>
[LBSE] Invert the 2D affine transform when mapping the paint dirty rect
<a href="https://bugs.webkit.org/show_bug.cgi?id=320815">https://bugs.webkit.org/show_bug.cgi?id=320815</a>

Reviewed by Rob Buis.

TransformPaintScope mapped the paint dirty rect back through the inverse
of the full 4x4 TransformationMatrix on every transformed SVG paint. For
the common SVG case the transform is a 2D affine (e.g. translate/rotate/
scale), for which the 2x3 AffineTransform we already computed can be
inverted far more cheaply than the general 4x4 matrix.

Invert the AffineTransform when the transform isAffine(), falling back to
the 4x4 inverse for non-affine, 3D transforms. Same result, less work per
paint.

Covered by existing tests.

* Source/WebCore/rendering/TransformPaintScope.h:
(WebCore::TransformPaintScope::TransformPaintScope):

Canonical link: <a href="https://commits.webkit.org/318411@main">https://commits.webkit.org/318411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd72ee0840a22afd10826666570904daa1321cd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138890 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119346 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41116 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39466 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39158 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36245 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190215 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51780 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148041 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39768 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52462 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147815 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42531 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124726 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119272 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50980 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14134 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50365 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50605 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->