### PR TITLE
[YARR] A /u match start position must never fall inside a surrogate pair

### DIFF
--- a/JSTests/stress/regexp-unicode-advance-string-index.js
+++ b/JSTests/stress/regexp-unicode-advance-string-index.js
@@ -1,0 +1,109 @@
+// A /u or /v match start position is never placed inside a surrogate pair.
+//
+// RegExpBuiltinExec (ES2025 22.2.7.2) step 11 retries a failed match attempt at
+// AdvanceStringIndex(S, lastIndex, true) (22.2.7.3), which steps over a whole
+// code point. So for a pattern that can match emptily, a position between a
+// leading and a trailing surrogate is never tried, and a match there is not
+// reported. The same advance governs RegExp.prototype[@@split]'s q and the
+// empty-match advance in [@@match] / [@@replace] / [@@matchAll].
+//
+// Section B is the counterpart constraint: an explicitly assigned lastIndex
+// inside a pair IS a legal start position, because the caller supplies it
+// rather than AdvanceStringIndex producing it. Sections C and F are unaffected
+// cases that must keep working.
+//
+// Expectations here are the spec's, cross-checked against V8. This test should
+// pass with both --useRegExpJIT=true and --useRegExpJIT=false.
+
+var failures = [];
+
+function check(label, actual, expected)
+{
+    var a = JSON.stringify(actual);
+    var e = JSON.stringify(expected);
+    if (a !== e)
+        failures.push(label + ": expected " + e + " but got " + a);
+}
+
+function execResult(re, string)
+{
+    var match = re.exec(string);
+    return match === null ? null : [match.index, Array.prototype.slice.call(match)];
+}
+
+// [X][D800+DE00][Z]: a lone position at index 2, in the middle of the pair.
+var pair = "X\u{1F600}Z";
+// Two adjacent pairs, so the interior positions are 1 and 3.
+var pairs = "\u{1F600}\u{1F600}";
+
+// A. A failed attempt skips the whole code point, so index 2 is never tried.
+check("/\\B/u.exec", execResult(/\B/u, pair), null);
+check("/\\B/v.exec", execResult(new RegExp("\\B", "v"), pair), null);
+check("/aa|\\B/u.exec", execResult(/aa|\B/u, pair), null);
+check("/a?\\B|q/u.exec", execResult(/a?\B|q/u, pair), null);
+check("/[\\u{1F600}]X|\\B/u.exec", execResult(/[\u{1F600}]X|\B/u, pair), null);
+check("/\\B|[\\u{1F600}]X/u.exec", execResult(/\B|[\u{1F600}]X/u, pair), null);
+check("/(?<=\\uD83D)/u.exec", execResult(/(?<=\uD83D)/u, pair), null);
+check("/\\B/u.exec adjacent pairs", execResult(/\B/u, pairs), [0, [""]]);
+
+// The first start position that is not interior to a pair still matches.
+check("/aa|(?=Z)/u.exec", execResult(/aa|(?=Z)/u, pair), [3, [""]]);
+check("/x+|q/u.exec", execResult(/x+|q/u, "\u{1F600}\u{1F600}q"), [4, ["q"]]);
+
+// B. A lastIndex the caller supplies is used as given, pair interior or not.
+function stickyAt(flags, index)
+{
+    var re = new RegExp("\\B", flags);
+    re.lastIndex = index;
+    var match = re.exec(pair);
+    return [match === null ? null : match.index, re.lastIndex];
+}
+check("/\\B/uy lastIndex=2", stickyAt("uy", 2), [2, 2]);
+check("/\\B/ug lastIndex=2", stickyAt("ug", 2), [2, 2]);
+check("/\\B/uy lastIndex=1", stickyAt("uy", 1), [null, 0]);
+check("/\\B/uy lastIndex=3", stickyAt("uy", 3), [null, 0]);
+
+// C. A failed non-global, non-sticky exec leaves lastIndex alone.
+check("/\\B/u lastIndex after failure", (function () {
+    var re = /\B/u;
+    re.lastIndex = 0;
+    re.exec(pair);
+    return re.lastIndex;
+})(), 0);
+
+// D. Repeated matching walks code points, so no empty match lands inside a pair.
+check("match(/\\B/gu)", pair.match(/\B/gu), null);
+check("matchAll(/\\B/gu) indices", Array.from(pair.matchAll(/\B/gu), function (m) { return m.index; }), []);
+check("match(/\\B/g) is unaffected", pair.match(/\B/g), [""]);
+// The empty pattern matches at every position it is tried at, which shows the
+// advance in isolation: 0, 1 (start of the pair), 3, 4 --- never 2.
+check("matchAll(/(?:)/gu) indices", Array.from(pair.matchAll(/(?:)/gu), function (m) { return m.index; }), [0, 1, 3, 4]);
+check("match(/(?:)/gu)", pair.match(/(?:)/gu), ["", "", "", ""]);
+check("match(/(?:)/g) is unaffected", pair.match(/(?:)/g), ["", "", "", "", ""]);
+check("match(/(?:)/gu) adjacent pairs", pairs.match(/(?:)/gu), ["", "", ""]);
+
+// E. replace and split inherit the same advance.
+check("replace(/\\B/gu)", pair.replace(/\B/gu, "-"), "X\u{1F600}Z");
+check("replace(/(?:)/gu)", pair.replace(/(?:)/gu, "-"), "-X-\u{1F600}-Z-");
+check("split(/\\B/u)", pair.split(/\B/u), ["X\u{1F600}Z"]);
+check("split(/\\B/gu)", pair.split(/\B/gu), ["X\u{1F600}Z"]);
+check("split(/(?:)/u)", pair.split(/(?:)/u), ["X", "\u{1F600}", "Z"]);
+
+// F. Patterns that consume a character are unaffected: a read at a pair's
+// trailing surrogate yields no code point, so those attempts already fail.
+check("match(/./gu)", pair.match(/./gu), ["X", "\u{1F600}", "Z"]);
+check("match(/[^q]/gu)", pair.match(/[^q]/gu), ["X", "\u{1F600}", "Z"]);
+check("/\\uDE00/u.exec", execResult(/\uDE00/u, pair), null);
+check("/\\uDE00/uy lastIndex=2", (function () {
+    var re = /\uDE00/uy;
+    re.lastIndex = 2;
+    return execResult(re, pair);
+})(), null);
+check("/\\uDC00/u.exec lone trailing surrogate", execResult(/\uDC00/u, "\u{10000}\uDC00"), [2, ["\uDC00"]]);
+check("/.x/u.exec", execResult(/.x/u, "a\u{10000}x"), [1, ["\u{10000}x"]]);
+
+if (failures.length) {
+    for (var i = 0; i < failures.length; ++i)
+        print(failures[i]);
+    throw new Error(failures.length + " of the AdvanceStringIndex expectations failed");
+}

--- a/JSTests/stress/regexp-unicode-nonbmp-advance-latch-bug.js
+++ b/JSTests/stress/regexp-unicode-nonbmp-advance-latch-bug.js
@@ -1,7 +1,7 @@
 // When a match attempt fails at a start position, /u patterns advance the start position past a whole
-// surrogate pair only if the character at the match start is a complete non-BMP surrogate pair and
-// every alternative consumes at least one character. Character reads elsewhere in the pattern must not
-// affect this. This test should pass with both --useRegExpJIT=true and --useRegExpJIT=false.
+// surrogate pair if and only if the character at the match start is a complete non-BMP surrogate pair.
+// Character reads elsewhere in the pattern must not affect this. This test should pass with both
+// --useRegExpJIT=true and --useRegExpJIT=false.
 
 function shouldBe(actual, expected, msg) {
     if (actual !== expected)
@@ -39,12 +39,12 @@ shouldBeMatch(/\u{1F600}ab|c/u, "\u{1F600}xc", [3, ["c"]]);
 shouldBeMatch(/\u{1F600}\u{1F600}xy|\u{1F600}z|q/u, "\u{1F600}\u{1F600}q", [4, ["q"]]);
 shouldBeMatch(/[a\u{10000}]{3}Z|b/u, "a\u{10000}Xb", [4, ["b"]]);
 
-// A zero minimum-size alternative can match in the middle of a surrogate pair, so the start position
-// must then advance one code unit at a time.
-shouldBeMatch(/aa|\B/u, "X\u{1F600}Z", [2, [""]]);
-shouldBeMatch(/a?\B|q/u, "X\u{1F600}Z", [2, [""]]);
-shouldBeMatch(/[\u{1F600}]X|\B/u, "X\u{1F600}Z", [2, [""]]);
-shouldBeMatch(/\B|[\u{1F600}]X/u, "X\u{1F600}Z", [2, [""]]);
+// A zero minimum-size alternative can match in the middle of a surrogate pair, but the position in
+// between is never offered to it: the advance steps over the pair as a whole.
+shouldBeMatch(/aa|\B/u, "X\u{1F600}Z", null);
+shouldBeMatch(/a?\B|q/u, "X\u{1F600}Z", null);
+shouldBeMatch(/[\u{1F600}]X|\B/u, "X\u{1F600}Z", null);
+shouldBeMatch(/\B|[\u{1F600}]X/u, "X\u{1F600}Z", null);
 shouldBeMatch(/aa|(?=Z)/u, "X\u{1F600}Z", [3, [""]]);
 shouldBeMatch(/x+|q/u, "\u{1F600}\u{1F600}q", [4, ["q"]]);
 
@@ -63,13 +63,12 @@ shouldBeMatch(/[\u{1F600}-\u{1F64F}]{2}Z|q/u, "\u{1F600}\u{1F601}Wq", [5, ["q"]]
 
     re = /\B/gu;
     input = "X\u{1F600}Z";
-    let indices = [];
-    let m;
-    while ((m = re.exec(input))) {
-        indices.push(m.index);
-        re.lastIndex++;
-    }
-    shouldBe(JSON.stringify(indices), JSON.stringify([2]), "global \\B");
+    shouldBe(JSON.stringify(input.match(re)), JSON.stringify(null), "global \\B");
+
+    // A lastIndex the caller assigns is used as given, pair interior or not.
+    re.lastIndex = 2;
+    let m = re.exec(input);
+    shouldBe(m === null ? "null" : m.index + "," + re.lastIndex, "2,2", "global \\B from an assigned lastIndex");
 }
 
 // /v (unicodeSets) shares the /u semantics.

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -280,9 +280,47 @@ public:
         {
         }
 
-        void NODELETE next()
+        // A complete surrogate pair starts at |p|, so CodePointAt(input, p) spans two code units.
+        // |unit| is the code unit at |p|, which every caller has already loaded; the surrogate test
+        // comes first because it rejects almost every character straight out of that register.
+        // https://tc39.es/ecma262/#sec-codepointat
+        bool NODELETE hasSurrogatePairAt(unsigned p, CharType unit)
         {
-            ++pos;
+            ASSERT(p < length);
+            ASSERT(unit == input[p]);
+            // An 8-bit subject holds no surrogate, so there is never a pair in it.
+            if constexpr (sizeof(CharType) > 1)
+                return U16_IS_LEAD(unit) && decodeSurrogatePairs && p + 1 < length && U16_IS_TRAIL(input[p + 1]);
+            else {
+                UNUSED_PARAM(p);
+                UNUSED_PARAM(unit);
+                return false;
+            }
+        }
+
+        // |p| holds the trailing surrogate of a complete pair, so it is not a code point boundary
+        // and no code point can be read there. |unit| is the code unit at |p|.
+        bool NODELETE isTrailOfSurrogatePairAt(unsigned p, CharType unit)
+        {
+            ASSERT(p < length);
+            ASSERT(unit == input[p]);
+            if constexpr (sizeof(CharType) > 1)
+                return U16_IS_TRAIL(unit) && decodeSurrogatePairs && p > 0 && U16_IS_LEAD(input[p - 1]);
+            else {
+                UNUSED_PARAM(p);
+                UNUSED_PARAM(unit);
+                return false;
+            }
+        }
+
+        void NODELETE advanceStartPosition()
+        {
+            // Retry a failed match attempt at AdvanceStringIndex(input, pos, unicode),
+            // which steps over a whole code point, so that a start position is never taken between a
+            // leading and a trailing surrogate. A lone surrogate advances by a single code unit.
+            // https://tc39.es/ecma262/#sec-advancestringindex
+            ASSERT(pos < length);
+            pos += hasSurrogatePairAt(pos, input[pos]) ? 2 : 1;
         }
 
         void NODELETE rewind(unsigned amount)
@@ -305,12 +343,13 @@ public:
             unsigned p = pos - negativePositionOffest;
             ASSERT(p < length);
             auto result = input[p];
-            if (U16_IS_LEAD(result) && decodeSurrogatePairs && p + 1 < length && U16_IS_TRAIL(input[p + 1])) {
+            if (hasSurrogatePairAt(p, result)) {
                 if (atEnd())
                     return errorCodePoint;
-                next();
+                ++pos;
                 return U16_GET_SUPPLEMENTARY(result, input[p + 1]);
-            } else if (decodeSurrogatePairs && p > 0 && U16_IS_TRAIL(result) && U16_IS_LEAD(input[p - 1]))
+            }
+            if (isTrailOfSurrogatePairAt(p, result))
                 return errorCodePoint;
             return result;
         }
@@ -319,31 +358,25 @@ public:
         {
             RELEASE_ASSERT(pos >= negativePositionOffest);
             unsigned p = pos - negativePositionOffest;
-            ASSERT(p < length);
-            auto result = input[p];
-            if (U16_IS_LEAD(result) && decodeSurrogatePairs && p + 1 < length && U16_IS_TRAIL(input[p + 1]))
-                return U16_GET_SUPPLEMENTARY(result, input[p + 1]);
-            if (U16_IS_TRAIL(result) && decodeSurrogatePairs && p > 0 && U16_IS_LEAD(input[p - 1]))
-                return errorCodePoint;
-            return result;
+            return reread(p);
         }
 
         // readForCharacterDump() is only for use by the DUMP_CURR_CHAR macro.
-        // We don't want any side effects like the next() in readChecked() above.
+        // We don't want any side effects like the ++pos in readChecked() above.
         char32_t NODELETE readForCharacterDump(unsigned negativePositionOffest)
         {
             RELEASE_ASSERT(pos >= negativePositionOffest);
             unsigned p = pos - negativePositionOffest;
             ASSERT(p < length);
             auto result = input[p];
-            if (U16_IS_LEAD(result) && decodeSurrogatePairs && p + 1 < length && U16_IS_TRAIL(input[p + 1])) {
+            if (hasSurrogatePairAt(p, result)) {
                 if (atEnd())
                     return errorCodePoint;
                 return U16_GET_SUPPLEMENTARY(result, input[p + 1]);
             }
             return result;
         }
-        
+
         char32_t NODELETE tryReadBackward(unsigned negativePositionOffest)
         {
             if (pos < negativePositionOffest)
@@ -351,7 +384,7 @@ public:
             unsigned p = pos - negativePositionOffest;
             ASSERT(p < length);
             auto result = input[p];
-            if (U16_IS_TRAIL(result) && decodeSurrogatePairs && p > 0 && U16_IS_LEAD(input[p - 1])) {
+            if (isTrailOfSurrogatePairAt(p, result)) {
                 rewind(1);
                 return U16_GET_SUPPLEMENTARY(input[p - 1], result);
             }
@@ -363,12 +396,12 @@ public:
             RELEASE_ASSERT(pos >= negativePositionOffset);
             unsigned p = pos - negativePositionOffset;
             ASSERT(p < length);
-            if (p + 1 >= length)
-                return errorCodePoint;
-            auto first = input[p];
-            auto second = input[p + 1];
-            if (U16_IS_LEAD(first) && U16_IS_TRAIL(second))
-                return U16_GET_SUPPLEMENTARY(first, second);
+            // Unlike the code point reads this does not consult decodeSurrogatePairs: it is only
+            // reached after a non-BMP code point has already been read, which implies it.
+            if constexpr (sizeof(CharType) > 1) {
+                if (p + 1 < length && U16_IS_LEAD(input[p]) && U16_IS_TRAIL(input[p + 1]))
+                    return U16_GET_SUPPLEMENTARY(input[p], input[p + 1]);
+            }
             return errorCodePoint;
         }
 
@@ -376,12 +409,10 @@ public:
         {
             ASSERT(from < length);
             auto result = input[from];
-            if (decodeSurrogatePairs) {
-                if (U16_IS_LEAD(result) && from + 1 < length && U16_IS_TRAIL(input[from + 1]))
-                    return U16_GET_SUPPLEMENTARY(result, input[from + 1]);
-                if (U16_IS_TRAIL(result) && from > 0 && U16_IS_LEAD(input[from - 1]))
-                    return errorCodePoint;
-            }
+            if (hasSurrogatePairAt(from, result))
+                return U16_GET_SUPPLEMENTARY(result, input[from + 1]);
+            if (isTrailOfSurrogatePairAt(from, result))
+                return errorCodePoint;
             return result;
         }
 
@@ -2113,7 +2144,7 @@ public:
                 return JSRegExpResult::NoMatch;
             }
 
-            input.next();
+            input.advanceStartPosition();
 
             context->matchBegin = input.getPos();
 

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1530,33 +1530,38 @@ class YarrGenerator final : public YarrJITInfo {
         std::ranges::sort(dest.m_ranges32, [](auto& a, auto& b) { return a.begin < b.begin; });
     }
 
-#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-    // Sets firstCharacterAdditionalReadSize to 1 iff the match start position (index - minimumSize) holds a
-    // complete non-BMP surrogate pair, so that a failed match attempt advances past the whole code point.
-    // Emitted whenever an alternative is entered as the first one attempted at a start position;
-    // |minimumSize| code units are known to be readable there.
-    void initAdvanceLatch(unsigned minimumSize)
+    // After a match attempt fails, the next start position tried is AdvanceStringIndex(input, start, true)
+    // (ES2025 22.2.7.3), which steps over a whole code point. Sets |result| to the number of code units to
+    // skip beyond the usual one: 1 when a complete surrogate pair begins at the match start position, 0
+    // otherwise (a lone lead or trail surrogate advances by a single code unit). The match start position is
+    // |startOffsetFromIndex| code units before |index|, which itself may be past the end of the input.
+    //
+    // |result| is settled by branches rather than by a compare-and-set on the loaded code units, because the
+    // caller adds it to |index| to reach the next start position and then loops. A conditional set would put
+    // the load on that loop-carried dependency; branching lets the advance issue on the predicted path, and
+    // whether a start position holds a pair is highly repetitive within one subject string.
+    void computeAdditionalReadSizeAtStartPosition(unsigned startOffsetFromIndex, MacroAssembler::RegisterID result, MacroAssembler::RegisterID scratch)
     {
-        if (!m_useFirstNonBMPCharacterOptimization)
-            return;
+        ASSERT(m_decodeSurrogatePairs);
+        ASSERT(result != scratch);
+        ASSERT(result != m_regs.index && scratch != m_regs.index);
 
-        ASSERT(minimumSize);
+        MacroAssembler::JumpList noPair;
 
-        m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.firstCharacterAdditionalReadSize);
+        m_jit.move(MacroAssembler::TrustedImm32(0), result);
 
-        // If only one unit is known readable and it is the last one, no pair can follow.
-        MacroAssembler::Jump startIsLastUnit;
-        if (minimumSize == 1)
-            startIsLastUnit = atEndOfInput();
+        // Both code units of a pair have to be within the input to form one.
+        m_jit.add32(MacroAssembler::TrustedImm32(2 - static_cast<int32_t>(startOffsetFromIndex)), m_regs.index, scratch);
+        noPair.append(m_jit.branch32(MacroAssembler::Above, scratch, m_regs.length));
 
-        m_jit.load32(negativeOffsetIndexedAddress(minimumSize, m_regs.regT0, m_regs.index), m_regs.regT0);
-        m_jit.and32(surrogateTagMask, m_regs.regT0);
-        m_jit.compare32(MacroAssembler::Equal, m_regs.regT0, surrogatePairTags, m_regs.firstCharacterAdditionalReadSize);
+        m_jit.load32(negativeOffsetIndexedAddress(startOffsetFromIndex, scratch, m_regs.index), scratch);
+        m_jit.and32(surrogateTagMask, scratch);
+        noPair.append(m_jit.branch32(MacroAssembler::NotEqual, scratch, surrogatePairTags));
 
-        if (minimumSize == 1)
-            startIsLastUnit.link(&m_jit);
+        m_jit.move(MacroAssembler::TrustedImm32(1), result);
+
+        noPair.link(&m_jit);
     }
-#endif
 #endif
 
     void readCharacter(Checked<unsigned> negativeCharacterOffset, MacroAssembler::RegisterID resultReg)
@@ -3834,12 +3839,6 @@ class YarrGenerator final : public YarrJITInfo {
 
                 termMatchTargets.append(MatchTargets());
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-                // Initialize before input check to prevent uninitialized data in arithmetic.
-                if (m_useFirstNonBMPCharacterOptimization)
-                    m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.firstCharacterAdditionalReadSize);
-#endif
-
                 // Upon entry at the head of the set of alternatives, check if input is available
                 // to run the first alternative. (This progresses the input position).
                 op.m_jumps.append(jumpIfNoAvailableInput(alternative->m_minimumSize));
@@ -4014,9 +4013,6 @@ class YarrGenerator final : public YarrJITInfo {
                 };
                 emitStartPositionPrefilters();
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-                initAdvanceLatch(alternative->m_minimumSize);
-#endif
                 break;
             }
             case YarrOpCode::BodyAlternativeNext:
@@ -4655,8 +4651,18 @@ class YarrGenerator final : public YarrJITInfo {
                 }
 
                 bool onceThrough = endOp.m_nextOp == notFound;
-                
+
                 MacroAssembler::JumpList lastStickyAlternativeFailures;
+
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
+                // Retrying a failed attempt one code point further needs the extra code unit of a surrogate
+                // pair added to the one code unit the paths below already advance by. On every one of them
+                // |index| is the last alternative's minimum size past the start position being abandoned.
+                bool advanceByCodePoint = m_decodeSurrogatePairs;
+#else
+                constexpr bool advanceByCodePoint = false;
+#endif
+                const MacroAssembler::RegisterID additionalReadSize = m_regs.regT1;
 
                 // First, generate code to handle cases where we backtrack out of an attempted match
                 // of the last alternative. If this is a 'once through' set of alternatives then we
@@ -4667,7 +4673,8 @@ class YarrGenerator final : public YarrJITInfo {
                     if (m_pattern.sticky()) {
                         // It is a sticky pattern and the last alternative failed, jump to the end.
                         m_backtrackingState.takeBacktracksToJumpList(lastStickyAlternativeFailures, &m_jit);
-                    } else if (m_pattern.m_body->m_hasFixedSize
+                    } else if (!advanceByCodePoint
+                        && m_pattern.m_body->m_hasFixedSize
                         && (alternative->m_minimumSize > beginOp->m_alternative->m_minimumSize)
                         && (alternative->m_minimumSize - beginOp->m_alternative->m_minimumSize == 1)) {
                         // If we don't need to move the input position, and the pattern has a fixed size
@@ -4683,24 +4690,27 @@ class YarrGenerator final : public YarrJITInfo {
                         // No need to advance and retry for a sticky pattern. And it is already handled before this branch.
                         ASSERT(!m_pattern.sticky());
 
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
+                        if (advanceByCodePoint)
+                            computeAdditionalReadSizeAtStartPosition(alternative->m_minimumSize, additionalReadSize, m_regs.regT0);
+#endif
+
                         // If the pattern size is not fixed, then store the start index for use if we match.
                         if (!m_pattern.m_body->m_hasFixedSize) {
-                            if (alternative->m_minimumSize == 1)
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-                                if (m_useFirstNonBMPCharacterOptimization) {
-                                    m_jit.add32(m_regs.firstCharacterAdditionalReadSize, m_regs.index, m_regs.regT0);
+                            if (alternative->m_minimumSize == 1) {
+                                if (advanceByCodePoint) {
+                                    m_jit.add32(additionalReadSize, m_regs.index, m_regs.regT0);
                                     setMatchStart(m_regs.regT0);
                                 } else
-#endif
-                                setMatchStart(m_regs.index);
-                            else {
+                                    setMatchStart(m_regs.index);
+                            } else {
                                 if (alternative->m_minimumSize)
                                     m_jit.sub32(m_regs.index, MacroAssembler::Imm32(alternative->m_minimumSize - 1), m_regs.regT0);
                                 else
                                     m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index, m_regs.regT0);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-                                if (m_useFirstNonBMPCharacterOptimization)
-                                    m_jit.add32(m_regs.firstCharacterAdditionalReadSize, m_regs.regT0);
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
+                                if (advanceByCodePoint)
+                                    m_jit.add32(additionalReadSize, m_regs.regT0);
 #endif
                                 setMatchStart(m_regs.regT0);
                             }
@@ -4713,9 +4723,9 @@ class YarrGenerator final : public YarrJITInfo {
                             // already correctly incremented, if more than one then decrement as appropriate.
                             unsigned delta = alternative->m_minimumSize - beginOp->m_alternative->m_minimumSize;
                             ASSERT(delta);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-                            if (m_useFirstNonBMPCharacterOptimization) {
-                                m_jit.add32(m_regs.firstCharacterAdditionalReadSize, m_regs.index);
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
+                            if (advanceByCodePoint) {
+                                m_jit.add32(additionalReadSize, m_regs.index);
                                 if (delta != 1)
                                     m_jit.sub32(MacroAssembler::Imm32(delta - 1), m_regs.index);
                                 checkInput().linkTo(beginOp->m_reentry, &m_jit);
@@ -4724,7 +4734,7 @@ class YarrGenerator final : public YarrJITInfo {
                                 if (delta != 1)
                                     m_jit.sub32(MacroAssembler::Imm32(delta - 1), m_regs.index);
                                 m_jit.jump(beginOp->m_reentry);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
                             }
 #endif
                         } else {
@@ -4733,9 +4743,9 @@ class YarrGenerator final : public YarrJITInfo {
                             unsigned delta = beginOp->m_alternative->m_minimumSize - alternative->m_minimumSize;
                             if (delta != 0xFFFFFFFFu) {
                                 // We need to check input because we are incrementing the input.
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-                                if (m_useFirstNonBMPCharacterOptimization)
-                                    m_jit.add32(m_regs.firstCharacterAdditionalReadSize, m_regs.index);
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
+                                if (advanceByCodePoint)
+                                    m_jit.add32(additionalReadSize, m_regs.index);
 #endif
                                 m_jit.add32(MacroAssembler::Imm32(delta + 1), m_regs.index);
                                 checkInput().linkTo(beginOp->m_reentry, &m_jit);
@@ -4773,11 +4783,6 @@ class YarrGenerator final : public YarrJITInfo {
                         unsigned delta = prevOp->m_alternative->m_minimumSize - nextOp->m_alternative->m_minimumSize;
                         m_jit.sub32(MacroAssembler::Imm32(delta), m_regs.index);
                         MacroAssembler::Jump fail = jumpIfNoAvailableInput();
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-                        // The next alternative is entered as the first one attempted at this start position,
-                        // bypassing the latch setup in BodyAlternativeBegin.
-                        initAdvanceLatch(nextOp->m_alternative->m_minimumSize);
-#endif
                         m_jit.add32(MacroAssembler::Imm32(delta), m_regs.index);
                         m_jit.jump(nextOp->m_reentry);
                         fail.link(&m_jit);
@@ -4803,12 +4808,23 @@ class YarrGenerator final : public YarrJITInfo {
 
                 bool needsToUpdateMatchStart = !m_pattern.m_body->m_hasFixedSize;
 
+                // A sticky pattern fails outright instead of retrying at the next start position.
+                bool advanceByCodePointHere = advanceByCodePoint && !m_pattern.sticky();
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
+                if (advanceByCodePointHere)
+                    computeAdditionalReadSizeAtStartPosition(alternative->m_minimumSize, additionalReadSize, m_regs.regT0);
+#endif
+
                 // Check for cases where input position is already incremented by 1 for the last
                 // alternative (this is particularly useful where the minimum size of the body
                 // disjunction is 0, e.g. /a*|b/).
                 if (needsToUpdateMatchStart && alternative->m_minimumSize == 1) {
                     // index is already incremented by 1, so just store it now!
-                    setMatchStart(m_regs.index);
+                    if (advanceByCodePointHere) {
+                        m_jit.add32(additionalReadSize, m_regs.index, m_regs.regT0);
+                        setMatchStart(m_regs.regT0);
+                    } else
+                        setMatchStart(m_regs.index);
                     needsToUpdateMatchStart = false;
                 }
 
@@ -4818,13 +4834,11 @@ class YarrGenerator final : public YarrJITInfo {
                     // is no point in looping if we're just going to fail all the input checks around
                     // the next iteration.
                     ASSERT(alternative->m_minimumSize >= m_pattern.m_body->m_minimumSize);
+                    if (advanceByCodePointHere)
+                        m_jit.add32(additionalReadSize, m_regs.index);
                     if (alternative->m_minimumSize == m_pattern.m_body->m_minimumSize) {
                         // If the last alternative had the same minimum size as the disjunction,
                         // just simply increment input pos by 1, no adjustment based on minimum size.
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-                        if (m_useFirstNonBMPCharacterOptimization)
-                            m_jit.add32(m_regs.firstCharacterAdditionalReadSize, m_regs.index);
-#endif
                         m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
                     } else {
                         // If the minumum for the last alternative was one greater than than that
@@ -6959,14 +6973,6 @@ public:
             return;
         }
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-        // A zero minimum-size alternative (e.g. /aa|\B/u) can match in the middle of a surrogate pair, so it must not be skipped.
-        if (m_decodeSurrogatePairs && m_executionMode != ExecutionMode::InlineTest && !m_pattern.multiline() && !m_pattern.m_containsBOL && !m_pattern.m_containsLookbehinds && !m_pattern.m_containsModifiers && m_pattern.m_body->m_minimumSize) {
-            ASSERT(m_regs.firstCharacterAdditionalReadSize != InvalidGPRReg);
-            m_useFirstNonBMPCharacterOptimization = true;
-        }
-#endif
-
         // We need to compile before generating code since we set flags based on compilation that
         // are used during generation.
         opCompileBody(m_pattern.m_body);
@@ -7536,9 +7542,6 @@ private:
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
     bool m_containsNestedSubpatterns { false };
     ParenContextSizes m_parenContextSizes;
-#endif
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-    bool m_useFirstNonBMPCharacterOptimization { false };
 #endif
     RegisterAtOffsetList m_calleeSaves;
     MacroAssembler::JumpList m_abortExecution;

--- a/Source/JavaScriptCore/yarr/YarrJITRegisters.h
+++ b/Source/JavaScriptCore/yarr/YarrJITRegisters.h
@@ -61,7 +61,6 @@ public:
     static constexpr GPRReg regUnicodeInputAndTrail = ARM64Registers::x10;
     static constexpr GPRReg unicodeAndSubpatternIdTemp = ARM64Registers::x5;
 
-    static constexpr GPRReg firstCharacterAdditionalReadSize { ARM64Registers::x12 };
     static constexpr GPRReg endOfStringAddress = ARM64Registers::x15;
 
     static constexpr GPRReg returnRegister = ARM64Registers::x0;
@@ -193,7 +192,6 @@ public:
     GPRReg regUnicodeInputAndTrail { InvalidGPRReg };
     GPRReg unicodeAndSubpatternIdTemp { InvalidGPRReg };
     GPRReg endOfStringAddress { InvalidGPRReg };
-    GPRReg firstCharacterAdditionalReadSize { InvalidGPRReg };
 
     // SIMD registers for Boyer-Moore SIMD lookahead
     // These are not used for inline JIT, but need to be present for template instantiation.

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -920,11 +920,6 @@
 #define ENABLE_YARR_JIT_UNICODE_EXPRESSIONS 1
 #endif
 
-/* Enables an optimiztion to advance two codepoints when we fail to match a non-BMP character */
-#if ENABLE(YARR_JIT) && CPU(ARM64)
-#define ENABLE_YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP 1
-#endif
-
 /* If either the JIT or the RegExp JIT is enabled, then the Assembler must be
    enabled as well: */
 #if ENABLE(JIT) || ENABLE(YARR_JIT) || !ENABLE(C_LOOP)


### PR DESCRIPTION
#### 323dd2146c18f6e19d8cd7b2ae3e66755baa962b
<pre>
[YARR] A /u match start position must never fall inside a surrogate pair
<a href="https://bugs.webkit.org/show_bug.cgi?id=320844">https://bugs.webkit.org/show_bug.cgi?id=320844</a>
<a href="https://rdar.apple.com/183872418">rdar://183872418</a>

Reviewed by NOBODY (OOPS!).

WIP

Test: JSTests/stress/regexp-unicode-advance-string-index.js

* JSTests/stress/regexp-unicode-advance-string-index.js: Added.
(execResult):
(stickyAt):
* JSTests/stress/regexp-unicode-nonbmp-advance-latch-bug.js:
(shouldBeMatch):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::InputStream::hasSurrogatePairAt):
(JSC::Yarr::Interpreter::InputStream::isTrailOfSurrogatePairAt):
(JSC::Yarr::Interpreter::InputStream::advanceStartPosition):
(JSC::Yarr::Interpreter::InputStream::readChecked):
(JSC::Yarr::Interpreter::InputStream::readCheckedDontAdvance):
(JSC::Yarr::Interpreter::InputStream::readForCharacterDump):
(JSC::Yarr::Interpreter::InputStream::tryReadBackward):
(JSC::Yarr::Interpreter::InputStream::readSurrogatePairChecked):
(JSC::Yarr::Interpreter::InputStream::reread):
(JSC::Yarr::Interpreter::matchDisjunction):
(JSC::Yarr::Interpreter::InputStream::next): Deleted.
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrJITRegisters.h:
* Source/WTF/wtf/PlatformEnable.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/323dd2146c18f6e19d8cd7b2ae3e66755baa962b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187869 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141503 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49b9b997-f076-4387-b259-943ad7bc9fd1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138959 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96474 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb68c5c4-bfab-4916-9b1b-5b9ae4d64642) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119415 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55cf1615-e985-4946-9a3d-cb6c642801e7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41183 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39536 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1384 "Found 1 new JSC stress test failure: stress/async-stack-trace-basic.js.ftl-no-cjit-no-put-stack-validate (failure)") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8214 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39223 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36326 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39528 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190296 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51861 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148112 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52543 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147885 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42600 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124807 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119390 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51061 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14198 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50446 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50686 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50508 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->