### PR TITLE
Build failure: WebViewTests.swift uses try/await outside of #expect

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift
@@ -79,13 +79,13 @@ struct WebViewTests {
         try await model.page.load(html: #"<div id="div">hello</div>"#).wait()
         await model.page.waitForNextPresentationUpdate()
 
-        try await #expect(isContentEditable())
+        #expect(try await isContentEditable())
 
         model.isEditable = false
 
         await model.page.waitForNextPresentationUpdate()
 
-        try await #expect(!isContentEditable())
+        #expect(!(try await isContentEditable()))
     }
 }
 


### PR DESCRIPTION
#### c2108a1ff19421107b45402a89468a0dcf356456
<pre>
Build failure: WebViewTests.swift uses try/await outside of #expect
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320879">https://bugs.webkit.org/show_bug.cgi?id=320879</a>&gt;
&lt;<a href="https://rdar.apple.com/183899413">rdar://183899413</a>&gt;

Unreviewed build fix.

Move `try await` inside the `#expect(...)` macro in
`applyingContentEnvironmentAffectsPageSemantics`.  The async, throwing
`isContentEditable()` call is evaluated inside the macro&apos;s autoclosure,
which is neither an async nor a throwing context, so placing `try await`
outside the macro fails to compile.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift:
(WebViewTests.applyingContentEnvironmentAffectsPageSemantics):

Canonical link: <a href="https://commits.webkit.org/318447@main">https://commits.webkit.org/318447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/694fb356bc6cfd9e57c31047f6b155c75a8f6f44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187947 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141580 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d8dabfd-fd1c-479c-9e09-31cde670c625) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139017 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96524 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1039848e-6d4d-4523-a441-b0045cb02475) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119472 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72d5a7a4-3574-40b2-9989-ab6584da912f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41248 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39599 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39277 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36403 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190375 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51938 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148172 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52620 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147947 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27050 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42663 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119484 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51138 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14252 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50523 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50763 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50585 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->