### PR TITLE
[WPT] Fix webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-loop-short-duration.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-loop-short-duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-loop-short-duration-expected.txt
@@ -1,0 +1,3 @@
+
+PASS audiobuffersource-loop-short-duration
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-loop-short-duration.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-loop-short-duration.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      audiobuffersource-loop-short-duration.html
+    </title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+      promise_test(async () => {
+        let sampleRate = 48000;
+        let context = new OfflineAudioContext(1, 128, sampleRate);
+
+        let buffer = context.createBuffer(1, 10, sampleRate);
+        let data = buffer.getChannelData(0);
+        for (let i = 0; i < 10; ++i) {
+          data[i] = 1.0;
+        }
+
+        let source = context.createBufferSource();
+        source.buffer = buffer;
+        source.loop = true;
+        // loopStart > duration
+        source.loopStart = 5 / sampleRate;
+        source.loopEnd = 8 / sampleRate;
+
+        source.connect(context.destination);
+        // Play only 2 frames (duration = 2/sampleRate)
+        source.start(0, 0, 2 / sampleRate);
+
+        let renderedBuffer = await context.startRendering();
+        let renderedData = renderedBuffer.getChannelData(0);
+        let expected = new Float32Array(128);
+        expected[0] = 1.0;
+        expected[1] = 1.0;
+        assert_array_equals(
+          renderedData,
+          expected,
+          'Rendered data should be exactly 2 frames of 1.0 followed by silence'
+        );
+      }, 'audiobuffersource-loop-short-duration');
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -219,8 +219,11 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
 
     // Avoid converting from time to sample-frames twice by computing
     // the grain end time first before computing the sample frame.
+    // When looping, playback is bounded by the loop points below (and stopped
+    // via m_endTime for a grain), so the grain duration must not clamp maxFrame
+    // here; otherwise a loopStart past the grain end collapses the loop range.
     unsigned maxFrame;
-    if (m_isGrain)
+    if (m_isGrain && !m_isLooping)
         maxFrame = AudioUtilities::timeToSampleFrame(m_grainOffset + m_grainDuration, bufferSampleRate);
     else
         maxFrame = bufferLength;


### PR DESCRIPTION
#### 03afbb84134b8c07a976f314fc4a2bf7fd8c7722
<pre>
[WPT] Fix webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-loop-short-duration.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=320865">https://bugs.webkit.org/show_bug.cgi?id=320865</a>

Reviewed by Darin Adler.

When a looping AudioBufferSourceNode was started with an explicit grain
duration, renderFromBuffer() clamped maxFrame to the grain end
(grainOffset + grainDuration). Intersecting the loop range against that
maxFrame could make virtualMinFrame (loopStart) exceed virtualMaxFrame,
producing a negative virtualDeltaFrames. The subsequent
`abs(pitchRate) &gt; virtualDeltaFrames` sanity check then bailed out and
the node output silence.

The grain-duration limit is already enforced separately via m_endTime
(set in adjustGrainParameters() and honored by updateSchedulingInfo()),
so when looping the read window should be bounded by the loop points, not
by the grain end. Only clamp maxFrame to the grain end for non-looping
grains. This matches the behavior of Blink &amp; Gecko.

Test: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-loop-short-duration.html

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-loop-short-duration-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-loop-short-duration.html: Added.
Import test from upstream WPT.

* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::renderFromBuffer):

Canonical link: <a href="https://commits.webkit.org/318514@main">https://commits.webkit.org/318514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c864949b182b720c9a8aaa786f971b5b72226ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141545 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b520d7d9-f630-4c7e-969e-96945923d581) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138993 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba6832dc-5dcc-4d0b-a9ae-00bbc7c27212) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119448 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/492b968c-2db5-4790-b64e-4947cbf89cf0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41221 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39574 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39259 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36368 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190340 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51903 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148145 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39828 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52585 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147920 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42636 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124849 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119449 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51103 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14234 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50488 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50728 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50550 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->