### PR TITLE
Float16 canvas and ImageData require RGBA16F

### DIFF
--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-disabled.html
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-disabled.html
@@ -1,6 +1,6 @@
 <!-- webkit-test-runner [ CanvasColorSpaceEnabled=false ] -->
 <html>
-    <script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -18,7 +18,5 @@
     testColorSpaceUnsupported({ colorSpace: "display-p3" });
     testColorSpaceUnsupported({ colorSpace: "foo" });
 </script>
-    
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-enabled.html
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-enabled.html
@@ -1,5 +1,5 @@
 <html>
-    <script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -54,7 +54,5 @@
     // Test setting colorSpace to an unsupported value.
     shouldThrowErrorName(`document.createElement("canvas").getContext("2d", { colorSpace: "foo" })`, "TypeError")
 </script>
-    
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled.html
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled.html
@@ -1,6 +1,6 @@
 <!-- webkit-test-runner [ CanvasColorTypeEnabled=false ] -->
 <html>
-    <script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -18,7 +18,5 @@
     testColorTypeUnsupported({ colorType: "float16" });
     testColorTypeUnsupported({ colorType: "foo" });
 </script>
-
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/canvas/hdr/CanvasRenderingContext2DSettings-pixelFormat-enabled-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/CanvasRenderingContext2DSettings-pixelFormat-enabled-expected.txt
@@ -5,7 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS testSettings.colorType is "unorm8"
 PASS testSettings.colorType is "unorm8"
-PASS getContext("2d", {"colorType":"float16"}) set colorType == float16 or threw TypeError as expected
+PASS testSettings.colorType is "float16"
 PASS document.createElement("canvas").getContext("2d", { colorType: "foo" }) threw exception TypeError: Type error.
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/canvas/hdr/CanvasRenderingContext2DSettings-pixelFormat-enabled.html
+++ b/LayoutTests/fast/canvas/hdr/CanvasRenderingContext2DSettings-pixelFormat-enabled.html
@@ -1,6 +1,6 @@
 <!-- webkit-test-runner [ CanvasColorTypeEnabled=true ] -->
 <html>
-<script src="../../resources/js-test.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -8,23 +8,18 @@
 
     function testColorType(settings, expectedColorType, allowedException = "") {
         let canvas = document.createElement("canvas");
-        if (!allowedException) {
+        try {
             let context = canvas.getContext("2d", settings);
             window.testSettings = context.getContextAttributes();
             shouldBeEqualToString("testSettings.colorType", expectedColorType);
-        } else {
-            try {
-                let context = canvas.getContext("2d", settings);
-                if (context.getContextAttributes().colorType == expectedColorType)
-                    testPassed(`getContext("2d", ${JSON.stringify(settings)}) set colorType == ${expectedColorType} or threw ${allowedException} as expected`);
-                else
-                    testPassed(`getContext("2d", ${JSON.stringify(settings)}) set colorType to "${context.getContextAttributes().colorType}" instead of ${expectedColorType}`);
-            } catch ({ name, message }) {
+        } catch ({ name, message }) {
+            if (allowedException) {
                 if (name == allowedException)
-                    testPassed(`getContext("2d", ${JSON.stringify(settings)}) set colorType == ${expectedColorType} or threw ${allowedException} as expected`);
+                    testPassed(`getContext("2d", ${JSON.stringify(settings)}) threw ${name} as allowed`);
                 else
                     testFailed(`getContext("2d", ${JSON.stringify(settings)}) threw ${name} instead of ${allowedException}`);
-            }
+            } else
+                testFailed(`getContext("2d", ${JSON.stringify(settings)}) threw ${name}`);
         }
     }
 

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.js
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.js
@@ -45,7 +45,6 @@ function verifyImageData(variable, constructor, bytesPerElement, red, green, blu
 
 function areEqualImageData(imageDataActual, imageDataExpected, tolerance)
 {
-    tolerance = 0;
     shouldBe(imageDataActual + '.width', imageDataExpected + '.width');
     shouldBe(imageDataActual + '.height', imageDataExpected + '.height');
     shouldBe(imageDataActual + '.data.constructor', imageDataExpected + '.data.constructor');

--- a/LayoutTests/fast/canvas/hdr/imagedata-storageformat-enabled-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/imagedata-storageformat-enabled-expected.txt
@@ -1,0 +1,87 @@
+Tests that ImageDataSettings contains pixelFormat.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS created_imageData_unorm8.width is 1
+PASS created_imageData_unorm8.height is 1
+PASS created_imageData_unorm8.data.constructor is Uint8ClampedArray
+PASS created_imageData_unorm8.data.BYTES_PER_ELEMENT is 1
+PASS created_imageData_unorm8.data.length is 4
+PASS created_imageData_unorm8.data.byteLength is 4
+PASS created_imageData_unorm8.data.at(0) is 0
+PASS created_imageData_unorm8.data.at(1) is 0
+PASS created_imageData_unorm8.data.at(2) is 0
+PASS created_imageData_unorm8.data.at(3) is 0
+PASS gotten_imageData_unorm8.width is 1
+PASS gotten_imageData_unorm8.height is 1
+PASS gotten_imageData_unorm8.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_unorm8.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_unorm8.data.length is 4
+PASS gotten_imageData_unorm8.data.byteLength is 4
+PASS gotten_imageData_unorm8.data.at(0) is 0
+PASS gotten_imageData_unorm8.data.at(1) is 128
+PASS gotten_imageData_unorm8.data.at(2) is 255
+PASS gotten_imageData_unorm8.data.at(3) is 255
+PASS created_imageData_float16.width is 1
+PASS created_imageData_float16.height is 1
+PASS created_imageData_float16.data.constructor is Float16Array
+PASS created_imageData_float16.data.BYTES_PER_ELEMENT is 2
+PASS created_imageData_float16.data.length is 4
+PASS created_imageData_float16.data.byteLength is 8
+PASS created_imageData_float16.data.at(0) is 0
+PASS created_imageData_float16.data.at(1) is 0
+PASS created_imageData_float16.data.at(2) is 0
+PASS created_imageData_float16.data.at(3) is 0
+PASS gotten_imageData_float16.width is 1
+PASS gotten_imageData_float16.height is 1
+PASS gotten_imageData_float16.data.constructor is Float16Array
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is 2
+PASS gotten_imageData_float16.data.length is 4
+PASS gotten_imageData_float16.data.byteLength is 8
+PASS gotten_imageData_float16.data.at(0) is within 0.00048828125 of 0
+PASS gotten_imageData_float16.data.at(1) is within 0.00048828125 of 0.5019607843137255
+PASS gotten_imageData_float16.data.at(2) is within 0.00048828125 of 1
+PASS gotten_imageData_float16.data.at(3) is within 0.00048828125 of 1
+PASS gotten_imageData_unorm8_from_float16.width is 1
+PASS gotten_imageData_unorm8_from_float16.height is 1
+PASS gotten_imageData_unorm8_from_float16.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_unorm8_from_float16.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_unorm8_from_float16.data.length is 4
+PASS gotten_imageData_unorm8_from_float16.data.byteLength is 4
+PASS gotten_imageData_unorm8_from_float16.data.at(0) is 0
+PASS gotten_imageData_unorm8_from_float16.data.at(1) is 128
+PASS gotten_imageData_unorm8_from_float16.data.at(2) is 255
+PASS gotten_imageData_unorm8_from_float16.data.at(3) is 255
+PASS canvas.width * canvas.height >= 256 * componentsToTest is true
+PASS pixelOffset is 256 * componentsToTest
+PASS gotten_imageData_unorm8.width is expected_imageData_unorm8.width
+PASS gotten_imageData_unorm8.height is expected_imageData_unorm8.height
+PASS gotten_imageData_unorm8.data.constructor is expected_imageData_unorm8.data.constructor
+PASS gotten_imageData_unorm8.data.BYTES_PER_ELEMENT is expected_imageData_unorm8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_unorm8.data.length is expected_imageData_unorm8.data.length
+PASS gotten_imageData_unorm8.data.byteLength is expected_imageData_unorm8.data.byteLength
+PASS gotten_imageData_float16.width is expected_imageData_float16.width
+PASS gotten_imageData_float16.height is expected_imageData_float16.height
+PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
+PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
+PASS gotten_imageData_float16.width is expected_imageData_float16.width
+PASS gotten_imageData_float16.height is expected_imageData_float16.height
+PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
+PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
+PASS gotten_imageData_unorm8.width is expected_imageData_unorm8.width
+PASS gotten_imageData_unorm8.height is expected_imageData_unorm8.height
+PASS gotten_imageData_unorm8.data.constructor is expected_imageData_unorm8.data.constructor
+PASS gotten_imageData_unorm8.data.BYTES_PER_ELEMENT is expected_imageData_unorm8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_unorm8.data.length is expected_imageData_unorm8.data.length
+PASS gotten_imageData_unorm8.data.byteLength is expected_imageData_unorm8.data.byteLength
+PASS context.createImageData(1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/hdr/imagedata-storageformat-enabled.html
+++ b/LayoutTests/fast/canvas/hdr/imagedata-storageformat-enabled.html
@@ -1,0 +1,151 @@
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests that ImageDataSettings contains pixelFormat.");
+
+var canvas = document.createElement("canvas");
+canvas.width = 10;
+canvas.height = 10;
+var context = canvas.getContext("2d");
+var r = 0;
+var g = 128;
+var b = 255;
+var a = 255;
+context.fillStyle = `rgb(${r} ${g} ${b})`;
+context.fillRect(0, 0, 1, 1);
+
+const componentsPerPixel = 4;
+
+function shouldBeAround(to_eval, targetNumber, tolerance, quiet)
+{
+    if (!tolerance)
+        return shouldBe(to_eval, String(targetNumber), quiet);
+    return shouldBeCloseTo(to_eval, targetNumber, tolerance, quiet);
+}
+
+function verifyImageData(variable, constructor, bytesPerElement, red, green, blue, alpha, tolerance, quiet) {
+    shouldBe(variable + '.width', '1', quiet);
+    shouldBe(variable + '.height', '1', quiet);
+    shouldBe(variable + '.data.constructor', constructor, quiet);
+    shouldBe(variable + '.data.BYTES_PER_ELEMENT', String(bytesPerElement), quiet);
+    shouldBe(variable + '.data.length', '4', quiet);
+    shouldBe(variable + '.data.byteLength', String(bytesPerElement * 4), quiet);
+    shouldBeAround(variable + '.data.at(0)', red, tolerance, quiet);
+    shouldBeAround(variable + '.data.at(1)', green, tolerance, quiet);
+    shouldBeAround(variable + '.data.at(2)', blue, tolerance, quiet);
+    shouldBeAround(variable + '.data.at(3)', alpha, tolerance, quiet);
+}
+
+function areEqualImageData(imageDataActual, imageDataExpected, tolerance)
+{
+    shouldBe(imageDataActual + '.width', imageDataExpected + '.width');
+    shouldBe(imageDataActual + '.height', imageDataExpected + '.height');
+    shouldBe(imageDataActual + '.data.constructor', imageDataExpected + '.data.constructor');
+    shouldBe(imageDataActual + '.data.BYTES_PER_ELEMENT', imageDataExpected + '.data.BYTES_PER_ELEMENT');
+    shouldBe(imageDataActual + '.data.length', imageDataExpected + '.data.length');
+    shouldBe(imageDataActual + '.data.byteLength', imageDataExpected + '.data.byteLength');
+    const actualData = eval(imageDataActual).data;
+    const expectedData = eval(imageDataExpected).data;
+    for (component = 0; component < actualData.length; ++component) {
+        if (Math.abs(actualData[component] - expectedData[component]) > tolerance)
+            shouldBeAround(imageDataActual + '.data[' + component + ']', expectedData[component], tolerance, true);
+    }
+}
+
+const unorm8_bytes_per_element = 1;
+const float16_bytes_per_element = 2;
+// Worst float16 precision in [0,1].
+const float16_01_tolerance = 1/2048;
+
+var created_imageData_unorm8 = context.createImageData(1, 1, { pixelFormat: "rgba-unorm8" });
+verifyImageData('created_imageData_unorm8', 'Uint8ClampedArray', unorm8_bytes_per_element, 0, 0, 0, 0);
+
+var gotten_imageData_unorm8 = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-unorm8" });
+verifyImageData('gotten_imageData_unorm8', 'Uint8ClampedArray', unorm8_bytes_per_element, r, g, b, a);
+
+var created_imageData_float16;
+try {
+created_imageData_float16 = context.createImageData(1, 1, { pixelFormat: "rgba-float16" });
+} catch (e) {
+    if (e instanceof TypeError)
+        testPassed(`context.createImageData(1, 1, { pixelFormat: "rgba-float16" }) threw ${e} as allowed, following tests will fail.`)
+    else
+        testFailed(`context.createImageData(1, 1, { pixelFormat: "rgba-float16" }) threw ${e}.`)
+}
+verifyImageData('created_imageData_float16', 'Float16Array', float16_bytes_per_element, 0, 0, 0, 0, 0);
+
+// This verifies the basic unorm8->float16 conversion.
+var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-float16" });
+verifyImageData('gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_01_tolerance);
+
+// Put the float16 ImageData back into the (unorm8-backed) canvas, and get a default (unorm8) ImageData.
+// This verifies the basic float16->unorm8 conversion:
+context.clearRect(0, 0, 1, 1);
+context.putImageData(gotten_imageData_float16, 0, 0);
+var gotten_imageData_unorm8_from_float16 = context.getImageData(0, 0, 1, 1);
+verifyImageData('gotten_imageData_unorm8_from_float16', 'Uint8ClampedArray', unorm8_bytes_per_element, r, g, b, a);
+
+// Exhaustive unorm8->float16->unorm8 round-trip test for all possible individual rgba-unorm8 component values. Only log errors.
+canvas.width = 64;
+canvas.height = 16;
+var componentsToTest = componentsPerPixel;
+shouldBeTrue('canvas.width * canvas.height >= 256 * componentsToTest');
+
+var input_imageData_unorm8 = context.createImageData(canvas.width, canvas.height);
+var expected_imageData_unorm8 = context.createImageData(canvas.width, canvas.height);
+var expected_imageData_float16 = context.createImageData(canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
+
+var pixelOffset = 0;
+for (let v = 0; v < 256; ++v) {
+    for (component = 0; component < componentsToTest; ++component) {
+        r = g = b = 0;
+        a = 255;
+        switch (component) {
+        case 0: r = v; break;
+        case 1: g = v; break;
+        case 2: b = v; break;
+        case 3: r = g = b = (v ? 255 : 0); a = v; break;
+        }
+        input_imageData_unorm8.data[pixelOffset * componentsPerPixel + 0] = r;
+        input_imageData_unorm8.data[pixelOffset * componentsPerPixel + 1] = g;
+        input_imageData_unorm8.data[pixelOffset * componentsPerPixel + 2] = b;
+        input_imageData_unorm8.data[pixelOffset * componentsPerPixel + 3] = a;
+
+        expected_imageData_unorm8.data[pixelOffset * componentsPerPixel + 0] = r;
+        expected_imageData_unorm8.data[pixelOffset * componentsPerPixel + 1] = g;
+        expected_imageData_unorm8.data[pixelOffset * componentsPerPixel + 2] = b;
+        expected_imageData_unorm8.data[pixelOffset * componentsPerPixel + 3] = a;
+
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 0] = r / 255;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 1] = g / 255;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 2] = b / 255;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 3] = a / 255;
+
+        ++pixelOffset;
+    }
+}
+shouldBe('pixelOffset', '256 * componentsToTest');
+
+context.putImageData(input_imageData_unorm8, 0, 0);
+gotten_imageData_unorm8 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-unorm8" });
+areEqualImageData('gotten_imageData_unorm8', 'expected_imageData_unorm8', 0);
+gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
+areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_01_tolerance);
+
+context.clearRect(0, 0, canvas.width, canvas.height);
+context.putImageData(gotten_imageData_float16, 0, 0);
+gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
+areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_01_tolerance);
+gotten_imageData_unorm8 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-unorm8" });
+areEqualImageData('gotten_imageData_unorm8', 'expected_imageData_unorm8', 0);
+
+shouldThrowErrorName(`context.createImageData(1, 1, { pixelFormat: "foo" })`, "TypeError")
+shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" })`, "TypeError")
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt
@@ -23,62 +23,6 @@ PASS gotten_imageData_unorm8.data.at(0) is 0
 PASS gotten_imageData_unorm8.data.at(1) is 128
 PASS gotten_imageData_unorm8.data.at(2) is 255
 PASS gotten_imageData_unorm8.data.at(3) is 255
-PASS created_imageData_float16.width is 1
-PASS created_imageData_float16.height is 1
-PASS created_imageData_float16.data.constructor is Float16Array
-PASS created_imageData_float16.data.BYTES_PER_ELEMENT is 2
-PASS created_imageData_float16.data.length is 4
-PASS created_imageData_float16.data.byteLength is 8
-PASS created_imageData_float16.data.at(0) is 0
-PASS created_imageData_float16.data.at(1) is 0
-PASS created_imageData_float16.data.at(2) is 0
-PASS created_imageData_float16.data.at(3) is 0
-PASS gotten_imageData_float16.width is 1
-PASS gotten_imageData_float16.height is 1
-PASS gotten_imageData_float16.data.constructor is Float16Array
-PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is 2
-PASS gotten_imageData_float16.data.length is 4
-PASS gotten_imageData_float16.data.byteLength is 8
-PASS gotten_imageData_float16.data.at(0) is within 0.001953125 of 0
-PASS gotten_imageData_float16.data.at(1) is within 0.001953125 of 0.5019607843137255
-PASS gotten_imageData_float16.data.at(2) is within 0.001953125 of 1
-PASS gotten_imageData_float16.data.at(3) is within 0.001953125 of 1
-PASS gotten_imageData_unorm8_from_float16.width is 1
-PASS gotten_imageData_unorm8_from_float16.height is 1
-PASS gotten_imageData_unorm8_from_float16.data.constructor is Uint8ClampedArray
-PASS gotten_imageData_unorm8_from_float16.data.BYTES_PER_ELEMENT is 1
-PASS gotten_imageData_unorm8_from_float16.data.length is 4
-PASS gotten_imageData_unorm8_from_float16.data.byteLength is 4
-PASS gotten_imageData_unorm8_from_float16.data.at(0) is 0
-PASS gotten_imageData_unorm8_from_float16.data.at(1) is 128
-PASS gotten_imageData_unorm8_from_float16.data.at(2) is 255
-PASS gotten_imageData_unorm8_from_float16.data.at(3) is 255
-PASS canvas.width * canvas.height >= 256 * componentsToTest is true
-PASS pixelOffset is 256 * componentsToTest
-PASS gotten_imageData_unorm8.width is expected_imageData_unorm8.width
-PASS gotten_imageData_unorm8.height is expected_imageData_unorm8.height
-PASS gotten_imageData_unorm8.data.constructor is expected_imageData_unorm8.data.constructor
-PASS gotten_imageData_unorm8.data.BYTES_PER_ELEMENT is expected_imageData_unorm8.data.BYTES_PER_ELEMENT
-PASS gotten_imageData_unorm8.data.length is expected_imageData_unorm8.data.length
-PASS gotten_imageData_unorm8.data.byteLength is expected_imageData_unorm8.data.byteLength
-PASS gotten_imageData_float16.width is expected_imageData_float16.width
-PASS gotten_imageData_float16.height is expected_imageData_float16.height
-PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
-PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
-PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
-PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
-PASS gotten_imageData_float16.width is expected_imageData_float16.width
-PASS gotten_imageData_float16.height is expected_imageData_float16.height
-PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
-PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
-PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
-PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
-PASS gotten_imageData_unorm8.width is expected_imageData_unorm8.width
-PASS gotten_imageData_unorm8.height is expected_imageData_unorm8.height
-PASS gotten_imageData_unorm8.data.constructor is expected_imageData_unorm8.data.constructor
-PASS gotten_imageData_unorm8.data.BYTES_PER_ELEMENT is expected_imageData_unorm8.data.BYTES_PER_ELEMENT
-PASS gotten_imageData_unorm8.data.length is expected_imageData_unorm8.data.length
-PASS gotten_imageData_unorm8.data.byteLength is expected_imageData_unorm8.data.byteLength
 PASS context.createImageData(1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
 PASS context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
 PASS successfullyParsed is true

--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -41,27 +41,7 @@ function verifyImageData(variable, constructor, bytesPerElement, red, green, blu
     shouldBeAround(variable + '.data.at(3)', alpha, tolerance, quiet);
 }
 
-function areEqualImageData(imageDataActual, imageDataExpected, tolerance)
-{
-    tolerance = 0;
-    shouldBe(imageDataActual + '.width', imageDataExpected + '.width');
-    shouldBe(imageDataActual + '.height', imageDataExpected + '.height');
-    shouldBe(imageDataActual + '.data.constructor', imageDataExpected + '.data.constructor');
-    shouldBe(imageDataActual + '.data.BYTES_PER_ELEMENT', imageDataExpected + '.data.BYTES_PER_ELEMENT');
-    shouldBe(imageDataActual + '.data.length', imageDataExpected + '.data.length');
-    shouldBe(imageDataActual + '.data.byteLength', imageDataExpected + '.data.byteLength');
-    const actualData = eval(imageDataActual).data;
-    const expectedData = eval(imageDataExpected).data;
-    for (component = 0; component < actualData.length; ++component) {
-        if (Math.abs(actualData[component] - expectedData[component]) > tolerance)
-            shouldBeAround(imageDataActual + '.data[' + component + ']', expectedData[component], tolerance, true);
-    }
-}
-
 const unorm8_bytes_per_element = 1;
-const float16_bytes_per_element = 2;
-// Less than half the range of a color component [0..255]/255 unit.
-const float16_nonzero_tolerance = (1 / 256) / 2;
 
 var created_imageData_unorm8 = context.createImageData(1, 1, { pixelFormat: "rgba-unorm8" });
 verifyImageData('created_imageData_unorm8', 'Uint8ClampedArray', unorm8_bytes_per_element, 0, 0, 0, 0);
@@ -69,77 +49,8 @@ verifyImageData('created_imageData_unorm8', 'Uint8ClampedArray', unorm8_bytes_pe
 var gotten_imageData_unorm8 = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-unorm8" });
 verifyImageData('gotten_imageData_unorm8', 'Uint8ClampedArray', unorm8_bytes_per_element, r, g, b, a);
 
-var created_imageData_float16 = context.createImageData(1, 1, { pixelFormat: "rgba-float16" });
-verifyImageData('created_imageData_float16', 'Float16Array', float16_bytes_per_element, 0, 0, 0, 0, 0);
-
-// This verifies the basic unorm8->float16 conversion.
-var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-float16" });
-verifyImageData('gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance);
-
-// Put the float16 ImageData back into the (unorm8-backed) canvas, and get a default (unorm8) ImageData.
-// This verifies the basic float16->unorm8 conversion:
-context.clearRect(0, 0, 1, 1);
-context.putImageData(gotten_imageData_float16, 0, 0);
-var gotten_imageData_unorm8_from_float16 = context.getImageData(0, 0, 1, 1);
-verifyImageData('gotten_imageData_unorm8_from_float16', 'Uint8ClampedArray', unorm8_bytes_per_element, r, g, b, a);
-
-// Exhaustive unorm8->float16->unorm8 round-trip test for all possible individual rgba-unorm8 component values. Only log errors.
-canvas.width = 64;
-canvas.height = 16;
-var componentsToTest = componentsPerPixel;
-shouldBeTrue('canvas.width * canvas.height >= 256 * componentsToTest');
-
-var input_imageData_unorm8 = context.createImageData(canvas.width, canvas.height);
-var expected_imageData_unorm8 = context.createImageData(canvas.width, canvas.height);
-var expected_imageData_float16 = context.createImageData(canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
-
-var pixelOffset = 0;
-for (let v = 0; v < 256; ++v) {
-    for (component = 0; component < componentsToTest; ++component) {
-        r = g = b = 0;
-        a = 255;
-        switch (component) {
-        case 0: r = v; break;
-        case 1: g = v; break;
-        case 2: b = v; break;
-        case 3: r = g = b = (v ? 255 : 0); a = v; break;
-        }
-        input_imageData_unorm8.data[pixelOffset * componentsPerPixel + 0] = r;
-        input_imageData_unorm8.data[pixelOffset * componentsPerPixel + 1] = g;
-        input_imageData_unorm8.data[pixelOffset * componentsPerPixel + 2] = b;
-        input_imageData_unorm8.data[pixelOffset * componentsPerPixel + 3] = a;
-
-        expected_imageData_unorm8.data[pixelOffset * componentsPerPixel + 0] = r;
-        expected_imageData_unorm8.data[pixelOffset * componentsPerPixel + 1] = g;
-        expected_imageData_unorm8.data[pixelOffset * componentsPerPixel + 2] = b;
-        expected_imageData_unorm8.data[pixelOffset * componentsPerPixel + 3] = a;
-
-        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 0] = r / 255;
-        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 1] = g / 255;
-        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 2] = b / 255;
-        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 3] = a / 255;
-
-        ++pixelOffset;
-    }
-}
-shouldBe('pixelOffset', '256 * componentsToTest');
-
-context.putImageData(input_imageData_unorm8, 0, 0);
-gotten_imageData_unorm8 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-unorm8" });
-areEqualImageData('gotten_imageData_unorm8', 'expected_imageData_unorm8', 0);
-gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
-areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_nonzero_tolerance);
-
-context.clearRect(0, 0, canvas.width, canvas.height);
-context.putImageData(gotten_imageData_float16, 0, 0);
-gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
-areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_nonzero_tolerance);
-gotten_imageData_unorm8 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-unorm8" });
-areEqualImageData('gotten_imageData_unorm8', 'expected_imageData_unorm8', 0);
-
 shouldThrowErrorName(`context.createImageData(1, 1, { pixelFormat: "foo" })`, "TypeError")
 shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" })`, "TypeError")
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -189,11 +189,9 @@ Ref<PixelBuffer> ImageData::pixelBuffer() const
     switch (m_data.pixelFormat()) {
     case ImageDataPixelFormat::RgbaUnorm8:
         return byteArrayPixelBuffer();
-    case ImageDataPixelFormat::RgbaFloat16:
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
+    case ImageDataPixelFormat::RgbaFloat16:
         return float16ArrayPixelBuffer();
-#else
-        RELEASE_ASSERT_NOT_REACHED("Unexpected ImageDataPixelFormat::RgbaFloat16");
 #endif
     }
     RELEASE_ASSERT_NOT_REACHED("Unexpected ImageDataPixelFormat value");

--- a/Source/WebCore/html/ImageDataArray.cpp
+++ b/Source/WebCore/html/ImageDataArray.cpp
@@ -76,12 +76,14 @@ std::optional<ImageDataArray> ImageDataArray::tryCreate(size_t length, ImageData
             array.emplace(typedArray.releaseNonNull());
         }
         break;
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
     case ImageDataPixelFormat::RgbaFloat16:
         if (RefPtr typedArray = JSC::Float16Array::tryCreateUninitialized(length)) {
             fillTypedArray(*typedArray, optionalBytes);
             array.emplace(typedArray.releaseNonNull());
         }
         break;
+#endif
     }
     return array;
 }
@@ -180,8 +182,10 @@ Ref<ArrayBufferView> ImageDataArray::extractBufferViewWithPixelFormat(std::optio
 
     switch (*overridingPixelFormat) {
     case ImageDataPixelFormat::RgbaUnorm8: return asUint8ClampedArray();
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
     case ImageDataPixelFormat::RgbaFloat16: return asFloat16Array();
-    }
+#endif
+}
     RELEASE_ASSERT_NOT_REACHED("Unexpected ImageDataPixelFormat value");
 }
 

--- a/Source/WebCore/html/ImageDataPixelFormat.h
+++ b/Source/WebCore/html/ImageDataPixelFormat.h
@@ -32,7 +32,9 @@ namespace WebCore {
 
 enum class ImageDataPixelFormat : bool {
     RgbaUnorm8,
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
     RgbaFloat16,
+#endif
 };
 
 constexpr PixelFormat toPixelFormat(ImageDataPixelFormat pixelFormat)
@@ -40,11 +42,9 @@ constexpr PixelFormat toPixelFormat(ImageDataPixelFormat pixelFormat)
     switch (pixelFormat) {
     case ImageDataPixelFormat::RgbaUnorm8:
         break;
-    case ImageDataPixelFormat::RgbaFloat16:
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
+    case ImageDataPixelFormat::RgbaFloat16:
         return PixelFormat::RGBA16F;
-#else
-        break;
 #endif
     }
     return PixelFormat::RGBA8;
@@ -54,7 +54,9 @@ constexpr std::optional<ImageDataPixelFormat> toImageDataPixelFormat(JSC::TypedA
 {
     switch (typedArrayType) {
     case JSC::TypeUint8Clamped: return ImageDataPixelFormat::RgbaUnorm8;
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
     case JSC::TypeFloat16: return ImageDataPixelFormat::RgbaFloat16;
+#endif
     default: return std::nullopt;
     }
 }

--- a/Source/WebCore/html/ImageDataPixelFormat.idl
+++ b/Source/WebCore/html/ImageDataPixelFormat.idl
@@ -26,5 +26,7 @@
 // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagedatapixelformat
 enum ImageDataPixelFormat {
     "rgba-unorm8",
+#if defined(ENABLE_PIXEL_FORMAT_RGBA16F) && ENABLE_PIXEL_FORMAT_RGBA16F
     "rgba-float16",
+#endif
 };

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3178,13 +3178,12 @@ PixelFormat CanvasRenderingContext2DBase::pixelFormat() const
     switch (m_settings.colorType) {
     case CanvasRenderingContext2DSettings::ColorType::Unorm8:
         return PixelFormat::BGRA8;
-    case CanvasRenderingContext2DSettings::ColorType::Float16:
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
+    case CanvasRenderingContext2DSettings::ColorType::Float16:
         return PixelFormat::RGBA16F;
-#else
-        return PixelFormat::BGRA8;
 #endif
     }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 DestinationColorSpace CanvasRenderingContext2DBase::colorSpace() const

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.h
@@ -37,7 +37,9 @@ struct CanvasRenderingContext2DSettings {
     PredefinedColorSpace colorSpace { PredefinedColorSpace::SRGB };
     enum class ColorType : bool {
         Unorm8,
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
         Float16,
+#endif
     };
     ColorType colorType { ColorType::Unorm8 };
     enum class RenderingMode {

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl
@@ -26,7 +26,9 @@
 // https://html.spec.whatwg.org/multipage/canvas.html#canvascolortype
 enum CanvasColorType {
     "unorm8",
+#if defined(ENABLE_PIXEL_FORMAT_RGBA16F) && ENABLE_PIXEL_FORMAT_RGBA16F
     "float16",
+#endif
 };
 
 enum RenderingMode {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -274,7 +274,11 @@ void RemoteGPU::paintNativeImageToImageBuffer(WebCore::NativeImage& nativeImage,
 #if ENABLE(GPU_PROCESS_MODEL)
 Vector<UniqueRef<WebCore::IOSurface>> RemoteGPU::createRenderBuffers(unsigned width, unsigned height, const WebCore::ProcessIdentity& processIdentity, bool standardDynamicRange)
 {
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
     const auto colorFormat = standardDynamicRange ? WebCore::IOSurface::Format::BGRA : WebCore::IOSurface::Format::RGBA16F;
+#else
+    const auto colorFormat = WebCore::IOSurface::Format::BGRA;
+#endif
     const auto colorSpace = standardDynamicRange ? WebCore::DestinationColorSpace::LinearDisplayP3() : WebCore::DestinationColorSpace::ExtendedLinearDisplayP3();
 
     Vector<UniqueRef<WebCore::IOSurface>> ioSurfaces;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -237,14 +237,18 @@ void WebModelPlayer::load(WebCore::NodeIdentifier nodeID, WebCore::Model& modelS
     bool standardDynamicRange = false;
 #endif
 
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
     m_lastSentContentsHeadroom = -1.f;
+#endif
     m_currentModel = static_cast<RemoteGPUProxy&>(gpu->backing()).createModelBacking(m_currentPixelSize.width(), m_currentPixelSize.height(), WTF::move(diffuseTexture), WTF::move(specularTexture), standardDynamicRange, [protectedThis = protect(*this)] (Vector<MachSendRight>&& surfaceHandles) {
         if (surfaceHandles.size()) {
             protectedThis->m_displayBuffers = WTF::move(surfaceHandles);
             protectedThis->m_renderTextureIndex = 0;
             protectedThis->m_displayTextureIndex = 0;
             protectedThis->m_hasRenderedFrame = false;
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
             protectedThis->updateScreenHeadroomFromPage();
+#endif
         }
     });
     if (!m_currentModel)
@@ -686,7 +690,9 @@ bool WebModelPlayer::render()
                 delegate->setContentsFormat(contentsFormatForDynamicRange(protectedThis->m_usingStandardDynamicRange));
 #endif
                 delegate->setDisplayBuffer(*machSendRight);
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
                 protectedThis->updateScreenHeadroomFromPage();
+#endif
             }
 
             protectedThis->notifyClientDidFinishLoading();


### PR DESCRIPTION
#### b29f6e40dca930fbde3ab958180dc9f0e10655b9
<pre>
Float16 canvas and ImageData require RGBA16F
<a href="https://bugs.webkit.org/show_bug.cgi?id=320848">https://bugs.webkit.org/show_bug.cgi?id=320848</a>
<a href="https://rdar.apple.com/183878218">rdar://183878218</a>

Reviewed by Mike Wyrzykowski.

On platforms where PixelFormat::RGBA16F is not available (because
ENABLE_PIXEL_FORMAT_RGBA16F is 0), allowing float16 canvas and ImageData
is not helpful:
- A 2D canvas context with colorType &quot;float16&quot; would not be able to
  interpret its data. It could probably be faked by immediately
  converting float16 data into unorm8 behind the scene, but that would
  lose the extra precision and out-of-gamut values.
- While it would be possible to store a Float16Array in an ImageData
  with pixelFormat &quot;rgba-float16&quot;, actually using it in a unorm8 canvas
  (or fake float16) would also lose precision and higher values.

So it&apos;s best to just disallow these values, so as not to give wrong
expectations.

This limitation can be detected, e.g.:
`canvas.getContext(&quot;2d&quot;, {colorType:&quot;float16&quot;})` would throw a TypeError;
so websites can know when not to try and use HDR canvas.

The relevant full float16 tests have been copied to fast/canvas/hdr for
platforms that do support RGBA16F. And the original tests in fast/canvas
(for all platforms) have been reduced to not test float16 cases anymore,
except to verify that trying float16 either works or throws the
expected TypeError.

* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-disabled.html:
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-enabled.html:
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled.html:
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled-expected.txt:
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled.html:
* LayoutTests/fast/canvas/hdr/CanvasRenderingContext2DSettings-pixelFormat-enabled-expected.txt: Copied from LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled-expected.txt.
* LayoutTests/fast/canvas/hdr/CanvasRenderingContext2DSettings-pixelFormat-enabled.html: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.js:
(areEqualImageData):
* LayoutTests/fast/canvas/hdr/imagedata-storageformat-enabled-expected.txt: Copied from LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt.
* LayoutTests/fast/canvas/hdr/imagedata-storageformat-enabled.html: Copied from LayoutTests/fast/canvas/imagedata-storageformat-enabled.html.
* LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt:
* LayoutTests/fast/canvas/imagedata-storageformat-enabled.html:
* Source/WebCore/html/ImageData.cpp:
(WebCore::ImageData::pixelBuffer const):
* Source/WebCore/html/ImageDataArray.cpp:
(WebCore::ImageDataArray::tryCreate):
(WebCore::ImageDataArray::extractBufferViewWithPixelFormat):
* Source/WebCore/html/ImageDataPixelFormat.h:
(WebCore::toPixelFormat):
(WebCore::toImageDataPixelFormat):
* Source/WebCore/html/ImageDataPixelFormat.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::pixelFormat const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::createRenderBuffers):
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):
(WebKit::WebModelPlayer::render):

Canonical link: <a href="https://commits.webkit.org/318494@main">https://commits.webkit.org/318494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ee3c505b8467324f4fcd53bcb47eacce0f8628f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188000 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141633 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e7b12ec-cf91-490a-bf9b-460c03c798c3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180248 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139064 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dadfb834-cf59-4c25-9471-53f7252e3c23) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119519 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9947f86-97a8-43ac-b0ea-b129b72062b2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41295 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39644 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39324 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36456 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190428 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159349 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148221 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39817 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52673 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147995 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42708 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124938 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119557 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51191 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14299 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50576 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50816 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50638 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->