### PR TITLE
[Win] Build broken by https://commits.webkit.org/318390@main

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIKeys.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIKeys.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/text/ASCIILiteral.h>
+
 #ifdef __OBJC__
 
 #import <Foundation/Foundation.h>


### PR DESCRIPTION
#### 2de51fe28bfcfbf30356a8602d2632f3ac7f7fc2
<pre>
[Win] Build broken by <a href="https://commits.webkit.org/318390@main">https://commits.webkit.org/318390@main</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320827">https://bugs.webkit.org/show_bug.cgi?id=320827</a>

Unreviewed build fix.

318390@main moved WebExtensionAPIKeys.h out of Cocoa/ and added
ASCIILiteral keys (&quot;delayInMinutes&quot;_s etc.) to the shared section, but
the header never includes &lt;wtf/text/ASCIILiteral.h&gt;. Cocoa translation
units pick up operator&quot;&quot;_s transitively, but on Windows the unified
source including WebExtensionAPIAlarms.cpp does not, failing with &quot;no
matching literal operator for call to &apos;operator&quot;&quot;_s&apos;&quot;. Include what we
use.

* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIKeys.h:

Canonical link: <a href="https://commits.webkit.org/318394@main">https://commits.webkit.org/318394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58dfae365a1b48f71c3003cdf021299cd47fb3cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52146 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187822 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51855 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181165 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/42476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119376 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41142 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39497 "Passed tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36279 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44746 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190249 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51814 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/159214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148071 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; 10 flakes 2 failures; Uploaded test results") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52496 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147844 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27022 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Skipped because there are no valid reviewers; Canonicalized commit; Running push-commit-to-webkit-repo") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/42559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51014 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/14162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50399 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->