### PR TITLE
[JSC] Use first-character-filter even for UntypedUse edge

### DIFF
--- a/JSTests/stress/regexp-and-arg-same.js
+++ b/JSTests/stress/regexp-and-arg-same.js
@@ -1,0 +1,8 @@
+function f() {
+    const re = /a/y;
+    return re.test(re);
+}
+noInline(f);
+
+for (let i = 0; i < testLoopCount; ++i)
+    f();

--- a/JSTests/stress/regexp-test-first-character-filter-untyped.js
+++ b/JSTests/stress/regexp-test-first-character-filter-untyped.js
@@ -1,0 +1,116 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+// The first-character fast-fail filter must agree with the RegExp engine even when the argument is
+// not speculated to be a string, in which case RegExp.prototype.test has to run ToString first.
+const anchored = /^[a-c]([a-z0-9_.]*)$/;
+const digits = /^[0-9]+$/;
+const sticky = /[a-c][0-9]*/y;
+
+let toStringCalls = 0;
+const toStringObject = {
+    toString() {
+        toStringCalls++;
+        return "abc";
+    }
+};
+
+function testAnchored(input) {
+    return anchored.test(input);
+}
+noInline(testAnchored);
+
+function testDigits(input) {
+    return digits.test(input);
+}
+noInline(testDigits);
+
+function testSticky(input) {
+    return sticky.test(input);
+}
+noInline(testSticky);
+
+function makeRope(a, b) {
+    return a + b;
+}
+noInline(makeRope);
+
+const anchoredCases = [
+    ["abc", true],
+    ["zzz", false],
+    ["", false],
+    ["a\u3042", false], // 16-bit string: never filtered.
+    ["c_9.x", true],
+    [undefined, false],
+    [null, false],
+    [123, false],
+    [true, false],
+    [{ }, false],
+    [toStringObject, true],
+    [new String("bcd"), true],
+];
+
+const digitsCases = [
+    [123, true],
+    [-1, false],
+    ["42", true],
+    ["x1", false],
+    [undefined, false],
+    [null, false],
+    [{ }, false],
+];
+
+for (let i = 0; i < 1e5; ++i) {
+    for (let j = 0; j < anchoredCases.length; ++j)
+        shouldBe(testAnchored(anchoredCases[j][0]), anchoredCases[j][1]);
+
+    for (let j = 0; j < digitsCases.length; ++j)
+        shouldBe(testDigits(digitsCases[j][0]), digitsCases[j][1]);
+
+    // Symbols reach ToString and throw rather than being filtered out.
+    let threw = false;
+    try {
+        testAnchored(Symbol.iterator);
+    } catch (error) {
+        threw = error instanceof TypeError;
+    }
+    shouldBe(threw, true);
+
+    // A rope and a 16-bit string are delegated to the operation.
+    shouldBe(testAnchored(makeRope("a", "bc")), true);
+    shouldBe(testAnchored(makeRope("z", "zz")), false);
+
+    // Sticky matching walks lastIndex forward on success and resets it to 0 on failure.
+    sticky.lastIndex = 0;
+    shouldBe(testSticky("a1z"), true);
+    shouldBe(sticky.lastIndex, 2);
+    shouldBe(testSticky("a1z"), false);
+    shouldBe(sticky.lastIndex, 0);
+
+    shouldBe(testSticky("zzz"), false);
+    shouldBe(sticky.lastIndex, 0);
+
+    shouldBe(testSticky(undefined), false);
+    shouldBe(sticky.lastIndex, 0);
+    shouldBe(testSticky(1), false);
+    shouldBe(sticky.lastIndex, 0);
+    shouldBe(testSticky({ }), false);
+    shouldBe(sticky.lastIndex, 0);
+
+    sticky.lastIndex = 1;
+    shouldBe(testSticky("zb2"), true);
+    shouldBe(sticky.lastIndex, 3);
+
+    // lastIndex past the end, and a non-int32 lastIndex, both have to reach the operation.
+    sticky.lastIndex = 100;
+    shouldBe(testSticky("a1"), false);
+    shouldBe(sticky.lastIndex, 0);
+
+    sticky.lastIndex = 0.5;
+    shouldBe(testSticky("a1"), true);
+    shouldBe(sticky.lastIndex, 2);
+}
+
+shouldBe(toStringCalls, 1e5);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -13474,72 +13474,8 @@ void SpeculativeJIT::compileRegExpTest(Node* node)
             speculateRegExpObject(node->child2(), baseGPR);
             speculateString(node->child3(), argumentGPR);
 
-#if CPU(ARM64) || CPU(X86_64)
-            // Anchored RegExp.test(string) fast-fail on a constant RegExpObject; tests input[0].
-            {
-                if (const auto* localBitmap = m_graph.tryGetConstantRegExpFirstCharacterBitmap(node->child2().node(), FirstCharacterFilterPosition::AtStart)) {
-                    const uint8_t* bitmap = localBitmap->storageBytes().data();
-
-                    GPRTemporary result(this);
-                    GPRTemporary scratch1(this);
-                    GPRTemporary scratch2(this);
-
-                    GPRReg resultGPR = result.gpr();
-                    GPRReg scratch1GPR = scratch1.gpr();
-                    GPRReg scratch2GPR = scratch2.gpr();
-
-                    flushRegisters();
-
-                    JumpList slowCases;
-                    JumpList doneCases;
-
-                    emitRegExpAnchoredFirstCharacterFilterGuards(bitmap, argumentGPR, scratch1GPR, scratch2GPR, resultGPR, slowCases);
-
-                    move(TrustedImm32(0), resultGPR);
-                    doneCases.append(jump());
-
-                    slowCases.link(this);
-                    callOperation(operationRegExpTestString, resultGPR, globalObjectGPR, baseGPR, argumentGPR);
-
-                    doneCases.link(this);
-                    unblessedBooleanResult(resultGPR, node);
-                    return;
-                }
-            }
-
-            // Sticky RegExp.test(string) fast-fail on a constant RegExpObject; tests input[lastIndex].
-            {
-                if (const auto* localBitmap = m_graph.tryGetConstantRegExpFirstCharacterBitmap(node->child2().node(), FirstCharacterFilterPosition::AtLastIndex)) {
-                    const uint8_t* bitmap = localBitmap->storageBytes().data();
-
-                    GPRTemporary result(this);
-                    GPRTemporary scratch1(this);
-                    GPRTemporary scratch2(this);
-                    GPRReg resultGPR = result.gpr();
-                    GPRReg scratch1GPR = scratch1.gpr();
-                    GPRReg scratch2GPR = scratch2.gpr();
-
-                    flushRegisters();
-
-                    JumpList slowCases;
-                    JumpList doneCases;
-
-                    emitRegExpStickyFirstCharacterFilterGuards(bitmap, baseGPR, argumentGPR, scratch1GPR, scratch2GPR, resultGPR, slowCases);
-
-                    // The byte cannot begin a match: reset lastIndex to 0 and return false.
-                    store64(TrustedImm64(JSValue::encode(jsNumber(0))), Address(baseGPR, RegExpObject::offsetOfLastIndex()));
-                    move(TrustedImm32(0), resultGPR);
-                    doneCases.append(jump());
-
-                    slowCases.link(this);
-                    callOperation(operationRegExpTestString, resultGPR, globalObjectGPR, baseGPR, argumentGPR);
-
-                    doneCases.link(this);
-                    unblessedBooleanResult(resultGPR, node);
-                    return;
-                }
-            }
-#endif
+            if (tryEmitRegExpTestFirstCharacterFilter(node, globalObjectGPR, baseGPR, JSValueRegs(argumentGPR), node->child2(), node->child3()))
+                return;
 
             flushRegisters();
             GPRFlushedCallResult result(this);
@@ -13554,6 +13490,9 @@ void SpeculativeJIT::compileRegExpTest(Node* node)
         GPRReg baseGPR = base.gpr();
         JSValueRegs argumentRegs = argument.jsValueRegs();
         speculateRegExpObject(node->child2(), baseGPR);
+
+        if (tryEmitRegExpTestFirstCharacterFilter(node, globalObjectGPR, baseGPR, argumentRegs, node->child2(), node->child3()))
+            return;
 
         flushRegisters();
         GPRFlushedCallResult result(this);
@@ -13573,6 +13512,65 @@ void SpeculativeJIT::compileRegExpTest(Node* node)
     callOperation(operationRegExpTestGeneric, result.gpr(), globalObjectGPR, baseRegs, argumentRegs);
 
     unblessedBooleanResult(result.gpr(), node);
+}
+
+// RegExp.test(input) fast-fail on a constant RegExpObject: when the one byte a match would have to
+// start at cannot begin a match, answer false without entering the RegExp engine. A sticky pattern
+// looks at input[lastIndex] and must also reset lastIndex to 0, as a failed RegExpBuiltinExec does.
+bool SpeculativeJIT::tryEmitRegExpTestFirstCharacterFilter(Node* node, GPRReg globalObjectGPR, GPRReg baseGPR, JSValueRegs argumentRegs, Edge baseEdge, Edge argumentEdge)
+{
+    // At most one position can apply: AtStart requires a non-global non-sticky pattern, AtLastIndex a sticky one.
+    auto position = FirstCharacterFilterPosition::AtStart;
+    const auto* localBitmap = m_graph.tryGetConstantRegExpFirstCharacterBitmap(baseEdge.node(), position);
+    if (!localBitmap) {
+        position = FirstCharacterFilterPosition::AtLastIndex;
+        localBitmap = m_graph.tryGetConstantRegExpFirstCharacterBitmap(baseEdge.node(), position);
+    }
+    if (!localBitmap)
+        return false;
+
+    const uint8_t* bitmap = localBitmap->storageBytes().data();
+    bool argumentIsString = argumentEdge.useKind() == StringUse || argumentEdge.useKind() == KnownStringUse;
+    GPRReg argumentGPR = argumentRegs.payloadGPR();
+
+    GPRTemporary result(this);
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
+    GPRReg resultGPR = result.gpr();
+    GPRReg scratch1GPR = scratch1.gpr();
+    GPRReg scratch2GPR = scratch2.gpr();
+
+    // baseGPR/argumentRegs/globalObjectGPR are preserved across flushRegisters for the slow-path
+    // operation call; the scratch registers are free to clobber.
+    flushRegisters();
+
+    JumpList slowCases;
+    JumpList doneCases;
+
+    if (!argumentIsString) {
+        slowCases.append(branchIfNotCell(argumentRegs));
+        slowCases.append(branchIfNotString(argumentGPR));
+    }
+
+    if (position == FirstCharacterFilterPosition::AtStart)
+        emitRegExpAnchoredFirstCharacterFilterGuards(bitmap, argumentGPR, scratch1GPR, scratch2GPR, resultGPR, slowCases);
+    else {
+        emitRegExpStickyFirstCharacterFilterGuards(bitmap, baseGPR, argumentGPR, scratch1GPR, scratch2GPR, resultGPR, slowCases);
+        store64(TrustedImm64(JSValue::encode(jsNumber(0))), Address(baseGPR, RegExpObject::offsetOfLastIndex()));
+    }
+
+    move(TrustedImm32(0), resultGPR);
+    doneCases.append(jump());
+
+    slowCases.link(this);
+    if (argumentIsString)
+        callOperation(operationRegExpTestString, resultGPR, globalObjectGPR, baseGPR, argumentGPR);
+    else
+        callOperation(operationRegExpTest, resultGPR, globalObjectGPR, baseGPR, argumentRegs);
+
+    doneCases.link(this);
+    unblessedBooleanResult(resultGPR, node);
+    return true;
 }
 
 void SpeculativeJIT::compileStringReplace(Node* node)
@@ -13754,7 +13752,6 @@ void SpeculativeJIT::compileRegExpExecNonGlobalOrSticky(Node* node)
 
     speculateString(node->child2(), argumentGPR);
 
-#if CPU(ARM64) || CPU(X86_64)
     // Anchored non-sticky exec fast-fail; tests input[0].
     {
         RegExp* regExp = node->castOperand<RegExp*>();
@@ -13788,7 +13785,6 @@ void SpeculativeJIT::compileRegExpExecNonGlobalOrSticky(Node* node)
             return;
         }
     }
-#endif
 
     flushRegisters();
     JSValueRegsFlushedCallResult result(this);
@@ -13812,7 +13808,6 @@ void SpeculativeJIT::compileRegExpExecSticky(Node* node)
     speculateRegExpObject(node->child2(), baseGPR);
     speculateString(node->child3(), argumentGPR);
 
-#if CPU(ARM64) || CPU(X86_64)
     // Sticky exec fast-fail; when input[lastIndex] cannot begin a match, reset lastIndex to 0 and
     // return null inline.
     {
@@ -13850,7 +13845,6 @@ void SpeculativeJIT::compileRegExpExecSticky(Node* node)
             return;
         }
     }
-#endif
 
     flushRegisters();
     JSValueRegsFlushedCallResult result(this);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1586,6 +1586,7 @@ public:
     void compileRegExpMatchFastGlobal(Node*);
     void compileRegExpSplitFast(Node*);
     void compileRegExpTest(Node*);
+    bool tryEmitRegExpTestFirstCharacterFilter(Node*, GPRReg globalObjectGPR, GPRReg baseGPR, JSValueRegs argumentRegs, Edge baseEdge, Edge argumentEdge);
     void compileRegExpTestInline(Node*);
     void compileRegExpSearch(Node*);
     void compileRegExpStringIteratorNext(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -10010,7 +10010,8 @@ void SpeculativeJIT::emitRegExpAnchoredFirstCharacterFilterGuards(const uint8_t*
 
 void SpeculativeJIT::emitRegExpStickyFirstCharacterFilterGuards(const uint8_t* bitmap, GPRReg baseGPR, GPRReg argumentGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR, JumpList& slowCases)
 {
-    ASSERT(noOverlap(baseGPR, argumentGPR, scratch1GPR, scratch2GPR, scratch3GPR));
+    ASSERT(noOverlap(baseGPR, scratch1GPR, scratch2GPR, scratch3GPR));
+    ASSERT(noOverlap(argumentGPR, scratch1GPR, scratch2GPR, scratch3GPR));
 
     // The string must be a resolved 8-bit string.
     loadPtr(Address(argumentGPR, JSString::offsetOfValue()), scratch1GPR);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -19356,11 +19356,29 @@ IGNORE_CLANG_WARNINGS_END
         return m_out.testNonZero32(bitmapByte, bit);
     }
 
+    // For an untyped argument, send everything that is not a JSString to the operation: it has to run
+    // ToString, which the filter cannot do.
+    void emitFirstCharacterGuardStringCheck(LValue argument, Edge argumentEdge, LBasicBlock isCellCase, LBasicBlock isStringCase, LBasicBlock nextBlock, LBasicBlock operationCase)
+    {
+        m_out.branch(isCell(argument, provenType(argumentEdge)), usually(isCellCase), rarely(operationCase));
+
+        m_out.appendTo(isCellCase, isStringCase);
+        m_out.branch(isString(argument, provenType(argumentEdge)), usually(isStringCase), rarely(operationCase));
+
+        m_out.appendTo(isStringCase, nextBlock);
+    }
+
     void emitAnchoredFirstCharacterGuardChain(LValue argument, Edge argumentEdge, const uint8_t* bitmap, LBasicBlock operationCase, LBasicBlock noMatchCase)
     {
+        bool knownString = argumentEdge.useKind() == StringUse || argumentEdge.useKind() == KnownStringUse;
+        LBasicBlock isCellCase = knownString ? nullptr : m_out.newBlock();
+        LBasicBlock isStringCase = knownString ? nullptr : m_out.newBlock();
         LBasicBlock check8Bit = m_out.newBlock();
         LBasicBlock checkLength = m_out.newBlock();
         LBasicBlock filterCase = m_out.newBlock();
+
+        if (!knownString)
+            emitFirstCharacterGuardStringCheck(argument, argumentEdge, isCellCase, isStringCase, check8Bit, operationCase);
 
         m_out.branch(isRopeString(argument, argumentEdge), rarely(operationCase), usually(check8Bit));
 
@@ -19428,11 +19446,17 @@ IGNORE_CLANG_WARNINGS_END
 
     void emitStickyFirstCharacterGuardChain(LValue base, LValue argument, Edge argumentEdge, const uint8_t* bitmap, LBasicBlock operationCase, LBasicBlock noMatchCase)
     {
+        bool knownString = argumentEdge.useKind() == StringUse || argumentEdge.useKind() == KnownStringUse;
+        LBasicBlock isCellCase = knownString ? nullptr : m_out.newBlock();
+        LBasicBlock isStringCase = knownString ? nullptr : m_out.newBlock();
         LBasicBlock check8Bit = m_out.newBlock();
         LBasicBlock checkWritable = m_out.newBlock();
         LBasicBlock checkInt32 = m_out.newBlock();
         LBasicBlock checkInBounds = m_out.newBlock();
         LBasicBlock filterCase = m_out.newBlock();
+
+        if (!knownString)
+            emitFirstCharacterGuardStringCheck(argument, argumentEdge, isCellCase, isStringCase, check8Bit, operationCase);
 
         m_out.branch(isRopeString(argument, argumentEdge), rarely(operationCase), usually(check8Bit));
 
@@ -19536,9 +19560,9 @@ IGNORE_CLANG_WARNINGS_END
 
             if (m_node->child3().useKind() == StringUse) {
                 LValue argument = lowString(m_node->child3());
-                if (compileRegExpTestAnchoredFilter(globalObject, base, argument))
+                if (compileRegExpTestAnchoredFilter(globalObject, base, argument, m_node->child2(), m_node->child3()))
                     return;
-                if (compileRegExpTestStickyFilter(globalObject, base, argument))
+                if (compileRegExpTestStickyFilter(globalObject, base, argument, m_node->child2(), m_node->child3()))
                     return;
                 LValue result = vmCall(Int32, operationRegExpTestString, globalObject, base, argument);
                 setBoolean(result);
@@ -19546,6 +19570,10 @@ IGNORE_CLANG_WARNINGS_END
             }
 
             LValue argument = lowJSValue(m_node->child3());
+            if (compileRegExpTestAnchoredFilter(globalObject, base, argument, m_node->child2(), m_node->child3()))
+                return;
+            if (compileRegExpTestStickyFilter(globalObject, base, argument, m_node->child2(), m_node->child3()))
+                return;
             LValue result = vmCall(Int32, operationRegExpTest, globalObject, base, argument);
             setBoolean(result);
             return;
@@ -19557,10 +19585,18 @@ IGNORE_CLANG_WARNINGS_END
         setBoolean(result);
     }
 
-    // Anchored RegExp.test(string) fast-fail on a constant RegExpObject; tests input[0].
-    bool compileRegExpTestAnchoredFilter(LValue globalObject, LValue base, LValue argument)
+    LValue emitRegExpTestOperationCall(LValue globalObject, LValue base, LValue argument, Edge argumentEdge)
     {
-        auto* localBitmap = m_graph.tryGetConstantRegExpFirstCharacterBitmap(m_node->child2().node(), FirstCharacterFilterPosition::AtStart);
+        bool knownString = argumentEdge.useKind() == StringUse || argumentEdge.useKind() == KnownStringUse;
+        if (knownString)
+            return vmCall(Int32, operationRegExpTestString, globalObject, base, argument);
+        return vmCall(Int32, operationRegExpTest, globalObject, base, argument);
+    }
+
+    // Anchored RegExp.test(input) fast-fail on a constant RegExpObject; tests input[0].
+    bool compileRegExpTestAnchoredFilter(LValue globalObject, LValue base, LValue argument, Edge baseEdge, Edge argumentEdge)
+    {
+        auto* localBitmap = m_graph.tryGetConstantRegExpFirstCharacterBitmap(baseEdge.node(), FirstCharacterFilterPosition::AtStart);
         if (!localBitmap)
             return false;
         const uint8_t* bitmap = localBitmap->storageBytes().data();
@@ -19570,14 +19606,14 @@ IGNORE_CLANG_WARNINGS_END
         LBasicBlock continuation = m_out.newBlock();
 
         LBasicBlock lastNext = m_out.insertNewBlocksBefore(falseCase);
-        emitAnchoredFirstCharacterGuardChain(argument, m_node->child3(), bitmap, operationCase, falseCase);
+        emitAnchoredFirstCharacterGuardChain(argument, argumentEdge, bitmap, operationCase, falseCase);
 
         m_out.appendTo(falseCase, operationCase);
         ValueFromBlock falseResult = m_out.anchor(m_out.int32Zero);
         m_out.jump(continuation);
 
         m_out.appendTo(operationCase, continuation);
-        ValueFromBlock operationResult = m_out.anchor(vmCall(Int32, operationRegExpTestString, globalObject, base, argument));
+        ValueFromBlock operationResult = m_out.anchor(emitRegExpTestOperationCall(globalObject, base, argument, argumentEdge));
         m_out.jump(continuation);
 
         m_out.appendTo(continuation, lastNext);
@@ -19585,11 +19621,11 @@ IGNORE_CLANG_WARNINGS_END
         return true;
     }
 
-    // Sticky RegExp.test(string) fast-fail on a constant RegExpObject; tests input[lastIndex]. `gy`
+    // Sticky RegExp.test(input) fast-fail on a constant RegExpObject; tests input[lastIndex]. `gy`
     // qualifies too: on a failed match RegExpBuiltinExec resets lastIndex to 0 for global as well as sticky.
-    bool compileRegExpTestStickyFilter(LValue globalObject, LValue base, LValue argument)
+    bool compileRegExpTestStickyFilter(LValue globalObject, LValue base, LValue argument, Edge baseEdge, Edge argumentEdge)
     {
-        auto* localBitmap = m_graph.tryGetConstantRegExpFirstCharacterBitmap(m_node->child2().node(), FirstCharacterFilterPosition::AtLastIndex);
+        auto* localBitmap = m_graph.tryGetConstantRegExpFirstCharacterBitmap(baseEdge.node(), FirstCharacterFilterPosition::AtLastIndex);
         if (!localBitmap)
             return false;
         const uint8_t* bitmap = localBitmap->storageBytes().data();
@@ -19599,7 +19635,7 @@ IGNORE_CLANG_WARNINGS_END
         LBasicBlock continuation = m_out.newBlock();
 
         LBasicBlock lastNext = m_out.insertNewBlocksBefore(falseCase);
-        emitStickyFirstCharacterGuardChain(base, argument, m_node->child3(), bitmap, operationCase, falseCase);
+        emitStickyFirstCharacterGuardChain(base, argument, argumentEdge, bitmap, operationCase, falseCase);
 
         m_out.appendTo(falseCase, operationCase);
         m_out.store64(m_out.constInt64(JSValue::encode(jsNumber(0))), base, m_heaps.RegExpObject_lastIndex);
@@ -19607,7 +19643,7 @@ IGNORE_CLANG_WARNINGS_END
         m_out.jump(continuation);
 
         m_out.appendTo(operationCase, continuation);
-        ValueFromBlock operationResult = m_out.anchor(vmCall(Int32, operationRegExpTestString, globalObject, base, argument));
+        ValueFromBlock operationResult = m_out.anchor(emitRegExpTestOperationCall(globalObject, base, argument, argumentEdge));
         m_out.jump(continuation);
 
         m_out.appendTo(continuation, lastNext);


### PR DESCRIPTION
#### fb299342a5802f73fa1bfd395dcc7aaac45e7010
<pre>
[JSC] Use first-character-filter even for UntypedUse edge
<a href="https://bugs.webkit.org/show_bug.cgi?id=320877">https://bugs.webkit.org/show_bug.cgi?id=320877</a>
<a href="https://rdar.apple.com/183897657">rdar://183897657</a>

Reviewed by Sosuke Suzuki.

Some real world code was not using this first-character-filter just
because it is taking UntypedUse instead of StringUse. This patch extend
the coverage by checking String at runtime to perform
first-character-filter.

Test: JSTests/stress/regexp-test-first-character-filter-untyped.js

* JSTests/stress/regexp-and-arg-same.js: Added.
(f):
* JSTests/stress/regexp-test-first-character-filter-untyped.js: Added.
(shouldBe):
(const.toStringObject.toString):
(testAnchored):
(testDigits):
(testSticky):
(makeRope):
(i.catch):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileRegExpTest):
(JSC::DFG::SpeculativeJIT::tryEmitRegExpTestFirstCharacterFilter):
(JSC::DFG::SpeculativeJIT::compileRegExpExecNonGlobalOrSticky):
(JSC::DFG::SpeculativeJIT::compileRegExpExecSticky):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitRegExpStickyFirstCharacterFilterGuards):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/318512@main">https://commits.webkit.org/318512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/392d4e692c9f0b1c409b15805106ccd83bc39545

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141663 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84df840a-299a-4d09-9613-f1640f3117d3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139093 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c00ec529-c3f5-40af-a7ca-dd6b9d0c64a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119547 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1dd5e6c4-ef18-42f2-a9c2-d843e344ffbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41319 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39670 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1516 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8338 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151719 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39349 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Skipped layout-tests; 343 new passes 8 flakes 1 failures; Uploaded test results; 343 new passes 3 flakes 2 failures; layout-tests; Passed layout tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36486 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39688 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190458 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52022 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148249 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52703 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148021 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27082 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42734 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124969 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119605 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51221 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14324 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50606 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50846 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50668 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->