### PR TITLE
Port WebExtensionAPINamespace to C++

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -157,7 +157,6 @@ set(WebKit_BINDINGS_IN_FILES
     WebProcess/Extensions/Interfaces/WebExtensionAPIExtension
     WebProcess/Extensions/Interfaces/WebExtensionAPILocalization
     WebProcess/Extensions/Interfaces/WebExtensionAPIMenus
-    WebProcess/Extensions/Interfaces/WebExtensionAPINamespace
     WebProcess/Extensions/Interfaces/WebExtensionAPINotifications
     WebProcess/Extensions/Interfaces/WebExtensionAPIOffscreen
     WebProcess/Extensions/Interfaces/WebExtensionAPIPermissions
@@ -171,7 +170,6 @@ set(WebKit_BINDINGS_IN_FILES
     WebProcess/Extensions/Interfaces/WebExtensionAPITabs
     WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigation
     WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigationEvent
-    WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageNamespace
     WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageRuntime
     WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequest
     WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent
@@ -181,7 +179,9 @@ set(WebKit_BINDINGS_IN_FILES
 
 set(WebKit_CPP_BINDINGS_IN_FILES
     WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms
+    WebProcess/Extensions/Interfaces/WebExtensionAPINamespace
     WebProcess/Extensions/Interfaces/WebExtensionAPITest
+    WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageNamespace
 )
 
 set(WebKit_MESSAGES_IN_FILES

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -559,7 +559,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPILocalization.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIMenus.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIMenus.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINotifications.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINotifications.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIOffscreen.h
@@ -591,7 +591,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigation.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigationEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigationEvent.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebPageNamespace.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebPageNamespace.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebPageNamespace.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebPageRuntime.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebPageRuntime.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebRequest.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -1062,7 +1062,6 @@ EXTENSION_INTERFACES = \
     WebExtensionAPIExtension \
     WebExtensionAPILocalization \
     WebExtensionAPIMenus \
-    WebExtensionAPINamespace \
     WebExtensionAPINotifications \
     WebExtensionAPIOffscreen \
     WebExtensionAPIPermissions \
@@ -1076,7 +1075,6 @@ EXTENSION_INTERFACES = \
     WebExtensionAPITabs \
     WebExtensionAPIWebNavigation \
     WebExtensionAPIWebNavigationEvent \
-    WebExtensionAPIWebPageNamespace \
     WebExtensionAPIWebPageRuntime \
     WebExtensionAPIWebRequest \
     WebExtensionAPIWebRequestEvent \
@@ -1086,7 +1084,9 @@ EXTENSION_INTERFACES = \
 
 CPP_EXTENSION_INTERFACES = \
 	WebExtensionAPIAlarms \
+	WebExtensionAPINamespace \
     WebExtensionAPITest \
+	WebExtensionAPIWebPageNamespace \
 #
 
 $(IDL_FILE_NAMES_LIST) : $(EXTENSION_INTERFACES:%=%.idl)

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -708,7 +708,9 @@ WebProcess/Extensions/WebExtensionContextProxy.cpp
 WebProcess/Extensions/WebExtensionControllerProxy.cpp
 
 WebProcess/Extensions/API/WebExtensionAPIAlarms.cpp
+WebProcess/Extensions/API/WebExtensionAPINamespace.cpp
 WebProcess/Extensions/API/WebExtensionAPITest.cpp
+WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.cpp
 
 WebProcess/FileAPI/BlobRegistryProxy.cpp
 

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -771,7 +771,6 @@ WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
-WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPINotificationsCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIOffscreenCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -786,7 +785,6 @@ WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
-WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -180,6 +180,17 @@ WebExtension::StringResources WebExtension::toStringResources(const WebExtension
     return result;
 }
 
+WebExtension::WebExtension(const JSON::Value& manifest, Resources&& resources)
+    : m_manifestJSON(manifest)
+    , m_dataResources(toDataResources(resources))
+    , m_stringResources(toStringResources(resources))
+{
+    auto manifestString = manifest.toJSONString();
+    RELEASE_ASSERT(manifestString);
+
+    m_stringResources.set("manifest.json"_s, manifestString);
+}
+
 WebExtension::WebExtension(Resources&& resources)
     : m_manifestJSON(JSON::Value::null())
     , m_dataResources(toDataResources(resources))

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -77,8 +77,8 @@ public:
     explicit WebExtension(NSDictionary *manifest, Resources&& = { });
 #else
     explicit WebExtension(GFile *resourcesFile, RefPtr<API::Error>&);
-    explicit WebExtension(const JSON::Value& manifest, Resources&& = { });
 #endif
+    explicit WebExtension(const JSON::Value& manifest, Resources&& = { });
 
     explicit WebExtension(Resources&& = { });
 

--- a/Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp
+++ b/Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp
@@ -63,17 +63,6 @@ WebExtension::WebExtension(GFile* resourcesFile, RefPtr<API::Error>& outError)
     }
 }
 
-WebExtension::WebExtension(const JSON::Value& manifest, Resources&& resources)
-    : m_manifestJSON(manifest)
-    , m_dataResources(toDataResources(resources))
-    , m_stringResources(toStringResources(resources))
-{
-    auto manifestString = manifest.toJSONString();
-    RELEASE_ASSERT(manifestString);
-
-    m_stringResources.set("manifest.json"_s, manifestString);
-}
-
 Expected<Ref<API::Data>, RefPtr<API::Error>> WebExtension::resourceDataForPath(const String& originalPath, CacheResult cacheResult, SuppressNotFoundErrors suppressErrors)
 {
     ASSERT(originalPath);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4364,9 +4364,7 @@
 		1C5ACFB72A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIWindowsCocoa.mm; sourceTree = "<group>"; };
 		1C5DC44E29087E7F0061EC62 /* WebExtensionAPIObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIObject.h; sourceTree = "<group>"; };
 		1C5DC44F290888140061EC62 /* WebExtensionAPINamespace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPINamespace.h; sourceTree = "<group>"; };
-		1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPINamespaceCocoa.mm; sourceTree = "<group>"; };
 		1C5DC4532908AC260061EC62 /* JSWebExtensionAPINamespace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPINamespace.h; sourceTree = "<group>"; };
-		1C5DC4542908AC260061EC62 /* JSWebExtensionAPINamespace.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPINamespace.mm; sourceTree = "<group>"; };
 		1C5DC45729099F010061EC62 /* JSWebExtensionWrapper.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebExtensionWrapper.cpp; sourceTree = "<group>"; };
 		1C5DC45829099F010061EC62 /* JSWebExtensionWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionWrapper.h; sourceTree = "<group>"; };
 		1C5DC45A29099F010061EC62 /* JSWebExtensionWrapperCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionWrapperCocoa.mm; sourceTree = "<group>"; };
@@ -7263,6 +7261,8 @@
 		7D1A8A0C2D405B34001715DF /* WebExtensionStorageSQLiteStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionStorageSQLiteStore.h; sourceTree = "<group>"; };
 		7D1A8A0D2D405B34001715DF /* WebExtensionStorageSQLiteStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionStorageSQLiteStore.cpp; sourceTree = "<group>"; };
 		7D2F27C3301C10470043C2CE /* JSWebExtensionAPIUnified.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebExtensionAPIUnified.cpp; sourceTree = "<group>"; };
+		7D3E8A4A2FEFB4D800C57922 /* JSWebExtensionAPINamespace.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebExtensionAPINamespace.cpp; sourceTree = "<group>"; };
+		7D3E8A4B2FEFB4D800C57922 /* JSWebExtensionAPIWebPageNamespace.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebExtensionAPIWebPageNamespace.cpp; sourceTree = "<group>"; };
 		7D3FF7012ECBBDB100A26C20 /* JSWebExtensionAPIAlarms.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebExtensionAPIAlarms.cpp; sourceTree = "<group>"; };
 		7D49D11F2D1AA1AE00C6855E /* WebExtensionSQLiteDatabase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSQLiteDatabase.h; sourceTree = "<group>"; };
 		7D49D1202D1AA1AE00C6855E /* WebExtensionSQLiteDatabase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionSQLiteDatabase.cpp; sourceTree = "<group>"; };
@@ -7280,6 +7280,8 @@
 		7D5ADAB42E50438300B9AA45 /* WebExtensionRegisteredScriptsSQLiteStoreCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionRegisteredScriptsSQLiteStoreCocoa.mm; sourceTree = "<group>"; };
 		7D6A7F372ED0D4C50082F746 /* WebExtensionContextAPIAlarms.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionContextAPIAlarms.cpp; sourceTree = "<group>"; };
 		7DB312D82ED01B42002CD05F /* WebExtensionAPIAlarms.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionAPIAlarms.cpp; sourceTree = "<group>"; };
+		7DC192E32FEF2CD20092B7BC /* WebExtensionAPINamespace.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionAPINamespace.cpp; sourceTree = "<group>"; };
+		7DC192E42FEF2D4C0092B7BC /* WebExtensionAPIWebPageNamespace.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionAPIWebPageNamespace.cpp; sourceTree = "<group>"; };
 		7DDEC9D32D4C5DDA000B1353 /* WebExtensionRegisteredScriptsSQLiteStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionRegisteredScriptsSQLiteStore.h; sourceTree = "<group>"; };
 		7DDEC9D42D4C5DDA000B1353 /* WebExtensionRegisteredScriptsSQLiteStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionRegisteredScriptsSQLiteStore.cpp; sourceTree = "<group>"; };
 		7DE4AC4A2E55521C00475DD8 /* WebExtensionDeclarativeNetRequestSQLiteStoreCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionDeclarativeNetRequestSQLiteStoreCocoa.mm; sourceTree = "<group>"; };
@@ -7917,7 +7919,6 @@
 		B6114A7C2939498000380B1B /* JSWebExtensionAPIEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIEvent.h; sourceTree = "<group>"; };
 		B6114A7D29394A1500380B1B /* JSWebExtensionAPIEvent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIEvent.mm; sourceTree = "<group>"; };
 		B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionEventListenerType.h; sourceTree = "<group>"; };
-		B61274A12B7D732400D8ACDA /* WebExtensionAPIWebPageNamespaceCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIWebPageNamespaceCocoa.mm; sourceTree = "<group>"; };
 		B61274A62B7D738100D8ACDA /* WebExtensionAPIWebPageNamespace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWebPageNamespace.h; sourceTree = "<group>"; };
 		B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIPermissions.h; sourceTree = "<group>"; };
 		B61AFA4729510D0F008220B1 /* JSWebExtensionAPIPermissions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIPermissions.mm; sourceTree = "<group>"; };
@@ -7932,7 +7933,6 @@
 		B62FB8622AA9180C00E61418 /* WebExtensionAPIScripting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIScripting.h; sourceTree = "<group>"; };
 		B63403F814910D57001070B5 /* APIObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIObject.cpp; sourceTree = "<group>"; };
 		B63A99732B7EA000004611FD /* JSWebExtensionAPIWebPageRuntime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIWebPageRuntime.h; sourceTree = "<group>"; };
-		B63A99742B7EA001004611FD /* JSWebExtensionAPIWebPageNamespace.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIWebPageNamespace.mm; sourceTree = "<group>"; };
 		B63A99752B7EA001004611FD /* JSWebExtensionAPIWebPageRuntime.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIWebPageRuntime.mm; sourceTree = "<group>"; };
 		B63C10322B51C09C004A69B8 /* JSWebExtensionAPIStorageArea.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIStorageArea.h; sourceTree = "<group>"; };
 		B63C10332B51C09C004A69B8 /* JSWebExtensionAPIStorage.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIStorage.mm; sourceTree = "<group>"; };
@@ -11154,6 +11154,7 @@
 				760CF4A4920709706E98B98C /* WebExtensionAPIKeys.h */,
 				B6E5F2A4299C105500DBCEA3 /* WebExtensionAPILocalization.h */,
 				1CCEE4542B098B070034E059 /* WebExtensionAPIMenus.h */,
+				7DC192E32FEF2CD20092B7BC /* WebExtensionAPINamespace.cpp */,
 				1C5DC44F290888140061EC62 /* WebExtensionAPINamespace.h */,
 				1C386F2F2AF4082F004108F0 /* WebExtensionAPINotifications.h */,
 				1C5DC44E29087E7F0061EC62 /* WebExtensionAPIObject.h */,
@@ -11171,6 +11172,7 @@
 				1C15497B2926BF6F001B9E5B /* WebExtensionAPITest.h */,
 				3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */,
 				33F6833D293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h */,
+				7DC192E42FEF2D4C0092B7BC /* WebExtensionAPIWebPageNamespace.cpp */,
 				B61274A62B7D738100D8ACDA /* WebExtensionAPIWebPageNamespace.h */,
 				726952DF2B7F4636009E5F0C /* WebExtensionAPIWebPageRuntime.h */,
 				3399E1552B59F0E5008BFB60 /* WebExtensionAPIWebRequest.h */,
@@ -11199,7 +11201,6 @@
 				1C5DC465290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm */,
 				B6E5F2A6299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm */,
 				1CCEE4562B098B4C0034E059 /* WebExtensionAPIMenusCocoa.mm */,
-				1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */,
 				1C386F312AF40849004108F0 /* WebExtensionAPINotificationsCocoa.mm */,
 				3365E6743023E75D003166AA /* WebExtensionAPIOffscreenCocoa.mm */,
 				B65DA1D2294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm */,
@@ -11214,7 +11215,6 @@
 				1C1549792926BF02001B9E5B /* WebExtensionAPITestCocoa.mm */,
 				3375A37029429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm */,
 				33F6833F293FFB3F005C63C0 /* WebExtensionAPIWebNavigationEventCocoa.mm */,
-				B61274A12B7D732400D8ACDA /* WebExtensionAPIWebPageNamespaceCocoa.mm */,
 				3399E1572B59F0FC008BFB60 /* WebExtensionAPIWebRequestCocoa.mm */,
 				337042052B58A2550077FF78 /* WebExtensionAPIWebRequestEventCocoa.mm */,
 				1C5ACFB72A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm */,
@@ -17328,8 +17328,8 @@
 				B6CCAAB729A445E90092E846 /* JSWebExtensionAPILocalization.mm */,
 				1CCEE4502B0989FC0034E059 /* JSWebExtensionAPIMenus.h */,
 				1CCEE4512B0989FC0034E059 /* JSWebExtensionAPIMenus.mm */,
+				7D3E8A4A2FEFB4D800C57922 /* JSWebExtensionAPINamespace.cpp */,
 				1C5DC4532908AC260061EC62 /* JSWebExtensionAPINamespace.h */,
-				1C5DC4542908AC260061EC62 /* JSWebExtensionAPINamespace.mm */,
 				1C386F332AF409F9004108F0 /* JSWebExtensionAPINotifications.h */,
 				1C386F342AF409F9004108F0 /* JSWebExtensionAPINotifications.mm */,
 				B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */,
@@ -17358,8 +17358,8 @@
 				3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */,
 				33F68335293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.h */,
 				33F68336293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.mm */,
+				7D3E8A4B2FEFB4D800C57922 /* JSWebExtensionAPIWebPageNamespace.cpp */,
 				B64AF4E32B7D7E6300357639 /* JSWebExtensionAPIWebPageNamespace.h */,
-				B63A99742B7EA001004611FD /* JSWebExtensionAPIWebPageNamespace.mm */,
 				B63A99732B7EA000004611FD /* JSWebExtensionAPIWebPageRuntime.h */,
 				B63A99752B7EA001004611FD /* JSWebExtensionAPIWebPageRuntime.mm */,
 				3399E1512B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.h */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -169,7 +169,12 @@ bool WebExtensionAPIPermissions::parseDetailsDictionary(NSDictionary *details, H
 
 bool WebExtensionAPIPermissions::verifyRequestedPermissions(HashSet<String>& permissions, HashSet<Ref<WebExtensionMatchPattern>>& matchPatterns, NSString *callingAPIName, NSString **outExceptionString)
 {
-    auto extension = WebExtension::create(extensionContext().manifest());
+    Ref extensionContext = this->extensionContext();
+    RefPtr manifest = extensionContext->manifest();
+    if (!manifest)
+        return false;
+
+    Ref extension = WebExtension::create(*manifest);
     HashSet<String> allowedPermissions = extension->requestedPermissions();
     WebExtension::MatchPatternSet allowedHostPermissions = extension->allRequestedMatchPatterns();
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -170,16 +170,17 @@ NSURL *WebExtensionAPIRuntime::getURL(const String& resourcePath, NSString **out
     return URL { extensionContext().baseURL(), resourcePath }.createNSURL().autorelease();
 }
 
-NSDictionary *WebExtensionAPIRuntime::getManifest()
+RefPtr<JSON::Object> WebExtensionAPIRuntime::getManifest()
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getManifest
 
-    return extensionContext().manifest();
+    return protect(extensionContext())->manifest();
 }
 
 String WebExtensionAPIRuntime::getVersion()
 {
-    return objectForKey<NSString>(extensionContext().manifest(), versionKey);
+    RefPtr manifest = protect(extensionContext())->manifest();
+    return manifest ? manifest->getString(versionKey) : nullString();
 }
 
 String WebExtensionAPIRuntime::runtimeIdentifier()

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.cpp
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2022-2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,26 +24,36 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if !__has_feature(objc_arc)
-#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
-#endif
-
-#import "config.h"
-#import "WebExtensionAPINamespace.h"
+#include "config.h"
+#include "WebExtensionAPINamespace.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#import "CocoaHelpers.h"
-#import "WKWebExtensionPermission.h"
-#import "WebExtensionControllerProxy.h"
+#include "WebExtensionControllerProxy.h"
+#include "WebExtensionPermission.h"
 
 #if ENABLE(INSPECTOR_EXTENSIONS) || ENABLE(WK_WEB_EXTENSIONS_SIDEBAR) ||  ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
-#import "WebPage.h"
-#import <WebCore/Page.h>
-#import <WebCore/Settings.h>
+#include "WebPage.h"
+#include <WebCore/Page.h>
+#include <WebCore/Settings.h>
 #endif
 
 namespace WebKit {
+
+static bool doesDictionaryExist(RefPtr<JSON::Object> value, const String& name, bool returningFalseIfEmpty = false)
+{
+    RefPtr object = value ? value->getObject(name) : nullptr;
+    if (!object)
+        return false;
+    return !returningFalseIfEmpty || object->size();
+}
+
+#if ENABLE(INSPECTOR_EXTENSIONS)
+static bool doesKeyExist(RefPtr<JSON::Object> value, const String& key)
+{
+    return value && !value->getString(key).isEmpty();
+}
+#endif
 
 bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPage* page)
 {
@@ -51,7 +62,7 @@ bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPa
         return false;
 
     if (name == "action"_s)
-        return extensionContext->supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext->manifest(), @"action", false);
+        return extensionContext->supportsManifestVersion(3) && doesDictionaryExist(extensionContext->manifest(), "action"_s);
 
 #if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
     if (name == "bookmarks"_s)
@@ -59,17 +70,17 @@ bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPa
 #endif
 
     if (name == "commands"_s)
-        return objectForKey<NSDictionary>(extensionContext->manifest(), @"commands", false);
+        return doesDictionaryExist(extensionContext->manifest(), "commands"_s);
 
     if (name == "declarativeNetRequest"_s)
         return extensionContext->hasPermission(name) || extensionContext->hasPermission("declarativeNetRequestWithHostAccess"_s);
 
     if (name == "browserAction"_s)
-        return !extensionContext->supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext->manifest(), @"browser_action", false);
+        return !extensionContext->supportsManifestVersion(3) && doesDictionaryExist(extensionContext->manifest(), "browser_action"_s);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     if (name == "devtools"_s)
-        return objectForKey<NSString>(extensionContext->manifest(), @"devtools_page") && page && (page->isInspectorPage() || extensionContext->isInspectorBackgroundPage(*page));
+        return doesKeyExist(extensionContext->manifest(), "devtools_page"_s) && page && (page->isInspectorPage() || extensionContext->isInspectorBackgroundPage(*page));
 #else
     if (name == "devtools"_s)
         return false;
@@ -84,16 +95,16 @@ bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPa
     }
 
     if (name == "pageAction"_s)
-        return !extensionContext->supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext->manifest(), @"page_action", false);
+        return !extensionContext->supportsManifestVersion(3) && doesDictionaryExist(extensionContext->manifest(), "page_action"_s);
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
     // If the extension requests both sidePanel and sidebarAction, we will give them sidebarAction --
     // we check in sidePanel that there is no sidebar_action key, but we do not check in sidebarAction
     // that there is no sidePanel permission
     if (name == "sidePanel"_s)
-        return page->corePage()->settings().webExtensionSidebarEnabled() && extensionContext->hasPermission("sidePanel"_s) && !objectForKey<NSDictionary>(extensionContext->manifest(), @"sidebar_action", true);
+        return page->corePage()->settings().webExtensionSidebarEnabled() && extensionContext->hasPermission("sidePanel"_s) && !doesDictionaryExist(extensionContext->manifest(), "sidebar_action"_s, true);
     if (name == "sidebarAction"_s)
-        return page->corePage()->settings().webExtensionSidebarEnabled() && objectForKey<NSDictionary>(extensionContext->manifest(), @"sidebar_action", true);
+        return page->corePage()->settings().webExtensionSidebarEnabled() && doesDictionaryExist(extensionContext->manifest(), "sidebar_action"_s, true);
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
     if (name == "storage"_s)
@@ -108,6 +119,7 @@ finish:
     return extensionContext->hasPermission(name);
 }
 
+#if PLATFORM(COCOA)
 WebExtensionAPIAction& WebExtensionAPINamespace::action()
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action
@@ -117,6 +129,7 @@ WebExtensionAPIAction& WebExtensionAPINamespace::action()
 
     return *m_action;
 }
+#endif
 
 WebExtensionAPIAlarms& WebExtensionAPINamespace::alarms()
 {
@@ -128,6 +141,7 @@ WebExtensionAPIAlarms& WebExtensionAPINamespace::alarms()
     return *m_alarms;
 }
 
+#if PLATFORM(COCOA)
 WebExtensionAPICommands& WebExtensionAPINamespace::commands()
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands
@@ -317,6 +331,7 @@ WebExtensionAPITabs& WebExtensionAPINamespace::tabs()
 
     return *m_tabs;
 }
+#endif
 
 WebExtensionAPITest& WebExtensionAPINamespace::test()
 {
@@ -328,6 +343,7 @@ WebExtensionAPITest& WebExtensionAPINamespace::test()
     return *m_test;
 }
 
+#if PLATFORM(COCOA)
 WebExtensionAPIWindows& WebExtensionAPINamespace::windows()
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows
@@ -357,6 +373,7 @@ WebExtensionAPIWebRequest& WebExtensionAPINamespace::webRequest()
 
     return *m_webRequest;
 }
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -65,9 +65,8 @@ class WebExtensionAPINamespace : public WebExtensionAPIObject, public JSWebExten
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPINamespace, namespace, browser);
 
 public:
-#if PLATFORM(COCOA)
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
-
+#if PLATFORM(COCOA)
     WebExtensionAPIAction& action();
 #endif
     WebExtensionAPIAlarms& alarms();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -67,7 +67,7 @@ public:
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
 
     NSURL *getURL(const String& resourcePath, NSString **outExceptionString);
-    NSDictionary *NODELETE getManifest();
+    RefPtr<JSON::Object> getManifest();
     String getVersion();
     void getPlatformInfo(Ref<WebExtensionCallbackHandler>&&);
     void getBackgroundPage(Ref<WebExtensionCallbackHandler>&&);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.cpp
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.cpp
@@ -23,21 +23,17 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if !__has_feature(objc_arc)
-#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
-#endif
-
-#import "config.h"
-#import "WebExtensionAPIWebPageNamespace.h"
+#include "config.h"
+#include "WebExtensionAPIWebPageNamespace.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#import "WebExtensionAPINamespace.h"
-#import "WebExtensionAPIRuntime.h"
-#import "WebExtensionAPITest.h"
-#import "WebExtensionContextProxy.h"
-#import "WebExtensionControllerProxy.h"
-#import "WebPage.h"
+#include "WebExtensionAPINamespace.h"
+#include "WebExtensionAPIRuntime.h"
+#include "WebExtensionAPITest.h"
+#include "WebExtensionContextProxy.h"
+#include "WebExtensionControllerProxy.h"
+#include "WebPage.h"
 
 namespace WebKit {
 
@@ -55,6 +51,7 @@ bool WebExtensionAPIWebPageNamespace::isPropertyAllowed(const ASCIILiteral& name
     return false;
 }
 
+#if PLATFORM(COCOA)
 WebExtensionAPIWebPageRuntime& WebExtensionAPIWebPageNamespace::runtime() const
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime
@@ -66,6 +63,7 @@ WebExtensionAPIWebPageRuntime& WebExtensionAPIWebPageNamespace::runtime() const
 
     return *m_runtime;
 }
+#endif
 
 WebExtensionAPITest& WebExtensionAPIWebPageNamespace::test()
 {

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
@@ -41,9 +41,8 @@ class WebExtensionAPIWebPageNamespace : public WebExtensionAPIObject, public JSW
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebPageNamespace, webPageNamespace, browser);
 
 public:
-#if PLATFORM(COCOA)
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
-
+#if PLATFORM(COCOA)
     WebExtensionAPIWebPageRuntime& runtime() const;
 #endif
     WebExtensionAPITest& test();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageRuntime.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-// FIXME: Remove once JSWebExtensionAPIWebPageNamespace.mm doesn't auto include it.
+// FIXME: Remove once JSWebExtensionAPIWebPageNamespace.cpp doesn't auto include it.
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -209,6 +209,11 @@ JSValueRef toWindowObject(JSContextRef, WebPage&);
 
 RefPtr<JSON::Value> fromJSValue(JSContextRef, JSValueRef);
 RefPtr<JSON::Value> toJSONValue(JSContextRef, JSValueRef, NullValuePolicy = NullValuePolicy::NotAllowed, ValuePolicy = ValuePolicy::Recursive);
+inline JSValueRef toJSValueRefOrJSNull(JSContextRef context, RefPtr<JSON::Object> value)
+{
+    ASSERT(context);
+    return value ? fromJSON(context, value) : JSValueMakeNull(context);
+}
 
 #ifdef __OBJC__
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -153,6 +153,14 @@ sub conditionalString
     return CodeGenerator::GenerateConditionalStringFromAttributeValue(0, $conditional);
 }
 
+sub platformString
+{
+    my ($node) = @_;
+    my $platform = $node->extendedAttributes->{"Platform"};
+    return "" unless $platform;
+    return "PLATFORM($platform)";
+}
+
 sub _generateHeaderFile
 {
     my ($self, $interface) = @_;
@@ -214,13 +222,16 @@ EOF
             $hasMainWorldOnlyProperties = 1 if $function->extendedAttributes->{"MainWorldOnly"};
 
             my $conditionalString = conditionalString($function);
+            my $platformString = platformString($function);
 
+            push(@contents, "#if ${platformString}\n") if $platformString;
             push(@contents, "#if ${conditionalString}\n") if $conditionalString;
             push(@contents, "    static JSValueRef @{[$function->name]}(JSContextRef, JSObjectRef, JSObjectRef, size_t, const JSValueRef[], JSValueRef*);\n");
             push(@contents, "    static bool setProperty(JSContextRef, JSObjectRef, JSStringRef, JSValueRef, JSValueRef*);\n") if $function->extendedAttributes->{"SetProperty"};
             push(@contents, "    static JSValueRef getProperty(JSContextRef, JSObjectRef, JSStringRef, JSValueRef*);\n") if $function->extendedAttributes->{"GetProperty"};
             push(@contents, "    static bool deleteProperty(JSContextRef, JSObjectRef, JSStringRef, JSValueRef*);\n") if $function->extendedAttributes->{"DeleteProperty"};
             push(@contents, "#endif // ${conditionalString}\n") if $conditionalString;
+            push(@contents, "#endif // ${platformString}\n") if $platformString;
         }
     }
 
@@ -241,11 +252,14 @@ EOF
             $hasMainWorldOnlyProperties = 1 if $attribute->extendedAttributes->{"MainWorldOnly"};
 
             my $conditionalString = conditionalString($attribute);
+            my $platformString = platformString($attribute);
 
+            push(@contents, "#if ${platformString}\n") if $platformString;
             push(@contents, "#if ${conditionalString}\n") if $conditionalString;
             push(@contents, "    static JSValueRef @{[$self->_getterName($attribute)]}(JSContextRef, JSObjectRef, JSStringRef, JSValueRef*);\n");
             push(@contents, "    static bool @{[$self->_setterName($attribute)]}(JSContextRef, JSObjectRef, JSStringRef, JSValueRef, JSValueRef*);\n") unless $attribute->isReadOnly;
             push(@contents, "#endif // ${conditionalString}\n") if $conditionalString;
+            push(@contents, "#endif // ${platformString}\n") if $platformString;
         }
     }
 
@@ -901,6 +915,11 @@ EOF
 
 EOF
 
+            my $platformString = platformString($attribute);
+            push(@contents, <<EOF) if $platformString;
+#if ${platformString}
+EOF
+
             my $conditionalString = conditionalString($attribute);
             push(@contents, <<EOF) if $conditionalString;
 #if ${conditionalString}
@@ -1001,6 +1020,9 @@ EOF
 
             push(@contents, <<EOF) if $conditionalString;
 #endif // ${conditionalString}
+EOF
+            push(@contents, <<EOF) if $platformString;
+#endif // ${platformString}
 EOF
         }
     }
@@ -1673,8 +1695,12 @@ sub _staticValuesGetterImplementation
         push(@attributes, "kJSPropertyAttributeDontEnum") if $_->extendedAttributes->{"DontEnum"};
         my $jsproperties = scalar @attributes == 0 ? "kJSPropertyAttributeNone" : join(" | ", @attributes);
         my $conditionalString = conditionalString($_);
+        my $platformString = platformString($_);
+        my $platformConditional = $platformString ? "\n#if ${platformString}\n" : "";
+        my $platformConditionalEnd = $platformString ? "#endif // ${platformString}" : "";
 
-        return "#if ${conditionalString}\n        { \"$attributeName\", $getterName, $setterName, $jsproperties },\n        #endif" if $conditionalString;
+        return "${platformConditional}#if ${conditionalString}\n        { \"$attributeName\", $getterName, $setterName, $jsproperties },\n        #endif${platformConditionalEnd}" if $conditionalString;
+        return "${platformConditional}        { \"$attributeName\", $getterName, $setterName, $jsproperties },\n        ${platformConditionalEnd}" if $platformString;
         return "{ \"$attributeName\", $getterName, $setterName, $jsproperties },";
     };
 
@@ -1764,12 +1790,15 @@ EOF
 
         my $condition = &$generateCondition($_);
         my $conditionalString = conditionalString($_);
+        my $platformString = platformString($_);
 
         my $content = "";
+        $content .= "#if ${platformString}\n" if $platformString;
         $content .= "#if ${conditionalString}\n" if $conditionalString;
         $content .= "    if (${condition})\n";
         $content .= "        SUPPRESS_UNCOUNTED_ARG JSPropertyNameAccumulatorAddName(propertyNames, toJSString(\"${name}\"_s).get());\n";
         $content .= "#endif // ${conditionalString}\n" if $conditionalString;
+        $content .= "#endif // ${platformString}\n" if $platformString;
         $content .= "\n";
         return $content;
     };
@@ -1797,12 +1826,15 @@ EOF
         my $name = $_->name;
         my $condition = &$generateCondition($_);
         my $conditionalString = conditionalString($_);
+        my $platformString = platformString($_);
 
         my $content = "";
+        $content .= "#if ${platformString}\n" if $platformString;
         $content .= "#if ${conditionalString}\n" if $conditionalString;
         $content .= "    if (JSStringIsEqualToUTF8CString(propertyName, \"${name}\"))\n";
         $content .= "        return ${condition};\n";
         $content .= "#endif // ${conditionalString}\n" if $conditionalString;
+        $content .= "#endif // ${platformString}\n" if $platformString;
         $content .= "\n";
         return $content;
     };
@@ -1843,11 +1875,14 @@ EOF
             $condition = &$generateCondition($attribute, "JSStringIsEqualToUTF8CString(propertyName, \"${name}\")") if $hasDynamicProperties;
 
             my $conditionalString = conditionalString($attribute);
+            my $platformString = platformString($attribute);
 
+            push(@contents, "#if ${platformString}\n") if $platformString;
             push(@contents, "#if ${conditionalString}\n") if $conditionalString;
             push(@contents, "    if (${condition})\n");
             push(@contents, "        return ${getterName}(context, thisObject, propertyName, exception);\n");
             push(@contents, "#endif // ${conditionalString}\n") if $conditionalString;
+            push(@contents, "#endif // ${platformString}\n") if $platformString;
             push(@contents, "\n");
         }
     }

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
@@ -23,6 +23,10 @@
             "values": ["*"],
             "supportsConjunction": true
         },
+        "Platform": {
+            "contextsAllowed": ["attribute"],
+            "values": ["*"]
+        },
         "CallbackHandler": {
             "contextsAllowed": ["argument"]
         },

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -85,7 +85,7 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExt
         context.m_grantedPermissions = parameters.grantedPermissions;
         context.m_localization = parseLocalization(parameters.localizationJSON, parameters.baseURL);
         Ref manifestJSON = *parameters.manifestJSON;
-        context.m_manifest = parseJSON(manifestJSON);
+        context.m_manifest = JSON::Value::parseJSON(String::fromUTF8(manifestJSON->span()));
         context.m_manifestVersion = parameters.manifestVersion;
         context.m_isSessionStorageAllowedInContentScripts = parameters.isSessionStorageAllowedInContentScripts;
         context.m_defaultSessionID = parameters.defaultSessionID;

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
@@ -26,59 +26,60 @@
 [
     Conditional=WK_WEB_EXTENSIONS,
     ReturnsPromiseWhenCallbackIsOmitted,
+    UseCPPAPI,
 ] interface WebExtensionAPINamespace {
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction action;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIAction action;
 
     [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAlarms alarms;
 
-    [MainWorldOnly, Dynamic, Conditional=WK_WEB_EXTENSIONS_BOOKMARKS] readonly attribute WebExtensionAPIBookmarks bookmarks;
+    [MainWorldOnly, Dynamic, Platform=COCOA, Conditional=WK_WEB_EXTENSIONS_BOOKMARKS] readonly attribute WebExtensionAPIBookmarks bookmarks;
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction browserAction;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIAction browserAction;
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPICookies cookies;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPICookies cookies;
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPICommands commands;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPICommands commands;
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIMenus contextMenus;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIMenus contextMenus;
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIDeclarativeNetRequest declarativeNetRequest;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIDeclarativeNetRequest declarativeNetRequest;
 
-    [Dynamic, Conditional=INSPECTOR_EXTENSIONS] readonly attribute WebExtensionAPIDevTools devtools;
+    [Dynamic, Platform=COCOA, Conditional=INSPECTOR_EXTENSIONS] readonly attribute WebExtensionAPIDevTools devtools;
 
-    readonly attribute WebExtensionAPIDOM dom;
+    [Platform=COCOA] readonly attribute WebExtensionAPIDOM dom;
 
-    readonly attribute WebExtensionAPIExtension extension;
+    [Platform=COCOA] readonly attribute WebExtensionAPIExtension extension;
 
-    readonly attribute WebExtensionAPILocalization i18n;
+    [Platform=COCOA] readonly attribute WebExtensionAPILocalization i18n;
 
-    readonly attribute WebExtensionAPIRuntime runtime;
+    [Platform=COCOA] readonly attribute WebExtensionAPIRuntime runtime;
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIMenus menus;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIMenus menus;
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPINotifications notifications;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPINotifications notifications;
 
-    [MainWorldOnly, Dynamic, Conditional=WK_WEB_EXTENSIONS_OFFSCREEN] readonly attribute WebExtensionAPIOffscreen offscreen;
+    [MainWorldOnly, Dynamic, Platform=COCOA, Conditional=WK_WEB_EXTENSIONS_OFFSCREEN] readonly attribute WebExtensionAPIOffscreen offscreen;
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction pageAction;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIAction pageAction;
 
-    [MainWorldOnly] readonly attribute WebExtensionAPIPermissions permissions;
+    [MainWorldOnly, Platform=COCOA] readonly attribute WebExtensionAPIPermissions permissions;
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIScripting scripting;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIScripting scripting;
 
-    [MainWorldOnly, Dynamic, Conditional=WK_WEB_EXTENSIONS_SIDEBAR] readonly attribute WebExtensionAPISidebarAction sidebarAction;
+    [MainWorldOnly, Dynamic, Platform=COCOA, Conditional=WK_WEB_EXTENSIONS_SIDEBAR] readonly attribute WebExtensionAPISidebarAction sidebarAction;
 
-    [MainWorldOnly, Dynamic, Conditional=WK_WEB_EXTENSIONS_SIDEBAR] readonly attribute WebExtensionAPISidePanel sidePanel;
+    [MainWorldOnly, Dynamic, Platform=COCOA, Conditional=WK_WEB_EXTENSIONS_SIDEBAR] readonly attribute WebExtensionAPISidePanel sidePanel;
 
-    [Dynamic] readonly attribute WebExtensionAPIStorage storage;
+    [Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIStorage storage;
 
-    [MainWorldOnly] readonly attribute WebExtensionAPITabs tabs;
+    [MainWorldOnly, Platform=COCOA] readonly attribute WebExtensionAPITabs tabs;
 
-    [MainWorldOnly] readonly attribute WebExtensionAPIWindows windows;
+    [MainWorldOnly, Platform=COCOA] readonly attribute WebExtensionAPIWindows windows;
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebNavigation webNavigation;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIWebNavigation webNavigation;
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebRequest webRequest;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIWebRequest webRequest;
 
     [Dynamic] readonly attribute WebExtensionAPITest test;
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageNamespace.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageNamespace.idl
@@ -26,9 +26,10 @@
 [
     Conditional=WK_WEB_EXTENSIONS,
     ReturnsPromiseWhenCallbackIsOmitted,
+    UseCPPAPI,
 ] interface WebExtensionAPIWebPageNamespace {
 
-    readonly attribute WebExtensionAPIWebPageRuntime runtime;
+    [Platform=COCOA] readonly attribute WebExtensionAPIWebPageRuntime runtime;
     [Dynamic] readonly attribute WebExtensionAPITest test;
 
 };

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -86,12 +86,10 @@ public:
 
     bool isURLForThisExtension(const URL&) const;
 
-#if PLATFORM(COCOA)
-    NSDictionary *manifest() const { return m_manifest.get(); }
+    RefPtr<JSON::Object> manifest() const { return m_manifest ? m_manifest.get()->asObject() : nullptr; }
 
     double manifestVersion() const { return m_manifestVersion; }
     bool supportsManifestVersion(double version) const { return manifestVersion() >= version; }
-#endif
     RefPtr<WebExtensionLocalization> localization() const { return m_localization; }
 
     bool isSessionStorageAllowedInContentScripts() const { return m_isSessionStorageAllowedInContentScripts; }
@@ -248,9 +246,7 @@ private:
     String m_uniqueIdentifier;
     HashSet<String> m_unsupportedAPIs;
     RefPtr<WebExtensionLocalization> m_localization;
-#if PLATFORM(COCOA)
-    RetainPtr<NSDictionary> m_manifest;
-#endif
+    RefPtr<JSON::Value> m_manifest;
     double m_manifestVersion { 0 };
     bool m_isSessionStorageAllowedInContentScripts { false };
     PAL::SessionID m_defaultSessionID { PAL::SessionID::defaultSessionID() };


### PR DESCRIPTION
#### 88312860c0da61c499488ed5627c2c77fc0e1df0
<pre>
Port WebExtensionAPINamespace to C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=320886">https://bugs.webkit.org/show_bug.cgi?id=320886</a>

Reviewed by Timothy Hatcher.

Ports WebExtensionAPINamespace to C++, including
WebExtensionAPIWebPageNamespace.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Sources.txt:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::WebExtension):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::WebExtension):
* Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
(WebKit::WebExtensionAPIPermissions::verifyRequestedPermissions):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::getManifest):
(WebKit::WebExtensionAPIRuntime::getVersion):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.cpp: Renamed from Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm.
(WebKit::doesDictionaryExist):
(WebKit::doesKeyExist):
(WebKit::WebExtensionAPINamespace::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.cpp: Renamed from Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageRuntime.h:
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
(WebKit::toJSValueRefOrJSNull):
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(conditionalString):
(platformString):
(_generateHeaderFile):
(_generateImplementationFile):
(_staticValuesGetterImplementation):
(_dynamicAttributesImplementation):
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json:
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::getOrCreate):
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageNamespace.idl:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:

Canonical link: <a href="https://commits.webkit.org/318942@main">https://commits.webkit.org/318942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf86c5c62af0ce41257cbc4ad3a3773e0fc58e9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47611 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144188 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53531 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161040 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40903 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152987 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40566 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1237 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192011 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53481 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149592 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54168 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149323 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27318 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43970 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126431 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121483 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52685 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15553 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52305 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->