### PR TITLE
Remove unreachable null check in XMLHttpRequestUpload::scriptExecutionContext()

### DIFF
--- a/Source/WebCore/xml/XMLHttpRequestUpload.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestUpload.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,9 +70,7 @@ void XMLHttpRequestUpload::dispatchProgressEvent(const AtomString& type, unsigne
 
 ScriptExecutionContext* XMLHttpRequestUpload::scriptExecutionContext() const
 {
-    if (RefPtr request = m_request.ptr())
-        return request->scriptExecutionContext();
-    return nullptr;
+    return protect(m_request)->scriptExecutionContext();
 }
 
 WebCoreOpaqueRoot root(XMLHttpRequestUpload* upload)


### PR DESCRIPTION
#### 82c30dd925e1726383e951ede5e761a56c991665
<pre>
Remove unreachable null check in XMLHttpRequestUpload::scriptExecutionContext()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320891">https://bugs.webkit.org/show_bug.cgi?id=320891</a>
<a href="https://rdar.apple.com/183909422">rdar://183909422</a>

Reviewed by Chris Dumez.

WeakRef::ptr() ends in RELEASE_ASSERT(ptr), so it never returns null and the
early return was dead code. Use protect() to get the counted reference in a
single expression, matching eventListenersDidChange() just above; dereferencing
the WeakRef directly would pass an uncounted &apos;this&apos; and trip Safer C++.

No change in behavior.

* Source/WebCore/xml/XMLHttpRequestUpload.cpp:
(WebCore::XMLHttpRequestUpload::scriptExecutionContext const):

Canonical link: <a href="https://commits.webkit.org/318532@main">https://commits.webkit.org/318532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d1ed4358bcba0e773b872f3d21ce24e3891bf1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188127 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141760 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fed662e8-dc18-4ed1-af86-83d5d47f27dd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139177 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5887d283-ddea-43a2-b296-6969d7b53695) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159923 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119631 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; run-api-tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5bf6f99b-33af-4098-a2d8-bcf02415acae) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41399 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39750 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151799 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39423 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190554 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52118 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148335 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39840 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52799 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148105 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42812 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125066 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119702 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51317 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14397 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50702 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50942 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50764 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->