### PR TITLE
Cherry-pick 318156@main (933452434c72). https://bugs.webkit.org/show_bug.cgi?id=320553

### DIFF
--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1222,7 +1222,7 @@ static void dispatchInputEvents(RefPtr<Element> startRoot, RefPtr<Element> endRo
     const String& data = { }, RefPtr<DataTransfer>&& dataTransfer = nullptr, const Vector<Ref<StaticRange>>& targetRanges = { })
 {
     if (startRoot)
-        dispatchInputEvent(*startRoot, inputTypeName, isInputMethodComposing, data, WTF::move(dataTransfer), targetRanges);
+        dispatchInputEvent(*startRoot, inputTypeName, isInputMethodComposing, data, dataTransfer.copyRef(), targetRanges);
     if (endRoot && endRoot != startRoot)
         dispatchInputEvent(*endRoot, inputTypeName, isInputMethodComposing, data, WTF::move(dataTransfer), targetRanges);
 }

--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -77,7 +77,7 @@ static bool urlRequiresChromeBrowser(const String& domain, const String& baseDom
 // quirk is good for websites that do macOS-specific things we don't want on
 // other platforms, and when the risk of the website doing Firefox-specific
 // things is relatively low.
-static bool urlRequiresFirefoxBrowser(const String& domain)
+static bool urlRequiresFirefoxBrowser(const String& domain, [[maybe_unused]] const String& baseDomain)
 {
     // Red Hat Bugzilla displays a warning page when performing searches with WebKitGTK's standard
     // user agent.
@@ -96,7 +96,7 @@ static bool urlRequiresFirefoxBrowser(const String& domain)
     if (domain == "www.disneyplus.com"_s)
         return true;
 
-    if (domain == "www.hbomax.com"_s || domain == "auth.hbomax.com"_s || domain == "play.hbomax.com"_s)
+    if (baseDomain == "hbomax.com"_s)
         return true;
 #endif
 
@@ -201,7 +201,7 @@ UserAgentQuirks UserAgentQuirks::quirksForURL(const URL& url)
 
     if (urlRequiresChromeBrowser(domain, baseDomain))
         quirks.add(UserAgentQuirks::NeedsChromeBrowser);
-    else if (urlRequiresFirefoxBrowser(domain))
+    else if (urlRequiresFirefoxBrowser(domain, baseDomain))
         quirks.add(UserAgentQuirks::NeedsFirefoxBrowser);
 
     if (urlRequiresMacintoshPlatform(domain, baseDomain))

--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -96,7 +96,7 @@ static bool urlRequiresFirefoxBrowser(const String& domain)
     if (domain == "www.disneyplus.com"_s)
         return true;
 
-    if (domain == "www.hbomax.com"_s || domain == "auth.hbomax.com"_s)
+    if (domain == "www.hbomax.com"_s || domain == "auth.hbomax.com"_s || domain == "play.hbomax.com"_s)
         return true;
 #endif
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2277,7 +2277,7 @@ bool RenderLayerBacking::updateAncestorClippingStack(Vector<CompositedClipData>&
         return false;
     }
     
-    m_ancestorClippingStack->updateWithClipData(scrollingCoordinator, WTF::move(clippingData));
+    m_ancestorClippingStack->updateWithClipData(scrollingCoordinator, Vector { clippingData });
     LOG_WITH_STREAM(Compositing, stream << "layer " << &m_owningLayer << " ancestorClippingStack " << *m_ancestorClippingStack);
     if (m_overflowControlsHostLayerAncestorClippingStack)
         m_overflowControlsHostLayerAncestorClippingStack->updateWithClipData(scrollingCoordinator, WTF::move(clippingData));

--- a/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
@@ -129,9 +129,10 @@ void CustomPropertyRegistry::registerFromStylesheet(const StyleRuleProperty::Des
 
     // Last rule wins.
     // https://drafts.css-houdini.org/css-properties-values-api/#determining-registration
-    m_propertiesFromStylesheet.set(property.name, makeUniqueRef<CSSRegisteredCustomProperty>(WTF::move(property)));
+    auto name = property.name;
+    m_propertiesFromStylesheet.set(name, makeUniqueRef<CSSRegisteredCustomProperty>(WTF::move(property)));
 
-    invalidate(property.name);
+    invalidate(name);
 }
 
 void CustomPropertyRegistry::clearRegisteredFromStylesheets()

--- a/Source/WebCore/style/values/masking/StyleClipPath.h
+++ b/Source/WebCore/style/values/masking/StyleClipPath.h
@@ -45,7 +45,7 @@ struct ClipPath {
     ClipPath(BoxPath&& box) : operation { WTF::move(box.operation) } { }
     ClipPath(const BoxPath& box) : operation { box.operation } { }
 
-    explicit ClipPath(RefPtr<PathOperation>&& operation) : operation { WTF::move(operation) } { RELEASE_ASSERT(isValid(operation)); }
+    explicit ClipPath(RefPtr<PathOperation>&& operation) : operation { WTF::move(operation) } { RELEASE_ASSERT(isValid(this->operation)); }
     explicit ClipPath(const RefPtr<PathOperation>& operation) : operation { operation } { RELEASE_ASSERT(isValid(operation)); }
 
     bool isNone() const { return !operation; }

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -146,7 +146,7 @@ void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecut
     ThreadableLoaderOptions options { WTF::move(fetchOptions) };
     options.sendLoadCallbacks = SendCallbackPolicy::SendCallbacks;
     options.contentSecurityPolicyEnforcement = contentSecurityPolicyEnforcement;
-    if (fetchOptions.destination == FetchOptions::Destination::Serviceworker)
+    if (options.destination == FetchOptions::Destination::Serviceworker)
         options.certificateInfoPolicy = CertificateInfoPolicy::IncludeCertificateInfo;
 
     // FIXME: We should drop the sameOriginDataURLFlag flag and implement the latest Fetch specification.

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -447,9 +447,10 @@ void ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent(BackgroundFetchInf
         RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread()->identifier().toUInt64());
 
         Ref manager = ServiceWorkerRegistrationBackgroundFetchAPI::backgroundFetch(serviceWorkerGlobalScope->registration());
+        auto failureReason = info.failureReason;
         BackgroundFetchEventInit eventInit { { }, manager->backgroundFetchRegistrationInstance(serviceWorkerGlobalScope, WTF::move(info)) };
         RefPtr<ExtendableEvent> event;
-        switch (info.failureReason) {
+        switch (failureReason) {
         case BackgroundFetchFailureReason::EmptyString:
             event = BackgroundFetchUpdateUIEvent::create(eventNames().backgroundfetchsuccessEvent, WTF::move(eventInit), Event::IsTrusted::Yes);
             break;

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -922,11 +922,12 @@ void SWServer::tryInstallContextData(const std::optional<ProcessIdentifier>& req
     RefPtr connection = contextConnectionForRegistrableDomain(site.domain());
     if (!connection) {
         auto firstPartyForCookies = data.registration.key.firstPartyForCookies();
+        auto serviceWorkerPageIdentifier = data.serviceWorkerPageIdentifier;
         m_pendingContextDatas.ensure(site.domain(), [] {
             return Vector<ServiceWorkerContextData> { };
         }).iterator->value.append(WTF::move(data));
 
-        createContextConnection(site, data.serviceWorkerPageIdentifier);
+        createContextConnection(site, serviceWorkerPageIdentifier);
         return;
     }
 

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
@@ -92,12 +92,13 @@ void NetworkCORSPreflightChecker::startPreflight()
 
 void NetworkCORSPreflightChecker::willPerformHTTPRedirection(WebCore::ResourceResponse&& response, WebCore::ResourceRequest&&, RedirectCompletionHandler&& completionHandler)
 {
+    auto httpStatusCode = response.httpStatusCode();
     if (m_shouldCaptureExtraNetworkLoadMetrics)
         m_loadInformation.response = WTF::move(response);
 
     CORS_CHECKER_RELEASE_LOG("willPerformHTTPRedirection");
     completionHandler({ });
-    m_completionCallback(ResourceError { errorDomainWebKitInternal, 0, m_parameters.originalRequest.url(), makeString("Preflight response is not successful. Status code: "_s, response.httpStatusCode()), ResourceError::Type::AccessControl });
+    m_completionCallback(ResourceError { errorDomainWebKitInternal, 0, m_parameters.originalRequest.url(), makeString("Preflight response is not successful. Status code: "_s, httpStatusCode), ResourceError::Type::AccessControl });
 }
 
 void NetworkCORSPreflightChecker::didReceiveChallenge(WebCore::AuthenticationChallenge&& challenge, NegotiatedLegacyTLS negotiatedLegacyTLS, ChallengeCompletionHandler&& completionHandler)

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -432,9 +432,9 @@ void WebProcessPool::setAutomationClient(std::unique_ptr<API::AutomationClient>&
 
 void WebProcessPool::setOverrideLanguages(Vector<String>&& languages)
 {
+    LOG_WITH_STREAM(Language, stream << "WebProcessPool is setting OverrideLanguages: " << languages);
     WebKit::setOverrideLanguages(WTF::move(languages));
 
-    LOG_WITH_STREAM(Language, stream << "WebProcessPool is setting OverrideLanguages: " << languages);
     sendToAllProcesses(Messages::WebProcess::UserPreferredLanguagesChanged(overrideLanguages()));
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1062,7 +1062,8 @@ void WebProcessProxy::assumeReadAccessToBaseURLs(WebPageProxy& page, const Vecto
     if (!networkProcessWillCheckBlobFileAccess())
         return completionHandler();
 
-    dataStore->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(coreProcessIdentifier(), WTF::move(paths)), [weakThis = WeakPtr { *this }, weakPage = WeakPtr { page }, paths, completionHandler = WTF::move(completionHandler)] mutable {
+    auto messagePaths = paths;
+    dataStore->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(coreProcessIdentifier(), WTF::move(messagePaths)), [weakThis = WeakPtr { *this }, weakPage = WeakPtr { page }, paths = WTF::move(paths), completionHandler = WTF::move(completionHandler)] mutable {
         if (!weakThis || !weakPage)
             return completionHandler();
 

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -814,8 +814,8 @@ void PushService::updateTopicLists(CompletionHandler<void()>&& completionHandler
         PushServiceConnection::TopicLists topicLists;
         topicLists.enabledTopics = WTF::move(topics.enabledTopics);
         topicLists.ignoredTopics = WTF::move(topics.ignoredTopics);
-        protectedThis->m_connection->setTopicLists(WTF::move(topicLists));
         protectedThis->m_topicCount = topicLists.enabledTopics.size() + topicLists.ignoredTopics.size();
+        protectedThis->m_connection->setTopicLists(WTF::move(topicLists));
         completionHandler();
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
@@ -121,6 +121,7 @@ TEST(UserAgentTest, Quirks)
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.disneyplus.com/");
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.hbomax.com/");
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://auth.hbomax.com/");
+    assertUserAgentForURLHasFirefoxBrowserQuirk("http://play.hbomax.com/");
 #endif
 
 #if ENABLE(WEBXR) && PLATFORM(WPE)


### PR DESCRIPTION
#### b6e1a8ee19d4b2f51c4eb180bcf30f7702539a1d
<pre>
Cherry-pick 318156@main (933452434c72). <a href="https://bugs.webkit.org/show_bug.cgi?id=320553">https://bugs.webkit.org/show_bug.cgi?id=320553</a>

    [GLib] Simplify hboxmax User-Agent quirk
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320553">https://bugs.webkit.org/show_bug.cgi?id=320553</a>

    Reviewed by Carlos Garcia Campos.

    Use Firefox UA for all hbomax.com sub-domains. The previous approach broke once already and we had
    to handle play.hbomax.com. This new approach should be more reliable in case of additional
    User-Agent checks on hbomax.

    * Source/WebCore/platform/glib/UserAgentQuirks.cpp:
    (WebCore::urlRequiresFirefoxBrowser):
    (WebCore::UserAgentQuirks::quirksForURL):

    Canonical link: <a href="https://commits.webkit.org/318156@main">https://commits.webkit.org/318156@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1022@webkitglib/2.52">https://commits.webkit.org/305877.1022@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 02a3b3829130fe53ec0cc58f185bdc1fcc351b3d
<pre>
Cherry-pick 318152@main (1d43d49faf11). <a href="https://bugs.webkit.org/show_bug.cgi?id=320550">https://bugs.webkit.org/show_bug.cgi?id=320550</a>

    [GLib] Quirks: Make HBOMax library accessible again
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320550">https://bugs.webkit.org/show_bug.cgi?id=320550</a>

    Reviewed by Carlos Garcia Campos.

    Without a firefox quirk for play.hbomax.com we are redirected to a page asking to install some HBO
    mobile app.

    Canonical link: <a href="https://commits.webkit.org/318152@main">https://commits.webkit.org/318152@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1021@webkitglib/2.52">https://commits.webkit.org/305877.1021@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9c6675a3939b8c42eced5a5035bfb375ce57c1c4
<pre>
Cherry-pick 318208@main (6ce79778ca49). <a href="https://bugs.webkit.org/show_bug.cgi?id=320534">https://bugs.webkit.org/show_bug.cgi?id=320534</a>

    Fix several use-after-moves in the codebase
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320534">https://bugs.webkit.org/show_bug.cgi?id=320534</a>

    Reviewed by Darin Adler.

    * Source/WebCore/css/calc/CSSCalcTree.cpp:
    (WebCore::CSSCalc::subtract):
    * Source/WebCore/editing/Editor.cpp:
    * Source/WebCore/rendering/RenderLayerBacking.cpp:
    (WebCore::RenderLayerBacking::updateAncestorClippingStack):
    * Source/WebCore/style/StyleCustomPropertyRegistry.cpp:
    (WebCore::Style::CustomPropertyRegistry::registerFromStylesheet):
    * Source/WebCore/style/values/masking/StyleClipPath.h:
    (WebCore::Style::ClipPath::ClipPath):
    * Source/WebCore/workers/WorkerScriptLoader.cpp:
    (WebCore::WorkerScriptLoader::loadAsynchronously):
    * Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
    (WebCore::ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent):
    * Source/WebCore/workers/service/server/SWServer.cpp:
    (WebCore::SWServer::tryInstallContextData):
    * Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp:
    (WebKit::NetworkCORSPreflightChecker::willPerformHTTPRedirection):
    * Source/WebKit/UIProcess/WebProcessPool.cpp:
    (WebKit::WebProcessPool::setOverrideLanguages):
    * Source/WebKit/UIProcess/WebProcessProxy.cpp:
    (WebKit::WebProcessProxy::assumeReadAccessToBaseURLs):
    * Source/WebKit/webpushd/PushService.mm:
    (WebPushD::PushService::updateTopicLists):

    Canonical link: <a href="https://commits.webkit.org/318208@main">https://commits.webkit.org/318208@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1020@webkitglib/2.52">https://commits.webkit.org/305877.1020@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b79ad3802d2a9890071b894347f27ca724a04fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178240 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52178 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45973 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187854 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141488 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180103 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53472 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51887 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138948 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141488 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181197 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53472 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/45973 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119404 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53472 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51887 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/45973 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53472 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45973 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36311 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/44778 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/51887 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190281 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51846 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/45973 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148100 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/52528 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45973 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147873 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27033 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/52528 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124792 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119363 "The change is no longer eligible for processing.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51046 "Build is in progress. Recent messages:") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/45973 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50431 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50671 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50493 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->