### PR TITLE
[JSC] Enable import defer proposal

### DIFF
--- a/JSTests/modules/import-meta-syntax.js
+++ b/JSTests/modules/import-meta-syntax.js
@@ -10,7 +10,7 @@ shouldNotThrow(() => {
 
 shouldThrow(() => {
     checkModuleSyntax(`(import.cocoa)`);
-}, `SyntaxError: Unexpected identifier 'cocoa'. "import." can only be followed with meta.:1`);
+}, `SyntaxError: Unexpected identifier 'cocoa'. "import." can only be followed with meta or defer.:1`);
 
 shouldThrow(() => {
     checkModuleSyntax(`(import["Cocoa"])`);
@@ -18,7 +18,7 @@ shouldThrow(() => {
 
 shouldThrow(() => {
     checkModuleSyntax(`import.cocoa`);
-}, `SyntaxError: Unexpected identifier 'cocoa'. "import." can only be followed with meta.:1`);
+}, `SyntaxError: Unexpected identifier 'cocoa'. "import." can only be followed with meta or defer.:1`);
 
 shouldThrow(() => {
     checkModuleSyntax(`import["Cocoa"]`);

--- a/JSTests/stress/import-syntax.js
+++ b/JSTests/stress/import-syntax.js
@@ -29,7 +29,7 @@ async function testSyntax(script, message) {
 
 testSyntaxError(`import)`, `SyntaxError: Unexpected token ')'. import call expects one or two arguments.`);
 testSyntaxError(`new import(`, `SyntaxError: Cannot use new with import.`);
-testSyntaxError(`import.hello()`, `SyntaxError: Unexpected identifier 'hello'. "import." can only be followed with meta.`);
+testSyntaxError(`import.hello()`, `SyntaxError: Unexpected identifier 'hello'. "import." can only be followed with meta or defer.`);
 testSyntaxError(`import[`, `SyntaxError: Unexpected token '['. import call expects one or two arguments.`);
 testSyntaxError(`import<`, `SyntaxError: Unexpected token '<'. import call expects one or two arguments.`);
 

--- a/JSTests/stress/modules-syntax-error.js
+++ b/JSTests/stress/modules-syntax-error.js
@@ -180,10 +180,6 @@ checkModuleSyntaxError(String.raw`
 import { hello, binding as
 `, `SyntaxError: Unexpected end of script:3`);
 
-checkModuleSyntaxError(String.raw`
-import defer * as ns from "mod"
-`, `SyntaxError: Unexpected token '*'. Expected 'from' before imported module name.:2`);
-
 // --------------- export -------------------
 
 checkModuleSyntaxError(String.raw`

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4141,7 +4141,7 @@ ImageControlsEnabled:
 
 ImportDeferEnabled:
   type: bool
-  status: testable
+  status: stable
   category: javascript
   humanReadableName: "Import Defer"
   humanReadableDescription: "Enable deferred module import."
@@ -4150,7 +4150,7 @@ ImportDeferEnabled:
   sharedPreferenceForWebProcess: true
   defaultValue:
     WebKit:
-      default: false
+      default: true
 
 InactiveMediaCaptureStreamRepromptIntervalInMinutes:
   type: double


### PR DESCRIPTION
#### 85e82ceefe1b2754706cf0def3eca10557d39384
<pre>
[JSC] Enable import defer proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=320867">https://bugs.webkit.org/show_bug.cgi?id=320867</a>
<a href="https://rdar.apple.com/183892394">rdar://183892394</a>

Reviewed by Keith Miller.

Enable import defer proposal[1] as it is reaching to stage-3.

[1]: <a href="https://github.com/tc39/proposal-defer-import-eval">https://github.com/tc39/proposal-defer-import-eval</a>

* JSTests/modules/import-meta-syntax.js:
(shouldThrow):
* JSTests/stress/import-syntax.js:
* JSTests/stress/modules-syntax-error.js:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/318481@main">https://commits.webkit.org/318481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7465e77fab845225df31e30887a7233bcc504c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188028 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141660 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/370b8fc7-b893-431c-a576-2811466d6b28) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139090 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45ac4f61-9c55-43cc-b852-d765f521b899) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119544 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/142c7484-ffe1-43d0-bce2-d19590a828bb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41321 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39671 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1513 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8343 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151721 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39354 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36483 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39685 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44950 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190455 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52019 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148246 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52700 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148019 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27065 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42737 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124965 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119602 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51218 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14329 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50603 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50843 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50665 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->