### PR TITLE
[JSC] RegExp.prototype.@@split should have fast path using RegExp's specific patterns

### DIFF
--- a/JSTests/microbenchmarks/string-split-regexp-atom.js
+++ b/JSTests/microbenchmarks/string-split-regexp-atom.js
@@ -1,0 +1,20 @@
+//@ skip if $buildType == "debug"
+// Splitting on a regexp that is a plain literal string, which is what Yarr classifies as
+// SpecificPattern::Atom. Only a subject whose StringImpl is an atom can be memoized, so joining the
+// pieces at runtime is what keeps the split cache out of this and leaves the scan being measured.
+(function() {
+    var pieces = [];
+    for (var i = 0; i < 1000; ++i)
+        pieces.push("element" + i);
+    var oneCharacterSeparatorSubject = pieces.join(",");
+    var multiCharacterSeparatorSubject = pieces.join("-|-");
+
+    var result = 0;
+    var n = 20000;
+    for (var i = 0; i < n; ++i) {
+        result += oneCharacterSeparatorSubject.split(/,/).length;
+        result += multiCharacterSeparatorSubject.split(/-\|-/).length;
+    }
+    if (result != n * 2000)
+        throw "Error: bad result: " + result;
+})();

--- a/JSTests/microbenchmarks/string-split-regexp-cached.js
+++ b/JSTests/microbenchmarks/string-split-regexp-cached.js
@@ -1,0 +1,19 @@
+//@ skip if $buildType == "debug"
+// Splitting the same string on the same regexp over and over, which is what the split cache exists
+// for. The subjects are string literals so their StringImpls are atoms, which is what makes a result
+// cacheable at all.
+(function() {
+    var commaSubject = "one,two,three,four,five,six,seven,eight,nine,ten";
+    var lineSubject = "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten";
+    var paddedSubject = "          one two three four five six seven eight nine ten          ";
+
+    var result = 0;
+    var n = 3000000;
+    for (var i = 0; i < n; ++i) {
+        result += commaSubject.split(/,/).length;
+        result += lineSubject.split(/\r\n?|\n/).length;
+        result += paddedSubject.split(/^\s+/).length;
+    }
+    if (result != n * 22)
+        throw "Error: bad result: " + result;
+})();

--- a/JSTests/microbenchmarks/string-split-regexp-newlines.js
+++ b/JSTests/microbenchmarks/string-split-regexp-newlines.js
@@ -1,0 +1,20 @@
+//@ skip if $buildType == "debug"
+// Splitting on \r\n?|\n, which is what Yarr classifies as SpecificPattern::Newlines. Only a subject
+// whose StringImpl is an atom can be memoized, so joining the pieces at runtime is what keeps the
+// split cache out of this and leaves the scan being measured.
+(function() {
+    var pieces = [];
+    for (var i = 0; i < 1000; ++i)
+        pieces.push("element" + i);
+    var unixSubject = pieces.join("\n");
+    var windowsSubject = pieces.join("\r\n");
+
+    var result = 0;
+    var n = 20000;
+    for (var i = 0; i < n; ++i) {
+        result += unixSubject.split(/\r\n?|\n/).length;
+        result += windowsSubject.split(/\r\n?|\n/).length;
+    }
+    if (result != n * 2000)
+        throw "Error: bad result: " + result;
+})();

--- a/JSTests/stress/regexp-split-huge-result-and-cacheable-sink.js
+++ b/JSTests/stress/regexp-split-huge-result-and-cacheable-sink.js
@@ -1,0 +1,177 @@
+//@ $skipModes << :lockdown
+
+// The "absurdly large result" path, taken when a split collects more spans than the span cap
+// (100000). It materializes what the span loop collected, does a dry run to bound the size, and then
+// finishes the split directly into the array. Which pass produces the match the legacy RegExp
+// statics end up holding depends on whether the finishing pass matches anything at all, so both
+// cases are covered below.
+//
+// Also the choice between collecting a specific-pattern split as spans and building it straight into
+// an array. Only a result collected as spans can become a cached butterfly, so a cacheable split has
+// to take the span route; building it directly is invisible in the elements and shows up only as the
+// result no longer being a copy-on-write array served by the StringSplitCache.
+
+function shouldBe(actual, expected, name) {
+    if (actual !== expected)
+        throw new Error("FAIL " + name + ": got=" + JSON.stringify(actual) + " expected=" + JSON.stringify(expected));
+}
+
+// Gives a string an atom StringImpl, which is what the split cache requires of a subject.
+function atomize(string) {
+    let object = {};
+    object[string] = 1;
+    return Object.keys(object)[0];
+}
+
+// 120000 matches of /e(\d)/ produce 240001 elements, well past the 100000 span cap.
+const hugeSeparatorCount = 120000;
+let hugeParts = [];
+for (let i = 0; i < hugeSeparatorCount; ++i)
+    hugeParts.push("e" + (i % 10));
+const hugeSubject = hugeParts.join("");
+
+// Points the statics at an unrelated match, so a path that fails to update them is visible.
+function clobber() {
+    /seed(s)/.exec("hello seeds world");
+}
+
+// The final match of splitting hugeSubject by /e(\d)/ is the trailing "e9".
+{
+    clobber();
+    let result = hugeSubject.split(/e(\d)/);
+    shouldBe(result.length, 2 * hugeSeparatorCount + 1, "huge length");
+    shouldBe(result[0], "", "huge [0]");
+    shouldBe(result[1], "0", "huge [1]");
+    shouldBe(result[result.length - 1], "", "huge last");
+
+    shouldBe(RegExp.input, hugeSubject, "huge input");
+    shouldBe(RegExp.lastMatch, "e9", "huge lastMatch");
+    shouldBe(RegExp.$1, "9", "huge $1");
+    // The last match is the final two characters, so nothing follows it.
+    shouldBe(RegExp.leftContext.length, hugeSubject.length - 2, "huge leftContext length");
+    shouldBe(RegExp.rightContext, "", "huge rightContext");
+}
+
+// A limit exactly at the span cap must still be honored: the split has more elements than the cap,
+// so it is only the limit that stops it, and the trailing element must not be appended on top.
+for (let limit of [99999, 100000, 100001]) {
+    let result = hugeSubject.split(/e(\d)/, limit);
+    shouldBe(result.length, limit, "huge limit=" + limit + " length");
+    // Elements alternate between a separated piece and the capture, starting with a piece.
+    let last = result[result.length - 1];
+    shouldBe(last, limit % 2 ? "" : String((limit / 2 - 1) % 10), "huge limit=" + limit + " last");
+}
+
+// A limit above the element count leaves the result complete, still through the huge path.
+{
+    clobber();
+    let result = hugeSubject.split(/e(\d)/, 0xFFFFFFFF);
+    shouldBe(result.length, 2 * hugeSeparatorCount + 1, "huge unlimited length");
+    shouldBe(RegExp.lastMatch, "e9", "huge unlimited lastMatch");
+    shouldBe(RegExp.rightContext, "", "huge unlimited rightContext");
+}
+
+// A separator ending exactly at the end of the subject leaves the finishing pass with nothing to
+// match, so the statics have to come from the match the span loop stopped on instead. Sizes around
+// the cap cover the boundary in both directions.
+for (let separatorCount of [99999, 100000, 100001]) {
+    clobber();
+    let subject = ",".repeat(separatorCount);
+    let result = subject.split(/,|,/);
+    shouldBe(result.length, separatorCount + 1, "trailing separator count=" + separatorCount + " length");
+    shouldBe(result[0], "", "trailing separator count=" + separatorCount + " [0]");
+    shouldBe(result[result.length - 1], "", "trailing separator count=" + separatorCount + " last");
+    shouldBe(RegExp.lastMatch, ",", "trailing separator count=" + separatorCount + " lastMatch");
+    shouldBe(RegExp.leftContext.length, separatorCount - 1, "trailing separator count=" + separatorCount + " leftContext length");
+    shouldBe(RegExp.rightContext, "", "trailing separator count=" + separatorCount + " rightContext");
+}
+
+// A cacheable specific-pattern split whose result outgrows the span cap cannot be cached, so it
+// abandons the spans it collected and rebuilds the result straight into an array.
+for (let separatorCount of [99999, 100000, 100001, 150000]) {
+    clobber();
+    let subject = atomize("a," .repeat(separatorCount));
+    let result = subject.split(/,/);
+    shouldBe(result.length, separatorCount + 1, "uncacheably large count=" + separatorCount + " length");
+    shouldBe(result[0], "a", "uncacheably large count=" + separatorCount + " [0]");
+    shouldBe(result[result.length - 1], "", "uncacheably large count=" + separatorCount + " last");
+    shouldBe(RegExp.lastMatch, ",", "uncacheably large count=" + separatorCount + " lastMatch");
+    shouldBe(RegExp.rightContext, "", "uncacheably large count=" + separatorCount + " rightContext");
+    // Only a result small enough for the cache is served as a copy-on-write butterfly.
+    let expectedMode = separatorCount + 1 < 100000 ? "CopyOnWriteArrayWithContiguous" : "ArrayWithContiguous";
+    shouldBe($vm.indexingMode(result), expectedMode, "uncacheably large count=" + separatorCount + " indexingMode");
+}
+
+// A cacheable split must be collected as spans so that it can be cached, which makes the result a
+// copy-on-write array. Building it directly into an array instead is otherwise unobservable.
+function shouldBeCached(regexp, subject, name) {
+    // The subject has to be an atom string for the split cache to accept it, which a literal is.
+    let first = subject.split(regexp);
+    shouldBe($vm.indexingMode(first), "CopyOnWriteArrayWithContiguous", name + " first indexingMode");
+
+    let expectedElements = first.join("|");
+    let expectedLastMatch = RegExp.lastMatch;
+    let expectedLeftContext = RegExp.leftContext;
+    let expectedRightContext = RegExp.rightContext;
+
+    // A split served out of the cache skips the match loop, so it has to republish the statics
+    // itself. Clobbering them first makes a missing replay visible, and repeating enough times
+    // covers the cache being dropped by a collection partway through.
+    for (let i = 0; i < 2e3; ++i) {
+        clobber();
+        let repeat = subject.split(regexp);
+        shouldBe($vm.indexingMode(repeat), "CopyOnWriteArrayWithContiguous", name + " repeat indexingMode");
+        shouldBe(repeat.join("|"), expectedElements, name + " repeat elements");
+        shouldBe(RegExp.lastMatch, expectedLastMatch, name + " repeat lastMatch");
+        shouldBe(RegExp.leftContext, expectedLeftContext, name + " repeat leftContext");
+        shouldBe(RegExp.rightContext, expectedRightContext, name + " repeat rightContext");
+        // Writing to one result must not be visible in the next split of the same subject.
+        repeat[0] = "MUTATED";
+    }
+
+    // After the cache is dropped the split is recomputed, and must still be cacheable.
+    $vm.clearStringSplitCache();
+    let recomputed = subject.split(regexp);
+    shouldBe($vm.indexingMode(recomputed), "CopyOnWriteArrayWithContiguous", name + " recomputed indexingMode");
+    shouldBe(recomputed.join("|"), expectedElements, name + " recomputed elements");
+}
+
+shouldBeCached(/,/, "a,b,c", "atom");
+shouldBeCached(/--/, "a--b--c", "atom multi character");
+shouldBeCached(/\r\n?|\n/, "a\nb\r\nc\rd", "newlines");
+shouldBeCached(/^\s*/, "  abc", "leading spaces star");
+shouldBeCached(/^\s+/, "  abc", "leading spaces plus");
+shouldBeCached(/\s*$/, "abc  ", "trailing spaces star");
+shouldBeCached(/\s+$/, "abc  ", "trailing spaces plus");
+// The generic path is cacheable on the same terms.
+shouldBeCached(/,|,/, "a,b,c", "generic");
+
+// A result of 100 elements or more is cached without the atom-strings structure, so it crosses the
+// cache's own size split as well as staying under the span cap.
+{
+    let manyElements = atomize("a,".repeat(300));
+    shouldBeCached(/,/, manyElements, "atom many elements");
+    let nonIdentifierElements = atomize("0-a,".repeat(300));
+    shouldBeCached(/,/, nonIdentifierElements, "atom many non identifier elements");
+}
+
+// A limit makes a split uncacheable, so those results are built directly and are not copy-on-write.
+{
+    let limited = "a,b,c".split(/,/, 2);
+    shouldBe($vm.indexingMode(limited), "ArrayWithContiguous", "limited indexingMode");
+    shouldBe(limited.join("|"), "a|b", "limited elements");
+}
+
+// The shortest subjects still have to reach the direct-array sink. A rope of a one character string
+// is that same string, so a limit is what takes those cases off the cacheable path.
+for (let subject of ["", ",", "a", " ", "\n"]) {
+    for (let regexp of [/,/, /\r\n?|\n/, /^\s*/, /^\s+/, /\s*$/, /\s+$/]) {
+        let direct = subject.split(regexp, 0xFFFFFFFE);
+        let oracle = subject.split(new RegExp(regexp.source + "|" + regexp.source), 0xFFFFFFFE);
+        let name = "short " + JSON.stringify(subject) + " " + regexp;
+        shouldBe(direct.length, oracle.length, name + " length");
+        shouldBe(direct.join("|"), oracle.join("|"), name + " elements");
+        if (subject.length)
+            shouldBe($vm.indexingMode(direct), "ArrayWithContiguous", name + " indexingMode");
+    }
+}

--- a/JSTests/stress/regexp-split-specific-pattern.js
+++ b/JSTests/stress/regexp-split-specific-pattern.js
@@ -1,0 +1,166 @@
+// Split fast paths keyed on Yarr::SpecificPattern must be indistinguishable from the generic split
+// loop, including the legacy RegExp statics (RegExp.input, lastMatch, leftContext, rightContext, $1)
+// and the results served out of the StringSplitCache.
+//
+// Oracle: for any pattern P, `P|P` matches exactly what P does, but having two alternatives makes
+// Yarr classify it as SpecificPattern::None, so it always runs the generic path.
+
+function snapshot()
+{
+    return JSON.stringify([RegExp.input, RegExp.lastMatch, RegExp.leftContext, RegExp.rightContext, RegExp.$1]);
+}
+
+function clobber()
+{
+    // Point the statics at an unrelated match, so a path that forgets to update them, or updates
+    // them when it must not, is visible.
+    /seed(s)/.exec("seeds are seeds");
+}
+
+function runSplit(regexp, subject, limit)
+{
+    clobber();
+    let result = limit === undefined ? subject.split(regexp) : subject.split(regexp, limit);
+    return JSON.stringify([result, snapshot()]);
+}
+
+// A subject built at runtime has a non-atom StringImpl, which is not cacheable. Concatenating with
+// an empty string returns the original string, so for a subject shorter than two characters this is
+// the same cacheable string back; the non-maximum limits in checkAllLimits are what cover the
+// uncached sink for those.
+function rope(string)
+{
+    return string.substring(0, 1) + string.substring(1);
+}
+
+function check(source, flags, subject, limit)
+{
+    let oracle = new RegExp(source + "|" + source, flags);
+    let expected = runSplit(oracle, subject, limit);
+
+    let description = `/${source}/${flags} on ${JSON.stringify(subject)} with limit ${limit}`;
+    let fast = new RegExp(source, flags);
+
+    // Run repeatedly: everything after the first run may be served by the StringSplitCache, which
+    // has to replay the final match into the statics.
+    for (let i = 0; i < 3; ++i) {
+        let actual = runSplit(fast, subject, limit);
+        if (actual !== expected)
+            throw new Error(`${description} run ${i}: expected ${expected} but got ${actual}`);
+    }
+
+    let actual = runSplit(fast, rope(subject), limit);
+    if (actual !== expected)
+        throw new Error(`${description} rope subject: expected ${expected} but got ${actual}`);
+}
+
+function checkAllLimits(source, flags, subject)
+{
+    for (let limit of [undefined, 0, 1, 2, 3, 0xFFFFFFFF, -1])
+        check(source, flags, subject, limit);
+}
+
+let atomSubjects = [
+    "",
+    ",",
+    ",,",
+    ",,,",
+    "a,b,c",
+    ",a,b,",
+    "a",
+    "no separator here",
+    "aaaa",
+    "aa",
+    "abab",
+    "a\uD83D\uDE00,b",
+    "\u1361,\u1362,\u1363",
+    "long,,,string,with,many,,commas,,,",
+];
+
+// The i, m and y flags are the ones that stop a pattern being classified at all, so they are here to
+// catch a classification that ever widens to include them: the fast paths search case-sensitively
+// from the current position and anchor only to the ends of the subject.
+for (let subject of atomSubjects) {
+    for (let source of [",", ",,", "aa", "ab", "a", "long"]) {
+        for (let flags of ["", "g", "u", "gd", "i", "m", "y", "gi", "my"])
+            checkAllLimits(source, flags, subject);
+    }
+}
+
+// 16-bit subject and separator.
+checkAllLimits("\u1361", "", "a\u1361b\u1361\u1361c");
+checkAllLimits("\u1361\u1362", "", "\u1361\u1362x\u1361\u1362");
+
+let spaceSubjects = [
+    "",
+    " ",
+    "   ",
+    "abc",
+    "  abc",
+    "abc  ",
+    "  abc  ",
+    " a b ",
+    // U+00A0, U+1680 and U+FEFF are \s; U+1361 is not.
+    "\t\n\u00a0\u1680\uFEFF abc \t",
+    "\u1361 ",
+    " \u1361",
+];
+
+for (let subject of spaceSubjects) {
+    for (let source of ["^\\s*", "^\\s+", "\\s*$", "\\s+$"])
+        for (let flags of ["", "i", "m", "y"])
+            checkAllLimits(source, flags, subject);
+}
+
+let newlineSubjects = [
+    "",
+    "\n",
+    "\r",
+    "\r\n",
+    "a\nb\r\nc\rd",
+    "\n\n\n",
+    "a\n",
+    "\na",
+    "a\r\n\r\nb",
+];
+
+for (let subject of newlineSubjects) {
+    for (let source of ["\\r\\n?|\\n", "\\n|\\r\\n?"])
+        for (let flags of ["", "i", "m", "y"])
+            checkAllLimits(source, flags, subject);
+}
+
+// Results large enough to cross StringSplitCache's atomStringsArrayLimit (100), and elements that do
+// not start with an identifier character, which forces the array's structure downgrade. Only an atom
+// subject reaches the cache at all, so each case is run both ways.
+{
+    let identifiers = [];
+    let nonIdentifiers = [];
+    for (let i = 0; i < 300; ++i) {
+        identifiers.push(`element${i}`);
+        nonIdentifiers.push(`${i}-element`);
+    }
+
+    function atomize(string)
+    {
+        let object = {};
+        object[string] = 1;
+        return Object.keys(object)[0];
+    }
+
+    for (let subject of [identifiers.join(","), nonIdentifiers.join(",")]) {
+        checkAllLimits(",", "", subject);
+        checkAllLimits(",", "", atomize(subject));
+    }
+    checkAllLimits("--", "", identifiers.join("--"));
+    checkAllLimits("--", "", atomize(identifiers.join("--")));
+}
+
+// Keep this last: an indexed accessor on Object.prototype makes the global object have a bad time,
+// which is irreversible. Results are then uncacheable and the arrays are slow-put.
+Object.defineProperty(Object.prototype, 0, { get() { return "getterOnPrototype"; }, configurable: true });
+
+for (let subject of ["", ",", "a,b,c", "  abc  ", "a\nb\nc"]) {
+    for (let source of [",", "a", "^\\s*", "^\\s+", "\\s*$", "\\s+$", "\\r\\n?|\\n"])
+        checkAllLimits(source, "", subject);
+}

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -467,8 +467,10 @@ void RegExp::deleteCode()
     if (!hasCode())
         return;
     m_state = NotCompiled;
-    m_atom = String();
+    // Clear the classification before the atom it describes, so a reader that has already sampled
+    // a non-None pattern cannot go on to read an emptied atom.
     m_specificPattern = Yarr::SpecificPattern::None;
+    m_atom = String();
 #if ENABLE(YARR_JIT)
     if (m_regExpJITCode)
         m_regExpJITCode->clear(locker);

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -31,6 +31,7 @@
 #include "JSRegExpStringIterator.h"
 #include "JSStringInlines.h"
 #include "ObjectConstructor.h"
+#include "ParseInt.h"
 #include "RegExpConstructor.h"
 #include "StringPrototypeInlines.h"
 #include "VMEntryScopeInlines.h"
@@ -676,7 +677,7 @@ enum SplitControl {
 
 template<typename ControlFunc, typename PushFunc>
 MatchResult genericSplit(
-    JSGlobalObject* globalObject, RegExp* regexp, JSString* inputString, StringView input, unsigned inputSize, unsigned& position,
+    JSGlobalObject* globalObject, RegExp* regexp, StringView input, unsigned inputSize, unsigned& position,
     unsigned& matchPosition, bool regExpIsSticky, bool regExpIsUnicode,
     const ControlFunc& control, const PushFunc& push)
 {
@@ -692,13 +693,13 @@ MatchResult genericSplit(
                 return lastMatchResult;
         }
 
-        int* ovector;
-
         // a. Perform ? Set(splitter, "lastIndex", q, true).
         // b. Let z be ? RegExpExec(splitter, S).
-        MatchResult result = globalObject->regExpGlobalData().performMatch(globalObject, regexp, inputString, input, matchPosition, &ovector);
-        int mpos = result.start;
+        // Only the last match of a split is observable through the legacy RegExp statics, so this
+        // matches without RegExpGlobalData::performMatch and leaves that single record to the caller.
+        int mpos = regexp->match(globalObject, input, matchPosition, regexp->ovectorSpan());
         RETURN_IF_EXCEPTION(scope, { });
+        int* ovector = regexp->ovectorSpan().data();
 
         // c. If z is null, let q be AdvanceStringIndex(S, q, unicodeMatching).
         if (mpos < 0) {
@@ -707,7 +708,9 @@ MatchResult genericSplit(
             matchPosition = advanceStringIndex(input, inputSize, matchPosition, regExpIsUnicode);
             continue;
         }
-        lastMatchResult = result;
+        ASSERT(ovector[0] == mpos);
+        ASSERT(ovector[1] >= mpos);
+        lastMatchResult = MatchResult(mpos, ovector[1]);
         if (static_cast<unsigned>(mpos) >= inputSize) {
             // The spec redoes the RegExpExec starting at the next character of the input.
             // But in our case, mpos < 0 means that the native regexp already searched all permutations
@@ -775,6 +778,11 @@ MatchResult genericSplit(
 // substring of the input, and is recorded with notFound as its start.
 static constexpr unsigned undefinedSplitSpanStart = static_cast<unsigned>(WTF::notFound);
 static_assert(JSString::MaxLength < undefinedSplitSpanStart, "notFound must not be a representable offset, or a real element would decode as undefined");
+
+// Collecting spans costs two entries in a scratch vector that lives as long as the VM, and only
+// pays for itself if the result can be cached. tryAddToRegExpSplitCache refuses anything this
+// large, so past it the collection is pure overhead and the split builds its array directly.
+static constexpr unsigned maxSpanCollectionCount = MIN_SPARSE_ARRAY_INDEX;
 
 static ALWAYS_INLINE void recordSplitSpan(Vector<unsigned>& spans, unsigned start, unsigned length)
 {
@@ -861,6 +869,244 @@ static NEVER_INLINE JSArray* tryAddToRegExpSplitCache(JSGlobalObject* globalObje
     return JSArray::createWithButterfly(vm, nullptr, arrayStructure, newButterfly->toButterfly());
 }
 
+template<bool buildArrayDirectly>
+static ALWAYS_INLINE void pushSplitElement(JSGlobalObject* globalObject, VM& vm, JSString* inputString, JSArray* directArray, Vector<unsigned>& spans, unsigned index, unsigned start, unsigned length)
+{
+    if constexpr (buildArrayDirectly)
+        directArray->putDirectIndex(globalObject, index, jsSubstringOfResolved(vm, inputString, start, length));
+    else {
+        ASSERT(splitSpanCount(spans) == index);
+        recordSplitSpan(spans, start, length);
+    }
+}
+
+template<bool buildArrayDirectly>
+static JSCell* finishSplitFast(JSGlobalObject* globalObject, RegExp* regexp, JSString* inputString, StringView input, JSArray* directArray, unsigned position, unsigned elementCount, unsigned limit, bool cacheable, MatchResult lastMatchResult)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    ASSERT(buildArrayDirectly == !!directArray);
+    auto& spans = vm.stringSplitIndice;
+    unsigned inputSize = input.length();
+
+    if (lastMatchResult)
+        globalObject->regExpGlobalData().recordMatch(vm, globalObject, regexp, inputString, lastMatchResult, /* oneCharacterMatch */ false);
+
+    if (elementCount < limit) {
+        // 20. Let substring be the substring of string from lastMatchEnd to size.
+        // 21. Perform ! CreateDataPropertyOrThrow(array, ! ToString(lengthA), substring).
+        pushSplitElement<buildArrayDirectly>(globalObject, vm, inputString, directArray, spans, elementCount, position, inputSize - position);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        if constexpr (!buildArrayDirectly) {
+            if (cacheable) {
+                JSArray* cached = tryAddToRegExpSplitCache(globalObject, vm, inputString, input, regexp, spans, lastMatchResult);
+                RETURN_IF_EXCEPTION(scope, { });
+                if (cached)
+                    return cached;
+            }
+        }
+    }
+
+    // 22. Return array.
+    if constexpr (buildArrayDirectly)
+        return directArray;
+    else
+        RELEASE_AND_RETURN(scope, createArrayFromSplitSpans(globalObject, vm, inputString, spans));
+}
+
+template<bool buildArrayDirectly>
+static NEVER_INLINE JSCell* splitFastByAtom(JSGlobalObject* globalObject, RegExp* regexp, JSString* inputString, StringView input, JSArray* directArray, unsigned limit, bool cacheable, bool& exceededSpanCollection)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto& spans = vm.stringSplitIndice;
+
+    ASSERT(regexp->hasValidAtom());
+    ASSERT(!regexp->numSubpatterns());
+    // The scan below searches case-sensitively from |position|, so a sticky, case-insensitive or
+    // multiline pattern would give a different answer than matching the regexp would.
+    ASSERT(!regexp->sticky() && !regexp->ignoreCase() && !regexp->multiline());
+    ASSERT(limit);
+
+    StringView separator { regexp->atom() };
+    unsigned separatorLength = separator.length();
+    // Nothing advances |position| past a zero-length separator, so the scan would not terminate.
+    RELEASE_ASSERT(separatorLength);
+
+    MatchResult lastMatchResult = MatchResult::failed();
+    unsigned elementCount = 0;
+    unsigned position = 0;
+
+    auto scan = [&](auto findSeparator) {
+        while (elementCount < limit) {
+            if constexpr (!buildArrayDirectly) {
+                if (elementCount >= maxSpanCollectionCount) [[unlikely]] {
+                    exceededSpanCollection = true;
+                    return;
+                }
+            }
+
+            size_t matchPosition = findSeparator(position);
+            if (matchPosition == notFound)
+                return;
+
+            lastMatchResult = MatchResult(matchPosition, matchPosition + separatorLength);
+            pushSplitElement<buildArrayDirectly>(globalObject, vm, inputString, directArray, spans, elementCount++, position, matchPosition - position);
+            RETURN_IF_EXCEPTION(scope, void());
+            position = matchPosition + separatorLength;
+        }
+    };
+
+    if (separatorLength == 1) {
+        char16_t separatorCharacter = separator[0];
+        if (input.is8Bit()) {
+            auto span = input.span8();
+            scan([&](unsigned from) ALWAYS_INLINE_LAMBDA {
+                return WTF::find(span, separatorCharacter, from);
+            });
+        } else {
+            auto span = input.span16();
+            scan([&](unsigned from) ALWAYS_INLINE_LAMBDA {
+                return WTF::find(span, separatorCharacter, from);
+            });
+        }
+    } else {
+        scan([&](unsigned from) ALWAYS_INLINE_LAMBDA {
+            return input.find(vm.adaptiveStringSearcherTables(), separator, from);
+        });
+    }
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if constexpr (!buildArrayDirectly) {
+        if (exceededSpanCollection) [[unlikely]]
+            return nullptr;
+    }
+
+    RELEASE_AND_RETURN(scope, finishSplitFast<buildArrayDirectly>(globalObject, regexp, inputString, input, directArray, position, elementCount, limit, cacheable, lastMatchResult));
+}
+
+template<bool buildArrayDirectly>
+static NEVER_INLINE JSCell* splitFastByNewlines(JSGlobalObject* globalObject, RegExp* regexp, JSString* inputString, StringView input, JSArray* directArray, unsigned limit, bool cacheable, bool& exceededSpanCollection)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto& spans = vm.stringSplitIndice;
+
+    ASSERT(!regexp->numSubpatterns());
+    ASSERT(!regexp->sticky() && !regexp->ignoreCase() && !regexp->multiline() && !regexp->eitherUnicode());
+    ASSERT(limit);
+
+    unsigned inputSize = input.length();
+    MatchResult lastMatchResult = MatchResult::failed();
+    unsigned elementCount = 0;
+    unsigned position = 0;
+
+    auto processSplit = [&](auto span) {
+        while (position < inputSize && elementCount < limit) {
+            if constexpr (!buildArrayDirectly) {
+                if (elementCount >= maxSpanCollectionCount) [[unlikely]] {
+                    exceededSpanCollection = true;
+                    return;
+                }
+            }
+
+            auto newlinePos = WTF::findNextNewline(span, position);
+            if (newlinePos.position == WTF::notFound)
+                break;
+
+            lastMatchResult = MatchResult(newlinePos.position, newlinePos.position + newlinePos.length);
+            pushSplitElement<buildArrayDirectly>(globalObject, vm, inputString, directArray, spans, elementCount++, position, newlinePos.position - position);
+            RETURN_IF_EXCEPTION(scope, void());
+            position = newlinePos.position + newlinePos.length;
+        }
+    };
+
+    if (input.is8Bit())
+        processSplit(input.span8());
+    else
+        processSplit(input.span16());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if constexpr (!buildArrayDirectly) {
+        if (exceededSpanCollection) [[unlikely]]
+            return nullptr;
+    }
+
+    RELEASE_AND_RETURN(scope, finishSplitFast<buildArrayDirectly>(globalObject, regexp, inputString, input, directArray, position, elementCount, limit, cacheable, lastMatchResult));
+}
+
+template<bool buildArrayDirectly>
+static NEVER_INLINE JSCell* splitFastBySpaces(JSGlobalObject* globalObject, RegExp* regexp, JSString* inputString, StringView input, JSArray* directArray, unsigned limit, bool cacheable, Yarr::SpecificPattern specificPattern)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto& spans = vm.stringSplitIndice;
+
+    ASSERT(!regexp->numSubpatterns());
+    ASSERT(!regexp->sticky() && !regexp->ignoreCase() && !regexp->multiline() && !regexp->eitherUnicode());
+    // Element 0 below is pushed without consulting |limit|, which is only sound because a zero
+    // limit returns an empty array before any of this runs.
+    ASSERT(limit);
+
+    unsigned inputSize = input.length();
+    auto finish = [&](MatchResult lastMatchResult, unsigned elementCount, unsigned position) -> JSCell* {
+        return finishSplitFast<buildArrayDirectly>(globalObject, regexp, inputString, input, directArray, position, elementCount, limit, cacheable, lastMatchResult);
+    };
+
+    if (specificPattern == Yarr::SpecificPattern::LeadingSpacesStar || specificPattern == Yarr::SpecificPattern::LeadingSpacesPlus) {
+        unsigned leadingSpaces = 0;
+        while (leadingSpaces < inputSize && isStrWhiteSpace(input.codeUnitAt(leadingSpaces)))
+            ++leadingSpaces;
+
+        if (!leadingSpaces) {
+            bool matchedEmptyAtStart = specificPattern == Yarr::SpecificPattern::LeadingSpacesStar;
+            RELEASE_AND_RETURN(scope, finish(matchedEmptyAtStart ? MatchResult(0, 0) : MatchResult::failed(), 0, 0));
+        }
+
+        pushSplitElement<buildArrayDirectly>(globalObject, vm, inputString, directArray, spans, 0, 0, 0);
+        RETURN_IF_EXCEPTION(scope, { });
+        RELEASE_AND_RETURN(scope, finish(MatchResult(0, leadingSpaces), 1, leadingSpaces));
+    }
+
+    ASSERT(specificPattern == Yarr::SpecificPattern::TrailingSpacesStar || specificPattern == Yarr::SpecificPattern::TrailingSpacesPlus);
+    unsigned trailingSpacesStart = inputSize;
+    while (trailingSpacesStart && isStrWhiteSpace(input.codeUnitAt(trailingSpacesStart - 1)))
+        --trailingSpacesStart;
+
+    if (trailingSpacesStart == inputSize) {
+        bool matchedEmptyAtEnd = specificPattern == Yarr::SpecificPattern::TrailingSpacesStar;
+        RELEASE_AND_RETURN(scope, finish(matchedEmptyAtEnd ? MatchResult(inputSize, inputSize) : MatchResult::failed(), 0, 0));
+    }
+
+    pushSplitElement<buildArrayDirectly>(globalObject, vm, inputString, directArray, spans, 0, 0, trailingSpacesStart);
+    RETURN_IF_EXCEPTION(scope, { });
+    RELEASE_AND_RETURN(scope, finish(MatchResult(trailingSpacesStart, inputSize), 1, inputSize));
+}
+
+// Returns null without an exception when the span-collecting instantiation gave up because the
+// result outgrew maxSpanCollectionCount; the caller then rebuilds it straight into an array.
+template<bool buildArrayDirectly>
+static ALWAYS_INLINE JSCell* splitFastBySpecificPattern(JSGlobalObject* globalObject, RegExp* regexp, JSString* inputString, StringView input, JSArray* directArray, unsigned limit, bool cacheable, Yarr::SpecificPattern specificPattern, bool& exceededSpanCollection)
+{
+    ASSERT(buildArrayDirectly == !!directArray);
+
+    switch (specificPattern) {
+    case Yarr::SpecificPattern::Atom:
+        return splitFastByAtom<buildArrayDirectly>(globalObject, regexp, inputString, input, directArray, limit, cacheable, exceededSpanCollection);
+    case Yarr::SpecificPattern::Newlines:
+        return splitFastByNewlines<buildArrayDirectly>(globalObject, regexp, inputString, input, directArray, limit, cacheable, exceededSpanCollection);
+    case Yarr::SpecificPattern::LeadingSpacesStar:
+    case Yarr::SpecificPattern::LeadingSpacesPlus:
+    case Yarr::SpecificPattern::TrailingSpacesStar:
+    case Yarr::SpecificPattern::TrailingSpacesPlus:
+        return splitFastBySpaces<buildArrayDirectly>(globalObject, regexp, inputString, input, directArray, limit, cacheable, specificPattern);
+    case Yarr::SpecificPattern::None:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 // Fast path used by RegExp.prototype[Symbol.split] and String.prototype.split when the
 // receiver is a primordial RegExpObject. Skips the species construct, custom flags, and
 // custom exec — caller must guarantee non-observability via isSymbolSplitFastAndNonObservable().
@@ -931,53 +1177,31 @@ JSCell* regExpSplitFast(JSGlobalObject* globalObject, RegExpObject* regexpObject
         return result;
     }
 
-    // Fast path for newline splitting pattern: \r\n?|\n
-    if (regexp->specificPattern() == Yarr::SpecificPattern::Newlines) {
-        JSArray* result = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 1);
-        if (!result) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return { };
-        }
+    auto& spans = vm.stringSplitIndice;
+    spans.shrink(0);
 
-        unsigned resultLength = 0;
-        MatchResult lastMatchResult = MatchResult::failed();
+    auto specificPattern = regexp->specificPattern();
 
-        auto processSplit = [&](auto span) {
-            while (position < inputSize && resultLength < limit) {
-                auto newlinePos = WTF::findNextNewline(span, position);
-                if (newlinePos.position == WTF::notFound)
-                    break;
-
-                // Record before pushing so limit-abort still reports the last match (matches genericSplit behavior).
-                lastMatchResult = MatchResult(newlinePos.position, newlinePos.position + newlinePos.length);
-
-                result->putDirectIndex(globalObject, resultLength++, jsSubstringOfResolved(vm, inputString, position, newlinePos.position - position));
-                RETURN_IF_EXCEPTION(scope, AbortSplit);
-
-                if (resultLength >= limit)
-                    break;
-
-                position = newlinePos.position + newlinePos.length;
-            }
-            return ContinueSplit;
+    if (specificPattern != Yarr::SpecificPattern::None) {
+        auto createDirectArray = [&]() -> JSArray* {
+            JSArray* array = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 1);
+            if (!array) [[unlikely]]
+                throwOutOfMemoryError(globalObject, scope);
+            return array;
         };
 
-        if (input->is8Bit())
-            processSplit(input->span8());
-        else
-            processSplit(input->span16());
+        bool exceededSpanCollection = false;
+        if (cacheable) {
+            JSCell* result = splitFastBySpecificPattern<false>(globalObject, regexp, inputString, input, nullptr, limit, cacheable, specificPattern, exceededSpanCollection);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (!exceededSpanCollection)
+                return result;
+            spans.shrink(0);
+        }
+
+        JSArray* directArray = createDirectArray();
         RETURN_IF_EXCEPTION(scope, { });
-
-        if (lastMatchResult)
-            globalObject->regExpGlobalData().recordMatch(vm, globalObject, regexp, inputString, lastMatchResult, false);
-
-        if (resultLength >= limit)
-            return result;
-
-        result->putDirectIndex(globalObject, resultLength++, jsSubstringOfResolved(vm, inputString, position, inputSize - position));
-        RETURN_IF_EXCEPTION(scope, { });
-
-        return result;
+        RELEASE_AND_RETURN(scope, splitFastBySpecificPattern<true>(globalObject, regexp, inputString, input, directArray, limit, /* cacheable */ false, specificPattern, exceededSpanCollection));
     }
 
     // 16. Let size be the length of string.
@@ -990,10 +1214,8 @@ JSCell* regExpSplitFast(JSGlobalObject* globalObject, RegExpObject* regexpObject
 
     unsigned maxSizeForDirectPath = 100000;
 
-    auto& spans = vm.stringSplitIndice;
-    spans.shrink(0);
     MatchResult lastMatchResult = genericSplit(
-        globalObject, regexp, inputString, input, inputSize, position, matchPosition, regExpIsSticky, regExpIsUnicode,
+        globalObject, regexp, input, inputSize, position, matchPosition, regExpIsSticky, regExpIsUnicode,
         [&] () -> SplitControl {
             if (splitSpanCount(spans) >= maxSizeForDirectPath)
                 return AbortSplit;
@@ -1007,28 +1229,14 @@ JSCell* regExpSplitFast(JSGlobalObject* globalObject, RegExpObject* regexpObject
         });
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (splitSpanCount(spans) >= limit)
-        RELEASE_AND_RETURN(scope, createArrayFromSplitSpans(globalObject, vm, inputString, spans));
-
-    if (splitSpanCount(spans) < maxSizeForDirectPath) {
-        // 20. Let substring be the substring of string from lastMatchEnd to size.
-        // 21. Perform ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(lengthA)), substring).
-        recordSplitSpan(spans, position, inputSize - position);
-
-        if (cacheable) {
-            JSArray* cached = tryAddToRegExpSplitCache(globalObject, vm, inputString, input, regexp, spans, lastMatchResult);
-            RETURN_IF_EXCEPTION(scope, { });
-            if (cached)
-                return cached;
-        }
-
-        // 22. Return array.
-        RELEASE_AND_RETURN(scope, createArrayFromSplitSpans(globalObject, vm, inputString, spans));
-    }
+    if (splitSpanCount(spans) >= limit || splitSpanCount(spans) < maxSizeForDirectPath)
+        RELEASE_AND_RETURN(scope, finishSplitFast<false>(globalObject, regexp, inputString, input, nullptr, position, splitSpanCount(spans), limit, cacheable, lastMatchResult));
 
     // Absurdly large results are not cached, and recording every element up front would cost more
     // scratch space than the dry run below needs to bound the total size. Materialize what the split
     // produced so far and finish it directly into the array.
+    if (lastMatchResult)
+        globalObject->regExpGlobalData().recordMatch(vm, globalObject, regexp, inputString, lastMatchResult, /* oneCharacterMatch */ false);
     JSArray* result = createArrayFromSplitSpans(globalObject, vm, inputString, spans);
     RETURN_IF_EXCEPTION(scope, { });
     unsigned resultLength = splitSpanCount(spans);
@@ -1038,7 +1246,7 @@ JSCell* regExpSplitFast(JSGlobalObject* globalObject, RegExpObject* regexpObject
     unsigned savedMatchPosition = matchPosition;
     unsigned dryRunCount = 0;
     genericSplit(
-        globalObject, regexp, inputString, input, inputSize, position, matchPosition, regExpIsSticky, regExpIsUnicode,
+        globalObject, regexp, input, inputSize, position, matchPosition, regExpIsSticky, regExpIsUnicode,
         [&] () -> SplitControl {
             if (resultLength + dryRunCount > MAX_STORAGE_VECTOR_LENGTH)
                 return AbortSplit;
@@ -1051,18 +1259,18 @@ JSCell* regExpSplitFast(JSGlobalObject* globalObject, RegExpObject* regexpObject
             return ContinueSplit;
         });
     RETURN_IF_EXCEPTION(scope, { });
-    
+
     if (resultLength + dryRunCount > MAX_STORAGE_VECTOR_LENGTH) {
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }
-    
+
     // OK, we know that if we finish the split, we won't have to OOM.
     position = savedPosition;
     matchPosition = savedMatchPosition;
 
-    genericSplit(
-        globalObject, regexp, inputString, input, inputSize, position, matchPosition, regExpIsSticky, regExpIsUnicode,
+    MatchResult remainingMatchResult = genericSplit(
+        globalObject, regexp, input, inputSize, position, matchPosition, regExpIsSticky, regExpIsUnicode,
         [&] () -> SplitControl {
             return ContinueSplit;
         },
@@ -1074,6 +1282,9 @@ JSCell* regExpSplitFast(JSGlobalObject* globalObject, RegExpObject* regexpObject
             return ContinueSplit;
         });
     RETURN_IF_EXCEPTION(scope, { });
+
+    if (remainingMatchResult)
+        globalObject->regExpGlobalData().recordMatch(vm, globalObject, regexp, inputString, remainingMatchResult, /* oneCharacterMatch */ false);
 
     if (resultLength >= limit)
         return result;

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -65,6 +65,7 @@
 #include "ShadowChicken.h"
 #include "Snippet.h"
 #include "SnippetParams.h"
+#include "StringSplitCache.h"
 #include "Strong.h"
 #include "StructureCreateInlines.h"
 #include "TypeProfiler.h"
@@ -2137,6 +2138,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionTriggerMemoryPressure);
 static JSC_DECLARE_HOST_FUNCTION(functionGC);
 static JSC_DECLARE_HOST_FUNCTION(functionEdenGC);
 static JSC_DECLARE_HOST_FUNCTION(functionGCSweepAsynchronously);
+static JSC_DECLARE_HOST_FUNCTION(functionClearStringSplitCache);
 static JSC_DECLARE_HOST_FUNCTION(functionDumpSubspaceHashes);
 static JSC_DECLARE_HOST_FUNCTION(functionCallFrame);
 static JSC_DECLARE_HOST_FUNCTION(functionCodeBlockForFrame);
@@ -2658,6 +2660,14 @@ JSC_DEFINE_HOST_FUNCTION(functionGCSweepAsynchronously, (JSGlobalObject* globalO
 {
     DollarVMAssertScope assertScope;
     globalObject->vm().heap.collectNow(Async, CollectionScope::Full);
+    return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionClearStringSplitCache, (JSGlobalObject* globalObject, CallFrame*))
+{
+    DollarVMAssertScope assertScope;
+    if (auto* cache = globalObject->vm().stringSplitCache())
+        cache->clear();
     return JSValue::encode(jsUndefined());
 }
 
@@ -4550,6 +4560,7 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, alwaysAllow, "triggerMemoryPressure"_s, functionTriggerMemoryPressure, 0);
     addFunction(vm, alwaysAllow, "gc"_s, functionGC, 0);
     addFunction(vm, alwaysAllow, "gcSweepAsynchronously"_s, functionGCSweepAsynchronously, 0);
+    addFunction(vm, alwaysAllow, "clearStringSplitCache"_s, functionClearStringSplitCache, 0);
     addFunction(vm, alwaysAllow, "edenGC"_s, functionEdenGC, 0);
     addFunction(vm, alwaysAllow, "dumpSubspaceHashes"_s, functionDumpSubspaceHashes, 0);
 


### PR DESCRIPTION
#### 2d381fd223950d0143f2bd52c7e7bbeab64819f4
<pre>
[JSC] RegExp.prototype.@@split should have fast path using RegExp&apos;s specific patterns
<a href="https://bugs.webkit.org/show_bug.cgi?id=320828">https://bugs.webkit.org/show_bug.cgi?id=320828</a>
<a href="https://rdar.apple.com/183840745">rdar://183840745</a>

Reviewed by NOBODY (OOPS!).

WIP

Tests: JSTests/microbenchmarks/string-split-regexp-atom.js
       JSTests/microbenchmarks/string-split-regexp-cached.js
       JSTests/microbenchmarks/string-split-regexp-newlines.js
       JSTests/stress/regexp-split-huge-result-and-cacheable-sink.js
       JSTests/stress/regexp-split-specific-pattern.js

* JSTests/microbenchmarks/string-split-regexp-atom.js: Added.
* JSTests/microbenchmarks/string-split-regexp-cached.js: Added.
* JSTests/microbenchmarks/string-split-regexp-newlines.js: Added.
* JSTests/stress/regexp-split-huge-result-and-cacheable-sink.js: Added.
(shouldBe):
(atomize):
(clobber):
(seed.exec):
(limit.2.string_appeared_here.String):
(shouldBeCached):
* JSTests/stress/regexp-split-specific-pattern.js: Added.
(snapshot):
(clobber):
(runSplit):
(rope):
(check):
(string_appeared_here.checkAllLimits.atomize):
(string_appeared_here.checkAllLimits):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::deleteCode):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::genericSplit):
(JSC::pushSplitElement):
(JSC::finishSplitFast):
(JSC::splitFastByAtom):
(JSC::splitFastByNewlines):
(JSC::splitFastBySpaces):
(JSC::splitFastBySpecificPattern):
(JSC::regExpSplitFast):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d381fd223950d0143f2bd52c7e7bbeab64819f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141463 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/054b5965-47f5-459e-9d14-105f5dcf6d28) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138927 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96452 "2 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb705370-e7a7-4d10-badb-2d56dba4e3fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119383 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d896b362-eed2-4f37-9b77-4d99ed479345) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41150 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39504 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1352 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8182 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39190 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36287 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39489 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190257 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51822 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148078 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52504 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35815 "Too many flaky failures: http/tests/cookies/same-site/user-load-cross-site-redirect.py, http/tests/media/media-element-frame-destroyed-crash.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/postredirect-basic.html, http/tests/resourceLoadStatistics/grandfathering.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/iframe-redirect-blocked-by-child-src.html, http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image-UpgradeMixedContent.https.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147851 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42566 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124768 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119325 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51022 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14166 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50407 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50647 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50469 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->