### PR TITLE
Web Inspector: Canvas: show WebGPU `label` where able

### DIFF
--- a/LayoutTests/inspector/canvas/create-context-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-webgpu-expected.txt
@@ -8,6 +8,7 @@ PASS: CanvasManager should initially have no canvases.
 -- Running test case: Canvas.CreateContextWebGPU.DeviceLifecycle
 PASS: Added a Canvas.
 PASS: Canvas should represent a WebGPU device.
+PASS: Canvas should use the GPUDevice label as its display name.
 PASS: CanvasManager should contain one Canvas.
 PASS: Canvas should contain WebGPU features.
 PASS: Canvas should report every enabled WebGPU feature.

--- a/LayoutTests/inspector/canvas/create-context-webgpu.html
+++ b/LayoutTests/inspector/canvas/create-context-webgpu.html
@@ -11,7 +11,7 @@ let garbageCollectionInterval = null;
 async function createDevice() {
     adapter = await navigator.gpu.requestAdapter();
     let firstSupportedFeature = adapter.features.values().next().value;
-    device = await adapter.requestDevice({requiredFeatures: firstSupportedFeature ? [firstSupportedFeature] : []});
+    device = await adapter.requestDevice({label: "Labeled WebGPU Device", requiredFeatures: firstSupportedFeature ? [firstSupportedFeature] : []});
     TestPage.dispatchEventToFrontend("WebGPUDeviceReady");
 }
 
@@ -51,6 +51,7 @@ function test() {
             let canvas = canvasAddedEvent.data.item;
             InspectorTest.expectThat(canvas instanceof WI.Canvas, "Added a Canvas.");
             InspectorTest.expectEqual(canvas.contextType, WI.Canvas.ContextType.WebGPU, "Canvas should represent a WebGPU device.");
+            InspectorTest.expectEqual(canvas.displayName, "Labeled WebGPU Device", "Canvas should use the GPUDevice label as its display name.");
             InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "CanvasManager should contain one Canvas.");
             let enabledFeatures = JSON.parse(await InspectorTest.evaluateInPage(`JSON.stringify(Array.from(device.features))`));
             InspectorTest.expectTrue(Array.isArray(canvas.features), "Canvas should contain WebGPU features.");

--- a/LayoutTests/inspector/canvas/resources/shaderProgram-utilities-webgpu.js
+++ b/LayoutTests/inspector/canvas/resources/shaderProgram-utilities-webgpu.js
@@ -34,13 +34,14 @@ async function initializeWebGPU() {
     device = await adapter.requestDevice();
     presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
-    await createComputePipeline();
-    await createRenderPipeline();
+    await createComputePipeline({label: "Labeled Compute Pipeline"});
+    await createRenderPipeline({label: "Labeled Render Pipeline"});
 }
 
-async function createComputePipeline({asynchronously = false} = {}) {
+async function createComputePipeline({asynchronously = false, label = ""} = {}) {
     let shaderModule = device.createShaderModule({code: computeShaderSource});
     let descriptor = {
+        label,
         layout: "auto",
         compute: {
             module: shaderModule,
@@ -51,10 +52,11 @@ async function createComputePipeline({asynchronously = false} = {}) {
     computePipelines.push(pipeline);
 }
 
-async function createRenderPipeline({asynchronously = false} = {}) {
+async function createRenderPipeline({asynchronously = false, label = ""} = {}) {
     let vertexShaderModule = device.createShaderModule({code: vertexShaderSource});
     let fragmentShaderModule = device.createShaderModule({code: fragmentShaderSource});
     let descriptor = {
+        label,
         layout: "auto",
         vertex: {
             module: vertexShaderModule,

--- a/LayoutTests/inspector/canvas/resources/webgpu-worker.js
+++ b/LayoutTests/inspector/canvas/resources/webgpu-worker.js
@@ -26,10 +26,11 @@ let offscreenContext = null;
 
 async function initialize() {
     adapter = await navigator.gpu.requestAdapter();
-    device = await adapter.requestDevice();
+    device = await adapter.requestDevice({label: "Labeled Worker WebGPU Device"});
 
     let computeShaderModule = device.createShaderModule({code: computeShaderSource});
     computePipeline = device.createComputePipeline({
+        label: "Labeled Worker Compute Pipeline",
         layout: "auto",
         compute: {
             module: computeShaderModule,
@@ -40,6 +41,7 @@ async function initialize() {
     let renderShaderModule = device.createShaderModule({code: renderShaderSource});
     let format = navigator.gpu.getPreferredCanvasFormat();
     renderPipeline = device.createRenderPipeline({
+        label: "Labeled Worker Render Pipeline",
         layout: "auto",
         vertex: {
             module: renderShaderModule,

--- a/LayoutTests/inspector/canvas/shaderProgram-add-remove-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/shaderProgram-add-remove-webgpu-expected.txt
@@ -5,9 +5,11 @@ Test that CanvasManager tracks creation and destruction of WebGPU pipelines.
 -- Running test case: Canvas.ShaderProgram.WebGPU.Existing
 PASS: Found the existing compute ShaderProgram.
 PASS: Compute ShaderProgram should have the WebGPU Canvas as its parent.
+PASS: Compute ShaderProgram should use the pipeline label as its display name.
 PASS: Compute ShaderProgram should not support disabling.
 PASS: Found the existing render ShaderProgram.
 PASS: Render ShaderProgram should have the WebGPU Canvas as its parent.
+PASS: Render ShaderProgram should use the pipeline label as its display name.
 PASS: Render ShaderProgram should support disabling.
 PASS: Canvas should initially have two ShaderPrograms.
 

--- a/LayoutTests/inspector/canvas/shaderProgram-add-remove-webgpu.html
+++ b/LayoutTests/inspector/canvas/shaderProgram-add-remove-webgpu.html
@@ -37,11 +37,13 @@ function test() {
             let computeProgram = InspectorTest.WebGPU.shaderProgramForType(canvas, WI.ShaderProgram.ProgramType.Compute);
             InspectorTest.expectThat(computeProgram instanceof WI.ShaderProgram, "Found the existing compute ShaderProgram.");
             InspectorTest.expectEqual(computeProgram.canvas, canvas, "Compute ShaderProgram should have the WebGPU Canvas as its parent.");
+            InspectorTest.expectEqual(computeProgram.displayName, "Labeled Compute Pipeline", "Compute ShaderProgram should use the pipeline label as its display name.");
             InspectorTest.expectFalse(computeProgram.supportsDisabling, "Compute ShaderProgram should not support disabling.");
 
             let renderProgram = InspectorTest.WebGPU.shaderProgramForType(canvas, WI.ShaderProgram.ProgramType.Render);
             InspectorTest.expectThat(renderProgram instanceof WI.ShaderProgram, "Found the existing render ShaderProgram.");
             InspectorTest.expectEqual(renderProgram.canvas, canvas, "Render ShaderProgram should have the WebGPU Canvas as its parent.");
+            InspectorTest.expectEqual(renderProgram.displayName, "Labeled Render Pipeline", "Render ShaderProgram should use the pipeline label as its display name.");
             InspectorTest.expectTrue(renderProgram.supportsDisabling, "Render ShaderProgram should support disabling.");
             InspectorTest.expectEqual(canvas.shaderProgramCollection.size, 2, "Canvas should initially have two ShaderPrograms.");
         },

--- a/LayoutTests/inspector/canvas/worker-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/worker-webgpu-expected.txt
@@ -5,6 +5,7 @@ Test WebGPU Canvas instrumentation for a Worker rendering to an OffscreenCanvas.
 -- Running test case: Canvas.WebGPU.Worker.Device
 PASS: Worker target should expose the Canvas domain.
 PASS: WebGPU Canvas should belong to the Worker target.
+PASS: Worker Canvas should use the GPUDevice label as its display name.
 PASS: Payload should have type "object".
 PASS: Payload should have className "GPUDevice".
 PASS: Worker GPUDevice should have no DOM client nodes.
@@ -13,8 +14,10 @@ PASS: Worker WebGPU Canvas content should not be empty.
 -- Running test case: Canvas.WebGPU.Worker.Pipelines
 PASS: Worker GPUDevice should have two ShaderPrograms.
 PASS: Found the Worker compute ShaderProgram.
+PASS: Worker compute ShaderProgram should use the pipeline label as its display name.
 PASS: Compute ShaderProgram should expose its WGSL source.
 PASS: Found the Worker render ShaderProgram.
+PASS: Worker render ShaderProgram should use the pipeline label as its display name.
 PASS: Worker render pipeline should report its shared shader module.
 PASS: Shared Worker vertex and fragment stages should expose the same WGSL source.
 PASS: Render ShaderProgram should expose both WGSL entry points.

--- a/LayoutTests/inspector/canvas/worker-webgpu.html
+++ b/LayoutTests/inspector/canvas/worker-webgpu.html
@@ -36,6 +36,7 @@ async function test() {
         async test() {
             InspectorTest.expectTrue(workerTarget.hasDomain("Canvas"), "Worker target should expose the Canvas domain.");
             InspectorTest.expectEqual(canvas.target, workerTarget, "WebGPU Canvas should belong to the Worker target.");
+            InspectorTest.expectEqual(canvas.displayName, "Labeled Worker WebGPU Device", "Worker Canvas should use the GPUDevice label as its display name.");
 
             const objectGroup = "test";
             let {object} = await canvas.target.CanvasAgent.resolveContext(canvas.identifier, objectGroup);
@@ -59,12 +60,14 @@ async function test() {
 
             let computeProgram = Array.from(canvas.shaderProgramCollection).find((shaderProgram) => shaderProgram.programType === WI.ShaderProgram.ProgramType.Compute);
             InspectorTest.expectThat(computeProgram instanceof WI.ShaderProgram, "Found the Worker compute ShaderProgram.");
+            InspectorTest.expectEqual(computeProgram.displayName, "Labeled Worker Compute Pipeline", "Worker compute ShaderProgram should use the pipeline label as its display name.");
             let computeSourceResult = await computeProgram.target.CanvasAgent.requestShaderSource(computeProgram.identifier, WI.ShaderProgram.ShaderType.Compute);
             let computeSource = computeSourceResult.source;
             InspectorTest.expectTrue(computeSource.includes("@compute") && computeSource.includes("computeMain"), "Compute ShaderProgram should expose its WGSL source.");
 
             let renderProgram = Array.from(canvas.shaderProgramCollection).find((shaderProgram) => shaderProgram.programType === WI.ShaderProgram.ProgramType.Render);
             InspectorTest.expectThat(renderProgram instanceof WI.ShaderProgram, "Found the Worker render ShaderProgram.");
+            InspectorTest.expectEqual(renderProgram.displayName, "Labeled Worker Render Pipeline", "Worker render ShaderProgram should use the pipeline label as its display name.");
             InspectorTest.expectTrue(renderProgram.sharesVertexFragmentShader, "Worker render pipeline should report its shared shader module.");
             let vertexSourceResult = await renderProgram.target.CanvasAgent.requestShaderSource(renderProgram.identifier, WI.ShaderProgram.ShaderType.Vertex);
             let vertexSource = vertexSourceResult.source;

--- a/Source/JavaScriptCore/inspector/protocol/Canvas.json
+++ b/Source/JavaScriptCore/inspector/protocol/Canvas.json
@@ -73,7 +73,8 @@
                 { "name": "contextAttributes", "$ref": "ContextAttributes", "optional": true, "description": "Context attributes for rendering contexts." },
                 { "name": "features", "type": "array", "items": { "type": "string" }, "optional": true, "description": "Enabled WebGPU device features." },
                 { "name": "memoryCost", "type": "number", "optional": true, "description": "Memory usage of the canvas in bytes." },
-                { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "Backtrace that was captured when this canvas context was created." }
+                { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "Backtrace that was captured when this canvas context was created." },
+                { "name": "name", "type": "string", "optional": true }
             ]
         },
         {
@@ -84,7 +85,8 @@
                 { "name": "programId", "$ref": "ProgramId" },
                 { "name": "programType", "$ref": "ProgramType" },
                 { "name": "canvasId", "$ref": "CanvasId" },
-                { "name": "sharesVertexFragmentShader", "type": "boolean", "optional": true, "description": "Indicates whether the vertex and fragment shader modules are the same object for a WebGPU render pipeline." }
+                { "name": "sharesVertexFragmentShader", "type": "boolean", "optional": true, "description": "Indicates whether the vertex and fragment shader modules are the same object for a WebGPU render pipeline." },
+                { "name": "name", "type": "string", "optional": true }
             ]
         }
     ],

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -611,6 +611,9 @@ Ref<Inspector::Protocol::Canvas::Canvas> InspectorCanvas::buildObjectForCanvas(b
                 features->addItem(feature);
             result->setFeatures(WTF::move(features));
 
+            if (auto label = device->label(); !label.isEmpty())
+                result->setName(label);
+
             return result;
         }
     );

--- a/Source/WebCore/inspector/InspectorShaderProgram.cpp
+++ b/Source/WebCore/inspector/InspectorShaderProgram.cpp
@@ -221,12 +221,17 @@ Ref<Inspector::Protocol::Canvas::ShaderProgram> InspectorShaderProgram::buildObj
 {
     auto programType = Inspector::Protocol::Canvas::ProgramType::Render;
     bool sharesVertexFragmentShader = false;
+    String name;
     WTF::switchOn(m_program
 #if ENABLE(WEBGL)
         , [](const WeakRef<WebGLProgram>&) { }
 #endif // ENABLE(WEBGL)
-        , [&](const WeakRef<GPUComputePipeline>&) {
+        , [&](const WeakRef<GPUComputePipeline>& weakPipeline) {
+            Ref pipeline = weakPipeline.get();
+
             programType = Inspector::Protocol::Canvas::ProgramType::Compute;
+
+            name = pipeline->label();
         }
         , [&](const WeakRef<GPURenderPipeline>& weakPipeline) {
             Ref pipeline = weakPipeline.get();
@@ -236,6 +241,8 @@ Ref<Inspector::Protocol::Canvas::ShaderProgram> InspectorShaderProgram::buildObj
                 programType = Inspector::Protocol::Canvas::ProgramType::Vertex;
             else
                 sharesVertexFragmentShader = pipeline->sharesVertexFragmentShader();
+
+            name = pipeline->label();
         }
     );
     auto payload = Inspector::Protocol::Canvas::ShaderProgram::create()
@@ -245,6 +252,8 @@ Ref<Inspector::Protocol::Canvas::ShaderProgram> InspectorShaderProgram::buildObj
         .release();
     if (sharesVertexFragmentShader)
         payload->setSharesVertexFragmentShader(true);
+    if (!name.isEmpty())
+        payload->setName(name);
     return payload;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js
@@ -252,13 +252,10 @@ WI.CanvasManager = class CanvasManager extends WI.Object
         if (!programType)
             programType = WI.ShaderProgram.ProgramType.Render;
 
-        let options = {};
-
-        // COMPATIBILITY (iOS 13.0): `Canvas.ShaderProgram.sharesVertexFragmentShader` did not exist yet.
-        if (shaderProgramPayload.sharesVertexFragmentShader)
-            options.sharesVertexFragmentShader = true;
-
-        let program = new WI.ShaderProgram(target, shaderProgramPayload.programId, programType, canvas, options);
+        let program = new WI.ShaderProgram(target, shaderProgramPayload.programId, programType, canvas, {
+            sharesVertexFragmentShader: shaderProgramPayload.sharesVertexFragmentShader,
+            displayName: shaderProgramPayload.name,
+        });
 
         let shaderProgramForIdentifierMap = this._shaderProgramForIdentifierForTargetMap.getOrInsert(target, new Map);
         console.assert(!shaderProgramForIdentifierMap.has(program.identifier), `ShaderProgram already exists with id ${program.identifier}.`);

--- a/Source/WebInspectorUI/UserInterface/Models/Canvas.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Canvas.js
@@ -25,7 +25,7 @@
 
 WI.Canvas = class Canvas extends WI.Object
 {
-    constructor(target, identifier, contextType, size, {domNode, cssCanvasName, contextAttributes, features, memoryCost, stackTrace} = {})
+    constructor(target, identifier, contextType, size, {domNode, cssCanvasName, contextAttributes, features, memoryCost, stackTrace, displayName} = {})
     {
         super();
 
@@ -34,6 +34,7 @@ WI.Canvas = class Canvas extends WI.Object
         console.assert(contextType);
         console.assert(!size || size instanceof WI.Size, size);
         console.assert(!stackTrace || stackTrace instanceof WI.StackTrace, stackTrace);
+        console.assert(!displayName || typeof displayName === "string", displayName);
 
         this._target = target;
         this._identifier = identifier;
@@ -46,6 +47,7 @@ WI.Canvas = class Canvas extends WI.Object
         this._extensions = new Set;
         this._memoryCost = memoryCost || NaN;
         this._stackTrace = stackTrace || null;
+        this._displayName = displayName || "";
 
         this._clientNodes = null;
         this._shaderProgramCollection = new WI.ShaderProgramCollection;
@@ -125,6 +127,7 @@ WI.Canvas = class Canvas extends WI.Object
             features: payload.features,
             memoryCost: payload.memoryCost,
             stackTrace: WI.StackTrace.fromPayload(target, payload.stackTrace),
+            displayName: payload.name,
         });
     }
 
@@ -202,6 +205,9 @@ WI.Canvas = class Canvas extends WI.Object
 
     get displayName()
     {
+        if (this._displayName)
+            return this._displayName;
+
         if (this._cssCanvasName)
             return WI.UIString("CSS canvas \u201C%s\u201D").format(this._cssCanvasName);
 

--- a/Source/WebInspectorUI/UserInterface/Models/ShaderProgram.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ShaderProgram.js
@@ -25,7 +25,7 @@
 
 WI.ShaderProgram = class ShaderProgram extends WI.Object
 {
-    constructor(target, identifier, programType, canvas, {sharesVertexFragmentShader} = {})
+    constructor(target, identifier, programType, canvas, {sharesVertexFragmentShader, displayName} = {})
     {
         console.assert(target instanceof WI.Target, target);
         console.assert(target === canvas.target, target, canvas.target);
@@ -33,6 +33,7 @@ WI.ShaderProgram = class ShaderProgram extends WI.Object
         console.assert(Object.values(ShaderProgram.ProgramType).includes(programType));
         console.assert(canvas instanceof WI.Canvas);
         console.assert(ShaderProgram.contextTypeSupportsProgramType(canvas.contextType, programType));
+        console.assert(!displayName || typeof displayName === "string", displayName);
 
         super();
 
@@ -40,6 +41,7 @@ WI.ShaderProgram = class ShaderProgram extends WI.Object
         this._identifier = identifier;
         this._programType = programType;
         this._canvas = canvas;
+        this._displayName = displayName || "";
 
         this._sharesVertexFragmentShader = !!sharesVertexFragmentShader;
         console.assert(!this._sharesVertexFragmentShader || (this._canvas.contextType === WI.Canvas.ContextType.WebGPU && this._programType === ShaderProgram.ProgramType.Render));
@@ -109,6 +111,9 @@ WI.ShaderProgram = class ShaderProgram extends WI.Object
 
     get displayName()
     {
+        if (this._displayName)
+            return this._displayName;
+
         let format = null;
         switch (this._canvas.contextType) {
         case WI.Canvas.ContextType.WebGL:


### PR DESCRIPTION
#### 86575c4e15164c6b9b9e76765cb9771ea2fda91b
<pre>
Web Inspector: Canvas: show WebGPU `label` where able
<a href="https://bugs.webkit.org/show_bug.cgi?id=320841">https://bugs.webkit.org/show_bug.cgi?id=320841</a>

Reviewed by Mike Wyrzykowski.

* Source/JavaScriptCore/inspector/protocol/Canvas.json:
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::buildObjectForCanvas):
* Source/WebCore/inspector/InspectorShaderProgram.cpp:
(WebCore::InspectorShaderProgram::buildObjectForShaderProgram):
Expose the `label` of a `GPUDevice`, `GPUComputePipeline`, and `GPURenderPipeline` as optional parameters of `Canvas.Canvas` and `Canvas.ShaderProgram`.

* Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js:
(WI.CanvasManager.prototype.programCreated):
* Source/WebInspectorUI/UserInterface/Models/Canvas.js:
(WI.Canvas):
(WI.Canvas.fromPayload):
(WI.Canvas.prototype.get displayName):
* Source/WebInspectorUI/UserInterface/Models/ShaderProgram.js:
(WI.ShaderProgram):
(WI.ShaderProgram.prototype.get displayName):
If a `label` is set then use that instead of any generated name.

* LayoutTests/inspector/canvas/resources/shaderProgram-utilities-webgpu.js:
(initializeWebGPU):
(createComputePipeline):
(createRenderPipeline):
* LayoutTests/inspector/canvas/resources/webgpu-worker.js:
(initialize):
* LayoutTests/inspector/canvas/create-context-webgpu.html:
* LayoutTests/inspector/canvas/create-context-webgpu-expected.txt:
* LayoutTests/inspector/canvas/shaderProgram-add-remove-webgpu.html:
* LayoutTests/inspector/canvas/shaderProgram-add-remove-webgpu-expected.txt:
* LayoutTests/inspector/canvas/worker-webgpu.html:
* LayoutTests/inspector/canvas/worker-webgpu-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318409@main">https://commits.webkit.org/318409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d18132d67beade0d4386e6665e1ef7af0fa53b54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141486 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138946 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119402 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41170 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39524 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1371 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8200 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151570 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39209 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36309 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39511 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190279 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159236 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148098 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39764 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52526 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147871 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42586 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124790 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119360 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51044 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14184 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50429 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50669 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50491 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->