### PR TITLE
[WPT] Fix "A lone surrogate is replaced with U+FFFD" subtest in domparsing/DOMParser-parseFromString-xml-parsererror.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-parsererror-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-parsererror-expected.txt
@@ -20,4 +20,6 @@ PASS text/xml is preserved in the error document
 PASS application/xml is preserved in the error document
 PASS application/xhtml+xml is preserved in the error document
 PASS image/svg+xml is preserved in the error document
+PASS A lone surrogate is replaced with U+FFFD
+PASS A valid surrogate pair is preserved
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-parsererror.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-parsererror.html
@@ -47,4 +47,22 @@ const xhtml_prologue = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     assert_equals(doc.contentType, mimeType);
   }, `${mimeType} is preserved in the error document`);
 })
+
+// This test is based on https://crbug.com/40814739:
+// DOMParser replaces lone surrogates in XML with U+FFFD.
+const parse = text => new DOMParser().parseFromString(
+    "<rss><title><![CDATA[" + text + "]]></title></rss>", "text/xml");
+
+test(() => {
+  const doc = parse("broken " + String.fromCharCode(0xD83C));
+  assert_equals(doc.documentElement.localName, "rss");
+  assert_equals(doc.querySelector("title").textContent, "broken \uFFFD");
+}, "A lone surrogate is replaced with U+FFFD");
+
+test(() => {
+  const fire = String.fromCharCode(0xD83D, 0xDD25);
+  const doc = parse("works " + fire);
+  assert_equals(doc.documentElement.localName, "rss");
+  assert_equals(doc.querySelector("title").textContent, "works " + fire);
+}, "A valid surrogate pair is preserved");
 </script>

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -128,7 +128,7 @@ void XMLDocumentParser::append(RefPtr<StringImpl>&& inputSource)
         return;
     }
 
-    doWrite(source);
+    doWrite(WTF::move(source));
 }
 
 void XMLDocumentParser::handleError(XMLErrors::Type type, const char* m, TextPosition position)

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -157,7 +157,7 @@ private:
     void createLeafTextNode();
     bool updateLeafTextNode();
 
-    void doWrite(const String&);
+    void doWrite(String&&);
     void doEnd();
 
     xmlParserCtxtPtr context() const { return m_context ? m_context->context() : nullptr; };

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -80,6 +80,7 @@
 #include <wtf/MallocSpan.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/AtomString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/unicode/CharacterNames.h>
 #include <wtf/unicode/UTF8Conversion.h>
@@ -700,7 +701,7 @@ XMLDocumentParser::~XMLDocumentParser()
     m_scriptWaitingForStylesheets = nullptr;
 }
 
-void XMLDocumentParser::doWrite(const String& parseString)
+void XMLDocumentParser::doWrite(String&& parseString)
 {
     ASSERT(!isDetached());
     if (!m_context)
@@ -709,8 +710,13 @@ void XMLDocumentParser::doWrite(const String& parseString)
     // Protect the libxml context from deletion during a callback
     RefPtr<XMLParserContext> context = m_context;
 
+    // Lone surrogates are not valid XML characters, so libxml2 would reject the
+    // whole document. Replace them with U+FFFD to do a best-effort parse instead
+    // (matching Firefox and Blink). See https://crbug.com/40814739.
+    String sanitizedString = replaceUnpairedSurrogatesWithReplacementCharacter(WTF::move(parseString));
+
     // libXML throws an error if you try to switch the encoding for an empty string.
-    if (parseString.length()) {
+    if (sanitizedString.length()) {
         // JavaScript may cause the parser to detach during xmlParseChunk
         // keep this alive until this function is done.
         Ref<XMLDocumentParser> protectedThis(*this);
@@ -719,7 +725,7 @@ void XMLDocumentParser::doWrite(const String& parseString)
 
         // FIXME: Can we parse 8-bit strings directly as Latin-1 instead of upconverting to UTF-16?
         switchToUTF16(context->context());
-        xmlParseChunk(context->context(), reinterpret_cast<const char*>(StringView(parseString).upconvertedCharacters().get()), sizeof(char16_t) * parseString.length(), 0);
+        xmlParseChunk(context->context(), reinterpret_cast<const char*>(StringView(sanitizedString).upconvertedCharacters().get()), sizeof(char16_t) * sanitizedString.length(), 0);
 
         // JavaScript (which may be run under the xmlParseChunk callstack) may
         // cause the parser to be stopped or detached.


### PR DESCRIPTION
#### ae8ba81610e4bf30c98fc9e376e50a0334d5fc1a
<pre>
[WPT] Fix &quot;A lone surrogate is replaced with U+FFFD&quot; subtest in domparsing/DOMParser-parseFromString-xml-parsererror.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=320858">https://bugs.webkit.org/show_bug.cgi?id=320858</a>

Reviewed by Darin Adler.

When DOMParser.parseFromString() was given XML containing a lone (unpaired)
surrogate, XMLDocumentParser::doWrite() upconverted the string to UTF-16 and
passed it directly to libxml2. Lone surrogates are not valid XML characters,
so libxml2 rejected the entire document, leaving documentElement null instead
of producing any parse result.

Replace unpaired surrogates with U+FFFD before handing the input to libxml2,
so the parser does a best-effort parse instead of discarding everything. This
matches Firefox and Blink (<a href="https://crbug.com/40814739).">https://crbug.com/40814739).</a> The fragment path
(appendFragmentSource) was already unaffected because String::utf8() defaults
to LenientConversion, which maps unpaired surrogates to U+FFFD.

Change doWrite() to take its input as an rvalue reference and pass it to the
existing replaceUnpairedSurrogatesWithReplacementCharacter(String&amp;&amp;), whose fast
path simply moves the string along when there is no unpaired surrogate. That way
the common case allocates no buffer, copies no characters and does not even bump
a refcount (hasUnpairedSurrogate() is O(1) for 8-bit strings).

No new tests, updated and rebaselined existing test.

* LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-parsererror-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-xml-parsererror.html:
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::XMLDocumentParser::append):
* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::doWrite):

Canonical link: <a href="https://commits.webkit.org/318609@main">https://commits.webkit.org/318609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20f48b533345a4780ac1ecdae2cd0c8ca15d9b9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52735 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46530 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188413 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139410 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ad318143-130f-405a-8d09-e32b54c20213) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42985 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119864 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35a4c9c7-3de9-4a15-9c4b-f75293f02160) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1834 "Build is in progress. Recent messages:") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45336 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190841 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52405 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/159680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39888 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53085 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148362 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43056 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125352 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120013 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51603 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/14636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50988 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51228 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->