### PR TITLE
Sync WPT tests for preload/

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/preload/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/WEB_FEATURES.yml
@@ -1,27 +1,17 @@
-features:
-- name: modulepreload
-  files:
-  - "*modulepreload*"
-- name: preloading-responsive-images
-  files:
-  - dynamic-adding-preload-imagesrcset.html
-  - link-header-preload-imagesrcset.html
-- name: link-rel-preconnect
-  files:
-  - "preconnect*"
-- name: link-rel-prefetch
-  files:
-  - "prefetch*"
-- name: link-rel-preload
-  files:
-  - "avoid-delaying-onload-link-preload*"
-  - delaying-onload-link-preload-after-discovery.html
-  - download-resources.html
-  - dynamic-adding-preload.html
-  - onerror-event.html
-  - onload-event.html
-  - "preload*"
-  - reflected-as-value.html
-  - "single-download-late*"
-  - "subresource-integrity*"
-  - supported-as-values.html
+rules:
+- "*modulepreload*": [modulepreload]
+- dynamic-adding-preload-imagesrcset.html: [preloading-responsive-images]
+- link-header-preload-imagesrcset.html: [preloading-responsive-images]
+- preconnect*: [link-rel-preconnect]
+- prefetch*: [link-rel-prefetch]
+- avoid-delaying-onload-link-preload*: [link-rel-preload]
+- delaying-onload-link-preload-after-discovery.html: [link-rel-preload]
+- download-resources.html: [link-rel-preload]
+- dynamic-adding-preload.html: [link-rel-preload]
+- onerror-event.html: [link-rel-preload]
+- onload-event.html: [link-rel-preload]
+- preload*: [link-rel-preload]
+- reflected-as-value.html: [link-rel-preload]
+- single-download-late*: [link-rel-preload]
+- subresource-integrity*: [link-rel-preload]
+- supported-as-values.html: [link-rel-preload]

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-already-in-module-map-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-already-in-module-map-expected.txt
@@ -1,0 +1,7 @@
+
+PASS already-fetched module fires load
+PASS already-fetched module with a syntax error fires load
+PASS already-fetched module that failed to fetch fires error
+PASS module still fetching that succeeds fires load
+PASS module still fetching that fails fires error
+

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-already-in-module-map.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-already-in-module-map.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>link rel=modulepreload for a URL already in the module map fires the right event</title>
+<meta name="timeout" content="long">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+// When a <link rel=modulepreload> targets a URL that is already present in the
+// module map (because a previous import()/<script type=module> fetched it, or
+// is still fetching it), it must fire the same event a fresh preload would:
+// "load" when fetching produces a (non-null) module script - even one with a
+// parse error - and "error" when fetching fails.
+
+// NOTE: crossorigin is what makes these tests exercise the "already in the
+// module map" path in implementations that key their preload cache on the CORS
+// mode: the preload and the import() of the same URL then don't share a preload
+// entry, so the preload has to be satisfied from the module map. Keep it.
+//
+// The still-fetching tests below append the link in the same task as the
+// import() call, relying on "fetch a single module script" having put the URL in
+// the module map as fetching before import() returns.
+function makeModulePreload(url) {
+  const link = document.createElement("link");
+  link.rel = "modulepreload";
+  link.as = "script";
+  link.crossOrigin = "";
+  link.href = url;
+  return link;
+}
+
+function attachAndWaitForLoad(link) {
+  return new Promise((resolve, reject) => {
+    link.addEventListener("load", resolve, { once: true });
+    link.addEventListener("error", () => reject(new Error("fired error")),
+                          { once: true });
+    document.head.appendChild(link);
+  });
+}
+
+function attachAndWaitForError(link) {
+  return new Promise((resolve, reject) => {
+    link.addEventListener("error", resolve, { once: true });
+    link.addEventListener("load", () => reject(new Error("fired load")),
+                          { once: true });
+    document.head.appendChild(link);
+  });
+}
+
+async function expectRejection(promise, description) {
+  await promise.then(
+    () => assert_unreached(description),
+    () => {});
+}
+
+promise_test(async _ => {
+  const url = "./resources/dummy-module.js?already-fetched-load";
+  await import(url);
+  await attachAndWaitForLoad(makeModulePreload(url));
+}, "already-fetched module fires load");
+
+promise_test(async _ => {
+  const url = "./resources/syntax-error.js?already-fetched-syntax-error";
+  await expectRejection(import(url), "import of a syntax-error module rejects");
+  // A parse error still produces a module script, so the preload succeeds and
+  // fires load; the error only surfaces when the module is evaluated.
+  await attachAndWaitForLoad(makeModulePreload(url));
+}, "already-fetched module with a syntax error fires load");
+
+promise_test(async _ => {
+  const url = "./resources/not-exist.js?already-fetched-network-error";
+  await expectRejection(import(url), "import of a missing module rejects");
+  await attachAndWaitForError(makeModulePreload(url));
+}, "already-fetched module that failed to fetch fires error");
+
+promise_test(async _ => {
+  const url = "./resources/dummy-module.js?fetching-load";
+  // Do not await: the modulepreload is appended while the import is still
+  // fetching the same URL.
+  const importPromise = import(url);
+  await attachAndWaitForLoad(makeModulePreload(url));
+  await importPromise;
+}, "module still fetching that succeeds fires load");
+
+promise_test(async _ => {
+  const url = "./resources/not-exist.js?fetching-network-error";
+  const importPromise = import(url).catch(() => {});
+  await attachAndWaitForError(makeModulePreload(url));
+  await importPromise;
+}, "module still fetching that fails fires error");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-consumed-by-script-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-consumed-by-script-expected.txt
@@ -1,0 +1,3 @@
+
+PASS modulepreload satisfied by an in-flight fetch fires load when a script element consumes it
+

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-consumed-by-script.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-consumed-by-script.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>link rel=modulepreload fires its event when a script element consumes the same module</title>
+<meta name="timeout" content="long">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="./resources/preload-module-helper.js"></script>
+<body>
+<script>
+// A <link rel=modulepreload> can be satisfied by a fetch of its URL that is
+// already in flight, and a <script type=module> for that URL added while the
+// fetch is still outstanding can then consume that same preload as its own load.
+// The link element must get its event either way: it is the element that asked
+// for the preload, and what the module ends up being used for afterwards is none
+// of its business.
+
+promise_test(async t => {
+  const uuid = token();
+  const url = moduleUrl({ block: 1, uuid });
+
+  // Puts the URL in the module map as fetching, and the server holds the
+  // response until the release below, so it stays that way.
+  const importPromise = import(url).catch(() => {});
+
+  // Satisfied by the fetch above rather than by a fetch of its own.
+  const link = makeModulePreload(url);
+  const linkEvent = eventFor(link);
+  document.head.appendChild(link);
+
+  // Consumes the preload while that fetch is still outstanding.
+  const script = document.createElement("script");
+  script.type = "module";
+  script.crossOrigin = "";
+  script.src = url;
+  const scriptEvent = eventFor(script);
+  document.body.appendChild(script);
+
+  await release(uuid);
+
+  assert_equals(await linkEvent, "load", "the modulepreload fired load");
+  assert_equals(await scriptEvent, "load", "the script element loaded as well");
+  await importPromise;
+}, "modulepreload satisfied by an in-flight fetch fires load when a script " +
+   "element consumes it");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-fires-before-dependencies-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-fires-before-dependencies-expected.txt
@@ -1,0 +1,5 @@
+
+PASS still-fetching top-level fires load before its dependencies
+PASS already-fetched top-level fires load before its dependencies
+PASS already-fetched syntax-error top-level fires load
+

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-fires-before-dependencies.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-fires-before-dependencies.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>link rel=modulepreload fires its event when the top-level module is fetched, before dependencies</title>
+<meta name="timeout" content="long">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="./resources/preload-module-helper.js"></script>
+<body>
+<script>
+// Per the "modulepreload" link type: "the appropriate load or error events will
+// occur after the specified module is fetched, and will not wait for any
+// dependencies." These tests give the top-level module a dependency that the
+// server holds open until the test releases it, and only release it after the
+// modulepreload event has fired, so the event is observed strictly before the
+// dependency completes. An implementation that waits for dependencies never
+// fires and fails by timing out. Covers the three top-level states: still
+// fetching, already fetched, and already fetched with a syntax error.
+
+// Case 1: the top-level module is still fetching (a concurrent import() of the
+// same URL is in flight) when the preload is added.
+promise_test(async t => {
+  const depUuid = token();
+  const topUuid = token();
+  const dep = moduleUrl({ block: 1, uuid: depUuid });
+  // The top-level blocks as well, so that it is unambiguously still fetching
+  // when the preload is added below.
+  const url = moduleUrl({ block: 1, import: dep, uuid: topUuid });
+
+  const importPromise = import(url).catch(() => {});
+
+  // import() has put the URL in the module map as fetching, so this preload can
+  // only be satisfied by that in-flight fetch.
+  const link = makeModulePreload(url);
+  const done = eventFor(link);
+  document.head.appendChild(link);
+
+  await release(topUuid);
+  const event = await done;
+
+  assert_false(hasResourceLoaded(dep),
+      "the dependency was still outstanding when the event fired");
+  await release(depUuid);
+  assert_equals(event, "load");
+  await importPromise;
+}, "still-fetching top-level fires load before its dependencies");
+
+// Case 2: the top-level module is already fetched when the preload is added,
+// while its dependency is still outstanding.
+promise_test(async t => {
+  const depUuid = token();
+  const topUuid = token();
+  const dep = moduleUrl({ block: 1, uuid: depUuid });
+  const url = moduleUrl({ import: dep, uuid: topUuid });
+
+  const importPromise = import(url).catch(() => {});
+  // Once the top-level's response has been received it is in the module map as
+  // fetched, and its dependency is what is still outstanding.
+  await resourceLoaded(url);
+
+  const link = makeModulePreload(url);
+  const done = eventFor(link);
+  document.head.appendChild(link);
+
+  const event = await done;
+
+  assert_false(hasResourceLoaded(dep),
+      "the dependency was still outstanding when the event fired");
+  await release(depUuid);
+  assert_equals(event, "load");
+  await importPromise;
+}, "already-fetched top-level fires load before its dependencies");
+
+// Case 3: the top-level module is already fetched but has a syntax error. A
+// parse error still produces a module script, so the preload fires load; there
+// are no dependencies to wait for.
+promise_test(async t => {
+  const url = moduleUrl({ syntaxerror: 1, uuid: token() });
+  await import(url).then(
+      () => assert_unreached("import of a syntax-error module should reject"),
+      () => {});
+
+  const link = makeModulePreload(url);
+  const done = eventFor(link);
+  document.head.appendChild(link);
+  assert_equals(await done, "load",
+      "already-fetched syntax-error top-level fires load");
+}, "already-fetched syntax-error top-level fires load");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Script should not be loaded if modulepreload's integrity is invalid promise_test: Unhandled rejection with value: object "[object Event]"
+FAIL A module script should load even if an earlier modulepreload for the same URL failed its integrity check promise_test: Unhandled rejection with value: object "Error: modulepreload should have failed its integrity check"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri-importmap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri-importmap-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Script should not be loaded if modulepreload's integrity is invalid promise_test: Unhandled rejection with value: object "[object Event]"
+FAIL A module script should load even if an earlier modulepreload for the same URL failed its integrity check, with an import map registered promise_test: Unhandled rejection with value: object "Error: modulepreload should have failed its integrity check"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri-importmap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri-importmap.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset=utf-8>
+<title>modulepreload with an invalid integrity does not poison a later import (with an import map)</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script type="importmap">
@@ -9,17 +10,35 @@
     }
   }
 </script>
-<link rel="modulepreload" href="resources/module1.js" integrity="sha384-invalid">
-<script type="module" src="resources/module1.js" id="myscript"></script>
 <body>
 <script>
-  // compared to modulepreload.html, this tests behavior when elements are
-  // initially on an HTML page instead of being added by JS
-  promise_test(() => {
-    return new Promise((resolve, reject) => {
-      let myscript = document.querySelector('#myscript');
-      myscript.onerror = resolve;
-      myscript.onload = reject;
+  // As modulepreload-sri.html, but with an import map registered. The import map
+  // does not affect resolution of module1.js, so it must not change the result:
+  // a modulepreload whose integrity check fails is a fetch error, which is not
+  // cached in the module map, so a later no-integrity <script type=module> for
+  // the same URL fetches it again and loads successfully.
+  // https://html.spec.whatwg.org/#fetch-a-single-module-script
+  //
+  // The <script> is only inserted after the modulepreload has finished, so the
+  // two never join a single in-flight fetch.
+  promise_test(async () => {
+    const link = document.createElement('link');
+    link.rel = 'modulepreload';
+    link.href = 'resources/module1.js';
+    link.integrity = 'sha384-invalid';
+    await new Promise((resolve, reject) => {
+      link.onload = () => reject(new Error('modulepreload should have failed its integrity check'));
+      link.onerror = resolve;
+      document.head.appendChild(link);
     });
-  }, "Script should not be loaded if modulepreload's integrity is invalid");
+
+    const script = document.createElement('script');
+    script.type = 'module';
+    script.src = 'resources/module1.js';
+    await new Promise((resolve, reject) => {
+      script.onload = resolve;
+      script.onerror = () => reject(new Error('script should have loaded'));
+      document.body.appendChild(script);
+    });
+  }, "A module script should load even if an earlier modulepreload for the same URL failed its integrity check, with an import map registered");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri.html
@@ -1,18 +1,36 @@
 <!doctype html>
 <meta charset=utf-8>
+<title>modulepreload with an invalid integrity does not poison a later import</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel="modulepreload" href="resources/module1.js" integrity="sha384-invalid">
-<script type="module" src="resources/module1.js" id="myscript"></script>
 <body>
 <script>
-  // compared to modulepreload.html, this tests behavior when elements are
-  // initially on an HTML page instead of being added by JS
-  promise_test(() => {
-    return new Promise((resolve, reject) => {
-      let myscript = document.querySelector('#myscript');
-      myscript.onerror = resolve;
-      myscript.onload = reject;
+  // A modulepreload whose integrity check fails is a fetch error, which per the
+  // HTML spec is not cached in the module map. A later <script type=module> for
+  // the same URL that has no integrity requirement must therefore be able to
+  // fetch it again and load successfully.
+  // https://html.spec.whatwg.org/#fetch-a-single-module-script
+  //
+  // The <script> is only inserted after the modulepreload has finished, so the
+  // two never join a single in-flight fetch.
+  promise_test(async () => {
+    const link = document.createElement('link');
+    link.rel = 'modulepreload';
+    link.href = 'resources/module1.js';
+    link.integrity = 'sha384-invalid';
+    await new Promise((resolve, reject) => {
+      link.onload = () => reject(new Error('modulepreload should have failed its integrity check'));
+      link.onerror = resolve;
+      document.head.appendChild(link);
     });
-  }, "Script should not be loaded if modulepreload's integrity is invalid");
+
+    const script = document.createElement('script');
+    script.type = 'module';
+    script.src = 'resources/module1.js';
+    await new Promise((resolve, reject) => {
+      script.onload = resolve;
+      script.onerror = () => reject(new Error('script should have loaded'));
+      document.body.appendChild(script);
+    });
+  }, "A module script should load even if an earlier modulepreload for the same URL failed its integrity check");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/preload-imagesrcset-in-markup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/preload-imagesrcset-in-markup-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Preload in markup with href and imagesrcset (w descriptors) does not fetch href assert_equals: resources/square.png?markup-w-href expected 0 but got 1
+FAIL Preload in markup with href and imagesrcset (x descriptors) does not fetch href assert_equals: resources/square.png?markup-x-href expected 0 but got 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/preload-imagesrcset-in-markup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/preload-imagesrcset-in-markup.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<title>A preload declared in markup with both href and imagesrcset only fetches the imagesrcset candidate</title>
+<meta name="timeout" content="long">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/links.html#preload">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/images.html#create-a-source-set">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/preload/resources/preload_helper.js"></script>
+<!--
+  dynamic-adding-preload-imagesrcset.html covers the same combination from
+  script, which the preload scanner never sees. These links are in markup so
+  the scanner does see them.
+
+  Keep the 1x candidate below: without it, href joins the source set as the 1x
+  candidate and may legitimately be fetched.
+-->
+<link rel="preload" as="image" href="resources/square.png?markup-w-href"
+      imagesrcset="resources/square.png?markup-w-200 200w, resources/square.png?markup-w-400 400w, resources/square.png?markup-w-800 800w"
+      imagesizes="400px">
+<link rel="preload" as="image" href="resources/square.png?markup-x-href"
+      imagesrcset="resources/square.png?markup-x-1x 1x, resources/square.png?markup-x-2x 2x">
+<body>
+<script>
+    function candidateFetches(urls) {
+        return urls.reduce((total, url) => total + numberOfResourceTimingEntries(url), 0);
+    }
+
+    promise_setup(() => new Promise(resolve => {
+        if (document.readyState === "complete")
+            resolve();
+        else
+            addEventListener("load", resolve);
+    }));
+
+    promise_test(async t => {
+        verifyPreloadAndRTSupport();
+        const candidates = [
+            "resources/square.png?markup-w-200",
+            "resources/square.png?markup-w-400",
+            "resources/square.png?markup-w-800",
+        ];
+        await t.step_wait(() => candidateFetches(candidates) >= 1,
+                          "a w-descriptor candidate should be preloaded", 3000);
+        verifyNumberOfResourceTimingEntries("resources/square.png?markup-w-href", 0);
+        assert_equals(candidateFetches(candidates), 1,
+                      "exactly one w-descriptor candidate should be preloaded");
+    }, "Preload in markup with href and imagesrcset (w descriptors) does not fetch href");
+
+    promise_test(async t => {
+        verifyPreloadAndRTSupport();
+        const candidates = [
+            "resources/square.png?markup-x-1x",
+            "resources/square.png?markup-x-2x",
+        ];
+        await t.step_wait(() => candidateFetches(candidates) >= 1,
+                          "an x-descriptor candidate should be preloaded", 3000);
+        verifyNumberOfResourceTimingEntries("resources/square.png?markup-x-href", 0);
+        assert_equals(candidateFetches(candidates), 1,
+                      "exactly one x-descriptor candidate should be preloaded");
+    }, "Preload in markup with href and imagesrcset (x descriptors) does not fetch href");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/resources/preload-module-helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/resources/preload-module-helper.js
@@ -1,0 +1,62 @@
+// Helpers for the modulepreload tests that drive resources/preload-module.py.
+// Paths are resolved against the test page, which is expected to be in
+// preload/.
+
+const MODULE_HANDLER = "./resources/preload-module.py";
+
+function moduleUrl(params) {
+  const url = new URL(MODULE_HANDLER, location.href);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return url.href;
+}
+
+// NOTE: crossorigin is what makes these tests exercise the "already in the
+// module map" path in implementations that key their preload cache on the CORS
+// mode: the preload and the import() of the same URL then don't share a preload
+// entry, so the preload has to be satisfied from the module map. Keep it.
+function makeModulePreload(url) {
+  const link = document.createElement("link");
+  link.rel = "modulepreload";
+  link.as = "script";
+  link.crossOrigin = "";
+  link.href = url;
+  return link;
+}
+
+function eventFor(element) {
+  return new Promise(resolve => {
+    element.addEventListener("load", () => resolve("load"), { once: true });
+    element.addEventListener("error", () => resolve("error"), { once: true });
+  });
+}
+
+// Lets a request blocked by preload-module.py's block=1 finish.
+function release(uuid) {
+  return fetch(moduleUrl({ release: 1, uuid }));
+}
+
+// Whether the response for `url` has been received. Resource timing is what the
+// tests use to observe the server's progress, rather than asking the server, so
+// that nothing has to keep mutable state that concurrent requests could race
+// over.
+function hasResourceLoaded(url) {
+  return performance.getEntriesByName(url).length > 0;
+}
+
+function resourceLoaded(url) {
+  return new Promise(resolve => {
+    if (hasResourceLoaded(url)) {
+      resolve();
+      return;
+    }
+    const observer = new PerformanceObserver(entries => {
+      if (entries.getEntries().some(entry => entry.name === url)) {
+        observer.disconnect();
+        resolve();
+      }
+    });
+    observer.observe({ type: "resource", buffered: true });
+  });
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/resources/preload-module.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/resources/preload-module.py
@@ -1,0 +1,50 @@
+import json
+import time
+
+
+# Serves a JavaScript module for modulepreload tests, letting the test control
+# when each module is served.
+#
+# Query parameters:
+#   uuid=<uuid>     Names the request so that the test can block and release it.
+#                   Required by all of the below.
+#   block=1         Block the response until a release=1 request with the same
+#                   uuid arrives (used to keep a module outstanding while the
+#                   test observes something else).
+#   release=1       Release the blocked request with the same uuid.
+#   import=<url>    Emit `import "<url>";` so the module has a dependency.
+#   syntaxerror=1   Emit a module with a parse error.
+#   (otherwise)     Emit an empty module.
+#
+# Only release=1 ever writes to the stash and only a blocked request ever reads
+# from it, so there is no read-modify-write to race over.
+def main(request, response):
+    params = request.GET
+    uuid = params.first(b"uuid").decode()
+
+    if b"release" in params:
+        try:
+            request.server.stash.put(uuid, True)
+        except Exception:
+            # Already released and not yet taken; nothing to do.
+            pass
+        return (200, [(b"Content-Type", b"text/javascript"),
+                      (b"Cache-Control", b"no-store")], b"")
+
+    if b"block" in params:
+        remaining = 300  # ~30s safety timeout
+        while remaining > 0 and not request.server.stash.take(uuid):
+            time.sleep(0.1)
+            remaining -= 1
+
+    headers = [(b"Content-Type", b"text/javascript"),
+               (b"Cache-Control", b"no-store")]
+
+    if b"syntaxerror" in params:
+        return (200, headers, b"if (")
+
+    if b"import" in params:
+        dep = params.first(b"import").decode()
+        return (200, headers, ("import " + json.dumps(dep) + ";\n").encode())
+
+    return (200, headers, b"export default 1;\n")

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/preload/resources/A4.ogv.sub.headers
@@ -51,6 +49,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/preload/resources/prefetch-helper.js
 /LayoutTests/imported/w3c/web-platform-tests/preload/resources/prefetch-info.py
 /LayoutTests/imported/w3c/web-platform-tests/preload/resources/preload-count.py
+/LayoutTests/imported/w3c/web-platform-tests/preload/resources/preload-module-helper.js
+/LayoutTests/imported/w3c/web-platform-tests/preload/resources/preload-module.py
 /LayoutTests/imported/w3c/web-platform-tests/preload/resources/preload_helper.js
 /LayoutTests/imported/w3c/web-platform-tests/preload/resources/slow-exec.js
 /LayoutTests/imported/w3c/web-platform-tests/preload/resources/sound_5.oga

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/preload/META.yml
@@ -23,6 +21,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/preload/avoid-prefetching-on-text-plain-inner.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/avoid-prefetching-on-text-plain-inner.html.headers
 /LayoutTests/imported/w3c/web-platform-tests/preload/avoid-prefetching-on-text-plain.html
+/LayoutTests/imported/w3c/web-platform-tests/preload/cross-origin-link-header-on-subresource.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/delaying-onload-link-preload-after-discovery.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/download-resources.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/dynamic-adding-preload-imagesrcset.html
@@ -39,7 +38,10 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/preload/link-header-preload-nonce.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/link-header-preload.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/link-header-preload.html.headers
+/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-already-in-module-map.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-as.html
+/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-consumed-by-script.html
+/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-fires-before-dependencies.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-json.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-multiple.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri-importmap.html
@@ -65,6 +67,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/preload/preload-dynamic-csp.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/preload-error.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/preload-font-crossorigin.html
+/LayoutTests/imported/w3c/web-platform-tests/preload/preload-imagesrcset-in-markup.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/preload-imagesrcset-no-href.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/preload-in-data-doc-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/preload/preload-in-data-doc-ref.html

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -5528,6 +5528,15 @@
     "imported/w3c/web-platform-tests/preload/link-header-preload-non-html.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/preload/modulepreload-already-in-module-map.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/preload/modulepreload-consumed-by-script.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/preload/modulepreload-fires-before-dependencies.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/preload/modulepreload.html": [
         "slow"
     ],
@@ -5553,6 +5562,9 @@
         "slow"
     ],
     "imported/w3c/web-platform-tests/preload/preload-error.sub.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/preload/preload-imagesrcset-in-markup.html": [
         "slow"
     ],
     "imported/w3c/web-platform-tests/preload/preload-imagesrcset-no-href.html": [


### PR DESCRIPTION
#### 3863ad3b7bf73a5374eec6ac2a558f77c7607eec
<pre>
Sync WPT tests for preload/
<a href="https://bugs.webkit.org/show_bug.cgi?id=320874">https://bugs.webkit.org/show_bug.cgi?id=320874</a>

Reviewed by Patrick Griffis.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/8ff51b7de9b569733c5be7d0636c92c258ffdd27">https://github.com/web-platform-tests/wpt/commit/8ff51b7de9b569733c5be7d0636c92c258ffdd27</a>

* LayoutTests/imported/w3c/web-platform-tests/preload/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-already-in-module-map-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-already-in-module-map.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-consumed-by-script-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-consumed-by-script.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-fires-before-dependencies-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-fires-before-dependencies.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri-importmap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri-importmap.html:
* LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-sri.html:
* LayoutTests/imported/w3c/web-platform-tests/preload/preload-imagesrcset-in-markup-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/preload/preload-imagesrcset-in-markup.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/preload/resources/preload-module-helper.js: Added.
(moduleUrl):
(makeModulePreload):
(eventFor):
(resourceLoaded):
* LayoutTests/imported/w3c/web-platform-tests/preload/resources/preload-module.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/preload/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/preload/w3c-import.log:
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/318452@main">https://commits.webkit.org/318452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e83539d039e3b1db1cb57d6207c13390db491ecc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178341 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187956 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141589 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139025 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41256 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39607 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39284 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36412 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190384 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148180 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39791 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52629 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147954 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42672 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119493 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51147 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14259 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->