### PR TITLE
AudioContext.close() should reject when called on an already-closed context

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-state-change-after-close.http.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-state-change-after-close.http.window-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Call close on a closed AudioContext assert_unreached: Should have rejected: A closed AudioContext should reject calls to close Reached unreachable code
+PASS Call close on a closed AudioContext
 PASS Call resume on a closed AudioContext
 PASS Call suspend on a closed AudioContext
 

--- a/LayoutTests/webaudio/construct-node-with-closed-context-expected.txt
+++ b/LayoutTests/webaudio/construct-node-with-closed-context-expected.txt
@@ -42,7 +42,7 @@ PASS context.createWaveShaper() did not throw exception.
 PASS context.createScriptProcessor() did not throw exception.
 PASS context.suspend() rejected promise  with InvalidStateError: Context is closed.
 PASS context.resume() rejected promise  with InvalidStateError: Context is closed.
-PASS context.close() rejected promise  with InvalidStateError: The object is in an invalid state..
+PASS context.close() rejected promise  with InvalidStateError: Context is closed.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -233,13 +233,8 @@ AudioTimestamp AudioContext::getOutputTimestamp()
 
 void AudioContext::close(DOMPromiseDeferred<void>&& promise)
 {
-    if (isStopped()) {
-        promise.reject(ExceptionCode::InvalidStateError);
-        return;
-    }
-
-    if (isClosed()) {
-        promise.resolve();
+    if (isStopped() || isClosed()) {
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "Context is closed"_s });
         return;
     }
 


### PR DESCRIPTION
#### 395cd1b2edcfaa8546d61e19fe4b8d1bae7999e2
<pre>
AudioContext.close() should reject when called on an already-closed context
<a href="https://bugs.webkit.org/show_bug.cgi?id=320872">https://bugs.webkit.org/show_bug.cgi?id=320872</a>

Reviewed by Darin Adler.

Calling close() on an AudioContext that is already in the &quot;closed&quot; state
resolved the returned promise instead of rejecting it. Per the Web Audio
spec, close() must reject with an InvalidStateError in this case, matching
the behavior of suspend() and resume() (which were already correct). Both
Blink and Gecko reject as expected.

Merge the already-closed check into the existing stopped check so that
close() rejects with an InvalidStateError, consistent with
suspendRendering() and resumeRendering().

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-state-change-after-close.http.window-expected.txt:
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::close):

Canonical link: <a href="https://commits.webkit.org/318522@main">https://commits.webkit.org/318522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a6e189344d374d68d48dbde66787d0bceb5164c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141593 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e33dd5c-07b7-4eb9-9779-973d7e222d6a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139029 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79035242-2e53-418d-9932-cec6b8c66ecd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119484 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cfe3f66b-edab-48e3-8c9e-0e9074fb9364) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/177668 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41259 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39611 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1453 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8280 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151659 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39290 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/multipart-three-part.py (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36416 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39618 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190388 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/177748 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159316 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148184 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39829 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52633 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147958 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42675 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124898 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119501 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51151 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14265 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50536 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50776 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->