### PR TITLE
AudioScheduledSourceNode does not fire "ended" event when not connected to the destination

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/suspend-with-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/suspend-with-navigation-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN suspend() with navigation Could have been BFCached but actually wasn't
+PASS suspend() with navigation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-constantsourcenode-interface/constant-source-onended-not-connected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-constantsourcenode-interface/constant-source-onended-not-connected-expected.txt
@@ -1,0 +1,3 @@
+
+PASS ConstantSourceNode fires onended when not connected to the destination
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-constantsourcenode-interface/constant-source-onended-not-connected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-constantsourcenode-interface/constant-source-onended-not-connected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      AudioScheduledSourceNode fires onended when not connected to the destination
+    </title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+      // A scheduled source node that is started and stopped must fire its
+      // "ended" event once it reaches its stop time, even if it was never
+      // connected to the destination.
+      // https://webaudio.github.io/web-audio-api/#dom-audioscheduledsourcenode-onended
+
+      const sampleRate = 44100;
+      // Number of frames the source will run; fairly arbitrary.
+      const numberOfFrames = 32;
+      // Number of frames to render; should be larger than numberOfFrames.
+      const renderFrames = 16 * numberOfFrames;
+
+      promise_test(async () => {
+        const context = new OfflineAudioContext(1, renderFrames, sampleRate);
+        const source = new ConstantSourceNode(context);
+        // Intentionally do not connect the source to context.destination.
+        const ended = new Promise(resolve => source.onended = resolve);
+
+        source.start();
+        source.stop(numberOfFrames / context.sampleRate);
+        context.startRendering();
+
+        await ended;
+      }, 'ConstantSourceNode fires onended when not connected to the destination');
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -40,6 +40,7 @@
 #include "AudioNodeInput.h"
 #include "AudioNodeOutput.h"
 #include "AudioParamDescriptor.h"
+#include "AudioScheduledSourceNode.h"
 #include "AudioSession.h"
 #include "AudioWorklet.h"
 #include "BiquadFilterNode.h"
@@ -231,6 +232,12 @@ void BaseAudioContext::uninitialize()
         // leaving nodes in m_referencedSourceNodes. Now that the audio thread is gone, make sure we deref those nodes
         // before the BaseAudioContext gets destroyed.
         derefFinishedSourceNodes();
+        // Any still-playing scheduled source nodes were registered as automatic pull nodes; remove
+        // them before their references are dropped so m_automaticPullNodes ends up empty.
+        for (auto& node : m_referencedSourceNodes) {
+            if (is<AudioScheduledSourceNode>(node.get()))
+                removeAutomaticPullNode(node.get());
+        }
         m_renderingAutomaticPullNodes.clear();
     }
 
@@ -555,7 +562,17 @@ void BaseAudioContext::derefFinishedSourceNodes()
     if (!m_hasFinishedAudioSourceNodes)
         return;
 
-    m_referencedSourceNodes.removeAllMatching([](auto& node) { return node->isFinishedSourceNode(); });
+    // Removing a node from the automatic pull node set may reallocate the underlying hash table.
+    // Heap allocations are forbidden on the audio thread for performance reasons so we need to
+    // explicitly allow the following allocation(s).
+    DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
+    m_referencedSourceNodes.removeAllMatching([&](auto& node) {
+        if (!node->isFinishedSourceNode())
+            return false;
+        if (is<AudioScheduledSourceNode>(node.get()))
+            removeAutomaticPullNode(Ref { node.get() });
+        return true;
+    });
     m_hasFinishedAudioSourceNodes = false;
 }
 
@@ -1003,6 +1020,11 @@ void BaseAudioContext::sourceNodeWillBeginPlayback(AudioNode& node)
     ASSERT(!m_referencedSourceNodes.contains(&node));
     // Reference source node to keep it alive and playing even if its JS wrapper gets garbage collected.
     m_referencedSourceNodes.append(node);
+
+    // Scheduled source nodes must be processed on every render quantum even when they are not
+    // connected to the destination, so that they reach their stop time and fire the ended event.
+    if (is<AudioScheduledSourceNode>(node))
+        addAutomaticPullNode(node);
 }
 
 void BaseAudioContext::sourceNodeDidFinishPlayback(AudioNode& node)

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -149,7 +149,8 @@ static bool shouldUseBackForwardCache(const std::string& pathOrURL)
 {
     return pathContains(pathOrURL, "navigation-api/")
         || pathContains(pathOrURL, "websockets/back-forward-cache")
-        || pathContains(pathOrURL, "webtransport/back-forward-cache");
+        || pathContains(pathOrURL, "webtransport/back-forward-cache")
+        || pathContains(pathOrURL, "the-audiocontext-interface/suspend-with-navigation");
 }
 
 static bool shouldDisableMutationEvents(const std::string& pathOrURL)


### PR DESCRIPTION
#### d0c18b999649f850d457a6e1d3f4f80dd5134f00
<pre>
AudioScheduledSourceNode does not fire &quot;ended&quot; event when not connected to the destination
<a href="https://bugs.webkit.org/show_bug.cgi?id=320884">https://bugs.webkit.org/show_bug.cgi?id=320884</a>

Reviewed by Darin Adler.

WebKit renders the audio graph by pulling from the destination node, so a source
node is only processed if it is reachable from the destination. As a result, a
scheduled source node (ConstantSourceNode, OscillatorNode, AudioBufferSourceNode)
that is started and stopped but never connected to the destination was never
processed: it never reached its stop time and never fired its &quot;ended&quot; event. This
diverges from the specification and from Blink, which process active source nodes
regardless of whether they are connected.

Fix this by registering a playing scheduled source node as an automatic pull node,
WebKit&apos;s existing mechanism for nodes that must be processed on every render quantum
even without a downstream connection. The node is registered when it begins playback
and unregistered once it finishes or when the context is torn down. Nodes that are
also connected to the destination are processed only once per quantum, since
AudioNode::processIfNecessary() already guards against reprocessing.

Removal happens in derefFinishedSourceNodes(), which runs on the audio thread, so the
call is wrapped in a DisableMallocRestrictionsForCurrentThreadScope: removing an entry
from the automatic pull node hash set can reallocate its backing store.

Add a dedicated regression test that starts and stops a ConstantSourceNode without
connecting it to the destination and waits for the &quot;ended&quot; event; it times out
without this fix. This also makes imported/w3c/web-platform-tests/webaudio/
the-audio-api/the-audiocontext-interface/suspend-with-navigation.html pass, since it
relies on an ended event from an unconnected source. That test also needs the
back/forward cache, so it is added to shouldUseBackForwardCache() in the test harness.

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-constantsourcenode-interface/constant-source-onended-not-connected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-constantsourcenode-interface/constant-source-onended-not-connected-expected.txt: Added.
Add WPT test coverage for this. This test fails in shipping Safari but
passes in both Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/suspend-with-navigation-expected.txt:
Rebaseline bfcache test that was failing due to this bug. This test fails
in shipping Safari but passes in both Chrome and Firefox.

* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::uninitialize):
(WebCore::BaseAudioContext::derefFinishedSourceNodes):
(WebCore::BaseAudioContext::sourceNodeWillBeginPlayback):
* Tools/TestRunnerShared/TestFeatures.cpp:
(WTR::shouldUseBackForwardCache):

Canonical link: <a href="https://commits.webkit.org/318515@main">https://commits.webkit.org/318515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5aa8d286fc13d792b9fa17dbb210614671d5dfdd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141605 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/40fd12e0-dfb1-498f-a486-9b87b9c808bc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139038 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d59150f7-130f-4c45-b153-a001823948a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119493 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4918f6a6-acf2-4839-8c42-b9bcd9739376) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41269 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39621 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151669 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.WindowClientNavigate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39299 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36428 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190400 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148198 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39830 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52645 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147965 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42687 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124910 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119517 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51163 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14274 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50548 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50788 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50610 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->