### PR TITLE
[JSC] Make the first corrective subtract in JSBigInt Crandall reduction branch-free

### DIFF
--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -2155,6 +2155,31 @@ JSBigInt::Digit JSBigInt::cachedModFoldFactor(std::span<const Digit> b)
     return rSpan[0];
 }
 
+// Subtract b from the value high * 2^(n * digitBits) + r once, if that value is at least b, and
+// return the new high digit. The difference is always formed and then selected in or discarded, so
+// no branch depends on the comparison; the borrow out of the low n digits answers it, since a borrow
+// is covered exactly when high is non-zero.
+template<typename RSpan, typename BSpan>
+ALWAYS_INLINE JSBigInt::Digit JSBigInt::reduceOnce(RSpan r, BSpan b, Digit high)
+{
+    constexpr size_t capacity = BSpan::extent == std::dynamic_extent ? maxCachedModDivisorSize : BSpan::extent;
+    size_t n = b.size();
+    ASSERT(n <= capacity && r.size() >= n);
+
+    std::array<Digit, capacity> difference;
+    Digit borrow = 0;
+    for (size_t i = 0; i < n; ++i) {
+        Digit borrowOut = 0;
+        difference[i] = digitSub2(r[i], b[i], borrow, borrowOut);
+        borrow = borrowOut;
+    }
+
+    bool subtract = high || !borrow;
+    for (size_t i = 0; i < n; ++i)
+        r[i] = subtract ? difference[i] : r[i];
+    return subtract ? high - borrow : high;
+}
+
 // This is Crandall reduction implementation. When factor is not appropriate for efficiency, we use
 // Barrett reduction instead.
 //
@@ -2215,6 +2240,16 @@ ALWAYS_INLINE void JSBigInt::cachedModFoldImpl(RSpan r, ASpan a, BSpan b, Digit 
         carry = propagate;
     }
 
+    // Peel the first corrective subtraction off as a branch-free one. With q at least two the loop
+    // below runs zero or one time in a near-even split, so its branch mispredicts about half the
+    // time; with q one no subtraction is ever needed, the branch always predicts, and the select
+    // would be pure overhead. q is one exactly when b is more than half of 2^(n * digitBits), that
+    // is when b's top bit is set. Static extents only: the select unrolls and costs a fixed amount
+    // there, whereas for a large dynamic n it costs more than the branch it replaces.
+    if constexpr (BSpan::extent != std::dynamic_extent) {
+        if (!(b.back() >> (digitBits - 1)))
+            carry = reduceOnce(r, b, carry);
+    }
     while (carry || greaterThanOrEqual(r, b))
         carry -= inplaceSub(r, b);
 }

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -617,6 +617,8 @@ private:
     template<size_t N, size_t ASize>
     static void cachedModFoldFixed(std::span<Digit, N> r, std::span<const Digit, ASize>, std::span<const Digit, N> b, Digit c);
     static void cachedModFold(std::span<Digit> r, std::span<const Digit>, std::span<const Digit> b, Digit c);
+    template<typename RSpan, typename BSpan>
+    static Digit reduceOnce(RSpan r, BSpan b, Digit high);
     static bool NODELETE greaterThanOrEqual(std::span<const Digit>, std::span<const Digit>);
 
     static std::span<Digit> rightShift(std::span<Digit> z, std::span<const Digit> x, unsigned);


### PR DESCRIPTION
#### 0270fd0a8d77d6e96aa6bfed787cc0ce199e4287
<pre>
[JSC] Make the first corrective subtract in JSBigInt Crandall reduction branch-free
<a href="https://bugs.webkit.org/show_bug.cgi?id=320860">https://bugs.webkit.org/show_bug.cgi?id=320860</a>
<a href="https://rdar.apple.com/183888656">rdar://183888656</a>

Reviewed by Yijia Huang.

Crandall reduction does correction loop at the end. Typically it runs
factor q times. But it turned out that this is really costly, and branch miss
of taking this loop or not becomes huge cost so far.

This patch adds reduceOnce. This *attempts* to perform r - b without
asking actually necessary. And the subtract result says whether we
needed to do it at all: if r is smaller than b, then we didn&apos;t need to
do it. So basically it is doing greaterThanOrEqual and inplaceSub at the
same time like what CPU&apos;s cmp operation does (in fact it is sub). And
based on this subtract result, we select

    r[i] = subtract ? difference[i] : r[i];

without a branch (csel will be used).

So ultimately whether this peeling loop is effective relies on how many
times we need to run the correction loop. This is bound by q, and when q
= 1, then we do not need this loop at all. This is when the divisor exceeds
half of 2^(n * digitBits), which can be checked with `b.back() &gt;&gt; (digitBits - 1)`.
So otherwise, running this is worth doing.

* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::reduceOnce):
(JSC::JSBigInt::cachedModFoldImpl):
* Source/JavaScriptCore/runtime/JSBigInt.h:

Canonical link: <a href="https://commits.webkit.org/318506@main">https://commits.webkit.org/318506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/877890157b9c5bdbfec8c31f22d0f6e516e79859

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178293 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141541 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0d0a711-f768-4fe8-9789-125cc27ae544) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138991 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/778bd4aa-5c71-4e84-8855-09ab20d86b3a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119446 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7c3ea58-fdb5-4678-948c-1c85ba926f19) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41216 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39570 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1415 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8247 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39256 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36364 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39566 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190335 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51899 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148142 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52581 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147917 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27079 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42632 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124845 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119445 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51099 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14231 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50484 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50724 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50546 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->