### PR TITLE
[run-benchmark] Add linux driver support for --generate-pgo-profiles

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import shutil
 import sys
 import tempfile
 import logging
@@ -48,6 +49,8 @@ class LinuxBrowserDriver(BrowserDriver):
     def __init__(self, browser_args):
         super().__init__(browser_args)
         self._temp_profiledir = None
+        self._pgo_collection_active = False
+        self._pgo_profile_directory = None
         self.process_name = self._get_first_executable_path_from_list(self.process_search_list)
         if self.process_name is None:
             raise ValueError('Cant find executable for browser {browser_name}. Searched list: {browser_process_list}'.format(
@@ -64,6 +67,10 @@ class LinuxBrowserDriver(BrowserDriver):
         self._temp_profiledir = tempfile.mkdtemp()
         self._test_environ = dict(os.environ)
         self._test_environ['HOME'] = self._temp_profiledir
+        if self._pgo_collection_active and not self._test_environ.get('LLVM_PROFILE_FILE'):
+            profile_dir = self.pgo_profile_output_directories[0]
+            self._test_environ['LLVM_PROFILE_FILE'] = os.path.join(
+                profile_dir, '{browser}-%p-%m.profraw'.format(browser=self.browser_name or 'webkit'))
 
     def prepare_initial_env(self, config):
         pass
@@ -72,7 +79,9 @@ class LinuxBrowserDriver(BrowserDriver):
         self._clean_temp_profiledir()
 
     def restore_env_after_all_testing(self):
-        pass
+        if self._pgo_profile_directory:
+            force_remove(self._pgo_profile_directory)
+            self._pgo_profile_directory = None
 
     def close_browsers(self):
         if self._browser_process:
@@ -83,21 +92,34 @@ class LinuxBrowserDriver(BrowserDriver):
                     _log.info('Killing browser {browser_name} with pid {browser_pid} and cmd: {browser_cmd}'.format(
                                browser_name=self.browser_name, browser_pid=self._browser_process.pid,
                                browser_cmd=' '.join(main_browser_process.cmdline()).strip() or main_browser_process.name()))
-                    main_browser_process.kill()
-                    for browser_child in browser_children:
-                        if browser_child.is_running():
-                            try:
-                                browser_child.kill()
-                                _log.info('Killed still alive {browser_name} child with pid {browser_pid} and cmd: {browser_cmd}'.format(
-                                          browser_name=self.browser_name, browser_pid=browser_child.pid,
-                                          browser_cmd=' '.join(browser_child.cmdline()).strip() or browser_child.name()))
-                            except psutil.NoSuchProcess:
-                                # There can be a race condition where the child ends in the interval between the is_running() and kill() calls.
-                                pass
+                    if self._pgo_collection_active:
+                        self._graceful_pgo_teardown(main_browser_process, browser_children)
+                    else:
+                        main_browser_process.kill()
+                        for browser_child in browser_children:
+                            if browser_child.is_running():
+                                try:
+                                    browser_child.kill()
+                                    _log.info('Killed still alive {browser_name} child with pid {browser_pid} and cmd: {browser_cmd}'.format(
+                                              browser_name=self.browser_name, browser_pid=browser_child.pid,
+                                              browser_cmd=' '.join(browser_child.cmdline()).strip() or browser_child.name()))
+                                except psutil.NoSuchProcess:
+                                    # Race: child ended between is_running() and kill().
+                                    pass
                 else:
                     _log.info('Killing browser {browser_name} with pid {browser_pid}'.format(
                                browser_name=self.browser_name, browser_pid=self._browser_process.pid))
-                    self._browser_process.kill()
+                    if self._pgo_collection_active:
+                        self._browser_process.terminate()
+                        try:
+                            rc = self._browser_process.wait(timeout=10)
+                            _log.info('[pgo] browser pid {pid} exited with {rc} (negative value = killed by that signal)'.format(
+                                      pid=self._browser_process.pid, rc=rc))
+                        except subprocess.TimeoutExpired:
+                            _log.warning('[pgo] browser pid {pid} did not exit within timeout; SIGKILL'.format(pid=self._browser_process.pid))
+                            self._browser_process.kill()
+                    else:
+                        self._browser_process.kill()
                     _log.warning('python psutil not found, can\'t check for '
                                  'still-alive browser children to kill.')
             else:
@@ -105,6 +127,74 @@ class LinuxBrowserDriver(BrowserDriver):
                             browser_name=self.browser_name, browser_pid=self._browser_process.pid,
                             browser_retcode=self._browser_process.returncode))
         self._clean_temp_profiledir()
+
+    def _graceful_pgo_teardown(self, main_browser_process, browser_children):
+        all_procs = [main_browser_process] + browser_children
+        proc_names = {}
+        for proc in all_procs:
+            try:
+                proc_names[proc.pid] = ' '.join(proc.cmdline()).strip() or proc.name()
+            except psutil.NoSuchProcess:
+                proc_names[proc.pid] = '<gone>'
+        _log.info('[pgo] graceful teardown of {n} process(es): {names}'.format(
+                  n=len(all_procs), names=proc_names))
+        # Leave the main process last as it might be a wrapper script like run-minibrowser
+        for proc in browser_children + [main_browser_process]:
+            try:
+                proc.terminate()
+            except psutil.NoSuchProcess:
+                pass
+        gone, alive = psutil.wait_procs(all_procs, timeout=10, callback=lambda proc: _log.info(
+            '[pgo] pid {pid} ({name}) exited with {rc}'.format(
+                pid=proc.pid, name=proc_names.get(proc.pid, '?'), rc=proc.returncode)))
+        for proc in alive:
+            _log.warning('[pgo] pid {pid} ({name}) did not exit within timeout; SIGKILL (profile might be lost)'.format(
+                         pid=proc.pid, name=proc_names.get(proc.pid, '?')))
+            try:
+                proc.kill()
+            except psutil.NoSuchProcess:
+                pass
+
+    @property
+    def pgo_profile_output_directories(self):
+        # A caller-set LLVM_PROFILE_FILE wins; its directory must be absolute (LLVM writes relative to
+        # the browser cwd, which we can't discover) and free of %p/%m/%t wildcards (which would make
+        # the real output dir vary at runtime). Otherwise return the private per-run dir that
+        # prepare_pgo_profile_collection() created.
+        profile_file = os.environ.get('LLVM_PROFILE_FILE')
+        if profile_file:
+            if not os.path.isabs(profile_file):
+                raise ValueError('LLVM_PROFILE_FILE={profile_file} must be an absolute path so .profraw '
+                                 'lands in a discoverable directory.'.format(profile_file=profile_file))
+            directory = os.path.dirname(os.path.realpath(profile_file))
+            if '%' in directory:
+                raise ValueError('LLVM_PROFILE_FILE={profile_file} expands a wildcard in its directory; '
+                                 'keep %p/%m in the filename only.'.format(profile_file=profile_file))
+            return [directory]
+        return [self._pgo_profile_directory]
+
+    def prepare_pgo_profile_collection(self):
+        self._pgo_collection_active = True
+        if os.environ.get('LLVM_PROFILE_FILE'):
+            # Access (and thereby validate) the caller's path now so a bad LLVM_PROFILE_FILE fails
+            # before the run. We neither create the dir (LLVM does, on first write) nor wipe it (could
+            # be a real location like /home); collect() tolerates its absence if the run flushed nothing.
+            assert self.pgo_profile_output_directories
+            return
+        # Driver-owned output: a fresh, unique dir per iteration -- mkdtemp so concurrent runs don't
+        # collide, and each iteration starts clean so collect copies only its own .profraw.
+        if self._pgo_profile_directory:
+            force_remove(self._pgo_profile_directory)
+        self._pgo_profile_directory = tempfile.mkdtemp(prefix='WebKitPGO-')
+
+    def collect_pgo_profile(self, destination):
+        _log.info('Copying PGO profiles from {sources} to {destination}'.format(
+                  sources=self.pgo_profile_output_directories, destination=destination))
+        for directory in self.pgo_profile_output_directories:
+            if not os.path.isdir(directory):
+                _log.warning('[pgo] no profile directory {directory}; the run flushed nothing'.format(directory=directory))
+                continue
+            shutil.copytree(directory, destination, dirs_exist_ok=True)
 
     def launch_url(self, url, options, browser_build_path, browser_path):
         if not self._default_browser_arguments:


### PR DESCRIPTION
#### 8075520c2775e69809ccc311ab1346450314605c
<pre>
[run-benchmark] Add linux driver support for --generate-pgo-profiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=317615">https://bugs.webkit.org/show_bug.cgi?id=317615</a>

Reviewed by NOBODY (OOPS!).

Implement the three hooks used by the benchmark runner to setup and
collect the profile data, initially for clang-based instrumented builds.
This includes ensuring LLVM_PROFILE_FILE, either set by the user or a
default temporary fallback, is injected into the browser&apos;s environment
during each iteration.

Note that, as the benchmarked browser runs with a temporary home, a
custom LLVM_PROFILE_FILE should not use relative paths, as the collected
profile would be deleted after the run. Also, wildcards like %p, %m, or
%t should live in the filename component of the path. This ensures the
script knows beforehand which directory will contain the collected
profiles.

After the iterations finishes, the individual .profraw files are copied
into the diagnose directory for further processing by other tools, like
merging, inspection, etc.

Also, ensure we first request a graceful termination of the browser
process tree in order to allow the collected profile data to be flushed
cleanly. If not collecting the profiles, we keep the original SIGKILL
approach.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py:
(LinuxBrowserDriver.__init__):
(LinuxBrowserDriver.prepare_env):
(LinuxBrowserDriver.restore_env_after_all_testing):
(LinuxBrowserDriver.close_browsers):
(LinuxBrowserDriver._graceful_pgo_teardown):
(LinuxBrowserDriver):
(LinuxBrowserDriver.pgo_profile_output_directories):
(LinuxBrowserDriver.prepare_pgo_profile_collection):
(LinuxBrowserDriver.collect_pgo_profile):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8075520c2775e69809ccc311ab1346450314605c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187923 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138999 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96510 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119454 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/177632 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41230 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39581 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39265 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36380 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190352 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51915 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148157 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52597 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147932 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42647 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119461 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51115 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14240 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50740 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->