### PR TITLE
Cherry-pick 01cef20028da. https://bugs.webkit.org/show_bug.cgi?id=311660

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3242,18 +3242,18 @@ FullScreenEnabled:
 
 FullScreenKeyboardLock:
   type: bool
-  status: stable
+  status: unstable
   category: dom
   humanReadableName: "Fullscreen API based Keyboard Lock"
   humanReadableDescription: "Fullscreen API based Keyboard Lock"
   condition: ENABLE(FULLSCREEN_API)
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
 
 FullscreenRequirementForScreenOrientationLockingEnabled:
   type: bool

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -539,7 +539,7 @@ void IDBConnectionProxy::handleMainThreadTasks()
 
 void IDBConnectionProxy::getAllDatabaseNamesAndVersions(ScriptExecutionContext& context, Function<void(std::optional<Vector<IDBDatabaseNameAndVersion>>&&)>&& callback)
 {
-    ClientOrigin origin { context.securityOrigin()->data(), context.topOrigin().data() };
+    ClientOrigin origin { context.topOrigin().data(), context.securityOrigin()->data() };
 
     RefPtr<IDBDatabaseNameAndVersionRequest> request;
     {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
@@ -26,8 +26,10 @@
 #import "config.h"
 
 #import "DeprecatedGlobalValues.h"
+#import "HTTPServer.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestNavigationDelegate.h"
 #import "TestURLSchemeHandler.h"
 #import "TestWKWebView.h"
 #import <WebCore/SQLiteFileSystem.h>
@@ -620,6 +622,43 @@ TEST(IndexedDB, IndexedDBGetDatabases)
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:appleDirectoryURL.get().path]);
     EXPECT_FALSE([defaultFileManager fileExistsAtPath:appleWebkitDirectoryURL.get().path]);
     EXPECT_FALSE([defaultFileManager fileExistsAtPath:webkitDirectoryURL.get().path]);
+}
+
+TEST(IndexedDB, IndexedDBGetDatabasesFromCrossOriginIframe)
+{
+    readyToContinue = false;
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[NSSet setWithObjects:WKWebsiteDataTypeIndexedDBDatabases, nil] modifiedSince:[NSDate distantPast] completionHandler:^() {
+        readyToContinue = true;
+    }];
+    TestWebKitAPI::Util::run(&readyToContinue);
+
+    TestWebKitAPI::HTTPServer server({
+        { "/main"_s, { "<script>"
+            "window.addEventListener('message', function(event) {"
+            "    window.webkit.messageHandlers.testHandler.postMessage(event.data);"
+            "});"
+            "</script>"
+            "<iframe src='https://webkit.org/iframe'></iframe>"_s } },
+        { "/iframe"_s, { "<script>"
+            "var request = indexedDB.open('CrossOriginIframeDB');"
+            "request.onsuccess = function(event) {"
+            "    indexedDB.databases().then(function(databases) {"
+            "        parent.postMessage('databases: ' + JSON.stringify(databases), '*');"
+            "    });"
+            "};"
+            "</script>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://apple.com/main"]]];
+    EXPECT_WK_STREQ(@"databases: [{\"name\":\"CrossOriginIframeDB\",\"version\":1}]", [getNextMessage() body]);
 }
 
 static NSString *openFileHTMLString = @"<input style='width: 100vw; height: 100vh;' id='file' type='file'> \


### PR DESCRIPTION
#### be48b756b9795a4f4130ff051fdee918c2fe8d52
<pre>
Cherry-pick 01cef20028da. <a href="https://bugs.webkit.org/show_bug.cgi?id=311660">https://bugs.webkit.org/show_bug.cgi?id=311660</a>

    indexedDB.databases() leaks database names across storage partitions due to swapped ClientOrigin
    <a href="https://rdar.apple.com/176596477">rdar://176596477</a>

    Reviewed by Chris Dumez.

    IDBConnectionProxy::getAllDatabaseNamesAndVersions constructs a ClientOrigin with topOrigin and clientOrigin swapped.
    ClientOrigin expects {topOrigin, clientOrigin}, but the code was passing {securityOrigin (client), topOrigin} instead.

    Test: IndexedDB.IndexedDBGetDatabasesFromCrossOriginIframe

    * Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
    (WebCore::IDBClient::IDBConnectionProxy::getAllDatabaseNamesAndVersions):
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm:
    ((IndexedDB, IndexedDBGetDatabasesFromCrossOriginIframe)):

    Identifier: 305413.871@safari-7624-branch

    Canonical link: <a href="https://commits.webkit.org/305413.917@safari-7624.4-branch">https://commits.webkit.org/305413.917@safari-7624.4-branch</a>

Canonical link: <a href="https://commits.webkit.org/305877.1030@webkitglib/2.52">https://commits.webkit.org/305877.1030@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 4d8d432a223f55758f9ce68d0678a018c59af7d1
<pre>
Cherry-pick 305413.885@safari-7624.4-branch (2f7b2e8b7f9f). <a href="https://bugs.webkit.org/show_bug.cgi?id=311660">https://bugs.webkit.org/show_bug.cgi?id=311660</a>

    Escape key no longer guarantees cancelling fullscreen (with keyboard lock) (311660)
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311660">https://bugs.webkit.org/show_bug.cgi?id=311660</a>
    <a href="https://rdar.apple.com/problem/174251766">rdar://problem/174251766</a>

    Reviewed by Brandon Stewart.

    Revert 303093@main since the User Interface information to instruct the user to hold
    the ESC key for 1.5 seconds (or longer) was not completed. This can lead to confusion
    and the possibility of spoofing users. We will reland the enablement when the UI portion
    is available.

    * Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

    Identifier: 305413.885@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/305877.1029@webkitglib/2.52">https://commits.webkit.org/305877.1029@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d72612e60c835fcee9d56c8cff79244fdec7659

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178590 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52528 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46323 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188206 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141840 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180453 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53822 "Build is in progress. Recent messages:") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52238 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139239 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141840 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181547 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/53822 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46323 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119693 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/53822 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52238 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1704 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46323 "The change is no longer eligible for processing.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/53822 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46323 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36661 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/39863 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45128 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52238 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190633 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52197 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46323 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148407 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/52878 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46323 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148174 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27112 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/52878 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125145 "The change is no longer eligible for processing.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119789 "Build is in progress. Recent messages:") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51396 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46323 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50781 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51021 "The change is no longer eligible for processing.") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50843 "Build is in progress. Recent messages:") | | | 
<!--EWS-Status-Bubble-End-->