### PR TITLE
SMILTime::operator== is inconsistent with spaceship operator for the unresolved and indefinite values

### DIFF
--- a/Source/WebCore/svg/animation/SMILTime.h
+++ b/Source/WebCore/svg/animation/SMILTime.h
@@ -81,7 +81,11 @@ private:
     Origin m_origin;
 };
 
-inline bool operator==(const SMILTime& a, const SMILTime& b) { return a.isFinite() && a.value() == b.value(); }
+// This has to compare the raw values to stay consistent with operator<=> below, which the compiler
+// also uses to rewrite <, >, <= and >=. Testing isFinite() here would make the unresolved and the
+// indefinite value unequal to themselves, so that "a != b", "a <= b" and "a >= b" would all be true
+// at once for them.
+inline bool operator==(const SMILTime& a, const SMILTime& b) { return a.value() == b.value(); }
 inline bool operator!(const SMILTime& a) { return !a.isFinite() || !a.value(); }
 inline auto operator<=>(const SMILTime& a, const SMILTime& b) { return a.value() <=> b.value(); }
 inline auto operator<=>(const SMILTimeWithOrigin& a, const SMILTimeWithOrigin& b) { return a.time() <=> b.time(); }

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -910,8 +910,7 @@ void SVGSMILElement::resolveFirstInterval()
     resolveInterval(true, begin, end);
     ASSERT(!begin.isIndefinite());
 
-    // Compare raw SMILTime values to avoids treating open-ended intervals as "new" on every call.
-    if (!begin.isUnresolved() && (begin.value() != m_intervalBegin.value() || end.value() != m_intervalEnd.value())) {
+    if (!begin.isUnresolved() && (begin != m_intervalBegin || end != m_intervalEnd)) {
         m_intervalBegin = begin;
         m_intervalEnd = end;
         notifyDependentsIntervalChanged();


### PR DESCRIPTION
#### 41943f3329fc8057bce65a4aa05403454cc54013
<pre>
SMILTime::operator== is inconsistent with spaceship operator for the unresolved and indefinite values
<a href="https://bugs.webkit.org/show_bug.cgi?id=320817">https://bugs.webkit.org/show_bug.cgi?id=320817</a>
<a href="https://rdar.apple.com/183830503">rdar://183830503</a>

Reviewed by Chris Dumez.

SMILTime::operator== tested isFinite() before comparing, but operator&lt;=&gt; compares the raw
values, and since 291172 the compiler rewrites &lt;, &gt;, &lt;= and &gt;= from operator&lt;=&gt;. For the
unresolved and the indefinite value that makes the two disagree: &quot;a == a&quot; is false while
&quot;a &lt;= a&quot;, &quot;a &gt;= a&quot; and &quot;a != a&quot; are all true at the same time.

Drop the isFinite() test so equality matches the ordering. Callers that need to reject the
sentinel values already ask for isFinite(), isUnresolved() or isIndefinite() explicitly.

This fixes several comparisons that were dead or wrong for open-ended intervals:

- resolveInterval() refined the end time under &quot;tempEnd == lastIntervalTempEnd&quot; and
  &quot;tempEnd == m_intervalEnd&quot;. lastIntervalTempEnd starts at infinity and m_intervalEnd at
  unresolved, so neither could ever match and the refinement never ran for indefinite
  intervals.
- PriorityCompare fell through its &quot;aBegin == bBegin&quot; tie-break whenever both animations had
  an unresolved interval begin, so their relative order came out of an unstable sort instead
  of document order.
- beginListChanged() compared the new interval begin against the old one to decide whether to
  notify dependents, and notified unconditionally when both were unresolved.
- insertSortedAndUnique() stopped scanning for a duplicate at the first entry whenever the
  time being inserted was not finite.

resolveFirstInterval() worked around the old behaviour by comparing SMILTime::value() by hand;
it can now use operator== again.

* Source/WebCore/svg/animation/SMILTime.h:
(WebCore::operator==):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::resolveFirstInterval):

Canonical link: <a href="https://commits.webkit.org/318422@main">https://commits.webkit.org/318422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/505e83a41de796cc877d24780308c2966756f86e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141431 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d720fa1d-099c-46ec-816c-57cb8630f86d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138900 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb8c3091-9877-4629-b21a-f550517882f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159669 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119356 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5457db2a-eacb-433f-9402-6cd08bb66c9d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41123 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39477 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151523 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39165 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36255 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43720 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190225 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51790 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148050 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39773 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52472 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147823 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42539 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124736 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119282 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50990 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14141 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50375 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50615 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->