### PR TITLE
<animateMotion> ignores a numeric 'rotate' value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-rotate-angle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-rotate-angle-expected.txt
@@ -1,0 +1,9 @@
+
+PASS rotate="45" applies a constant 45 degree rotation
+PASS rotate="-90" applies a constant -90 degree rotation
+PASS rotate="30" applies a constant 30 degree rotation to a path animation
+PASS rotate="0" applies no rotation
+PASS an absent rotate attribute applies no rotation
+PASS an unparseable rotate value applies no rotation
+PASS rotate="auto" follows the direction of motion
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-rotate-angle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-rotate-angle.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<title>&lt;animateMotion> with a numeric 'rotate' value</title>
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#RotateAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="svg" width="400" height="400">
+  <!-- rotate="<number>" applies a constant rotation of that many degrees. -->
+  <rect id="angle" width="10" height="10">
+    <animateMotion from="0,0" to="200,0" rotate="45" fill="freeze" dur="4s"/>
+  </rect>
+  <rect id="angle-negative" width="10" height="10">
+    <animateMotion from="0,0" to="200,0" rotate="-90" fill="freeze" dur="4s"/>
+  </rect>
+  <!-- The same holds for path animations; 'path' is not special w.r.t. 'rotate'. -->
+  <rect id="angle-path" width="10" height="10">
+    <animateMotion path="M0,0 L200,0" rotate="30" fill="freeze" dur="4s"/>
+  </rect>
+  <!-- Explicit zero, absent, and unparseable values all mean no rotation:
+       the initial value of 'rotate' is 0. -->
+  <rect id="angle-zero" width="10" height="10">
+    <animateMotion from="0,0" to="200,0" rotate="0" fill="freeze" dur="4s"/>
+  </rect>
+  <rect id="no-rotate" width="10" height="10">
+    <animateMotion from="0,0" to="200,0" fill="freeze" dur="4s"/>
+  </rect>
+  <rect id="bogus-rotate" width="10" height="10">
+    <animateMotion from="0,0" to="200,0" rotate="bogus" fill="freeze" dur="4s"/>
+  </rect>
+  <!-- Control: rotate="auto" follows the direction of motion. -->
+  <rect id="auto" width="10" height="10">
+    <animateMotion from="0,0" to="0,200" rotate="auto" fill="freeze" dur="4s"/>
+  </rect>
+</svg>
+<script>
+const rootSVGElement = document.getElementById('svg');
+
+// The rotation is post-multiplied onto the translation computed for the motion,
+// so the resulting matrix is [cos, sin, -sin, cos, tx, ty].
+function assert_animation_transform(id, angleInDegrees, tx, ty) {
+  const ctm = document.getElementById(id).getCTM();
+  const radians = angleInDegrees * Math.PI / 180;
+  const epsilon = 1e-4;
+  assert_approx_equals(ctm.a, Math.cos(radians), epsilon, `${id}: matrix a`);
+  assert_approx_equals(ctm.b, Math.sin(radians), epsilon, `${id}: matrix b`);
+  assert_approx_equals(ctm.c, -Math.sin(radians), epsilon, `${id}: matrix c`);
+  assert_approx_equals(ctm.d, Math.cos(radians), epsilon, `${id}: matrix d`);
+  assert_approx_equals(ctm.e, tx, epsilon, `${id}: translation x`);
+  assert_approx_equals(ctm.f, ty, epsilon, `${id}: translation y`);
+}
+
+// Document begin is the moment the load event is triggered, so the timeline
+// cannot be sampled until after that event has been dispatched. Yield once
+// before pausing and driving it manually.
+const ready = new Promise(resolve => {
+  window.addEventListener('load', () => requestAnimationFrame(() => {
+    rootSVGElement.pauseAnimations();
+    resolve();
+  }));
+});
+
+promise_test(async () => {
+  await ready;
+  rootSVGElement.setCurrentTime(2);
+  assert_animation_transform('angle', 45, 100, 0);
+  rootSVGElement.setCurrentTime(4);
+  assert_animation_transform('angle', 45, 200, 0);
+}, 'rotate="45" applies a constant 45 degree rotation');
+
+promise_test(async () => {
+  await ready;
+  rootSVGElement.setCurrentTime(2);
+  assert_animation_transform('angle-negative', -90, 100, 0);
+}, 'rotate="-90" applies a constant -90 degree rotation');
+
+promise_test(async () => {
+  await ready;
+  rootSVGElement.setCurrentTime(2);
+  assert_animation_transform('angle-path', 30, 100, 0);
+}, 'rotate="30" applies a constant 30 degree rotation to a path animation');
+
+promise_test(async () => {
+  await ready;
+  rootSVGElement.setCurrentTime(2);
+  assert_animation_transform('angle-zero', 0, 100, 0);
+}, 'rotate="0" applies no rotation');
+
+promise_test(async () => {
+  await ready;
+  rootSVGElement.setCurrentTime(2);
+  assert_animation_transform('no-rotate', 0, 100, 0);
+}, 'an absent rotate attribute applies no rotation');
+
+promise_test(async () => {
+  await ready;
+  rootSVGElement.setCurrentTime(2);
+  assert_animation_transform('bogus-rotate', 0, 100, 0);
+}, 'an unparseable rotate value applies no rotation');
+
+promise_test(async () => {
+  await ready;
+  rootSVGElement.setCurrentTime(2);
+  assert_animation_transform('auto', 90, 0, 100);
+}, 'rotate="auto" follows the direction of motion');
+</script>

--- a/LayoutTests/svg/animations/animateMotion-accumulate-1a.svg
+++ b/LayoutTests/svg/animations/animateMotion-accumulate-1a.svg
@@ -4,7 +4,7 @@
 <svg viewBox="0 0 500 350" onload="loaded()"
   xmlns="http://www.w3.org/2000/svg" version="1.1" baseProfile="tiny"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <meta name="fuzzy" content="maxDifference=1; totalPixels=1" />
+  <meta name="fuzzy" content="maxDifference=0-17; totalPixels=0-52" />
   <g id="test-body-content" font-family="SVGFreeSansASCII,sans-serif" font-size="18">
     <rect x="0" y="0" width="480" height="360" fill="#fff" />
     <g transform="translate(80,-20) scale(0.45)">

--- a/LayoutTests/svg/animations/animateMotion-accumulate-1b.svg
+++ b/LayoutTests/svg/animations/animateMotion-accumulate-1b.svg
@@ -4,7 +4,7 @@
 <svg viewBox="0 0 500 350" onload="loaded()"
   xmlns="http://www.w3.org/2000/svg" version="1.1" baseProfile="tiny"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <meta name="fuzzy" content="maxDifference=1; totalPixels=1" />
+  <meta name="fuzzy" content="maxDifference=0-17; totalPixels=0-49" />
   <g id="test-body-content" font-family="SVGFreeSansASCII,sans-serif" font-size="18">
     <rect x="0" y="0" width="480" height="360" fill="#fff" />
     <g transform="translate(80,-20) scale(0.45)">

--- a/LayoutTests/svg/animations/animateMotion-accumulate-1c.svg
+++ b/LayoutTests/svg/animations/animateMotion-accumulate-1c.svg
@@ -4,7 +4,7 @@
 <svg viewBox="0 0 500 350" onload="loaded()"
   xmlns="http://www.w3.org/2000/svg" version="1.1" baseProfile="tiny"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <meta name="fuzzy" content="maxDifference=1; totalPixels=1" />
+  <meta name="fuzzy" content="maxDifference=0-17; totalPixels=0-49" />
   <g id="test-body-content" font-family="SVGFreeSansASCII,sans-serif" font-size="18">
     <rect x="0" y="0" width="480" height="360" fill="#fff" />
     <g transform="translate(80,-20) scale(0.45)">

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -111,7 +111,8 @@ void SVGAnimateMotionElement::attributeChanged(const QualifiedName& name, const 
     SVGAnimationElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
     
-SVGAnimateMotionElement::RotateMode SVGAnimateMotionElement::rotateMode() const
+// https://w3c.github.io/svgwg/specs/animations/#RotateAttribute
+Variant<SVGAnimateMotionElement::RotateMode, float> SVGAnimateMotionElement::rotate() const
 {
     static MainThreadNeverDestroyed<const AtomString> autoReverse("auto-reverse"_s);
     auto& rotate = getAttribute(SVGNames::rotateAttr);
@@ -119,7 +120,7 @@ SVGAnimateMotionElement::RotateMode SVGAnimateMotionElement::rotateMode() const
         return RotateMode::Auto;
     if (rotate == autoReverse)
         return RotateMode::AutoReverse;
-    return RotateMode::Angle;
+    return valueOrDefault(parseNumber(rotate));
 }
 
 void SVGAnimateMotionElement::updateAnimationPath()
@@ -244,16 +245,15 @@ void SVGAnimateMotionElement::calculateAnimatedValue(float percentage, unsigned 
         angle = traversalState.normalAngle();
     }
 
-    switch (rotateMode()) {
-    case RotateMode::Auto:
-        break;
-    case RotateMode::AutoReverse:
-        angle += 180;
-        break;
-    case RotateMode::Angle:
-        angle = 0;
-        break;
-    }
+    WTF::switchOn(rotate(),
+        [&](RotateMode mode) {
+            if (mode == RotateMode::AutoReverse)
+                angle += 180.0f;
+        },
+        [&](float value) {
+            angle = value;
+        }
+    );
 
     transform->rotate(angle);
 }

--- a/Source/WebCore/svg/SVGAnimateMotionElement.h
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.h
@@ -22,6 +22,7 @@
 
 #include "Path.h"
 #include "SVGAnimationElement.h"
+#include <wtf/Variant.h>
 
 namespace WebCore {
 
@@ -51,12 +52,11 @@ private:
     void applyResultsToTarget() override;
     std::optional<float> calculateDistance(const String& fromString, const String& toString) override;
 
-    enum class RotateMode : uint8_t {
-        Angle,
+    enum class RotateMode : bool {
         Auto,
         AutoReverse
     };
-    RotateMode rotateMode() const;
+    Variant<RotateMode, float> rotate() const;
     void buildTransformForProgress(AffineTransform*, float percentage);
 
     void updateAnimationMode() override;


### PR DESCRIPTION
#### 89a079c61a9e457fa419fed803f32ba370a6afe2
<pre>
&lt;animateMotion&gt; ignores a numeric &apos;rotate&apos; value
<a href="https://bugs.webkit.org/show_bug.cgi?id=320821">https://bugs.webkit.org/show_bug.cgi?id=320821</a>
<a href="https://rdar.apple.com/183832405">rdar://183832405</a>

Reviewed by Said Abou-Hallawa.

SVG 2 defines &apos;rotate&apos; on &lt;animateMotion&gt; as `&lt;number&gt; | auto |
auto-reverse`, where a &lt;number&gt; &quot;indicates that the target element has a
constant rotation transformation applied to it, where the rotation angle
is the specified number of degrees&quot; [1].

rotateMode() folded every value that is not &apos;auto&apos; or &apos;auto-reverse&apos;
into RotateMode::Angle, but calculateAnimatedValue() then hardcoded the
angle to 0 for that case, so a specified rotate=&quot;45&quot; was silently
dropped and no rotation was applied at all.

Replace rotateMode() with rotate(), which mirrors the attribute grammar
by returning a Variant&lt;RotateMode, float&gt;: the two keywords stay as
RotateMode, and anything else is parsed as a number. This removes the
RotateMode::Angle placeholder, whose only purpose was to mean &quot;not a
keyword&quot;. An absent or unparseable value still yields no rotation,
matching the initial value of 0.

Firefox already applies the specified angle; Chrome shares the WebKit
behavior of dropping it.

The svg/animations/animateMotion-accumulate-1a..1c tests need slightly
wider fuzziness. Each of them animates four circles, and while three use
no &apos;rotate&apos;, &apos;auto&apos; and &apos;auto-reverse&apos;, the innermost one specifies
rotate=&quot;60&quot;, which this change stops discarding. Those circles are
centered on the rotation origin, so a 60 degree rotation maps each one
onto itself and the rendered geometry is unchanged; only the rasterized
result moves, because the Bezier arcs making up the circle now meet the
pixel grid at rotated positions and are antialiased slightly
differently. The tests already needed fuzziness before this change, as
the accumulated translation comes from an approximate path traversal.

[1] <a href="https://w3c.github.io/svgwg/specs/animations/#RotateAttribute">https://w3c.github.io/svgwg/specs/animations/#RotateAttribute</a>

Test: imported/w3c/web-platform-tests/svg/animations/animateMotion-rotate-angle.html

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-rotate-angle-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-rotate-angle.html: Added.
* LayoutTests/svg/animations/animateMotion-accumulate-1a.svg: Widen fuzziness for the rotate=&quot;60&quot; circle.
* LayoutTests/svg/animations/animateMotion-accumulate-1b.svg: Ditto.
* LayoutTests/svg/animations/animateMotion-accumulate-1c.svg: Ditto.
* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::rotate const):
(WebCore::SVGAnimateMotionElement::calculateAnimatedValue):
(WebCore::SVGAnimateMotionElement::rotateMode const): Deleted.
* Source/WebCore/svg/SVGAnimateMotionElement.h:

Canonical link: <a href="https://commits.webkit.org/318565@main">https://commits.webkit.org/318565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c15517a4ca718012511f518909b59cd3aa3100b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141700 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0a07a7a-7ad9-48e7-93c5-bdcf80984e22) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139122 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/080dafc2-f811-466f-8126-a7aadb25a97b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119576 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e2d3bae0-c77e-4ab8-86bd-57b631fae8ae) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41352 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39697 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39378 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36522 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190494 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148283 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39867 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52739 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148054 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42764 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125048 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119642 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51257 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14353 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50642 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50882 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->