### PR TITLE
Remove duplicate m_exceptionCode assignment in XMLHttpRequest::didReachTimeout()

### DIFF
--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -1177,7 +1177,6 @@ void XMLHttpRequest::didReachTimeout()
 
     if (!m_async) {
         m_readyState = DONE;
-        m_exceptionCode = ExceptionCode::TimeoutError;
         return;
     }
 


### PR DESCRIPTION
#### 246673dcae2a1e008f9ebf8b3ac37b68417de4f0
<pre>
Remove duplicate m_exceptionCode assignment in XMLHttpRequest::didReachTimeout()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320893">https://bugs.webkit.org/show_bug.cgi?id=320893</a>
<a href="https://rdar.apple.com/183909305">rdar://183909305</a>

Reviewed by Chris Dumez.

didReachTimeout() sets m_exceptionCode to ExceptionCode::TimeoutError
unconditionally, and then sets it to the same value again inside the
!m_async branch. Nothing in between can change it, so the second
assignment is dead. Remove it; no behavior change.

* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::didReachTimeout):

Canonical link: <a href="https://commits.webkit.org/318533@main">https://commits.webkit.org/318533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fe182e95d59406080db95a37bce3826e86b38a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187970 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141603 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5a9fa76-b51d-4e74-b566-dd0ec05d7c2d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139036 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43c18fae-692b-4b7d-a602-a39427d5c11e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119491 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01f5c025-cc76-4d55-9fef-b17b76f7947a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41267 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39619 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39419 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36426 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44893 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43861 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; Ignored 9 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190398 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51962 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148192 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39841 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52643 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147966 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42682 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124908 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119515 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51161 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14276 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50546 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50786 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50608 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->