### PR TITLE
k-rate AudioParam input diverges from equivalent automation for AudioBufferSourceNode.detune

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audiobuffersource-connections-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audiobuffersource-connections-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Verify k-rate AudioParam input works correctly for playbackRate
-FAIL Verify k-rate AudioParam input works correctly for detune assert_array_approx_equals: AudioBufferSourceNode detune: actual matches expected for k-rate AudioParam input property 405, expected 0.11203312128782272 +/- 0, expected 0.11203312128782272 but got 0.11203312873840332
+PASS Verify k-rate AudioParam input works correctly for detune
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audiobuffersource-connections-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audiobuffersource-connections-expected.txt
@@ -1,4 +1,0 @@
-
-PASS Verify k-rate AudioParam input works correctly for playbackRate
-PASS Verify k-rate AudioParam input works correctly for detune
-

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4637,7 +4637,6 @@ webkit.org/b/254398 webgl/2.0.y/conformance/extensions/webgl-compressed-texture-
 imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-multi-line.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color.html [ Failure ]
-imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audiobuffersource-connections.html [ Failure ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-dynamics-compressor-connections.html [ Failure ]
 webaudio/ScriptProcessor/scriptprocessor-offlineaudiocontext.html [ Failure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1921,7 +1921,6 @@ webkit.org/b/254044 http/wpt/webxr [ Skip ]
 webkit.org/b/237415 webgl/1.0.x/conformance/rendering/clipping-wide-points.html [ Pass Failure ]
 
 # webkit.org/b/255427 [ Ventura ] 4/13 batch mark expectations and branch bugs
-imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audiobuffersource-connections.html [ Failure ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-dynamics-compressor-connections.html [ Failure ]
 [ arm64 ] webaudio/ScriptProcessor/scriptprocessor-offlineaudiocontext.html [ Failure ]
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1130,7 +1130,6 @@ webkit.org/b/309369 [ arm64 ] svg/W3C-SVG-1.1/metadata-example-01-b.svg [ Failur
 
 webkit.org/b/309369 [ arm64 ] imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-003.html [ ImageOnlyFailure ]
 
-webkit.org/b/309372 [ arm64 ] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audiobuffersource-connections.html [ Failure ]
 webkit.org/b/309372 [ arm64 ] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-dynamics-compressor-connections.html [ Failure ]
 webkit.org/b/309372 [ arm64 ] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-convolvernode-interface/convolution-mono-mono.html [ Failure ]
 webkit.org/b/309372 [ arm64 ] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-convolvernode-interface/realtime-conv.html [ Failure ]

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
@@ -553,10 +553,15 @@ void AudioParamTimeline::processLinearRamp(const AutomationState& currentState, 
     if (writeIndex >= 1)
         value = values[writeIndex - 1];
 
-    // Serially process remaining values.
+    // Serially process remaining values. Compute (currentFrame / sampleRate - time1) * k first so
+    // the product stays bounded even when 1 / deltaTime is huge (very close event times), then
+    // apply valueDelta and value1 as separate statements. Splitting the multiply and add prevents
+    // fused multiply-add contraction, which would otherwise make single-value k-rate reads (which
+    // land here) diverge from the vectorized VectorMath multi-value path whenever valueDelta != 1.
     for (; writeIndex < currentState.fillToFrame; ++writeIndex) {
         float x = (currentFrame * currentState.samplingPeriod - currentState.time1.value()) * k;
-        value = currentState.value1 + valueDelta * x;
+        float scaledDelta = valueDelta * x;
+        value = currentState.value1 + scaledDelta;
         values[writeIndex] = value;
         ++currentFrame;
     }


### PR DESCRIPTION
#### 588fdd26e06c5082ec0f8fe9a3c513c8aef09100
<pre>
k-rate AudioParam input diverges from equivalent automation for AudioBufferSourceNode.detune
<a href="https://bugs.webkit.org/show_bug.cgi?id=320892">https://bugs.webkit.org/show_bug.cgi?id=320892</a>

Reviewed by Darin Adler.

The k-rate WPT test compares two AudioBufferSourceNodes that should produce
identical detune: a reference node driven by setValueAtTime/linearRampToValueAtTime,
and a test node whose detune is modulated by a connected a-rate ConstantSourceNode.
The reference node&apos;s k-rate read asks the timeline for a single value, which lands
in the serial remainder loop of AudioParamTimeline::processLinearRamp. The connected
input renders a full quantum through the vectorized VectorMath (vDSP/NEON) path.

The serial loop computed the ramp as one expression (value1 + valueDelta * x), which
Apple clang contracts into a fused multiply-add (a single rounding), while the
vectorized path performs the multiply and add as separate operations (two roundings,
no FMA). For detune (valueDelta = 2400) the two paths disagreed by ~1 ULP; that
difference flows through pow(2, detune/1200) into the pitch rate and accumulates in
the buffer read index, failing the tolerance-0 comparison. playbackRate passed only
because its valueDelta == 1 makes both roundings coincide.

Split the serial multiply-add into separate statements so FMA contraction cannot
occur, making the serial path bit-match the vectorized path. Keep the original
offset * k grouping (evaluated in double, staying bounded) rather than folding into
k * valueDelta, which would overflow to FLT_MAX for very-close event times and
regress audioparam-close.html.

No new tests, rebaselined existing WPT test.

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audiobuffersource-connections-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audiobuffersource-connections-expected.txt: Removed.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp:
(WebCore::AudioParamTimeline::processLinearRamp):

Canonical link: <a href="https://commits.webkit.org/318516@main">https://commits.webkit.org/318516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d22980872d04138ed673797372b1e297bbdad3cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141604 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1710f0d5-775f-460d-b6a1-335b6e212312) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52004 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139039 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c403730c-285e-445b-a749-272ba8d9b0de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42604 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159800 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; 1 api test failed or timed out; re-run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119494 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a97ef5c-ef7d-4bc8-9e1b-2fe3c1259822) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41270 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39620 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39298 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36427 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190399 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148194 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39831 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52644 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147968 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42685 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124909 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119516 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51162 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14273 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50547 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50787 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50609 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->