### PR TITLE
Site-isolated iframe processes keep a page load assertion after a cross-site navigation

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -175,6 +175,8 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 
 @property (nonatomic, readonly) BOOL _hasAccessibilityActivityForTesting;
 
++ (NSUInteger)_suspendedRemotePageNetworkActivityCountForTesting;
+
 - (void)_setMediaVolumeForTesting:(float)volume;
 
 - (void)_textFragmentRangesWithCompletionHandlerForTesting:(void(^)(NSArray<NSValue *> *fragmentRanges))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -37,6 +37,7 @@
 #import "PrintInfo.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteScrollingCoordinatorProxy.h"
+#import "SuspendedPageProxy.h"
 #import "UserMediaProcessManager.h"
 #import "ViewGestureController.h"
 #import "ViewSnapshotStore.h"
@@ -1033,6 +1034,11 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 #else
     completionHandler(nil);
 #endif
+}
+
++ (NSUInteger)_suspendedRemotePageNetworkActivityCountForTesting
+{
+    return WebKit::SuspendedPageProxy::remotePagesWithNetworkActivityCountForTesting();
 }
 
 - (BOOL)_hasAccessibilityActivityForTesting

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -43,6 +43,7 @@
 #include "WebPageMessages.h"
 #include "WebPageProxy.h"
 #include "WebPageProxyMessages.h"
+#include "WebProcessActivityState.h"
 #include "WebProcessMessages.h"
 #include "WebProcessPool.h"
 #include <wtf/CallbackAggregator.h>
@@ -64,6 +65,21 @@ static WeakHashSet<SuspendedPageProxy>& NODELETE allSuspendedPages()
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SuspendedPageProxy);
+
+unsigned SuspendedPageProxy::remotePagesWithNetworkActivityCountForTesting()
+{
+    unsigned count = 0;
+    for (Ref suspendedPage : allSuspendedPages()) {
+        RefPtr page = suspendedPage->page();
+        if (!page)
+            continue;
+        suspendedPage->m_browsingContextGroup->forEachRemotePage(*page, [&count](auto& remotePage) {
+            if (remotePage.processActivityState().hasValidNetworkActivity())
+                ++count;
+        });
+    }
+    return count;
+}
 
 RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(WebProcessPool& processPool, const RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
 {

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -89,6 +89,8 @@ public:
 
     bool hasSubframeInProcess(WebCore::ProcessIdentifier) const;
 
+    static unsigned remotePagesWithNetworkActivityCountForTesting();
+
     std::optional<WebCore::BackForwardFrameItemIdentifier> suspendedFrameItemID() const { return m_suspendedFrameItemID; }
     HashSet<Ref<WebProcessProxy>> iframeProcesses() const;
 

--- a/Source/WebKit/UIProcess/WebProcessActivityState.cpp
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.cpp
@@ -154,6 +154,7 @@ void WebProcessActivityState::reset()
 #if PLATFORM(IOS_FAMILY)
     m_openingAppLinkActivity = nullptr;
 #endif
+    m_networkActivity = nullptr;
 }
 
 void WebProcessActivityState::dropVisibleActivity()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8043,6 +8043,44 @@ TEST(SiteIsolation, SharedProcessInProcessCacheAfterNavigation)
     }
 }
 
+#if USE(RUNNINGBOARD)
+TEST(SiteIsolation, SharedProcessDropsPageLoadActivityAfterCrossSiteNavigation)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/webkit'>"_s } },
+        { "/webkit"_s, { "webkit"_s } },
+        { "/safari"_s, { "<body>safari</body>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewWithSharedProcess(server, EnableProcessCache::No, nil, nil, nil, EnableBackForwardCache::Yes);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        {
+            "https://example.com"_s,
+            { { RemoteFrame } }
+        },
+        {
+            RemoteFrame,
+            { { "https://webkit.org"_s } }
+        },
+    });
+    auto sharedProcess = [webView mainFrame].childFrames[0].info._processIdentifier;
+    EXPECT_NE(sharedProcess, [webView mainFrame].info._processIdentifier);
+
+    // Cross-site navigation. The example.com page enters the back/forward cache, which keeps the
+    // old BrowsingContextGroup and webkit.org remote page alive.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://apple.com/safari"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // The shared process is still alive so the cached example.com page can be restored, but it
+    // shouldn't be holding on to any page load activity.
+    EXPECT_TRUE(processStillRunning(sharedProcess));
+    EXPECT_EQ([WKWebView _suspendedRemotePageNetworkActivityCountForTesting], 0u);
+}
+#endif // USE(RUNNINGBOARD)
+
 TEST(SiteIsolation, WebProcessCacheCrashWithZeroSharedProcess)
 {
     HTTPServer server({


### PR DESCRIPTION
#### 7d0d43fa56ea5b4b7d036bfac65ad19dfcf0f92e
<pre>
Site-isolated iframe processes keep a page load assertion after a cross-site navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=320790">https://bugs.webkit.org/show_bug.cgi?id=320790</a>
<a href="https://rdar.apple.com/183676310">rdar://183676310</a>

Reviewed by Per Arne Vollan.

We are seeing that remote frame processes are running too long after a main frame navigation due to
the remote frame processes holding a page load activity (m_networkActivity in
WebProcessActivityState).

The reason for this is that 304180@main removed the line that resets the page load activity in
`WebProcessActivityState::reset`. It notes that this is not necessary because NavigationState has a
timer that resets the page load activity. However, that timer doesn&apos;t work, since it resets the
activity on all remote pages associated with the browsing context group post-navigation. The page
load activity is actually held by remote pages associated with the old pre-navigation browsing
context group.

The old BrowsingContextGroup is kept alive by the multi-process back/forward cache (via
SuspendedPageProxy), so remote frame processes end up running with this orphaned page load activity
for much longer than expected (until they get evicted out of the B/F cache).

Fix this by dropping the page load activity in `WebProcessActivityState::reset`.

This shouldn&apos;t re-regress the original issue 304180@main was trying to fix, since the other part of
304180@main (checking for isLoading instead of checking hasValidNetworkActivity) should be
sufficient for fixing the original issue.

* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::WebProcessActivityState::reset):

Canonical link: <a href="https://commits.webkit.org/318458@main">https://commits.webkit.org/318458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/107340c0455264ffa5c2a374ef8a3f7360d4cf65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178260 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187874 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141508 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/102ba440-9846-4ccc-8e70-51610c12cf25) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138964 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c915962e-ef71-4e1f-9a16-59bba000a44b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119420 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4a2c53fa-8904-40e8-acba-18a763c9ea44) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41187 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39541 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39226 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36331 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190301 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51866 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148115 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39796 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52548 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147888 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42603 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124812 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119397 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51066 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14201 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50451 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50691 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50513 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->