### PR TITLE
[YARR] Fix the never-taken intersection short cut in nonLatin1OpSorted

### DIFF
--- a/JSTests/stress/regexp-v-flag-intersection-rhs-exhausted.js
+++ b/JSTests/stress/regexp-v-flag-intersection-rhs-exhausted.js
@@ -1,0 +1,134 @@
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(message + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+function repeat(fn) {
+    for (let i = 0; i < testLoopCount; ++i)
+        fn();
+}
+
+// Non-Latin-1 set operations are evaluated in 2048 character chunks starting at
+// the lowest character of either operand, so the chunk boundaries below fall at
+// 0x8FF/0x900 and 0x10FF/0x1100.
+
+// The right hand side runs out of characters in the very first chunk while the
+// left hand side continues to the top of the code point space.
+repeat(() => {
+    let re = /[[\u0100-\u{10FFFF}]&&[\u0100-\u0101]]/v;
+    shouldBe(re.test("\u0100"), true, "first chunk RHS lo");
+    shouldBe(re.test("\u0101"), true, "first chunk RHS hi");
+    shouldBe(re.test("\u0102"), false, "first chunk just above RHS");
+    shouldBe(re.test("\u2000"), false, "first chunk later chunk char");
+    shouldBe(re.test("\u{10FFFF}"), false, "first chunk top of code space");
+    shouldBe(re.test("a"), false, "first chunk Latin-1");
+});
+
+repeat(() => {
+    let re = /[\p{L}&&[\u0100-\u0101]]/v;
+    shouldBe(re.test("\u0100"), true, "property LHS RHS lo");
+    shouldBe(re.test("\u0101"), true, "property LHS RHS hi");
+    shouldBe(re.test("\u0102"), false, "property LHS above RHS");
+    shouldBe(re.test("\u{10400}"), false, "property LHS non-BMP letter");
+    shouldBe(re.test("5"), false, "property LHS digit");
+});
+
+// The right hand side runs out in a later chunk.
+repeat(() => {
+    let re = /[[\u0100-\u{10FFFF}]&&[\u1000-\u1001]]/v;
+    shouldBe(re.test("\u1000"), true, "later chunk RHS lo");
+    shouldBe(re.test("\u1001"), true, "later chunk RHS hi");
+    shouldBe(re.test("\u0fff"), false, "later chunk below RHS");
+    shouldBe(re.test("\u1002"), false, "later chunk above RHS");
+    shouldBe(re.test("\u0100"), false, "later chunk first chunk char");
+});
+
+// The last right hand side range straddles a chunk boundary.
+repeat(() => {
+    let re = /[[\u0100-\u{10FFFF}]&&[\u08f0-\u0910]]/v;
+    shouldBe(re.test("\u08f0"), true, "straddling RHS lo");
+    shouldBe(re.test("\u08ff"), true, "straddling RHS last char of chunk");
+    shouldBe(re.test("\u0900"), true, "straddling RHS first char of next chunk");
+    shouldBe(re.test("\u0910"), true, "straddling RHS hi");
+    shouldBe(re.test("\u08ef"), false, "straddling RHS below");
+    shouldBe(re.test("\u0911"), false, "straddling RHS above");
+});
+
+// The last right hand side entry is a single character rather than a range.
+repeat(() => {
+    let re = /[[\u0100-\u{10FFFF}]&&[\u0100\u2000]]/v;
+    shouldBe(re.test("\u0100"), true, "single char RHS first");
+    shouldBe(re.test("\u2000"), true, "single char RHS last");
+    shouldBe(re.test("\u0101"), false, "single char RHS gap");
+    shouldBe(re.test("\u2001"), false, "single char RHS above");
+});
+
+// The whole right hand side sits below everything in the left hand side, so the
+// intersection is empty.
+repeat(() => {
+    let re = /[[\u{10000}-\u{10FFFF}]&&[\u0100-\u0200]]/v;
+    shouldBe(re.test("\u0150"), false, "disjoint RHS char");
+    shouldBe(re.test("\u{10000}"), false, "disjoint LHS lo");
+    shouldBe(re.test("\u{10FFFF}"), false, "disjoint LHS hi");
+});
+
+repeat(() => {
+    let re = /[[\u0100-\u0200]&&[\u{10000}-\u{10FFFF}]]/v;
+    shouldBe(re.test("\u0150"), false, "disjoint reversed LHS char");
+    shouldBe(re.test("\u{10000}"), false, "disjoint reversed RHS lo");
+});
+
+// Union and subtraction keep the part of the left hand side that lies above the
+// end of the right hand side.
+repeat(() => {
+    let re = /[[\u0100-\u{10FFFF}]--[\u0100-\u0101]]/v;
+    shouldBe(re.test("\u0100"), false, "subtraction removed lo");
+    shouldBe(re.test("\u0101"), false, "subtraction removed hi");
+    shouldBe(re.test("\u0102"), true, "subtraction keeps just above");
+    shouldBe(re.test("\u{10FFFF}"), true, "subtraction keeps top of code space");
+});
+
+repeat(() => {
+    let re = /[[\u0100-\u0101][\u{10000}-\u{10001}]]/v;
+    shouldBe(re.test("\u0100"), true, "union low operand");
+    shouldBe(re.test("\u{10000}"), true, "union high operand");
+    shouldBe(re.test("\u0102"), false, "union gap");
+});
+
+repeat(() => {
+    let re = /[^[\p{L}&&[\u0100-\u0101]]]/v;
+    shouldBe(re.test("\u0100"), false, "inverted intersection member");
+    shouldBe(re.test("\u0102"), true, "inverted intersection non-member");
+    shouldBe(re.test("a"), true, "inverted intersection Latin-1");
+});
+
+repeat(() => {
+    let re = /[[[\u0100-\u{10FFFF}]&&[\u0100-\u2000]]&&[\u0101-\u0102]]/v;
+    shouldBe(re.test("\u0101"), true, "chained intersection lo");
+    shouldBe(re.test("\u0102"), true, "chained intersection hi");
+    shouldBe(re.test("\u0100"), false, "chained intersection below");
+    shouldBe(re.test("\u0103"), false, "chained intersection above");
+});
+
+// Latin-1 and non-Latin-1 members of the same intersection.
+repeat(() => {
+    let re = /[[\u0080-\u{10FFFF}]&&[\u0090\u0100]]/v;
+    shouldBe(re.test("\u0090"), true, "mixed width Latin-1 member");
+    shouldBe(re.test("\u0100"), true, "mixed width non-Latin-1 member");
+    shouldBe(re.test("\u0091"), false, "mixed width Latin-1 non-member");
+    shouldBe(re.test("\u0101"), false, "mixed width non-Latin-1 non-member");
+});
+
+repeat(() => {
+    let re = /[[\u0100-\u{10FFFF}]&&[\u0100-\u0101]]+/v;
+    let m = re.exec("\u00ff\u0100\u0101\u0102");
+    shouldBe(m !== null, true, "exec found a match");
+    shouldBe(m[0], "\u0100\u0101", "exec match");
+    shouldBe(m.index, 1, "exec index");
+});
+
+repeat(() => {
+    let re = new RegExp("[[\\u0100-\\u{10FFFF}]&&[\\u0100-\\u0101]]", "v");
+    shouldBe(re.test("\u0101"), true, "dynamic pattern member");
+    shouldBe(re.test("\u{10FFFF}"), false, "dynamic pattern non-member");
+});

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -907,7 +907,7 @@ private:
             return;
 
         while (lhsMatchIndex < m_matches32.size() || lhsRangeIndex < m_ranges32.size() || rhsMatchIndex < rhsMatches32.size() || rhsRangeIndex < rhsRanges32.size()) {
-            if (rhsMatchIndex >= rhsMatches32.size() && rhsRangeIndex > rhsRanges32.size() && m_setOp == CharacterClassSetOp::Intersection) {
+            if (rhsMatchIndex >= rhsMatches32.size() && rhsRangeIndex >= rhsRanges32.size() && m_setOp == CharacterClassSetOp::Intersection) {
                 // RHS is exhausted, we can short cut from here. Can't intersect anything more so bail out.
                 break;
             }


### PR DESCRIPTION
#### 06844528db0b779a93f65d3bea9f9af709bcfe60
<pre>
[YARR] Fix the never-taken intersection short cut in nonLatin1OpSorted
<a href="https://bugs.webkit.org/show_bug.cgi?id=320816">https://bugs.webkit.org/show_bug.cgi?id=320816</a>
<a href="https://rdar.apple.com/183829577">rdar://183829577</a>

Reviewed by NOBODY (OOPS!).

nonLatin1OpSorted evaluates /v character class set operations in 2048
character chunks, and stops early once an intersection has consumed its
whole right hand side. The guard tested rhsRangeIndex &gt; rhsRanges32.size(),
but rhsRangeIndex never exceeds size(), so the short cut never fired.
Results were already correct; the loop just kept visiting chunks that
produced nothing. Compare with &gt;= instead.

Test: JSTests/stress/regexp-v-flag-intersection-rhs-exhausted.js

* JSTests/stress/regexp-v-flag-intersection-rhs-exhausted.js: Added.
(shouldBe):
(repeat):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::nonLatin1OpSorted):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06844528db0b779a93f65d3bea9f9af709bcfe60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187793 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141426 "Failed to checkout and rebase branch from PR 70686") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1c4950e-93cc-4a92-b584-8a8aa7fcfbd4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138893 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/141426 "Failed to checkout and rebase branch from PR 70686") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92771433-deff-4b7f-a490-75a90f875155) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42449 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159658 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119349 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/697bb715-7492-40f2-8ad6-406cf42f8b28) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41115 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39472 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1318 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8146 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39154 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36250 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39452 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190220 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51785 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148044 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52467 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147818 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42530 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124731 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119277 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50985 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14130 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50370 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50610 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50432 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->