### PR TITLE
[JSC] Remove various scratch registers as branchIfNumber etc. no longer need to take a scratch for 64bit

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -4035,8 +4035,12 @@ void SpeculativeJIT::emitUntypedOrAnyBigIntBitOp(Node* node)
 
     GPRTemporary result(this);
     JSValueRegs resultRegs = JSValueRegs(result.gpr());
-    GPRTemporary scratch(this);
-    GPRReg scratchGPR = scratch.gpr();
+    std::optional<GPRTemporary> scratch;
+    GPRReg scratchGPR = InvalidGPRReg;
+    if constexpr (SnippetGenerator::needsScratchGPR) {
+        scratch.emplace(this);
+        scratchGPR = scratch->gpr();
+    }
 
     SnippetOperand leftOperand;
     SnippetOperand rightOperand;
@@ -4061,7 +4065,12 @@ void SpeculativeJIT::emitUntypedOrAnyBigIntBitOp(Node* node)
         rightRegs = right->jsValueRegs();
     }
 
-    SnippetGenerator gen(leftOperand, rightOperand, resultRegs, leftRegs, rightRegs, scratchGPR);
+    SnippetGenerator gen = [&] {
+        if constexpr (SnippetGenerator::needsScratchGPR)
+            return SnippetGenerator(leftOperand, rightOperand, resultRegs, leftRegs, rightRegs, scratchGPR);
+        else
+            return SnippetGenerator(leftOperand, rightOperand, resultRegs, leftRegs, rightRegs);
+    }();
     gen.generateFastPath(*this);
 
     ASSERT(gen.didEmitFastPath());
@@ -7304,15 +7313,13 @@ void SpeculativeJIT::compileNotDoubleNeitherDoubleNorHeapBigIntNorStringStrictEq
     JSValueOperand left(this, notDoubleChild, ManualOperandSpeculation);
     JSValueOperand right(this, neitherDoubleNorHeapBigIntNorStringChild, ManualOperandSpeculation);
 
-    GPRTemporary temp(this);
     GPRTemporary result(this, Reuse, left, right);
     JSValueRegs leftRegs = left.jsValueRegs();
     JSValueRegs rightRegs = right.jsValueRegs();
-    GPRReg tempGPR = temp.gpr();
     GPRReg resultGPR = result.gpr();
 
-    speculateNotDouble(notDoubleChild, leftRegs, tempGPR);
-    speculateNeitherDoubleNorHeapBigIntNorString(neitherDoubleNorHeapBigIntNorStringChild, rightRegs, tempGPR);
+    speculateNotDouble(notDoubleChild, leftRegs);
+    speculateNeitherDoubleNorHeapBigIntNorString(neitherDoubleNorHeapBigIntNorStringChild, rightRegs);
 
     emitBitwiseJSValueEquality(leftRegs, rightRegs, resultGPR);
     unblessedBooleanResult(resultGPR, node);
@@ -7323,13 +7330,11 @@ void SpeculativeJIT::compilePeepHoleNotDoubleNeitherDoubleNorHeapBigIntNorString
     JSValueOperand left(this, notDoubleChild, ManualOperandSpeculation);
     JSValueOperand right(this, neitherDoubleNorHeapBigIntNorStringChild, ManualOperandSpeculation);
 
-    GPRTemporary temp(this);
     JSValueRegs leftRegs = left.jsValueRegs();
     JSValueRegs rightRegs = right.jsValueRegs();
-    GPRReg tempGPR = temp.gpr();
 
-    speculateNotDouble(notDoubleChild, leftRegs, tempGPR);
-    speculateNeitherDoubleNorHeapBigIntNorString(neitherDoubleNorHeapBigIntNorStringChild, rightRegs, tempGPR);
+    speculateNotDouble(notDoubleChild, leftRegs);
+    speculateNeitherDoubleNorHeapBigIntNorString(neitherDoubleNorHeapBigIntNorStringChild, rightRegs);
 
     BasicBlock* taken = branchNode->branchData()->taken.block;
     BasicBlock* notTaken = branchNode->branchData()->notTaken.block;
@@ -12325,7 +12330,7 @@ void SpeculativeJIT::speculateNotCellNorBigInt(Edge edge)
 #endif
 }
 
-void SpeculativeJIT::speculateNotDouble(Edge edge, JSValueRegs regs, GPRReg tempGPR)
+void SpeculativeJIT::speculateNotDouble(Edge edge, JSValueRegs regs)
 {
     if (!needsTypeCheck(edge, ~SpecFullDouble))
         return;
@@ -12336,7 +12341,7 @@ void SpeculativeJIT::speculateNotDouble(Edge edge, JSValueRegs regs, GPRReg temp
     if (mayBeInt32)
         done = branchIfInt32(regs);
 
-    DFG_TYPE_CHECK(regs, edge, ~SpecFullDouble, branchIfNumber(regs, tempGPR));
+    DFG_TYPE_CHECK(regs, edge, ~SpecFullDouble, branchIfNumber(regs));
 
     if (mayBeInt32)
         done.link(this);
@@ -12348,14 +12353,10 @@ void SpeculativeJIT::speculateNotDouble(Edge edge)
         return;
     
     JSValueOperand operand(this, edge, ManualOperandSpeculation);
-    GPRTemporary temp(this);
-    JSValueRegs regs = operand.jsValueRegs();
-    GPRReg tempGPR = temp.gpr();
-    
-    speculateNotDouble(edge, regs, tempGPR);
+    speculateNotDouble(edge, operand.jsValueRegs());
 }
 
-void SpeculativeJIT::speculateNeitherDoubleNorHeapBigInt(Edge edge, JSValueRegs regs, GPRReg tempGPR)
+void SpeculativeJIT::speculateNeitherDoubleNorHeapBigInt(Edge edge, JSValueRegs regs)
 {
     if (!needsTypeCheck(edge, ~(SpecFullDouble | SpecHeapBigInt)))
         return;
@@ -12366,7 +12367,7 @@ void SpeculativeJIT::speculateNeitherDoubleNorHeapBigInt(Edge edge, JSValueRegs 
     if (mayBeInt32)
         done.append(branchIfInt32(regs));
 
-    DFG_TYPE_CHECK(regs, edge, ~SpecFullDouble, branchIfNumber(regs, tempGPR));
+    DFG_TYPE_CHECK(regs, edge, ~SpecFullDouble, branchIfNumber(regs));
 
     bool mayBeNotCell = needsTypeCheck(edge, SpecCell);
     if (mayBeNotCell)
@@ -12384,14 +12385,10 @@ void SpeculativeJIT::speculateNeitherDoubleNorHeapBigInt(Edge edge)
         return;
 
     JSValueOperand operand(this, edge, ManualOperandSpeculation);
-    GPRTemporary temp(this);
-    JSValueRegs regs = operand.jsValueRegs();
-    GPRReg tempGPR = temp.gpr();
-
-    speculateNeitherDoubleNorHeapBigInt(edge, regs, tempGPR);
+    speculateNeitherDoubleNorHeapBigInt(edge, operand.jsValueRegs());
 }
 
-void SpeculativeJIT::speculateNeitherDoubleNorHeapBigIntNorString(Edge edge, JSValueRegs regs, GPRReg tempGPR)
+void SpeculativeJIT::speculateNeitherDoubleNorHeapBigIntNorString(Edge edge, JSValueRegs regs)
 {
     if (!needsTypeCheck(edge, ~(SpecFullDouble | SpecString | SpecHeapBigInt)))
         return;
@@ -12402,7 +12399,7 @@ void SpeculativeJIT::speculateNeitherDoubleNorHeapBigIntNorString(Edge edge, JSV
     if (mayBeInt32)
         done.append(branchIfInt32(regs));
 
-    DFG_TYPE_CHECK(regs, edge, ~SpecFullDouble, branchIfNumber(regs, tempGPR));
+    DFG_TYPE_CHECK(regs, edge, ~SpecFullDouble, branchIfNumber(regs));
 
     bool mayBeNotCell = needsTypeCheck(edge, SpecCell);
     if (mayBeNotCell)
@@ -12421,11 +12418,7 @@ void SpeculativeJIT::speculateNeitherDoubleNorHeapBigIntNorString(Edge edge)
         return;
 
     JSValueOperand operand(this, edge, ManualOperandSpeculation);
-    GPRTemporary temp(this);
-    JSValueRegs regs = operand.jsValueRegs();
-    GPRReg tempGPR = temp.gpr();
-
-    speculateNeitherDoubleNorHeapBigIntNorString(edge, regs, tempGPR);
+    speculateNeitherDoubleNorHeapBigIntNorString(edge, operand.jsValueRegs());
 }
 
 void SpeculativeJIT::speculateOther(Edge edge, JSValueRegs regs, GPRReg tempGPR)
@@ -12694,7 +12687,7 @@ void SpeculativeJIT::emitSwitchImm(Node* node, SwitchData* data)
 
         notInt32.link(this);
         JumpList failureCases;
-        failureCases.append(branchIfNotNumber(valueRegs, scratchGPR1));
+        failureCases.append(branchIfNotNumber(valueRegs));
         unboxDoubleWithoutAssertions(valueRegs.payloadGPR(), scratchGPR1, scratchFPR3);
         branchConvertDoubleToInt32(scratchFPR3, scratchGPR1, failureCases, scratchFPR4, /* negZeroCheck */ false);
         addBranch(failureCases, data->fallThrough.block);
@@ -14369,7 +14362,7 @@ void SpeculativeJIT::compileNormalizeMapKey(Node* node)
     auto slowPath = jump();
     isNotCell.link(this);
 
-    passThroughCases.append(branchIfNotNumber(keyRegs, scratchGPR));
+    passThroughCases.append(branchIfNotNumber(keyRegs));
     passThroughCases.append(branchIfInt32(keyRegs));
 
     unboxDoubleWithoutAssertions(keyRegs.gpr(), scratchGPR, doubleValueFPR);
@@ -16026,18 +16019,16 @@ void SpeculativeJIT::compileToPropertyKeyOrNumber(Node* node)
     DFG_ASSERT(m_graph, node, node->child1().useKind() == UntypedUse, node->child1().useKind());
     JSValueOperand argument(this, node->child1());
     JSValueRegsTemporary result(this, Reuse, argument);
-    GPRTemporary temp(this);
 
     JSValueRegs argumentRegs = argument.jsValueRegs();
     JSValueRegs resultRegs = result.regs();
-    GPRReg tempGPR = temp.gpr();
 
     argument.use();
 
     JumpList alreadyPropertyKey;
     JumpList slowCases;
 
-    alreadyPropertyKey.append(branchIfNumber(argumentRegs, tempGPR));
+    alreadyPropertyKey.append(branchIfNumber(argumentRegs));
     slowCases.append(branchIfNotCell(argumentRegs));
     alreadyPropertyKey.append(branchIfSymbol(argumentRegs.payloadGPR()));
     slowCases.append(branchIfNotString(argumentRegs.payloadGPR()));
@@ -16055,11 +16046,9 @@ void SpeculativeJIT::compileToNumeric(Node* node)
     DFG_ASSERT(m_graph, node, node->child1().useKind() == UntypedUse, node->child1().useKind());
     JSValueOperand argument(this, node->child1());
     JSValueRegsTemporary result(this);
-    GPRTemporary temp(this);
 
     JSValueRegs argumentRegs = argument.jsValueRegs();
     JSValueRegs resultRegs = result.regs();
-    GPRReg scratch = temp.gpr();
     // FIXME: add a fast path for BigInt32 here.
     // https://bugs.webkit.org/show_bug.cgi?id=211064
 
@@ -16070,7 +16059,7 @@ void SpeculativeJIT::compileToNumeric(Node* node)
     Jump isHeapBigInt = jump();
 
     notCell.link(this);
-    slowCases.append(branchIfNotNumber(argumentRegs, scratch));
+    slowCases.append(branchIfNotNumber(argumentRegs));
 
     isHeapBigInt.link(this);
     moveValueRegs(argumentRegs, resultRegs);
@@ -16099,16 +16088,14 @@ void SpeculativeJIT::compileCallNumberConstructor(Node* node)
     DFG_ASSERT(m_graph, node, node->child1().useKind() == UntypedUse, node->child1().useKind());
     JSValueOperand argument(this, node->child1());
     JSValueRegsTemporary result(this);
-    GPRTemporary temp(this);
 
     JSValueRegs argumentRegs = argument.jsValueRegs();
     JSValueRegs resultRegs = result.regs();
-    GPRReg tempGPR = temp.gpr();
     // FIXME: add a fast path for BigInt32 here.
     // https://bugs.webkit.org/show_bug.cgi?id=211064
 
     JumpList slowCases;
-    slowCases.append(branchIfNotNumber(argumentRegs, tempGPR));
+    slowCases.append(branchIfNotNumber(argumentRegs));
     moveValueRegs(argumentRegs, resultRegs);
     addSlowPathGenerator(slowPathCall(slowCases, this, operationCallNumberConstructor, resultRegs, LinkableConstant::globalObject(*this, node), argumentRegs));
 
@@ -16868,7 +16855,7 @@ void SpeculativeJIT::compileProfileType(Node* node)
     else if (cachedTypeLocation->m_lastSeenType == TypeAnyInt)
         jumpToEnd.append(branchIfInt32(valueRegs));
     else if (cachedTypeLocation->m_lastSeenType == TypeNumber)
-        jumpToEnd.append(branchIfNumber(valueRegs, scratch1GPR));
+        jumpToEnd.append(branchIfNumber(valueRegs));
     else if (cachedTypeLocation->m_lastSeenType == TypeString) {
         Jump isNotCell = branchIfNotCell(valueRegs);
         jumpToEnd.append(branchIfString(valueRegs.payloadGPR()));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1896,11 +1896,11 @@ public:
     void speculateNotCell(Edge, JSValueRegs);
     void speculateNotCell(Edge);
     void speculateNotCellNorBigInt(Edge);
-    void speculateNotDouble(Edge, JSValueRegs, GPRReg temp);
+    void speculateNotDouble(Edge, JSValueRegs);
     void speculateNotDouble(Edge);
-    void speculateNeitherDoubleNorHeapBigInt(Edge, JSValueRegs, GPRReg temp);
+    void speculateNeitherDoubleNorHeapBigInt(Edge, JSValueRegs);
     void speculateNeitherDoubleNorHeapBigInt(Edge);
-    void speculateNeitherDoubleNorHeapBigIntNorString(Edge, JSValueRegs, GPRReg temp);
+    void speculateNeitherDoubleNorHeapBigIntNorString(Edge, JSValueRegs);
     void speculateNeitherDoubleNorHeapBigIntNorString(Edge);
     void speculateOther(Edge, JSValueRegs, GPRReg temp);
     void speculateOther(Edge, JSValueRegs);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -393,7 +393,7 @@ void SpeculativeJIT::compileNeitherDoubleNorHeapBigIntToNotDoubleStrictEquality(
     if (needsTypeCheck(leftNeitherDoubleNorHeapBigIntChild, ~SpecFullDouble)) {
         if (needsTypeCheck(leftNeitherDoubleNorHeapBigIntChild, ~SpecInt32Only))
             trueCase.append(branchIfInt32(leftRegs));
-        speculationCheck(BadType, leftRegs, leftNeitherDoubleNorHeapBigIntChild.node(), branchIfNumber(leftRegs, tempGPR));
+        speculationCheck(BadType, leftRegs, leftNeitherDoubleNorHeapBigIntChild.node(), branchIfNumber(leftRegs));
     }
     if (needsTypeCheck(leftNeitherDoubleNorHeapBigIntChild, ~SpecHeapBigInt)) {
         if (needsTypeCheck(leftNeitherDoubleNorHeapBigIntChild, SpecCell))
@@ -403,8 +403,8 @@ void SpeculativeJIT::compileNeitherDoubleNorHeapBigIntToNotDoubleStrictEquality(
     trueCase.append(jump());
     notEqual.link(this);
 
-    speculateNotDouble(rightNotDoubleChild, rightRegs, tempGPR);
-    speculateNotDouble(leftNeitherDoubleNorHeapBigIntChild, leftRegs, tempGPR);
+    speculateNotDouble(rightNotDoubleChild, rightRegs);
+    speculateNotDouble(leftNeitherDoubleNorHeapBigIntChild, leftRegs);
 
     if (needsTypeCheck(leftNeitherDoubleNorHeapBigIntChild, SpecCellCheck))
         falseCase.append(branchIfNotCell(leftRegs));

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -22692,7 +22692,7 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         RefPtr<PatchpointExceptionHandle> exceptionHandle =
             preparePatchpointForExceptions(patchpoint);
-        patchpoint->numGPScratchRegisters = 1;
+        patchpoint->numGPScratchRegisters = BinaryBitOpGenerator::needsScratchGPR ? 1 : 0;
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
         patchpoint->resultConstraints = { ValueRep::SomeEarlyRegister };
         State* state = &m_ftlState;
@@ -22704,9 +22704,17 @@ IGNORE_CLANG_WARNINGS_END
                 Box<CCallHelpers::JumpList> exceptions =
                     exceptionHandle->scheduleExitCreation(params)->jumps(jit);
 
-                auto generator = Box<BinaryBitOpGenerator>::create(
-                    leftOperand, rightOperand, JSValueRegs(params[0].gpr()),
-                    JSValueRegs(params[1].gpr()), JSValueRegs(params[2].gpr()), params.gpScratch(0));
+                auto generator = [&] {
+                    if constexpr (BinaryBitOpGenerator::needsScratchGPR) {
+                        return Box<BinaryBitOpGenerator>::create(
+                            leftOperand, rightOperand, JSValueRegs(params[0].gpr()),
+                            JSValueRegs(params[1].gpr()), JSValueRegs(params[2].gpr()), params.gpScratch(0));
+                    } else {
+                        return Box<BinaryBitOpGenerator>::create(
+                            leftOperand, rightOperand, JSValueRegs(params[0].gpr()),
+                            JSValueRegs(params[1].gpr()), JSValueRegs(params[2].gpr()));
+                    }
+                }();
 
                 generator->generateFastPath(jit);
                 generator->endJumpList().link(&jit);

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -234,9 +234,8 @@ public:
         move(TrustedImm64(JSValue::encode(value)), regs.gpr());
     }
 
-    void storeValue(JSValue value, Address address, JSValueRegs tmpJSR)
+    void storeValue(JSValue value, Address address)
     {
-        UNUSED_PARAM(tmpJSR);
         store64(Imm64(JSValue::encode(value)), address);
     }
 
@@ -583,25 +582,16 @@ public:
         return branchIfNotInt32(regs.gpr(), mode);
     }
 
-    // Note that the tempGPR is not used in 64-bit mode.
-    Jump branchIfNumber(JSValueRegs regs, GPRReg tempGPR, TagRegistersMode mode = HaveTagRegisters)
-    {
-        UNUSED_PARAM(tempGPR);
-        return branchIfNumber(regs.gpr(), mode);
-    }
-
     Jump branchIfNumber(GPRReg gpr, TagRegistersMode mode = HaveTagRegisters)
     {
         if (mode == HaveTagRegisters)
             return branchTest64(NonZero, gpr, GPRInfo::numberTagRegister);
         return branchTest64(NonZero, gpr, TrustedImm64(JSValue::NumberTag));
     }
-    
-    // Note that the tempGPR is not used in 64-bit mode.
-    Jump branchIfNotNumber(JSValueRegs regs, GPRReg tempGPR, TagRegistersMode mode = HaveTagRegisters)
+
+    Jump branchIfNumber(JSValueRegs regs, TagRegistersMode mode = HaveTagRegisters)
     {
-        UNUSED_PARAM(tempGPR);
-        return branchIfNotNumber(regs.gpr(), mode);
+        return branchIfNumber(regs.gpr(), mode);
     }
 
     Jump branchIfNotNumber(GPRReg gpr, TagRegistersMode mode = HaveTagRegisters)
@@ -609,6 +599,11 @@ public:
         if (mode == HaveTagRegisters)
             return branchTest64(Zero, gpr, GPRInfo::numberTagRegister);
         return branchTest64(Zero, gpr, TrustedImm64(JSValue::NumberTag));
+    }
+
+    Jump branchIfNotNumber(JSValueRegs regs, TagRegistersMode mode = HaveTagRegisters)
+    {
+        return branchIfNotNumber(regs.gpr(), mode);
     }
 
     Jump branchIfNotDoubleKnownNotInt32(JSValueRegs regs, TagRegistersMode mode = HaveTagRegisters)
@@ -1574,7 +1569,7 @@ public:
         
         notCell.link(this);
 
-        Jump notNumber = branchIfNotNumber(regs, tempGPR);
+        Jump notNumber = branchIfNotNumber(regs);
         functor(TypeofType::Number, false);
         notNumber.link(this);
         

--- a/Source/JavaScriptCore/jit/CCallHelpers.h
+++ b/Source/JavaScriptCore/jit/CCallHelpers.h
@@ -190,9 +190,8 @@ private:
     template<typename RegType>
     using InfoTypeForReg = decltype(toInfoFromReg(RegType(-1)));
 
-    // extraGPRArgs is used to track 64-bit argument types passed in register on 32-bit architectures.
     // extraPoke is used to track 64-bit argument types passed on the stack.
-    template<unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke>
+    template<unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke>
     struct ArgCollection {
         ArgCollection()
         {
@@ -204,8 +203,8 @@ private:
             crossDestinations.fill(InvalidGPRReg);
         }
 
-        template<unsigned a, unsigned b, unsigned c, unsigned d, unsigned e, unsigned f, unsigned g, unsigned h>
-        ArgCollection(ArgCollection<a, b, c, d, e, f, g, h>& other)
+        template<unsigned a, unsigned b, unsigned c, unsigned d, unsigned e, unsigned f, unsigned g>
+        ArgCollection(ArgCollection<a, b, c, d, e, f, g>& other)
         {
             gprSources = other.gprSources;
             gprDestinations = other.gprDestinations;
@@ -215,77 +214,63 @@ private:
             crossDestinations = other.crossDestinations;
         }
 
-        ArgCollection<numGPRArgs + 1, numGPRSources + 1, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> pushRegArg(GPRReg argument, GPRReg destination)
+        ArgCollection<numGPRArgs + 1, numGPRSources + 1, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> pushRegArg(GPRReg argument, GPRReg destination)
         {
-            ArgCollection<numGPRArgs + 1, numGPRSources + 1, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> result(*this);
+            ArgCollection<numGPRArgs + 1, numGPRSources + 1, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> result(*this);
 
             result.gprSources[numGPRSources] = argument;
             result.gprDestinations[numGPRSources] = destination;
             return result;
         }
 
-        ArgCollection<numGPRArgs, numGPRSources, numFPRArgs + 1, numFPRSources + 1, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> pushRegArg(FPRReg argument, FPRReg destination)
+        ArgCollection<numGPRArgs, numGPRSources, numFPRArgs + 1, numFPRSources + 1, numCrossSources, nonArgGPRs, extraPoke> pushRegArg(FPRReg argument, FPRReg destination)
         {
-            ArgCollection<numGPRArgs, numGPRSources, numFPRArgs + 1, numFPRSources + 1, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> result(*this);
+            ArgCollection<numGPRArgs, numGPRSources, numFPRArgs + 1, numFPRSources + 1, numCrossSources, nonArgGPRs, extraPoke> result(*this);
 
             result.fprSources[numFPRSources] = argument;
             result.fprDestinations[numFPRSources] = destination;
             return result;
         }
 
-        ArgCollection<numGPRArgs, numGPRSources, numFPRArgs + 1, numFPRSources, numCrossSources + 1, extraGPRArgs, nonArgGPRs, extraPoke> pushRegArg(FPRReg argument, GPRReg destination)
+        ArgCollection<numGPRArgs, numGPRSources, numFPRArgs + 1, numFPRSources, numCrossSources + 1, nonArgGPRs, extraPoke> pushRegArg(FPRReg argument, GPRReg destination)
         {
-            ArgCollection<numGPRArgs, numGPRSources, numFPRArgs + 1, numFPRSources, numCrossSources + 1, extraGPRArgs, nonArgGPRs, extraPoke> result(*this);
+            ArgCollection<numGPRArgs, numGPRSources, numFPRArgs + 1, numFPRSources, numCrossSources + 1, nonArgGPRs, extraPoke> result(*this);
 
             result.crossSources[numCrossSources] = argument;
             result.crossDestinations[numCrossSources] = destination;
             return result;
         }
 
-        ArgCollection<numGPRArgs, numGPRSources + 1, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs + 1, nonArgGPRs, extraPoke> pushExtraRegArg(GPRReg argument, GPRReg destination)
+        ArgCollection<numGPRArgs, numGPRSources + 1, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs + 1, extraPoke> pushNonArg(GPRReg argument, GPRReg destination)
         {
-            ArgCollection<numGPRArgs, numGPRSources + 1, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs + 1, nonArgGPRs, extraPoke> result(*this);
+            ArgCollection<numGPRArgs, numGPRSources + 1, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs + 1, extraPoke> result(*this);
 
             result.gprSources[numGPRSources] = argument;
             result.gprDestinations[numGPRSources] = destination;
             return result;
         }
 
-        ArgCollection<numGPRArgs, numGPRSources + 1, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs + 1, extraPoke> pushNonArg(GPRReg argument, GPRReg destination)
+        ArgCollection<numGPRArgs + 1, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> addGPRArg()
         {
-            ArgCollection<numGPRArgs, numGPRSources + 1, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs + 1, extraPoke> result(*this);
-
-            result.gprSources[numGPRSources] = argument;
-            result.gprDestinations[numGPRSources] = destination;
-            return result;
+            return ArgCollection<numGPRArgs + 1, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke>(*this);
         }
 
-        ArgCollection<numGPRArgs + 1, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> addGPRArg()
+        ArgCollection<numGPRArgs + 1, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> addStackArg(GPRReg)
         {
-            return ArgCollection<numGPRArgs + 1, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke>(*this);
+            return ArgCollection<numGPRArgs + 1, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke>(*this);
         }
 
-        ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs + 1, nonArgGPRs, extraPoke> addGPRExtraArg()
+        ArgCollection<numGPRArgs, numGPRSources, numFPRArgs + 1, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> addStackArg(FPRReg)
         {
-            return ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs + 1, nonArgGPRs, extraPoke>(*this);
+            return ArgCollection<numGPRArgs, numGPRSources, numFPRArgs + 1, numFPRSources, numCrossSources, nonArgGPRs, extraPoke>(*this);
         }
 
-        ArgCollection<numGPRArgs + 1, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> addStackArg(GPRReg)
+        ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke + 1> addPoke()
         {
-            return ArgCollection<numGPRArgs + 1, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke>(*this);
+            return ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke + 1>(*this);
         }
 
-        ArgCollection<numGPRArgs, numGPRSources, numFPRArgs + 1, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> addStackArg(FPRReg)
-        {
-            return ArgCollection<numGPRArgs, numGPRSources, numFPRArgs + 1, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke>(*this);
-        }
-
-        ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke + 1> addPoke()
-        {
-            return ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke + 1>(*this);
-        }
-
-        unsigned argCount(GPRReg) { return numGPRArgs + extraGPRArgs; }
+        unsigned argCount(GPRReg) { return numGPRArgs; }
         unsigned argCount(FPRReg) { return numFPRArgs; }
 
         // store GPR -> GPR assignments
@@ -320,7 +305,7 @@ private:
         return result;
     }
 
-    ALWAYS_INLINE unsigned calculatePokeOffset(unsigned currentGPRArgument, unsigned currentFPRArgument, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke)
+    ALWAYS_INLINE unsigned calculatePokeOffset(unsigned currentGPRArgument, unsigned currentFPRArgument, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke)
     {
         // Clang claims that it cannot find the symbol for FPRReg/GPRReg::numberOfArgumentRegisters when they are passed directly to std::max... seems like a bug
         unsigned numberOfFPArgumentRegisters = FPRInfo::numberOfArgumentRegisters;
@@ -328,7 +313,6 @@ private:
 
         UNUSED_PARAM(nonArgGPRs);
 
-        currentGPRArgument += extraGPRArgs;
         currentFPRArgument -= numCrossSources;
 
         IGNORE_WARNINGS_BEGIN("type-limits")
@@ -342,18 +326,18 @@ private:
     }
 
     template<typename ArgType>
-    ALWAYS_INLINE void pokeForArgument(ArgType arg, unsigned currentGPRArgument, unsigned currentFPRArgument, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke)
+    ALWAYS_INLINE void pokeForArgument(ArgType arg, unsigned currentGPRArgument, unsigned currentFPRArgument, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke)
     {
-        unsigned pokeOffset = calculatePokeOffset(currentGPRArgument, currentFPRArgument, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke);
+        unsigned pokeOffset = calculatePokeOffset(currentGPRArgument, currentFPRArgument, numCrossSources, nonArgGPRs, extraPoke);
         if constexpr (std::derived_from<ArgType, ConstantMaterializer>)
             arg.store(*this, addressForPoke(pokeOffset));
         else
             poke(arg, pokeOffset);
     }
 
-    ALWAYS_INLINE bool stackAligned(unsigned currentGPRArgument, unsigned currentFPRArgument, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke)
+    ALWAYS_INLINE bool stackAligned(unsigned currentGPRArgument, unsigned currentFPRArgument, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke)
     {
-        unsigned pokeOffset = calculatePokeOffset(currentGPRArgument, currentFPRArgument, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke);
+        unsigned pokeOffset = calculatePokeOffset(currentGPRArgument, currentFPRArgument, numCrossSources, nonArgGPRs, extraPoke);
         return !(pokeOffset & 1);
     }
 
@@ -369,8 +353,8 @@ private:
 #define RESULT_TYPE typename FunctionTraits<OperationType>::ResultType
 
     // Avoid MSVC optimization time explosion associated with __forceinline in recursive templates.
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename RegType, typename... Args>
-    ALWAYS_INLINE void marshallArgumentRegister(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, RegType arg, Args... args)
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename RegType, typename... Args>
+    ALWAYS_INLINE void marshallArgumentRegister(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, RegType arg, Args... args)
     {
         using InfoType = InfoTypeForReg<RegType>;
         unsigned numArgRegisters = InfoType::numberOfArgumentRegisters;
@@ -381,92 +365,92 @@ private:
             return;
         }
 
-        pokeForArgument(arg, numGPRArgs, numFPRArgs, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke);
+        pokeForArgument(arg, numGPRArgs, numFPRArgs, numCrossSources, nonArgGPRs, extraPoke);
         setupArgumentsImpl<OperationType>(argSourceRegs.addStackArg(arg), args...);
     }
 
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename... Args>
-    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, FPRReg arg, Args... args)
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename... Args>
+    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, FPRReg arg, Args... args)
     {
         static_assert(std::is_same_v<CURRENT_ARGUMENT_TYPE, double>, "We should only be passing FPRRegs to a double. We use moveDouble / loadDouble / storeDouble exclusively");
         marshallArgumentRegister<OperationType>(argSourceRegs, arg, args...);
     }
 
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename... Args>
-    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, GPRReg arg, Args... args)
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename... Args>
+    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, GPRReg arg, Args... args)
     {
         marshallArgumentRegister<OperationType>(argSourceRegs, arg, args...);
     }
 
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename... Args>
-    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, JSValueRegs arg, Args... args)
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename... Args>
+    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, JSValueRegs arg, Args... args)
     {
         marshallArgumentRegister<OperationType>(argSourceRegs, arg.gpr(), args...);
     }
 
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename... Args>
-    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, CellValue arg, Args... args)
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename... Args>
+    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, CellValue arg, Args... args)
     {
         marshallArgumentRegister<OperationType>(argSourceRegs, arg.gpr(), args...);
     }
 
 
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
         requires DerivedFromOrConvertibleTo<Arg, TrustedImm> // DerivedFromOrConvertibleTo instead of derived_from since DFGSpeculativeJIT has its own implementation of TrustedImmPtr
-    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, Arg arg, Args... args)
+    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, Arg arg, Args... args)
     {
         // Right now this only supports non-floating point immediate arguments since we never call operations with non-register values.
         // If we ever needed to support immediate floating point arguments we would need to duplicate this logic for both types, which sounds
         // gross so it's probably better to do that marshalling before the call operation...
         static_assert(!std::is_floating_point_v<CURRENT_ARGUMENT_TYPE>, "We don't support immediate floats/doubles in setupArguments");
         auto numArgRegisters = GPRInfo::numberOfArgumentRegisters;
-        auto currentArgCount = numGPRArgs + extraGPRArgs;
+        auto currentArgCount = numGPRArgs;
         if (currentArgCount < numArgRegisters) {
             setupArgumentsImpl<OperationType>(argSourceRegs.addGPRArg(), args...);
             move(arg, GPRInfo::toArgumentRegister(currentArgCount));
             return;
         }
 
-        pokeForArgument(arg, numGPRArgs, numFPRArgs, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke);
+        pokeForArgument(arg, numGPRArgs, numFPRArgs, numCrossSources, nonArgGPRs, extraPoke);
         setupArgumentsImpl<OperationType>(argSourceRegs.addGPRArg(), args...);
     }
 
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
         requires (std::same_as<CURRENT_ARGUMENT_TYPE, Arg> && std::integral<CURRENT_ARGUMENT_TYPE> && sizeof(CURRENT_ARGUMENT_TYPE) <= 4)
-    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, Arg arg, Args... args)
+    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, Arg arg, Args... args)
     {
         setupArgumentsImpl<OperationType>(argSourceRegs, TrustedImm32(arg), args...);
     }
 
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
         requires (std::same_as<CURRENT_ARGUMENT_TYPE, Arg> && std::integral<CURRENT_ARGUMENT_TYPE> && sizeof(CURRENT_ARGUMENT_TYPE) == 8)
-    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, Arg arg, Args... args)
+    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, Arg arg, Args... args)
     {
         setupArgumentsImpl<OperationType>(argSourceRegs, TrustedImm64(arg), args...);
     }
 
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
         requires (std::is_pointer_v<CURRENT_ARGUMENT_TYPE> && std::same_as<Arg, std::nullptr_t>)
-    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, Arg arg, Args... args)
+    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, Arg arg, Args... args)
     {
         setupArgumentsImpl<OperationType>(argSourceRegs, TrustedImmPtr(arg), args...);
     }
 
     // Special case DFG::RegisteredStructure because it's really annoying to deal with otherwise...
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
         requires (std::same_as<CURRENT_ARGUMENT_TYPE, Structure*> && std::same_as<Arg, DFG::RegisteredStructure>)
-    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, Arg arg, Args... args)
+    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, Arg arg, Args... args)
     {
         setupArgumentsImpl<OperationType>(argSourceRegs, TrustedImmPtr(arg.get()), args...);
     }
 
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename Arg, typename... Args>
         requires std::derived_from<Arg, ConstantMaterializer>
-    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, Arg arg, Args... args)
+    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, Arg arg, Args... args)
     {
         static_assert(!std::is_floating_point_v<CURRENT_ARGUMENT_TYPE>, "We don't support immediate floats/doubles in setupArguments");
         auto numArgRegisters = GPRInfo::numberOfArgumentRegisters;
-        auto currentArgCount = numGPRArgs + extraGPRArgs;
+        auto currentArgCount = numGPRArgs;
         if (currentArgCount < numArgRegisters) {
             setupArgumentsImpl<OperationType>(argSourceRegs.addGPRArg(), args...);
             arg.materialize(*this, GPRInfo::toArgumentRegister(currentArgCount));
@@ -474,7 +458,7 @@ private:
         }
 
 
-        pokeForArgument(arg, numGPRArgs, numFPRArgs, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke);
+        pokeForArgument(arg, numGPRArgs, numFPRArgs, numCrossSources, nonArgGPRs, extraPoke);
         setupArgumentsImpl<OperationType>(argSourceRegs.addGPRArg(), args...);
     }
 
@@ -526,8 +510,8 @@ private:
     }
 
     // Base case; set up the argument registers.
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke>
-    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs)
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke>
+    ALWAYS_INLINE void setupArgumentsImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs)
     {
         using TraitsType = FunctionTraits<OperationType>;
         static_assert(TraitsType::arity == numGPRArgs + numFPRArgs, "One last sanity check");
@@ -541,8 +525,8 @@ private:
         shuffleRegisters<FPRReg, numFPRSources>(clampArrayToSize<numFPRSources, FPRReg>(argSourceRegs.fprSources), clampArrayToSize<numFPRSources, FPRReg>(argSourceRegs.fprDestinations));
     }
 
-    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename... Args>
-    ALWAYS_INLINE void setupArgumentsEntryImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, Args... args)
+    template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned nonArgGPRs, unsigned extraPoke, typename... Args>
+    ALWAYS_INLINE void setupArgumentsEntryImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, nonArgGPRs, extraPoke> argSourceRegs, Args... args)
     {
         if constexpr (!FunctionTraits<OperationType>::arity) {
             static_assert(!sizeof...(Args), "Basic sanity check");
@@ -566,19 +550,19 @@ public:
     template<typename OperationType, typename... Args>
     ALWAYS_INLINE void setupArguments(Args... args)
     {
-        setupArgumentsEntryImpl<OperationType>(ArgCollection<0, 0, 0, 0, 0, 0, 0, 0>(), args...);
+        setupArgumentsEntryImpl<OperationType>(ArgCollection<0, 0, 0, 0, 0, 0, 0>(), args...);
     }
 
     template<typename OperationType, typename... Args>
     ALWAYS_INLINE void setupArgumentsForIndirectCall(GPRReg functionGPR, Args... args)
     {
-        setupArgumentsEntryImpl<OperationType>(ArgCollection<0, 0, 0, 0, 0, 0, 0, 0>().pushNonArg(functionGPR, GPRInfo::nonArgGPR0), args...);
+        setupArgumentsEntryImpl<OperationType>(ArgCollection<0, 0, 0, 0, 0, 0, 0>().pushNonArg(functionGPR, GPRInfo::nonArgGPR0), args...);
     }
 
     template<typename OperationType, typename... Args>
     ALWAYS_INLINE void setupArgumentsForIndirectCall(Address address, Args... args)
     {
-        setupArgumentsEntryImpl<OperationType>(ArgCollection<0, 0, 0, 0, 0, 0, 0, 0>().pushNonArg(address.base, GPRInfo::nonArgGPR0), args...);
+        setupArgumentsEntryImpl<OperationType>(ArgCollection<0, 0, 0, 0, 0, 0, 0>().pushNonArg(address.base, GPRInfo::nonArgGPR0), args...);
     }
 
     void setupResults(GPRReg destA, GPRReg destB = InvalidGPRReg)

--- a/Source/JavaScriptCore/jit/JITAddGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITAddGenerator.cpp
@@ -102,7 +102,7 @@ bool JITAddGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
         // Try to do doubleVar + double(intConstant).
         notInt32.link(&jit);
         if (!varOpr.definitelyIsNumber())
-            slowPathJumpList.append(jit.branchIfNotNumber(var, m_scratchGPR));
+            slowPathJumpList.append(jit.branchIfNotNumber(var));
 
         jit.unboxDoubleNonDestructive(var, m_leftFPR, m_scratchGPR);
 
@@ -130,9 +130,9 @@ bool JITAddGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
 
         leftNotInt.link(&jit);
         if (!m_leftOperand.definitelyIsNumber())
-            slowPathJumpList.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
+            slowPathJumpList.append(jit.branchIfNotNumber(m_left));
         if (!m_rightOperand.definitelyIsNumber())
-            slowPathJumpList.append(jit.branchIfNotNumber(m_right, m_scratchGPR));
+            slowPathJumpList.append(jit.branchIfNotNumber(m_right));
 
         jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
         CCallHelpers::Jump rightIsDouble = jit.branchIfNotInt32(m_right);
@@ -142,7 +142,7 @@ bool JITAddGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
 
         rightNotInt.link(&jit);
         if (!m_rightOperand.definitelyIsNumber())
-            slowPathJumpList.append(jit.branchIfNotNumber(m_right, m_scratchGPR));
+            slowPathJumpList.append(jit.branchIfNotNumber(m_right));
 
         jit.convertInt32ToDouble(m_left.payloadGPR(), m_leftFPR);
 

--- a/Source/JavaScriptCore/jit/JITArithmetic.cpp
+++ b/Source/JavaScriptCore/jit/JITArithmetic.cpp
@@ -403,7 +403,7 @@ void JIT::emit_compareSlowImpl(VirtualRegister op1, VirtualRegister op2, size_t 
             return false;
         linkAllSlowCases(iter);
 
-        Jump fail1 = branchIfNotNumber(jsReg2, regT4);
+        Jump fail1 = branchIfNotNumber(jsReg2);
         unboxDouble(jsReg2, fpReg2);
 
         move(Imm32(getConstantOperand(op).asInt32()), jsReg1.payloadGPR());
@@ -429,8 +429,8 @@ void JIT::emit_compareSlowImpl(VirtualRegister op1, VirtualRegister op2, size_t 
 
     linkSlowCase(iter); // LHS is not Int.
 
-    Jump fail1 = branchIfNotNumber(jsRegT10, regT4);
-    Jump fail2 = branchIfNotNumber(jsRegT32, regT4);
+    Jump fail1 = branchIfNotNumber(jsRegT10);
+    Jump fail2 = branchIfNotNumber(jsRegT32);
     Jump fail3 = branchIfInt32(jsRegT32);
     unboxDouble(jsRegT10, fpRegT0);
     unboxDouble(jsRegT32, fpRegT1);
@@ -607,7 +607,7 @@ void JIT::emit_op_pow(const JSInstruction* currentInstruction)
     convertInt32ToDouble(leftRegs.payloadGPR(), fpRegT0);
     Jump lhsReady = jump();
     lhsNotInt.link(this);
-    addSlowCase(branchIfNotNumber(leftRegs, scratchGPR));
+    addSlowCase(branchIfNotNumber(leftRegs));
     unboxDouble(leftRegs.payloadGPR(), scratchGPR, fpRegT0);
     lhsReady.link(this);
 
@@ -685,7 +685,14 @@ void JIT::emitBitBinaryOpFastPath(const JSInstruction* currentInstruction)
     if (!rightOperand.isConst())
         emitGetVirtualRegister(op2, rightRegs);
 
-    SnippetGenerator gen(leftOperand, rightOperand, resultRegs, leftRegs, rightRegs, scratchGPR);
+    SnippetGenerator gen = [&] {
+        if constexpr (SnippetGenerator::needsScratchGPR)
+            return SnippetGenerator(leftOperand, rightOperand, resultRegs, leftRegs, rightRegs, scratchGPR);
+        else {
+            UNUSED_VARIABLE(scratchGPR);
+            return SnippetGenerator(leftOperand, rightOperand, resultRegs, leftRegs, rightRegs);
+        }
+    }();
 
     gen.generateFastPath(*this);
 

--- a/Source/JavaScriptCore/jit/JITBitAndGenerator.h
+++ b/Source/JavaScriptCore/jit/JITBitAndGenerator.h
@@ -33,12 +33,18 @@ namespace JSC {
 
 class JITBitAndGenerator : public JITBitBinaryOpGenerator {
 public:
+    static constexpr bool needsScratchGPR = true;
+
     JITBitAndGenerator(const SnippetOperand& leftOperand, const SnippetOperand& rightOperand,
         JSValueRegs result, JSValueRegs left, JSValueRegs right, GPRReg scratchGPR)
-        : JITBitBinaryOpGenerator(leftOperand, rightOperand, result, left, right, scratchGPR)
+        : JITBitBinaryOpGenerator(leftOperand, rightOperand, result, left, right)
+        , m_scratchGPR(scratchGPR)
     { }
 
     void generateFastPath(CCallHelpers&);
+
+private:
+    GPRReg m_scratchGPR;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/JITBitBinaryOpGenerator.h
+++ b/Source/JavaScriptCore/jit/JITBitBinaryOpGenerator.h
@@ -35,13 +35,12 @@ namespace JSC {
 class JITBitBinaryOpGenerator {
 public:
     JITBitBinaryOpGenerator(const SnippetOperand& leftOperand, const SnippetOperand& rightOperand,
-        JSValueRegs result, JSValueRegs left, JSValueRegs right, GPRReg scratchGPR)
+        JSValueRegs result, JSValueRegs left, JSValueRegs right)
         : m_leftOperand(leftOperand)
         , m_rightOperand(rightOperand)
         , m_result(result)
         , m_left(left)
         , m_right(right)
-        , m_scratchGPR(scratchGPR)
     {
         ASSERT(!m_leftOperand.isConstInt32() || !m_rightOperand.isConstInt32());
     }
@@ -56,7 +55,6 @@ protected:
     JSValueRegs m_result;
     JSValueRegs m_left;
     JSValueRegs m_right;
-    GPRReg m_scratchGPR;
     bool m_didEmitFastPath { false };
 
     CCallHelpers::JumpList m_endJumpList;

--- a/Source/JavaScriptCore/jit/JITBitOrGenerator.h
+++ b/Source/JavaScriptCore/jit/JITBitOrGenerator.h
@@ -33,9 +33,11 @@ namespace JSC {
 
 class JITBitOrGenerator : public JITBitBinaryOpGenerator {
 public:
+    static constexpr bool needsScratchGPR = false;
+
     JITBitOrGenerator(const SnippetOperand& leftOperand, const SnippetOperand& rightOperand,
-        JSValueRegs result, JSValueRegs left, JSValueRegs right, GPRReg unused = InvalidGPRReg)
-        : JITBitBinaryOpGenerator(leftOperand, rightOperand, result, left, right, unused)
+        JSValueRegs result, JSValueRegs left, JSValueRegs right)
+        : JITBitBinaryOpGenerator(leftOperand, rightOperand, result, left, right)
     { }
 
     void generateFastPath(CCallHelpers&);

--- a/Source/JavaScriptCore/jit/JITBitXorGenerator.h
+++ b/Source/JavaScriptCore/jit/JITBitXorGenerator.h
@@ -33,9 +33,11 @@ namespace JSC {
 
 class JITBitXorGenerator : public JITBitBinaryOpGenerator {
 public:
+    static constexpr bool needsScratchGPR = false;
+
     JITBitXorGenerator(const SnippetOperand& leftOperand, const SnippetOperand& rightOperand,
-        JSValueRegs result, JSValueRegs left, JSValueRegs right, GPRReg unused = InvalidGPRReg)
-        : JITBitBinaryOpGenerator(leftOperand, rightOperand, result, left, right, unused)
+        JSValueRegs result, JSValueRegs left, JSValueRegs right)
+        : JITBitBinaryOpGenerator(leftOperand, rightOperand, result, left, right)
     { }
 
     void generateFastPath(CCallHelpers&);

--- a/Source/JavaScriptCore/jit/JITDivGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITDivGenerator.cpp
@@ -48,7 +48,7 @@ void JITDivGenerator::loadOperand(CCallHelpers& jit, SnippetOperand& opr, JSValu
         jit.move64ToDouble(m_scratchGPR, destFPR);
     } else {
         if (!opr.definitelyIsNumber())
-            m_slowPathJumpList.append(jit.branchIfNotNumber(oprRegs, m_scratchGPR));
+            m_slowPathJumpList.append(jit.branchIfNotNumber(oprRegs));
         CCallHelpers::Jump notInt32 = jit.branchIfNotInt32(oprRegs);
         jit.convertInt32ToDouble(oprRegs.payloadGPR(), destFPR);
         CCallHelpers::Jump oprIsLoaded = jit.jump();

--- a/Source/JavaScriptCore/jit/JITLeftShiftGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITLeftShiftGenerator.cpp
@@ -32,10 +32,6 @@ namespace JSC {
 
 void JITLeftShiftGenerator::generateFastPath(CCallHelpers& jit)
 {
-    ASSERT(m_scratchGPR != InvalidGPRReg);
-    ASSERT(m_scratchGPR != m_left.payloadGPR());
-    ASSERT(m_scratchGPR != m_right.payloadGPR());
-
     ASSERT(!m_leftOperand.isConstInt32() || !m_rightOperand.isConstInt32());
 
     m_didEmitFastPath = true;

--- a/Source/JavaScriptCore/jit/JITLeftShiftGenerator.h
+++ b/Source/JavaScriptCore/jit/JITLeftShiftGenerator.h
@@ -33,9 +33,11 @@ namespace JSC {
 
 class JITLeftShiftGenerator : public JITBitBinaryOpGenerator {
 public:
+    static constexpr bool needsScratchGPR = false;
+
     JITLeftShiftGenerator(const SnippetOperand& leftOperand, const SnippetOperand& rightOperand,
-        JSValueRegs result, JSValueRegs left, JSValueRegs right, GPRReg scratchGPR)
-        : JITBitBinaryOpGenerator(leftOperand, rightOperand, result, left, right, scratchGPR)
+        JSValueRegs result, JSValueRegs left, JSValueRegs right)
+        : JITBitBinaryOpGenerator(leftOperand, rightOperand, result, left, right)
     { }
 
     void generateFastPath(CCallHelpers&);

--- a/Source/JavaScriptCore/jit/JITMulGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITMulGenerator.cpp
@@ -50,9 +50,9 @@ JITMathICInlineResult JITMulGenerator::generateInline(CCallHelpers& jit, MathICG
         ASSERT(m_left);
         ASSERT(m_right);
         if (!m_leftOperand.definitelyIsNumber())
-            state.slowPathJumps.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
+            state.slowPathJumps.append(jit.branchIfNotNumber(m_left));
         if (!m_rightOperand.definitelyIsNumber())
-            state.slowPathJumps.append(jit.branchIfNotNumber(m_right, m_scratchGPR));
+            state.slowPathJumps.append(jit.branchIfNotNumber(m_right));
         state.slowPathJumps.append(jit.branchIfInt32(m_left));
         state.slowPathJumps.append(jit.branchIfInt32(m_right));
         jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
@@ -118,7 +118,7 @@ bool JITMulGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
         // Try to do doubleVar * double(intConstant).
         notInt32.link(&jit);
         if (!varOpr.definitelyIsNumber())
-            slowPathJumpList.append(jit.branchIfNotNumber(var, m_scratchGPR));
+            slowPathJumpList.append(jit.branchIfNotNumber(var));
 
         jit.unboxDoubleNonDestructive(var, m_leftFPR, m_scratchGPR);
 
@@ -145,9 +145,9 @@ bool JITMulGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
 
         leftNotInt.link(&jit);
         if (!m_leftOperand.definitelyIsNumber())
-            slowPathJumpList.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
+            slowPathJumpList.append(jit.branchIfNotNumber(m_left));
         if (!m_rightOperand.definitelyIsNumber())
-            slowPathJumpList.append(jit.branchIfNotNumber(m_right, m_scratchGPR));
+            slowPathJumpList.append(jit.branchIfNotNumber(m_right));
 
         jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
         CCallHelpers::Jump rightIsDouble = jit.branchIfNotInt32(m_right);
@@ -157,7 +157,7 @@ bool JITMulGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
 
         rightNotInt.link(&jit);
         if (!m_rightOperand.definitelyIsNumber())
-            slowPathJumpList.append(jit.branchIfNotNumber(m_right, m_scratchGPR));
+            slowPathJumpList.append(jit.branchIfNotNumber(m_right));
 
         jit.convertInt32ToDouble(m_left.payloadGPR(), m_leftFPR);
 

--- a/Source/JavaScriptCore/jit/JITNegGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITNegGenerator.cpp
@@ -35,10 +35,6 @@ namespace JSC {
 
 JITMathICInlineResult JITNegGenerator::generateInline(CCallHelpers& jit, MathICGenerationState& state, const UnaryArithProfile* arithProfile)
 {
-    ASSERT(m_scratchGPR != InvalidGPRReg);
-    ASSERT(m_scratchGPR != m_src.payloadGPR());
-    ASSERT(m_scratchGPR != m_result.payloadGPR());
-
     // We default to speculating int32.
     ObservedType observedTypes = ObservedType().withInt32();
     if (arithProfile)
@@ -59,7 +55,7 @@ JITMathICInlineResult JITNegGenerator::generateInline(CCallHelpers& jit, MathICG
     }
     if (observedTypes.isOnlyNumber()) {
         state.slowPathJumps.append(jit.branchIfInt32(m_src));
-        state.slowPathJumps.append(jit.branchIfNotNumber(m_src, m_scratchGPR));
+        state.slowPathJumps.append(jit.branchIfNotNumber(m_src));
         jit.xor64(CCallHelpers::TrustedImm64(static_cast<int64_t>(1ull << 63)), m_src.payloadGPR(), m_result.payloadGPR());
         return JITMathICInlineResult::GeneratedFastPath;
     }
@@ -84,7 +80,7 @@ bool JITNegGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
     endJumpList.append(jit.jump());
 
     srcNotInt.link(&jit);
-    slowPathJumpList.append(jit.branchIfNotNumber(m_src, m_scratchGPR));
+    slowPathJumpList.append(jit.branchIfNotNumber(m_src));
 
     // For a double, all we need to do is to invert the sign bit.
     jit.xor64(CCallHelpers::TrustedImm64((int64_t)(1ull << 63)), m_result.payloadGPR());

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -56,7 +56,7 @@ void JIT::emit_op_mov(const JSInstruction* currentInstruction)
 
     if (src.isConstant()) {
         if (m_profiledCodeBlock->isConstantOwnedByUnlinkedCodeBlock(src)) {
-            storeValue(m_unlinkedCodeBlock->getConstant(src), addressFor(dst), jsRegT10);
+            storeValue(m_unlinkedCodeBlock->getConstant(src), addressFor(dst));
         } else {
             loadCodeBlockConstant(src, jsRegT10);
             storeValue(jsRegT10, addressFor(dst));
@@ -336,7 +336,7 @@ void JIT::emit_op_to_property_key_or_number(const JSInstruction* currentInstruct
 
     JumpList done;
 
-    done.append(branchIfNumber(jsRegT10, regT2));
+    done.append(branchIfNumber(jsRegT10));
     addSlowCase(branchIfNotCell(jsRegT10));
     done.append(branchIfSymbol(jsRegT10.payloadGPR()));
     addSlowCase(branchIfNotString(jsRegT10.payloadGPR()));
@@ -1075,7 +1075,7 @@ void JIT::emit_op_to_number(const JSInstruction* currentInstruction)
     emitGetVirtualRegister(srcVReg, jsRegT10);
 
     auto isInt32 = branchIfInt32(jsRegT10);
-    addSlowCase(branchIfNotNumber(jsRegT10, regT2));
+    addSlowCase(branchIfNotNumber(jsRegT10));
     if (arithProfile && shouldEmitProfiling())
         arithProfile->emitUnconditionalSet(*this, UnaryArithProfile::observedNumberBits());
     isInt32.link(this);
@@ -1101,7 +1101,7 @@ void JIT::emit_op_to_numeric(const JSInstruction* currentInstruction)
     Jump isBigInt = jump();
 
     isNotCell.link(this);
-    addSlowCase(branchIfNotNumber(jsRegT10, regT2));
+    addSlowCase(branchIfNotNumber(jsRegT10));
     if (arithProfile && shouldEmitProfiling())
         move(TrustedImm32(UnaryArithProfile::observedNumberBits()), regT5);
     isBigInt.link(this);
@@ -1250,7 +1250,7 @@ void JIT::emit_op_switch_imm(const JSInstruction* currentInstruction)
 
     notInt32.link(this);
     JumpList failureCases;
-    failureCases.append(branchIfNotNumber(jsRegT10, regT2));
+    failureCases.append(branchIfNotNumber(jsRegT10));
     unboxDoubleWithoutAssertions(jsRegT10.payloadGPR(), regT2, fpRegT0);
     branchConvertDoubleToInt32(fpRegT0, jsRegT10.payloadGPR(), failureCases, fpRegT1, /* shouldCheckNegativeZero */ false);
     jump().linkTo(dispatch, this);
@@ -1997,7 +1997,7 @@ void JIT::emit_op_profile_type(const JSInstruction* currentInstruction)
     else if (cachedTypeLocation->m_lastSeenType == TypeAnyInt)
         jumpToEnd.append(branchIfInt32(jsRegT10));
     else if (cachedTypeLocation->m_lastSeenType == TypeNumber)
-        jumpToEnd.append(branchIfNumber(jsRegT10, regT2));
+        jumpToEnd.append(branchIfNumber(jsRegT10));
     else if (cachedTypeLocation->m_lastSeenType == TypeString) {
         Jump isNotCell = branchIfNotCell(jsRegT10);
         jumpToEnd.append(branchIfString(jsRegT10.payloadGPR()));

--- a/Source/JavaScriptCore/jit/JITRightShiftGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITRightShiftGenerator.cpp
@@ -57,7 +57,7 @@ void JITRightShiftGenerator::generateFastPath(CCallHelpers& jit)
 
         // Try to do (doubleVar >> intConstant).
         notInt.link(&jit);
-        m_slowPathJumpList.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
+        m_slowPathJumpList.append(jit.branchIfNotNumber(m_left));
         jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
 #if CPU(ARM64)
         if (MacroAssemblerARM64::supportsDoubleToInt32ConversionUsingJavaScriptSemantics())
@@ -99,7 +99,7 @@ void JITRightShiftGenerator::generateFastPath(CCallHelpers& jit)
 
     // Try to do (doubleVar >> intVar).
     leftNotInt.link(&jit);
-    m_slowPathJumpList.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
+    m_slowPathJumpList.append(jit.branchIfNotNumber(m_left));
     jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
 #if CPU(ARM64)
     if (MacroAssemblerARM64::supportsDoubleToInt32ConversionUsingJavaScriptSemantics())

--- a/Source/JavaScriptCore/jit/JITRightShiftGenerator.h
+++ b/Source/JavaScriptCore/jit/JITRightShiftGenerator.h
@@ -41,9 +41,10 @@ public:
     JITRightShiftGenerator(const SnippetOperand& leftOperand, const SnippetOperand& rightOperand,
         JSValueRegs result, JSValueRegs left, JSValueRegs right,
         FPRReg leftFPR, GPRReg scratchGPR, ShiftType type = SignedShift)
-        : JITBitBinaryOpGenerator(leftOperand, rightOperand, result, left, right, scratchGPR)
+        : JITBitBinaryOpGenerator(leftOperand, rightOperand, result, left, right)
         , m_shiftType(type)
         , m_leftFPR(leftFPR)
+        , m_scratchGPR(scratchGPR)
     { }
 
     void generateFastPath(CCallHelpers&);
@@ -51,6 +52,7 @@ public:
 private:
     ShiftType m_shiftType;
     FPRReg m_leftFPR;
+    GPRReg m_scratchGPR;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/JITSubGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITSubGenerator.cpp
@@ -48,9 +48,9 @@ JITMathICInlineResult JITSubGenerator::generateInline(CCallHelpers& jit, MathICG
 
     if (lhs.isOnlyNumber() && rhs.isOnlyNumber()) {
         if (!m_leftOperand.definitelyIsNumber())
-            state.slowPathJumps.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
+            state.slowPathJumps.append(jit.branchIfNotNumber(m_left));
         if (!m_rightOperand.definitelyIsNumber())
-            state.slowPathJumps.append(jit.branchIfNotNumber(m_right, m_scratchGPR));
+            state.slowPathJumps.append(jit.branchIfNotNumber(m_right));
         state.slowPathJumps.append(jit.branchIfInt32(m_left));
         state.slowPathJumps.append(jit.branchIfInt32(m_right));
         jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
@@ -98,9 +98,9 @@ bool JITSubGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
 
     leftNotInt.link(&jit);
     if (!m_leftOperand.definitelyIsNumber())
-        slowPathJumpList.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
+        slowPathJumpList.append(jit.branchIfNotNumber(m_left));
     if (!m_rightOperand.definitelyIsNumber())
-        slowPathJumpList.append(jit.branchIfNotNumber(m_right, m_scratchGPR));
+        slowPathJumpList.append(jit.branchIfNotNumber(m_right));
 
     jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
     CCallHelpers::Jump rightIsDouble = jit.branchIfNotInt32(m_right);
@@ -110,7 +110,7 @@ bool JITSubGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
 
     rightNotInt.link(&jit);
     if (!m_rightOperand.definitelyIsNumber())
-        slowPathJumpList.append(jit.branchIfNotNumber(m_right, m_scratchGPR));
+        slowPathJumpList.append(jit.branchIfNotNumber(m_right));
 
     jit.convertInt32ToDouble(m_left.payloadGPR(), m_leftFPR);
 

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -1135,7 +1135,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> numberConstructorCallThunkGenerator(VM& vm
 {
     SpecializedThunkJIT jit(vm, 1);
     jit.loadJSArgument(0, JSRInfo::jsRegT10);
-    jit.appendFailure(jit.branchIfNotNumber(JSRInfo::jsRegT10, JSRInfo::jsRegT32.payloadGPR()));
+    jit.appendFailure(jit.branchIfNotNumber(JSRInfo::jsRegT10));
     jit.returnJSValue(JSRInfo::jsRegT10);
     return jit.finalize(vm.jitStubs->ctiNativeTailCall(vm), "Number");
 }

--- a/Source/JavaScriptCore/lol/LOLJIT.cpp
+++ b/Source/JavaScriptCore/lol/LOLJIT.cpp
@@ -1046,7 +1046,7 @@ void LOLJIT::emitCompareSlowImpl(const auto& allocations, VirtualRegister lhs, J
             return false;
         linkAllSlowCases(iter);
 
-        Jump fail1 = branchIfNotNumber(nonConstantRegs, s_scratch);
+        Jump fail1 = branchIfNotNumber(nonConstantRegs);
         unboxDouble(nonConstantRegs.payloadGPR(), s_scratch, nonConstantFPR);
 
         convertInt32ToDouble(constantRegs.payloadGPR(), constantFPR);
@@ -1076,8 +1076,8 @@ void LOLJIT::emitCompareSlowImpl(const auto& allocations, VirtualRegister lhs, J
 
     JumpList slows;
     JIT_COMMENT(*this, "checking for both doubles");
-    slows.append(branchIfNotNumber(lhsRegs, s_scratch));
-    slows.append(branchIfNotNumber(rhsRegs, s_scratch));
+    slows.append(branchIfNotNumber(lhsRegs));
+    slows.append(branchIfNotNumber(rhsRegs));
     // We only have to check if rhs is an Int32 as we already must have failed the isInt32(lhs) from the fast path.
     slows.append(branchIfInt32(rhsRegs));
     unboxDouble(lhsRegs, s_scratch, lhsFPR);
@@ -1362,7 +1362,7 @@ void LOLJIT::emit_op_to_number(const JSInstruction* currentInstruction)
     UnaryArithProfile* arithProfile = &m_unlinkedCodeBlock->unaryArithProfile(bytecode.m_profileIndex);
 
     auto isInt32 = branchIfInt32(operand);
-    addSlowCase(branchIfNotNumber(operand, InvalidGPRReg));
+    addSlowCase(branchIfNotNumber(operand));
     if (arithProfile && shouldEmitProfiling())
         arithProfile->emitUnconditionalSet(*this, UnaryArithProfile::observedNumberBits());
     isInt32.link(this);
@@ -1403,7 +1403,7 @@ void LOLJIT::emit_op_to_numeric(const JSInstruction* currentInstruction)
     Jump isBigInt = jump();
 
     isNotCell.link(this);
-    addSlowCase(branchIfNotNumber(operandRegs, s_scratch));
+    addSlowCase(branchIfNotNumber(operandRegs));
     if (arithProfile && shouldEmitProfiling())
         move(TrustedImm32(UnaryArithProfile::observedNumberBits()), s_scratch);
     isBigInt.link(this);
@@ -1459,7 +1459,7 @@ void LOLJIT::emit_op_to_property_key_or_number(const JSInstruction* currentInstr
 
     JumpList done;
 
-    done.append(branchIfNumber(srcRegs, s_scratch));
+    done.append(branchIfNumber(srcRegs));
     addSlowCase(branchIfNotCell(srcRegs));
     done.append(branchIfSymbol(srcRegs.payloadGPR()));
     addSlowCase(branchIfNotString(srcRegs.payloadGPR()));
@@ -2357,7 +2357,7 @@ void LOLJIT::emit_op_switch_imm(const JSInstruction* currentInstruction)
 
     notInt32.link(this);
     JumpList failureCases;
-    failureCases.append(branchIfNotNumber(scrutineeRegs, s_scratch));
+    failureCases.append(branchIfNotNumber(scrutineeRegs));
     unboxDoubleWithoutAssertions(scrutineeRegs.payloadGPR(), s_scratch, fpRegT0);
     branchConvertDoubleToInt32(fpRegT0, scrutineeRegs.payloadGPR(), failureCases, fpRegT1, /* shouldCheckNegativeZero */ false);
     jump().linkTo(dispatch, this);
@@ -2518,7 +2518,7 @@ void LOLJIT::emit_op_lshift(const JSInstruction* currentInstruction)
 
     RELEASE_ASSERT(!leftOperand.isConst() || !rightOperand.isConst());
 
-    JITLeftShiftGenerator gen(leftOperand, rightOperand, destRegs, leftRegs, rightRegs, s_scratch);
+    JITLeftShiftGenerator gen(leftOperand, rightOperand, destRegs, leftRegs, rightRegs);
 
     gen.generateFastPath(*this);
 
@@ -2556,7 +2556,12 @@ void LOLJIT::emitBitBinaryOpFastPath(const JSInstruction* currentInstruction)
 
     RELEASE_ASSERT(!leftOperand.isConst() || !rightOperand.isConst());
 
-    SnippetGenerator gen(leftOperand, rightOperand, resultRegs, leftRegs, rightRegs, s_scratch);
+    SnippetGenerator gen = [&] {
+        if constexpr (SnippetGenerator::needsScratchGPR)
+            return SnippetGenerator(leftOperand, rightOperand, resultRegs, leftRegs, rightRegs, s_scratch);
+        else
+            return SnippetGenerator(leftOperand, rightOperand, resultRegs, leftRegs, rightRegs);
+    }();
 
     gen.generateFastPath(*this);
 

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -628,7 +628,7 @@ CodePtr<JSEntryPtrTag> RTT::jsToWasmICEntrypoint() const
                 scratchFPR = wasmCallInfo.params[i].location.fpr();
 
             jit.loadValue(jsParam, scratchJSR);
-            slowPath.append(jit.branchIfNotNumber(scratchJSR, InvalidGPRReg));
+            slowPath.append(jit.branchIfNotNumber(scratchJSR));
             auto isInt32 = jit.branchIfInt32(scratchJSR);
             jit.unboxDouble(scratchJSR.payloadGPR(), scratchJSR.payloadGPR(), scratchFPR);
             if (argumentType(i).isF32())

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -309,8 +309,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(const 
         }
     }
 
-    // jsArg10 might overlap with regT0, so store 'this' argument first
-    jit.storeValue(jsUndefined(), calleeFrame.withOffset(CallFrameSlot::thisArgument * static_cast<int>(sizeof(Register))), jsArg10);
+    jit.storeValue(jsUndefined(), calleeFrame.withOffset(CallFrameSlot::thisArgument * static_cast<int>(sizeof(Register))));
     ASSERT(!wasmCC.calleeSaveRegisters.contains(importJSCellGPRReg, IgnoreVectors));
     materializeImportJSCell(jit, info, importIndex, importJSCellGPRReg);
     jit.storeCell(importJSCellGPRReg, calleeFrame.withOffset(CallFrameSlot::callee * static_cast<int>(sizeof(Register))));
@@ -343,7 +342,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(const 
             CCallHelpers::JumpList slowPath;
             JSValueRegs destJSR = wasmCallInfo.results[0].location.jsr();
 
-            slowPath.append(jit.branchIfNotNumber(JSRInfo::returnValueJSR, jit.scratchRegister(), DoNotHaveTagRegisters));
+            slowPath.append(jit.branchIfNotNumber(JSRInfo::returnValueJSR, DoNotHaveTagRegisters));
             slowPath.append(jit.branchIfNotInt32(JSRInfo::returnValueJSR, DoNotHaveTagRegisters));
             jit.zeroExtend32ToWord(JSRInfo::returnValueJSR.payloadGPR(), destJSR.payloadGPR());
             done.append(jit.jump());
@@ -362,7 +361,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(const 
             FPRReg dest = wasmCallInfo.results[0].location.fpr();
 
             CCallHelpers::JumpList done;
-            auto notANumber = jit.branchIfNotNumber(JSRInfo::returnValueJSR, jit.scratchRegister(), DoNotHaveTagRegisters);
+            auto notANumber = jit.branchIfNotNumber(JSRInfo::returnValueJSR, DoNotHaveTagRegisters);
             auto isDouble = jit.branchIfNotInt32(JSRInfo::returnValueJSR, DoNotHaveTagRegisters);
             // We're an int32
             jit.convertInt32ToFloat(GPRInfo::returnValueGPR, dest);
@@ -387,7 +386,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(const 
             FPRReg dest = wasmCallInfo.results[0].location.fpr();
             CCallHelpers::JumpList done;
 
-            auto notANumber = jit.branchIfNotNumber(JSRInfo::returnValueJSR, jit.scratchRegister(), DoNotHaveTagRegisters);
+            auto notANumber = jit.branchIfNotNumber(JSRInfo::returnValueJSR, DoNotHaveTagRegisters);
             auto isDouble = jit.branchIfNotInt32(JSValueRegs(JSRInfo::returnValueJSR), DoNotHaveTagRegisters);
             // We're an int32
             jit.convertInt32ToDouble(GPRInfo::returnValueGPR, dest);


### PR DESCRIPTION
#### 84f83abd45c912c01cee7bda9deffc2bc74dd85c
<pre>
[JSC] Remove various scratch registers as branchIfNumber etc. no longer need to take a scratch for 64bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=320861">https://bugs.webkit.org/show_bug.cgi?id=320861</a>
<a href="https://rdar.apple.com/183890729">rdar://183890729</a>

Reviewed by Sosuke Suzuki.

We had unnecessary scratch registers on 64bit because 32bit
branchIfNotNumber etc. requires a scratch register which was not
necessary in 64bit. But now 32bit JIT is removed so we can remove this
scratch register and remove the allocation of that. This patch
simplifies the code using branchIfNumber etc. and remove unnecessary
scratch register allocations.

Also drop extraGPRArgs from CCallHelpers as it is no longer necessary. It
was used only on 32bit to represent 64bit values in two registers.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::emitUntypedOrAnyBigIntBitOp):
(JSC::DFG::SpeculativeJIT::compileNotDoubleNeitherDoubleNorHeapBigIntNorStringStrictEquality):
(JSC::DFG::SpeculativeJIT::compilePeepHoleNotDoubleNeitherDoubleNorHeapBigIntNorStringStrictEquality):
(JSC::DFG::SpeculativeJIT::speculateNotDouble):
(JSC::DFG::SpeculativeJIT::speculateNeitherDoubleNorHeapBigInt):
(JSC::DFG::SpeculativeJIT::speculateNeitherDoubleNorHeapBigIntNorString):
(JSC::DFG::SpeculativeJIT::emitSwitchImm):
(JSC::DFG::SpeculativeJIT::compileNormalizeMapKey):
(JSC::DFG::SpeculativeJIT::compileToPropertyKeyOrNumber):
(JSC::DFG::SpeculativeJIT::compileToNumeric):
(JSC::DFG::SpeculativeJIT::compileCallNumberConstructor):
(JSC::DFG::SpeculativeJIT::compileProfileType):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileNeitherDoubleNorHeapBigIntToNotDoubleStrictEquality):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::storeValue):
(JSC::AssemblyHelpers::branchIfNumber):
(JSC::AssemblyHelpers::branchIfNotNumber):
(JSC::AssemblyHelpers::emitTypeOf):
* Source/JavaScriptCore/jit/CCallHelpers.h:
(JSC::CCallHelpers::ArgCollection::ArgCollection):
(JSC::CCallHelpers::ArgCollection::pushRegArg):
(JSC::CCallHelpers::ArgCollection::pushNonArg):
(JSC::CCallHelpers::ArgCollection::addGPRArg):
(JSC::CCallHelpers::ArgCollection::addStackArg):
(JSC::CCallHelpers::ArgCollection::addPoke):
(JSC::CCallHelpers::ArgCollection::argCount):
(JSC::CCallHelpers::calculatePokeOffset):
(JSC::CCallHelpers::pokeForArgument):
(JSC::CCallHelpers::stackAligned):
(JSC::CCallHelpers::marshallArgumentRegister):
(JSC::CCallHelpers::setupArgumentsImpl):
(JSC::CCallHelpers::setupArgumentsEntryImpl):
(JSC::CCallHelpers::setupArguments):
(JSC::CCallHelpers::setupArgumentsForIndirectCall):
(JSC::CCallHelpers::ArgCollection::pushExtraRegArg): Deleted.
(JSC::CCallHelpers::ArgCollection::addGPRExtraArg): Deleted.
* Source/JavaScriptCore/jit/JITAddGenerator.cpp:
(JSC::JITAddGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITArithmetic.cpp:
(JSC::JIT::emit_compareSlowImpl):
(JSC::JIT::emit_op_pow):
(JSC::JIT::emitBitBinaryOpFastPath):
* Source/JavaScriptCore/jit/JITBitAndGenerator.h:
(JSC::JITBitAndGenerator::JITBitAndGenerator):
* Source/JavaScriptCore/jit/JITBitBinaryOpGenerator.h:
(JSC::JITBitBinaryOpGenerator::JITBitBinaryOpGenerator):
* Source/JavaScriptCore/jit/JITBitOrGenerator.h:
(JSC::JITBitOrGenerator::JITBitOrGenerator):
* Source/JavaScriptCore/jit/JITBitXorGenerator.h:
(JSC::JITBitXorGenerator::JITBitXorGenerator):
* Source/JavaScriptCore/jit/JITDivGenerator.cpp:
(JSC::JITDivGenerator::loadOperand):
* Source/JavaScriptCore/jit/JITLeftShiftGenerator.cpp:
(JSC::JITLeftShiftGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITLeftShiftGenerator.h:
(JSC::JITLeftShiftGenerator::JITLeftShiftGenerator):
* Source/JavaScriptCore/jit/JITMulGenerator.cpp:
(JSC::JITMulGenerator::generateInline):
(JSC::JITMulGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITNegGenerator.cpp:
(JSC::JITNegGenerator::generateInline):
(JSC::JITNegGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emit_op_mov):
(JSC::JIT::emit_op_to_property_key_or_number):
(JSC::JIT::emit_op_to_number):
(JSC::JIT::emit_op_to_numeric):
(JSC::JIT::emit_op_switch_imm):
(JSC::JIT::emit_op_profile_type):
* Source/JavaScriptCore/jit/JITRightShiftGenerator.cpp:
(JSC::JITRightShiftGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITRightShiftGenerator.h:
(JSC::JITRightShiftGenerator::JITRightShiftGenerator):
* Source/JavaScriptCore/jit/JITSubGenerator.cpp:
(JSC::JITSubGenerator::generateInline):
(JSC::JITSubGenerator::generateFastPath):
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::numberConstructorCallThunkGenerator):
* Source/JavaScriptCore/lol/LOLJIT.cpp:
(JSC::LOL::LOLJIT::emitCompareSlowImpl):
(JSC::LOL::LOLJIT::emit_op_to_number):
(JSC::LOL::LOLJIT::emit_op_to_numeric):
(JSC::LOL::LOLJIT::emit_op_to_property_key_or_number):
(JSC::LOL::LOLJIT::emit_op_switch_imm):
(JSC::LOL::LOLJIT::emit_op_lshift):
(JSC::LOL::LOLJIT::emitBitBinaryOpFastPath):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::RTT::jsToWasmICEntrypoint const):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):

Canonical link: <a href="https://commits.webkit.org/318511@main">https://commits.webkit.org/318511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e8e8e77711ebadc3f991dd6282b36f1cca287fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178411 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141659 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52a0ec18-215b-4d54-af7f-212ed74e8947) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139089 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/244a6bb6-e5cd-41a8-9218-5669b9bff141) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119543 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/654c5f0b-ee49-469a-bc8c-d7febcd6081d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41316 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39668 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1512 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8339 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151716 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39350 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/multipart-three-part.py (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36482 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39684 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44949 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190454 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52018 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148244 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52699 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148017 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27081 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42732 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124964 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119601 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51217 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14325 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50602 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50842 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50664 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->