### PR TITLE
[WebDriver] Gardening user-prompt failures

### DIFF
--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -478,8 +478,34 @@
         }
     },
 
+    "imported/w3c/webdriver/tests/classic/add_cookie/user_prompts.py": {
+        "subtests": {
+            "test_accept[alert-None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            },
+            "test_accept[confirm-True]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            },
+            "test_accept[prompt-]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            },
+            "test_dismiss[alert-None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            },
+            "test_dismiss[confirm-False]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            },
+            "test_dismiss[prompt-None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            }
+        }
+    },
+
     "imported/w3c/webdriver/tests/classic/add_cookie/add.py": {
         "subtests": {
+            "test_add_cookie_with_expiry_in_the_future": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            },
             "test_add_cookie_for_ip": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
             },
@@ -1623,6 +1649,21 @@
 
     "imported/w3c/webdriver/tests/classic/close_window/user_prompts.py": {
         "subtests": {
+            "test_accept[beforeunload]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
+            },
+            "test_accept_and_notify[beforeunload-None]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
+            },
+            "test_default[beforeunload-None]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
+            },
+            "test_dismiss[beforeunload]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
+            },
+            "test_ignore[beforeunload]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
+            },
             "test_handle_prompt_accept": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
             }
@@ -2432,13 +2473,33 @@
         "subtests": {
             "notes": "",
             "test_fullscreen_from_normal_window": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"}}
+                "expected": {
+                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             },
             "test_fullscreen_from_maximized_window": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"}}
+                "expected": {
+                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             },
+            "test_fullscreen_twice_is_idempotent": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+            },
+            "test_response_payload": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/fullscreen_window/from_minimized_window.py": {
+        "subtests": {
             "test_fullscreen_from_minimized_window": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/277945"}}
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"},
+                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/277945"}
+                }
             }
         }
     },
@@ -2446,23 +2507,23 @@
     "imported/w3c/webdriver/tests/classic/fullscreen_window/user_prompts.py": {
         "subtests": {
             "notes": "Some WPE tests are skipped as they trigger failure or timeout regardless of the expectation if they are run. Also, some tests expect the browser to start in non fullscreen mode, which isn't happening in the headless backend.",
-            "test_accept[capabilities0-alert-None]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+            "test_accept[alert-None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
-            "test_accept[capabilities0-confirm-True]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+            "test_accept[confirm-True]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
-            "test_accept[capabilities0-prompt-]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+            "test_accept[prompt-]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
-            "test_dismiss[capabilities0-alert-None]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+            "test_dismiss[alert-None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
-            "test_dismiss[capabilities0-confirm-False]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+            "test_dismiss[confirm-False]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
-            "test_dismiss[capabilities0-prompt-None]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+            "test_dismiss[prompt-None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             }
         }
     },
@@ -2470,19 +2531,34 @@
         "subtests": {
             "notes": "Some WPE tests are skipped as they trigger failure or timeout regardless of the expectation if they are run. Also, some tests expect the browser to start in non fullscreen mode, which isn't happening in the headless backend.",
             "test_stress[0]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+                "expected": {
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             },
             "test_stress[1]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+                "expected": {
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             },
             "test_stress[2]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+                "expected": {
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             },
             "test_stress[3]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+                "expected": {
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             },
             "test_stress[4]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+                "expected": {
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             }
         }
     },


### PR DESCRIPTION
#### 4f2ba3b3a281a985ebe89719094ef30c05d8b855
<pre>
[WebDriver] Gardening user-prompt failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=320859">https://bugs.webkit.org/show_bug.cgi?id=320859</a>

Unreviewed test gardening.

* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/318426@main">https://commits.webkit.org/318426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d25ab7fae0cede3e649063c13ce07f951ea83969

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52228 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/187904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181247 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/36361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/51937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/190331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/190331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/52578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/190331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27038 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/52578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->