### PR TITLE
[YARR] Clean up YarrJIT ifdefs

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3060,7 +3060,6 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
     } }
 }
 
-#if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
 void SpeculativeJIT::compileRegExpTestInline(Node* node)
 {
     RegExp* regExp = uncheckedDowncast<RegExp>(node->cellOperand2()->value());
@@ -3191,14 +3190,6 @@ void SpeculativeJIT::compileRegExpTestInline(Node* node)
     doneCases.link(this);
     unblessedBooleanResult(temp0GPR, node);
 }
-#else
-void SpeculativeJIT::compileRegExpTestInline(Node* node)
-{
-    UNUSED_PARAM(node);
-    ASSERT_NOT_REACHED();
-    compileRegExpTest(node);
-}
-#endif
 
 #if USE(LARGE_TYPED_ARRAYS)
 void SpeculativeJIT::compileNewTypedArrayWithInt52Size(Node* node)

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1140,7 +1140,6 @@ private:
                 return true;
             };
 
-#if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
             auto convertTestToTestInline = [&] {
                 if (m_node->op() != RegExpTest)
                     return false;
@@ -1177,7 +1176,6 @@ private:
                 m_changed = true;
                 return true;
             };
-#endif
 
             auto convertToStatic = [&] {
                 if (m_node->op() != RegExpExec)
@@ -1216,10 +1214,8 @@ private:
                     break;
             }
 
-#if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
             if (convertTestToTestInline())
                 break;
-#endif
 
             if (convertToStatic())
                 break;

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -19598,7 +19598,6 @@ IGNORE_CLANG_WARNINGS_END
         return true;
     }
 
-#if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
     void compileRegExpTestInline()
     {
         RegExp* regExp = uncheckedDowncast<RegExp>(m_node->cellOperand2()->value());
@@ -19753,12 +19752,6 @@ IGNORE_CLANG_WARNINGS_END
         m_out.appendTo(continuation, lastNext);
         setBoolean(m_out.phi(Int32, inlineresult, operationResult));
     }
-#else
-    [[noreturn]] void compileRegExpTestInline()
-    {
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-#endif
 
     void compileRegExpMatchFast()
     {

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -317,12 +317,7 @@ void RegExp::compile(VM* vm, Yarr::CharSize charSize, std::optional<StringView> 
     }
 
 #if ENABLE(YARR_JIT)
-    if (!pattern.containsUnsignedLengthPattern() && Options::useRegExpJIT()
-#if !ENABLE(YARR_JIT_BACKREFERENCES)
-        && !pattern.m_containsBackreferences
-#endif
-        && !pattern.m_containsLookbehinds
-        ) {
+    if (!pattern.containsUnsignedLengthPattern() && Options::useRegExpJIT() && !pattern.m_containsLookbehinds) {
         auto& jitCode = ensureRegExpJITCode();
         Yarr::jitCompile(pattern, m_patternString, charSize, sampleString, vm, jitCode, Yarr::ExecutionMode::IncludeSubpatterns);
         if (!jitCode.failureReason()) {
@@ -405,12 +400,7 @@ void RegExp::compileMatchOnly(VM* vm, Yarr::CharSize charSize, std::optional<Str
     }
 
 #if ENABLE(YARR_JIT)
-    if (!pattern.containsUnsignedLengthPattern() && Options::useRegExpJIT()
-#if !ENABLE(YARR_JIT_BACKREFERENCES)
-        && !pattern.m_containsBackreferences
-#endif
-        && !pattern.m_containsLookbehinds
-        ) {
+    if (!pattern.containsUnsignedLengthPattern() && Options::useRegExpJIT() && !pattern.m_containsLookbehinds) {
         auto& jitCode = ensureRegExpJITCode();
         Yarr::jitCompile(pattern, m_patternString, charSize, sampleString, vm, jitCode, Yarr::ExecutionMode::MatchOnly);
         if (!jitCode.failureReason()) {

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -32,9 +32,7 @@
 #include "LinkBuffer.h"
 #include "Options.h"
 #include "ProbeContext.h"
-#if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
 #include "JITThunks.h"
-#endif
 #include "VM.h"
 #include "Yarr.h"
 #include "YarrCanonicalize.h"
@@ -59,11 +57,8 @@ static constexpr bool verbose = false;
 
 static constexpr int32_t errorCodePoint = -1;
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
 static MacroAssemblerCodeRef<JITThunkPtrTag> tryReadUnicodeCharSlowThunkGenerator(VM&);
-#endif
 
-#if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationAreCanonicallyEquivalent, bool, (unsigned, unsigned, CanonicalMode));
 
 static MacroAssemblerCodeRef<JITThunkPtrTag> areCanonicallyEquivalentThunkGenerator(VM&);
@@ -83,8 +78,6 @@ static constexpr GPRReg areCanonicallyEquivalentCanonicalModeArgReg = X86Registe
 // The thunk code assumes that we return the result to areCanonicallyEquivalentCharArgReg.
 static_assert(areCanonicallyEquivalentCharArgReg == GPRInfo::returnValueGPR);
 #endif
-#endif
-
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BoyerMooreBitmap);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BoyerMooreFastCandidates);
@@ -452,7 +445,6 @@ static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler:
 static constexpr MacroAssembler::TrustedImm32 surrogatePairTags = MacroAssembler::TrustedImm32(0xdc00d800);
 static constexpr MacroAssembler::TrustedImm32 surrogateTagShiftedRight11 = MacroAssembler::TrustedImm32(0xd800 >> 11);
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
 static void tryReadUnicodeCharImpl(VM& vm, CCallHelpers& jit, MacroAssembler::RegisterID resultReg)
 {
     MacroAssembler::JumpList slowCases;
@@ -586,9 +578,6 @@ static void tryReadUnicodeCharSlowImpl(CCallHelpers& jit)
     haveResult.link(&jit);
 }
 
-
-#endif // ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
-
 template<class YarrJITRegs = YarrJITDefaultRegisters>
 class YarrGenerator final : public YarrJITInfo {
     class MatchTargets {
@@ -661,7 +650,6 @@ class YarrGenerator final : public YarrJITInfo {
         PreferredTarget m_preferredTarget;
     };
 
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
     struct ParenContextSizes {
         size_t m_numSubpatterns;
         size_t m_numDuplicateNamedCaptures;
@@ -965,7 +953,6 @@ class YarrGenerator final : public YarrJITInfo {
             }
         }
     }
-#endif
 
     void NODELETE optimizeAlternative(PatternAlternative* alternative)
     {
@@ -1268,10 +1255,8 @@ class YarrGenerator final : public YarrJITInfo {
         ASSERT(term->type == PatternTerm::Type::CharacterClass);
 
         auto processCharacterClass = [&] (CharacterClass* characterClassToProcess) {
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
             if (m_decodeSurrogatePairs && term->invert())
                 failures.append(m_jit.branch32(MacroAssembler::Equal, character, MacroAssembler::TrustedImm32(errorCodePoint)));
-#endif
             if (term->invert())
                 matchCharacterClass(character, scratch, failures, characterClassToProcess);
             else if (characterClassToProcess->m_matches8.isEmpty() && characterClassToProcess->m_matches32.isEmpty()
@@ -1299,7 +1284,6 @@ class YarrGenerator final : public YarrJITInfo {
         // Note that this falls through on a successful characterClass match.
     }
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
     void advanceIndexAfterCharacterClassTermMatch(const PatternTerm* term, MacroAssembler::JumpList& failuresAfterIncrementingIndex, const MacroAssembler::RegisterID character)
     {
         ASSERT(term->type == PatternTerm::Type::CharacterClass);
@@ -1317,7 +1301,6 @@ class YarrGenerator final : public YarrJITInfo {
             isBMPChar.link(&m_jit);
         }
     }
-#endif
 
     // Jumps if input not available; will have (incorrectly) incremented already!
     MacroAssembler::Jump jumpIfNoAvailableInput(unsigned countToCheck = 0)
@@ -1390,7 +1373,6 @@ class YarrGenerator final : public YarrJITInfo {
         return MacroAssembler::BaseIndex(base, indexReg, MacroAssembler::TimesTwo, characterOffset * static_cast<int32_t>(sizeof(char16_t)));
     }
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
     void tryReadUnicodeChar(MacroAssembler::BaseIndex address, MacroAssembler::RegisterID resultReg)
     {
         ASSERT(m_charSize == CharSize::Char16);
@@ -1557,7 +1539,6 @@ class YarrGenerator final : public YarrJITInfo {
             startIsLastUnit.link(&m_jit);
     }
 #endif
-#endif
 
     void readCharacter(Checked<unsigned> negativeCharacterOffset, MacroAssembler::RegisterID resultReg)
     {
@@ -1570,10 +1551,8 @@ class YarrGenerator final : public YarrJITInfo {
 
         if (m_charSize == CharSize::Char8)
             m_jit.load8(address, resultReg);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         else if (m_decodeSurrogatePairs)
             tryReadUnicodeChar(address, resultReg);
-#endif
         else
             m_jit.load16Unaligned(address, resultReg);
     }
@@ -1701,12 +1680,10 @@ class YarrGenerator final : public YarrJITInfo {
         m_jit.move(MacroAssembler::TrustedImmPtr((void*)WTF::notFound), m_regs.returnRegister);
         m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.returnRegister2);
 
-#if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
         if (m_executionMode == ExecutionMode::InlineTest) {
             m_inlinedFailedMatch.append(m_jit.jump());
             return;
         }
-#endif
 
         generateReturn();
     }
@@ -2366,7 +2343,6 @@ class YarrGenerator final : public YarrJITInfo {
         backtrackTermDefault(opIndex);
     }
 
-#if ENABLE(YARR_JIT_BACKREFERENCES)
     void matchBackreference(size_t opIndex, MacroAssembler::JumpList& characterMatchFails, MacroAssembler::RegisterID character, MacroAssembler::RegisterID patternIndex, MacroAssembler::RegisterID patternCharacter, MacroAssembler::RegisterID subpatternIdReg)
     {
         YarrOp& op = m_ops[opIndex];
@@ -2377,7 +2353,6 @@ class YarrGenerator final : public YarrJITInfo {
 
         MacroAssembler::Label loop(&m_jit);
 
-#if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
         if (!m_decodeSurrogatePairs)
             readCharacter(0, patternCharacter, patternIndex);
         else {
@@ -2386,9 +2361,6 @@ class YarrGenerator final : public YarrJITInfo {
             readCharacter(0, character, patternIndex);
             m_jit.move(character, patternCharacter);
         }
-#else
-        readCharacter(0, patternCharacter, patternIndex);
-#endif
         readCharacter(op.m_checkedOffset - term->inputPosition, character);
 
         if (!term->ignoreCase()) {
@@ -2407,9 +2379,7 @@ class YarrGenerator final : public YarrJITInfo {
             m_jit.load16(patternTableEntry, patternCharacter);
             characterMatchFails.append(m_jit.branch32(MacroAssembler::NotEqual, character, patternCharacter));
             charactersMatch.link(&m_jit);
-        }
-#if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
-        else {
+        } else {
             // 16 Bit ignore case matching.
             RELEASE_ASSERT(character == areCanonicallyEquivalentCharArgReg);
             RELEASE_ASSERT(patternCharacter == areCanonicallyEquivalentPattCharArgReg);
@@ -2453,7 +2423,6 @@ class YarrGenerator final : public YarrJITInfo {
             // Add code to compare non-ASCII Unicode codepoints.
             charactersMatch.link(&m_jit);
         }
-#endif
 
         m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
         m_jit.add32(MacroAssembler::TrustedImm32(1), patternIndex);
@@ -2482,13 +2451,6 @@ class YarrGenerator final : public YarrJITInfo {
     {
         YarrOp& op = m_ops[opIndex];
         PatternTerm* term = op.m_term;
-
-#if !ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
-        if (term->ignoreCase() && m_charSize != CharSize::Char8) {
-            m_failureReason = JITFailureReason::BackReference;
-            return;
-        }
-#endif
 
         unsigned subpatternId = term->backReferenceSubpatternId;
         unsigned duplicateNamedGroupId = (isNamed && m_pattern.hasDuplicateNamedCaptureGroups()) ? m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId] : 0;
@@ -2730,7 +2692,6 @@ class YarrGenerator final : public YarrJITInfo {
         failures.link(&m_jit);
         m_backtrackingState.fallthrough();
     }
-#endif
 
     void generatePatternCharacterOnce(size_t opIndex, MatchTargets& matchTargets)
     {
@@ -3144,11 +3105,9 @@ class YarrGenerator final : public YarrJITInfo {
         }
 
         op.m_jumps.append(m_jit.branch32(MacroAssembler::NotEqual, character, MacroAssembler::Imm32(ch)));
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs && !U_IS_BMP(ch))
             m_jit.add32(MacroAssembler::TrustedImm32(2), countRegister);
         else
-#endif
             m_jit.add32(MacroAssembler::TrustedImm32(1), countRegister);
         m_jit.branch32(MacroAssembler::NotEqual, countRegister, m_regs.index).linkTo(loop, &m_jit);
     }
@@ -3176,7 +3135,6 @@ class YarrGenerator final : public YarrJITInfo {
             failures.append(jumpIfCharNotEquals(ch, op.m_checkedOffset - term->inputPosition, character, term->ignoreCase()));
 
             m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
             if (m_decodeSurrogatePairs && !U_IS_BMP(ch)) {
                 MacroAssembler::Jump surrogatePairOk = notAtEndOfInput();
                 m_jit.sub32(MacroAssembler::TrustedImm32(1), m_regs.index);
@@ -3184,7 +3142,6 @@ class YarrGenerator final : public YarrJITInfo {
                 surrogatePairOk.link(&m_jit);
                 m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
             }
-#endif
             m_jit.add32(MacroAssembler::TrustedImm32(1), countRegister);
 
             if (term->quantityMaxCount == quantifyInfinite)
@@ -3261,7 +3218,6 @@ class YarrGenerator final : public YarrJITInfo {
             nonGreedyFailures.append(jumpIfCharNotEquals(ch, op.m_checkedOffset - term->inputPosition, character, term->ignoreCase()));
 
             m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
             if (m_decodeSurrogatePairs && !U_IS_BMP(ch)) {
                 MacroAssembler::Jump surrogatePairOk = notAtEndOfInput();
                 m_jit.sub32(MacroAssembler::TrustedImm32(1), m_regs.index);
@@ -3269,7 +3225,6 @@ class YarrGenerator final : public YarrJITInfo {
                 surrogatePairOk.link(&m_jit);
                 m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
             }
-#endif
             m_jit.add32(MacroAssembler::TrustedImm32(1), countRegister);
 
             m_jit.jump(op.m_reentry);
@@ -3298,7 +3253,6 @@ class YarrGenerator final : public YarrJITInfo {
             storeToFrame(m_regs.index, term->frameLocation + BackTrackInfoCharacterClass::beginIndex());
         }
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs && !term->invert()) {
             if (auto sharedLead = term->characterClass->hasSharedLeadSurrogate()) {
                 CharacterClass trailsOnlyClass;
@@ -3307,26 +3261,22 @@ class YarrGenerator final : public YarrJITInfo {
                 return;
             }
         }
-#endif
 
         readCharacter(op.m_checkedOffset - term->inputPosition, character);
 
         matchCharacterClassTermInner(term, op.m_jumps, character, scratch);
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs && (!term->characterClass->hasOneCharacterSize() || term->invert())) {
             MacroAssembler::Jump isBMPChar = m_jit.branch32(MacroAssembler::LessThan, character, MacroAssembler::TrustedImm32(0x10000));
             op.m_jumps.append(atEndOfInput());
             m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
             isBMPChar.link(&m_jit);
         }
-#endif
     }
 
     void backtrackCharacterClassOnce(size_t opIndex, bool fallThroughToCharacterClassFixedCount)
     {
         UNUSED_PARAM(fallThroughToCharacterClassFixedCount);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs) {
             YarrOp& op = m_ops[opIndex];
             PatternTerm* term = op.m_term;
@@ -3337,7 +3287,6 @@ class YarrGenerator final : public YarrJITInfo {
                 loadFromFrame(term->frameLocation + BackTrackInfoCharacterClass::beginIndex(), m_regs.index);
             m_backtrackingState.fallthrough();
         }
-#endif
         backtrackTermDefault(opIndex);
     }
 
@@ -3361,7 +3310,6 @@ class YarrGenerator final : public YarrJITInfo {
 
         Checked<unsigned> scaledMaxCount = term->quantityMaxCount;
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         bool nonBMPOnly = false;
         if (m_decodeSurrogatePairs && !term->invert() && term->characterClass->hasOnlyNonBMPCharacters()) {
             scaledMaxCount *= 2;
@@ -3383,7 +3331,6 @@ class YarrGenerator final : public YarrJITInfo {
                 return;
             }
         }
-#endif
 
         m_jit.sub32(m_regs.index, MacroAssembler::Imm32(scaledMaxCount), countRegister);
 
@@ -3394,7 +3341,6 @@ class YarrGenerator final : public YarrJITInfo {
 
         matchCharacterClassTermInner(term, op.m_jumps, character, scratch);
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs) {
             if (term->isFixedWidthCharacterClass())
                 m_jit.add32(MacroAssembler::TrustedImm32(term->characterClass->hasNonBMPCharacters() ? 2 : 1), countRegister);
@@ -3407,24 +3353,20 @@ class YarrGenerator final : public YarrJITInfo {
                 isBMPChar.link(&m_jit);
             }
         } else
-#endif
             m_jit.add32(MacroAssembler::TrustedImm32(1), countRegister);
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (nonBMPOnly) {
             done.append(m_jit.branch32(MacroAssembler::Equal, countRegister, m_regs.index));
             tryReadNonBMPUnicodeChar(op.m_checkedOffset - term->inputPosition - scaledMaxCount, character, countRegister);
             m_jit.jump().linkTo(nonBMPLoop, &m_jit);
         } else
-#endif
-        m_jit.branch32(MacroAssembler::NotEqual, countRegister, m_regs.index).linkTo(loop, &m_jit);
+            m_jit.branch32(MacroAssembler::NotEqual, countRegister, m_regs.index).linkTo(loop, &m_jit);
 
         done.link(&m_jit);
     }
 
     void backtrackCharacterClassFixed(size_t opIndex)
     {
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs) {
             YarrOp& op = m_ops[opIndex];
             PatternTerm* term = op.m_term;
@@ -3436,7 +3378,6 @@ class YarrGenerator final : public YarrJITInfo {
                 return;
             }
         }
-#endif
         backtrackTermDefault(opIndex);
     }
 
@@ -3454,7 +3395,6 @@ class YarrGenerator final : public YarrJITInfo {
             storeToFrame(m_regs.index, term->frameLocation + BackTrackInfoCharacterClass::beginIndex());
         m_jit.move(MacroAssembler::TrustedImm32(0), countRegister);
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs && !term->invert()) {
             if (auto sharedLead = term->characterClass->hasSharedLeadSurrogate()) {
                 ASSERT(term->isFixedWidthCharacterClass());
@@ -3484,7 +3424,6 @@ class YarrGenerator final : public YarrJITInfo {
                 return;
             }
         }
-#endif
 
         MacroAssembler::JumpList failures;
         MacroAssembler::JumpList failuresDecrementIndex;
@@ -3495,11 +3434,9 @@ class YarrGenerator final : public YarrJITInfo {
 
         matchCharacterClassTermInner(term, failures, character, scratch);
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs)
             advanceIndexAfterCharacterClassTermMatch(term, failuresDecrementIndex, character);
         else
-#endif
             m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
         m_jit.add32(MacroAssembler::TrustedImm32(1), countRegister);
 
@@ -3581,10 +3518,8 @@ class YarrGenerator final : public YarrJITInfo {
 
         m_jit.move(MacroAssembler::TrustedImm32(0), countRegister);
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs)
             storeToFrame(m_regs.index, term->frameLocation + BackTrackInfoCharacterClass::beginIndex());
-#endif
 
         defineReentryLabel(op);
 
@@ -3615,11 +3550,9 @@ class YarrGenerator final : public YarrJITInfo {
 
         matchCharacterClassTermInner(term, nonGreedyFailures, character, scratch);
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs)
             advanceIndexAfterCharacterClassTermMatch(term, nonGreedyFailuresDecrementIndex, character);
         else
-#endif
             m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
         m_jit.add32(MacroAssembler::TrustedImm32(1), countRegister);
 
@@ -3631,11 +3564,9 @@ class YarrGenerator final : public YarrJITInfo {
         }
         nonGreedyFailures.link(&m_jit);
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs)
             loadFromFrame(term->frameLocation + BackTrackInfoCharacterClass::beginIndex(), m_regs.index);
         else
-#endif
             m_jit.sub32(countRegister, m_regs.index);
         m_backtrackingState.fallthrough();
     }
@@ -3786,11 +3717,7 @@ class YarrGenerator final : public YarrJITInfo {
 
         case PatternTerm::Type::NumberedBackReference:
         case PatternTerm::Type::NamedBackReference:
-#if ENABLE(YARR_JIT_BACKREFERENCES)
             generateBackReference(term->type == PatternTerm::Type::NamedBackReference, opIndex);
-#else
-            m_failureReason = JITFailureReason::BackReference;
-#endif
             break;
         case PatternTerm::Type::DotStarEnclosure:
             generateDotStarEnclosure(opIndex);
@@ -3876,11 +3803,7 @@ class YarrGenerator final : public YarrJITInfo {
 
         case PatternTerm::Type::NumberedBackReference:
         case PatternTerm::Type::NamedBackReference:
-#if ENABLE(YARR_JIT_BACKREFERENCES)
             backtrackBackReference(opIndex);
-#else
-            m_failureReason = JITFailureReason::BackReference;
-#endif
             break;
 
         case PatternTerm::Type::DotStarEnclosure:
@@ -3936,7 +3859,7 @@ class YarrGenerator final : public YarrJITInfo {
 
                 termMatchTargets.append(MatchTargets());
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
                 // Initialize before input check to prevent uninitialized data in arithmetic.
                 if (m_useFirstNonBMPCharacterOptimization)
                     m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.firstCharacterAdditionalReadSize);
@@ -4116,7 +4039,7 @@ class YarrGenerator final : public YarrJITInfo {
                 };
                 emitStartPositionPrefilters();
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
                 initAdvanceLatch(alternative->m_minimumSize);
 #endif
                 break;
@@ -4551,7 +4474,6 @@ class YarrGenerator final : public YarrJITInfo {
             case YarrOpCode::ParenthesesSubpatternBegin: {
                 termMatchTargets.append(MatchTargets());
 
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
                 PatternTerm* term = op.m_term;
                 unsigned parenthesesFrameLocation = term->frameLocation;
 
@@ -4589,15 +4511,11 @@ class YarrGenerator final : public YarrJITInfo {
                 // If the parenthese are capturing, store the starting index value to the captures array.
                 if (term->capture() && shouldRecordSubpatterns())
                     emitCaptureStart(term, op.m_checkedOffset, m_regs.regT0);
-#else // !YARR_JIT_ALL_PARENS_EXPRESSIONS
-                RELEASE_ASSERT_NOT_REACHED();
-#endif
                 break;
             }
             case YarrOpCode::ParenthesesSubpatternEnd: {
                 termMatchTargets.takeLast();
 
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
                 PatternTerm* term = op.m_term;
                 YarrOp& beginOp = m_ops[op.m_previousOp];
                 unsigned parenthesesFrameLocation = term->frameLocation;
@@ -4644,9 +4562,6 @@ class YarrGenerator final : public YarrJITInfo {
                     break;
                 }
                 }
-#else // !YARR_JIT_ALL_PARENS_EXPRESSIONS
-                RELEASE_ASSERT_NOT_REACHED();
-#endif
                 break;
             }
 
@@ -4788,7 +4703,7 @@ class YarrGenerator final : public YarrJITInfo {
                         // If the pattern size is not fixed, then store the start index for use if we match.
                         if (!m_pattern.m_body->m_hasFixedSize) {
                             if (alternative->m_minimumSize == 1)
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
                                 if (m_useFirstNonBMPCharacterOptimization) {
                                     m_jit.add32(m_regs.firstCharacterAdditionalReadSize, m_regs.index, m_regs.regT0);
                                     setMatchStart(m_regs.regT0);
@@ -4800,7 +4715,7 @@ class YarrGenerator final : public YarrJITInfo {
                                     m_jit.sub32(m_regs.index, MacroAssembler::Imm32(alternative->m_minimumSize - 1), m_regs.regT0);
                                 else
                                     m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index, m_regs.regT0);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
                                 if (m_useFirstNonBMPCharacterOptimization)
                                     m_jit.add32(m_regs.firstCharacterAdditionalReadSize, m_regs.regT0);
 #endif
@@ -4815,7 +4730,7 @@ class YarrGenerator final : public YarrJITInfo {
                             // already correctly incremented, if more than one then decrement as appropriate.
                             unsigned delta = alternative->m_minimumSize - beginOp->m_alternative->m_minimumSize;
                             ASSERT(delta);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
                             if (m_useFirstNonBMPCharacterOptimization) {
                                 m_jit.add32(m_regs.firstCharacterAdditionalReadSize, m_regs.index);
                                 if (delta != 1)
@@ -4826,7 +4741,7 @@ class YarrGenerator final : public YarrJITInfo {
                                 if (delta != 1)
                                     m_jit.sub32(MacroAssembler::Imm32(delta - 1), m_regs.index);
                                 m_jit.jump(beginOp->m_reentry);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
                             }
 #endif
                         } else {
@@ -4835,7 +4750,7 @@ class YarrGenerator final : public YarrJITInfo {
                             unsigned delta = beginOp->m_alternative->m_minimumSize - alternative->m_minimumSize;
                             if (delta != 0xFFFFFFFFu) {
                                 // We need to check input because we are incrementing the input.
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
                                 if (m_useFirstNonBMPCharacterOptimization)
                                     m_jit.add32(m_regs.firstCharacterAdditionalReadSize, m_regs.index);
 #endif
@@ -4875,7 +4790,7 @@ class YarrGenerator final : public YarrJITInfo {
                         unsigned delta = prevOp->m_alternative->m_minimumSize - nextOp->m_alternative->m_minimumSize;
                         m_jit.sub32(MacroAssembler::Imm32(delta), m_regs.index);
                         MacroAssembler::Jump fail = jumpIfNoAvailableInput();
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
                         // The next alternative is entered as the first one attempted at this start position,
                         // bypassing the latch setup in BodyAlternativeBegin.
                         initAdvanceLatch(nextOp->m_alternative->m_minimumSize);
@@ -4923,7 +4838,7 @@ class YarrGenerator final : public YarrJITInfo {
                     if (alternative->m_minimumSize == m_pattern.m_body->m_minimumSize) {
                         // If the last alternative had the same minimum size as the disjunction,
                         // just simply increment input pos by 1, no adjustment based on minimum size.
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
                         if (m_useFirstNonBMPCharacterOptimization)
                             m_jit.add32(m_regs.firstCharacterAdditionalReadSize, m_regs.index);
 #endif
@@ -5286,7 +5201,6 @@ class YarrGenerator final : public YarrJITInfo {
             // FixedCount is simply min == max == N.
 
             case YarrOpCode::ParenthesesSubpatternBegin: {
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
                 PatternTerm* term = op.m_term;
                 unsigned parenthesesFrameLocation = term->frameLocation;
                 m_backtrackingState.link(*this, op);
@@ -5383,13 +5297,9 @@ class YarrGenerator final : public YarrJITInfo {
                     break;
                 }
                 }
-#else // !YARR_JIT_ALL_PARENS_EXPRESSIONS
-                RELEASE_ASSERT_NOT_REACHED();
-#endif
                 break;
             }
             case YarrOpCode::ParenthesesSubpatternEnd: {
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
                 PatternTerm* term = op.m_term;
                 YarrOp& beginOp = m_ops[op.m_previousOp];
                 unsigned parenthesesFrameLocation = term->frameLocation;
@@ -5445,9 +5355,6 @@ class YarrGenerator final : public YarrJITInfo {
                 m_backtrackingState.fallthrough();
                 m_backtrackingState.append(op.m_jumps);
                 op.m_contentBacktrackEntryLabel = m_jit.label();
-#else // !YARR_JIT_ALL_PARENS_EXPRESSIONS
-                RELEASE_ASSERT_NOT_REACHED();
-#endif
                 break;
             }
 
@@ -5578,7 +5485,6 @@ class YarrGenerator final : public YarrJITInfo {
             parenthesesBeginOpCode = YarrOpCode::ParenthesesSubpatternTerminalBegin;
             parenthesesEndOpCode = YarrOpCode::ParenthesesSubpatternTerminalEnd;
         } else {
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
             if (term->quantityType == QuantifierType::FixedCount) {
                 bool hasMultipleAlternatives = term->parentheses.disjunction->m_alternatives.size() != 1;
                 bool hasBacktrackableContent = term->quantityMaxCount > 1 && disjunctionContainsBacktrackableContent(term->parentheses.disjunction);
@@ -5619,11 +5525,6 @@ class YarrGenerator final : public YarrJITInfo {
                     alternativeEndOpCode = YarrOpCode::NestedAlternativeEnd;
                 }
             }
-#else
-            // This subpattern is not supported by the JIT.
-            m_failureReason = JITFailureReason::ParenthesizedSubpattern;
-            return;
-#endif
         }
 
         size_t parenBegin = m_ops.size();
@@ -6854,12 +6755,10 @@ class YarrGenerator final : public YarrJITInfo {
 
     void generateReturn()
     {
-#if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
         if (m_executionMode == ExecutionMode::InlineTest) {
             m_inlinedMatched.append(m_jit.jump());
             return;
         }
-#endif
 
         m_jit.emitRestoreCalleeSavesFor(&m_calleeSaves);
 #if CPU(X86_64) || CPU(RISCV64)
@@ -6928,9 +6827,7 @@ public:
         , m_decode16BitForBackreferencesWithCalls(m_charSize == CharSize::Char16 && m_pattern.m_containsBackreferences && (m_pattern.ignoreCase() || m_pattern.m_containsModifiers))
         , m_callFrameSizeInBytes(alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize))
         , m_canonicalMode(m_pattern.eitherUnicode() ? CanonicalMode::Unicode : CanonicalMode::UCS2)
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
         , m_parenContextSizes(needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numSubpatterns : 0, needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numDuplicateNamedCaptureGroups : 0, m_pattern.m_maxParenContextFrameSize)
-#endif
         , m_sampleString(sampleString)
         , m_sampler(charSize)
     {
@@ -6952,9 +6849,7 @@ public:
         , m_decode16BitForBackreferencesWithCalls(m_charSize == CharSize::Char16 && m_pattern.m_containsBackreferences && (m_pattern.ignoreCase() || m_pattern.m_containsModifiers))
         , m_callFrameSizeInBytes(alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize))
         , m_canonicalMode(m_pattern.eitherUnicode() ? CanonicalMode::Unicode : CanonicalMode::UCS2)
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
         , m_parenContextSizes(needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numSubpatterns : 0, needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numDuplicateNamedCaptureGroups : 0, m_pattern.m_maxParenContextFrameSize)
-#endif
         , m_sampler(charSize)
     {
         if (m_pattern.m_containsBackreferences)
@@ -6964,7 +6859,6 @@ public:
 
     void NODELETE initializeInternalSubpatternStorageIfNeeded()
     {
-#if ENABLE(YARR_JIT_BACKREFERENCES)
         // For MatchOnly mode with backreferences, we need internal storage for subpattern results
         // since m_regs.output is not available for subpattern storage in MatchOnly mode.
         if (m_executionMode == ExecutionMode::MatchOnly && m_pattern.m_containsBackreferences) {
@@ -6977,7 +6871,6 @@ public:
             unsigned totalAdditionalSlots = subpatternSlots + duplicateNamedGroupSlots;
             m_callFrameSizeInBytes = alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize + totalAdditionalSlots);
         }
-#endif
     }
 
     bool isSafeToRecurse() const
@@ -7033,37 +6926,12 @@ public:
     {
         MacroAssembler::Label startOfMainCode;
 
-#if !ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
-        if (m_decodeSurrogatePairs) {
-            codeBlock.setFallBackWithFailureReason(JITFailureReason::DecodeSurrogatePair);
-            return;
-        }
-#endif
-
-        // With YARR_JIT_BACKREFERENCES enabled, we can now handle backreferences in MatchOnly mode
-        // by using internal frame storage for subpattern results.
-#if ENABLE(YARR_JIT_BACKREFERENCES)
-#if !ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
-        // Without 16-bit backreference support, fail for ignoreCase 16-bit patterns
-        if (m_pattern.m_containsBackreferences && m_pattern.ignoreCase() && m_charSize != CharSize::Char8) {
-            codeBlock.setFallBackWithFailureReason(JITFailureReason::BackReference);
-            return;
-        }
-#endif
-#else
-        // Without YARR_JIT_BACKREFERENCES, fail for any backreference pattern
-        if (m_pattern.m_containsBackreferences) {
-            codeBlock.setFallBackWithFailureReason(JITFailureReason::BackReference);
-            return;
-        }
-#endif
-
         if (m_pattern.m_containsLookbehinds) {
             codeBlock.setFallBackWithFailureReason(JITFailureReason::Lookbehind);
             return;
         }
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
         // A zero minimum-size alternative (e.g. /aa|\B/u) can match in the middle of a surrogate pair, so it must not be skipped.
         if (m_decodeSurrogatePairs && m_executionMode != ExecutionMode::InlineTest && !m_pattern.multiline() && !m_pattern.m_containsBOL && !m_pattern.m_containsLookbehinds && !m_pattern.m_containsModifiers && m_pattern.m_body->m_minimumSize) {
             ASSERT(m_regs.firstCharacterAdditionalReadSize != InvalidGPRReg);
@@ -7120,12 +6988,9 @@ public:
             m_jit.move(m_regs.regT0, MacroAssembler::stackPointerRegister);
         }
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs)
             m_jit.getEffectiveAddress(MacroAssembler::BaseIndex(m_regs.input, m_regs.length, MacroAssembler::TimesTwo), m_regs.endOfStringAddress);
-#endif
 
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
         if (m_containsNestedSubpatterns) {
 #if CPU(X86_64)
             // Preserve the MatchingContextHolder* in m_regs.matchingContext.
@@ -7142,7 +7007,6 @@ public:
             else
                 m_jit.storePtr(MacroAssembler::TrustedImmPtr(nullptr), MacroAssembler::Address(m_regs.matchingContext, MatchingContextHolder::offsetOfFreeList()));
         }
-#endif
 
         // Initialize subpatterns' starts. And initialize matchStart if `!m_pattern.m_body->m_hasFixedSize`.
         // If shouldRecordSubpatterns(), then matchStart is subpatterns[0]'s start.
@@ -7186,10 +7050,8 @@ public:
                 return false;
             if (m_callFrameSizeInBytes)
                 return false;
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
             if (m_containsNestedSubpatterns)
                 return false;
-#endif
             if (m_pattern.m_containsBackreferences)
                 return false;
             if (m_pattern.m_saveInitialStartValue)
@@ -7245,7 +7107,6 @@ public:
             codeBlock.setFallBackWithFailureReason(*m_failureReason);
     }
 
-#if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
     void compileInline(YarrBoyerMooreData& boyerMooreData)
     {
         RELEASE_ASSERT(!m_pattern.m_containsBackreferences);
@@ -7254,13 +7115,7 @@ public:
         // are used during generation.
         opCompileBody(m_pattern.m_body);
 
-#if !ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
-        RELEASE_ASSERT(!m_decodeSurrogatePairs);
-#endif
-
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
         RELEASE_ASSERT(!m_containsNestedSubpatterns);
-#endif
 
         if (Options::dumpDisassembly() || Options::dumpRegExpDisassembly()) [[unlikely]]
             m_disassembler = makeUnique<YarrDisassembler>(this);
@@ -7298,10 +7153,8 @@ public:
             m_jit.move(m_regs.regT0, MacroAssembler::stackPointerRegister);
         }
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs)
             m_jit.getEffectiveAddress(MacroAssembler::BaseIndex(m_regs.input, m_regs.length, MacroAssembler::TimesTwo), m_regs.endOfStringAddress);
-#endif
 
         emitClearAllCaptures();
         if (!m_pattern.m_body->m_hasFixedSize) {
@@ -7338,7 +7191,6 @@ public:
 
         boyerMooreData.saveMaps(WTF::move(m_bmMaps));
     }
-#endif
 
     const char* variant() final
     {
@@ -7645,11 +7497,9 @@ private:
     // Frame offset (in slots) for internal subpattern output storage
     unsigned m_internalSubpatternOutputOffsetInFrame { 0 };
     const CanonicalMode m_canonicalMode;
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
     bool m_containsNestedSubpatterns { false };
     ParenContextSizes m_parenContextSizes;
-#endif
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
     bool m_useFirstNonBMPCharacterOptimization { false };
 #endif
     RegisterAtOffsetList m_calleeSaves;
@@ -7673,7 +7523,6 @@ private:
     SubjectSampler m_sampler;
 };
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
 static MacroAssemblerCodeRef<JITThunkPtrTag> tryReadUnicodeCharSlowThunkGenerator(VM&)
 {
     CCallHelpers jit(nullptr);
@@ -7686,9 +7535,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> tryReadUnicodeCharSlowThunkGenerato
 
     return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "Yarr tryReadUnicodeChar"_s, "YARR tryReadUnicodeChar thunk");
 }
-#endif
 
-#if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
 static MacroAssemblerCodeRef<JITThunkPtrTag> areCanonicallyEquivalentThunkGenerator(VM&)
 {
     CCallHelpers jit(nullptr);
@@ -7775,22 +7622,12 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationAreCanonicallyEquivalent, bool, (unsi
 {
     return areCanonicallyEquivalent(static_cast<char32_t>(a), static_cast<char32_t>(b), canonicalMode);
 }
-#endif
 
 static void dumpCompileFailure(JITFailureReason failure)
 {
     switch (failure) {
-    case JITFailureReason::DecodeSurrogatePair:
-        dataLog("Can't JIT a pattern decoding surrogate pairs\n");
-        break;
-    case JITFailureReason::BackReference:
-        dataLog("Can't JIT some patterns containing back references\n");
-        break;
     case JITFailureReason::Lookbehind:
         dataLog("Can't JIT a pattern containing lookbehinds\n");
-        break;
-    case JITFailureReason::ParenthesizedSubpattern:
-        dataLog("Can't JIT a pattern containing parenthesized subpatterns\n");
         break;
     case JITFailureReason::ParenthesisNestedTooDeep:
         dataLog("Can't JIT pattern due to parentheses nested too deeply\n");
@@ -7825,11 +7662,6 @@ void jitCompile(YarrPattern& pattern, StringView patternString, CharSize charSiz
     }
 }
 
-#if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
-#if !(CPU(ARM64) || CPU(X86_64) || CPU(RISCV64))
-#error "No support for inlined JIT'ing of RegExp.test for this CPU / OS combination."
-#endif
-
 void jitCompileInlinedTest(StackCheck* m_compilationThreadStackChecker, StringView patternString, OptionSet<Yarr::Flags> flags, CharSize charSize, VM* vm, YarrBoyerMooreData& boyerMooreData, CCallHelpers& jit, YarrJITRegisters& jitRegisters)
 {
     Yarr::ErrorCode errorCode;
@@ -7847,7 +7679,6 @@ void jitCompileInlinedTest(StackCheck* m_compilationThreadStackChecker, StringVi
     yarrGenerator.setStackChecker(m_compilationThreadStackChecker);
     yarrGenerator.compileInline(boyerMooreData);
 }
-#endif
 
 void YarrCodeBlock::dumpSimpleName(PrintStream& out) const
 {

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -56,10 +56,7 @@ class MatchingContextHolder;
 class YarrCodeBlock;
 
 enum class JITFailureReason : uint8_t {
-    DecodeSurrogatePair,
-    BackReference,
     Lookbehind,
-    ParenthesizedSubpattern,
     ParenthesisNestedTooDeep,
     ExecutableMemoryAllocationFailure,
     OffsetTooLarge,
@@ -439,13 +436,9 @@ private:
 
 void jitCompile(YarrPattern&, StringView patternString, CharSize, std::optional<StringView> sampleString, VM*, YarrCodeBlock& jitObject, ExecutionMode);
 
-#if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
-
-
 class YarrJITRegisters;
 
 void jitCompileInlinedTest(StackCheck*, StringView, OptionSet<Yarr::Flags>, CharSize, VM*, YarrBoyerMooreData&, CCallHelpers&, YarrJITRegisters&);
-#endif
 
 } } // namespace JSC::Yarr
 

--- a/Source/JavaScriptCore/yarr/YarrJITRegisters.h
+++ b/Source/JavaScriptCore/yarr/YarrJITRegisters.h
@@ -145,7 +145,6 @@ public:
 #endif
 };
 
-#if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
 class YarrJITRegisters {
 public:
     YarrJITRegisters() = default;
@@ -211,8 +210,6 @@ public:
     static constexpr FPRReg vectorScratch2 = InvalidFPRReg;
     static constexpr FPRReg vectorScratch3 = InvalidFPRReg;
 };
-#endif
-
 
 } } // namespace JSC::Yarr
 

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -900,26 +900,6 @@
 #define ENABLE_YARR_JIT_DEBUG 0
 #endif
 
-/* Enable JIT'ing Regular Expressions that have nested parenthesis . */
-#if ENABLE(YARR_JIT) && (CPU(ARM64) || CPU(X86_64) || CPU(RISCV64))
-#define ENABLE_YARR_JIT_ALL_PARENS_EXPRESSIONS 1
-#define ENABLE_YARR_JIT_REGEXP_TEST_INLINE 1
-#endif
-
-/* Enable JIT'ing Regular Expressions that have back references. */
-#if ENABLE(YARR_JIT) && (CPU(ARM64) || CPU(X86_64) || CPU(RISCV64))
-#define ENABLE_YARR_JIT_BACKREFERENCES 1
-#if CPU(ARM64) || CPU(X86_64)
-#define ENABLE_YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS 1
-#else
-#define ENABLE_YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS 0
-#endif
-#endif
-
-#if ENABLE(YARR_JIT) && (CPU(ARM64) || CPU(X86_64) || CPU(RISCV64))
-#define ENABLE_YARR_JIT_UNICODE_EXPRESSIONS 1
-#endif
-
 /* Enables an optimiztion to advance two codepoints when we fail to match a non-BMP character */
 #if ENABLE(YARR_JIT) && CPU(ARM64)
 #define ENABLE_YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP 1


### PR DESCRIPTION
#### ac2afd10b8ac26ed79a3781501cc1ea1381d3bd9
<pre>
[YARR] Clean up YarrJIT ifdefs
<a href="https://bugs.webkit.org/show_bug.cgi?id=320845">https://bugs.webkit.org/show_bug.cgi?id=320845</a>
<a href="https://rdar.apple.com/183873163">rdar://183873163</a>

Reviewed by Yijia Huang.

ARMv7 JIT is dropped. So upstream JIT we care is only ARM64 and X86_64
(RISCV64 is unmaintained). We can clean up many of YarrJIT flags so that
it makes code much cleaner.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileRegExpTestInline):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::compile):
(JSC::RegExp::compileMatchOnly):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::tryReadUnicodeCharSlowThunkGenerator):
(JSC::Yarr::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
(JSC::Yarr::dumpCompileFailure):
(JSC::Yarr::jitCompileInlinedTest):
* Source/JavaScriptCore/yarr/YarrJIT.h:
* Source/JavaScriptCore/yarr/YarrJITRegisters.h:
* Source/WTF/wtf/PlatformEnable.h:

Canonical link: <a href="https://commits.webkit.org/318417@main">https://commits.webkit.org/318417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbb65422a7f5854fe9e63bfbec21aa9a4e54e19f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187873 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141507 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8f029276-b913-4b9e-9ccd-ee1caa70d3b4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138963 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ffe53bd5-39e0-4389-9732-262941dd1d9e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119419 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6be53b7e-17f7-4b89-8791-cd30781aacf3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41186 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39540 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1388 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8216 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151586 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; 1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39225 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36330 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39532 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190300 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51865 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148114 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52547 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147887 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27035 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42602 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124811 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119396 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51065 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14200 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50450 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50690 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->