### PR TITLE
Use a default member initializer for MathMLOperatorDictionary::Property::form

### DIFF
--- a/Source/WebCore/mathml/MathMLOperatorDictionary.h
+++ b/Source/WebCore/mathml/MathMLOperatorDictionary.h
@@ -47,7 +47,8 @@ enum Flag {
 };
 const unsigned allFlags = Accent | Fence | LargeOp | MovableLimits | Separator | Stretchy | Symmetric;
 struct Property {
-    MathMLOperatorDictionary::Form form;
+    // Default form is "infix".
+    MathMLOperatorDictionary::Form form { MathMLOperatorDictionary::Form::Infix };
     // Default leading and trailing spaces are "thickmathspace".
     unsigned short leadingSpaceInMathUnit { 5 };
     unsigned short trailingSpaceInMathUnit { 5 };


### PR DESCRIPTION
#### eeac234329e99b241fc77dd9e069a6f8e7dbc83d
<pre>
Use a default member initializer for MathMLOperatorDictionary::Property::form
<a href="https://bugs.webkit.org/show_bug.cgi?id=320894">https://bugs.webkit.org/show_bug.cgi?id=320894</a>
<a href="https://rdar.apple.com/183910863">rdar://183910863</a>

Reviewed by Frédéric Wang Nélar.

Property::form was the only member of the struct left without a default member
initializer, so a default-constructed Property had an indeterminate form until
each field was assigned. Give it Form::Infix, which is both the spec&apos;s default
form and what MathMLOperatorElement::computeDictionaryProperty() already assumed
when default-constructing a Property before selecting the form.

No change in behavior: Property is never aggregate-initialized; every
construction site default-constructs and then assigns each field.

* Source/WebCore/mathml/MathMLOperatorDictionary.h:

Canonical link: <a href="https://commits.webkit.org/318463@main">https://commits.webkit.org/318463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02c1e76d2942b297cec2836e56e3a88222ed8269

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141608 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98859ab8-60b6-41f0-873f-ebafc393aa45) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139040 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c76eaac2-9208-439a-a727-7f98fb23c5a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119495 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f58b310a-4ba5-4b16-88c6-3997250ad6f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41273 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39622 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151673 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39303 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36431 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190403 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51967 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148197 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39800 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52648 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147975 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42684 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124913 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119520 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51166 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14278 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50551 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50791 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50613 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->