### PR TITLE
Computed value of `line-height: 1lh` affected by browser setting for minimum font size

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4591,7 +4591,6 @@ webkit.org/b/203356 imported/w3c/web-platform-tests/css/css-transitions/properti
 imported/w3c/web-platform-tests/css/css-transitions/transitioncancel-003.html [ Failure Pass ]
 
 # wpt css-values failures
-webkit.org/b/203320 imported/w3c/web-platform-tests/css/css-values/percentage-rem-low.html [ ImageOnlyFailure ]
 webkit.org/b/259025 imported/w3c/web-platform-tests/css/css-values/ic-unit-015.html [ ImageOnlyFailure ]
 webkit.org/b/277995 imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-aspect-ratio-001.html [ ImageOnlyFailure ]
 webkit.org/b/277995 imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-aspect-ratio-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/css/line-height-font-relative-minimum-font-size-expected.txt
+++ b/LayoutTests/fast/css/line-height-font-relative-minimum-font-size-expected.txt
@@ -1,0 +1,15 @@
+x
+x
+x
+x
+x
+x
+x
+
+PASS Setup: the minimum font size clamps the children but not the parent
+PASS line-height: 1lh equals the parent line-height, unscaled by the minimum font size
+PASS line-height: 1lh is unscaled for a font size closer to the minimum
+PASS line-height: 1rlh equals the root line-height, unscaled by the minimum font size
+PASS A font-relative line-height tracks the minimum font size exactly once
+PASS Number and percentage line-heights track the clamped font size
+

--- a/LayoutTests/fast/css/line-height-font-relative-minimum-font-size.html
+++ b/LayoutTests/fast/css/line-height-font-relative-minimum-font-size.html
@@ -1,0 +1,73 @@
+<!-- webkit-test-runner [ MinimumFontSize=18 ] -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The minimum font size setting must not scale a font-relative or line-height-relative line-height</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#lh">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<style>
+/* The minimum font size is 18px for this test. The root and the parent use a font size above
+   that minimum, so neither is clamped and their line-heights are predictable. */
+:root { font-size: 20px; line-height: 30px; }
+
+#parent { font-size: 20px; line-height: 1.3; }              /* 26px, not clamped */
+
+/* All of these children have a font size below the minimum, so their font size is clamped to 18px. */
+#lhChild { font-size: 6px; line-height: 1lh; }              /* parent's line-height: 26px */
+#lhChild12 { font-size: 12px; line-height: 1lh; }           /* parent's line-height: 26px */
+#rlhChild { font-size: 6px; line-height: 1rlh; }            /* root's line-height: 30px */
+#emChild { font-size: 6px; line-height: 1.2em; }            /* 1.2 * clamped 18px */
+#numberChild { font-size: 6px; line-height: 1.3; }          /* 1.3 * clamped 18px */
+#percentChild { font-size: 6px; line-height: 130%; }        /* 130% of clamped 18px */
+#pxChild { font-size: 6px; line-height: 20px; }             /* absolute: boosted by 18/6 */
+</style>
+
+<div id="parent">
+    <div id="lhChild">x</div>
+    <div id="lhChild12">x</div>
+    <div id="rlhChild">x</div>
+    <div id="emChild">x</div>
+    <div id="numberChild">x</div>
+    <div id="percentChild">x</div>
+    <div id="pxChild">x</div>
+</div>
+
+<div id="log"></div>
+
+<script>
+// Computed lengths are quantised to LayoutUnit (1/64px).
+var EPS = 1 / 64;
+
+function lineHeight(id) { return parseFloat(getComputedStyle(document.getElementById(id)).lineHeight); }
+function fontSize(id) { return parseFloat(getComputedStyle(document.getElementById(id)).fontSize); }
+
+test(function() {
+    assert_equals(fontSize('lhChild'), 18, 'child font size is clamped to the minimum font size');
+    assert_equals(fontSize('parent'), 20, 'parent font size is above the minimum and is not clamped');
+    assert_approx_equals(lineHeight('parent'), 26, EPS, 'parent line-height');
+}, 'Setup: the minimum font size clamps the children but not the parent');
+
+test(function() {
+    assert_approx_equals(lineHeight('lhChild'), 26, EPS);
+}, 'line-height: 1lh equals the parent line-height, unscaled by the minimum font size');
+
+test(function() {
+    assert_approx_equals(lineHeight('lhChild12'), 26, EPS);
+}, 'line-height: 1lh is unscaled for a font size closer to the minimum');
+
+test(function() {
+    assert_approx_equals(lineHeight('rlhChild'), 30, EPS);
+}, 'line-height: 1rlh equals the root line-height, unscaled by the minimum font size');
+
+test(function() {
+    // 1.2em resolves against the specified 6px font size, and the minimum font size adjustment then
+    // scales the result by 18/6, so the used line-height is 1.2 times the used font size.
+    assert_approx_equals(lineHeight('emChild'), 21.6, EPS);
+}, 'A font-relative line-height tracks the minimum font size exactly once');
+
+test(function() {
+    assert_approx_equals(lineHeight('numberChild'), 23.4, EPS, 'number');
+    assert_approx_equals(lineHeight('percentChild'), 23.4, EPS, 'percentage');
+}, 'Number and percentage line-heights track the clamped font size');
+</script>

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -47,6 +47,7 @@ public:
     bool isParentFontRelativeLength() const { return isParentFontRelativeLength(primitiveUnitType()); }
     bool isPercentageOrParentFontRelativeLength() const { return isPercentage() || isParentFontRelativeLength(); }
     bool isRootFontRelativeLength() const { return isRootFontRelativeLength(primitiveUnitType()); }
+    bool isLineHeightRelativeLength() const { return isLineHeightRelativeLength(primitiveUnitType()); }
     bool isLength() const { return isLength(static_cast<CSSUnitType>(primitiveType())); }
     bool isNumber() const { return primitiveType() == CSSUnitType::CSS_NUMBER; }
     bool isInteger() const { return primitiveType() == CSSUnitType::CSS_INTEGER; }
@@ -116,6 +117,7 @@ private:
     static constexpr bool isFontRelativeLength(CSSUnitType);
     static constexpr bool isParentFontRelativeLength(CSSUnitType);
     static constexpr bool isRootFontRelativeLength(CSSUnitType);
+    static constexpr bool isLineHeightRelativeLength(CSSUnitType);
     static constexpr bool isContainerPercentageLength(CSSUnitType);
     static constexpr bool isViewportPercentageLength(CSSUnitType);
 
@@ -162,6 +164,12 @@ constexpr bool CSSPrimitiveValue::isFontRelativeLength(CSSUnitType type)
 {
     return isParentFontRelativeLength(type)
         || isRootFontRelativeLength(type);
+}
+
+constexpr bool CSSPrimitiveValue::isLineHeightRelativeLength(CSSUnitType type)
+{
+    return type == CSSUnitType::CSS_LH
+        || type == CSSUnitType::CSS_RLH;
 }
 
 constexpr bool CSSPrimitiveValue::isContainerPercentageLength(CSSUnitType type)

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -334,7 +334,11 @@ static inline float computeLineHeightMultiplierDueToFontSize(const Document& doc
 {
     bool percentageAutosizingEnabled = document.settings().textAutosizingEnabled() && style.textSizeAdjust().isPercentage();
 
-    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value); primitiveValue && primitiveValue->isLength()) {
+    // This adjustment keeps a length line-height proportional to the boosted font size, so it applies to
+    // lengths that resolve against this element's font size, including font-relative ones like em and ch.
+    // It must not apply to lh and rlh, which resolve against another element's line-height and so do not
+    // scale with this element's font size. Numbers and percentages are handled by CSSValueConversion.
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value); primitiveValue && primitiveValue->isLength() && !primitiveValue->isLineHeightRelativeLength()) {
         auto minimumFontSize = document.settings().minimumFontSize();
         if (minimumFontSize > 0) {
             auto specifiedFontSize = computeBaseSpecifiedFontSize(document, style, percentageAutosizingEnabled);

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -86,38 +86,49 @@ static double unzoomFontMetric(double metric, const FontDescription& fontDescrip
     return metric;
 }
 
+// MARK: - Minimum Font Size
+
+// The minimum font size setting is a user restriction on the used font size. It must be applied to used
+// values only, and in particular must not affect the resolution of font-relative lengths, so those
+// resolve against the specified size rather than the clamped computed size.
+// https://drafts.csswg.org/css-values-4/#font-relative-lengths
+static double unclampedFontSize(const FontCascadeDescription& fontDescription)
+{
+    return fontDescription.specifiedSize();
+}
+
+// Font metrics are measured at the used font size, which the minimum font size setting may have boosted
+// above the specified size. Scale them back down so the boost does not leak into font-relative lengths.
+static double unclampFontMetric(double metric, const FontCascadeDescription& fontDescription)
+{
+    auto unzoomedComputedSize = fontDescription.unzoomedComputedSize();
+    if (unzoomedComputedSize <= 0)
+        return metric;
+    return metric * unclampedFontSize(fontDescription) / unzoomedComputedSize;
+}
+
 
 // MARK: - "font dependent" and "root font dependent" resolution functions
 
 // Resolve the "em", "rem" and "quirky-em" units.
 // https://drafts.csswg.org/css-values-4/#em
 // https://drafts.csswg.org/css-values-4/#rem
-static double resolveEm(CSSPropertyID propertyToCompute, const FontCascade& fontCascadeForUnit)
+static double resolveEm(CSSPropertyID, const FontCascade& fontCascadeForUnit)
 {
-    auto& fontDescription = fontCascadeForUnit.fontDescription();
-
-    // FIXME: Should probably use specifiedSize for every property.
-    if (propertyToCompute == CSSPropertyFontSize)
-        return fontDescription.specifiedSize();
-
-    return fontDescription.unzoomedComputedSize();
+    return unclampedFontSize(fontCascadeForUnit.fontDescription());
 }
 
 // Resolve the "ex" and "rex" units.
 // https://drafts.csswg.org/css-values-4/#ex
 // https://drafts.csswg.org/css-values-4/#rex
-static double resolveEx(CSSPropertyID propertyToCompute, const FontCascade& fontCascadeForUnit)
+static double resolveEx(CSSPropertyID, const FontCascade& fontCascadeForUnit)
 {
     auto& fontDescription = fontCascadeForUnit.fontDescription();
     auto& fontMetrics = fontCascadeForUnit.metricsOfPrimaryFont();
     if (fontMetrics.xHeight())
-        return unzoomFontMetric(fontMetrics.xHeight().value(), fontDescription);
+        return unclampFontMetric(unzoomFontMetric(fontMetrics.xHeight().value(), fontDescription), fontDescription);
 
-    // FIXME: Should probably use specifiedSize for every property.
-    if (propertyToCompute == CSSPropertyFontSize)
-        return fontDescription.specifiedSize() / 2.0;
-
-    return fontDescription.unzoomedComputedSize() / 2.0;
+    return unclampedFontSize(fontDescription) / 2.0;
 }
 
 // Resolve the "cap" and "rcap" units.
@@ -128,8 +139,8 @@ static double resolveCap(CSSPropertyID, const FontCascade& fontCascadeForUnit)
     auto& fontDescription = fontCascadeForUnit.fontDescription();
     auto& fontMetrics = fontCascadeForUnit.metricsOfPrimaryFont();
     if (fontMetrics.capHeight())
-        return unzoomFontMetric(fontMetrics.capHeight().value(), fontDescription);
-    return unzoomFontMetric(fontMetrics.intAscent(), fontDescription);
+        return unclampFontMetric(unzoomFontMetric(fontMetrics.capHeight().value(), fontDescription), fontDescription);
+    return unclampFontMetric(unzoomFontMetric(fontMetrics.intAscent(), fontDescription), fontDescription);
 }
 
 // Resolve the "ch" and "rch" units.
@@ -137,7 +148,8 @@ static double resolveCap(CSSPropertyID, const FontCascade& fontCascadeForUnit)
 // https://drafts.csswg.org/css-values-4/#rch
 static double resolveCh(CSSPropertyID, const FontCascade& fontCascadeForUnit)
 {
-    return unzoomFontMetric(fontCascadeForUnit.zeroWidth(), fontCascadeForUnit.fontDescription());
+    auto& fontDescription = fontCascadeForUnit.fontDescription();
+    return unclampFontMetric(unzoomFontMetric(fontCascadeForUnit.zeroWidth(), fontDescription), fontDescription);
 }
 
 // Resolve the "ic" and "ric" units.
@@ -148,8 +160,8 @@ static double resolveIc(CSSPropertyID, const FontCascade& fontCascadeForUnit)
     auto& fontDescription = fontCascadeForUnit.fontDescription();
     auto ideogramWidth = fontCascadeForUnit.metricsOfPrimaryFont().ideogramWidth();
     if (!ideogramWidth)
-        return fontDescription.unzoomedComputedSize();
-    return unzoomFontMetric(ideogramWidth.value(), fontDescription);
+        return unclampedFontSize(fontDescription);
+    return unclampFontMetric(unzoomFontMetric(ideogramWidth.value(), fontDescription), fontDescription);
 }
 
 // Resolve the "lh" unit.


### PR DESCRIPTION
#### 0433986f3911cd8ad18670e98a3b7b6720df0252
<pre>
Computed value of `line-height: 1lh` affected by browser setting for minimum font size
<a href="https://bugs.webkit.org/show_bug.cgi?id=252108">https://bugs.webkit.org/show_bug.cgi?id=252108</a>
<a href="https://rdar.apple.com/105630538">rdar://105630538</a>

Reviewed by NOBODY (OOPS!).

The minimum font size setting is a user restriction on the used font size. Per css-values-4 such
restrictions &quot;must be applied to the used value of the affected properties only; they must not
affect the resolution of font-relative lengths used in properties&quot;. We clamp the FontDescription&apos;s
computed size and then resolve em, ex, cap, ch and ic against that clamped size, so the restriction
leaks into every font-relative length, in every property:

    &lt;div style=&quot;font-size: 6px; width: 10em&quot;&gt;   &lt;!-- 180px with an 18px minimum, should be 60px --&gt;

Resolve those units against the specified size instead, which is what the two FIXMEs in
StyleLengthResolution.cpp already asked for. This also fixes rem when the root font size is below
the minimum logical font size, which is nonzero by default (bug 203320).

Line-height then needs a second look. When the minimum font size boosts an element&apos;s font size,
computeLineHeightMultiplierDueToFontSize() scales a length line-height by
minimumFontSize / specifiedFontSize to keep it proportional. That is right for lengths which
resolve against this element&apos;s font size: absolute ones, as added by bug 174406, and now
font-relative ones too, since those no longer arrive already clamped. It is wrong for lh and rlh,
which resolve against another element&apos;s line-height and so do not scale with this element&apos;s font
size at all:

    &lt;div style=&quot;font-size: 20px; line-height: 1.3&quot;&gt;     &lt;!-- 26px --&gt;
        &lt;div style=&quot;font-size: 6px; line-height: 1lh&quot;&gt;  &lt;!-- 78px, should be 26px --&gt;

As the multiplier depends on each element&apos;s own font size, siblings sharing one line-height: 1lh
declaration also diverged from each other. Restrict the adjustment to lengths that are not
line-height relative. Numbers and percentages were already excluded.

Test: fast/css/line-height-font-relative-minimum-font-size.html

* LayoutTests/TestExpectations: Unskip percentage-rem-low.html, which now passes.
* LayoutTests/fast/css/line-height-font-relative-minimum-font-size-expected.txt: Added.
* LayoutTests/fast/css/line-height-font-relative-minimum-font-size.html: Added.
* Source/WebCore/css/CSSPrimitiveValue.h:
(WebCore::CSSPrimitiveValue::isLineHeightRelativeLength):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::computeLineHeightMultiplierDueToFontSize):
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
(WebCore::Style::unclampedFontSize):
(WebCore::Style::unclampFontMetric):
(WebCore::Style::resolveEm):
(WebCore::Style::resolveEx):
(WebCore::Style::resolveCap):
(WebCore::Style::resolveCh):
(WebCore::Style::resolveIc):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0433986f3911cd8ad18670e98a3b7b6720df0252

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141742 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52141 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139161 "Found 3 new test failures: fast/backgrounds/background-position-parsing.html fast/css/line-height-font-relative-minimum-font-size.html imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96637 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da2be098-371a-44f1-8556-4ea7412e57e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181450 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42719 "Found 3 new test failures: fast/backgrounds/background-position-parsing.html fast/text-autosizing/ios/text-size-adjust-inline-style.html fast/text/line-height-minimumFontSize.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119615 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46779afb-9453-437c-a171-e5960ffb14ab) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41385 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39734 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151785 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39408 "Found 3 new test failures: fast/backgrounds/background-position-parsing.html fast/text/line-height-minimumFontSize.html imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem.html (failure)") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45031 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43976 "Found 3 new test failures: fast/backgrounds/background-position-parsing.html fast/text/line-height-minimumFontSize.html imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190536 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159433 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148321 "Found 2 new test failures: fast/css/line-height-font-relative-minimum-font-size.html imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52781 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36032 "Found 3 new test failures: fast/backgrounds/background-position-parsing.html fast/text/line-height-minimumFontSize.html imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148091 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42799 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125047 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119684 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51299 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14383 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50684 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50924 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50746 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->