### PR TITLE
[Wasm] `JSWebAssemblyInstance::updateCachedMemories()` crashes on a partially-linked instance

### DIFF
--- a/JSTests/wasm/stress/multimemory-grow-during-partial-link.js
+++ b/JSTests/wasm/stress/multimemory-grow-during-partial-link.js
@@ -1,0 +1,36 @@
+//@ requireOptions("--useWasmMultiMemory=1")
+
+import * as assert from "../assert.js";
+import { compile } from "../wabt-wrapper.js";
+
+// A grow reaching an instance whose memory imports were not all resolved (LinkError midway,
+// or a re-entrant grow from an import getter) must not touch the still-empty memory slots.
+
+const wat = `
+(module
+  (import "env" "m0" (memory $m0 1 8))
+  (import "env" "m1" (memory $m1 1 8))
+  (func (export "size0") (result i32) (memory.size $m0))
+  (func (export "load0") (param $a i32) (result i32) (i32.load $m0 (local.get $a)))
+  (func (export "load1") (param $a i32) (result i32) (i32.load $m1 (local.get $a))))`;
+const module = await compile(wat, { multi_memory: true });
+
+// 1. The second memory import fails, so linking throws after the first memory was set.
+{
+    const mem0 = new WebAssembly.Memory({ initial: 1, maximum: 8 });
+    assert.throws(() => new WebAssembly.Instance(module, { env: { m0: mem0, m1: 42 } }), WebAssembly.LinkError, "Memory import env:m1 is not an instance of WebAssembly.Memory");
+    assert.eq(mem0.grow(0), 1);
+    assert.eq(mem0.grow(1), 1);
+    assert.eq(mem0.buffer.byteLength, 2 * 65536);
+}
+
+// 2. The getter of the second memory import grows the already-linked first memory.
+{
+    const mem0 = new WebAssembly.Memory({ initial: 1, maximum: 8 });
+    const mem1 = new WebAssembly.Memory({ initial: 1, maximum: 8 });
+    const importObject = { env: { m0: mem0, get m1() { assert.eq(mem0.grow(1), 1); return mem1; } } };
+    const instance = new WebAssembly.Instance(module, importObject);
+    assert.eq(instance.exports.size0(), 2);
+    assert.eq(instance.exports.load0(65536), 0);
+    assert.eq(instance.exports.load1(0), 0);
+}

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -214,6 +214,8 @@ public:
 
             // reload all of the cached base and size pointers
             for (unsigned i = 0; i < m_moduleInformation->memoryCount(); i++) {
+                if (!m_memories[i])
+                    continue;
                 cachedMemoryBaseSizePairs()[i] = {
                     m_memories[i]->basePointer(),
 #if CPU(ARM)


### PR DESCRIPTION
#### bfe5073f4c99579f6c21a68c606bea5cff94f072
<pre>
[Wasm] `JSWebAssemblyInstance::updateCachedMemories()` crashes on a partially-linked instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=320857">https://bugs.webkit.org/show_bug.cgi?id=320857</a>

Reviewed by Yusuke Suzuki.

setMemory() registers the instance as an anchor of each memory as soon as that memory
slot is filled, while updateCachedMemories() walks every memory slot. Since imports are
linked one by one, a grow can reach an instance whose remaining imported memories are not
set yet -- from a later import&apos;s getter, or after a LinkError left the half-linked instance
anchored -- and dereferences the null slots:

    const mem0 = new WebAssembly.Memory({ initial: 1, maximum: 8 });
    // module imports memories env:m0 and env:m1
    try { new WebAssembly.Instance(module, { env: { m0: mem0, m1: 42 } }); } catch { }
    mem0.grow(0); // crash

Skip memory slots that are not set yet in updateCachedMemories() so that it can be called
in the middle of instance construction.

* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:

Canonical link: <a href="https://commits.webkit.org/318505@main">https://commits.webkit.org/318505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ca3a3365b719f6bedd21e6e460af4bfb9af8300

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141634 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139065 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159827 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119520 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41294 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39646 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1489 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8315 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151694 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39326 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36457 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39659 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190429 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51993 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148222 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39822 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52674 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147996 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42710 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124939 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119558 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51192 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14301 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50817 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->