### PR TITLE
[YARR] Read raw code units for surrogate-free BMP character classes in unicode mode

### DIFF
--- a/JSTests/microbenchmarks/regexp-u-flag-character-class-greedy.js
+++ b/JSTests/microbenchmarks/regexp-u-flag-character-class-greedy.js
@@ -1,0 +1,27 @@
+// /u greedy character classes (\w, [a-z], \d) that hold no non-BMP or surrogate members, over UTF-16 text.
+function splitmix32(seed) {
+    var a = seed;
+    return function () {
+        a |= 0; a = (a + 0x9e3779b9) | 0;
+        var t = a ^ (a >>> 16); t = Math.imul(t, 0x21f0aaad);
+        t = t ^ (t >>> 15); t = Math.imul(t, 0x735a2d97);
+        return ((t = t ^ (t >>> 15)) >>> 0) / 4294967296;
+    };
+}
+let rnd = splitmix32(42);
+let words = [];
+for (let i = 0; i < 60; ++i) {
+    let n = 300 + (rnd() * 400 | 0);
+    let w = "";
+    for (let j = 0; j < n; ++j)
+        w += String.fromCharCode(0x61 + (rnd() * 26 | 0));
+    words.push(w + (rnd() * 100000 | 0));
+}
+let text = words.join(" あ ");
+
+let identifier = /^(?:\w+(?: あ )?)+$/u;
+let word = /^(?:[a-z]+\d+(?: あ )?)+$/u;
+for (let i = 0; i < 2000; ++i) {
+    if (!identifier.test(text) || !word.test(text))
+        throw new Error("bad match");
+}

--- a/JSTests/microbenchmarks/regexp-u-flag-class-astral-subject.js
+++ b/JSTests/microbenchmarks/regexp-u-flag-class-astral-subject.js
@@ -1,0 +1,11 @@
+// BMP-only /u character class scanning a subject dense in surrogate pairs.
+let unit = "\u{1F600}a\u{1F601}bcd";
+let text = "";
+for (let i = 0; i < 4000; ++i)
+    text += unit + (i % 10);
+
+let re = /^(?:[\u{1F600}\u{1F601}]+[a-z0-9]+)+$/u;
+for (let i = 0; i < 1500; ++i) {
+    if (!re.test(text))
+        throw new Error("bad match");
+}

--- a/JSTests/stress/regexp-unicode-code-unit-read-for-bmp-terms.js
+++ b/JSTests/stress/regexp-unicode-code-unit-read-for-bmp-terms.js
@@ -1,0 +1,44 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Bad value: ${actual}, expected ${expected}`);
+}
+
+function shouldBeMatch(actual, expected) {
+    shouldBe(JSON.stringify(actual), JSON.stringify(expected));
+}
+
+for (let i = 0; i < 200; ++i) {
+    // BMP-only classes reading a surrogate pair position must not match either half.
+    shouldBeMatch(/[a-z]/u.exec("\u{1F600}b"), ["b"]);
+    shouldBeMatch(/\w+/u.exec("\u{1F600}ab\u{1F601}"), ["ab"]);
+    shouldBeMatch(/[\d\s]/u.exec("\uD83D 1"), [" "]);
+    shouldBeMatch(/\w{2}\s/u.exec("ab\uD83Dcd "), ["cd "]);
+
+    // Reading in the middle of a surrogate pair (sticky lastIndex on the trail surrogate).
+    let sticky = /[a-z\u{1F600}]/uy;
+    sticky.lastIndex = 1;
+    shouldBeMatch(sticky.exec("\u{1F600}x"), null);
+    sticky = /\w/uy;
+    sticky.lastIndex = 1;
+    shouldBeMatch(sticky.exec("\u{1F600}x"), null);
+
+    // Lone surrogates are never members of a surrogate-free class.
+    shouldBeMatch(/[\s\S]&&[a\uD800]/v.exec("\uD800a"), null);
+    shouldBeMatch(/[a-z]|q/u.exec("\uDBFFz\uDC00"), ["z"]);
+
+    // Word boundary around non-BMP characters and lone surrogates.
+    shouldBeMatch(/\b\w+\b/u.exec("\u{1F600}abc\u{1F600}"), ["abc"]);
+    shouldBeMatch(/\B\w/u.exec("\uD83Dab"), ["b"]);
+    shouldBeMatch(/a\b/u.exec("a\u{1F600}"), ["a"]);
+    shouldBeMatch(/\bK/iu.exec("K"), ["K"]);
+    shouldBeMatch(/\b\w\b/iu.exec("\u{1F600} ſ \u{1F600}"), ["ſ"]);
+
+    // Multiline anchors next to non-BMP characters.
+    shouldBeMatch(/^b$/mu.exec("\u{1F600}\nb\n\u{1F601}"), ["b"]);
+    shouldBeMatch(/^\w+$/mu.exec("a\u{1F600}\nxyz\n"), ["xyz"]);
+    shouldBeMatch(/x$/mu.exec("x "), ["x"]);
+
+    // A BMP pattern character next to a non-BMP class term keeps decoding for the class.
+    shouldBeMatch(/a[\u{1F600}-\u{1F64F}]b/u.exec("xa\u{1F60D}b"), ["a\u{1F60D}b"]);
+    shouldBeMatch(/a?\B|q/u.exec("X\u{1F600}Z"), [""]);
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1166,26 +1166,46 @@ class YarrGenerator final : public YarrJITInfo {
         matchCharacterClassOnlyOneRange(character, scratch, failMatches, ranges[0]);
     }
 
-    void matchCharacterClassTable(MacroAssembler::RegisterID character, MacroAssembler::JumpList& failMatches, const char* table, bool tableInverted = false)
+    // For a class holding only non-surrogate BMP code points, the code unit at the current position is a
+    // member exactly when the decoded code point would be: a surrogate code unit, a decoded non-BMP code
+    // point and errorCodePoint all lie outside of such a class.
+    bool shouldReadRawCodeUnitForCharacterClassTerm(const PatternTerm* term)
     {
-        ASSERT(!m_decodeSurrogatePairs);
-        MacroAssembler::ExtendedAddress tableEntry(character, reinterpret_cast<intptr_t>(table));
-        failMatches.append(m_jit.branchTest8(tableInverted ? MacroAssembler::NonZero : MacroAssembler::Zero, tableEntry));
+        ASSERT(term->type == PatternTerm::Type::CharacterClass);
+        return !m_decodeSurrogatePairs || (!term->invert() && term->characterClass->hasOnlyNonSurrogateBMPCharacters());
+    }
+
+    void matchCharacterClassTable(MacroAssembler::RegisterID character, MatchTargets& matchTargets, const CharacterClass* charClass)
+    {
+        MacroAssembler::ExtendedAddress tableEntry(character, reinterpret_cast<intptr_t>(charClass->m_table));
+        if (matchTargets.hasFailedTarget())
+            matchTargets.appendFailed(m_jit.branchTest8(charClass->m_tableInverted ? MacroAssembler::NonZero : MacroAssembler::Zero, tableEntry));
+        else
+            matchTargets.appendSucceeded(m_jit.branchTest8(charClass->m_tableInverted ? MacroAssembler::Zero : MacroAssembler::NonZero, tableEntry));
+    }
+
+    void matchCharacterClass(MacroAssembler::RegisterID character, MacroAssembler::RegisterID scratch, MatchTargets matchTargets, const PatternTerm* characterClassTerm)
+    {
+        ASSERT(characterClassTerm->type == PatternTerm::Type::CharacterClass);
+        const CharacterClass* charClass = characterClassTerm->characterClass;
+        if (charClass->m_table && shouldReadRawCodeUnitForCharacterClassTerm(characterClassTerm)) {
+            matchCharacterClassTable(character, matchTargets, charClass);
+            return;
+        }
+        matchCharacterClassMatchesAndRanges(character, scratch, matchTargets, charClass);
     }
 
     void matchCharacterClass(MacroAssembler::RegisterID character, MacroAssembler::RegisterID scratch, MatchTargets matchTargets, const CharacterClass* charClass)
     {
         if (charClass->m_table && !m_decodeSurrogatePairs) {
-            if (matchTargets.hasFailedTarget()) {
-                MacroAssembler::ExtendedAddress tableEntry(character, reinterpret_cast<intptr_t>(charClass->m_table));
-                matchTargets.appendFailed(m_jit.branchTest8(charClass->m_tableInverted ? MacroAssembler::NonZero : MacroAssembler::Zero, tableEntry));
-                return;
-            }
-            MacroAssembler::ExtendedAddress tableEntry(character, reinterpret_cast<intptr_t>(charClass->m_table));
-            matchTargets.appendSucceeded(m_jit.branchTest8(charClass->m_tableInverted ? MacroAssembler::Zero : MacroAssembler::NonZero, tableEntry));
+            matchCharacterClassTable(character, matchTargets, charClass);
             return;
         }
+        matchCharacterClassMatchesAndRanges(character, scratch, matchTargets, charClass);
+    }
 
+    void matchCharacterClassMatchesAndRanges(MacroAssembler::RegisterID character, MacroAssembler::RegisterID scratch, MatchTargets matchTargets, const CharacterClass* charClass)
+    {
         if (charClass->m_latin1Table) {
             bool pureLatin1 = charClass->m_matches32.isEmpty() && charClass->m_ranges32.isEmpty();
             if (m_charSize == CharSize::Char8 || pureLatin1) {
@@ -1271,7 +1291,7 @@ class YarrGenerator final : public YarrJITInfo {
                 // If we are matching the "any character" builtin class for non-unicode patterns,
                 // we only need to read the character and don't need to match as it will always succeed.
                 if (!characterClassToProcess->m_anyCharacter) {
-                    matchCharacterClass(character, scratch, MatchTargets(matchDest, failures, MatchTargets::PreferredTarget::MatchSuccessFallThrough), characterClassToProcess);
+                    matchCharacterClass(character, scratch, MatchTargets(matchDest, failures, MatchTargets::PreferredTarget::MatchSuccessFallThrough), term);
                     if (!matchDest.empty())
                         failures.append(m_jit.jump());
                 }
@@ -1557,12 +1577,30 @@ class YarrGenerator final : public YarrJITInfo {
             m_jit.load16Unaligned(address, resultReg);
     }
 
+    void readCharacterForCharacterClassTerm(Checked<unsigned> negativeCharacterOffset, MacroAssembler::RegisterID resultReg, const PatternTerm* term)
+    {
+        readCharacterForCharacterClassTerm(negativeCharacterOffset, resultReg, m_regs.index, term);
+    }
+
+    void readCharacterForCharacterClassTerm(Checked<unsigned> negativeCharacterOffset, MacroAssembler::RegisterID resultReg, MacroAssembler::RegisterID indexReg, const PatternTerm* term)
+    {
+        if (shouldReadRawCodeUnitForCharacterClassTerm(term))
+            readCharacterRaw(negativeCharacterOffset, resultReg, indexReg);
+        else
+            readCharacter(negativeCharacterOffset, resultReg, indexReg);
+    }
+
     // Read a raw code unit without surrogate pair decoding. This is used for
     // Boyer-Moore lookahead which is a hash-based prefilter where false positives
     // are safe, so exact codepoint decoding is unnecessary.
     void readCharacterRaw(Checked<unsigned> negativeCharacterOffset, MacroAssembler::RegisterID resultReg)
     {
-        MacroAssembler::BaseIndex address = negativeOffsetIndexedAddress(negativeCharacterOffset, resultReg, m_regs.index);
+        readCharacterRaw(negativeCharacterOffset, resultReg, m_regs.index);
+    }
+
+    void readCharacterRaw(Checked<unsigned> negativeCharacterOffset, MacroAssembler::RegisterID resultReg, MacroAssembler::RegisterID indexReg)
+    {
+        MacroAssembler::BaseIndex address = negativeOffsetIndexedAddress(negativeCharacterOffset, resultReg, indexReg);
 
         if (m_charSize == CharSize::Char8)
             m_jit.load8(address, resultReg);
@@ -3262,7 +3300,7 @@ class YarrGenerator final : public YarrJITInfo {
             }
         }
 
-        readCharacter(op.m_checkedOffset - term->inputPosition, character);
+        readCharacterForCharacterClassTerm(op.m_checkedOffset - term->inputPosition, character, term);
 
         matchCharacterClassTermInner(term, op.m_jumps, character, scratch);
 
@@ -3335,7 +3373,7 @@ class YarrGenerator final : public YarrJITInfo {
         m_jit.sub32(m_regs.index, MacroAssembler::Imm32(scaledMaxCount), countRegister);
 
         MacroAssembler::Label loop(&m_jit);
-        readCharacter(op.m_checkedOffset - term->inputPosition - scaledMaxCount, character, countRegister);
+        readCharacterForCharacterClassTerm(op.m_checkedOffset - term->inputPosition - scaledMaxCount, character, countRegister, term);
 
         MacroAssembler::Label nonBMPLoop(&m_jit);
 
@@ -3430,7 +3468,7 @@ class YarrGenerator final : public YarrJITInfo {
         MacroAssembler::Label loop(&m_jit);
         failures.append(atEndOfInput());
 
-        readCharacter(op.m_checkedOffset - term->inputPosition, character);
+        readCharacterForCharacterClassTerm(op.m_checkedOffset - term->inputPosition, character, term);
 
         matchCharacterClassTermInner(term, failures, character, scratch);
 
@@ -3546,7 +3584,7 @@ class YarrGenerator final : public YarrJITInfo {
         nonGreedyFailures.append(atEndOfInput());
         nonGreedyFailures.append(m_jit.branch32(MacroAssembler::Equal, countRegister, MacroAssembler::Imm32(term->quantityMaxCount)));
 
-        readCharacter(op.m_checkedOffset - term->inputPosition, character);
+        readCharacterForCharacterClassTerm(op.m_checkedOffset - term->inputPosition, character, term);
 
         matchCharacterClassTermInner(term, nonGreedyFailures, character, scratch);
 

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -3529,6 +3529,21 @@ std::unique_ptr<CharacterClass> anycharCreate()
     return characterClass;
 }
 
+bool CharacterClass::hasOnlyNonSurrogateBMPCharacters() const
+{
+    if (hasStrings() || !hasOnlyBMPCharacters())
+        return false;
+    for (auto character : m_matches32) {
+        if (U_IS_SURROGATE(character))
+            return false;
+    }
+    for (auto& range : m_ranges32) {
+        if (range.end >= 0xd800 && range.begin <= 0xdfff)
+            return false;
+    }
+    return true;
+}
+
 std::optional<char16_t> CharacterClass::hasSharedLeadSurrogate() const
 {
     if (!hasOnlyNonBMPCharacters())

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -145,11 +145,13 @@ public:
     bool NODELETE hasNonBMPCharacters() const { return m_characterWidths & CharacterClassWidths::HasNonBMPChars; }
 
     bool hasOneCharacterSize() const { return m_characterWidths == CharacterClassWidths::HasBMPChars || m_characterWidths == CharacterClassWidths::HasNonBMPChars; }
+    bool hasOnlyBMPCharacters() const { return m_characterWidths == CharacterClassWidths::HasBMPChars; }
     bool hasOnlyNonBMPCharacters() const { return m_characterWidths == CharacterClassWidths::HasNonBMPChars; }
     bool hasStrings() const { return !m_strings.isEmpty(); }
     bool hasSingleCharacters() const { return !m_matches8.isEmpty() || !m_ranges8.isEmpty() || !m_matches32.isEmpty() || !m_ranges32.isEmpty(); }
 
     std::optional<char16_t> hasSharedLeadSurrogate() const;
+    bool hasOnlyNonSurrogateBMPCharacters() const;
 
     Vector<Vector<char32_t>> m_strings;
     Vector<char32_t> m_matches8;


### PR DESCRIPTION
#### bbc000ae4f3ddb38ec1598977b06aad6236d9ac1
<pre>
[YARR] Read raw code units for surrogate-free BMP character classes in unicode mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=320903">https://bugs.webkit.org/show_bug.cgi?id=320903</a>

Reviewed by Yusuke Suzuki.

With the /u and /v flags, YARR JIT decodes surrogate pairs for every character read.
For a non-inverted character class holding only non-surrogate BMP code points, the
decode is unnecessary: a surrogate code unit, a decoded non-BMP code point and
errorCodePoint all lie outside of such a class, so testing the raw code unit is
equivalent to testing the decoded code point.

This patch reads the raw code unit for such character class terms (\w, \d, \s, [a-z],
BMP-only property escapes ...) in unicode mode and lets them use the class&apos;s 64K
m_table, which was disabled whenever surrogate pairs were being decoded.

                                             Base                     Patch

    regexp-u-flag-class-astral-subject     43.2756+-0.5243     ^     35.8856+-1.3000        ^ definitely 1.2059x faster
    regexp-u-flag-character-class-greedy   88.1351+-4.7293     ^     39.2828+-0.2972        ^ definitely 2.2436x faster

Tests: JSTests/microbenchmarks/regexp-u-flag-character-class-greedy.js
       JSTests/microbenchmarks/regexp-u-flag-class-astral-subject.js
       JSTests/stress/regexp-unicode-code-unit-read-for-bmp-terms.js

* JSTests/microbenchmarks/regexp-u-flag-character-class-greedy.js: Added.
(splitmix32):
* JSTests/microbenchmarks/regexp-u-flag-class-astral-subject.js: Added.
* JSTests/stress/regexp-unicode-code-unit-read-for-bmp-terms.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClass::hasOnlyNonSurrogateBMPCharacters const):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::CharacterClass::hasOnlyBMPCharacters const):

Canonical link: <a href="https://commits.webkit.org/318881@main">https://commits.webkit.org/318881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dee9b60f7c181eb0127a2d1e26e716538622942

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189593 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144072 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140217 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120668 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40813 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2637 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9439 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152895 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40473 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1047 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41036 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191815 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53370 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149494 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40049 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54051 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149228 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43884 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126323 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121348 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52568 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15463 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51953 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->