### PR TITLE
[YARR] Let `\A` and `\z` use the anchoring optimizations of non-multiline `^` and `$`

### DIFF
--- a/JSTests/microbenchmarks/regexp-buffer-boundary-anchor-end.js
+++ b/JSTests/microbenchmarks/regexp-buffer-boundary-anchor-end.js
@@ -1,0 +1,19 @@
+//@ requireOptions("--useRegExpBufferBoundaries=1")
+
+(function() {
+    var urls = [];
+    for (var i = 0; i < 1000; i++)
+        urls.push("https://cdn.example.com/assets/build/" + i + "/static/media/components/very/deeply/nested/directory/structure/image-" + i + (i % 7 == 0 ? ".png" : ".webp?width=1024&quality=80"));
+
+    var re = /\.png\z/u;
+    var n = 400;
+    var result = 0;
+    for (var i = 0; i < n; i++) {
+        for (var j = 0; j < urls.length; j++) {
+            if (re.test(urls[j]))
+                result++;
+        }
+    }
+    if (result !== n * 143)
+        throw "Error: bad result: " + result;
+})();

--- a/JSTests/microbenchmarks/regexp-buffer-boundary-anchor-start.js
+++ b/JSTests/microbenchmarks/regexp-buffer-boundary-anchor-start.js
@@ -1,0 +1,20 @@
+//@ requireOptions("--useRegExpBufferBoundaries=1")
+
+(function() {
+    var source = "";
+    for (var i = 0; i < 4000; i++)
+        source += "const value" + i + " = compute(" + i + "); // no shebang, no BOM\n";
+
+    var shebang = /\A#!.*\n/u;
+    var bom = /\A\uFEFF/u;
+    var n = 1000;
+    var result = 0;
+    for (var i = 0; i < n; i++) {
+        if (shebang.test(source))
+            result++;
+        if (bom.test(source))
+            result++;
+    }
+    if (result !== 0)
+        throw "Error: bad result: " + result;
+})();

--- a/JSTests/stress/regexp-buffer-boundaries-anchoring.js
+++ b/JSTests/stress/regexp-buffer-boundaries-anchoring.js
@@ -1,0 +1,109 @@
+//@ requireOptions("--useRegExpBufferBoundaries=1")
+
+// \A and \z participate in the same anchoring optimizations as non-multiline ^ and $
+// (once-through alternatives and end-anchored fixed-size matching). Check that these
+// patterns still produce exactly the same results as their lookaround equivalents at
+// every start position, for every flag combination.
+
+function shouldBe(actual, expected, message)
+{
+    if (actual !== expected)
+        throw new Error(message + ": expected " + expected + " but got " + actual);
+}
+
+const inputs = [
+    "", "a", "b", "c", "ab", "ba", "abc", "cba", "aab", "aaaa", "aaaaaaaaaaaab",
+    "foo", "xfoo", "foox", "barfoo", "foobar", "afoob", "bcd", "abcd", "xbcd", "bcdx",
+    "\n", "\r\n", "a\n", "\na", "a\nb", "b\na", "ab\nfoo", "foo\nbar", "foo\r\n", "\nabc",
+    "abc\n", "b\nfoo\nfoo", "foo\nfoo\n", "a\r\n\n", "a b", "GET /", "PUT",
+];
+
+const boundaryToLookaround = new Map([
+    ["\\A", "(?<![^])"],
+    ["\\z", "(?![^])"],
+    ["\\Z", "(?=(?:\\r\\n|\\n|\\r|\\u2028|\\u2029)?(?![^]))"],
+]);
+
+function checkEquivalent(source, flags)
+{
+    let reference = source;
+    for (const [boundary, lookaround] of boundaryToLookaround)
+        reference = reference.replaceAll(boundary, lookaround);
+    const re = new RegExp(source, flags);
+    const referenceRE = new RegExp(reference, flags);
+    for (const input of inputs) {
+        for (let lastIndex = 0; lastIndex <= input.length; ++lastIndex) {
+            re.lastIndex = lastIndex;
+            referenceRE.lastIndex = lastIndex;
+            shouldBe(JSON.stringify(re.exec(input)), JSON.stringify(referenceRE.exec(input)), "/" + source + "/" + flags + " on " + JSON.stringify(input) + " at " + lastIndex);
+            shouldBe(re.lastIndex, referenceRE.lastIndex, "lastIndex of /" + source + "/" + flags + " on " + JSON.stringify(input) + " at " + lastIndex);
+        }
+        shouldBe(JSON.stringify(input.split(re)), JSON.stringify(input.split(referenceRE)), "split /" + source + "/" + flags + " on " + JSON.stringify(input));
+        if (flags.includes("g"))
+            shouldBe(JSON.stringify(input.replace(re, "<$&>")), JSON.stringify(input.replace(referenceRE, "<$&>")), "replace /" + source + "/" + flags + " on " + JSON.stringify(input));
+    }
+}
+
+const sources = [
+    // \A anchored alternatives (once-through) mixed with looping ones.
+    "\\A",
+    "\\Afoo",
+    "\\Afoo|bar",
+    "bar|\\Afoo",
+    "\\Afoo|foo",
+    "\\Aa|\\Ab|c",
+    "\\A(?:foo|bar)",
+    "\\A(?:a+|b)*c",
+    "\\A(a)(b)?",
+    "(?:\\Aa|b)+",
+    "(?:x|\\Ay)z",
+    "\\Aa*b",
+    "\\A[ab]{2,}",
+    "(\\A)?x",
+    "(\\Aa|b)\\1",
+    "(?<n>\\Aa)b|\\k<n>c",
+    "(?=\\Aa)a",
+    "(?!\\Aa)[ab]",
+    "(?<=\\Aa)b",
+    "(?<!\\Ab)a",
+    "(?:(?<=\\A.)b|c)",
+    "\\Afoo|^bar",
+    "^a|\\Ab|c$",
+    "\\A(?:GET|PUT|POST) ",
+    // \z end anchoring (fixed and variable size).
+    "\\z",
+    "foo\\z",
+    "foo\\z|bar",
+    "bar|foo\\z",
+    "(?:ab|cd)\\z",
+    "(?:a|bcd)\\z",
+    "a\\zb",
+    "(a)(b)\\z",
+    "(a\\z)?b",
+    "a.\\z",
+    "[ab]{2,}\\z",
+    ".*\\z",
+    ".+\\z",
+    "a(?=\\z)|b(?!\\z)",
+    "(?:a\\z|b)+",
+    "a$|b\\z|c",
+    "(?:\\A|x)\\z",
+    // Both anchors.
+    "\\Aa\\z",
+    "\\A(?:a|ab)\\z",
+    "\\A|\\z",
+    "\\A\\z",
+    "\\A.*\\z",
+    "\\A[\\s\\S]*\\z",
+    "\\Afoo\\z|\\Abar",
+    // \Z stays a variable-length assertion.
+    "\\Z",
+    "foo\\Z",
+    "\\Aa\\Z",
+    "a\\Z|b\\z",
+];
+
+for (const source of sources) {
+    for (const flags of ["u", "v", "gu", "yu", "guy", "iu", "su", "mu", "smu", "gmu"])
+        checkEquivalent(source, flags);
+}

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1292,10 +1292,11 @@ public:
     }
     void assertionBOI()
     {
-        // FIXME: \A always anchors to the start of input, like ^ in non-multiline mode,
-        // but unlike assertionBOL(), this doesn't set m_startsWithBOL/m_containsBOL,
-        // and recomputeStartsWithBOL() doesn't recognize AssertionBOI. Wiring it in
-        // would let optimizeBOL() & friends unroll \A-anchored alternatives too.
+        if (!m_alternative->m_terms.size() && !parenthesisInvert() && parenthesisMatchDirection() == Forward) {
+            m_alternative->m_startsWithBOL = true;
+            m_alternative->m_containsBOL = true;
+            m_pattern.m_containsBOL = true;
+        }
         auto boiTerm = PatternTerm::BOI(m_flags);
         boiTerm.setMatchDirection(parenthesisMatchDirection());
         m_alternative->m_terms.append(boiTerm);
@@ -2417,6 +2418,7 @@ public:
                 bool termStartsWithBOL = false;
                 switch (term.type) {
                 case PatternTerm::Type::AssertionBOL:
+                case PatternTerm::Type::AssertionBOI:
                     termStartsWithBOL = term.matchDirection() == Forward;
                     break;
                 case PatternTerm::Type::ParenthesesSubpattern:
@@ -2461,6 +2463,8 @@ public:
         PatternDisjunction* disjunction = m_pattern.m_body;
         
         // We'll start by being safe, since `m` mode could change with modifiers
+        // FIXME: A \A anchored alternative could be made once-through even in a multiline pattern,
+        // but m_startsWithBOL does not distinguish \A from a multiline ^.
         if (m_pattern.m_containsModifiers || !m_pattern.m_containsBOL || m_pattern.multiline())
             return;
         
@@ -2616,12 +2620,16 @@ public:
 
     void computeEndAnchoredFixedSize()
     {
-        if (m_pattern.multiline() || m_pattern.sticky() || m_pattern.m_containsModifiers || m_pattern.m_containsBOL || m_pattern.m_containsUnsignedLengthPattern || !m_pattern.m_body->m_hasFixedSize || m_pattern.m_saveInitialStartValue)
+        if (m_pattern.sticky() || m_pattern.m_containsModifiers || m_pattern.m_containsBOL || m_pattern.m_containsUnsignedLengthPattern || !m_pattern.m_body->m_hasFixedSize || m_pattern.m_saveInitialStartValue)
             return;
 
         unsigned maximumSize = 0;
         for (auto& alternative : m_pattern.m_body->m_alternatives) {
-            if (!alternative->m_hasFixedSize || alternative->m_terms.isEmpty() || alternative->m_terms.last().type != PatternTerm::Type::AssertionEOL)
+            if (!alternative->m_hasFixedSize || alternative->m_terms.isEmpty())
+                return;
+            // Non-multiline $ and \z anchor the alternative at the end of input; \Z does not, since it can match before a trailing line terminator.
+            const PatternTerm& lastTerm = alternative->m_terms.last();
+            if (!(lastTerm.type == PatternTerm::Type::AssertionEOL && !lastTerm.multiline()) && !(lastTerm.type == PatternTerm::Type::AssertionEOI && !lastTerm.m_withOptionalLineTerminator))
                 return;
             maximumSize = std::max(maximumSize, alternative->m_minimumSize);
         }
@@ -3623,6 +3631,8 @@ private:
         switch (term.type) {
         case Type::AssertionBOL:
         case Type::AssertionEOL:
+        case Type::AssertionBOI:
+        case Type::AssertionEOI:
         case Type::AssertionWordBoundary:
         case Type::ParentheticalAssertion:
             return;
@@ -3714,18 +3724,17 @@ std::optional<WTF::BitSet<256>> computeFirstCharacterBitmap(StringView patternSt
     if (hasError(errorCode) || !pattern.m_body)
         return std::nullopt;
     if (!pattern.sticky()) {
-        if (pattern.global())
-            return std::nullopt;
-        if (pattern.multiline() || pattern.m_containsModifiers)
+        if (pattern.global() || pattern.m_containsModifiers)
             return std::nullopt;
         // Check the leading term rather than PatternAlternative::m_startsWithBOL: the parser sets
         // that flag optimistically and recomputeStartsWithBOL() corrects it, but here an over-eager
-        // flag is a wrong answer rather than a lost optimization.
+        // flag is a wrong answer rather than a lost optimization. \A anchors at the start of input
+        // regardless of the multiline flag, whereas a multiline ^ can also match after a line terminator.
         for (auto& alternative : pattern.m_body->m_alternatives) {
             if (alternative->m_terms.isEmpty())
                 return std::nullopt;
             const PatternTerm& firstTerm = alternative->m_terms[0];
-            if (firstTerm.type != PatternTerm::Type::AssertionBOL || firstTerm.m_matchDirection != Forward)
+            if ((firstTerm.type != PatternTerm::Type::AssertionBOI && (firstTerm.type != PatternTerm::Type::AssertionBOL || firstTerm.multiline())) || firstTerm.m_matchDirection != Forward)
                 return std::nullopt;
         }
     }


### PR DESCRIPTION
#### 37f4628ab5fec6362ec0b39da1179445f7616dea
<pre>
[YARR] Let `\A` and `\z` use the anchoring optimizations of non-multiline `^` and `$`
<a href="https://bugs.webkit.org/show_bug.cgi?id=320873">https://bugs.webkit.org/show_bug.cgi?id=320873</a>

Reviewed by Yusuke Suzuki.

\A and \z were compiled into their own assertion terms without participating in the
BOL/EOL anchoring machinery, so a failing /\Afoo/u or /foo\z/u scanned every start
position of the input while /^foo/u and /foo$/u give up immediately.

1. assertionBOI() sets m_startsWithBOL/m_containsBOL like assertionBOL(), and
   recomputeStartsWithBOL() treats AssertionBOI as an anchor, so optimizeBOL()
   makes \A-anchored alternatives once-through.
2. computeEndAnchoredFixedSize() accepts alternatives ending with \z. Since \z
   does not depend on the multiline flag, it no longer bails on multiline
   patterns; a trailing $ still requires a non-multiline term.
3. The first-character bitmap builder treats \A/\z/\Z as zero-width and
   accepts \A as the leading anchor.

                                              Baseline                  Patched

regexp-buffer-boundary-anchor-start      130.5870+-4.7993     ^      0.4691+-0.0210        ^ definitely 278.3501x faster
regexp-buffer-boundary-anchor-end          9.0441+-0.2902     ^      3.7459+-0.4817        ^ definitely 2.4144x faster

Tests: JSTests/microbenchmarks/regexp-buffer-boundary-anchor-end.js
       JSTests/microbenchmarks/regexp-buffer-boundary-anchor-start.js
       JSTests/stress/regexp-buffer-boundaries-anchoring.js

* JSTests/microbenchmarks/regexp-buffer-boundary-anchor-end.js: Added.
* JSTests/microbenchmarks/regexp-buffer-boundary-anchor-start.js: Added.
* JSTests/stress/regexp-buffer-boundaries-anchoring.js: Added.
(shouldBe):
(checkEquivalent):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::assertionBOI):
(JSC::Yarr::YarrPatternConstructor::recomputeStartsWithBOL):
(JSC::Yarr::YarrPatternConstructor::optimizeBOL):
(JSC::Yarr::YarrPatternConstructor::computeEndAnchoredFixedSize):
(JSC::Yarr::FirstCharacterBitmapBuilder::addTerm):
(JSC::Yarr::computeFirstCharacterBitmap):

Canonical link: <a href="https://commits.webkit.org/318540@main">https://commits.webkit.org/318540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55d3539777edfa66ffbf7c613f55a8d672fde40f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188195 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139229 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42788 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119683 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41454 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39808 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1652 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8467 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39478 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36650 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39852 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190622 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52186 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148395 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39850 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52867 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148163 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42868 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125134 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119774 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51385 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14453 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50770 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51010 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->