### PR TITLE
[scroll-animations] An unresolved progress-based timeline current time is treated as a progress timeline boundary

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-unresolved-current-time-at-effect-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-unresolved-current-time-at-effect-end-expected.txt
@@ -1,0 +1,3 @@
+
+PASS An animation held at its effect end does not apply its effect when the view timeline current time is unresolved
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-unresolved-current-time-at-effect-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-unresolved-current-time-at-effect-end.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An animation held at its effect end is not at a progress timeline boundary when the timeline's current time is unresolved</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations-2/#at-progress-timeline-boundary">
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#view-timelines">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+<style>
+  #scroller {
+    position: relative;
+    height: 200px;
+    width: 200px;
+    overflow: auto;
+  }
+  #subject {
+    position: absolute;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    view-timeline: --view;
+  }
+  #spacer {
+    height: 1000px;
+  }
+
+  @keyframes tinted {
+    0% { background-color: green; }
+    100% { background-color: green; }
+  }
+  #target {
+    width: 25px;
+    height: 25px;
+    background-color: transparent;
+    animation: tinted;
+    animation-timeline: --view;
+  }
+</style>
+</head>
+<body>
+<div id="scroller">
+  <div id="subject"><div id="target"></div></div>
+  <div id="spacer"></div>
+</div>
+<script>
+promise_test(async t => {
+    const scroller = document.getElementById('scroller');
+    const subject = document.getElementById('subject');
+    const target = document.getElementById('target');
+
+    await waitForNextFrame();
+
+    scroller.scrollTop = 200;
+    await waitForNextFrame();
+
+    const animation = target.getAnimations()[0];
+    assert_equals(animation.playState, 'finished', 'animation finished past its cover range');
+    assert_equals(animation.currentTime.toString(), '100%', 'animation holds at its effect end');
+    assert_equals(getComputedStyle(target).backgroundColor, 'rgba(0, 0, 0, 0)',
+        'effect does not apply past its active range');
+
+    scroller.style.height = '0px';
+    subject.style.height = '0px';
+    await waitForNextFrame();
+
+    assert_equals(animation.timeline.currentTime, null, 'timeline current time is unresolved');
+    assert_equals(animation.currentTime.toString(), '100%', 'animation still holds at its effect end');
+    assert_equals(animation.startTime.toString(), '0%', 'animation start time is resolved');
+    assert_equals(getComputedStyle(target).backgroundColor, 'rgba(0, 0, 0, 0)',
+        'an unresolved timeline current time is not a progress timeline boundary');
+}, 'An animation held at its effect end does not apply its effect when the view timeline current time is unresolved');
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/AnimationEffectTiming.cpp
+++ b/Source/WebCore/animation/AnimationEffectTiming.cpp
@@ -167,7 +167,11 @@ BasicEffectTiming AnimationEffectTiming::getBasicTiming(const ResolutionData& da
             // Set unlimited current time based on the first matching condition:
             // - start time is resolved: (timeline time - start time) × playback rate
             // - Otherwise: animation's current time
-            auto unlimitedCurrentTime = (data.startTime && data.timelineTime) ? (*data.timelineTime - *data.startTime) * data.playbackRate : *data.localTime;
+            // An unresolved timeline time leaves the first case unresolved, and so leaves
+            // "effective timeline progress" below neither 0 nor 1.
+            if (data.startTime && !data.timelineTime)
+                return false;
+            auto unlimitedCurrentTime = data.startTime ? (*data.timelineTime - *data.startTime) * data.playbackRate : *data.localTime;
             // Let effective timeline time be unlimited current time / animation’s playback rate + effective start time
             auto effectiveTimelineTime = unlimitedCurrentTime / data.playbackRate + effectiveStartTime;
             // Let effective timeline progress be effective timeline time / timeline duration


### PR DESCRIPTION
#### 928daa1cfd842184684d3f14365f82c93352695f
<pre>
[scroll-animations] An unresolved progress-based timeline current time is treated as a progress timeline boundary
<a href="https://bugs.webkit.org/show_bug.cgi?id=320882">https://bugs.webkit.org/show_bug.cgi?id=320882</a>
<a href="https://rdar.apple.com/183902668">rdar://183902668</a>

Reviewed by Antoine Quint.

Step 3 of [1] sets &quot;unlimited current time&quot; from the timeline time when the animation&apos;s
start time is resolved, and only otherwise falls back to the animation&apos;s current time.
We additionally required the timeline time to be resolved before taking the first
branch, so a resolved start time paired with an unresolved timeline time silently took
the fallback.

That is wrong for an animation holding at its effect end: its hold time equals the
timeline duration, so &quot;effective timeline progress&quot; is exactly 1 and we report a
boundary even though the timeline has no current time. Being at a boundary suppresses
the after phase, so a &quot;none&quot; fill mode animation stays active and keeps applying its
100% keyframe instead of reverting to its unanimated style. Per [1] an unresolved
timeline time instead propagates to &quot;effective timeline progress&quot;, which is then
neither 0 nor 1, so the procedure returns false. Return false on that branch, leaving
the start-time-unresolved branch to use the animation&apos;s current time as [1] specifies.

This is why animation-inactive-outside-range-test.html is flaky. Its &quot;After cover
phase&quot; indicator is the only one of the four whose local time is held exactly on its
active-after boundary, so it is the only one whose phase hinges on this predicate
rather than on a strict inequality; one frame with an unresolved view timeline current
time paints it green instead of grey.

[1] <a href="https://drafts.csswg.org/web-animations-2/#at-progress-timeline-boundary">https://drafts.csswg.org/web-animations-2/#at-progress-timeline-boundary</a>

Test: imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-unresolved-current-time-at-effect-end.html

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-unresolved-current-time-at-effect-end-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-unresolved-current-time-at-effect-end.html: Added.
* Source/WebCore/animation/AnimationEffectTiming.cpp:
(WebCore::AnimationEffectTiming::getBasicTiming const):

Canonical link: <a href="https://commits.webkit.org/319442@main">https://commits.webkit.org/319442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2c508d9b00062dfa81153aa7407bc65dd6fc1e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191566 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145669 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d31d752-8540-471b-92f1-a08c08e55649) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141529 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/538b1069-22aa-41f7-8979-de2209ff3399) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121969 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e01ea94-b9e8-46ea-9329-fb696a816e4c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43886 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42158 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41811 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2722 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193494 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150926 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40453 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55646 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150632 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45218 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127927 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123522 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54162 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16809 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53544 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53782 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53609 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->