### PR TITLE
Web Inspector: Canvas: expose client metadata for WebGPU devices

### DIFF
--- a/LayoutTests/inspector/canvas/requestClientNodes-css.html
+++ b/LayoutTests/inspector/canvas/requestClientNodes-css.html
@@ -42,8 +42,8 @@ function test() {
         test(resolve, reject) {
             WI.Canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged)
             .then((event) => {
-                InspectorTest.expectEqual(event.target.cssCanvasName, "css-canvas", `Canvas with created client should have CSS name "css-canvas".`);
                 event.target.requestClientNodes((clientNodes) => {
+                    InspectorTest.expectShallowEqual(event.target.cssCanvasNames, ["css-canvas"], `Canvas with created client should have CSS name "css-canvas".`);
                     InspectorTest.expectEqual(clientNodes.length, 1, "There should be one client node.");
                     logClientNodes(clientNodes);
                     resolve();
@@ -60,8 +60,8 @@ function test() {
         test(resolve, reject) {
             WI.Canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged)
             .then((event) => {
-                InspectorTest.expectEqual(event.target.cssCanvasName, "css-canvas", `Canvas with destroyed client should have CSS name "css-canvas".`);
                 event.target.requestClientNodes((clientNodes) => {
+                    InspectorTest.expectShallowEqual(event.target.cssCanvasNames, ["css-canvas"], `Canvas with destroyed client should have CSS name "css-canvas".`);
                     InspectorTest.expectEqual(clientNodes.length, 0, "There should be no client nodes.");
                     logClientNodes(clientNodes);
                     resolve();

--- a/LayoutTests/inspector/canvas/requestClientNodes-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/requestClientNodes-webgpu-expected.txt
@@ -4,30 +4,81 @@ Test that CanvasAgent tracks GPUCanvasContext client nodes for WebGPU devices.
 == Running test suite: Canvas.requestClientNodes.WebGPU
 -- Running test case: Canvas.requestClientNodes.WebGPU.Initial
 PASS: GPUDevice should initially have no client nodes.
+PASS: GPUDevice should initially have no CSS canvas names.
+PASS: GPUDevice should not have a size.
+PASS: GPUDevice should initially have no canvas node.
 
 -- Running test case: Canvas.requestClientNodes.WebGPU.Configure
 PASS: Client nodes changed for the expected Canvas.
 PASS: GPUDevice should have one client node.
 PASS: Client node should be the configured canvas element.
+PASS: GPUDevice should resolve its only canvas node.
+PASS: GPUDevice should not have multiple canvas sizes.
+PASS: GPUDevice width should be 10.
+PASS: GPUDevice height should be 20.
 PASS: GPUCanvasContext should not create a separate Canvas.
 
--- Running test case: Canvas.requestClientNodes.WebGPU.MultipleCanvases
+-- Running test case: Canvas.requestClientNodes.WebGPU.MultipleCanvasesSameSize
 PASS: Client nodes changed for the expected Canvas.
 PASS: GPUDevice should have two client nodes.
 PASS: GPUDevice should include the original canvas element.
 PASS: GPUDevice should include the additional canvas element.
+PASS: GPUDevice should not resolve a canvas node when multiple canvases are bound.
+PASS: GPUDevice should not have multiple canvas sizes.
+PASS: GPUDevice width should be 10.
+PASS: GPUDevice height should be 20.
 PASS: Two GPUCanvasContexts should still create only one Canvas.
+
+-- Running test case: Canvas.requestClientNodes.WebGPU.CoalesceChangesUntilRequest
+PASS: Client nodes changed for the expected Canvas.
+PASS: Client node changes should only be reported once before requestClientNodes.
+PASS: GPUDevice should report its final client nodes.
+
+-- Running test case: Canvas.requestClientNodes.WebGPU.MultipleCanvasesDifferentSizes
+PASS: Size changed for the expected Canvas.
+PASS: GPUDevice should have multiple canvas sizes.
+PASS: GPUDevice should expose all canvas sizes.
+PASS: GPUDevice should not resolve a canvas node when multiple canvases are bound.
+
+-- Running test case: Canvas.requestClientNodes.WebGPU.ReturnToUniqueCanvas
 PASS: Client nodes changed after unconfiguring one canvas.
 PASS: GPUDevice should retain one client node.
 PASS: Remaining client node should be the original canvas element.
+PASS: GPUDevice should again resolve its only canvas node.
+PASS: GPUDevice should not have multiple canvas sizes.
+PASS: GPUDevice width should be 10.
+PASS: GPUDevice height should be 20.
 PASS: Unconfiguring one client should preserve the single GPUDevice Canvas.
 
 -- Running test case: Canvas.requestClientNodes.WebGPU.Unconfigure
 PASS: Client nodes changed for the expected Canvas.
 PASS: GPUDevice should again have no client nodes.
+PASS: GPUDevice should not have a size.
+PASS: GPUDevice should again have no canvas node.
+
+-- Running test case: Canvas.requestClientNodes.WebGPU.CSSCanvas
+PASS: Client nodes changed for the expected Canvas.
+PASS: GPUDevice should not update its CSS canvas names before requestClientNodes.
+PASS: GPUDevice should include its CSS canvas name.
+PASS: GPUDevice should have one CSS canvas client node.
+PASS: Client node should be the CSS canvas consumer.
+PASS: GPUDevice should not have multiple canvas sizes.
+PASS: GPUDevice width should be 30.
+PASS: GPUDevice height should be 40.
+
+-- Running test case: Canvas.requestClientNodes.WebGPU.CSSCanvasUnconfigure
+PASS: Client nodes changed for the expected Canvas.
+PASS: GPUDevice should preserve its CSS canvas names before requestClientNodes.
+PASS: GPUDevice should no longer have CSS canvas names.
+PASS: GPUDevice should no longer have CSS canvas client nodes.
+PASS: GPUDevice should not have a size.
 
 -- Running test case: Canvas.requestClientNodes.WebGPU.OffscreenCanvas
 PASS: Client nodes changed for the expected Canvas.
 PASS: OffscreenCanvas should not create a DOM client node.
+PASS: GPUDevice should not have multiple canvas sizes.
+PASS: GPUDevice width should be 4.
+PASS: GPUDevice height should be 4.
+PASS: OffscreenCanvas should not create a canvas node.
 PASS: OffscreenCanvas GPUCanvasContext should not create a separate Canvas.
 

--- a/LayoutTests/inspector/canvas/requestClientNodes-webgpu.html
+++ b/LayoutTests/inspector/canvas/requestClientNodes-webgpu.html
@@ -10,6 +10,9 @@ let clientCanvas = null;
 let clientContext = null;
 let additionalClientCanvas = null;
 let additionalClientContext = null;
+let cssClient = null;
+let cssCanvasName = null;
+let cssClientContext = null;
 let offscreenCanvas = null;
 let offscreenContext = null;
 
@@ -22,6 +25,8 @@ async function load() {
 function configureClient() {
     clientCanvas = document.body.appendChild(document.createElement("canvas"));
     clientCanvas.id = "webgpu-client";
+    clientCanvas.width = 10;
+    clientCanvas.height = 20;
     clientContext = clientCanvas.getContext("webgpu");
     clientContext.configure({
         device,
@@ -39,6 +44,8 @@ function unconfigureClient() {
 function configureAdditionalClient() {
     additionalClientCanvas = document.body.appendChild(document.createElement("canvas"));
     additionalClientCanvas.id = "additional-webgpu-client";
+    additionalClientCanvas.width = 10;
+    additionalClientCanvas.height = 20;
     additionalClientContext = additionalClientCanvas.getContext("webgpu");
     additionalClientContext.configure({
         device,
@@ -53,6 +60,30 @@ function unconfigureAdditionalClient() {
     additionalClientCanvas = null;
 }
 
+function resizeAdditionalClient() {
+    additionalClientCanvas.width = 20;
+}
+
+function configureCSSClient() {
+    cssCanvasName = `webgpu-css-canvas-${crypto.randomUUID()}`;
+    cssClientContext = document.getCSSCanvasContext("webgpu", cssCanvasName, 30, 40);
+    cssClient = document.body.appendChild(document.createElement("div"));
+    cssClient.id = "webgpu-css-client";
+    cssClient.style.backgroundImage = `-webkit-canvas(${cssCanvasName})`;
+    cssClient.getBoundingClientRect();
+    cssClientContext.configure({
+        device,
+        format: navigator.gpu.getPreferredCanvasFormat(),
+    });
+}
+
+function unconfigureCSSClient() {
+    cssClientContext.unconfigure();
+    cssClient.remove();
+    cssClientContext = null;
+    cssClient = null;
+}
+
 function configureOffscreenClient() {
     offscreenCanvas = new OffscreenCanvas(4, 4);
     offscreenContext = offscreenCanvas.getContext("webgpu");
@@ -65,10 +96,34 @@ function configureOffscreenClient() {
 function test() {
     let suite = InspectorTest.createAsyncSuite("Canvas.requestClientNodes.WebGPU");
     let canvas = Array.from(WI.canvasManager.canvasCollection).find((canvas) => canvas.contextType === WI.Canvas.ContextType.WebGPU);
+    let cssCanvasName;
     InspectorTest.assert(canvas, "There should be a WebGPU Canvas.");
 
     function requestClientNodes() {
         return new Promise((resolve) => canvas.requestClientNodes(resolve));
+    }
+
+    function waitForSize(predicate) {
+        return new Promise((resolve) => {
+            function handleSizeChanged(event) {
+                if (!predicate())
+                    return;
+
+                canvas.removeEventListener(WI.Canvas.Event.SizeChanged, handleSizeChanged);
+                resolve(event);
+            }
+            canvas.addEventListener(WI.Canvas.Event.SizeChanged, handleSizeChanged);
+        });
+    }
+
+    function expectSize(width, height) {
+        InspectorTest.expectFalse(canvas.sizes.length > 1, "GPUDevice should not have multiple canvas sizes.");
+        InspectorTest.expectEqual(canvas.sizes[0]?.width, width, `GPUDevice width should be ${width}.`);
+        InspectorTest.expectEqual(canvas.sizes[0]?.height, height, `GPUDevice height should be ${height}.`);
+    }
+
+    function expectNoSize() {
+        InspectorTest.expectEqual(canvas.sizes.length, 0, "GPUDevice should not have a size.");
     }
 
     suite.addTestCase({
@@ -77,6 +132,9 @@ function test() {
         async test() {
             let clientNodes = await requestClientNodes();
             InspectorTest.expectEqual(clientNodes.length, 0, "GPUDevice should initially have no client nodes.");
+            InspectorTest.expectShallowEqual(canvas.cssCanvasNames, [], "GPUDevice should initially have no CSS canvas names.");
+            expectNoSize();
+            InspectorTest.expectNull(await canvas.requestNode(), "GPUDevice should initially have no canvas node.");
         },
     });
 
@@ -85,20 +143,24 @@ function test() {
         description: "Check that configuring a GPUCanvasContext adds its canvas as a GPUDevice client node.",
         async test() {
             let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let sizeChangedPromise = waitForSize(() => canvas.sizes.length === 1 && canvas.sizes[0].width === 10 && canvas.sizes[0].height === 20);
             InspectorTest.evaluateInPage(`configureClient()`);
 
             let event = await clientNodesChangedPromise;
+            await sizeChangedPromise;
             InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
             let clientNodes = await requestClientNodes();
             InspectorTest.expectEqual(clientNodes.length, 1, "GPUDevice should have one client node.");
             InspectorTest.expectEqual(clientNodes[0].appropriateSelectorFor(), "canvas#webgpu-client", "Client node should be the configured canvas element.");
+            InspectorTest.expectEqual((await canvas.requestNode())?.appropriateSelectorFor(), "canvas#webgpu-client", "GPUDevice should resolve its only canvas node.");
+            expectSize(10, 20);
             InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "GPUCanvasContext should not create a separate Canvas.");
         },
     });
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.WebGPU.MultipleCanvases",
-        description: "Check that one GPUDevice simultaneously tracks multiple canvas client nodes and preserves one when the other is unconfigured.",
+        name: "Canvas.requestClientNodes.WebGPU.MultipleCanvasesSameSize",
+        description: "Check that one GPUDevice simultaneously tracks multiple same-sized canvas client nodes.",
         async test() {
             let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
             InspectorTest.evaluateInPage(`configureAdditionalClient()`);
@@ -110,16 +172,63 @@ function test() {
             let selectors = new Set(clientNodes.map((node) => node.appropriateSelectorFor()));
             InspectorTest.expectTrue(selectors.has("canvas#webgpu-client"), "GPUDevice should include the original canvas element.");
             InspectorTest.expectTrue(selectors.has("canvas#additional-webgpu-client"), "GPUDevice should include the additional canvas element.");
+            InspectorTest.expectNull(await canvas.requestNode(), "GPUDevice should not resolve a canvas node when multiple canvases are bound.");
+            expectSize(10, 20);
             InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "Two GPUCanvasContexts should still create only one Canvas.");
+        },
+    });
 
-            clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+    suite.addTestCase({
+        name: "Canvas.requestClientNodes.WebGPU.CoalesceChangesUntilRequest",
+        description: "Check that client node changes are only reported once until the frontend requests the updated nodes.",
+        async test() {
+            let clientNodesChangedCount = 0;
+            let listener = canvas.addEventListener(WI.Canvas.Event.ClientNodesChanged, () => ++clientNodesChangedCount);
+            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            await InspectorTest.evaluateInPage(`unconfigureAdditionalClient()`);
+
+            let event = await clientNodesChangedPromise;
+            await InspectorTest.evaluateInPage(`configureAdditionalClient()`);
+            canvas.removeEventListener(WI.Canvas.Event.ClientNodesChanged, listener);
+
+            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
+            InspectorTest.expectEqual(clientNodesChangedCount, 1, "Client node changes should only be reported once before requestClientNodes.");
+            let clientNodes = await requestClientNodes();
+            InspectorTest.expectEqual(clientNodes.length, 2, "GPUDevice should report its final client nodes.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.requestClientNodes.WebGPU.MultipleCanvasesDifferentSizes",
+        description: "Check that one GPUDevice reports when its canvas clients have different sizes.",
+        async test() {
+            let sizeChangedPromise = waitForSize(() => canvas.sizes.length > 1);
+            InspectorTest.evaluateInPage(`resizeAdditionalClient()`);
+
+            let event = await sizeChangedPromise;
+            InspectorTest.expectEqual(event.target, canvas, "Size changed for the expected Canvas.");
+            InspectorTest.expectTrue(canvas.sizes.length > 1, "GPUDevice should have multiple canvas sizes.");
+            InspectorTest.expectShallowEqual(canvas.sizes.map((size) => [size.width, size.height]).sort(), [[10, 20], [20, 20]], "GPUDevice should expose all canvas sizes.");
+            InspectorTest.expectNull(await canvas.requestNode(), "GPUDevice should not resolve a canvas node when multiple canvases are bound.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.requestClientNodes.WebGPU.ReturnToUniqueCanvas",
+        description: "Check that unconfiguring one of multiple canvas clients restores the remaining canvas metadata.",
+        async test() {
+            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let sizeChangedPromise = waitForSize(() => canvas.sizes.length === 1 && canvas.sizes[0].width === 10 && canvas.sizes[0].height === 20);
             InspectorTest.evaluateInPage(`unconfigureAdditionalClient()`);
 
-            event = await clientNodesChangedPromise;
+            let event = await clientNodesChangedPromise;
+            await sizeChangedPromise;
             InspectorTest.expectEqual(event.target, canvas, "Client nodes changed after unconfiguring one canvas.");
-            clientNodes = await requestClientNodes();
+            let clientNodes = await requestClientNodes();
             InspectorTest.expectEqual(clientNodes.length, 1, "GPUDevice should retain one client node.");
             InspectorTest.expectEqual(clientNodes[0].appropriateSelectorFor(), "canvas#webgpu-client", "Remaining client node should be the original canvas element.");
+            InspectorTest.expectEqual((await canvas.requestNode())?.appropriateSelectorFor(), "canvas#webgpu-client", "GPUDevice should again resolve its only canvas node.");
+            expectSize(10, 20);
             InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "Unconfiguring one client should preserve the single GPUDevice Canvas.");
         },
     });
@@ -129,12 +238,56 @@ function test() {
         description: "Check that unconfiguring a GPUCanvasContext removes its canvas from the GPUDevice client nodes.",
         async test() {
             let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let sizeChangedPromise = waitForSize(() => !canvas.sizes.length);
             InspectorTest.evaluateInPage(`unconfigureClient()`);
 
             let event = await clientNodesChangedPromise;
+            await sizeChangedPromise;
             InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
             let clientNodes = await requestClientNodes();
             InspectorTest.expectEqual(clientNodes.length, 0, "GPUDevice should again have no client nodes.");
+            expectNoSize();
+            InspectorTest.expectNull(await canvas.requestNode(), "GPUDevice should again have no canvas node.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.requestClientNodes.WebGPU.CSSCanvas",
+        description: "Check that a CSS WebGPU canvas reports its name and CSS client node.",
+        async test() {
+            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let sizeChangedPromise = waitForSize(() => canvas.sizes.length === 1 && canvas.sizes[0].width === 30 && canvas.sizes[0].height === 40);
+            InspectorTest.evaluateInPage(`configureCSSClient()`);
+
+            let event = await clientNodesChangedPromise;
+            await sizeChangedPromise;
+            cssCanvasName = await InspectorTest.evaluateInPage(`cssCanvasName`);
+            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
+            InspectorTest.expectShallowEqual(canvas.cssCanvasNames, [], "GPUDevice should not update its CSS canvas names before requestClientNodes.");
+            let clientNodes = await requestClientNodes();
+            InspectorTest.expectShallowEqual(canvas.cssCanvasNames, [cssCanvasName], "GPUDevice should include its CSS canvas name.");
+            InspectorTest.expectEqual(clientNodes.length, 1, "GPUDevice should have one CSS canvas client node.");
+            InspectorTest.expectEqual(clientNodes[0].appropriateSelectorFor(), "div#webgpu-css-client", "Client node should be the CSS canvas consumer.");
+            expectSize(30, 40);
+        },
+    });
+
+    suite.addTestCase({
+        name: "Canvas.requestClientNodes.WebGPU.CSSCanvasUnconfigure",
+        description: "Check that unconfiguring a CSS WebGPU canvas clears its name and client node.",
+        async test() {
+            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let sizeChangedPromise = waitForSize(() => !canvas.sizes.length);
+            InspectorTest.evaluateInPage(`unconfigureCSSClient()`);
+
+            let event = await clientNodesChangedPromise;
+            await sizeChangedPromise;
+            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
+            InspectorTest.expectShallowEqual(canvas.cssCanvasNames, [cssCanvasName], "GPUDevice should preserve its CSS canvas names before requestClientNodes.");
+            let clientNodes = await requestClientNodes();
+            InspectorTest.expectShallowEqual(canvas.cssCanvasNames, [], "GPUDevice should no longer have CSS canvas names.");
+            InspectorTest.expectEqual(clientNodes.length, 0, "GPUDevice should no longer have CSS canvas client nodes.");
+            expectNoSize();
         },
     });
 
@@ -143,12 +296,16 @@ function test() {
         description: "Check that an OffscreenCanvas can use the GPUDevice without creating a DOM client node or a separate Canvas.",
         async test() {
             let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let sizeChangedPromise = waitForSize(() => canvas.sizes.length === 1 && canvas.sizes[0].width === 4 && canvas.sizes[0].height === 4);
             InspectorTest.evaluateInPage(`configureOffscreenClient()`);
 
             let event = await clientNodesChangedPromise;
+            await sizeChangedPromise;
             InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
             let clientNodes = await requestClientNodes();
             InspectorTest.expectEqual(clientNodes.length, 0, "OffscreenCanvas should not create a DOM client node.");
+            expectSize(4, 4);
+            InspectorTest.expectNull(await canvas.requestNode(), "OffscreenCanvas should not create a canvas node.");
             InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "OffscreenCanvas GPUCanvasContext should not create a separate Canvas.");
         },
     });

--- a/LayoutTests/inspector/canvas/resources/create-context-utilities.js
+++ b/LayoutTests/inspector/canvas/resources/create-context-utilities.js
@@ -157,7 +157,7 @@ TestPage.registerInitializer(() => {
             test(resolve, reject) {
                 awaitCanvasAdded(contextType)
                 .then((canvas) => {
-                    InspectorTest.expectEqual(canvas.cssCanvasName, "css-canvas", "Canvas name should equal the identifier passed to -webkit-canvas.");
+                    InspectorTest.expectShallowEqual(canvas.cssCanvasNames, ["css-canvas"], "Canvas name should equal the identifier passed to -webkit-canvas.");
                 })
                 .then(resolve, reject);
 

--- a/LayoutTests/inspector/canvas/worker-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/worker-webgpu-expected.txt
@@ -9,6 +9,7 @@ PASS: Worker Canvas should use the GPUDevice label as its display name.
 PASS: Payload should have type "object".
 PASS: Payload should have className "GPUDevice".
 PASS: Worker GPUDevice should have no DOM client nodes.
+PASS: Worker GPUDevice should have the size of its OffscreenCanvas.
 PASS: Worker WebGPU Canvas content should not be empty.
 
 -- Running test case: Canvas.WebGPU.Worker.Pipelines

--- a/LayoutTests/inspector/canvas/worker-webgpu.html
+++ b/LayoutTests/inspector/canvas/worker-webgpu.html
@@ -34,6 +34,9 @@ async function test() {
         name: "Canvas.WebGPU.Worker.Device",
         description: "Check that a GPUDevice created in a Worker is discovered on the Worker target and can be resolved.",
         async test() {
+            if (!canvas.sizes.length)
+                await canvas.awaitEvent(WI.Canvas.Event.SizeChanged);
+
             InspectorTest.expectTrue(workerTarget.hasDomain("Canvas"), "Worker target should expose the Canvas domain.");
             InspectorTest.expectEqual(canvas.target, workerTarget, "WebGPU Canvas should belong to the Worker target.");
             InspectorTest.expectEqual(canvas.displayName, "Labeled Worker WebGPU Device", "Worker Canvas should use the GPUDevice label as its display name.");
@@ -45,6 +48,7 @@ async function test() {
 
             let clientNodes = await new Promise((resolve) => canvas.requestClientNodes(resolve));
             InspectorTest.expectEqual(clientNodes.length, 0, "Worker GPUDevice should have no DOM client nodes.");
+            InspectorTest.expectTrue(canvas.sizes.length === 1 && canvas.sizes[0].equals(new WI.Size(4, 4)), "Worker GPUDevice should have the size of its OffscreenCanvas.");
 
             let content = await canvas.requestContent();
             InspectorTest.expectGreaterThan(content.length, "data:image/png;base64,".length, "Worker WebGPU Canvas content should not be empty.");

--- a/Source/JavaScriptCore/inspector/protocol/Canvas.json
+++ b/Source/JavaScriptCore/inspector/protocol/Canvas.json
@@ -66,10 +66,9 @@
             "properties": [
                 { "name": "canvasId", "$ref": "CanvasId", "description": "Canvas identifier." },
                 { "name": "contextType", "$ref": "ContextType", "description": "The type of rendering context backing the canvas." },
-                { "name": "width", "type": "number", "optional": true, "description": "Width of the canvas in pixels." },
-                { "name": "height", "type": "number", "optional": true, "description": "Height of the canvas in pixels." },
+                { "name": "sizes", "type": "array", "items": { "$ref": "GenericTypes.Size" }, "optional": true },
                 { "name": "nodeId", "$ref": "DOM.NodeId", "optional": true, "description": "The corresponding DOM node id." },
-                { "name": "cssCanvasName", "type": "string", "optional": true, "description": "The CSS canvas identifier, for canvases created with <code>document.getCSSCanvasContext</code>." },
+                { "name": "cssCanvasNames", "type": "array", "items": { "type": "string" }, "optional": true, "description": "The CSS canvas identifiers, for canvases created with <code>document.getCSSCanvasContext</code>." },
                 { "name": "contextAttributes", "$ref": "ContextAttributes", "optional": true, "description": "Context attributes for rendering contexts." },
                 { "name": "features", "type": "array", "items": { "type": "string" }, "optional": true, "description": "Enabled WebGPU device features." },
                 { "name": "memoryCost", "type": "number", "optional": true, "description": "Memory usage of the canvas in bytes." },
@@ -128,7 +127,8 @@
                 { "name": "canvasId", "$ref": "CanvasId" }
             ],
             "returns": [
-                { "name": "clientNodeIds", "type": "array", "items": { "$ref": "DOM.NodeId" } }
+                { "name": "clientNodeIds", "type": "array", "items": { "$ref": "DOM.NodeId" } },
+                { "name": "cssCanvasNames", "type": "array", "items": { "type": "string" }, "description": "The CSS canvas identifiers, for canvases created with <code>document.getCSSCanvasContext</code>." }
             ]
         },
         {
@@ -221,8 +221,7 @@
             "name": "canvasSizeChanged",
             "parameters": [
                 { "name": "canvasId", "$ref": "CanvasId", "description": "Identifier of canvas that changed." },
-                { "name": "width", "type": "number", "description": "Width of the canvas in pixels." },
-                { "name": "height", "type": "number", "description": "Height of the canvas in pixels." }
+                { "name": "sizes", "type": "array", "items": { "$ref": "GenericTypes.Size" }, "optional": true }
             ]
         },
         {

--- a/Source/JavaScriptCore/inspector/protocol/GenericTypes.json
+++ b/Source/JavaScriptCore/inspector/protocol/GenericTypes.json
@@ -10,6 +10,15 @@
                 { "name": "lineNumber", "type": "number", "description": "Line number in resource content." },
                 { "name": "lineContent", "type": "string", "description": "Line with match content." }
             ]
+        },
+        {
+            "id": "Size",
+            "type": "object",
+            "description": "A two-dimensional size.",
+            "properties": [
+                { "name": "width", "type": "number" },
+                { "name": "height", "type": "number" }
+            ]
         }
     ]
 }

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -381,8 +381,12 @@ RefPtr<CanvasRenderingContext> HTMLCanvasElement::getContext(const String& type)
         return getContextWebGL(HTMLCanvasElement::toWebGLVersion(type));
 #endif
 
-    if (HTMLCanvasElement::isWebGPUType(type))
-        return getContextWebGPU(type, nullptr);
+    if (HTMLCanvasElement::isWebGPUType(type)) {
+        RefPtr<GPU> gpu;
+        if (RefPtr window = document().window())
+            gpu = protect(window->navigator())->gpu();
+        return getContextWebGPU(type, gpu);
+    }
 
     return nullptr;
 }

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -345,8 +345,6 @@ void GPUCanvasContextCocoa::didUpdateCanvasSizeProperties(bool)
 
     auto configuration = WTF::move(m_configuration);
     m_configuration.reset();
-    if (configuration)
-        InspectorInstrumentation::didChangeGPUDeviceClientNodes(configuration->device);
     unconfigure();
     if (configuration) {
         GPUCanvasConfiguration canvasConfiguration {
@@ -358,7 +356,8 @@ void GPUCanvasContextCocoa::didUpdateCanvasSizeProperties(bool)
             configuration->toneMapping,
             configuration->compositingAlphaMode,
         };
-        configure(WTF::move(canvasConfiguration), true);
+        if (configure(WTF::move(canvasConfiguration), true).hasException())
+            InspectorInstrumentation::didChangeGPUDeviceClientNodes(configuration->device);
     }
 }
 
@@ -542,7 +541,8 @@ ExceptionOr<void> GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& conf
         0,
         std::nullopt,
     };
-    InspectorInstrumentation::didChangeGPUDeviceClientNodes(m_configuration->device);
+    if (!dueToReshape)
+        InspectorInstrumentation::didChangeGPUDeviceClientNodes(m_configuration->device);
     return { };
 }
 

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -75,6 +75,7 @@
 #include <JavaScriptCore/IdentifiersFactory.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
+#include <ranges>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/Function.h>
 #include <wtf/RefPtr.h>
@@ -164,10 +165,87 @@ HTMLCanvasElement* InspectorCanvas::canvasElement() const
             Ref context = weakContext;
             return dynamicDowncast<HTMLCanvasElement>(context->canvasBase());
         },
-        [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>&) -> HTMLCanvasElement* {
-            return nullptr;
+        [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>& weakDevice) {
+            Ref device = weakDevice;
+
+            RefPtr<HTMLCanvasElement> canvasElement;
+            Locker locker { CanvasRenderingContext::instancesLock() };
+            for (SUPPRESS_UNCOUNTED_ARG auto* context : CanvasRenderingContext::instances()) {
+                if (!context->isContextThread() || !canvasContextMatchesDevice(*context, device))
+                    continue;
+
+                RefPtr currentCanvasElement = dynamicDowncast<HTMLCanvasElement>(context->canvasBase());
+                if (!currentCanvasElement)
+                    continue;
+
+                if (canvasElement) {
+                    canvasElement = nullptr;
+                    break;
+                }
+                canvasElement = currentCanvasElement;
+            }
+            return canvasElement.unsafeGet();
         }
     );
+}
+
+Vector<IntSize> InspectorCanvas::sizes() const
+{
+    return WTF::switchOn(m_context,
+        [](const WeakRef<CanvasRenderingContext>& weakContext) -> Vector<IntSize> {
+            Ref context = weakContext;
+            return { context->canvasBase().size() };
+        },
+        [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>& weakDevice) {
+            Ref device = weakDevice;
+
+            Vector<IntSize> sizes;
+            Locker locker { CanvasRenderingContext::instancesLock() };
+            for (SUPPRESS_UNCOUNTED_ARG auto* context : CanvasRenderingContext::instances()) {
+                if (!context->isContextThread() || !canvasContextMatchesDevice(*context, device))
+                    continue;
+
+                sizes.appendIfNotContains(context->canvasBase().size());
+            }
+            return sizes;
+        }
+    );
+}
+
+Vector<String> InspectorCanvas::cssCanvasNames() const
+{
+    auto cssCanvasNames = WTF::switchOn(m_context,
+        [](const WeakRef<CanvasRenderingContext>& weakContext) {
+            Ref context = weakContext;
+
+            Vector<String> cssCanvasNames;
+            if (RefPtr canvasElement = dynamicDowncast<HTMLCanvasElement>(context->canvasBase())) {
+                if (String cssCanvasName = canvasElement->document().nameForCSSCanvasElement(*canvasElement); !cssCanvasName.isEmpty())
+                    cssCanvasNames.append(cssCanvasName);
+            }
+            return cssCanvasNames;
+        },
+        [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>& weakDevice) {
+            Ref device = weakDevice;
+
+            Vector<String> cssCanvasNames;
+            Locker locker { CanvasRenderingContext::instancesLock() };
+            for (SUPPRESS_UNCOUNTED_ARG auto* context : CanvasRenderingContext::instances()) {
+                if (!context->isContextThread() || !canvasContextMatchesDevice(*context, device))
+                    continue;
+
+                if (RefPtr canvasElement = dynamicDowncast<HTMLCanvasElement>(context->canvasBase())) {
+                    if (String cssCanvasName = canvasElement->document().nameForCSSCanvasElement(*canvasElement); !cssCanvasName.isEmpty())
+                        cssCanvasNames.appendIfNotContains(cssCanvasName);
+                }
+
+            }
+            return cssCanvasNames;
+        }
+    );
+
+    std::ranges::sort(cssCanvasNames, codePointCompareLessThan);
+    return cssCanvasNames;
 }
 
 ScriptExecutionContext* InspectorCanvas::scriptExecutionContext() const
@@ -229,8 +307,15 @@ HashSet<Element*> InspectorCanvas::clientNodes() const
             for (SUPPRESS_UNCOUNTED_ARG auto* context : CanvasRenderingContext::instances()) {
                 if (!context->isContextThread() || !canvasContextMatchesDevice(*context, device))
                     continue;
-                if (RefPtr canvasElement = dynamicDowncast<HTMLCanvasElement>(context->canvasBase()))
-                    clientNodes.add(canvasElement);
+
+                if (RefPtr canvasElement = dynamicDowncast<HTMLCanvasElement>(context->canvasBase())) {
+                    if (canvasElement->document().nameForCSSCanvasElement(*canvasElement).isEmpty())
+                        clientNodes.add(canvasElement);
+                    else {
+                        for (auto& clientNode : context->canvasBase().cssCanvasClients())
+                            clientNodes.add(clientNode);
+                    }
+                }
             }
             return clientNodes;
         }
@@ -581,17 +666,7 @@ Ref<Inspector::Protocol::Canvas::Canvas> InspectorCanvas::buildObjectForCanvas(b
                 .setContextType(contextType)
                 .release();
 
-            const auto& size = context->canvasBase().size();
-            result->setWidth(size.width());
-            result->setHeight(size.height());
-
-            if (RefPtr node = dynamicDowncast<HTMLCanvasElement>(context->canvasBase())) {
-                String cssCanvasName = node->document().nameForCSSCanvasElement(*node);
-                if (!cssCanvasName.isEmpty())
-                    result->setCssCanvasName(cssCanvasName);
-
-                // FIXME: <https://webkit.org/b/178282> Web Inspector: send a DOM node with each Canvas payload and eliminate Canvas.requestNode
-            }
+            // FIXME: <https://webkit.org/b/178282> Web Inspector: send a DOM node with each Canvas payload and eliminate Canvas.requestNode
 
             if (auto attributes = buildObjectForCanvasContextAttributes(context))
                 result->setContextAttributes(attributes.releaseNonNull());
@@ -617,6 +692,24 @@ Ref<Inspector::Protocol::Canvas::Canvas> InspectorCanvas::buildObjectForCanvas(b
             return result;
         }
     );
+
+    if (auto sizes = this->sizes(); !sizes.isEmpty()) {
+        auto sizesPayload = JSON::ArrayOf<Inspector::Protocol::GenericTypes::Size>::create();
+        for (auto& size : sizes) {
+            sizesPayload->addItem(Inspector::Protocol::GenericTypes::Size::create()
+                .setWidth(size.width())
+                .setHeight(size.height())
+                .release());
+        }
+        canvas->setSizes(WTF::move(sizesPayload));
+    }
+
+    if (auto cssCanvasNames = this->cssCanvasNames(); !cssCanvasNames.isEmpty()) {
+        auto cssCanvasNamesPayload = JSON::ArrayOf<String>::create();
+        for (auto& cssCanvasName : cssCanvasNames)
+            cssCanvasNamesPayload->addItem(cssCanvasName);
+        canvas->setCssCanvasNames(WTF::move(cssCanvasNamesPayload));
+    }
 
     if (size_t memoryCost = this->memoryCost())
         canvas->setMemoryCost(memoryCost);

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -28,6 +28,7 @@
 
 #include "CanvasRenderingContext2DBase.h"
 #include "InspectorCanvasProcessedArguments.h"
+#include "IntSize.h"
 #include "WebGL2RenderingContext.h"
 #include "WebGLRenderingContextBase.h"
 #include <JavaScriptCore/AsyncStackTrace.h>
@@ -73,6 +74,9 @@ public:
     GPUDevice* deviceContext() const;
 
     HTMLCanvasElement* canvasElement() const;
+
+    Vector<IntSize> sizes() const;
+    Vector<String> cssCanvasNames() const;
 
     ScriptExecutionContext* scriptExecutionContext() const;
 

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -45,6 +45,7 @@
 #include "FrameDebuggerAgent.h"
 #include "FrameInspectorController.h"
 #include "FrameRuntimeAgent.h"
+#include "GPUCanvasContext.h"
 #include "InspectorAnimationAgent.h"
 #include "InspectorCSSAgent.h"
 #include "InspectorCanvasAgent.h"
@@ -1253,7 +1254,22 @@ void InspectorInstrumentation::didSendWebSocketFrameImpl(InstrumentingAgents& in
 
 void InspectorInstrumentation::didChangeCSSCanvasClientNodesImpl(InstrumentingAgents& instrumentingAgents, CanvasBase& canvasBase)
 {
-    if (CheckedPtr pageCanvasAgent = instrumentingAgents.enabledPageCanvasAgent())
+    CheckedPtr<PageCanvasAgent> pageCanvasAgent;
+
+    if (RefPtr gpuCanvasContext = dynamicDowncast<GPUCanvasContext>(canvasBase.renderingContext())) {
+        RefPtr device = gpuCanvasContext->device();
+        if (!device)
+            return;
+
+        RefPtr agents = InspectorInstrumentation::instrumentingAgents(protect(device->scriptExecutionContext()));
+        if (!agents)
+            return;
+
+        pageCanvasAgent = agents->enabledPageCanvasAgent();
+    } else
+        pageCanvasAgent = instrumentingAgents.enabledPageCanvasAgent();
+
+    if (pageCanvasAgent)
         pageCanvasAgent->didChangeCSSCanvasClientNodes(canvasBase);
 }
 
@@ -1265,7 +1281,22 @@ void InspectorInstrumentation::didCreateCanvasRenderingContextImpl(Instrumenting
 
 void InspectorInstrumentation::didChangeCanvasSizeImpl(InstrumentingAgents& instrumentingAgents, CanvasRenderingContext& context)
 {
-    if (CheckedPtr canvasAgent = instrumentingAgents.enabledCanvasAgent())
+    CheckedPtr<InspectorCanvasAgent> canvasAgent;
+
+    if (RefPtr gpuCanvasContext = dynamicDowncast<GPUCanvasContext>(context)) {
+        RefPtr device = gpuCanvasContext->device();
+        if (!device)
+            return;
+
+        RefPtr agents = InspectorInstrumentation::instrumentingAgents(protect(device->scriptExecutionContext()));
+        if (!agents)
+            return;
+
+        canvasAgent = agents->enabledCanvasAgent();
+    } else
+        canvasAgent = instrumentingAgents.enabledCanvasAgent();
+
+    if (canvasAgent)
         canvasAgent->didChangeCanvasSize(context);
 }
 
@@ -1336,8 +1367,8 @@ void InspectorInstrumentation::willDestroyWebGPUDeviceImpl(InstrumentingAgents& 
 
 void InspectorInstrumentation::didChangeGPUDeviceClientNodesImpl(InstrumentingAgents& instrumentingAgents, GPUDevice& device)
 {
-    if (CheckedPtr pageCanvasAgent = instrumentingAgents.enabledPageCanvasAgent())
-        pageCanvasAgent->didChangeGPUDeviceClientNodes(device);
+    if (CheckedPtr canvasAgent = instrumentingAgents.enabledCanvasAgent())
+        canvasAgent->didChangeGPUDeviceClientNodes(device);
 }
 
 void InspectorInstrumentation::didCreateWebGPUComputePipelineImpl(InstrumentingAgents& instrumentingAgents, GPUDevice& device, GPUComputePipeline& pipeline)

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -46,7 +46,6 @@
 #include "ImageBitmapRenderingContext.h"
 #include "ImageData.h"
 #include "InspectorCanvasCallTracer.h"
-#include "InspectorInstrumentation.h"
 #include "InspectorShaderProgram.h"
 #include "InstrumentingAgents.h"
 #include "JSExecState.h"
@@ -415,13 +414,20 @@ void InspectorCanvasAgent::didCreateCanvasRenderingContext(CanvasRenderingContex
 
 void InspectorCanvasAgent::didChangeCanvasSize(CanvasRenderingContext& context)
 {
-    RefPtr inspectorCanvas = findInspectorCanvas(context);
+    RefPtr<InspectorCanvas> inspectorCanvas;
+    if (WeakPtr gpuCanvasContext = dynamicDowncast<GPUCanvasContext>(context)) {
+        WeakPtr device = gpuCanvasContext->device();
+        if (!device)
+            return;
+        inspectorCanvas = findInspectorCanvas(*device);
+    } else
+        inspectorCanvas = findInspectorCanvas(context);
+
     ASSERT(inspectorCanvas);
     if (!inspectorCanvas)
         return;
 
-    const auto& size = context.canvasBase().size();
-    m_frontendDispatcher->canvasSizeChanged(inspectorCanvas->identifier(), size.width(), size.height());
+    dispatchCanvasSizeChanged(*inspectorCanvas);
 }
 
 void InspectorCanvasAgent::didChangeCanvasMemory(const CanvasRenderingContext& context)
@@ -648,6 +654,15 @@ void InspectorCanvasAgent::willDestroyWebGPUDevice(GPUDevice& device)
         return;
 
     unbindCanvas(*inspectorCanvas);
+}
+
+void InspectorCanvasAgent::didChangeGPUDeviceClientNodes(GPUDevice& device)
+{
+    RefPtr inspectorCanvas = findInspectorCanvas(device);
+    if (!inspectorCanvas)
+        return;
+
+    dispatchCanvasSizeChanged(*inspectorCanvas);
 }
 
 void InspectorCanvasAgent::didCreateWebGPUComputePipeline(GPUDevice& device, GPUComputePipeline& pipeline)
@@ -877,7 +892,7 @@ InspectorCanvas& InspectorCanvasAgent::bindCanvas(CanvasRenderingContext& contex
 
     context.canvasBase().addObserver(*this);
 
-    m_frontendDispatcher->canvasAdded(inspectorCanvas->buildObjectForCanvas(captureBacktrace));
+    m_frontendDispatcher->canvasAdded(buildObjectForCanvas(inspectorCanvas, captureBacktrace));
 
 #if ENABLE(WEBGL)
     if (is<WebGLRenderingContextBase>(context)) {
@@ -899,9 +914,30 @@ InspectorCanvas& InspectorCanvasAgent::bindCanvas(GPUDevice& device, bool captur
     auto inspectorCanvas = InspectorCanvas::create(device);
     m_identifierToInspectorCanvas.set(inspectorCanvas->identifier(), inspectorCanvas.copyRef());
 
-    m_frontendDispatcher->canvasAdded(inspectorCanvas->buildObjectForCanvas(captureBacktrace));
+    m_frontendDispatcher->canvasAdded(buildObjectForCanvas(inspectorCanvas, captureBacktrace));
 
     return inspectorCanvas.unsafeGet();
+}
+
+Ref<Inspector::Protocol::Canvas::Canvas> InspectorCanvasAgent::buildObjectForCanvas(InspectorCanvas& inspectorCanvas, bool captureBacktrace)
+{
+    return inspectorCanvas.buildObjectForCanvas(captureBacktrace);
+}
+
+void InspectorCanvasAgent::dispatchCanvasSizeChanged(InspectorCanvas& inspectorCanvas)
+{
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::GenericTypes::Size>> sizesPayload;
+    auto sizes = inspectorCanvas.sizes();
+    if (!sizes.isEmpty()) {
+        sizesPayload = JSON::ArrayOf<Inspector::Protocol::GenericTypes::Size>::create();
+        for (auto& size : sizes) {
+            sizesPayload->addItem(Inspector::Protocol::GenericTypes::Size::create()
+                .setWidth(size.width())
+                .setHeight(size.height())
+                .release());
+        }
+    }
+    m_frontendDispatcher->canvasSizeChanged(inspectorCanvas.identifier(), WTF::move(sizesPayload));
 }
 
 void InspectorCanvasAgent::unbindCanvas(InspectorCanvas& inspectorCanvas)

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -118,6 +118,7 @@ public:
 #endif // ENABLE(WEBGL)
     void didCreateWebGPUDevice(GPUDevice&);
     void willDestroyWebGPUDevice(GPUDevice&);
+    virtual void didChangeGPUDeviceClientNodes(GPUDevice&);
     void didCreateWebGPUComputePipeline(GPUDevice&, GPUComputePipeline&);
     void willDestroyWebGPUComputePipeline(GPUComputePipeline&);
     void didCreateWebGPURenderPipeline(GPUDevice&, GPURenderPipeline&);
@@ -143,6 +144,7 @@ protected:
     void reset();
     void unbindCanvas(InspectorCanvas&);
 
+    virtual Ref<Inspector::Protocol::Canvas::Canvas> buildObjectForCanvas(InspectorCanvas&, bool captureBacktrace);
     virtual bool matchesCurrentContext(ScriptExecutionContext*) const = 0;
 
     const UniqueRef<Inspector::CanvasFrontendDispatcher> m_frontendDispatcher;
@@ -165,6 +167,7 @@ private:
 
     InspectorCanvas& bindCanvas(CanvasRenderingContext&, bool captureBacktrace);
     InspectorCanvas& bindCanvas(GPUDevice&, bool captureBacktrace);
+    void dispatchCanvasSizeChanged(InspectorCanvas&);
 
     void unbindProgram(InspectorShaderProgram&);
     RefPtr<InspectorShaderProgram> assertInspectorProgram(Inspector::Protocol::ErrorString&, const String& programId);

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
@@ -34,6 +34,8 @@
 #include "DocumentPage.h"
 #include "Element.h"
 #include "FrameDestructionObserverInlines.h"
+#include "GPUCanvasContext.h"
+#include "GPUDevice.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLVideoElement.h"
@@ -104,7 +106,7 @@ Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> PageCanvasA
     return agents->persistentDOMAgent()->pushNodeToFrontend(errorString, documentNodeId, node);
 }
 
-Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> PageCanvasAgent::requestClientNodes(const Inspector::Protocol::Canvas::CanvasId& canvasId)
+Inspector::Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>, Ref<JSON::ArrayOf<String>>>> PageCanvasAgent::requestClientNodes(const Inspector::Protocol::Canvas::CanvasId& canvasId)
 {
     Inspector::Protocol::ErrorString errorString;
 
@@ -122,7 +124,14 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::N
         if (auto documentNodeId = domAgent->boundNodeId(protect(clientNode->document()).ptr()))
             clientNodeIds->addItem(domAgent->pushNodeToFrontend(errorString, documentNodeId, clientNode));
     }
-    return clientNodeIds;
+
+    Ref cssCanvasNamesPayload = JSON::ArrayOf<String>::create();
+    for (auto& cssCanvasName : inspectorCanvas->cssCanvasNames())
+        cssCanvasNamesPayload->addItem(cssCanvasName);
+
+    m_inspectorCanvasesWithPendingClientNodesChange.remove(*inspectorCanvas);
+
+    return { { WTF::move(clientNodeIds), WTF::move(cssCanvasNamesPayload) } };
 }
 
 void PageCanvasAgent::frameNavigated(LocalFrame& frame)
@@ -134,6 +143,8 @@ void PageCanvasAgent::frameNavigated(LocalFrame& frame)
 
     Vector<InspectorCanvas*> inspectorCanvases;
     for (auto& inspectorCanvas : m_identifierToInspectorCanvas.values()) {
+        if (!inspectorCanvas->canvasContext())
+            continue;
         if (RefPtr canvasElement = inspectorCanvas->canvasElement()) {
             if (canvasElement->document().frame() == &frame)
                 inspectorCanvases.append(inspectorCanvas.ptr());
@@ -151,21 +162,65 @@ void PageCanvasAgent::didChangeCSSCanvasClientNodes(CanvasBase& canvasBase)
         return;
     }
 
-    auto inspectorCanvas = findInspectorCanvas(*context);
+    RefPtr<InspectorCanvas> inspectorCanvas;
+    if (WeakPtr gpuCanvasContext = dynamicDowncast<GPUCanvasContext>(*context)) {
+        WeakPtr device = gpuCanvasContext->device();
+        if (!device)
+            return;
+        inspectorCanvas = findInspectorCanvas(*device);
+    } else
+        inspectorCanvas = findInspectorCanvas(*context);
+
     ASSERT(inspectorCanvas);
     if (!inspectorCanvas)
         return;
 
-    m_frontendDispatcher->clientNodesChanged(inspectorCanvas->identifier());
+    dispatchClientNodesChanged(*inspectorCanvas);
 }
 
 void PageCanvasAgent::didChangeGPUDeviceClientNodes(GPUDevice& device)
 {
+    InspectorCanvasAgent::didChangeGPUDeviceClientNodes(device);
+
     RefPtr inspectorCanvas = findInspectorCanvas(device);
     if (!inspectorCanvas)
         return;
 
-    m_frontendDispatcher->clientNodesChanged(inspectorCanvas->identifier());
+    dispatchClientNodesChanged(*inspectorCanvas);
+}
+
+Ref<Inspector::Protocol::Canvas::Canvas> PageCanvasAgent::buildObjectForCanvas(InspectorCanvas& inspectorCanvas, bool captureBacktrace)
+{
+    Ref result = InspectorCanvasAgent::buildObjectForCanvas(inspectorCanvas, captureBacktrace);
+
+    RefPtr canvasElement = inspectorCanvas.canvasElement();
+    if (auto nodeId = nodeIdForCanvas(canvasElement))
+        result->setNodeId(*nodeId);
+
+    return result;
+}
+
+std::optional<Inspector::Protocol::DOM::NodeId> PageCanvasAgent::nodeIdForCanvas(HTMLCanvasElement* canvasElement)
+{
+    if (!canvasElement)
+        return std::nullopt;
+
+    CheckedPtr domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    if (!domAgent)
+        return std::nullopt;
+
+    auto nodeId = domAgent->pushNodeToFrontend(canvasElement);
+    if (!nodeId)
+        return std::nullopt;
+    return nodeId;
+}
+
+void PageCanvasAgent::dispatchClientNodesChanged(InspectorCanvas& inspectorCanvas)
+{
+    if (!m_inspectorCanvasesWithPendingClientNodesChange.add(inspectorCanvas).isNewEntry)
+        return;
+
+    m_frontendDispatcher->clientNodesChanged(inspectorCanvas.identifier());
 }
 
 bool PageCanvasAgent::matchesCurrentContext(ScriptExecutionContext* scriptExecutionContext) const

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.h
@@ -27,6 +27,7 @@
 
 #include "InspectorCanvasAgent.h"
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
@@ -43,12 +44,12 @@ public:
 
     // CanvasBackendDispatcherHandler
     Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> requestNode(const Inspector::Protocol::Canvas::CanvasId&) override;
-    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&) override;
+    Inspector::Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>, Ref<JSON::ArrayOf<String>>>> requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&) override;
 
     // InspectorInstrumentation
     void frameNavigated(LocalFrame&);
     void didChangeCSSCanvasClientNodes(CanvasBase&);
-    void didChangeGPUDeviceClientNodes(GPUDevice&);
+    void didChangeGPUDeviceClientNodes(GPUDevice&) override;
 
 private:
     bool enabled() const override;
@@ -56,9 +57,14 @@ private:
     void internalEnable() override;
     void internalDisable() override;
 
+    Ref<Inspector::Protocol::Canvas::Canvas> buildObjectForCanvas(InspectorCanvas&, bool captureBacktrace) override;
+    std::optional<Inspector::Protocol::DOM::NodeId> nodeIdForCanvas(HTMLCanvasElement*);
+    void dispatchClientNodesChanged(InspectorCanvas&);
+
     bool matchesCurrentContext(ScriptExecutionContext*) const override;
 
     WeakRef<Page> m_inspectedPage;
+    WeakHashSet<InspectorCanvas> m_inspectorCanvasesWithPendingClientNodesChange;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp
@@ -49,7 +49,7 @@ Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> WorkerCanva
     return makeUnexpected("Not supported"_s);
 }
 
-Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> WorkerCanvasAgent::requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&)
+Inspector::Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>, Ref<JSON::ArrayOf<String>>>> WorkerCanvasAgent::requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&)
 {
     return makeUnexpected("Not supported"_s);
 }

--- a/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.h
@@ -42,7 +42,7 @@ public:
 
     // CanvasBackendDispatcherHandler
     Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> requestNode(const Inspector::Protocol::Canvas::CanvasId&) override;
-    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&) override;
+    Inspector::Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>, Ref<JSON::ArrayOf<String>>>> requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&) override;
 
 private:
     bool matchesCurrentContext(ScriptExecutionContext*) const override;

--- a/Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js
@@ -178,13 +178,13 @@ WI.CanvasManager = class CanvasManager extends WI.Object
         canvas.shaderProgramCollection.clear();
     }
 
-    canvasSizeChanged(target, canvasIdentifier, width, height)
+    canvasSizeChanged(target, canvasIdentifier, sizes)
     {
         let canvas = this._canvasForIdentifier(target, canvasIdentifier);
         if (!canvas)
             return;
 
-        canvas.sizeChanged(new WI.Size(width, height));
+        canvas.sizeChanged(sizes.map(WI.Size.fromJSON));
     }
 
     canvasMemoryChanged(target, canvasIdentifier, memoryCost)

--- a/Source/WebInspectorUI/UserInterface/Models/Canvas.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Canvas.js
@@ -25,23 +25,23 @@
 
 WI.Canvas = class Canvas extends WI.Object
 {
-    constructor(target, identifier, contextType, size, {domNode, cssCanvasName, contextAttributes, features, memoryCost, stackTrace, displayName} = {})
+    constructor(target, identifier, contextType, sizes, {domNode, cssCanvasNames, contextAttributes, features, memoryCost, stackTrace, displayName} = {})
     {
         super();
 
         console.assert(target instanceof WI.Target, target);
         console.assert(identifier);
         console.assert(contextType);
-        console.assert(!size || size instanceof WI.Size, size);
+        console.assert(Array.isArray(sizes) && sizes.every((size) => size instanceof WI.Size), sizes);
         console.assert(!stackTrace || stackTrace instanceof WI.StackTrace, stackTrace);
         console.assert(!displayName || typeof displayName === "string", displayName);
 
         this._target = target;
         this._identifier = identifier;
         this._contextType = contextType;
-        this._size = size || null;
+        this._sizes = sizes;
         this._domNode = domNode || null;
-        this._cssCanvasName = cssCanvasName || "";
+        this._cssCanvasNames = cssCanvasNames || [];
         this._contextAttributes = contextAttributes || {};
         this._features = features || [];
         this._extensions = new Set;
@@ -50,12 +50,14 @@ WI.Canvas = class Canvas extends WI.Object
         this._displayName = displayName || "";
 
         this._clientNodes = null;
+        this._requestClientNodesCallbacks = [];
+
         this._shaderProgramCollection = new WI.ShaderProgramCollection;
         this._recordingCollection = new WI.RecordingCollection;
 
         this._nextShaderProgramDisplayNumber = null;
 
-        this._requestNodePromise = null;
+        this._requestNodePromise = this._domNode ? Promise.resolve(this._domNode) : null;
 
         this._recordingState = WI.Canvas.RecordingState.Inactive;
         this._recordingFrames = [];
@@ -63,7 +65,7 @@ WI.Canvas = class Canvas extends WI.Object
 
         // COMPATIBILITY (macOS 14.0, iOS 17.0): `Canvas.canvasSizeChanged` did not exist yet.
         if (!InspectorBackend.hasEvent("Canvas.canvasSizeChanged")) {
-            console.assert(!size);
+            console.assert(!sizes.length);
 
             this.requestNode().then((node) => {
                 if (node) {
@@ -112,23 +114,37 @@ WI.Canvas = class Canvas extends WI.Object
             console.error("Invalid canvas context type", payload.contextType);
         }
 
-        // COMPATIBILITY (macOS 14.0, iOS 17.0): `width` and `height` did not exist yet.
-        let size = ("width" in payload && "height" in payload) ? new WI.Size(payload.width, payload.height) : null;
+        let sizes = payload.sizes?.map(WI.Size.fromJSON) || [];
+
+        // COMPATIBILITY (macOS X.Y, iOS X.Y): `width` and `height` were replaced by `sizes`.
+        if (!payload.sizes && "width" in payload && "height" in payload)
+            sizes.push(new WI.Size(payload.width, payload.height));
+
+        // COMPATIBILITY (macOS X.Y, iOS X.Y): `cssCanvasName` was renamed to `cssCanvasNames`.
+        let cssCanvasNames = payload.cssCanvasNames || (payload.cssCanvasName ? [payload.cssCanvasName] : []);
 
         // COMPATIBILITY (macOS 13.0, iOS 16.0): `backtrace` was renamed to `stackTrace`.
         if (payload.backtrace)
             payload.stackTrace = {callFrames: payload.backtrace};
 
-        return new WI.Canvas(target, payload.canvasId, contextType, size, {
-            height: payload.height,
-            domNode: payload.nodeId ? WI.domManager.nodeForId(payload.nodeId) : null,
-            cssCanvasName: payload.cssCanvasName,
+        return new WI.Canvas(target, payload.canvasId, contextType, sizes, {
+            domNode: WI.Canvas._domNodeForId(target, payload.nodeId),
+            cssCanvasNames,
             contextAttributes: payload.contextAttributes,
             features: payload.features,
             memoryCost: payload.memoryCost,
             stackTrace: WI.StackTrace.fromPayload(target, payload.stackTrace),
             displayName: payload.name,
         });
+    }
+
+    static _domNodeForId(target, nodeId)
+    {
+        if (!nodeId)
+            return null;
+        if (target instanceof WI.FrameTarget)
+            return WI.domManager.nodeForIdInFrameTarget(nodeId, target);
+        return WI.domManager.nodeForId(nodeId);
     }
 
     static displayNameForContextType(contextType)
@@ -186,9 +202,9 @@ WI.Canvas = class Canvas extends WI.Object
     get target() { return this._target; }
     get identifier() { return this._identifier; }
     get contextType() { return this._contextType; }
-    get size() { return this._size; }
+    get sizes() { return this._sizes; }
     get memoryCost() { return this._memoryCost; }
-    get cssCanvasName() { return this._cssCanvasName; }
+    get cssCanvasNames() { return this._cssCanvasNames; }
     get contextAttributes() { return this._contextAttributes; }
     get features() { return this._features; }
     get extensions() { return this._extensions; }
@@ -208,19 +224,19 @@ WI.Canvas = class Canvas extends WI.Object
         if (this._displayName)
             return this._displayName;
 
-        if (this._cssCanvasName)
-            return WI.UIString("CSS canvas \u201C%s\u201D").format(this._cssCanvasName);
+        if (this._contextType === Canvas.ContextType.WebGPU) {
+            if (!this._uniqueDisplayNameNumber)
+                this._uniqueDisplayNameNumber = Canvas._nextDeviceUniqueDisplayNameNumber++;
+            return WI.UIString("Device %d").format(this._uniqueDisplayNameNumber);
+        }
+
+        if (this._cssCanvasNames.length === 1)
+            return WI.UIString("CSS canvas \u201C%s\u201D").format(this._cssCanvasNames[0]);
 
         if (this._domNode) {
             let idSelector = this._domNode.escapedIdSelector;
             if (idSelector)
                 return WI.UIString("Canvas %s").format(idSelector);
-        }
-
-        if (this._contextType === Canvas.ContextType.WebGPU) {
-            if (!this._uniqueDisplayNameNumber)
-                this._uniqueDisplayNameNumber = Canvas._nextDeviceUniqueDisplayNameNumber++;
-            return WI.UIString("Device %d").format(this._uniqueDisplayNameNumber);
         }
 
         if (!this._uniqueDisplayNameNumber)
@@ -251,7 +267,7 @@ WI.Canvas = class Canvas extends WI.Object
     requestNode()
     {
         if (!this._requestNodePromise) {
-            this._requestNodePromise = new Promise((resolve, reject) => {
+            let promise = new Promise((resolve, reject) => {
                 WI.domManager.ensureDocument();
 
                 if (!this._target.hasCommand("Canvas.requestNode")) {
@@ -260,12 +276,17 @@ WI.Canvas = class Canvas extends WI.Object
                 }
 
                 this._target.CanvasAgent.requestNode(this._identifier, (error, nodeId) => {
+                    if (promise !== this._requestNodePromise) {
+                        resolve(this._domNode);
+                        return;
+                    }
+
                     if (error) {
                         resolve(null);
                         return;
                     }
 
-                    this._domNode = WI.domManager.nodeForId(nodeId);
+                    this._domNode = WI.Canvas._domNodeForId(this._target, nodeId);
                     if (!this._domNode) {
                         resolve(null);
                         return;
@@ -274,6 +295,7 @@ WI.Canvas = class Canvas extends WI.Object
                     resolve(this._domNode);
                 });
             });
+            this._requestNodePromise = promise;
         }
         return this._requestNodePromise;
     }
@@ -290,17 +312,25 @@ WI.Canvas = class Canvas extends WI.Object
             return;
         }
 
+        this._requestClientNodesCallbacks.push(callback);
+        if (this._requestClientNodesCallbacks.length > 1)
+            return;
+
         WI.domManager.ensureDocument();
 
-        let wrappedCallback = (error, clientNodeIds) => {
-            if (error) {
-                callback([]);
-                return;
+        let wrappedCallback = (error, clientNodeIds, cssCanvasNames) => {
+            let clientNodes = [];
+            if (!error) {
+                if (cssCanvasNames)
+                    this._cssCanvasNames = cssCanvasNames;
+
+                this._clientNodes = clientNodes = clientNodeIds.map((clientNodeId) => WI.Canvas._domNodeForId(this._target, clientNodeId));
             }
 
-            clientNodeIds = Array.isArray(clientNodeIds) ? clientNodeIds : [];
-            this._clientNodes = clientNodeIds.map((clientNodeId) => WI.domManager.nodeForId(clientNodeId));
-            callback(this._clientNodes);
+            let callbacks = this._requestClientNodesCallbacks;
+            this._requestClientNodesCallbacks = [];
+            for (let callback of callbacks)
+                callback(clientNodes);
         };
 
         if (this._target.hasCommand("Canvas.requestClientNodes")) {
@@ -342,22 +372,24 @@ WI.Canvas = class Canvas extends WI.Object
 
     saveIdentityToCookie(cookie)
     {
-        if (this._cssCanvasName)
-            cookie[WI.Canvas.CSSCanvasNameCookieKey] = this._cssCanvasName;
+        if (this._cssCanvasNames.length)
+            cookie[WI.Canvas.CSSCanvasNameCookieKey] = this._cssCanvasNames.join(",");
         else if (this._domNode)
             cookie[WI.Canvas.NodePathCookieKey] = this._domNode.path;
 
     }
 
-    sizeChanged(size)
+    sizeChanged(sizes)
     {
         // Called from WI.CanvasManager.
 
-        // COMPATIBILITY (macOS 14.0, iOS 17.0): `width` and `height` did not exist yet.
-        if (this._size?.equals(size))
+        console.assert(Array.isArray(sizes), sizes);
+        console.assert(sizes.every((size) => size instanceof WI.Size), sizes);
+
+        if (Array.shallowEqual(this._sizes, sizes))
             return;
 
-        this._size = size;
+        this._sizes = sizes;
 
         this.dispatchEventToListeners(WI.Canvas.Event.SizeChanged);
     }
@@ -386,6 +418,9 @@ WI.Canvas = class Canvas extends WI.Object
     clientNodesChanged()
     {
         // Called from WI.CanvasManager.
+
+        if (this._contextType === Canvas.ContextType.WebGPU)
+            this._requestNodePromise = null;
 
         this._clientNodes = null;
 
@@ -472,7 +507,7 @@ WI.Canvas = class Canvas extends WI.Object
         let size = await remoteObject.callFunctionJSON(inspectedPage_context_getCanvasSize);
         remoteObject.release();
 
-        this.sizeChanged(WI.Size.fromJSON(size));
+        this.sizeChanged([WI.Size.fromJSON(size)]);
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Protocol/CanvasObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/CanvasObserver.js
@@ -37,9 +37,13 @@ WI.CanvasObserver = class CanvasObserver extends InspectorBackend.Dispatcher
         WI.canvasManager.canvasRemoved(this._target, canvasId);
     }
 
-    canvasSizeChanged(canvasId, width, height)
+    canvasSizeChanged(canvasId, sizes)
     {
-        WI.canvasManager.canvasSizeChanged(this._target, canvasId, width, height);
+        // COMPATIBILITY (macOS X.Y, iOS X.Y): `width` and `height` were replaced by `sizes`.
+        if (!Array.isArray(sizes))
+            sizes = Number.isFinite(sizes) && Number.isFinite(arguments[2]) ? [{width: sizes, height: arguments[2]}] : [];
+
+        WI.canvasManager.canvasSizeChanged(this._target, canvasId, sizes);
     }
 
     canvasMemoryChanged(canvasId, memoryCost)

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js
@@ -41,6 +41,7 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
         this._pendingContent = null;
         this._pixelSizeElement = null;
         this._canvasNode = null;
+        this._requestNodePromise = null;
 
         this._refreshButtonNavigationItem = new WI.ButtonNavigationItem("refresh", WI.UIString("Refresh"), "Images/ReloadFull.svg", 13, 13);
         this._refreshButtonNavigationItem.visibilityPriority = WI.NavigationItem.VisibilityPriority.Low;
@@ -205,22 +206,14 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
 
         this.representedObject.addEventListener(WI.Canvas.Event.SizeChanged, this._updateSize, this);
         this.representedObject.addEventListener(WI.Canvas.Event.MemoryChanged, this._updateMemoryCost, this);
+        this.representedObject.addEventListener(WI.Canvas.Event.ClientNodesChanged, this._updateCanvasNode, this);
         this.representedObject.addEventListener(WI.Canvas.Event.RecordingStarted, this.needsLayout, this);
         this.representedObject.addEventListener(WI.Canvas.Event.RecordingProgress, this.needsLayout, this);
         this.representedObject.addEventListener(WI.Canvas.Event.RecordingStopped, this.needsLayout, this);
         this.representedObject.shaderProgramCollection.addEventListener(WI.Collection.Event.ItemAdded, this.needsLayout, this);
         this.representedObject.shaderProgramCollection.addEventListener(WI.Collection.Event.ItemRemoved, this.needsLayout, this);
 
-        this.representedObject.requestNode().then((node) => {
-            if (!node)
-                return;
-
-            console.assert(!this._canvasNode || this._canvasNode === node);
-            if (this._canvasNode === node)
-                return;
-
-            this._canvasNode = node;
-        });
+        this._updateCanvasNode();
 
         WI.settings.showImageGrid.addEventListener(WI.Setting.Event.Changed, this._updateImageGrid, this);
 
@@ -231,6 +224,7 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
     {
         this.representedObject.removeEventListener(WI.Canvas.Event.SizeChanged, this._updateSize, this);
         this.representedObject.removeEventListener(WI.Canvas.Event.MemoryChanged, this._updateMemoryCost, this);
+        this.representedObject.removeEventListener(WI.Canvas.Event.ClientNodesChanged, this._updateCanvasNode, this);
         this.representedObject.removeEventListener(WI.Canvas.Event.RecordingStarted, this.needsLayout, this);
         this.representedObject.removeEventListener(WI.Canvas.Event.RecordingProgress, this.needsLayout, this);
         this.representedObject.removeEventListener(WI.Canvas.Event.RecordingStopped, this.needsLayout, this);
@@ -238,6 +232,7 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
         this.representedObject.shaderProgramCollection.removeEventListener(WI.Collection.Event.ItemRemoved, this.needsLayout, this);
 
         this._canvasNode = null;
+        this._requestNodePromise = null;
 
         WI.settings.showImageGrid.removeEventListener(WI.Setting.Event.Changed, this._updateImageGrid, this);
 
@@ -305,7 +300,7 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
     _updateSize()
     {
         if (this._pixelSizeElement) {
-            let size = this.representedObject.size;
+            let size = this.representedObject.sizes.length === 1 ? this.representedObject.sizes[0] : null;
             if (size)
                 this._pixelSizeElement.textContent = `${size.width} ${multiplicationSign} ${size.height}`;
             else
@@ -313,6 +308,28 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
         }
 
         this.refreshPreview();
+    }
+
+    _updateCanvasNode()
+    {
+        this._canvasNode = null;
+
+        let requestNode = () => {
+            let requestNodePromise = this.representedObject.requestNode();
+            this._requestNodePromise = requestNodePromise;
+            requestNodePromise.then((node) => {
+                if (this._requestNodePromise !== requestNodePromise)
+                    return;
+                this._canvasNode = node;
+            });
+        };
+
+        if (this.representedObject.cssCanvasNames.length || this.representedObject.contextType === WI.Canvas.ContextType.WebGPU) {
+            this.representedObject.requestClientNodes(requestNode);
+            return;
+        }
+
+        requestNode();
     }
 
     _updateMemoryCost()

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.css
@@ -27,6 +27,10 @@
     display: block;
 }
 
+.sidebar > .panel.details.canvas .details-section > .content .row.simple.multiple > .value {
+    color: var(--text-color-gray-medium);
+}
+
 .sidebar > .panel.details.canvas .details-section.canvas-extensions .content > ul {
     margin: 4px 0;
     padding-inline-start: 22.5px;

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.js
@@ -32,7 +32,7 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         this.element.classList.add("canvas");
 
         this._canvas = null;
-        this._node = null;
+        this._nodeRequestPromise = null;
 
         this._sections = [];
         this._emptyContentPlaceholder = null;
@@ -68,17 +68,13 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         if (canvas === this._canvas)
             return;
 
-        if (this._node) {
-            this._node.removeEventListener(WI.DOMNode.Event.AttributeModified, this._refreshSourceSection, this);
-            this._node.removeEventListener(WI.DOMNode.Event.AttributeRemoved, this._refreshSourceSection, this);
-
-            this._node = null;
-        }
+        this._nodeRequestPromise = null;
 
         if (this._canvas) {
             this._canvas.removeEventListener(WI.Canvas.Event.MemoryChanged, this._canvasMemoryChanged, this);
             this._canvas.removeEventListener(WI.Canvas.Event.ExtensionEnabled, this._refreshExtensionsSection, this);
-            this._canvas.removeEventListener(WI.Canvas.Event.ClientNodesChanged, this._refreshClientsSection, this);
+            this._canvas.removeEventListener(WI.Canvas.Event.SizeChanged, this._refreshSourceSection, this);
+            this._canvas.removeEventListener(WI.Canvas.Event.ClientNodesChanged, this._handleClientNodesChanged, this);
         }
 
         this._canvas = canvas || null;
@@ -86,7 +82,8 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         if (this._canvas) {
             this._canvas.addEventListener(WI.Canvas.Event.MemoryChanged, this._canvasMemoryChanged, this);
             this._canvas.addEventListener(WI.Canvas.Event.ExtensionEnabled, this._refreshExtensionsSection, this);
-            this._canvas.addEventListener(WI.Canvas.Event.ClientNodesChanged, this._refreshClientsSection, this);
+            this._canvas.addEventListener(WI.Canvas.Event.SizeChanged, this._refreshSourceSection, this);
+            this._canvas.addEventListener(WI.Canvas.Event.ClientNodesChanged, this._handleClientNodesChanged, this);
         }
 
         this.needsLayout();
@@ -199,72 +196,34 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         if (!this.didInitialLayout)
             return;
 
-        let hideNode = this._canvas.cssCanvasName || this._canvas.contextType === WI.Canvas.ContextType.WebGPU;
-
-        this._nodeRow.value = hideNode ? null : emDash;
-        this._cssCanvasRow.value = this._canvas.cssCanvasName || null;
-        this._widthRow.value = emDash;
-        this._heightRow.value = emDash;
         this._detachedRow.value = null;
 
-        this._canvas.requestNode().then((node) => {
-            if (!node) {
-                this._nodeRow.value = null;
-                return;
-            }
+        if (this._canvas.cssCanvasNames.length)
+            this._nodeRow.value = null;
+        else {
+            let nodeRequestPromise = this._canvas.requestNode();
+            this._nodeRequestPromise = nodeRequestPromise;
+            this._nodeRequestPromise.then((node) => {
+                if (this._nodeRequestPromise !== nodeRequestPromise)
+                    return;
 
-            if (node !== this._node) {
-                if (this._node) {
-                    this._node.removeEventListener(WI.DOMNode.Event.AttributeModified, this._refreshSourceSection, this);
-                    this._node.removeEventListener(WI.DOMNode.Event.AttributeRemoved, this._refreshSourceSection, this);
-
-                    this._node = null;
+                if (!node) {
+                    this._nodeRow.value = null;
+                    return;
                 }
 
-                this._node = node;
+                this._nodeRow.value = WI.linkifyNodeReference(node);
+                this._detachedRow.value = node.parentNode ? null : WI.UIString("Yes");
+            });
+        }
 
-                this._node.addEventListener(WI.DOMNode.Event.AttributeModified, this._refreshSourceSection, this);
-                this._node.addEventListener(WI.DOMNode.Event.AttributeRemoved, this._refreshSourceSection, this);
-            }
+        this._cssCanvasRow.value = this._canvas.cssCanvasNames.join(", ") || null;
 
-            if (!hideNode) {
-                this._nodeRow.value = WI.linkifyNodeReference(this._node);
+        this._widthRow.value = this._canvas.sizes.length > 1 ? WI.UIString("(multiple)") : (this._canvas.sizes[0]?.width ?? emDash);
+        this._widthRow.element.classList.toggle("multiple", this._canvas.sizes.length > 1);
 
-                if (!this._node.parentNode)
-                    this._detachedRow.value = WI.UIString("Yes");
-            }
-
-            let setRowValueIfValidAttributeValue = (row, attribute) => {
-                let value = Number(this._node.getAttribute(attribute));
-                if (!Number.isInteger(value) || value < 0)
-                    return false;
-
-                row.value = value;
-                return true;
-            };
-
-            let validWidth = setRowValueIfValidAttributeValue(this._widthRow, "width");
-            let validHeight = setRowValueIfValidAttributeValue(this._heightRow, "height");
-            if (!validWidth || !validHeight) {
-                // Since the "width" and "height" properties of canvas elements are more than just
-                // attributes, we need to invoke the getter for each to get the actual value.
-                //  - https://html.spec.whatwg.org/multipage/canvas.html#attr-canvas-width
-                //  - https://html.spec.whatwg.org/multipage/canvas.html#attr-canvas-height
-                WI.RemoteObject.resolveNode(node).then((remoteObject) => {
-                    function setRowValueToPropertyValue(row, property) {
-                        remoteObject.getProperty(property, (error, result, wasThrown) => {
-                            if (!error && result.type === "number")
-                                row.value = `${result.value}px`;
-                        });
-                    }
-
-                    setRowValueToPropertyValue(this._widthRow, "width");
-                    setRowValueToPropertyValue(this._heightRow, "height");
-
-                    remoteObject.release();
-                });
-            }
-        });
+        this._heightRow.value = this._canvas.sizes.length > 1 ? WI.UIString("(multiple)") : (this._canvas.sizes[0]?.height ?? emDash);
+        this._heightRow.element.classList.toggle("multiple", this._canvas.sizes.length > 1);
     }
 
     _refreshAttributesSection()
@@ -328,7 +287,7 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         if (!this.didInitialLayout)
             return;
 
-        if (!this._canvas.cssCanvasName && this._canvas.contextType !== WI.Canvas.ContextType.WebGPU) {
+        if (!this._canvas.cssCanvasNames.length && this._canvas.contextType !== WI.Canvas.ContextType.WebGPU) {
             this._clientsSection.element.hidden = true;
             return;
         }
@@ -338,6 +297,8 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         this._clientsSection.element.hidden = false;
 
         this._canvas.requestClientNodes((clientNodes) => {
+            this._refreshSourceSection();
+
             if (!clientNodes.length)
                 return;
 
@@ -371,5 +332,13 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
     _canvasMemoryChanged(event)
     {
         this._formatMemoryRow();
+    }
+
+    _handleClientNodesChanged(event)
+    {
+        if (!this.didInitialLayout)
+            return;
+
+        this._refreshClientsSection();
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.js
@@ -150,7 +150,7 @@ WI.CanvasOverviewContentView = class CanvasOverviewContentView extends WI.Collec
             return;
 
         let canvas = contentView.representedObject;
-        if (canvas.cssCanvasName || canvas.contextType === WI.Canvas.ContextType.WebGPU) {
+        if (canvas.cssCanvasNames.length || canvas.contextType === WI.Canvas.ContextType.WebGPU) {
             canvas.requestClientNodes((clientNodes) => {
                 WI.domManager.highlightDOMNodeList(clientNodes);
             });

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasTreeElement.js
@@ -114,7 +114,7 @@ WI.CanvasTreeElement = class CanvasTreeElement extends WI.FolderizedTreeElement
 
     _handleMouseOver(event)
     {
-        if (this.representedObject.cssCanvasName || this.representedObject.contextType === WI.Canvas.ContextType.WebGPU) {
+        if (this.representedObject.cssCanvasNames.length || this.representedObject.contextType === WI.Canvas.ContextType.WebGPU) {
             this.representedObject.requestClientNodes((clientNodes) => {
                 WI.domManager.highlightDOMNodeList(clientNodes);
             });


### PR DESCRIPTION
#### 4ccb3f3a1c85f1983007f8721f5696f88266a0dc
<pre>
Web Inspector: Canvas: expose client metadata for WebGPU devices
<a href="https://bugs.webkit.org/show_bug.cgi?id=320876">https://bugs.webkit.org/show_bug.cgi?id=320876</a>

Reviewed by Mike Wyrzykowski.

* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getContext):
Use `navigator.gpu` when creating a WebGPU context for internal callers such as `document.getCSSCanvasContext`.

* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::didUpdateCanvasSizeProperties):
(WebCore::GPUCanvasContextCocoa::configure):
Do not report the configured `GPUDevice` as temporarily detached while an internal resize reconfigures its `GPUCanvasContext`.
Only report it if reconfiguration fails.

* Source/WebCore/inspector/InspectorCanvas.h:
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::canvasElement const):
(WebCore::InspectorCanvas::sizes const): Added.
(WebCore::InspectorCanvas::cssCanvasNames const): Added.
(WebCore::InspectorCanvas::clientNodes const):
(WebCore::InspectorCanvas::buildObjectForCanvas):
Collect distinct sizes, a single `HTMLCanvasElement`, and CSS canvas names across every configured `GPUCanvasContext` using a `GPUDevice`.

* Source/JavaScriptCore/inspector/protocol/GenericTypes.json:
* Source/JavaScriptCore/inspector/protocol/Canvas.json:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didChangeCSSCanvasClientNodesImpl):
(WebCore::InspectorInstrumentation::didChangeCanvasSizeImpl):
(WebCore::InspectorInstrumentation::didChangeGPUDeviceClientNodesImpl):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.h:
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::didChangeCanvasSize):
(WebCore::InspectorCanvasAgent::didChangeGPUDeviceClientNodes): Added.
(WebCore::InspectorCanvasAgent::bindCanvas):
(WebCore::InspectorCanvasAgent::buildObjectForCanvas): Added.
(WebCore::InspectorCanvasAgent::dispatchCanvasSizeChanged): Added.
Represent canvas `width` and `height` as an array of `GenericTypes.Size` since a single `GPUDevice` can be configured for multiple `&lt;canvas&gt;`.
Rename `cssCanvasName` to `cssCanvasNames`.

* Source/WebCore/inspector/agents/page/PageCanvasAgent.h:
* Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp:
(WebCore::PageCanvasAgent::requestClientNodes):
(WebCore::PageCanvasAgent::frameNavigated):
(WebCore::PageCanvasAgent::didChangeCSSCanvasClientNodes):
(WebCore::PageCanvasAgent::didChangeGPUDeviceClientNodes):
(WebCore::PageCanvasAgent::buildObjectForCanvas): Added.
(WebCore::PageCanvasAgent::nodeIdForCanvas): Added.
(WebCore::PageCanvasAgent::dispatchClientNodesChanged): Added.
* Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp:
(WebCore::WorkerCanvasAgent::requestClientNodes):
Return the current client nodes and CSS `&lt;canvas&gt;` names with `Canvas.requestClientNodes`.
Provide an initial `nodeId` only when a `GPUDevice` has exactly one `&lt;canvas&gt;`.

* Source/WebInspectorUI/UserInterface/Protocol/CanvasObserver.js:
(WI.CanvasObserver.prototype.canvasSizeChanged):
* Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js:
(WI.CanvasManager.prototype.canvasSizeChanged):
* Source/WebInspectorUI/UserInterface/Models/Canvas.js:
(WI.Canvas):
(WI.Canvas.fromPayload):
(WI.Canvas._domNodeForId): Added.
(WI.Canvas.prototype.get size): Removed.
(WI.Canvas.prototype.get sizes): Added.
(WI.Canvas.prototype.get cssCanvasNames): Renamed from `cssCanvasName`.
(WI.Canvas.prototype.get displayName):
(WI.Canvas.prototype.requestNode):
(WI.Canvas.prototype.requestClientNodes):
(WI.Canvas.prototype.saveIdentityToCookie):
(WI.Canvas.prototype.sizeChanged):
(WI.Canvas.prototype.clientNodesChanged):
(WI.Canvas.prototype._calculateSize):
Store every distinct size instead of assuming that there&apos;s only a single size.
Coalesce concurrent `Canvas.requestClientNodes` calls into one backend request and deliver its result to every callback.

* Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js:
(WI.CanvasContentView):
(WI.CanvasContentView.prototype.attached):
(WI.CanvasContentView.prototype.detached):
(WI.CanvasContentView.prototype._updateSize):
(WI.CanvasContentView.prototype._updateCanvasNode): Added.
* Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.js:
(WI.CanvasDetailsSidebarPanel):
(WI.CanvasDetailsSidebarPanel.prototype.set canvas):
(WI.CanvasDetailsSidebarPanel.prototype._refreshSourceSection):
(WI.CanvasDetailsSidebarPanel.prototype._refreshClientsSection):
(WI.CanvasDetailsSidebarPanel.prototype._handleClientNodesChanged): Added.
* Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.js:
(WI.CanvasOverviewContentView.prototype._contentViewMouseEnter):
* Source/WebInspectorUI/UserInterface/Views/CanvasTreeElement.js:
(WI.CanvasTreeElement.prototype._handleMouseOver):
* Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.css:
(.sidebar &gt; .panel.details.canvas .details-section &gt; .content .row.simple.multiple &gt; .value): Added.
Show &quot;(multiple)&quot; in the details sidebar &quot;Width&quot; and &quot;Height&quot; rows when there are multiple sizes.
Request invalidated client metadata before refreshing source links and canvas highlighting.
Drive-by: use `WI.Canvas.prototype.get sizes` instead of inspecting DOM attributes or resolving a remote object.
Drive-by: listen for `WI.Canvas.Event.SizeChanged` instead of observing DOM attribute changes.

* LayoutTests/inspector/canvas/resources/create-context-utilities.js:
* LayoutTests/inspector/canvas/requestClientNodes-css.html:
* LayoutTests/inspector/canvas/requestClientNodes-webgpu.html:
* LayoutTests/inspector/canvas/requestClientNodes-webgpu-expected.txt:
* LayoutTests/inspector/canvas/worker-webgpu.html:
* LayoutTests/inspector/canvas/worker-webgpu-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318467@main">https://commits.webkit.org/318467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0de421646d680967e9806fb40bf8b1d7beb5a414

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178333 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187948 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141581 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139020 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159781 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41250 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39600 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1444 "Found 1 new JSC stress test failure: stress/get-array-length-concurrently-change-mode.js.eager-jettison-no-cjit (failure)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8269 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39278 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36404 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39606 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190376 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148173 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39802 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52621 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147948 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42666 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124886 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119485 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51139 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14253 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50524 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50764 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->