### PR TITLE
[SVG] animateMotion walks the animation path up to 4 times per frame

### DIFF
--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -187,19 +187,6 @@ bool SVGAnimateMotionElement::setToAtEndOfDurationValue(const String& toAtEndOfD
     return true;
 }
 
-void SVGAnimateMotionElement::buildTransformForProgress(AffineTransform* transform, float percentage)
-{
-    ASSERT(!m_animationPath.isEmpty());
-
-    float positionOnPath = m_animationPath.length() * percentage;
-    auto traversalState(m_animationPath.traversalStateAtLength(positionOnPath));
-    if (!traversalState.success())
-        return;
-
-    FloatPoint position = traversalState.current();
-    transform->translate(position);
-}
-
 void SVGAnimateMotionElement::calculateAnimatedValue(float percentage, unsigned repeatCount)
 {
     RefPtr targetElement = this->targetElement();
@@ -234,14 +221,25 @@ void SVGAnimateMotionElement::calculateAnimatedValue(float percentage, unsigned 
         angle = rad2deg(delta.slopeAngleRadians());
     } else {
         // Path animation
-        buildTransformForProgress(transform, percentage);
+        ASSERT(!m_animationPath.isEmpty());
+
+        // Path traversal is O(segments), so walk the path once for the position and
+        // its normal angle, and at most once more for the accumulated repeats.
+        float pathLength = m_animationPath.length();
+
+        auto traversalState = m_animationPath.traversalStateAtLength(pathLength * percentage);
+        if (traversalState.success())
+            transform->translate(traversalState.current());
 
         if (isAccumulated() && repeatCount) {
-            for (unsigned i = 0; i < repeatCount; ++i)
-                buildTransformForProgress(transform, 1);
+            auto endOfPathState = m_animationPath.traversalStateAtLength(pathLength);
+            if (endOfPathState.success()) {
+                auto endOfPath = endOfPathState.current();
+                for (unsigned i = 0; i < repeatCount; ++i)
+                    transform->translate(endOfPath);
+            }
         }
 
-        auto traversalState = m_animationPath.traversalStateAtLength(m_animationPath.length() * percentage);
         angle = traversalState.normalAngle();
     }
 

--- a/Source/WebCore/svg/SVGAnimateMotionElement.h
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.h
@@ -26,8 +26,6 @@
 
 namespace WebCore {
 
-class AffineTransform;
-
 class SVGAnimateMotionElement final : public SVGAnimationElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGAnimateMotionElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAnimateMotionElement);
@@ -57,7 +55,6 @@ private:
         AutoReverse
     };
     Variant<RotateMode, float> rotate() const;
-    void buildTransformForProgress(AffineTransform*, float percentage);
 
     void updateAnimationMode() override;
     void childrenChanged(const ChildChange&) final;


### PR DESCRIPTION
#### b113f83f34dd67b5a2e1c94feb544c39db415cf2
<pre>
[SVG] animateMotion walks the animation path up to 4 times per frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=320823">https://bugs.webkit.org/show_bug.cgi?id=320823</a>
<a href="https://rdar.apple.com/183833913">rdar://183833913</a>

Reviewed by Nikolas Zimmermann.

buildTransformForProgress() called Path::length() and
Path::traversalStateAtLength() to get the position, then its only caller
immediately recomputed both with identical arguments just to read
normalAngle(). Both are full applyElements() walks, O(segments) with
per-curve subdivision, and Path caches neither. The accumulation loop
added 2 more walks per repeat for a loop-invariant result.

Inline the helper so the position and angle come from one traversal
state, hoist Path::length(), and compute the end-of-path position once
before the accumulation loop. That is 4 + 2 * repeatCount walks per
frame down to 1, or 2 when accumulating.

No behavior change. The angle now comes from a state with the same input
as the one it replaces, including on failure, which the old code also
read from. The loop still composes repeatCount separate translations
rather than one scaled translation, since AffineTransform accumulates
through tx * a + ty * c.

* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::calculateAnimatedValue):
(WebCore::SVGAnimateMotionElement::buildTransformForProgress): Deleted.
* Source/WebCore/svg/SVGAnimateMotionElement.h:

Canonical link: <a href="https://commits.webkit.org/318880@main">https://commits.webkit.org/318880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0b1a1b26013380d6a3011f09f29dc47f42f4241

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53729 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144101 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45307f81-7c15-488c-b825-7a61c5cbfed7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140244 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a86e047b-0c32-424e-90af-da3194b68ce7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43852 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120695 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b34e4b3-3f27-41f8-ac5b-85eae7ea1567) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152923 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1076 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46335 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191844 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53399 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/160500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149523 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40048 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54080 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149257 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43911 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126352 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121386 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52597 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/15496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51982 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52223 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52043 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->