### PR TITLE
Sync `tools/lint` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/lint.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/lint.py
@@ -35,7 +35,7 @@ from ..manifest.sourcefile import SourceFile, js_meta_re, python_meta_re, space_
 from ..metadata.yaml.load import load_data_to_dict
 from ..metadata.meta.schema import META_YML_FILENAME, MetaFile
 from ..metadata.webfeatures.schema import (WEB_FEATURES_YML_FILENAME, WebFeaturesFile,
-                                          FileMatchingMode)
+                                          FeatureFile)
 
 # The Ignorelist is a two level dictionary. The top level is indexed by
 # error names (e.g. 'TRAILING WHITESPACE'). Each of those then has a map of
@@ -714,7 +714,7 @@ def check_script_metadata(repo_root: Text, path: Text, f: IO[bytes]) -> List[rul
                     errors.append(rules.MultipleTestharness.error(path, line_no=line_no))
                 elif value == b"/resources/testharnessreport.js":
                     errors.append(rules.MultipleTestharnessReport.error(path, line_no=line_no))
-            elif key not in (b"title", b"quic"):
+            elif key not in (b"title", b"quic", b"spec"):
                 errors.append(rules.UnknownMetadata.error(path, line_no=line_no))
         else:
             done = True
@@ -781,31 +781,22 @@ def check_web_features_file(repo_root: Text, path: Text, f: IO[bytes]) -> List[r
     base_dir = os.path.join(repo_root, os.path.dirname(path))
     files_in_directory = [
         f for f in os.listdir(base_dir) if os.path.isfile(os.path.join(base_dir, f))]
-    for feature in web_features_file.features:
-        if isinstance(feature.files, list):
-            # Resolve inclusion patterns to files, then subtract exclusions.
-            included: Set[str] = set()
-            dir_path = os.path.dirname(path)
-            for file in feature.files:
-                matched = file.match_files(files_in_directory)
-                if file.matching_mode == FileMatchingMode.INCLUDE:
-                    if not matched:
-                        errors.append(rules.MissingTestInWebFeaturesFile.error(path, (file)))
-                    included.update(matched)
-                    # Only check explicitly named files (no wildcards).
-                    if "*" not in str(file):
-                        for filename in matched:
-                            rel_path = os.path.join(dir_path, filename)
-                            source_file = SourceFile(repo_root, rel_path, "/")
-                            if source_file.possible_types == {"support"}:
-                                errors.append(rules.NonTestFileInWebFeaturesFile.error(path, (
-                                    filename, feature.name)))
-                elif file.matching_mode == FileMatchingMode.EXCLUDE:
-                    excluded = set(matched) & included
-                    if not excluded:
-                        errors.append(rules.UnnecessaryExclusionInWebFeaturesFile.error(path, (
-                            f"'{file}' in feature '{feature.name}'",)))
-                    included -= excluded
+    for rule in web_features_file.rules:
+        if not isinstance(rule.file, FeatureFile):
+            continue
+        # Resolve inclusion patterns to files, then subtract exclusions.
+        dir_path = os.path.dirname(path)
+        matched = rule.file.match_files(files_in_directory)
+        if not matched:
+            errors.append(rules.MissingTestInWebFeaturesFile.error(path, (rule.file,)))
+        # Only check explicitly named files (no wildcards).
+        if "*" not in str(rule):
+            for filename in matched:
+                rel_path = os.path.join(dir_path, filename)
+                source_file = SourceFile(repo_root, rel_path, "/")
+                if source_file.possible_types == {"support"}:
+                    errors.append(rules.NonTestFileInWebFeaturesFile.error(path, (
+                        filename, rule)))
 
     return errors
 
@@ -1018,7 +1009,8 @@ def main(venv: Any = None, **kwargs: Any) -> int:
 
     jobs = kwargs.get("jobs", 0)
 
-    return lint(repo_root, paths, output_format, ignore_glob, github_checks_outputter, jobs)
+    error_count = lint(repo_root, paths, output_format, ignore_glob, github_checks_outputter, jobs)
+    return 1 if error_count > 0 else 0
 
 
 # best experimental guess at a decent cut-off for using the parallel path
@@ -1149,14 +1141,12 @@ def all_paths_lints() -> Any:
 
 def _run_main(argv: List[Text]) -> None:
     try:
-        error_count = main(**vars(create_parser().parse_args(argv)))
+        sys.exit(main(**vars(create_parser().parse_args(argv))))
     except SystemExit:
         raise
     except Exception:
         traceback.print_exc()
-        sys.exit(3)
-    if error_count > 0:
-        sys.exit(1)
+        sys.exit(getattr(os, "EX_SOFTWARE", 70))
 
 
 if __name__ == "__main__":

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/rules.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/rules.py
@@ -33,12 +33,10 @@ class MissingLink(Rule):
     name = "MISSING-LINK"
     description = "Testcase file must have a link to a spec"
     to_fix = """
-        Ensure that there is a `<link rel="help" href="[url]">` for the spec.
-        `MISSING-LINK` is designed to ensure that the CSS build tool can find
-        the tests. Note that the CSS build system is primarily used by
-        [test.csswg.org/](http://test.csswg.org/), which doesn't use
-        `wptserve`, so `*.any.js` and similar tests won't work there; stick
-        with the `.html` equivalent.
+        Ensure that there is a `<link rel="help" href="[url]">` for the spec
+        in HTML tests, or a `// META: spec=[url]` line in script-based tests
+        (`*.any.js`, `*.window.js`, `*.worker.js`). `MISSING-LINK` is designed
+        to ensure that tests can be associated with the relevant spec.
     """
 
 
@@ -379,13 +377,6 @@ class MissingTestInWebFeaturesFile(Rule):
     """)
 
 
-class UnnecessaryExclusionInWebFeaturesFile(Rule):
-    name = "UNNECESSARY-EXCLUSION-IN-WEB-FEATURES-FILE"
-    description = collapse("""
-        The WEB_FEATURES.yml file contains a redundant or inoperable exclusion pattern: %s
-    """)
-
-
 class WebFeaturesFileInNonTestDirectory(Rule):
     name = "WEB-FEATURES-FILE-IN-NON-TEST-DIRECTORY"
     description = collapse("""
@@ -396,7 +387,7 @@ class WebFeaturesFileInNonTestDirectory(Rule):
 class NonTestFileInWebFeaturesFile(Rule):
     name = "NON-TEST-FILE-IN-WEB-FEATURES-FILE"
     description = collapse("""
-        The WEB_FEATURES.yml file references a non-test file: '%s' in feature '%s'
+        The WEB_FEATURES.yml file references a non-test file: '%s' in rule '%s'
     """)
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/support/tools/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/support/tools/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/support/tools/a.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/support/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/support/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/support/a.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/tools/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/tools/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/tools/a.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/a-ref.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/not-match/support/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/not-match/support/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/not-match/support/a.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/not-match/tools/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/not-match/tools/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/not-match/tools/a.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/not-match/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/not-match/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/not-match/a-ref.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/selectors/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/selectors/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/selectors/a.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/support/tools/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/support/tools/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/support/tools/a.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/support/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/support/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/support/a.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/tools/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/tools/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/tools/a.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/a-ref.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/ref/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/ref/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/ref/absolute.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/tests/dir1/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/tests/dir1/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/tests/dir1/a.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/tests/dir2/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/tests/dir2/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/tests/dir2/a.xhtml

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/tests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/tests/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/tests/relative-testharness-manual.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/about_blank.html

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/test_file_lints.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/test_file_lints.py
@@ -1132,31 +1132,25 @@ def test_invalid_meta_file():
     (
         ["file1.html", "file2.html", "file3.html"],
         b"""\
-features:
-- name: feature1
-  files:
-  - file1.html
+rules:
+- file1.html: [feature1]
 """,
         []
     ),
     (
         ["file1.html", "file2.html", "file3.html"],
         b"""\
-features:
-- name: feature1
-  files:
-  - file*.html
+rules:
+- file*.html: [feature1]
 """,
         []
     ),
     (
         ["file1.html", "file2.html", "file3.html"],
         b"""\
-features:
-- name: feature1
-  files:
-  - file*.html
-  - foo.html
+rules:
+- file*.html: [feature1]
+- foo.html: [feature1]
 """,
         [
             ("MISSING-WEB-FEATURES-FILE",
@@ -1168,11 +1162,9 @@ features:
     (
         ["bar1.html", "bar2.html", "bar3.html"],
         b"""\
-features:
-- name: feature1
-  files:
-  - file*.html
-  - bar*.html
+rules:
+- file*.html: [feature1]
+- bar*.html: [feature1]
 """,
         [
             ("MISSING-WEB-FEATURES-FILE",
@@ -1184,10 +1176,8 @@ features:
     (
         ["file1.html", "file2.html", "file3.html"],
         b"""\
-features:
-- name: feature1
-  files:
-  - foo.html
+rules:
+- foo.html: [feature1]
 """,
         [
             ("MISSING-WEB-FEATURES-FILE",
@@ -1199,62 +1189,38 @@ features:
     (
         ["file1.html", "file2.html", "file3.html"],
         b"""\
-features:
-- name: feature1
-  files: "**"
+rules:
+- "**": [feature1]
 """,
         []
     ),
     (
         ["file1.html", "file2.html", "file3.html"],
         b"""\
-features:
-- name: feature1
-  files:
-  - "*"
-  - "!file3.html"
+rules:
+- file3.html: []
+- "*": [feature1]
 """,
         []
     ),
     (
         ["foobar.html", "foo.html", "bar.html"],
         b"""\
-features:
-- name: feature1
-  files:
-  - "*foo*"
-  - "!*bar*"
+rules:
+- "*bar*": []
+- "*foo*": [feature1]
 """,
         []
     ),
     (
-        ["foo-1.html", "bar-1.html"],
-        b"""\
-features:
-- name: feature1
-  files:
-  - foo-*
-  - "!bar-*"
-""",
-        [
-            ("UNNECESSARY-EXCLUSION-IN-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file contains a redundant or inoperable exclusion pattern: "
-             "'!bar-*' in feature 'feature1'",
-             "css/WEB_FEATURES.yml",
-             None),
-        ]
-    ),
-    (
         ["test.html", "META.yml"],
         b"""\
-features:
-- name: feature1
-  files:
-  - META.yml
+rules:
+- META.yml: [feature1]
 """,
         [
             ("NON-TEST-FILE-IN-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file references a non-test file: 'META.yml' in feature 'feature1'",
+             "The WEB_FEATURES.yml file references a non-test file: 'META.yml' in rule 'META.yml: ['feature1']'",
              "css/WEB_FEATURES.yml",
              None),
         ]
@@ -1262,14 +1228,12 @@ features:
     (
         ["test.html", "test.html.headers"],
         b"""\
-features:
-- name: feature1
-  files:
-  - test.html.headers
+rules:
+- test.html.headers: [feature1]
 """,
         [
             ("NON-TEST-FILE-IN-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file references a non-test file: 'test.html.headers' in feature 'feature1'",
+             "The WEB_FEATURES.yml file references a non-test file: 'test.html.headers' in rule 'test.html.headers: ['feature1']'",
              "css/WEB_FEATURES.yml",
              None),
         ]
@@ -1277,14 +1241,12 @@ features:
     (
         ["test.html", ".hidden"],
         b"""\
-features:
-- name: feature1
-  files:
-  - .hidden
+rules:
+- .hidden: [feature1]
 """,
         [
             ("NON-TEST-FILE-IN-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file references a non-test file: '.hidden' in feature 'feature1'",
+             "The WEB_FEATURES.yml file references a non-test file: '.hidden' in rule '.hidden: ['feature1']'",
              "css/WEB_FEATURES.yml",
              None),
         ]
@@ -1292,14 +1254,12 @@ features:
     (
         ["test.html", "MANIFEST.json"],
         b"""\
-features:
-- name: feature1
-  files:
-  - MANIFEST.json
+rules:
+- MANIFEST.json: [feature1]
 """,
         [
             ("NON-TEST-FILE-IN-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file references a non-test file: 'MANIFEST.json' in feature 'feature1'",
+             "The WEB_FEATURES.yml file references a non-test file: 'MANIFEST.json' in rule 'MANIFEST.json: ['feature1']'",
              "css/WEB_FEATURES.yml",
              None),
         ]
@@ -1335,20 +1295,6 @@ def test_valid_web_features_file(monkeypatch, files, yml, expected_errors):
             None),
         ]
     ),
-    (
-        b"""\
-features:
-- name: feature1
-  files:
-  - "**"
-""",
-        [
-            ('INVALID-WEB-FEATURES-FILE',
-            'The WEB_FEATURES.yml file contains an invalid structure: Feature feature1 contains "**" in a list. It should be `files: "**"`',
-            "css/WEB_FEATURES.yml",
-            None),
-        ]
-    ),
 ])
 def test_invalid_web_features_file(contents, expected_errors):
     # Check when the value is named correctly. It should find the error.
@@ -1366,14 +1312,10 @@ def test_invalid_web_features_file(contents, expected_errors):
 
 def test_duplicate_keys_invalid_web_features_file():
     code = b"""\
-features:
-- name: feature1
-  files:
-  - feature1-*
-features:
-- name: feature2
-  files:
-  - "feature2-*"
+rules:
+- feature1-*: [feature1]
+rules:
+- "feature2-*": [feature2]
 """
     # Check when the value is named correctly. It should find the error.
     errors = check_file_contents("", "css/WEB_FEATURES.yml", io.BytesIO(code))
@@ -1381,7 +1323,7 @@ features:
 
     assert errors == [
         ('INVALID-WEB-FEATURES-FILE',
-         "The WEB_FEATURES.yml file contains an invalid structure: Duplicate 'features' key found in YAML.",
+         "The WEB_FEATURES.yml file contains an invalid structure: Duplicate 'rules' key found in YAML.",
          "css/WEB_FEATURES.yml",
          None),
     ]

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/test_lint.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/test_lint.py
@@ -442,14 +442,50 @@ def test_main_all():
         sys.argv = orig_argv
 
 
+def test_main_returns_zero_on_clean():
+    orig_argv = sys.argv
+    try:
+        sys.argv = ['./lint']
+        with _mock_lint('lint', return_value=0):
+            with _mock_lint('changed_files', return_value=['foo', 'bar']):
+                rv = lint_mod.main(**vars(create_parser().parse_args()))
+                assert rv == 0
+    finally:
+        sys.argv = orig_argv
 
-def test_run_main_no_errors_returns():
+
+def test_main_returns_one_on_errors():
+    orig_argv = sys.argv
+    try:
+        sys.argv = ['./lint']
+        with _mock_lint('lint', return_value=5):
+            with _mock_lint('changed_files', return_value=['foo', 'bar']):
+                rv = lint_mod.main(**vars(create_parser().parse_args()))
+                assert rv == 1
+    finally:
+        sys.argv = orig_argv
+
+
+def test_main_json_markdown_exits_2():
+    orig_argv = sys.argv
+    try:
+        sys.argv = ['./lint', '--json', '--markdown']
+        with pytest.raises(SystemExit) as excinfo:
+            lint_mod.main(**vars(create_parser().parse_args()))
+        assert excinfo.value.code == 2
+    finally:
+        sys.argv = orig_argv
+
+
+def test_run_main_no_errors_exits_0():
     with mock.patch.object(lint_mod, 'main', return_value=0):
-        lint_mod._run_main(['--all'])  # should not raise
+        with pytest.raises(SystemExit) as exc_info:
+            lint_mod._run_main(['--all'])
+    assert exc_info.value.code == 0
 
 
 def test_run_main_errors_exits_1():
-    with mock.patch.object(lint_mod, 'main', return_value=5):
+    with mock.patch.object(lint_mod, 'main', return_value=1):
         with pytest.raises(SystemExit) as exc_info:
             lint_mod._run_main(['--all'])
     assert exc_info.value.code == 1
@@ -461,11 +497,11 @@ def test_run_main_argument_error_exits_2():
     assert exc_info.value.code == 2
 
 
-def test_run_main_exception_exits_3(capsys):
+def test_run_main_exception_exits_ex_software(capsys):
     with mock.patch.object(lint_mod, 'main', side_effect=RuntimeError('simulated crash')):
         with pytest.raises(SystemExit) as exc_info:
             lint_mod._run_main(['--all'])
-    assert exc_info.value.code == 3
+    assert exc_info.value.code == getattr(os, "EX_SOFTWARE", 70)
 
     captured = capsys.readouterr()
     assert 'Traceback (most recent call last):' in captured.err

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/__init__.py

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/lint/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/lint/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/lint/__init__.py


### PR DESCRIPTION
#### 9919a89ca15a249b0fa07e90c059d82c3b7c9752
<pre>
Sync `tools/lint` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=320875">https://bugs.webkit.org/show_bug.cgi?id=320875</a>
<a href="https://rdar.apple.com/183894755">rdar://183894755</a>

Reviewed by Simon Fraser.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/8ff51b7de9b569733c5be7d0636c92c258ffdd27">https://github.com/web-platform-tests/wpt/commit/8ff51b7de9b569733c5be7d0636c92c258ffdd27</a>

* LayoutTests/imported/w3c/web-platform-tests/tools/lint/lint.py:
(check_script_metadata):
(check_web_features_file):
(main):
(_run_main):
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/rules.py:
(MissingLink):
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/support/tools/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/support/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/tools/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/match/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/not-match/support/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/not-match/tools/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/not-match/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/selectors/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/support/tools/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/support/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/tools/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/css/css-unique/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/ref/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/tests/dir1/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/tests/dir2/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/tests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/dummy/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/test_file_lints.py:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/test_lint.py:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/tests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/lint/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/318459@main">https://commits.webkit.org/318459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12411a73005ccc6d47f8b77298fe94885314e909

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141565 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55768aae-99fc-4fe6-b4fe-af4a81c60c50) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139005 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/080a2d7e-ae26-4834-897d-12180ea44f5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119460 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f3d549c-ee6d-4fa6-bca1-4ae15883eae1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41233 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39587 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151633 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39289 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36388 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190360 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51923 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148161 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39797 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52605 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147936 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42650 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119469 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51123 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14248 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50508 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50570 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->