### PR TITLE
SMILTimeContainer::updateAnimations() copies the scheduled animations map twice per frame

### DIFF
--- a/Source/WebCore/svg/animation/SMILTimeContainer.cpp
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.cpp
@@ -267,15 +267,23 @@ void SMILTimeContainer::updateAnimations(SMILTime elapsed, bool seekToTime)
     // Don't mutate the DOM while updating the animations.
     EventQueueScope scope;
 
-    processScheduledAnimations([](auto& animation) {
-        if (!animation.hasConditionsConnected())
-            animation.connectConditions();
-    });
+    // One snapshot for the whole frame: progressing an animation can run script, which may
+    // schedule() or unschedule() and invalidate m_scheduledAnimations. See webkit.org/b/212192.
+    auto scheduledAnimations = copyToVector(m_scheduledAnimations.values());
+
+    // Connect every animation before progressing any of them; connectConditions() can add instance
+    // times to another animation, but cannot run script, so the snapshot stays valid.
+    for (auto& animations : scheduledAnimations) {
+        for (Ref animation : animations) {
+            if (!animation->hasConditionsConnected())
+                animation->connectConditions();
+        }
+    }
 
     Vector<Ref<SVGSMILElement>> animationsToApply;
     SMILTime earliestFireTime = SMILTime::unresolved();
 
-    for (auto& animations : copyToVector(m_scheduledAnimations.values())) {
+    for (auto& animations : scheduledAnimations) {
         // Advance every animation's current interval to `elapsed` before sorting. An animation
         // whose interval only restarts at (or before) the current time -- e.g. a sync-base
         // dependent that just gained a new, later begin time -- must be sorted using that new


### PR DESCRIPTION
#### 93a88853044da9b0fa1c3f07a42945b909fb68b7
<pre>
SMILTimeContainer::updateAnimations() copies the scheduled animations map twice per frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=320819">https://bugs.webkit.org/show_bug.cgi?id=320819</a>
<a href="https://rdar.apple.com/183831859">rdar://183831859</a>

Reviewed by Chris Dumez.

updateAnimations() is the per-frame entry point for SMIL, and it deep-copies
m_scheduledAnimations twice: once via processScheduledAnimations() for the
lazy connectConditions() pass, and again for the loop that progresses the
animations. Since the map value type is a Vector&lt;WeakRef&lt;SVGSMILElement&gt;&gt;,
each copyToVector() allocates the outer vector plus one inner vector per
element/attribute group, and ref/derefs every scheduled animation&apos;s
WeakPtrImpl. All of that happens twice on every animation tick.

Take one snapshot and share it between the two passes. The copy itself has
to stay: 225240@main added it because progressing an animation can run
script that calls schedule()/unschedule() and invalidates the map&apos;s
iterators. Connecting conditions cannot do that, though. connectConditions()
can reach addTimeDependent() -&gt; createInstanceTimesFromSyncbase() -&gt;
addInstanceTime() -&gt; beginListChanged()/endListChanged(), but nothing on
that path schedules or unschedules, and SMIL events are queued through
SMILEventSender::dispatchEventSoon() rather than dispatched synchronously.
So the first pass cannot invalidate the snapshot the second pass relies on.

The connect pass is inlined rather than left in processScheduledAnimations(),
since sharing a snapshot means iterating a vector the caller owns.
processScheduledAnimations() is still used by setElapsed().

No change in behavior.

* Source/WebCore/svg/animation/SMILTimeContainer.cpp:
(WebCore::SMILTimeContainer::updateAnimations):

Canonical link: <a href="https://commits.webkit.org/318420@main">https://commits.webkit.org/318420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24a7daaf71de568f5b9a826da2493981588c051c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141436 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27c5531c-f7f4-4c5a-89f7-2f498df4f7da) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138903 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6ead625-1cfd-466a-9670-571657f90d10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119359 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b44d31f-f9e2-4db2-8b0b-d6eec5363423) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41126 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39479 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151526 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39170 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36260 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190230 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51795 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148054 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39774 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52477 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147827 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42541 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124741 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119287 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50995 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14146 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50380 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50442 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->