### PR TITLE
[Test Coverage] Media element playback state across a cross-document move

### DIFF
--- a/LayoutTests/media/adopt-node-playback-state-expected.txt
+++ b/LayoutTests/media/adopt-node-playback-state-expected.txt
@@ -1,0 +1,47 @@
+Test that moving a media element to another document preserves its playback state.
+
+
+
+A playing element keeps its paused state and its playback pseudo-classes across a document move
+EVENT(playing)
+EXPECTED (video.paused == 'false') OK
+EXPECTED (video.matches(":playing") == 'true') OK
+EXPECTED (video.matches(":paused") == 'false') OK
+EXPECTED (document.querySelector("video:playing") == '[object HTMLVideoElement]') OK
+RUN(iframeDocument.body.appendChild(video))
+EXPECTED (video.ownerDocument === iframeDocument == 'true') OK
+EXPECTED (video.paused == 'false') OK
+EXPECTED (video.matches(":playing") == 'true') OK
+EXPECTED (video.matches(":paused") == 'false') OK
+EXPECTED (iframeDocument.querySelector("video:playing") == '[object HTMLVideoElement]') OK
+EXPECTED (document.querySelector("video:playing") == 'null') OK
+EXPECTED (video.paused == 'false') OK
+EXPECTED (video.matches(":playing") == 'true') OK
+EXPECTED (video.matches(":paused") == 'false') OK
+RUN(video.remove())
+
+A playing element fires no play or pause event across a document move, and playback continues
+EVENT(playing)
+RUN(iframeDocument.body.appendChild(video))
+EXPECTED (video.ownerDocument === iframeDocument == 'true') OK
+EXPECTED (pauseEventCount == '0') OK
+EXPECTED (playEventCount == '0') OK
+EXPECTED (video.paused == 'false') OK
+EXPECTED (playbackAdvanced() == 'true') OK
+RUN(video.remove())
+
+A paused element stays paused across a document move
+EVENT(playing)
+RUN(video.pause())
+EVENT(pause)
+EXPECTED (video.paused == 'true') OK
+RUN(iframeDocument.body.appendChild(video))
+EXPECTED (video.ownerDocument === iframeDocument == 'true') OK
+EXPECTED (video.paused == 'true') OK
+EXPECTED (video.matches(":paused") == 'true') OK
+EXPECTED (video.matches(":playing") == 'false') OK
+EXPECTED (iframeDocument.querySelector("video:paused") == '[object HTMLVideoElement]') OK
+EXPECTED (playEventCount == '0') OK
+RUN(video.remove())
+END OF TEST
+

--- a/LayoutTests/media/adopt-node-playback-state.html
+++ b/LayoutTests/media/adopt-node-playback-state.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>adopt-node-playback-state</title>
+    <script src="video-test.js"></script>
+    <script src="media-file.js"></script>
+    <script>
+    // Moving a media element into another document is not one of the pause triggers in the
+    // HTML specification, so an element that was playing must still be playing after the
+    // move, and an element that was paused must still be paused. Removing an element from a
+    // document does pause it, but asynchronously, so these tests also cover that the pending
+    // pause is not applied to an element that was inserted into a different document in the
+    // same task.
+
+    var video;
+    var iframeDocument;
+    var playEventCount;
+    var pauseEventCount;
+    var timeAtMove;
+
+    async function createPlayingVideo()
+    {
+        video = document.createElement('video');
+        video.loop = true;
+        video.src = findMediaFile('video', 'content/test');
+        document.body.appendChild(video);
+        video.play();
+        await waitFor(video, 'playing');
+    }
+
+    function countPlaybackEvents()
+    {
+        playEventCount = 0;
+        pauseEventCount = 0;
+        video.addEventListener('play', () => ++playEventCount);
+        video.addEventListener('pause', () => ++pauseEventCount);
+    }
+
+    function playbackAdvanced()
+    {
+        return video.currentTime > timeAtMove;
+    }
+
+    function moveVideoToIFrameDocument()
+    {
+        timeAtMove = video.currentTime;
+        run('iframeDocument.body.appendChild(video)');
+        testExpected('video.ownerDocument === iframeDocument', true);
+    }
+
+    async function testPlayingElementStatePreserved()
+    {
+        consoleWrite('<br>A playing element keeps its paused state and its playback pseudo-classes across a document move');
+
+        await createPlayingVideo();
+        testExpected('video.paused', false);
+        testExpected('video.matches(":playing")', true);
+        testExpected('video.matches(":paused")', false);
+        testExpected('document.querySelector("video:playing")', video);
+
+        moveVideoToIFrameDocument();
+
+        testExpected('video.paused', false);
+        testExpected('video.matches(":playing")', true);
+        testExpected('video.matches(":paused")', false);
+        testExpected('iframeDocument.querySelector("video:playing")', video);
+        testExpected('document.querySelector("video:playing")', null);
+
+        // The pause queued by the removal from the old document runs in a later task; it must
+        // not fire for an element that is still connected, to a different document.
+        await sleepFor(0);
+        testExpected('video.paused', false);
+        testExpected('video.matches(":playing")', true);
+        testExpected('video.matches(":paused")', false);
+
+        run('video.remove()');
+    }
+
+    async function testPlayingElementFiresNoStateTransitionEvents()
+    {
+        consoleWrite('<br>A playing element fires no play or pause event across a document move, and playback continues');
+
+        await createPlayingVideo();
+        countPlaybackEvents();
+
+        moveVideoToIFrameDocument();
+        await sleepFor(0);
+
+        // The element never left the "potentially playing" state, so neither of the paused
+        // state transitions ran.
+        testExpected('pauseEventCount', 0);
+        testExpected('playEventCount', 0);
+        testExpected('video.paused', false);
+
+        // Playback really is still progressing in the new document.
+        await testExpectedEventually('playbackAdvanced()', true, '==', 3000);
+
+        run('video.remove()');
+    }
+
+    async function testPausedElementStaysPaused()
+    {
+        consoleWrite('<br>A paused element stays paused across a document move');
+
+        await createPlayingVideo();
+        run('video.pause()');
+        await waitFor(video, 'pause');
+        testExpected('video.paused', true);
+        countPlaybackEvents();
+
+        moveVideoToIFrameDocument();
+        await sleepFor(0);
+
+        testExpected('video.paused', true);
+        testExpected('video.matches(":paused")', true);
+        testExpected('video.matches(":playing")', false);
+        testExpected('iframeDocument.querySelector("video:paused")', video);
+        testExpected('playEventCount', 0);
+
+        run('video.remove()');
+    }
+
+    window.addEventListener('load', async event => {
+        const iframe = document.querySelector('iframe');
+        if (!iframe.contentDocument.body)
+            await waitFor(iframe, 'load', true);
+        iframeDocument = iframe.contentDocument;
+
+        await testPlayingElementStatePreserved();
+        await testPlayingElementFiresNoStateTransitionEvents();
+        await testPausedElementStaysPaused();
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <p>Test that moving a media element to another document preserves its playback state.</p>
+    <iframe src="about:blank"></iframe>
+</body>
+</html>


### PR DESCRIPTION
#### bd33f93c1a0989bda65eb45bd345f0669165cb0c
<pre>
[Test Coverage] Media element playback state across a cross-document move
<a href="https://bugs.webkit.org/show_bug.cgi?id=320838">https://bugs.webkit.org/show_bug.cgi?id=320838</a>
<a href="https://rdar.apple.com/183856196">rdar://183856196</a>

Reviewed by NOBODY (OOPS!).

Moving a media element into another document is not one of the pause triggers in
the HTML specification, so a playing element must still be playing after the move
and a paused element must still be paused. WebKit already behaves correctly, but
nothing covered it. Add a layout test asserting that a playing element keeps
`paused` false, keeps matching :playing and not :paused, fires no `play` or
`pause` event, and keeps advancing currentTime; and that a paused element stays
paused.

The element is inserted into both documents&apos; trees so the removal really does
queue the pause in HTMLMediaElement::removingSteps(), covering the
m_inActiveDocument early return in HTMLMediaElement::pauseAfterDetachedTask().

* LayoutTests/media/adopt-node-playback-state-expected.txt: Added.
* LayoutTests/media/adopt-node-playback-state.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd33f93c1a0989bda65eb45bd345f0669165cb0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187846 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141479 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/81fef9e9-4e4c-4cc8-81bc-d8e03e838cbb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138940 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96460 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2353f334-2df4-4d87-a4cd-2d04cadca4b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42498 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159707 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119396 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/269c2444-f4fd-4f3c-9f08-39f3f8591e76) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41164 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39519 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39203 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36303 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190273 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148092 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52520 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147865 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42581 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119350 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51038 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14179 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50423 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50663 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50485 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->