### PR TITLE
[WPT] webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative.html is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt
@@ -1,0 +1,17 @@
+
+PASS AudioBufferSourceNode supports negative playbackRate (-1.0)
+PASS AudioBufferSourceNode supports high negative playbackRate (-2.0)
+PASS AudioBufferSourceNode supports high negative playbackRate (-5.0)
+PASS AudioBufferSourceNode supports fractional negative playbackRate
+PASS AudioBufferSourceNode supports very low negative playbackRate (-0.02)
+PASS AudioBufferSourceNode enters loop backwards from offset > loopEnd
+PASS AudioBufferSourceNode clamps offset to loopStart for playbackRate < 0
+PASS AudioBufferSourceNode loops backwards with negative rate (offset in loop)
+PASS AudioBufferSourceNode handles offset exactly at duration with negative rate
+PASS AudioBufferSourceNode handles out-of-bounds start offset correctly
+PASS AudioBufferSourceNode performs sub-sample interpolation backwards
+PASS AudioBufferSourceNode ran successfully with zero delta and playbackRate 0
+PASS AudioBufferSourceNode loops backwards using entire buffer when loopStart > loopEnd
+PASS AudioBufferSourceNode loops backwards using clamped loopStart when loopStart < 0
+PASS AudioBufferSourceNode loops backwards using entire buffer when loopEnd < 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>AudioBufferSourceNode: Negative PlaybackRate Edge Cases</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+  <script>
+    /**
+     * Helper to run a test on AudioBufferSourceNode.
+     * @param {number} renderFrames - Total frames to render in
+     *     OfflineAudioContext.
+     * @param {number} bufferFrames - Number of frames in the AudioBuffer.
+     * @param {Function} setupSource - Callback to configure:
+     *     (source, sampleRate) => void
+     * @param {Function} verifyResult - Callback to verify the output:
+     *     (renderedData) => void
+     * @param {Array|null} bufferData - Optional initial buffer data. If null,
+     *     populated with 1.0, 2.0, 3.0...
+     */
+    async function runSourceNodeTest(
+      renderFrames, bufferFrames, setupSource, verifyResult,
+      bufferData = null) {
+      const sampleRate = 44100;
+      const context = new OfflineAudioContext(1, renderFrames, sampleRate);
+      const buffer = new AudioBuffer({
+        numberOfChannels: 1,
+        length: bufferFrames,
+        sampleRate: sampleRate
+      });
+      const channelData = buffer.getChannelData(0);
+
+      if (bufferData) {
+        channelData.set(bufferData);
+      } else {
+        // Populate with distinct values to easily verify interpolation.
+        for (let i = 0; i < bufferFrames; i++) {
+          channelData[i] = i + 1.0;
+        }
+      }
+
+      const source = new AudioBufferSourceNode(context, { buffer });
+      source.connect(context.destination);
+
+      setupSource(source, sampleRate);
+
+      const renderedBuffer = await context.startRendering();
+      verifyResult(renderedBuffer.getChannelData(0));
+    }
+
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -1.0;
+          source.start(0, 3 / sampleRate);
+        },
+        (renderedData) => {
+          assert_equals(renderedData[0], 4.0, 'Frame 0 should be 4.0');
+          assert_equals(renderedData[1], 3.0, 'Frame 1 should be 3.0');
+          assert_equals(renderedData[2], 2.0, 'Frame 2 should be 2.0');
+          assert_equals(renderedData[3], 1.0, 'Frame 3 should be 1.0');
+        }
+      );
+    }, 'AudioBufferSourceNode supports negative playbackRate (-1.0)');
+
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -2.0;
+          source.start(0, 3 / sampleRate);
+        },
+        (renderedData) => {
+          assert_equals(renderedData[0], 4.0, 'Frame 0 should be 4.0');
+          assert_equals(renderedData[1], 2.0, 'Frame 1 should be 2.0');
+          assert_equals(renderedData[2], 0.0, 'Frame 2 should be silence');
+          assert_equals(renderedData[3], 0.0, 'Frame 3 should be silence');
+        }
+      );
+    }, 'AudioBufferSourceNode supports high negative playbackRate (-2.0)');
+
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 8,
+        (source, sampleRate) => {
+          source.playbackRate.value = -5.0;
+          source.start(0, 7 / sampleRate);
+        },
+        (renderedData) => {
+          assert_equals(renderedData[0], 8.0, 'Frame 0 should be 8.0');
+          assert_equals(renderedData[1], 3.0, 'Frame 1 should be 3.0');
+          assert_equals(renderedData[2], 0.0, 'Frame 2 should be silence');
+          assert_equals(renderedData[3], 0.0, 'Frame 3 should be silence');
+        }
+      );
+    }, 'AudioBufferSourceNode supports high negative playbackRate (-5.0)');
+
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 2,
+        (source, sampleRate) => {
+          source.playbackRate.value = -0.5;
+          source.start(0, 1 / sampleRate);
+        },
+        (renderedData) => {
+          assert_equals(renderedData[0], 2.0, 'Frame 0 should be 2.0');
+          assert_equals(renderedData[1], 1.5, 'Frame 1 should be 1.5');
+          assert_equals(renderedData[2], 1.0, 'Frame 2 should be 1.0');
+          assert_equals(renderedData[3], 0.0, 'Frame 3 should be silence');
+        }
+      );
+    }, 'AudioBufferSourceNode supports fractional negative playbackRate');
+
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -0.02;
+          source.start(0, 3 / sampleRate);
+        },
+        (renderedData) => {
+          assert_approx_equals(renderedData[0], 4.00, 1e-4, 'Frame 0');
+          assert_approx_equals(renderedData[1], 3.98, 1e-4, 'Frame 1');
+          assert_approx_equals(renderedData[2], 3.96, 1e-4, 'Frame 2');
+          assert_approx_equals(renderedData[3], 3.94, 1e-4, 'Frame 3');
+        }
+      );
+    }, 'AudioBufferSourceNode supports very low negative playbackRate (-0.02)');
+
+    // EDGE CASE: Offset post loopEnd
+    promise_test(async () => {
+      await runSourceNodeTest(
+        6, 8,
+        (source, sampleRate) => {
+          source.loop = true;
+          source.loopStart = 2 / sampleRate;
+          source.loopEnd = 4 / sampleRate;
+          source.playbackRate.value = -1.0;
+          source.start(0, 6 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [7.0, 6.0, 5.0, 4.0, 3.0, 4.0];
+          for (let i = 0; i < expected.length; i++) {
+            assert_equals(
+              renderedData[i], expected[i],
+              `Frame ${i} should be ${expected[i]}`);
+          }
+        }
+      );
+    }, 'AudioBufferSourceNode enters loop backwards from offset > loopEnd');
+
+    // EDGE CASE: offset < loopStart
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 8,
+        (source, sampleRate) => {
+          source.loop = true;
+          source.loopStart = 4 / sampleRate;
+          source.loopEnd = 6 / sampleRate;
+          source.playbackRate.value = -1.0;
+          source.start(0, 2 / sampleRate);
+        },
+        (renderedData) => {
+          // Spec clamps offset to loopStart when playbackRate < 0.
+          const expected = [5.0, 6.0, 5.0, 6.0];
+          for (let i = 0; i < expected.length; i++) {
+            assert_equals(
+              renderedData[i], expected[i],
+              `Frame ${i} should be ${expected[i]}`);
+          }
+        }
+      );
+    }, 'AudioBufferSourceNode clamps offset to loopStart for playbackRate < 0');
+
+    // EDGE CASE: offset in loop
+    promise_test(async () => {
+      await runSourceNodeTest(
+        8, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -1.0;
+          source.loop = true;
+          source.loopStart = 1 / sampleRate;
+          source.loopEnd = 3 / sampleRate;
+          source.start(0, 2 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [3.0, 2.0, 3.0, 2.0, 3.0, 2.0, 3.0, 2.0];
+          for (let i = 0; i < expected.length; i++) {
+            assert_equals(
+              renderedData[i], expected[i],
+              `Frame ${i} should be ${expected[i]}`);
+          }
+        }
+      );
+    }, 'AudioBufferSourceNode loops backwards with negative rate ' +
+    '(offset in loop)');
+
+    // EDGE CASE: offset = buffer.duration
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -1.0;
+          source.start(0, 4 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [0.0, 4.0, 3.0, 2.0];
+          for (let i = 0; i < expected.length; i++) {
+            assert_equals(
+              renderedData[i], expected[i],
+              `Frame ${i} should be ${expected[i]}`);
+          }
+        }
+      );
+    }, 'AudioBufferSourceNode handles offset exactly at duration with ' +
+    'negative rate');
+
+    // EDGE CASE: offset > buffer.duration (out-of-bounds offset clamped)
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -1.0;
+          source.start(0, 10 / sampleRate);
+        },
+        (renderedData) => {
+          assert_equals(renderedData[0], 0.0, 'Frame 0 should be silence');
+          assert_equals(renderedData[1], 4.0, 'Frame 1 should be 4.0');
+          assert_equals(renderedData[2], 3.0, 'Frame 2 should be 3.0');
+          assert_equals(renderedData[3], 2.0, 'Frame 3 should be 2.0');
+        }
+      );
+    }, 'AudioBufferSourceNode handles out-of-bounds start offset correctly');
+
+    // Sub-sample interpolation backwards
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -1.0;
+          source.start(0, 2.5 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [3.5, 2.5, 1.5, 0.0];
+          for (let i = 0; i < expected.length; i++) {
+            assert_approx_equals(
+              renderedData[i], expected[i], 1e-4,
+              `Frame ${i} should be approx ${expected[i]}`);
+          }
+        }
+      );
+    }, 'AudioBufferSourceNode performs sub-sample interpolation backwards');
+
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.loop = true;
+          source.loopStart = 2 / sampleRate;
+          source.loopEnd = 2 / sampleRate;
+          source.playbackRate.value = 0;
+          source.start(0, 2 / sampleRate);
+        },
+        (renderedData) => {
+          assert_true(true, 'Test ran successfully!');
+        }
+      );
+    }, 'AudioBufferSourceNode ran successfully with zero delta and ' +
+    'playbackRate 0');
+
+    // Negative playback rate with constraint violation:
+    // loopStart > loopEnd (expects fallback)
+    promise_test(async () => {
+      await runSourceNodeTest(
+        8, 4,
+        (source, sampleRate) => {
+          source.loop = true;
+          source.loopStart = 3 / sampleRate;
+          source.loopEnd = 1 / sampleRate;
+          source.playbackRate.value = -1.0;
+          source.start(0, 3 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [4.0, 3.0, 2.0, 1.0, 4.0, 3.0, 2.0, 1.0];
+          assert_array_equals(renderedData, expected);
+        }
+      );
+    }, 'AudioBufferSourceNode loops backwards using entire buffer when ' +
+       'loopStart > loopEnd');
+
+    // Negative playback rate with constraint violation:
+    // loopStart < 0 (expects clamping)
+    promise_test(async () => {
+      await runSourceNodeTest(
+        8, 4,
+        (source, sampleRate) => {
+          source.loop = true;
+          source.loopStart = -1 / sampleRate;
+          source.loopEnd = 2 / sampleRate;
+          source.playbackRate.value = -1.0;
+          source.start(0, 3 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [4.0, 3.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0];
+          assert_array_equals(renderedData, expected);
+        }
+      );
+    }, 'AudioBufferSourceNode loops backwards using clamped loopStart when ' +
+       'loopStart < 0');
+
+    // Negative playback rate with constraint violation:
+    // loopEnd < 0 (expects fallback)
+    promise_test(async () => {
+      await runSourceNodeTest(
+        8, 4,
+        (source, sampleRate) => {
+          source.loop = true;
+          source.loopStart = 1 / sampleRate;
+          source.loopEnd = -2 / sampleRate;
+          source.playbackRate.value = -1.0;
+          source.start(0, 3 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [4.0, 3.0, 2.0, 1.0, 4.0, 3.0, 2.0, 1.0];
+          assert_array_equals(renderedData, expected);
+        }
+      );
+    }, 'AudioBufferSourceNode loops backwards using entire buffer when ' +
+       'loopEnd < 0');
+
+  </script>
+</body>
+
+</html>

--- a/LayoutTests/webaudio/AudioBufferSource/audiobuffersource-loop-comprehensive-expected.txt
+++ b/LayoutTests/webaudio/AudioBufferSource/audiobuffersource-loop-comprehensive-expected.txt
@@ -32,8 +32,8 @@ PASS   Case 12: illegal loop: loopStartFrame > loopEndFrame is identical to the 
 PASS   Case 12: illegal loop: loopStartFrame > loopEndFrame: tail contains only the constant 0.
 PASS   Case 13: illegal loop: loopStartFrame == loopEndFrame is identical to the array [0,1,2,3,4,5,6,7,0,1,2,3,4,5,6,7...].
 PASS   Case 13: illegal loop: loopStartFrame == loopEndFrame: tail contains only the constant 0.
-PASS   Case 14: illegal loop: loopStartFrame < 0 is identical to the array [0,1,2,3,4,5,6,7,0,1,2,3,4,5,6,7...].
-PASS   Case 14: illegal loop: loopStartFrame < 0: tail contains only the constant 0.
+PASS   Case 14: illegal loop: loopStartFrame < 0 (clamps to 0) is identical to the array [0,1,2,0,1,2,0,1,2,0,1,2,0,1,2,0...].
+PASS   Case 14: illegal loop: loopStartFrame < 0 (clamps to 0): tail contains only the constant 0.
 PASS   Case 15: illegal loop: loopEndFrame > bufferLength is identical to the array [0,1,2,3,4,5,6,7,0,1,2,3,4,5,6,7...].
 PASS   Case 15: illegal loop: loopEndFrame > bufferLength: tail contains only the constant 0.
 PASS   Case 16: loop from 3 -> 6 with offset 1 for 20 frames is identical to the array [1,2,3,4,5,3,4,5,3,4,5,3,4,5,3,4...].

--- a/LayoutTests/webaudio/AudioBufferSource/audiobuffersource-loop-comprehensive.html
+++ b/LayoutTests/webaudio/AudioBufferSource/audiobuffersource-loop-comprehensive.html
@@ -154,12 +154,12 @@
         },
 
         {
-          description: 'illegal loop: loopStartFrame < 0',
+          description: 'illegal loop: loopStartFrame < 0 (clamps to 0)',
           loopStartFrame: -8,
           loopEndFrame: 3,
           renderFrames: 16,
           playbackRate: 1,
-          expected: [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7]
+          expected: [0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0]
         },
 
         {

--- a/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated-loop.html
+++ b/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated-loop.html
@@ -20,7 +20,7 @@
         description:"Test looping playback at -0.75 playbackRate",
         offsetFrame:0,
         renderFrames:renderFrames,
-        expected:[104,103.25,102.5,101.75,101,100.25,102,103.75,103,102.25],
+        expected:[100,103,103.5,102.75,102,101.25,100.5,101,104,103.25],
     }];
 
     function go() {

--- a/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated.html
+++ b/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated.html
@@ -30,7 +30,9 @@
 
         bufferSource.connect(context.destination);
         bufferSource.playbackRate.value = -0.75;
-        bufferSource.start(0);
+        // With a negative playbackRate, playback starts at the given offset and moves
+        // backwards, so start at the last sample to play the whole buffer in reverse.
+        bufferSource.start(0, (sourceFrames - 1) / sampleRate);
 
         context.oncomplete = checkAllTests;
         context.startRendering();

--- a/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-loop.html
+++ b/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-loop.html
@@ -20,7 +20,7 @@
         description:"Test looping playback at -1 playbackRate",
         offsetFrame:0,
         renderFrames:renderFrames,
-        expected:[104, 103, 102, 101, 100, 104, 103, 102, 101, 100],
+        expected:[100, 104, 103, 102, 101, 100, 104, 103, 102, 101],
     }];
 
     function go() {

--- a/LayoutTests/webaudio/audiobuffersource-negative-playbackrate.html
+++ b/LayoutTests/webaudio/audiobuffersource-negative-playbackrate.html
@@ -30,7 +30,9 @@
 
         bufferSource.connect(context.destination);
         bufferSource.playbackRate.value = -1;
-        bufferSource.start(0);
+        // With a negative playbackRate, playback starts at the given offset and moves
+        // backwards, so start at the last sample to play the whole buffer in reverse.
+        bufferSource.start(0, (sourceFrames - 1) / sampleRate);
 
         context.oncomplete = checkAllTests;
         context.startRendering();

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -235,9 +235,17 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
     double virtualMinFrame = 0;
     double virtualDeltaFrames = maxFrame;
 
-    if (m_isLooping && (m_loopStart || m_loopEnd) && m_loopStart >= 0 && m_loopEnd > 0 && m_loopStart < m_loopEnd) {
+    // Per the loopStart attribute definition, "If loopStart is less than 0, looping will begin at 0",
+    // so a negative loopStart is clamped rather than treated as a constraint violation. If the
+    // resulting range is empty (loopStart >= loopEnd) or loopEnd is not positive, the constraints are
+    // violated and the loop covers the entire buffer.
+    // Note that the spec's normative playback algorithm contradicts the attribute definition here by
+    // guarding on loopStart >= 0; WPT follows the attribute definition, which is what we implement.
+    // See https://github.com/WebAudio/web-audio-api/issues/2689.
+    double clampedLoopStart = std::max(0.0, m_loopStart);
+    if (m_isLooping && (m_loopStart || m_loopEnd) && m_loopEnd > 0 && clampedLoopStart < m_loopEnd) {
         // Convert from seconds to sample-frames.
-        double loopMinFrame = m_loopStart * m_buffer->sampleRate();
+        double loopMinFrame = clampedLoopStart * m_buffer->sampleRate();
         double loopMaxFrame = m_loopEnd * m_buffer->sampleRate();
 
         virtualMaxFrame = std::min(loopMaxFrame, virtualMaxFrame);
@@ -245,7 +253,7 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
         virtualDeltaFrames = virtualMaxFrame - virtualMinFrame;
     }
 
-    if (m_virtualReadIndex >= virtualMaxFrame) {
+    if (!reverse && m_virtualReadIndex >= virtualMaxFrame) {
         // Early exit to avoid going past the end of the source buffer.
         if (!m_isLooping)
             return false;
@@ -264,8 +272,10 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
 
     // Adjust the read index by the startFrameOffset (compensated by the pitch rate) because
     // we always start output on a frame boundary with interpolation if necessary.
-    if (startFrameOffset < 0 && pitchRate)
-        virtualReadIndex += std::abs(startFrameOffset * pitchRate);
+    // Since startFrameOffset is negative, this moves the index forward for a positive pitch rate
+    // and backward for a negative one.
+    if (startFrameOffset < 0)
+        virtualReadIndex -= startFrameOffset * pitchRate;
 
     bool needsInterpolation = virtualReadIndex != floor(virtualReadIndex)
         || virtualDeltaFrames != floor(virtualDeltaFrames)
@@ -274,6 +284,23 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
 
     // Render loop - reading from the source buffer to the destination using linear interpolation.
     int framesToProcess = numberOfFrames;
+
+    if (reverse) {
+        // When looping backwards, the spec clamps an offset that lands before loopStart up to loopStart.
+        if (m_isLooping)
+            virtualReadIndex = std::max(virtualReadIndex, virtualMinFrame);
+
+        // The read index can start at the end of the buffer, since the offset is clamped to the
+        // buffer's duration. Emit leading silence until it walks back into the buffer; pitchRate is
+        // negative here, so adding it decreases the index.
+        while (framesToProcess > 0 && virtualReadIndex >= bufferLength) {
+            for (unsigned i = 0; i < numberOfChannels; ++i)
+                m_destinationChannels[i][writeIndex] = 0;
+            ++writeIndex;
+            virtualReadIndex += pitchRate;
+            --framesToProcess;
+        }
+    }
 
     // Optimize for the very common case of playing back with pitchRate == 1.
     // We can avoid the linear interpolation.
@@ -305,7 +332,7 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
         int readIndex = static_cast<int>(virtualReadIndex);
         int deltaFrames = static_cast<int>(virtualDeltaFrames);
         int maxFrame = static_cast<int>(virtualMaxFrame);
-        if (readIndex > maxFrame)
+        if (!m_isLooping && readIndex > maxFrame)
             readIndex = maxFrame;
 
         int minFrame = static_cast<int>(virtualMinFrame) - 1;
@@ -615,9 +642,12 @@ void AudioBufferSourceNode::adjustGrainParameters()
     // at a sub-sample position since it will degrade the quality.
     // When aligned to the sample-frame the playback will be identical to the PCM data stored in the buffer.
     // Since playbackRate == 1 is very common, it's worth considering quality.
-    if (playbackRate().value() < 0)
-        m_virtualReadIndex = AudioUtilities::timeToSampleFrame(m_grainOffset + m_grainDuration, m_buffer->sampleRate()) - 1;
-    else
+    if (playbackRate().value() < 0) {
+        // For a negative playback rate we start reading at the offset and play backwards from
+        // there. Compute the index directly (rather than via timeToSampleFrame) to preserve the
+        // sub-sample position, which is needed for correct backwards interpolation.
+        m_virtualReadIndex = m_grainOffset * m_buffer->sampleRate();
+    } else
         m_virtualReadIndex = AudioUtilities::timeToSampleFrame(m_grainOffset, m_buffer->sampleRate());
 }
 


### PR DESCRIPTION
#### e8df30cefb3766529d984d88e94ef5629348c38d
<pre>
[WPT] webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=320870">https://bugs.webkit.org/show_bug.cgi?id=320870</a>

Reviewed by NOBODY (OOPS!).

When playing an AudioBufferSourceNode backwards (negative playbackRate), the
backwards playhead was always initialized to the last frame of the buffer
(grainOffset + grainDuration - 1) rather than to the requested start offset.
Since the default grainDuration is (bufferDuration - grainOffset), this sum
always collapses to the buffer duration, so the offset passed to start() was
effectively discarded for negative rates. This produced correct output only
by coincidence, whenever the offset happened to equal the last frame.

Align the behavior with the spec, which says &quot;Looping does not affect the
interpretation of the offset argument of start(). Playback always starts at the
requested offset&quot;: for a negative rate the read index now starts at the offset
and plays backwards from there. The index is computed directly
(offset * sampleRate) rather than via timeToSampleFrame() so that the
sub-sample position is preserved for backwards interpolation.

This also required teaching the reverse render path a few things it previously
only handled for forward playback:
  - The forward &quot;past the end of the buffer, wrap to loopStart&quot; early-exit is
    now skipped for negative rates, which instead read backwards through any
    tail past loopEnd before entering the loop.
  - When looping backwards, an offset that lands before loopStart is clamped up
    to loopStart.
  - An offset at or beyond the buffer&apos;s duration now emits leading silence until
    the playhead re-enters the buffer, instead of clamping to the buffer end.
  - The pitchRate == -1 fast path no longer clamps the read index down to the
    loop end when looping, so it can start in the tail.

Additionally, a negative loopStart is now clamped to 0 rather than disabling the
loop range and playing the whole buffer, so the loop plays from 0 to loopEnd.
This follows the loopStart attribute definition (&quot;If loopStart is less than 0,
looping will begin at 0&quot;) and is what the imported WPT test asserts. Note that
the spec is self-inconsistent here: its normative playback algorithm instead
guards on loopStart &gt;= 0 and falls back to the entire buffer, which is what we
did before and what Firefox still does. We follow the attribute definition and
WPT; the contradiction is tracked in
<a href="https://github.com/WebAudio/web-audio-api/issues/2689.">https://github.com/WebAudio/web-audio-api/issues/2689.</a>
audiobuffersource-loop-comprehensive.html is updated to match.

Test: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative.html

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative.html: Added.
Import WPT test from upstream.

* LayoutTests/webaudio/AudioBufferSource/audiobuffersource-loop-comprehensive.html:
* LayoutTests/webaudio/AudioBufferSource/audiobuffersource-loop-comprehensive-expected.txt:
Rebaseline the negative-loopStart case: it now clamps loopStart to 0 and loops
[0, loopEnd) instead of looping the whole buffer.

* LayoutTests/webaudio/audiobuffersource-negative-playbackrate-loop.html:
* LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated-loop.html:
Update expected output to start at the requested offset.

* LayoutTests/webaudio/audiobuffersource-negative-playbackrate.html:
* LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated.html:
Start at the last sample so the whole buffer is played in reverse.

* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::renderFromBuffer):
Clamp a negative loopStart to 0; skip the forward loop-reset early-exit for
negative rates; adjust the start-frame offset in the correct direction; clamp a
backwards offset up to loopStart when looping and emit leading silence for an
out-of-bounds backwards offset; do not clamp the read index to the loop end when
looping in the pitchRate == -1 path.

(WebCore::AudioBufferSourceNode::adjustGrainParameters):
Start the backwards playhead at the offset, preserving the sub-sample position.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8df30cefb3766529d984d88e94ef5629348c38d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141816 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139217 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96665 "1 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/abe54d79-b3d0-4244-9f5e-d81ad2f97a93) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42775 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119671 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e54f444d-ca5b-4a64-aa5f-bf86d9a23612) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41441 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39800 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8459 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151841 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39470 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190609 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148382 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52854 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36093 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148150 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42855 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125121 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119757 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51372 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14445 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50757 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50997 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50819 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->