### PR TITLE
[Text Extraction] Include links and link URLs in extracted PDFs

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -225,7 +225,7 @@ static String NODELETE stringOnlyIfHumanReadable(const String& string)
     return { };
 }
 
-static String shortenedURLString(const URL& url)
+String shortenedURLString(const URL& url)
 {
     auto shortenedURL = StringEntropyHelpers::removeHighEntropyComponents(url);
     if (shortenedURL.protocolIsFile()) {
@@ -1273,7 +1273,7 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
         if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(node); iframe && item) {
             if (RefPtr frame = dynamicDowncast<LocalFrame>(iframe->contentFrame())) {
                 if (RefPtr document = frame->document(); document && areSameOrigin(*document, protect(node.document()))) {
-                    auto [rootItem, textLength, pdfContent] = extractItem([&] {
+                    auto [rootItem, textLength] = extractItem([&] {
                         auto request = context.originalRequest;
                         request.targetNodeHandleIdentifier = { };
                         return request;
@@ -1461,7 +1461,7 @@ Result extractItem(Request&& request, LocalFrame& frame)
 
     RefPtr document = frame.document();
     if (!document)
-        return { root, 0, { } };
+        return { root, 0 };
 
     RefPtr bodyOrDocumentElement = [&] -> RefPtr<Element> {
         if (RefPtr bodyElement = document->body())
@@ -1471,7 +1471,7 @@ Result extractItem(Request&& request, LocalFrame& frame)
     }();
 
     if (!bodyOrDocumentElement)
-        return { root, 0, { } };
+        return { root, 0 };
 
     document->updateLayoutIgnorePendingStylesheets();
 
@@ -1494,11 +1494,11 @@ Result extractItem(Request&& request, LocalFrame& frame)
         addBoxShadowIfNeeded(*extractionRootNode, extractingWithDataDetectors ? "#0088FF"_s : "#ff8d28"_s);
 
     if (!extractionRootNode)
-        return { root, 0, { } };
+        return { root, 0 };
 
     RefPtr view = frame.view();
     if (!view)
-        return { root, 0, { } };
+        return { root, 0 };
 
     root.data = { ScrollableItemData {
         .contentSize = view->contentsSize(),
@@ -1509,7 +1509,7 @@ Result extractItem(Request&& request, LocalFrame& frame)
 
     root.rectInRootView = view->contentsToRootView(IntRect { IntPoint::zero(), view->contentsSize() });
     if (root.rectInRootView.isEmpty())
-        return { root, 0, { } };
+        return { root, 0 };
 
     unsigned visibleTextLength = 0;
     {
@@ -1595,7 +1595,7 @@ Result extractItem(Request&& request, LocalFrame& frame)
     pruneWhitespaceRecursive(root);
     pruneEmptyContainersRecursive(root);
 
-    return { WTF::move(root), visibleTextLength, { } };
+    return { WTF::move(root), visibleTextLength };
 }
 
 using Token = Variant<String, IntSize>;

--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -41,6 +41,8 @@ namespace TextExtraction {
 
 WEBCORE_EXPORT Result extractItem(Request&&, LocalFrame&);
 
+WEBCORE_EXPORT String shortenedURLString(const URL&);
+
 WEBCORE_EXPORT Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page&);
 
 WEBCORE_EXPORT void handleInteraction(Interaction&&, LocalFrame&, CompletionHandler<void(bool, String&&, FloatRect)>&&);

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -249,7 +249,6 @@ struct Result {
 
     Item rootItem;
     unsigned visibleTextLength { 0 };
-    std::optional<String> pdfMarkdownContent;
 };
 
 struct PageResults {

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -2179,44 +2179,4 @@ void convertToText(TextExtraction::Item&& item, TextExtractionOptions&& options,
     addTextRepresentationRecursive(item, { }, 0, aggregator);
 }
 
-String formatPDFMarkdownForOutput(const String& pdfText, TextExtractionOutputFormat outputFormat)
-{
-    using enum TextExtractionOutputFormat;
-    switch (outputFormat) {
-    case Markdown:
-    case PlainText:
-        return pdfText;
-
-    case TextTree: {
-        auto visibleText = trimAndSimplifyWhitespace(pdfText);
-        return makeString("root\n\t'"_s, escapeString(visibleText), '\'');
-    }
-
-    case HTMLMarkup: {
-        auto escaped = trimAndSimplifyWhitespace(pdfText);
-        escaped = makeStringByReplacingAll(escaped, '&', "&amp;"_s);
-        escaped = makeStringByReplacingAll(escaped, '<', "&lt;"_s);
-        escaped = makeStringByReplacingAll(escaped, '>', "&gt;"_s);
-        return makeString("<body>"_s, WTF::move(escaped), "</body>"_s);
-    }
-
-    case MinifiedJSON: {
-        Ref textObject = JSON::Object::create();
-        textObject->setString("type"_s, "text"_s);
-        textObject->setString("content"_s, trimAndSimplifyWhitespace(pdfText));
-
-        Ref children = JSON::Array::create();
-        children->pushObject(WTF::move(textObject));
-
-        Ref root = JSON::Object::create();
-        root->setString("type"_s, "root"_s);
-        root->setArray("children"_s, WTF::move(children));
-        return root->toJSONString();
-    }
-    }
-
-    ASSERT_NOT_REACHED();
-    return pdfText;
-}
-
 } // namespace WebKit

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -126,8 +126,6 @@ struct TextExtractionResult {
 
 void convertToText(WebCore::TextExtraction::Item&&, TextExtractionOptions&&, CompletionHandler<void(TextExtractionResult&&)>&&);
 
-String formatPDFMarkdownForOutput(const String& pdfText, TextExtractionOutputFormat);
-
 std::optional<ExtractedNodeInfo> parseExtractedNodeInfo(StringView);
 
 String foldTextForReplacement(const String& source);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4920,7 +4920,6 @@ header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::Result {
     WebCore::TextExtraction::Item rootItem;
     unsigned visibleTextLength;
-    std::optional<String> pdfMarkdownContent;
 };
 
 header: <WebCore/TextExtractionTypes.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm
@@ -396,18 +396,6 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
             WTF::move(maxWordsPerParagraph),
             WTF::move(topHostName),
         };
-        if (result->pdfMarkdownContent) {
-            RELEASE_LOG(TextExtraction, "<%@: %p> PDF extraction complete (%.0f ms)", [strongSelf class], strongSelf.get(), (MonotonicTime::now() - startTime).milliseconds());
-            auto formattedText = WebKit::formatPDFMarkdownForOutput(*result->pdfMarkdownContent, outputFormat);
-            completionHandler(adoptNS([[_WKTextExtractionResult alloc]
-                initWithWebView:strongSelf
-                origin:wrapper(API::SecurityOrigin::create(origin))
-                textContent:formattedText.createNSString()
-                filteredOutAnyText:NO
-                shortenedURLs:@{ }
-                textToContainerMap:{ }]));
-            return;
-        }
 
         WebKit::convertToText(WTF::move(result->rootItem), WTF::move(options), [weakSelf, startTime, urlCache, origin = WTF::move(origin), completionHandler = WTF::move(completionHandler), endTextExtractionScope = WTF::move(endTextExtractionScope)](auto&& result) {
             RetainPtr strongSelf = weakSelf.get();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -33,6 +33,7 @@
 #include "WebFoundTextRange.h"
 #include "WebMouseEvent.h"
 #include <WebCore/AffineTransform.h>
+#include <WebCore/CharacterRange.h>
 #include <WebCore/EventTarget.h>
 #include <WebCore/FindOptions.h>
 #include <WebCore/FloatRect.h>
@@ -53,6 +54,7 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeTraits.h>
+#include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS NSData;
@@ -111,6 +113,17 @@ concept CanMakeFloatRect = requires(T t)
 struct PDFPluginPasteboardItem {
     RetainPtr<NSData> data;
     RetainPtr<NSString> type;
+};
+
+struct PDFPluginTextExtractionLink {
+    URL url;
+    WebCore::CharacterRange rangeInText;
+    WebCore::FloatRect rectInRootView;
+};
+
+struct PDFPluginTextExtractionContent {
+    String text;
+    Vector<PDFPluginTextExtractionLink> links;
 };
 
 class PDFPluginBase : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PDFPluginBase, WTF::DestructionThread::Main>, public CanMakeThreadSafeCheckedPtr<PDFPluginBase>, public WebCore::ScrollableArea, public Identified<PDFPluginIdentifier> {
@@ -189,6 +202,7 @@ public:
     virtual bool isEditingCommandEnabled(const String& commandName) = 0;
 
     virtual String fullDocumentString() const { return { }; }
+    virtual PDFPluginTextExtractionContent textExtractionContent() const { return { }; }
     virtual String selectionString() const = 0;
     virtual std::pair<String, String> stringsBeforeAndAfterSelection(int /* characterCount */) const { return { }; }
     virtual bool existingSelectionContainsPoint(const WebCore::FloatPoint&) const = 0;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -432,6 +432,7 @@ private:
     void showOrHideSelectionLayerAsNecessary();
 
     String fullDocumentString() const override;
+    PDFPluginTextExtractionContent textExtractionContent() const override;
     String selectionString() const override;
     std::pair<String, String> stringsBeforeAndAfterSelection(int characterCount) const override;
     bool existingSelectionContainsPoint(const WebCore::FloatPoint&) const override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -123,6 +123,7 @@
 #include <wtf/cocoa/TypeCastsCocoa.h>
 #include <wtf/spi/darwin/OSVariantSPI.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/TextStream.h>
 
@@ -3221,6 +3222,68 @@ void UnifiedPDFPlugin::setCurrentSelection(RetainPtr<PDFSelection>&& selection)
 String UnifiedPDFPlugin::fullDocumentString() const
 {
     return [pdfDocument() string];
+}
+
+PDFPluginTextExtractionContent UnifiedPDFPlugin::textExtractionContent() const
+{
+    if (!m_pdfDocument)
+        return { };
+
+    StringBuilder textBuilder;
+    Vector<PDFPluginTextExtractionLink> links;
+
+    for (PDFDocumentLayout::PageIndex pageIndex = 0; pageIndex < m_documentLayout.pageCount(); ++pageIndex) {
+        RetainPtr page = m_documentLayout.pageAtIndex(pageIndex);
+        if (!page)
+            continue;
+
+        String pageText = [page string];
+        if (pageText.isEmpty())
+            continue;
+
+        if (textBuilder.length())
+            textBuilder.append("\n\n"_s);
+
+        auto pageTextStart = textBuilder.length();
+        textBuilder.append(pageText);
+
+        RetainPtr annotationsInReadingOrder = [[page annotations] sortedArrayUsingComparator:^NSComparisonResult(PDFAnnotation *first, PDFAnnotation *second) {
+            auto firstBounds = [first bounds];
+            auto secondBounds = [second bounds];
+            if (firstBounds.origin.y != secondBounds.origin.y)
+                return firstBounds.origin.y > secondBounds.origin.y ? NSOrderedAscending : NSOrderedDescending;
+            if (firstBounds.origin.x != secondBounds.origin.x)
+                return firstBounds.origin.x < secondBounds.origin.x ? NSOrderedAscending : NSOrderedDescending;
+            return NSOrderedSame;
+        }];
+
+        size_t searchOffset = 0;
+        for (PDFAnnotation *annotation in annotationsInReadingOrder.get()) {
+            if (!annotationIsExternalLink(annotation))
+                continue;
+
+            URL url { [annotation URL] };
+            if (url.isEmpty())
+                continue;
+
+            RetainPtr linkSelection = [page selectionForRect:[annotation bounds]];
+            String linkText = linkSelection ? String { [linkSelection string] } : nullString();
+            if (linkText.isEmpty())
+                continue;
+
+            auto offset = pageText.find(linkText, searchOffset);
+            if (offset == notFound)
+                offset = pageText.find(linkText);
+            if (offset == notFound)
+                continue;
+
+            searchOffset = offset + linkText.length();
+
+            links.append(PDFPluginTextExtractionLink { WTF::move(url), CharacterRange { pageTextStart + offset, linkText.length() }, pageToRootView([annotation bounds], page) });
+        }
+    }
+
+    return { textBuilder.toString(), WTF::move(links) };
 }
 
 String UnifiedPDFPlugin::selectionString() const

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -685,6 +685,14 @@ String PluginView::fullDocumentString() const
     return m_plugin->fullDocumentString();
 }
 
+PDFPluginTextExtractionContent PluginView::textExtractionContent() const
+{
+    if (!m_isInitialized)
+        return { };
+
+    return m_plugin->textExtractionContent();
+}
+
 String PluginView::selectionString() const
 {
     if (!m_isInitialized)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -66,6 +66,7 @@ struct DocumentEditingContextRequest;
 struct DocumentEditingContext;
 struct EditorState;
 struct FrameInfoData;
+struct PDFPluginTextExtractionContent;
 struct WebHitTestResultData;
 
 class PluginView final : public WebCore::PluginViewBase {
@@ -135,6 +136,7 @@ public:
     void scrollToRevealTextMatch(const WebFoundTextRange::PDFData&);
 
     String fullDocumentString() const;
+    PDFPluginTextExtractionContent textExtractionContent() const;
     String selectionString() const;
     std::pair<String, String> stringsBeforeAndAfterSelection(int characterCount) const;
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -147,6 +147,10 @@
 #include <WebCore/LegacyWebArchive.h>
 #endif
 
+#if ENABLE(PDF_PLUGIN)
+#include "PDFPluginBase.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -1807,6 +1811,52 @@ void WebFrame::sendMessageToInspectorTarget(const String& message)
     ensureInspectorTarget()->sendMessageToTargetBackend(message);
 }
 
+#if ENABLE(PDF_PLUGIN)
+
+static Vector<TextExtraction::Item> itemsForPDFTextAndLinks(String&& text, Vector<PDFPluginTextExtractionLink>&& links)
+{
+    std::ranges::sort(links, [](auto& a, auto& b) {
+        return a.rangeInText.location < b.rangeInText.location;
+    });
+
+    Vector<TextExtraction::Item> items;
+    unsigned cursor = 0;
+    for (auto& link : links) {
+        auto linkLocation = static_cast<unsigned>(link.rangeInText.location);
+        auto linkLength = static_cast<unsigned>(link.rangeInText.length);
+        if (linkLocation < cursor)
+            continue;
+
+        if (linkLocation > cursor) {
+            TextExtraction::Item textItem;
+            textItem.data = TextExtraction::TextItemData { { }, { }, text.substring(cursor, linkLocation - cursor), { } };
+            items.append(WTF::move(textItem));
+        }
+
+        TextExtraction::Item linkTextItem;
+        linkTextItem.data = TextExtraction::TextItemData { { }, { }, text.substring(linkLocation, linkLength), { } };
+
+        TextExtraction::Item linkItem;
+        linkItem.data = TextExtraction::LinkItemData { { }, link.url, TextExtraction::shortenedURLString(link.url), false, { } };
+        linkItem.rectInRootView = link.rectInRootView;
+        linkItem.nodeName = "a"_s;
+        linkItem.children = { WTF::move(linkTextItem) };
+        items.append(WTF::move(linkItem));
+
+        cursor = linkLocation + linkLength;
+    }
+
+    if (cursor < text.length()) {
+        TextExtraction::Item textItem;
+        textItem.data = TextExtraction::TextItemData { { }, { }, text.substring(cursor), { } };
+        items.append(WTF::move(textItem));
+    }
+
+    return items;
+}
+
+#endif // ENABLE(PDF_PLUGIN)
+
 void WebFrame::requestTextExtraction(TextExtraction::Request&& request, CompletionHandler<void(TextExtraction::Result&&)>&& completion)
 {
     RefPtr frame = coreLocalFrame();
@@ -1815,7 +1865,7 @@ void WebFrame::requestTextExtraction(TextExtraction::Request&& request, Completi
 
 #if ENABLE(PDF_PLUGIN)
     if (RefPtr pluginView = WebPage::pluginViewForFrame(frame.get())) {
-        if (auto pdfText = pluginView->fullDocumentString(); !pdfText.isEmpty()) {
+        if (auto pdfContent = pluginView->textExtractionContent(); !pdfContent.text.isEmpty()) {
             TextExtraction::Result result;
             TextExtraction::ScrollableItemData scrollableData;
             if (RefPtr view = frame->view()) {
@@ -1825,8 +1875,8 @@ void WebFrame::requestTextExtraction(TextExtraction::Request&& request, Completi
             scrollableData.isRoot = true;
             result.rootItem.data = WTF::move(scrollableData);
             result.rootItem.frameIdentifier = frame->frameID();
-            result.visibleTextLength = pdfText.length();
-            result.pdfMarkdownContent = WTF::move(pdfText);
+            result.visibleTextLength = pdfContent.text.length();
+            result.rootItem.children = itemsForPDFTextAndLinks(WTF::move(pdfContent.text), WTF::move(pdfContent.links));
             return completion(WTF::move(result));
         }
     }

--- a/Tools/TestWebKitAPI/Helpers/cocoa/PDFTestHelpers.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/PDFTestHelpers.h
@@ -62,6 +62,8 @@ RetainPtr<WKWebViewConfiguration> configurationForWebViewTestingUnifiedPDF(bool 
 
 RetainPtr<NSData> testPDFData();
 
+RetainPtr<NSData> testPDFDataWithLink();
+
 }
 
 #endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/PDFTestHelpers.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/PDFTestHelpers.mm
@@ -29,6 +29,7 @@
 #import "Helpers/cocoa/TestNSBundleExtras.h"
 #import "Helpers/Utilities.h"
 #import "Helpers/cocoa/WKWebViewConfigurationExtras.h"
+#import <CoreText/CoreText.h>
 #import <Foundation/Foundation.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKUIDelegate.h>
@@ -85,6 +86,53 @@ RetainPtr<WKWebViewConfiguration> configurationForWebViewTestingUnifiedPDF(bool 
 RetainPtr<NSData> testPDFData()
 {
     return [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
+}
+
+static size_t appendPDFBytes(void* info, const void* buffer, size_t count)
+{
+    [(NSMutableData *)info appendBytes:buffer length:count];
+    return count;
+}
+
+RetainPtr<NSData> testPDFDataWithLink()
+{
+    RetainPtr pdfData = adoptNS([[NSMutableData alloc] init]);
+
+    CGDataConsumerCallbacks callbacks { appendPDFBytes, nullptr };
+    RetainPtr consumer = adoptCF(CGDataConsumerCreate(pdfData, &callbacks));
+
+    CGRect mediaBox = CGRectMake(0, 0, 400, 200);
+    RetainPtr pdfContext = adoptCF(CGPDFContextCreate(consumer, &mediaBox, nullptr));
+
+    CGPDFContextBeginPage(pdfContext, nullptr);
+
+    RetainPtr font = adoptCF(CTFontCreateWithName((CFStringRef)@"Helvetica", 24, nullptr));
+    RetainPtr attributedString = adoptNS([[NSAttributedString alloc] initWithString:@"Visit our website for details" attributes:@{ (id)kCTFontAttributeName: (id)font.get() }]);
+    RetainPtr line = adoptCF(CTLineCreateWithAttributedString((CFAttributedStringRef)attributedString.get()));
+
+    CGFloat baselineX = 20;
+    CGFloat baselineY = 100;
+    CGContextSetTextPosition(pdfContext, baselineX, baselineY);
+    CTLineDraw(line, pdfContext);
+
+    // "Visit our website for details"
+    //  0123456789...
+    // "our website" spans [6, 17).
+    CGFloat linkStartX = baselineX + CTLineGetOffsetForStringIndex(line, 6, nullptr);
+    CGFloat linkEndX = baselineX + CTLineGetOffsetForStringIndex(line, 17, nullptr);
+
+    CGFloat ascent = 0;
+    CGFloat descent = 0;
+    CGFloat leading = 0;
+    CTLineGetTypographicBounds(line, &ascent, &descent, &leading);
+
+    CGRect linkRect = CGRectMake(linkStartX, baselineY - descent, linkEndX - linkStartX, ascent + descent);
+    CGPDFContextSetURLForRect(pdfContext, (CFURLRef)[NSURL URLWithString:@"https://www.example.com/"], linkRect);
+
+    CGPDFContextEndPage(pdfContext);
+    CGPDFContextClose(pdfContext);
+
+    return pdfData;
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -2760,6 +2760,76 @@ TEST(TextExtractionTests, ExtractFromPDFAsPlainText)
     EXPECT_TRUE([text containsString:@"555-555-1234"]);
 }
 
+static RetainPtr<TestWKWebView> loadPDFWithLinkInWebView()
+{
+    RetainPtr configuration = configurationForWebViewTestingUnifiedPDF();
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    [webView loadData:testPDFDataWithLink() MIMEType:@"application/pdf" characterEncodingName:@"" baseURL:[NSURL URLWithString:@"https://www.example.com/test-with-link.pdf"]];
+    [webView _test_waitForDidFinishNavigation];
+    return webView;
+}
+
+TEST(TextExtractionTests, ExtractFromPDFLink)
+{
+    RetainPtr webView = loadPDFWithLinkInWebView();
+    {
+        RetainPtr text = [webView synchronouslyGetDebugText:^{
+            RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+            [configuration setOutputFormat:_WKTextExtractionOutputFormatMarkdown];
+            return configuration.autorelease();
+        }()];
+
+        EXPECT_TRUE([text containsString:@"[our website](https://www.example.com/)"]);
+    }
+    {
+        RetainPtr text = [webView synchronouslyGetDebugText:^{
+            RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+            [configuration setOutputFormat:_WKTextExtractionOutputFormatHTML];
+            return configuration.autorelease();
+        }()];
+
+        EXPECT_TRUE([text containsString:@"<a href='https://www.example.com/'>our website</a>"]);
+    }
+    {
+        RetainPtr text = [webView synchronouslyGetDebugText:^{
+            RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+            [configuration setOutputFormat:_WKTextExtractionOutputFormatJSON];
+            return configuration.autorelease();
+        }()];
+
+        NSError *error = nil;
+        NSDictionary *json = [NSJSONSerialization JSONObjectWithData:[text dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&error];
+        EXPECT_NULL(error);
+
+        NSDictionary *linkNode = nil;
+        for (NSDictionary *child in [json objectForKey:@"children"]) {
+            if ([[child objectForKey:@"type"] isEqualToString:@"link"]) {
+                linkNode = child;
+                break;
+            }
+        }
+
+        EXPECT_NOT_NULL(linkNode);
+        EXPECT_WK_STREQ("https://www.example.com/", [linkNode objectForKey:@"url"]);
+        NSArray *linkChildren = [linkNode objectForKey:@"children"];
+        EXPECT_EQ([linkChildren count], 1u);
+        EXPECT_WK_STREQ("our website", [[linkChildren firstObject] objectForKey:@"content"]);
+    }
+    {
+        RetainPtr text = [webView synchronouslyGetDebugText:^{
+            RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+            [configuration setOutputFormat:_WKTextExtractionOutputFormatTextTree];
+            return configuration.autorelease();
+        }()];
+
+        EXPECT_TRUE([text containsString:@"link"]);
+        EXPECT_TRUE([text containsString:@"url=https://www.example.com/"]);
+        EXPECT_TRUE([text containsString:@"our website"]);
+    }
+}
+
 #endif // ENABLE(UNIFIED_PDF)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 34437eecfc86da42a5bc7de40f1090e30c988fdd
<pre>
[Text Extraction] Include links and link URLs in extracted PDFs
<a href="https://bugs.webkit.org/show_bug.cgi?id=320847">https://bugs.webkit.org/show_bug.cgi?id=320847</a>
<a href="https://rdar.apple.com/183875371">rdar://183875371</a>

Reviewed by Abrar Rahman Protyasha.

Refactor how text extraction handles PDF data to properly handle link URLs; see below for more info.

Test: TextExtractionTests.ExtractFromPDFLink

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::shortenedURLString):
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::extractItem):
* Source/WebCore/page/text-extraction/TextExtraction.h:
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:

Remove `pdfMarkdownContent`, and push existing PDF text extraction logic into `UnifiedPDFPlugin`,
where we can more easily include structured data (like links with link URLs).

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::formatPDFMarkdownForOutput): Deleted.
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm:
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::textExtractionContent const):

Add a helper method that returns a textual representation of the extracted PDF that includes URLs
(in the future, we can augment this to include more metadata, such as lists and images).

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::textExtractionContent const):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::textExtractionContent const):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::itemsForPDFTextAndLinks):
(WebKit::WebFrame::requestTextExtraction):
* Tools/TestWebKitAPI/Helpers/cocoa/PDFTestHelpers.h:
* Tools/TestWebKitAPI/Helpers/cocoa/PDFTestHelpers.mm:
(TestWebKitAPI::appendPDFBytes):
(TestWebKitAPI::testPDFDataWithLink):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::(TextExtractionTests, ExtractFromPDFLink)):

Canonical link: <a href="https://commits.webkit.org/318433@main">https://commits.webkit.org/318433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28eed9efc06aa7b807381ecd1a1d5561c529cf5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141523 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d636d198-daf4-4c90-9d71-5a8ba17bff18) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138973 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fba49974-d744-4c88-9703-54e7849c2bdc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159745 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119428 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4e22bf5-ba1c-4b97-ba50-2bbf3be71847) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41199 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39554 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39242 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36346 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190316 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51881 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39781 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52563 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147899 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42617 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124827 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119420 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51081 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14217 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50466 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50706 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50528 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->