### PR TITLE
[SwiftUI WebKit API] Expose _overrideViewportWithArguments on WebPage

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage+SPI.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+SPI.swift
@@ -37,14 +37,6 @@ extension WebPage {
     public func setMenuBuilder(_ menuBuilder: ((WKContextMenuElementInfoAdapter) -> NSMenu)?) {
         backingUIDelegate.menuBuilder = menuBuilder
     }
-
-    // SPI for testing.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    @_spi(Testing)
-    public var smartListsEnabled: Bool {
-        get { backingWebView._isSmartListsEnabled() }
-        set { backingWebView._setSmartListsEnabled(newValue) }
-    }
     #endif // os(macOS)
 
     // SPI for the cross-import overlay.
@@ -150,6 +142,37 @@ extension WebPage {
 
         editorStateSnapshotsContinuations[id] = continuation
         return stream
+    }
+
+    #if WTF_PLATFORM_MAC
+    // SPI for testing.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(Testing)
+    public var smartListsEnabled: Bool {
+        get { backingWebView._isSmartListsEnabled() }
+        set { backingWebView._setSmartListsEnabled(newValue) }
+    }
+    #endif // WTF_PLATFORM_MAC
+
+    // SPI for testing.
+    // FIXME: This should probably just use the SwiftUI `MagnifyGesture` API.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(Testing)
+    public var magnification: CGFloat {
+        get {
+            #if WTF_PLATFORM_MAC
+            backingWebView.magnification
+            #else
+            backingWebView.scrollView.zoomScale
+            #endif
+        }
+        set {
+            #if WTF_PLATFORM_MAC
+            backingWebView.magnification = newValue
+            #else
+            backingWebView.scrollView.zoomScale = newValue
+            #endif
+        }
     }
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		0715310F2F3037C100B56C0E /* WebPageProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0715310E2F3037C100B56C0E /* WebPageProxy.swift */; };
 		07187E0B2F2DC28E005FC058 /* GestureTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 07187E092F2DC276005FC058 /* GestureTypes.h */; };
 		071BC59023CE1EAA00680D7C /* RemoteMediaPlayerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 071BC58D23CE1EAA00680D7C /* RemoteMediaPlayerProxyMessages.h */; };
+		071E14BC301EEFEC001BF5DA /* WebView+ViewportConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071E14BB301EEFEC001BF5DA /* WebView+ViewportConfiguration.swift */; };
 		07275C612D00CD24002315A5 /* CrossImportOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07275C602D00CD24002315A5 /* CrossImportOverlay.swift */; };
 		07275C632D00D32D002315A5 /* WebPage+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07275C622D00D32D002315A5 /* WebPage+SwiftUI.swift */; };
 		07275C682D00E3D6002315A5 /* SwiftUI.swiftoverlay in Install SwiftUI Cross Import Overlay */ = {isa = PBXBuildFile; fileRef = 07275C662D00E3CA002315A5 /* SwiftUI.swiftoverlay */; };
@@ -3443,6 +3444,7 @@
 		071BC58B23CDFE7500680D7C /* RemoteMediaPlayerProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteMediaPlayerProxy.messages.in; sourceTree = "<group>"; };
 		071BC58C23CE1EA900680D7C /* RemoteMediaPlayerProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerProxyMessageReceiver.cpp; sourceTree = "<group>"; };
 		071BC58D23CE1EAA00680D7C /* RemoteMediaPlayerProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerProxyMessages.h; sourceTree = "<group>"; };
+		071E14BB301EEFEC001BF5DA /* WebView+ViewportConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebView+ViewportConfiguration.swift"; sourceTree = "<group>"; };
 		0725EFAB239AE38400A538A9 /* RemoteMediaPlayerManagerProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteMediaPlayerManagerProxy.messages.in; sourceTree = "<group>"; };
 		0725EFAC239AE38500A538A9 /* RemoteMediaPlayerManagerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerManagerProxy.h; sourceTree = "<group>"; };
 		0725EFAD239B024500A538A9 /* RemoteMediaPlayerManagerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerManagerProxy.cpp; sourceTree = "<group>"; };
@@ -9724,6 +9726,7 @@
 				078B04B52CF2B4D300B453A6 /* View+WebViewModifiers.swift */,
 				07275C622D00D32D002315A5 /* WebPage+SwiftUI.swift */,
 				07A4CEC62D0933E700764F5E /* WebPageNavigationAction+SwiftUI.swift */,
+				071E14BB301EEFEC001BF5DA /* WebView+ViewportConfiguration.swift */,
 				076867F62D4C26A8004DA801 /* WebView.swift */,
 				BFD28341B551FAD199FFF404 /* WebViewImmersiveEnvironmentView.swift */,
 			);
@@ -17246,7 +17249,6 @@
 		C0CE729D1247E71D00BC0EC4 /* Derived Sources */ = {
 			isa = PBXGroup;
 			children = (
-				7D2F27C3301C10470043C2CE /* JSWebExtensionAPIUnified.cpp */,
 				38DE371D763C9F8323F87E41 /* IPC */,
 				2D7DEBE221269E4B00B9F73C /* unified-sources */,
 				9955A6F01C79866400EB6A93 /* AutomationBackendDispatchers.cpp */,
@@ -17319,6 +17321,7 @@
 				1C5ACFA92A96F8D400C041C0 /* JSWebExtensionAPITabs.mm */,
 				1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.cpp */,
 				1C15497D2926C05A001B9E5B /* JSWebExtensionAPITest.h */,
+				7D2F27C3301C10470043C2CE /* JSWebExtensionAPIUnified.cpp */,
 				1C0F05BD2CFA5D2E007D1F62 /* JSWebExtensionAPIUnified.mm */,
 				3399E14F2B59EFD6008BFB60 /* JSWebExtensionAPIWebNavigation.h */,
 				3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */,
@@ -21885,6 +21888,7 @@
 				07AF79D02D68E210004E8D3A /* ViewModifierContexts.swift in Sources */,
 				07275C632D00D32D002315A5 /* WebPage+SwiftUI.swift in Sources */,
 				07A4CEC72D0933E700764F5E /* WebPageNavigationAction+SwiftUI.swift in Sources */,
+				071E14BC301EEFEC001BF5DA /* WebView+ViewportConfiguration.swift in Sources */,
 				076868022D4C285B004DA801 /* WebView.swift in Sources */,
 				B6B64F30272BA2A17EF9AD14 /* WebViewImmersiveEnvironmentView.swift in Sources */,
 				076867FF2D4C283E004DA801 /* WebViewRepresentable.swift in Sources */,
@@ -22160,6 +22164,7 @@
 				074D6A652F385435006089F6 /* IntRectCG.swift in Sources */,
 				5CF250AF2EE06491006A7172 /* IPCTesterReceiver.swift in Sources */,
 				5C448C662EE06E11008931C7 /* IPCTesterReceiverMessageReceiver.swift in Sources */,
+				7D2F27C4301C2EF50043C2CE /* JSWebExtensionAPIUnified.cpp in Sources */,
 				1C0F05BE2CFA5D2E007D1F62 /* JSWebExtensionAPIUnified.mm in Sources */,
 				E385F3672E86D6C900461B0C /* LaunchLogHook.mm in Sources */,
 				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,
@@ -22190,7 +22195,6 @@
 				2D72A1FA212BF46E00517A20 /* RemoteLayerTreeDrawingArea.mm in Sources */,
 				2DC18FB4218A6E9E0025A88D /* RemoteLayerTreeViews.mm in Sources */,
 				0701789E23BE9CFC005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp in Sources */,
-				7D2F27C4301C2EF50043C2CE /* JSWebExtensionAPIUnified.cpp in Sources */,
 				1AF572302D690813008266F2 /* RemoteScrollingTreeCocoa.mm in Sources */,
 				7BCF70DE2615D06E00E4FB70 /* ScopedRenderingResourcesRequestCocoa.mm in Sources */,
 				E3D0A9422D62B1C90094538A /* ServiceWorkerDebuggableFrontendChannel.cpp in Sources */,

--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -226,6 +226,45 @@ extension View {
     public nonisolated func webViewContentEnvironmentV0(_ value: WebView.ContentEnvironment_v0) -> some View {
         environment(\.webViewContentEnvironment, value)
     }
+
+    /// Configures the viewport of the web view, overriding any attributes the web content may set itself.
+    ///
+    /// These values correspond to those of the CSS [Viewport `<meta>` element](https://drafts.csswg.org/css-viewport/#viewport-meta).
+    ///
+    /// - Parameters:
+    ///   - width: The pixel width of the viewport, establishing the value of the `vw` unit. This can be set to a positive whole number of pixels between `[10, 10000]`, or the special `deviceWidth` value.
+    ///   - height: The pixel height of the viewport, establishing the value of the `vh` unit. This can be set to a positive whole number of pixels between `[10, 10000]`, or the special `deviceHeight` value.
+    ///   - initialScale: The ratio between the device width and the viewport size.
+    ///   - minimumScale: The minimum zoom level.
+    ///   - maximumScale: The maximum amount to zoom in.
+    ///   - userScalable: If `true`, the user can zoom the web view..
+    ///   - interactiveWidget: The effect that interactive UI widgets, such as virtual keyboards, have on a page's viewport.
+    ///   - viewportFit: The viewable portions of the web page.
+    /// - Returns: A view with the specified viewport configuration.
+    @_spi(Experimental)
+    public nonisolated func webViewViewportConfigurationV0(
+        width: WebView.ViewportConfiguration_v0.Width? = nil,
+        height: WebView.ViewportConfiguration_v0.Height? = nil,
+        initialScale: Float? = nil,
+        minimumScale: Float? = nil,
+        maximumScale: Float? = nil,
+        userScalable: Bool? = nil,
+        interactiveWidget: WebView.ViewportConfiguration_v0.InteractiveWidget? = nil,
+        viewportFit: WebView.ViewportConfiguration_v0.ViewportFit? = nil,
+    ) -> some View {
+        let configuration = WebView.ViewportConfiguration_v0(
+            width: width,
+            height: height,
+            initialScale: initialScale,
+            minimumScale: minimumScale,
+            maximumScale: maximumScale,
+            userScalable: userScalable,
+            interactiveWidget: interactiveWidget,
+            viewportFit: viewportFit
+        )
+
+        return environment(\.webViewViewportConfiguration, configuration)
+    }
 }
 
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView+ViewportConfiguration.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView+ViewportConfiguration.swift
@@ -1,0 +1,181 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI
+
+@available(anyAppleOSAndDownlevels 26.0, *)
+@_spi_available(watchOSAndOpenSourceTBA, *)
+@_spi_available(tvOSAndOpenSourceTBA, *)
+extension WebView {
+    /// Represents the attributes used for the `<meta name="viewport">` HTML element.
+    @_spi(Experimental)
+    public struct ViewportConfiguration_v0: Sendable {
+        /// The pixel width of the viewport.
+        @_spi(Experimental)
+        public struct Width: Sendable, ExpressibleByIntegerLiteral {
+            enum Storage: Sendable {
+                case value(Int)
+                case deviceWidth
+            }
+
+            let storage: Storage
+
+            /// The special sentinel width value representing the physical size of the device screen in CSS pixels.
+            public static var deviceWidth: Width {
+                Width(storage: .deviceWidth)
+            }
+
+            private init(storage: Storage) {
+                self.storage = storage
+            }
+
+            // Protocol conformance.
+            // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+            @_spi(Experimental)
+            public init(integerLiteral value: Int) {
+                self.init(storage: .value(value))
+            }
+        }
+
+        /// The pixel height of the viewport.
+        @_spi(Experimental)
+        public struct Height: Sendable, ExpressibleByIntegerLiteral {
+            enum Storage: Sendable {
+                case value(Int)
+                case deviceHeight
+            }
+
+            let storage: Storage
+
+            /// The special sentinel height value representing the physical size of the device screen in CSS pixels.
+            public static var deviceHeight: Height {
+                Height(storage: .deviceHeight)
+            }
+
+            private init(storage: Storage) {
+                self.storage = storage
+            }
+
+            // Protocol conformance.
+            // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+            @_spi(Experimental)
+            public init(integerLiteral value: Int) {
+                self.init(storage: .value(value))
+            }
+        }
+
+        /// The effect that interactive UI widgets, such as virtual keyboards, have on a page's viewport.
+        @_spi(Experimental)
+        public enum InteractiveWidget: Sendable {
+            /// The visual viewport gets resized by the interactive widget. This is the default.
+            case resizesVisual
+
+            /// The viewport gets resized by the interactive widget.
+            case resizesContent
+
+            /// Neither the viewport nor the visual viewport gets resized by the interactive widget.
+            case overlaysContent
+        }
+
+        /// Defines the viewable portions of the webpage.
+        @_spi(Experimental)
+        public enum ViewportFit: Sendable {
+            /// Doesn't affect the initial layout viewport, and the whole web page is viewable.
+            case auto
+
+            /// The viewport is scaled to fit the largest rectangle inscribed within the display.
+            case contain
+
+            /// The viewport is scaled to fill the device display.
+            case cover
+        }
+
+        let width: Width?
+        let height: Height?
+        let initialScale: Float?
+        let minimumScale: Float?
+        let maximumScale: Float?
+        let userScalable: Bool?
+        let interactiveWidget: InteractiveWidget?
+        let viewportFit: ViewportFit?
+    }
+}
+
+extension WebView.ViewportConfiguration_v0.Width {
+    var dictionaryRepresentation: String {
+        switch storage {
+        case .deviceWidth: "device-width"
+        case .value(let value): "\(value)"
+        }
+    }
+}
+
+extension WebView.ViewportConfiguration_v0.Height {
+    var dictionaryRepresentation: String {
+        switch storage {
+        case .deviceHeight: "device-height"
+        case .value(let value): "\(value)"
+        }
+    }
+}
+
+extension WebView.ViewportConfiguration_v0.InteractiveWidget {
+    var dictionaryRepresentation: String {
+        switch self {
+        case .resizesVisual: "resizes-visual"
+        case .resizesContent: "resizes-content"
+        case .overlaysContent: "overlays-content"
+        }
+    }
+}
+
+extension WebView.ViewportConfiguration_v0.ViewportFit {
+    var dictionaryRepresentation: String {
+        switch self {
+        case .auto: "auto"
+        case .contain: "contain"
+        case .cover: "cover"
+        }
+    }
+}
+
+extension WebView.ViewportConfiguration_v0 {
+    var dictionaryRepresentation: [String: String] {
+        var result: [String: String] = [:]
+
+        result["width"] = width?.dictionaryRepresentation
+        result["height"] = height?.dictionaryRepresentation
+
+        result["initial-scale"] = initialScale.map { "\($0)" }
+        result["minimum-scale"] = minimumScale.map { "\($0)" }
+        result["maximum-scale"] = maximumScale.map { "\($0)" }
+        result["user-scalable"] = userScalable.map { "\($0)" }
+
+        result["interactive-widget"] = interactiveWidget?.dictionaryRepresentation
+        result["viewport-fit"] = viewportFit?.dictionaryRepresentation
+
+        return result
+    }
+}
+
+#endif // ENABLE_SWIFTUI

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
@@ -70,6 +70,9 @@ extension EnvironmentValues {
 
     @Entry
     var webViewContentEnvironment = WebView.ContentEnvironment_v0.standard
+
+    @Entry
+    var webViewViewportConfiguration: WebView.ViewportConfiguration_v0? = nil
 }
 
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -141,6 +141,13 @@ struct WebViewRepresentable {
 
         webView._isEditable = environment.webViewContentEnvironment.storage == .editable
 
+        #if WTF_PLATFORM_IOS_FAMILY
+        // FIXME: It's a bit silly to serialize this to a dictionary only to later deserialize it back to a typed value.
+        if let viewportArguments = environment.webViewViewportConfiguration?.dictionaryRepresentation {
+            webView._overrideViewport(withArguments: viewportArguments.isEmpty ? nil : viewportArguments)
+        }
+        #endif // WTF_PLATFORM_IOS_FAMILY
+
         platformView.onScrollGeometryChange = environment.webViewOnScrollGeometryChange
 
         #if ENABLE_MODEL_ELEMENT_IMMERSIVE

--- a/Tools/TestWebKitAPI/Helpers/cocoa/SwiftUI+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/SwiftUI+Extras.swift
@@ -22,6 +22,69 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 
 public import SwiftUI
+#if WTF_PLATFORM_MAC
+private import AppKit
+#else
+private import UIKit
+#endif
+
+#if ENABLE_SWIFTUI && !os(watchOS)
+
+/// Renders a SwiftUI view, updating whenever its observable state changes.
+///
+/// For example, to render a view whose state depends on an `isEditable` property of some model:
+///
+/// ```swift
+/// let model = ViewModel()
+///
+/// render {
+///     TestView().environment(model)
+/// } observing: {
+///     model.isEditable
+/// }
+///
+/// model.isEditable = true // -> updates TestView
+/// model.isEditable = false // -> updates TestView
+/// ```
+///
+/// - Parameters:
+///   - rootView: The view to render.
+///   - observable: A closure that contains properties to track. The properties that `rootView` depends on must be captured within the `observable` closure.
+#if hasAttribute(diagnose)
+@diagnose(DeprecatedDeclaration, as: ignored, reason: "rdar://183894032")
+#endif
+@MainActor
+public func render(
+    @ViewBuilder rootView: () -> some View,
+    @_inheritActorContext observing observable: @escaping @isolated(any) @Sendable () -> some Sendable
+) {
+    let resolvedView = rootView()
+
+    #if WTF_PLATFORM_MAC
+    let viewController = NSHostingController(rootView: resolvedView)
+    #else
+    let viewController = UIHostingController(rootView: resolvedView)
+
+    // The hosting controller must be installed in a window for a layout pass to run,
+    // otherwise the web view's constraints are never resolved and it stays zero-sized.
+
+    let window = UIWindow(frame: .init(x: 0, y: 0, width: 800, height: 600))
+    window.rootViewController = viewController
+    window.isHidden = false
+    window.layoutIfNeeded()
+    viewController.view.layoutIfNeeded()
+    #endif
+
+    viewController._render(seconds: 1.0 / 60.0)
+
+    Task.immediate {
+        for await _ in Observations(observable) {
+            viewController._render(seconds: 1.0 / 60.0)
+        }
+    }
+}
+
+#endif // ENABLE_SWIFTUI && !os(watchOS)
 
 extension Font {
     #if canImport(UIKit)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift
@@ -26,7 +26,7 @@
 import Observation
 import SwiftUI
 import Testing
-import WebKit
+@_spi(Testing) import WebKit
 @_spi(Experimental) import _WebKit_SwiftUI
 private import TestWebKitAPILibrary
 import struct _Concurrency.Task
@@ -42,22 +42,31 @@ private final class ViewModel {
     let page = WebPage()
 
     var isEditable: Bool = false
+
+    // The `_WebKit_SwiftUI` qualifier is needed to disambiguate from WebKitLegacy's WebView.
+    // FIXME: Consider alternative designs to avoid this requirement.
+    var viewportWidth: _WebKit_SwiftUI.WebView.ViewportConfiguration_v0.Width? = nil
+    var viewportInitialScale: Float? = nil
+}
+
+private struct TestView: View {
+    @Environment(ViewModel.self)
+    var model
+
+    var body: some View {
+        WebView(model.page)
+            .webViewContentEnvironmentV0(model.isEditable ? .editable : .standard)
+            .webViewViewportConfigurationV0(
+                width: model.viewportWidth,
+                initialScale: model.viewportInitialScale
+            )
+    }
 }
 
 @MainActor
 struct WebViewTests {
     @Test
     func applyingContentEnvironmentAffectsPageSemantics() async throws {
-        struct TestView: View {
-            @Environment(ViewModel.self)
-            var model
-
-            var body: some View {
-                WebView(model.page)
-                    .webViewContentEnvironmentV0(model.isEditable ? .editable : .standard)
-            }
-        }
-
         func isContentEditable() async throws -> Bool {
             try await model.page.callJavaScript(returning: Bool.self) {
                 """
@@ -69,9 +78,11 @@ struct WebViewTests {
 
         let model = ViewModel()
 
-        render(observing: model) {
+        render {
             TestView()
                 .environment(model)
+        } observing: {
+            model.isEditable
         }
 
         model.isEditable = true
@@ -87,26 +98,73 @@ struct WebViewTests {
 
         #expect(!(try await isContentEditable()))
     }
-}
 
-@MainActor
-func render(
-    observing observable: @escaping @isolated(any) @autoclosure @Sendable () -> some Observable & Sendable,
-    @ViewBuilder rootView: () -> some View
-) {
-    let resolvedView = rootView()
+    #if WTF_PLATFORM_IOS_FAMILY
+    @Test
+    func overrideViewportArgumentsAffectsPageViewport() async throws {
+        func bodyWidth() async throws -> Int {
+            await model.page.waitForNextPresentationUpdate()
 
-    #if WTF_PLATFORM_MAC
-    let viewController = NSHostingController(rootView: resolvedView)
-    #else
-    let viewController = UIHostingController(rootView: resolvedView)
-    #endif
-
-    Task.immediate {
-        for await _ in Observations(observable) {
-            viewController._render(seconds: 1.0 / 60.0)
+            return try await model.page.callJavaScript(returning: Int.self) {
+                """
+                return document.body.clientWidth;
+                """
+            }
         }
+
+        let model = ViewModel()
+
+        render {
+            TestView()
+                .frame(width: 20, height: 20)
+                .environment(model)
+        } observing: {
+            (model.viewportWidth, model.viewportInitialScale)
+        }
+
+        let htmlWithInitialScale = """
+            <meta name='viewport' content='initial-scale=1'>
+            <div id='divWithViewportUnits' style='width: 100vw;'></div>
+            """
+
+        try await model.page.load(html: htmlWithInitialScale).wait()
+
+        try await #expect(bodyWidth() == 20)
+
+        model.viewportWidth = 1000
+        try await #expect(bodyWidth() == 1000)
+
+        model.viewportInitialScale = 1
+        try await #expect(bodyWidth() == 1000)
+        #expect(model.page.magnification == 1)
+
+        model.viewportInitialScale = 5
+        try await #expect(bodyWidth() == 1000)
+        #expect(model.page.magnification == 5)
+
+        model.viewportWidth = nil
+        model.viewportInitialScale = nil
+
+        try await #expect(bodyWidth() == 20)
+
+        let htmlWithWidth = """
+            <meta name='viewport' content='width=10'>
+            <div id='divWithViewportUnits' style='width: 100vw;'></div>
+            """
+
+        try await model.page.load(html: htmlWithWidth).wait()
+
+        try await #expect(bodyWidth() == 10)
+
+        model.viewportWidth = 1000
+        model.viewportInitialScale = 1
+        try await #expect(bodyWidth() == 1000)
+
+        model.viewportWidth = .deviceWidth
+        model.viewportInitialScale = 1
+        try await #expect(bodyWidth() == 20)
     }
+    #endif // WTF_PLATFORM_IOS_FAMILY
 }
 
 #endif // ENABLE_SWIFTUI && !os(watchOS) && !os(tvOS)


### PR DESCRIPTION
#### f1b689718fc338cb424e1e572e376f3783d19c32
<pre>
[SwiftUI WebKit API] Expose _overrideViewportWithArguments on WebPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=320832">https://bugs.webkit.org/show_bug.cgi?id=320832</a>
<a href="https://rdar.apple.com/183775063">rdar://183775063</a>

Reviewed by Aditya Keerthi.

Expose SPI on `WebView` in the form of a view modifier to allow clients to custom the values of viewport
attributes, similar to the existing `WKWebView._overrideViewportWithArguments` SPI.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift

* Source/WebKit/UIProcess/API/Swift/WebPage+SPI.swift:
(WebPage.setMenuBuilder(_:)):
(smartListsEnabled):
(magnification):
(WebPage.smartListsEnabled): Deleted.
* Tools/TestWebKitAPI/Helpers/cocoa/SwiftUI+Extras.swift:

Testing infrastructure.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:
* Source/WebKit/_WebKit_SwiftUI/API/WebView+ViewportConfiguration.swift: Added.
(deviceWidth):
(Storage.deviceHeight):
(WebView.dictionaryRepresentation):
* Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift:
(EnvironmentValues.webViewViewportConfiguration):
* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):

Add the new view modifier.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift:
(ViewModel.viewportWidth):
(ViewModel.viewportInitialScale):
(TestView.body):
(WebViewTests.applyingContentEnvironmentAffectsPageSemantics):
(WebViewTests.overrideViewportArgumentsAffectsPageViewport):

Add a new test.

Canonical link: <a href="https://commits.webkit.org/318497@main">https://commits.webkit.org/318497@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df0075c314af108463a42e1d87d3436f1ae8b41e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188062 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e124cd2-35ee-4e88-8e5b-6dcd9039cb24) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139118 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e97fe629-b568-458e-92d2-00b5dda1cddc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159876 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119572 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8c89362-63d2-4cb2-951d-eca4129da07a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41343 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39695 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39375 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36517 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190489 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52053 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148277 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39816 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52734 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148048 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42759 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125000 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119637 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51252 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14350 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50637 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50877 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50699 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->