### PR TITLE
[GStreamer][Skia] Video rendering support for Qualcomm decoder

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
@@ -59,9 +59,9 @@ std::unique_ptr<CoordinatedPlatformLayerBufferExternalOES> CoordinatedPlatformLa
 }
 
 #if USE(GSTREAMER) && USE(GBM)
-std::unique_ptr<CoordinatedPlatformLayerBufferExternalOES> CoordinatedPlatformLayerBufferExternalOES::create(GRefPtr<GstBuffer>&& buffer, uint32_t fourcc, const IntSize& size, OptionSet<TextureMapperFlags> flags)
+std::unique_ptr<CoordinatedPlatformLayerBufferExternalOES> CoordinatedPlatformLayerBufferExternalOES::create(GRefPtr<GstBuffer>&& buffer, uint32_t fourcc, CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace yuvColorSpace, SampleRange sampleRange, const IntSize& size, OptionSet<TextureMapperFlags> flags)
 {
-    return makeUnique<CoordinatedPlatformLayerBufferExternalOES>(WTF::move(buffer), fourcc, size, flags);
+    return makeUnique<CoordinatedPlatformLayerBufferExternalOES>(WTF::move(buffer), fourcc, yuvColorSpace, sampleRange, size, flags);
 }
 #endif
 
@@ -72,9 +72,11 @@ CoordinatedPlatformLayerBufferExternalOES::CoordinatedPlatformLayerBufferExterna
 }
 
 #if USE(GSTREAMER) && USE(GBM)
-CoordinatedPlatformLayerBufferExternalOES::CoordinatedPlatformLayerBufferExternalOES(GRefPtr<GstBuffer>&& buffer, uint32_t fourcc, const IntSize& size, OptionSet<TextureMapperFlags> flags)
+CoordinatedPlatformLayerBufferExternalOES::CoordinatedPlatformLayerBufferExternalOES(GRefPtr<GstBuffer>&& buffer, uint32_t fourcc, CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace yuvColorSpace, SampleRange sampleRange, const IntSize& size, OptionSet<TextureMapperFlags> flags)
     : CoordinatedPlatformLayerBuffer(Type::ExternalOES, size, flags, nullptr)
     , m_fourcc(fourcc)
+    , m_yuvColorSpace(yuvColorSpace)
+    , m_sampleRange(sampleRange)
     , m_buffer(WTF::move(buffer))
 {
 }
@@ -82,18 +84,15 @@ CoordinatedPlatformLayerBufferExternalOES::CoordinatedPlatformLayerBufferExterna
 
 CoordinatedPlatformLayerBufferExternalOES::~CoordinatedPlatformLayerBufferExternalOES() = default;
 
-void CoordinatedPlatformLayerBufferExternalOES::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity)
-{
-    waitForContentsIfNeeded();
-    if (m_textureID) {
-        textureMapper.drawTextureExternalOES(m_textureID, m_flags, targetRect, modelViewMatrix, opacity);
-        return;
-    }
-
 #if USE(GSTREAMER) && USE(GBM)
+RefPtr<BitmapTexture> CoordinatedPlatformLayerBufferExternalOES::createExternalOESTexture()
+{
+    if (m_externalOESTexture)
+        return m_externalOESTexture;
+
     auto memory = gst_buffer_peek_memory(m_buffer.get(), 0);
     if (!gst_is_fd_memory(memory)) [[unlikely]]
-        return;
+        return nullptr;
 
     int fd = gst_fd_memory_get_fd(memory);
 
@@ -105,7 +104,7 @@ void CoordinatedPlatformLayerBufferExternalOES::paintToTextureMapper(TextureMapp
     // when importing via EGL_LINUX_DMA_BUF_EXT, causing intermittent green frames.
     EGLint stride = WTF::roundUpToMultipleOf(128, m_size.width());
     EGLint uvStride = stride;
-    std::optional<EGLAttrib> uvOffset;
+    EGLAttrib uvOffset = static_cast<EGLAttrib>(stride) * m_size.height();
     if (const auto videoMeta = gst_buffer_get_video_meta(m_buffer.get()); videoMeta && videoMeta->n_planes >= 2) {
         WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN; // GLib port
         stride = videoMeta->stride[0];
@@ -136,34 +135,74 @@ void CoordinatedPlatformLayerBufferExternalOES::paintToTextureMapper(TextureMapp
         attributes.append(std::span<const EGLAttrib> { plane0Modifier });
     }
 
-    if (uvOffset) {
-        std::array<EGLAttrib, 6> plane1Attributes {
-            EGL_DMA_BUF_PLANE1_FD_EXT, static_cast<EGLAttrib>(fd),
-            EGL_DMA_BUF_PLANE1_OFFSET_EXT, *uvOffset,
-            EGL_DMA_BUF_PLANE1_PITCH_EXT, static_cast<EGLAttrib>(uvStride),
+    std::array<EGLAttrib, 6> plane1Attributes {
+        EGL_DMA_BUF_PLANE1_FD_EXT, static_cast<EGLAttrib>(fd),
+        EGL_DMA_BUF_PLANE1_OFFSET_EXT, uvOffset,
+        EGL_DMA_BUF_PLANE1_PITCH_EXT, static_cast<EGLAttrib>(uvStride),
+    };
+    attributes.append(std::span<const EGLAttrib> { plane1Attributes });
+    if (display.eglExtensions().EXT_image_dma_buf_import_modifiers) {
+        std::array<EGLAttrib, 4> plane1Modifier {
+            EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT, static_cast<EGLAttrib>(DRM_FORMAT_MOD_LINEAR >> 32),
+            EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT, static_cast<EGLAttrib>(DRM_FORMAT_MOD_LINEAR & 0xffffffff),
         };
-        attributes.append(std::span<const EGLAttrib> { plane1Attributes });
-        if (display.eglExtensions().EXT_image_dma_buf_import_modifiers) {
-            std::array<EGLAttrib, 4> plane1Modifier {
-                EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT, static_cast<EGLAttrib>(DRM_FORMAT_MOD_LINEAR >> 32),
-                EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT, static_cast<EGLAttrib>(DRM_FORMAT_MOD_LINEAR & 0xffffffff),
-            };
-            attributes.append(std::span<const EGLAttrib> { plane1Modifier });
-        }
+        attributes.append(std::span<const EGLAttrib> { plane1Modifier });
     }
 
+    auto colorSpaceHint = [&]() -> std::optional<EGLAttrib> {
+        switch (m_yuvColorSpace) {
+        case CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt601:
+            return EGL_ITU_REC601_EXT;
+        case CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt709:
+            return EGL_ITU_REC709_EXT;
+        case CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt2020:
+            return EGL_ITU_REC2020_EXT;
+        case CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Smpte240M:
+            // EGL has no token for it.
+            return std::nullopt;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }();
+
+    auto attributesWithHints = attributes;
+    if (colorSpaceHint) {
+        attributesWithHints.appendList<EGLAttrib>({
+            EGL_YUV_COLOR_SPACE_HINT_EXT, *colorSpaceHint,
+            EGL_SAMPLE_RANGE_HINT_EXT, m_sampleRange == SampleRange::Full ? EGL_YUV_FULL_RANGE_EXT : EGL_YUV_NARROW_RANGE_EXT,
+        });
+    }
+    attributesWithHints.append(EGL_NONE);
     attributes.append(EGL_NONE);
 
-    auto image = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);
-    if (!image) [[unlikely]]
-        return;
+    auto image = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributesWithHints);
+    if (!image && colorSpaceHint) [[unlikely]]
+        image = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);
+
+    if (!image) [[unlikely]] {
+        LOG_ERROR("Cannot create EGLImage from the Qualcomm decoder dma-buf -- video will not render.");
+        return nullptr;
+    }
 
     OptionSet<BitmapTexture::Flags> textureFlags { BitmapTexture::Flags::ExternalOESRenderTarget };
     if (m_flags.contains(TextureMapperFlags::ShouldBlend))
         textureFlags.add(BitmapTexture::Flags::SupportsAlpha);
-    auto texture = BitmapTexturePool::singleton().createTextureForImage(image, m_size, textureFlags);
-    textureMapper.drawTextureExternalOESYUV(texture->id(), m_flags, targetRect, modelViewMatrix, opacity);
+    m_externalOESTexture = BitmapTexturePool::singleton().createTextureForImage(image, m_size, textureFlags);
     display.destroyEGLImage(image);
+    return m_externalOESTexture;
+}
+#endif // USE(GSTREAMER) && USE(GBM)
+
+void CoordinatedPlatformLayerBufferExternalOES::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity)
+{
+    waitForContentsIfNeeded();
+    if (m_textureID) {
+        textureMapper.drawTextureExternalOES(m_textureID, m_flags, targetRect, modelViewMatrix, opacity);
+        return;
+    }
+
+#if USE(GSTREAMER) && USE(GBM)
+    if (auto texture = createExternalOESTexture())
+        textureMapper.drawTextureExternalOESYUV(texture->id(), m_flags, targetRect, modelViewMatrix, opacity);
 #endif // USE(GSTREAMER) && USE(GBM)
 }
 
@@ -172,20 +211,29 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferExternalOES::skiaImage()
 {
     waitForContentsIfNeeded();
 
-    if (!m_textureID) {
-        // FIXME: support Qualcomm decoder.
-        return nullptr;
+    auto textureID = m_textureID;
+
+#if USE(GSTREAMER) && USE(GBM)
+    // The Qualcomm decoder gives us a GBM FD instead of a texture, so import it here.
+    if (!textureID && m_buffer) {
+        if (auto texture = createExternalOESTexture())
+            textureID = texture->id();
     }
+#endif // USE(GSTREAMER) && USE(GBM)
+
+    if (!textureID)
+        return nullptr;
 
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
     ASSERT(grContext);
     GrGLTextureInfo externalTexture;
     externalTexture.fTarget = GL_TEXTURE_EXTERNAL_OES;
-    externalTexture.fID = m_textureID;
+    externalTexture.fID = textureID;
     externalTexture.fFormat = GL_RGBA8;
     auto backendTexture = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
+    auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
     auto alphaType = m_flags.contains(TextureMapperFlags::ShouldBlend) ? kPremul_SkAlphaType : kOpaque_SkAlphaType;
-    return SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, alphaType, sRGBColorSpaceSingleton());
+    return SkImages::BorrowTextureFrom(grContext, backendTexture, origin, kRGBA_8888_SkColorType, alphaType, sRGBColorSpaceSingleton());
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.h
@@ -29,18 +29,22 @@
 #include "CoordinatedPlatformLayerBuffer.h"
 
 #if USE(GSTREAMER) && USE(GBM)
+#include "CoordinatedPlatformLayerBufferYUV.h"
 #include "GRefPtrGStreamer.h"
 #endif
 
 namespace WebCore {
+
+class BitmapTexture;
 
 class CoordinatedPlatformLayerBufferExternalOES final : public CoordinatedPlatformLayerBuffer {
 public:
     static std::unique_ptr<CoordinatedPlatformLayerBufferExternalOES> create(unsigned textureID, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     CoordinatedPlatformLayerBufferExternalOES(unsigned textureID, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
 #if USE(GSTREAMER) && USE(GBM)
-    static std::unique_ptr<CoordinatedPlatformLayerBufferExternalOES> create(GRefPtr<GstBuffer>&&, uint32_t fourcc, const IntSize&, OptionSet<TextureMapperFlags>);
-    CoordinatedPlatformLayerBufferExternalOES(GRefPtr<GstBuffer>&&, uint32_t fourcc, const IntSize&, OptionSet<TextureMapperFlags>);
+    enum class SampleRange : bool { Narrow, Full };
+    static std::unique_ptr<CoordinatedPlatformLayerBufferExternalOES> create(GRefPtr<GstBuffer>&&, uint32_t fourcc, CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace, SampleRange, const IntSize&, OptionSet<TextureMapperFlags>);
+    CoordinatedPlatformLayerBufferExternalOES(GRefPtr<GstBuffer>&&, uint32_t fourcc, CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace, SampleRange, const IntSize&, OptionSet<TextureMapperFlags>);
 #endif
 
     virtual ~CoordinatedPlatformLayerBufferExternalOES();
@@ -52,10 +56,17 @@ private:
     sk_sp<SkImage> skiaImage() override;
 #endif
 
+#if USE(GSTREAMER) && USE(GBM)
+    RefPtr<BitmapTexture> createExternalOESTexture();
+#endif
+
     unsigned m_textureID { 0 };
 #if USE(GSTREAMER) && USE(GBM)
     uint32_t m_fourcc { 0 };
+    CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace m_yuvColorSpace { CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt601 };
+    SampleRange m_sampleRange { SampleRange::Narrow };
     GRefPtr<GstBuffer> m_buffer;
+    RefPtr<BitmapTexture> m_externalOESTexture;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
@@ -83,6 +83,26 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
     return CoordinatedPlatformLayerBufferRGB::create(WTF::move(texture), m_flags, nullptr);
 }
 
+#if USE(GBM) || USE(GSTREAMER_GL)
+static std::pair<CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace, CoordinatedPlatformLayerBufferYUV::TransferFunction> yuvColorSpaceFromVideoInfo(const GstVideoInfo& info)
+{
+    // Default to bt601. This is the same behaviour as GStreamer's glcolorconvert element.
+    auto yuvToRgbColorSpace = CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt601;
+    auto transferFunction = CoordinatedPlatformLayerBufferYUV::TransferFunction::Bt709;
+    const auto& colorimetry = GST_VIDEO_INFO_COLORIMETRY(&info);
+    if (gst_video_colorimetry_matches(&colorimetry, GST_VIDEO_COLORIMETRY_BT709))
+        yuvToRgbColorSpace = CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt709;
+    else if (gst_video_colorimetry_matches(&colorimetry, GST_VIDEO_COLORIMETRY_BT2020))
+        yuvToRgbColorSpace = CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt2020;
+    else if (gst_video_colorimetry_matches(&colorimetry, GST_VIDEO_COLORIMETRY_BT2100_PQ)) {
+        yuvToRgbColorSpace = CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt2020;
+        transferFunction = CoordinatedPlatformLayerBufferYUV::TransferFunction::Pq;
+    } else if (gst_video_colorimetry_matches(&colorimetry, GST_VIDEO_COLORIMETRY_SMPTE240M))
+        yuvToRgbColorSpace = CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Smpte240M;
+    return { yuvToRgbColorSpace, transferFunction };
+}
+#endif
+
 std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferIfNeeded(bool gstGLEnabled)
 {
     const auto& sample = m_videoFrame->sample();
@@ -98,7 +118,13 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
         // rendering.
         auto dmabufFormat = m_videoFrame->dmaBufFormat();
         RELEASE_ASSERT(dmabufFormat);
-        return CoordinatedPlatformLayerBufferExternalOES::create(GRefPtr(buffer), dmabufFormat->first, m_size, m_flags);
+        // The driver converts YUV to RGB while sampling, so it needs the frame colorimetry.
+        const auto& info = m_videoFrame->info();
+        auto yuvColorSpace = yuvColorSpaceFromVideoInfo(info).first;
+        auto sampleRange = GST_VIDEO_INFO_COLORIMETRY(&info).range == GST_VIDEO_COLOR_RANGE_0_255
+            ? CoordinatedPlatformLayerBufferExternalOES::SampleRange::Full
+            : CoordinatedPlatformLayerBufferExternalOES::SampleRange::Narrow;
+        return CoordinatedPlatformLayerBufferExternalOES::create(GRefPtr(buffer), dmabufFormat->first, yuvColorSpace, sampleRange, m_size, m_flags);
     }
 
 #if GST_CHECK_VERSION(1, 24, 0)
@@ -225,19 +251,7 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
             yuvPlaneOffset[i] = m_mappedVideoFrame->componentPlaneOffset(i);
         }
 
-        // Default to bt601. This is the same behaviour as GStreamer's glcolorconvert element.
-        CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace yuvToRgbColorSpace = CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt601;
-        CoordinatedPlatformLayerBufferYUV::TransferFunction transferFunction = CoordinatedPlatformLayerBufferYUV::TransferFunction::Bt709;
-        if (gst_video_colorimetry_matches(&GST_VIDEO_INFO_COLORIMETRY(m_mappedVideoFrame->info()), GST_VIDEO_COLORIMETRY_BT709))
-            yuvToRgbColorSpace = CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt709;
-        else if (gst_video_colorimetry_matches(&GST_VIDEO_INFO_COLORIMETRY(m_mappedVideoFrame->info()), GST_VIDEO_COLORIMETRY_BT2020))
-            yuvToRgbColorSpace = CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt2020;
-        else if (gst_video_colorimetry_matches(&GST_VIDEO_INFO_COLORIMETRY(m_mappedVideoFrame->info()), GST_VIDEO_COLORIMETRY_BT2100_PQ)) {
-            yuvToRgbColorSpace = CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Bt2020;
-            transferFunction = CoordinatedPlatformLayerBufferYUV::TransferFunction::Pq;
-        } else if (gst_video_colorimetry_matches(&GST_VIDEO_INFO_COLORIMETRY(m_mappedVideoFrame->info()), GST_VIDEO_COLORIMETRY_SMPTE240M))
-            yuvToRgbColorSpace = CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Smpte240M;
-
+        auto [yuvToRgbColorSpace, transferFunction] = yuvColorSpaceFromVideoInfo(*m_mappedVideoFrame->info());
         return CoordinatedPlatformLayerBufferYUV::create(*format, numberOfPlanes, WTF::move(planes), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset), yuvToRgbColorSpace, transferFunction, m_size, m_flags, nullptr);
     }
 


### PR DESCRIPTION
#### 239e39ffdf78c6980c68cdb1df46ae7c6c09f9e4
<pre>
[GStreamer][Skia] Video rendering support for Qualcomm decoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=320897">https://bugs.webkit.org/show_bug.cgi?id=320897</a>

Reviewed by Adrian Perez de Castro.

307174@main added Qualcomm decoder support for TextureMapper only, skiaImage()
was left unimplemented so videos couldn&apos;t render.

EXT_YUV_target cannot be reproduced under Skia, Ganesh generates its own fragment
program and only emits samplerExternalOES. Use its implicit YUV to RGB conversion,
steered by EGL_YUV_COLOR_SPACE_HINT_EXT and EGL_SAMPLE_RANGE_HINT_EXT taken from
the frame colorimetry, and fall back to an hint-free import if the driver rejects
them.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp:
(WebCore::CoordinatedPlatformLayerBufferExternalOES::create):
(WebCore::CoordinatedPlatformLayerBufferExternalOES::CoordinatedPlatformLayerBufferExternalOES):
(WebCore::CoordinatedPlatformLayerBufferExternalOES::createExternalOESTexture):
(WebCore::CoordinatedPlatformLayerBufferExternalOES::paintToTextureMapper):
(WebCore::CoordinatedPlatformLayerBufferExternalOES::skiaImage):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp:
(WebCore::yuvColorSpaceFromVideoInfo):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferIfNeeded):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferFromGLMemory):

Canonical link: <a href="https://commits.webkit.org/319367@main">https://commits.webkit.org/319367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca7c0149e1a7697859d8a5d4efc98472be9bd0ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144837 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140796 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97534 "1 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43134 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41420 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41098 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1886 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192662 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54127 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150161 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40410 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54815 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37713 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149883 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44506 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127078 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122263 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53332 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16087 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52714 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52951 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->