### PR TITLE
[GTK][WPE] Skia compositor: CoordinatedPlatformLayer::hasCommittedContentsBuffer() uses m_skiaTarget and can be called from different threads

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -147,6 +147,7 @@ void CoordinatedPlatformLayer::invalidateTarget()
         m_imageBackingStore.committed = nullptr;
         if (shouldReleaseBuffer(m_contentsBuffer.committed.get()))
             m_contentsBuffer.committed = nullptr;
+        m_contentsBuffer.hasCommitted = false;
     }
     m_target = nullptr;
 #if USE(SKIA)
@@ -494,21 +495,10 @@ float CoordinatedPlatformLayer::contentsScale() const
     return m_contentsScale;
 }
 
-bool CoordinatedPlatformLayer::hasCommittedContentsBuffer() const
-{
-    assertIsHeld(m_lock);
-#if USE(SKIA)
-    if (m_skiaTarget)
-        return !!m_skiaTarget->contentsBuffer();
-#endif
-
-    return !!m_contentsBuffer.committed;
-}
-
 void CoordinatedPlatformLayer::setContentsBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&& buffer, std::optional<Damage>&& dirtyRegion, RequireComposition requireComposition)
 {
     assertIsHeld(m_lock);
-    if (!buffer && !m_contentsBuffer.pending && !hasCommittedContentsBuffer())
+    if (!buffer && !m_contentsBuffer.pending && !m_contentsBuffer.hasCommitted)
         return;
 
     m_contentsBuffer.pending = WTF::move(buffer);
@@ -529,7 +519,7 @@ void CoordinatedPlatformLayer::setContentsBuffer(std::unique_ptr<CoordinatedPlat
 void CoordinatedPlatformLayer::replaceCurrentContentsBufferWithCopy()
 {
     Locker locker { m_lock };
-    if (!hasCommittedContentsBuffer())
+    if (!m_contentsBuffer.hasCommitted)
         return;
 
     m_contentsBuffer.pending = nullptr;
@@ -539,6 +529,7 @@ void CoordinatedPlatformLayer::replaceCurrentContentsBufferWithCopy()
         if (auto* buffer = m_skiaTarget->contentsBuffer()) {
             if (is<CoordinatedPlatformLayerBufferVideo>(*buffer))
                 m_contentsBuffer.pending = downcast<CoordinatedPlatformLayerBufferVideo>(*buffer).copyBuffer();
+            m_contentsBuffer.hasCommitted = !!m_contentsBuffer.pending;
             m_skiaTarget->setContentsBuffer(WTF::move(m_contentsBuffer.pending));
         }
         return;
@@ -547,6 +538,7 @@ void CoordinatedPlatformLayer::replaceCurrentContentsBufferWithCopy()
     if (is<CoordinatedPlatformLayerBufferVideo>(*m_contentsBuffer.committed))
         m_contentsBuffer.pending = downcast<CoordinatedPlatformLayerBufferVideo>(*m_contentsBuffer.committed).copyBuffer();
     m_contentsBuffer.committed = WTF::move(m_contentsBuffer.pending);
+    m_contentsBuffer.hasCommitted = !!m_contentsBuffer.committed;
     ensureTarget().setContentsLayer(m_contentsBuffer.committed.get());
 }
 #endif
@@ -1283,6 +1275,7 @@ void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<Com
     if (reasons.containsAny({ CompositionReason::RenderingUpdate, CompositionReason::VideoFrame, CompositionReason::AsyncScrolling })) {
         if (m_pendingChanges.contains(Change::ContentsBuffer)) {
             m_contentsBuffer.committed = WTF::move(m_contentsBuffer.pending);
+            m_contentsBuffer.hasCommitted = !!m_contentsBuffer.committed;
             m_pendingChanges.remove(Change::ContentsBuffer);
         }
 
@@ -1478,6 +1471,7 @@ void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet
         }
 #endif
         if (m_pendingChanges.contains(Change::ContentsBuffer)) {
+            m_contentsBuffer.hasCommitted = !!m_contentsBuffer.pending;
             layer.setContentsBuffer(WTF::move(m_contentsBuffer.pending));
             m_pendingChanges.remove(Change::ContentsBuffer);
         }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -230,8 +230,6 @@ private:
     bool needsBackingStore() const;
     void purgeBackingStores();
 
-    bool hasCommittedContentsBuffer() const WTF_REQUIRES_LOCK(m_lock);
-
 #if ENABLE(DAMAGE_TRACKING)
     void addDamage(Damage&&) WTF_REQUIRES_LOCK(m_lock);
 #endif
@@ -332,6 +330,7 @@ private:
     struct {
         std::unique_ptr<CoordinatedPlatformLayerBuffer> pending;
         std::unique_ptr<CoordinatedPlatformLayerBuffer> committed;
+        bool hasCommitted { false };
     } m_contentsBuffer WTF_GUARDED_BY_LOCK(m_lock);
     struct {
         Path path;


### PR DESCRIPTION
#### 68b163ff10b4fd22635480485907df5de9e6bc7a
<pre>
[GTK][WPE] Skia compositor: CoordinatedPlatformLayer::hasCommittedContentsBuffer() uses m_skiaTarget and can be called from different threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=320890">https://bugs.webkit.org/show_bug.cgi?id=320890</a>

Reviewed by Nikolas Zimmermann.

In CoordinatedPlatformLayer m_skiaTarget is not pretected by any lock
because it&apos;s only expected to be used from the compositing thread, but
it&apos;s used from hasCommittedContentsBuffer() that can be called from gst
threads. Add a bool flag protected by m_lock to note when the layer has
a committed contents buffer and use it instead of hasCommittedContentsBuffer().

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::invalidateTarget):
(WebCore::CoordinatedPlatformLayer::setContentsBuffer):
(WebCore::CoordinatedPlatformLayer::replaceCurrentContentsBufferWithCopy):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnTarget):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget):
(WebCore::CoordinatedPlatformLayer::hasCommittedContentsBuffer const): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:

Canonical link: <a href="https://commits.webkit.org/318445@main">https://commits.webkit.org/318445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1311481b561638e7b8376daae82a8a6f9220f2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141598 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139032 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119487 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41264 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39615 "Passed tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39294 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36421 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44888 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190393 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51957 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148188 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52638 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147962 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27048 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42679 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124903 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119508 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51156 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14269 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50541 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50781 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50603 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->