### PR TITLE
[Moon Player: AI -Enhanced 3D] blank black screen in full screen and video paused

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -618,8 +618,11 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
             m_totalVideoFrames += numberOfSamples;
 
             if (!result) {
-                if (result.error() == kVTInvalidSessionErr) {
-                    ALWAYS_LOG(LOGIDENTIFIER, "VTDecompressionSession got invalidated, requesting flush");
+                // Invalidating a session while a sample is in flight is reported either as an
+                // invalid session or as a decoder malfunction, depending on how far that sample
+                // had got. Both mean the session is gone and a flush is what resumes decoding.
+                if (result.error() == kVTInvalidSessionErr || result.error() == kVTVideoDecoderMalfunctionErr) {
+                    ALWAYS_LOG(LOGIDENTIFIER, "VTDecompressionSession got invalidated (", result.error(), "), requesting flush");
                     invalidateDecompressionSession();
                     return;
                 }


### PR DESCRIPTION
#### c76c998e366bd3c9672d1971398cbf4b459e8399
<pre>
[Moon Player: AI -Enhanced 3D] blank black screen in full screen and video paused
<a href="https://bugs.webkit.org/show_bug.cgi?id=320850">https://bugs.webkit.org/show_bug.cgi?id=320850</a>
<a href="https://rdar.apple.com/183773748">rdar://183773748</a>

Reviewed by Abrar Rahman Protyasha.

When moon player extract the video layer from the WKWebView page, the
video very briefly goes invisible. While the transition usually works
out okay, it has been observed that the VTDecompressionSession gets invalidated.
When this happens, the decoding of the next sample typically returns error
error -12903 (kVTInvalidSessionErr) which we handled differently from other
decoding error and didn&apos;t treat it as a fatal error.
Intermittently however, the next error returned is -12911 (kVTVideoDecoderMalfunctionErr).
When this happened the error would be returned as a HTMLMediaElement decoding
error and YouTube then tears down the media player and re-create a new one.
This condition isn&apos;t handled by the Moon player and it continues to display
the old, now invalidated layer resulting in a black screen being shown.

We now handle kVTVideoDecoderMalfunctionErr the same as kVTInvalidSessionErr
and will recover from it by flushing the VideoMediaSampleRenderer and re-creating
a WebCoreDecompressionSession.

Manually tested, couldn&apos;t reproduce the issue anymore.

* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::decodeNextSampleIfNeeded):

Canonical link: <a href="https://commits.webkit.org/318498@main">https://commits.webkit.org/318498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58328ba4f8e96e1420f29f1361a013cd323c0f50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187891 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141525 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3709ab74-383d-45ec-8424-964d1fe3d180) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138978 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/162595d3-2ecd-4cc1-8f8c-dbbf91d82961) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119433 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2abedbd3-a07b-4a12-95d5-1ca91ed119b3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41204 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39556 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39243 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36348 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190318 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51883 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148128 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39819 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52565 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147902 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42620 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124829 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119422 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51083 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14218 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50468 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50708 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50530 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->