### PR TITLE
[Test Coverage] Add a layout test for inserting a media element into a document with no browsing context

### DIFF
--- a/LayoutTests/media/adopt-node-into-inactive-document-expected.txt
+++ b/LayoutTests/media/adopt-node-into-inactive-document-expected.txt
@@ -1,0 +1,31 @@
+Test that inserting a media element into a document with no browsing context does not create controls, and that discarding the media element's original document afterwards does not crash.
+
+
+* A media element with controls in the frame's active document has a populated user agent shadow tree.
+EXPECTED (internals.shadowRoot(movedElement).childNodes.length > '0') OK
+
+* document.implementation.createHTMLDocument() creates a document with no browsing context, so it is never active.
+EXPECTED (inactiveDocument.defaultView == 'null') OK
+
+* Moving the media element into the inactive document keeps its existing controls.
+EXPECTED (movedElement.ownerDocument === inactiveDocument == 'true') OK
+EXPECTED (internals.shadowRoot(movedElement).childNodes.length > '0') OK
+
+* A media element with controls that is only ever inserted into the inactive document does not create controls at all.
+EXPECTED (neverInsertedElement.ownerDocument === inactiveDocument == 'true') OK
+EXPECTED (internals.shadowRoot(neverInsertedElement) == 'null') OK
+
+* Discarding the original document does not cause anything unusual to happen.
+EXPECTED (movedElement.controls == 'true') OK
+EXPECTED (movedElement.currentTime == '0') OK
+EXPECTED (internals.shadowRoot(movedElement).childNodes.length > '0') OK
+EXPECTED (neverInsertedElement.controls == 'true') OK
+EXPECTED (internals.shadowRoot(neverInsertedElement) == 'null') OK
+
+* Moving both media elements into this active document creates their controls.
+EXPECTED (movedElement.ownerDocument === document == 'true') OK
+EXPECTED (internals.shadowRoot(movedElement).childNodes.length > '0') OK
+EXPECTED (neverInsertedElement.ownerDocument === document == 'true') OK
+EXPECTED (internals.shadowRoot(neverInsertedElement).childNodes.length > '0') OK
+END OF TEST
+

--- a/LayoutTests/media/adopt-node-into-inactive-document.html
+++ b/LayoutTests/media/adopt-node-into-inactive-document.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src=video-test.js></script>
+</head>
+<body>
+<p>Test that inserting a media element into a document with no browsing context does not create controls, and that discarding the media element's original document afterwards does not crash.</p>
+<iframe id="frame" srcdoc="<video controls></video>"></iframe>
+<script>
+
+var frame = document.getElementById("frame");
+var frameDocument = null;
+var inactiveDocument = null;
+var movedElement = null;
+var neverInsertedElement = null;
+
+function forceGC()
+{
+    if (window.GCController)
+        GCController.collect();
+}
+
+frame.addEventListener("load", () => {
+    frameDocument = frame.contentDocument;
+
+    consoleWrite("<br>* A media element with controls in the frame's active document has a populated user agent shadow tree.");
+    movedElement = frameDocument.querySelector("video");
+    testExpected("internals.shadowRoot(movedElement).childNodes.length", 0, ">");
+
+    consoleWrite("<br>* document.implementation.createHTMLDocument() creates a document with no browsing context, so it is never active.");
+    inactiveDocument = frameDocument.implementation.createHTMLDocument();
+    testExpected("inactiveDocument.defaultView", null);
+
+    consoleWrite("<br>* Moving the media element into the inactive document keeps its existing controls.");
+    inactiveDocument.body.appendChild(movedElement);
+    testExpected("movedElement.ownerDocument === inactiveDocument", true);
+    testExpected("internals.shadowRoot(movedElement).childNodes.length", 0, ">");
+
+    consoleWrite("<br>* A media element with controls that is only ever inserted into the inactive document does not create controls at all.");
+    neverInsertedElement = frameDocument.createElement("video");
+    neverInsertedElement.setAttribute("controls", "");
+    inactiveDocument.body.appendChild(neverInsertedElement);
+    testExpected("neverInsertedElement.ownerDocument === inactiveDocument", true);
+    testExpected("internals.shadowRoot(neverInsertedElement)", null);
+
+    consoleWrite("<br>* Discarding the original document does not cause anything unusual to happen.");
+    frame.remove();
+    frameDocument = null;
+    forceGC();
+    testExpected("movedElement.controls", true);
+    testExpected("movedElement.currentTime", 0);
+    testExpected("internals.shadowRoot(movedElement).childNodes.length", 0, ">");
+    testExpected("neverInsertedElement.controls", true);
+    testExpected("internals.shadowRoot(neverInsertedElement)", null);
+
+    consoleWrite("<br>* Moving both media elements into this active document creates their controls.");
+    document.body.appendChild(movedElement);
+    document.body.appendChild(neverInsertedElement);
+    testExpected("movedElement.ownerDocument === document", true);
+    testExpected("internals.shadowRoot(movedElement).childNodes.length", 0, ">");
+    testExpected("neverInsertedElement.ownerDocument === document", true);
+    testExpected("internals.shadowRoot(neverInsertedElement).childNodes.length", 0, ">");
+
+    endTest();
+});
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### a6d1d5a3c9c112b9e922e524d84050ee05384001
<pre>
[Test Coverage] Add a layout test for inserting a media element into a document with no browsing context
<a href="https://bugs.webkit.org/show_bug.cgi?id=320839">https://bugs.webkit.org/show_bug.cgi?id=320839</a>
<a href="https://rdar.apple.com/183856803">rdar://183856803</a>

Reviewed by NOBODY (OOPS!).

Add coverage for HTMLMediaElement::configureMediaControls()&apos;s &quot;!isConnected() ||
!inActiveDocument()&quot; early return, which is reached when a media element with
the controls attribute is inserted into a document created by
DOMImplementation::createHTMLDocument(), i.e. one that has no browsing context
and is therefore never active.

The test asserts the script-observable behavior:

- A media element that already built its controls keeps its user agent shadow
  tree when moved into the inactive document, since WebKit does not tear
  controls down on removal.
- A media element that is only ever inserted into the inactive document gets no
  user agent shadow root at all, so no controls are created.
- Discarding the original document afterwards, by removing the iframe that owns
  it and collecting, does not crash, and the elements remain usable.
- Appending both elements to an active document after their original document
  was discarded creates their controls, which is the same claim as
  media/video-controls-adoptNode.html in the opposite direction.

* LayoutTests/media/adopt-node-into-inactive-document-expected.txt: Added.
* LayoutTests/media/adopt-node-into-inactive-document.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6d1d5a3c9c112b9e922e524d84050ee05384001

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141480 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cfbece2b-58e5-4e83-8ca9-8c1234a6111d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138941 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96461 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d31817e-123b-4541-a69b-7b7729238822) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119397 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fcd87d7-f961-466c-9ce6-11a6783f4332) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41165 "Found 1 new test failure: imported/w3c/web-platform-tests/background-fetch/match.https.window.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39520 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151565 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39205 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36304 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190274 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159233 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148093 "Found 1 new test failure: compositing/geometry/abs-position-inside-opacity.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52521 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147866 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42582 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119351 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51039 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14181 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50424 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50664 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50486 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->