### PR TITLE
[Test Coverage] Add layout test for the :seeking pseudo-class

### DIFF
--- a/LayoutTests/media/media-css-seeking-expected.txt
+++ b/LayoutTests/media/media-css-seeking-expected.txt
@@ -1,0 +1,50 @@
+
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(canplay)
+
+* :seeking does not match before any seek is started.
+EXPECTED (video.seeking == 'false') OK
+EXPECTED (document.querySelector("video:seeking") == 'null') OK
+EXPECTED (document.querySelector("video:not(:seeking)") == '[object HTMLVideoElement]') OK
+EXPECTED (getComputedStyle(subject).backgroundColor == 'rgb(255, 0, 0)') OK
+
+* Starting a seek matches :seeking synchronously.
+RUN(video.currentTime = 0.5)
+EXPECTED (video.seeking == 'true') OK
+EXPECTED (document.querySelector("video:seeking") == '[object HTMLVideoElement]') OK
+EXPECTED (document.querySelector("video:not(:seeking)") == 'null') OK
+EXPECTED (getComputedStyle(subject).backgroundColor == 'rgb(0, 128, 0)') OK
+EVENT(seeking)
+EXPECTED (video.seeking == 'true') OK
+EXPECTED (document.querySelector("video:seeking") == '[object HTMLVideoElement]') OK
+
+* Finishing the seek stops matching :seeking.
+EVENT(seeked)
+EXPECTED (video.seeking == 'false') OK
+EXPECTED (document.querySelector("video:seeking") == 'null') OK
+EXPECTED (document.querySelector("video:not(:seeking)") == '[object HTMLVideoElement]') OK
+EXPECTED (getComputedStyle(subject).backgroundColor == 'rgb(255, 0, 0)') OK
+
+* :seeking is independent of :playing and :paused.
+RUN(video.play())
+EVENT(playing)
+EXPECTED (document.querySelector("video:playing") == '[object HTMLVideoElement]') OK
+EXPECTED (document.querySelector("video:seeking") == 'null') OK
+RUN(video.currentTime = 0.2)
+EXPECTED (document.querySelector("video:seeking") == '[object HTMLVideoElement]') OK
+EXPECTED (document.querySelector("video:playing") == '[object HTMLVideoElement]') OK
+EXPECTED (document.querySelector("video:paused") == 'null') OK
+EVENT(seeked)
+EXPECTED (document.querySelector("video:seeking") == 'null') OK
+
+* Pausing while seeking leaves :seeking matching.
+RUN(video.currentTime = 0.4)
+EXPECTED (document.querySelector("video:seeking") == '[object HTMLVideoElement]') OK
+RUN(video.pause())
+EXPECTED (document.querySelector("video:seeking") == '[object HTMLVideoElement]') OK
+EXPECTED (document.querySelector("video:paused") == '[object HTMLVideoElement]') OK
+EVENT(seeked)
+EXPECTED (document.querySelector("video:seeking") == 'null') OK
+EXPECTED (getComputedStyle(subject).backgroundColor == 'rgb(255, 0, 0)') OK
+END OF TEST
+

--- a/LayoutTests/media/media-css-seeking.html
+++ b/LayoutTests/media/media-css-seeking.html
@@ -1,0 +1,76 @@
+<!doctype HTML>
+<html>
+<head>
+    <title>Test :seeking pseudo-class</title>
+    <style>
+        #subject {
+            background-color: red;
+        }
+        #subject:has(:seeking) {
+            background-color: green;
+        }
+    </style>
+    <script src="video-test.js"></script>
+    <script src="media-file.js"></script>
+    <script>
+    window.addEventListener('load', async event => {
+        findMediaElement();
+        run('video.src = findMediaFile("video", "content/test")');
+        await waitFor(video, 'canplay');
+
+        consoleWrite('<br>* :seeking does not match before any seek is started.');
+        testExpected('video.seeking', false);
+        testExpected('document.querySelector("video:seeking")', null);
+        testExpected('document.querySelector("video:not(:seeking)")', video);
+        testExpected('getComputedStyle(subject).backgroundColor', "rgb(255, 0, 0)");
+
+        consoleWrite('<br>* Starting a seek matches :seeking synchronously.');
+        run('video.currentTime = 0.5');
+        testExpected('video.seeking', true);
+        testExpected('document.querySelector("video:seeking")', video);
+        testExpected('document.querySelector("video:not(:seeking)")', null);
+        testExpected('getComputedStyle(subject).backgroundColor', "rgb(0, 128, 0)");
+
+        await waitFor(video, 'seeking');
+        testExpected('video.seeking', true);
+        testExpected('document.querySelector("video:seeking")', video);
+
+        consoleWrite('<br>* Finishing the seek stops matching :seeking.');
+        await waitFor(video, 'seeked');
+        testExpected('video.seeking', false);
+        testExpected('document.querySelector("video:seeking")', null);
+        testExpected('document.querySelector("video:not(:seeking)")', video);
+        testExpected('getComputedStyle(subject).backgroundColor', "rgb(255, 0, 0)");
+
+        consoleWrite('<br>* :seeking is independent of :playing and :paused.');
+        run('video.play()');
+        await waitFor(video, 'playing');
+        testExpected('document.querySelector("video:playing")', video);
+        testExpected('document.querySelector("video:seeking")', null);
+        run('video.currentTime = 0.2');
+        testExpected('document.querySelector("video:seeking")', video);
+        testExpected('document.querySelector("video:playing")', video);
+        testExpected('document.querySelector("video:paused")', null);
+        await waitFor(video, 'seeked');
+        testExpected('document.querySelector("video:seeking")', null);
+
+        consoleWrite('<br>* Pausing while seeking leaves :seeking matching.');
+        run('video.currentTime = 0.4');
+        testExpected('document.querySelector("video:seeking")', video);
+        run('video.pause()');
+        testExpected('document.querySelector("video:seeking")', video);
+        testExpected('document.querySelector("video:paused")', video);
+        await waitFor(video, 'seeked');
+        testExpected('document.querySelector("video:seeking")', null);
+        testExpected('getComputedStyle(subject).backgroundColor', "rgb(255, 0, 0)");
+
+        endTest();
+    });
+    </script>
+<head>
+<body>
+    <div id="subject">
+        <video></video>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
#### a83544ed6a93dffc922cadbdeddd1330c3fa9124
<pre>
[Test Coverage] Add layout test for the :seeking pseudo-class
<a href="https://bugs.webkit.org/show_bug.cgi?id=320851">https://bugs.webkit.org/show_bug.cgi?id=320851</a>
<a href="https://rdar.apple.com/183885278">rdar://183885278</a>

Reviewed by NOBODY (OOPS!).

:seeking has been supported since it was added to CSSPseudoSelectors.json, but
unlike :muted, :playing/:paused, and :volume-locked it has no layout test. Add
media/media-css-seeking.html, modeled on media-css-volume-locked.html, so the
pseudo-class and its style invalidation are both covered.

The test loads content/test.mp4 and asserts that :seeking:

- does not match before any seek is started,
- matches synchronously on setting video.currentTime, since
  HTMLMediaElement::seekWithTolerance() calls setSeeking() -- and therefore
  runs the PseudoClass::Seeking invalidation -- before queueing seekTask() on
  TaskSource::MediaElement,
- still matches when the &apos;seeking&apos; event fires, and stops matching at &apos;seeked&apos;,
- is independent of :playing and :paused, including when pause() lands while a
  seek is still in flight.

A #subject:has(:seeking) rule is checked with getComputedStyle() alongside the
querySelector() assertions so that the invalidation path is exercised rather
than just selector matching.

* LayoutTests/media/media-css-seeking-expected.txt: Added.
* LayoutTests/media/media-css-seeking.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a83544ed6a93dffc922cadbdeddd1330c3fa9124

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187892 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141526 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d824c5c9-6f46-4426-88bf-69dec1ac3400) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138979 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96492 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c66d73cc-42e5-498c-8a23-6613e837235d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119434 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc7f064c-3976-4f3b-8583-ea9d066cda6e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41202 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39557 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39241 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36349 "Built successfully") | | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43800 "338 new passes 18 flakes 16 failures") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190319 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148129 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52566 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35866 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147903 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42618 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119426 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51084 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14216 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50469 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50709 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->