### PR TITLE
[Coordinated Graphics] Unnecessary texture allocation in the fast path of CoordinatedBackingStoreTile::processPendingUpdates

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
@@ -46,6 +46,30 @@ void CoordinatedBackingStoreTile::addUpdate(Update&& update)
     m_updates.append(WTF::move(update));
 }
 
+void CoordinatedBackingStoreTile::ensureTexture(const IntSize& size, CoordinatedTileBuffer& buffer)
+{
+    OptionSet<BitmapTexture::Flags> flags;
+    if (buffer.supportsAlpha())
+        flags.add(BitmapTexture::Flags::SupportsAlpha);
+
+#if USE(SKIA) && USE(GBM)
+    if (SkiaPaintingEngine::shouldUseLinearTileTextures()) {
+        flags.add(BitmapTexture::Flags::BackedByDMABuf);
+        flags.add(BitmapTexture::Flags::ForceLinearBuffer);
+    } else if (SkiaPaintingEngine::shouldUseVivanteSuperTiledTileTextures()) {
+        flags.add(BitmapTexture::Flags::BackedByDMABuf);
+        flags.add(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer);
+    }
+#endif
+
+    WTFBeginSignpost(this, AcquireTexture);
+    if (!m_texture)
+        m_texture = BitmapTexturePool::singleton().acquireTexture(size, flags);
+    else if (buffer.supportsAlpha() == m_texture->isOpaque())
+        m_texture->reset(size, flags);
+    WTFEndSignpost(this, AcquireTexture);
+}
+
 void CoordinatedBackingStoreTile::processPendingUpdates()
 {
     auto updates = WTF::move(m_updates);
@@ -59,32 +83,15 @@ void CoordinatedBackingStoreTile::processPendingUpdates()
 
         WTFBeginSignpost(this, CoordinatedSwapBuffer, "%u/%zu, rect %ix%i+%i+%i", updateIndex + 1, updatesCount, update.tileRect.x(), update.tileRect.y(), update.tileRect.width(), update.tileRect.height());
 
+        update.buffer->waitUntilPaintingComplete();
+
         FloatRect unscaledTileRect(update.tileRect);
         unscaledTileRect.scale(1. / m_scale);
 
-        OptionSet<BitmapTexture::Flags> flags { };
-        if (update.buffer->supportsAlpha())
-            flags.add(BitmapTexture::Flags::SupportsAlpha);
-
-#if USE(SKIA) && USE(GBM)
-        if (SkiaPaintingEngine::shouldUseLinearTileTextures()) {
-            flags.add(BitmapTexture::Flags::BackedByDMABuf);
-            flags.add(BitmapTexture::Flags::ForceLinearBuffer);
-        } else if (SkiaPaintingEngine::shouldUseVivanteSuperTiledTileTextures()) {
-            flags.add(BitmapTexture::Flags::BackedByDMABuf);
-            flags.add(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer);
-        }
-#endif
-
-        WTFBeginSignpost(this, AcquireTexture);
-        if (!m_texture || unscaledTileRect != m_rect) {
+        if (unscaledTileRect != m_rect) {
             m_rect = unscaledTileRect;
-            m_texture = BitmapTexturePool::singleton().acquireTexture(update.tileRect.size(), flags);
-        } else if (update.buffer->supportsAlpha() == m_texture->isOpaque())
-            m_texture->reset(update.tileRect.size(), flags);
-        WTFEndSignpost(this, AcquireTexture);
-
-        update.buffer->waitUntilPaintingComplete();
+            m_texture = nullptr;
+        }
 
 #if USE(SKIA)
         if (update.buffer->isBackedByOpenGL()) {
@@ -97,19 +104,25 @@ void CoordinatedBackingStoreTile::processPendingUpdates()
             // Fast path: whole tile content changed -- take ownership of the incoming texture, replacing the existing tile buffer (avoiding texture copies).
             if (update.sourceRect.size() == update.tileRect.size()) {
                 ASSERT(update.sourceRect.location().isZero());
-                m_texture->swapTexture(*texture);
-            } else
+                if (m_texture)
+                    m_texture->swapTexture(*texture);
+                else
+                    m_texture = WTF::move(texture);
+            } else {
+                ensureTexture(update.tileRect.size(), buffer);
                 m_texture->copyFromExternalTexture(texture->id(), update.sourceRect, toIntSize(update.bufferOffset));
+            }
 
             WTFEndSignpost(this, CopyTextureGPUToGPU);
             WTFEndSignpost(this, CoordinatedSwapBuffer);
             continue;
         }
 #endif
+        auto& buffer = static_cast<CoordinatedUnacceleratedTileBuffer&>(update.buffer.get());
+        ensureTexture(update.tileRect.size(), buffer);
 
         WTFBeginSignpost(this, CopyTextureCPUToGPU);
         ASSERT(!update.buffer->isBackedByOpenGL());
-        auto& buffer = static_cast<CoordinatedUnacceleratedTileBuffer&>(update.buffer.get());
         m_texture->updateContents(buffer.data(), update.sourceRect, update.bufferOffset, buffer.stride(), update.buffer->pixelFormat());
         WTFEndSignpost(this, CopyTextureCPUToGPU);
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
@@ -51,6 +51,8 @@ public:
     bool canBePainted() const { return !!m_texture; }
 
 private:
+    void ensureTexture(const IntSize&, CoordinatedTileBuffer&);
+
     RefPtr<BitmapTexture> m_texture;
     Vector<Update> m_updates;
     float m_scale { 1. };


### PR DESCRIPTION
#### 6580afcaf2cd700c78e415ec852b2c37227fce88
<pre>
[Coordinated Graphics] Unnecessary texture allocation in the fast path of CoordinatedBackingStoreTile::processPendingUpdates
<a href="https://bugs.webkit.org/show_bug.cgi?id=320881">https://bugs.webkit.org/show_bug.cgi?id=320881</a>

Reviewed by Carlos Garcia Campos.

CoordinatedBackingStoreTile::processPendingUpdates() has the fast path for the
case the whole tile content is changed. In this case, a texture was allocated,
then it was just freed in the case m_texture is null.

SkiaBackingStore also has this fast path, but it doesn&apos;t have this problem.
Follow the style of SkiaBackingStore.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp:
(WebCore::CoordinatedBackingStoreTile::ensureTexture): Added.
(WebCore::CoordinatedBackingStoreTile::processPendingUpdates):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h:

Canonical link: <a href="https://commits.webkit.org/318446@main">https://commits.webkit.org/318446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01da5b8212de4a6018d68b49c4b0cabed1308caa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178369 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187984 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141617 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52017 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181326 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/42611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/119505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36440 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44907 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190412 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51976 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52657 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/147980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27049 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/42692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124922 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119531 "Failed to checkout and rebase branch from PR 70749") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51175 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50800 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->