### PR TITLE
CSS clip on a child is ignored when determining whether an ancestor's background is obscured

### DIFF
--- a/LayoutTests/fast/backgrounds/obscured-background-css-clipped-child-expected.html
+++ b/LayoutTests/fast/backgrounds/obscured-background-css-clipped-child-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<title>A child with CSS clip does not obscure its parent's background</title>
+<style>
+#parent {
+    position: relative;
+    width: 200px;
+    height: 200px;
+    background-color: green;
+}
+#child {
+    position: absolute;
+    left: 50px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+}
+</style>
+<body>
+<p>The green square below should have a blue square in its center. There should be no white area inside the green square.</p>
+<div id="parent">
+    <div id="child"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/backgrounds/obscured-background-css-clipped-child.html
+++ b/LayoutTests/fast/backgrounds/obscured-background-css-clipped-child.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<title>A child with CSS clip does not obscure its parent's background</title>
+<style>
+#parent {
+    position: relative;
+    width: 200px;
+    height: 200px;
+    background-color: green;
+}
+#child {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background-color: blue;
+    /* Clip the 200x200 box down to a centered, 100x100 square. */
+    clip: rect(50px, 150px, 150px, 50px);
+}
+</style>
+<body>
+<p>The green square below should have a blue square in its center. There should be no white area inside the green square.</p>
+<div id="parent">
+    <div id="child"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/backgrounds/obscured-background-css-clipped-grandchild-expected.html
+++ b/LayoutTests/fast/backgrounds/obscured-background-css-clipped-grandchild-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<title>An opaque grandchild inside a CSS clipped child does not obscure the parent's background</title>
+<style>
+#parent {
+    position: relative;
+    width: 200px;
+    height: 200px;
+    background-color: green;
+}
+#grandchild {
+    position: absolute;
+    left: 50px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+}
+</style>
+<body>
+<p>The green square below should have a blue square in its center. There should be no white area inside the green square.</p>
+<div id="parent">
+    <div id="grandchild"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/backgrounds/obscured-background-css-clipped-grandchild.html
+++ b/LayoutTests/fast/backgrounds/obscured-background-css-clipped-grandchild.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<title>An opaque grandchild inside a CSS clipped child does not obscure the parent's background</title>
+<style>
+#parent {
+    position: relative;
+    width: 200px;
+    height: 200px;
+    background-color: green;
+}
+#child {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    /* Clip the 200x200 box down to a centered, 100x100 square. */
+    clip: rect(50px, 150px, 150px, 50px);
+}
+#grandchild {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background-color: blue;
+}
+</style>
+<body>
+<p>The green square below should have a blue square in its center. There should be no white area inside the green square.</p>
+<div id="parent">
+    <div id="child">
+        <div id="grandchild"></div>
+    </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2035,6 +2035,8 @@ static bool isCandidateForOpaquenessTest(const RenderBox& childBox)
         return false;
     if (!childStyle.shapeOutside().isNone())
         return false;
+    if (childBox.hasClip())
+        return false;
     if (!childBox.borderBoxWidth() || !childBox.borderBoxHeight())
         return false;
     if (CheckedPtr childLayer = childBox.layer()) {


### PR DESCRIPTION
#### daa83dc8ed6a2a6c6364b9c6de5e024649c4d842
<pre>
CSS clip on a child is ignored when determining whether an ancestor&apos;s background is obscured
<a href="https://bugs.webkit.org/show_bug.cgi?id=320829">https://bugs.webkit.org/show_bug.cgi?id=320829</a>
<a href="https://rdar.apple.com/183841775">rdar://183841775</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/f3d25d319c4feb8ad68c6fde2b3ef3972384f1fe">https://chromium.googlesource.com/chromium/src.git/+/f3d25d319c4feb8ad68c6fde2b3ef3972384f1fe</a>

RenderBox::foregroundIsKnownToBeOpaqueInRect() computes whether a box&apos;s
background is obscured by recursively checking if any descendant fully
covers it, letting BackgroundPainter skip painting the background. The
recursion did not account for descendants with CSS clip, so an ancestor
could be treated as obscured even though the covering descendant only
painted part of its border box.

RenderBox::backgroundIsKnownToBeOpaqueInRect() already bails out on
hasClip(), so a directly clipped child was handled. The gap was one level
down: a clipped child with no background of its own was still recursed
into, and an opaque grandchild filling that child was taken as covering
the ancestor. The clip on the intermediate child was never consulted.

Reject clipped boxes in isCandidateForOpaquenessTest() instead of in
backgroundIsKnownToBeOpaqueInRect(), since CSS clip applies to a box&apos;s
foreground as well as its background. hasClip() is
isOutOfFlowPositioned() &amp;&amp; !style().clip().isAuto(), so it already
encodes that clip only applies to out-of-flow boxes.

This makes the obscuration optimization fire less often and so paints
some backgrounds that were previously skipped. The compositing path is
unaffected: RenderLayerBacking::setContentsOpaque() reaches
RenderBox::backgroundIsKnownToBeOpaqueInRect(), which already checked
hasClip().

Tests: fast/backgrounds/obscured-background-css-clipped-child.html
       fast/backgrounds/obscured-background-css-clipped-grandchild.html

* LayoutTests/fast/backgrounds/obscured-background-css-clipped-child-expected.html: Added.
* LayoutTests/fast/backgrounds/obscured-background-css-clipped-child.html: Added.
* LayoutTests/fast/backgrounds/obscured-background-css-clipped-grandchild-expected.html: Added.
* LayoutTests/fast/backgrounds/obscured-background-css-clipped-grandchild.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::isCandidateForOpaquenessTest):

Canonical link: <a href="https://commits.webkit.org/318636@main">https://commits.webkit.org/318636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc6bcfc4a63677986c2af7f4906cab3c07f1caf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187829 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141462 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4245e4bc-50c9-49ea-80af-97cb5940ab3f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138926 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96451 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8a8dcb7-bb41-4bf6-b296-8b45f43d0a36) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119382 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75af614e-b09a-4af7-ad87-2592af3975dc) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41148 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed layout tests; Ignored 4 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39502 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39189 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190256 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148077 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39905 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52503 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147850 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42564 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124767 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119324 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51021 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14165 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50406 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50646 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50468 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->