### PR TITLE
RemoteProgressBasedTimelineRegistry keeps empty source entries of threaded animations after a progress-based timeline changes source

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp
@@ -111,20 +111,20 @@ void RemoteProgressBasedTimelineRegistry::update(const RemoteScrollingTree& scro
         ASSERT_NOT_REACHED();
     });
 
-    HashSet<WebCore::ScrollingNodeID> emptySources;
     for (auto& destroyedTimelineIdentifier : timelinesUpdate.destroyed) {
         TimelineID destroyedTimelineID { destroyedTimelineIdentifier, processIdentifier };
-        for (auto& [source, existingTimelines] : processTimelines) {
+        for (auto& existingTimelines : processTimelines.values()) {
             existingTimelines.removeIf([destroyedTimelineID](auto& existingTimeline) {
                 return existingTimeline->identifier() == destroyedTimelineID;
             });
-            if (existingTimelines.isEmpty())
-                emptySources.add(source);
         }
     }
 
-    for (auto& emptySource : emptySources)
-        processTimelines.remove(emptySource);
+    // A timeline that moves to a different source leaves its former source's set empty, so every
+    // empty source must be swept here, not only while processing destroyed timelines.
+    processTimelines.removeIf([](auto& entry) {
+        return entry.value.isEmpty();
+    });
 
     if (processTimelines.isEmpty())
         m_timelines.remove(processIdentifier);


### PR DESCRIPTION
#### 2d3a7739eeee703e402ce301ae460d440e6f1930
<pre>
RemoteProgressBasedTimelineRegistry keeps empty source entries of threaded animations after a progress-based timeline changes source
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320837">https://bugs.webkit.org/show_bug.cgi?id=320837</a>&gt;
&lt;<a href="https://rdar.apple.com/183856184">rdar://183856184</a>&gt;

Reviewed by Antoine Quint.

Every entry in `processTimelines` is expected to hold at least one
timeline, since an entry with an empty set describes a scrolling node
that no longer sources anything.  Taking a timeline out of its former
source and moving it to a new one empties that set, so the invariant
must be restored on every update.  Restoring it only while iterating
`timelinesUpdate.destroyed` fails to remove empty source entries from
`processTimelines` whenever an update does not destroy a timeline, so
they survive until some later update for that process destroys one.

Sweep empty entries unconditionally so the invariant no longer depends
on what an update happens to contain.  Erasing them in a single pass
also removes the need to collect their keys in a temporary `HashSet`.

No new tests since an empty entry is indistinguishable from an absent
one through the existing testing interfaces.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp:
(WebKit::RemoteProgressBasedTimelineRegistry::update):

Canonical link: <a href="https://commits.webkit.org/318657@main">https://commits.webkit.org/318657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c671e25bf8370dfacaa8a59a0c2747459b258968

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141524 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5338c68-60c6-4262-b517-18874ff10826) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138975 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96490 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d3184d5-bf56-42ba-bd18-93b55d0fe3a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181233 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42535 "Found 1 new test failure: http/tests/download/anchor-download-redirect-cross-origin-top-level.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119430 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/59481adf-3405-4af9-930f-7a6097026476) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41201 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39555 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39235 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190317 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51882 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148127 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52564 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147901 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27159 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42619 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124828 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119421 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51082 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14210 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50467 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50529 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->