### PR TITLE
[CoordinatedGraphics] Remove the lock requirement for CoordinatedPlatformLayer members that are only accessed from the main thread

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
@@ -97,13 +97,13 @@ Ref<CoordinatedBackingStoreProxy> CoordinatedBackingStoreProxy::create()
     return adoptRef(*new CoordinatedBackingStoreProxy());
 }
 
-OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStoreProxy::updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>& dirtyRegion, Damage& damage, CoordinatedPlatformLayer& layer)
+OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStoreProxy::updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, const IntSize& unscaledViewportSize, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>& dirtyRegion, Damage& damage, CoordinatedPlatformLayer& layer)
 {
     assertIsHeld(layer.lock());
     Vector<uint32_t> tilesToCreate;
     Vector<uint32_t> tilesToRemove;
     if (shouldCreateAndDestroyTiles)
-        createOrDestroyTiles(unscaledVisibleRect, unscaledContentsRect, enclosingIntRect(layer.visibleRect()).size(), contentsScale, layer.maxTextureSize(), damage, tilesToCreate, tilesToRemove);
+        createOrDestroyTiles(unscaledVisibleRect, unscaledContentsRect, unscaledViewportSize, contentsScale, layer.maxTextureSize(), damage, tilesToCreate, tilesToRemove);
 
     if (!m_tiles.isEmpty())
         invalidateRegion(dirtyRegion);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -81,7 +81,7 @@ public:
         TilesPending = 1 << 1,
         TilesChanged = 1 << 2
     };
-    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>&, Damage&, CoordinatedPlatformLayer&);
+    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, const IntSize& unscaledViewportSize, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>&, Damage&, CoordinatedPlatformLayer&);
     Update takePendingUpdate();
 
     void waitUntilPaintingComplete();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -75,7 +75,7 @@ CoordinatedPlatformLayer::~CoordinatedPlatformLayer() = default;
 
 void CoordinatedPlatformLayer::setOwner(GraphicsLayerCoordinated* owner)
 {
-    ASSERT(isMainThread());
+    assertIsMainThread();
     if (m_owner == owner)
         return;
 
@@ -93,7 +93,7 @@ void CoordinatedPlatformLayer::setOwner(GraphicsLayerCoordinated* owner)
 
 GraphicsLayerCoordinated* CoordinatedPlatformLayer::owner() const
 {
-    ASSERT(isMainThread());
+    assertIsMainThread();
     return m_owner;
 }
 
@@ -303,27 +303,22 @@ const TransformationMatrix& CoordinatedPlatformLayer::childrenTransform() const
 
 void CoordinatedPlatformLayer::didUpdateLayerTransform()
 {
+    assertIsMainThread();
     m_needsTilesUpdate = true;
 }
 
 void CoordinatedPlatformLayer::setVisibleRect(const FloatRect& visibleRect)
 {
-    assertIsHeld(m_lock);
+    assertIsMainThread();
     if (m_visibleRect == visibleRect)
         return;
 
     m_visibleRect = visibleRect;
 }
 
-const FloatRect& CoordinatedPlatformLayer::visibleRect() const
-{
-    assertIsHeld(m_lock);
-    return m_visibleRect;
-}
-
 void CoordinatedPlatformLayer::setTransformedVisibleRect(IntRect&& transformedVisibleRect)
 {
-    assertIsHeld(m_lock);
+    assertIsMainThread();
     if (m_transformedVisibleRect == transformedVisibleRect)
         return;
 
@@ -347,7 +342,7 @@ const Markable<ScrollingNodeID>& CoordinatedPlatformLayer::scrollingNodeID() con
 
 void CoordinatedPlatformLayer::setDrawsContent(bool drawsContent)
 {
-    assertIsHeld(m_lock);
+    assertIsMainThread();
     m_drawsContent = drawsContent;
 }
 
@@ -483,6 +478,7 @@ void CoordinatedPlatformLayer::setContentsClippingRect(const FloatRoundedRect& c
 
 void CoordinatedPlatformLayer::setContentsScale(float contentsScale)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     if (m_contentsScale == contentsScale)
         return;
@@ -602,6 +598,7 @@ void CoordinatedPlatformLayer::setContentsTilePhase(const FloatSize& contentsTil
 
 void CoordinatedPlatformLayer::setDirtyRegion(Damage&& damage)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     auto dirtyRegion = damage.rects();
     if (m_dirtyRegion != dirtyRegion) {
@@ -814,6 +811,7 @@ void CoordinatedPlatformLayer::setDebugBorder(Color&& borderColor, float borderW
 
 void CoordinatedPlatformLayer::setShowRepaintCounter(bool showRepaintCounter)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     if ((m_repaintCount != -1 && showRepaintCounter) || (m_repaintCount == -1 && !showRepaintCounter))
         return;
@@ -825,6 +823,7 @@ void CoordinatedPlatformLayer::setShowRepaintCounter(bool showRepaintCounter)
 
 bool CoordinatedPlatformLayer::needsBackingStore() const
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     if (!m_owner)
         return false;
@@ -846,6 +845,7 @@ bool CoordinatedPlatformLayer::needsBackingStore() const
 
 void CoordinatedPlatformLayer::updateBackingStore()
 {
+    assertIsMainThread();
     Locker locker { m_lock };
     if (!m_backingStoreProxy)
         return;
@@ -855,7 +855,7 @@ void CoordinatedPlatformLayer::updateBackingStore()
 
     Damage damage(m_size, Damage::Mode::Rectangles);
     IntRect contentsRect(IntPoint::zero(), IntSize(m_size));
-    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRect, contentsRect, m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
+    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRect, contentsRect, enclosingIntRect(m_visibleRect).size(), m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
     m_needsTilesUpdate = false;
 #if ENABLE(DAMAGE_TRACKING)
     addDamage(WTF::move(damage));
@@ -877,6 +877,7 @@ void CoordinatedPlatformLayer::updateBackingStore()
 
 void CoordinatedPlatformLayer::updateContents(bool affectedByTransformAnimation)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
 
     if (needsBackingStore()) {
@@ -964,6 +965,7 @@ void CoordinatedPlatformLayer::didPaintTile()
 
 Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::paint(const IntRect& dirtyRect)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     ASSERT(m_client);
     ASSERT(m_owner);
@@ -991,6 +993,7 @@ sk_sp<GrContextThreadSafeProxy> CoordinatedPlatformLayer::threadSafeGrContext() 
 
 Ref<SkiaRecordingResult> CoordinatedPlatformLayer::record(const IntRect& recordRect, unsigned dirtyTilesCount)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     ASSERT(m_client);
     ASSERT(m_owner);
@@ -999,6 +1002,7 @@ Ref<SkiaRecordingResult> CoordinatedPlatformLayer::record(const IntRect& recordR
 
 Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::replay(Ref<SkiaRecordingResult>&& recording, const IntRect& tileRect, const IntRect& dirtyRect)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     ASSERT(m_client);
     ASSERT(m_owner);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -36,6 +36,7 @@
 #include "TransformationMatrix.h"
 #include <wtf/EnumSet.h>
 #include <wtf/Lock.h>
+#include <wtf/MainThread.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
@@ -136,16 +137,15 @@ public:
     const TransformationMatrix& childrenTransform() const WTF_REQUIRES_LOCK(m_lock);
     void didUpdateLayerTransform();
 
-    void setVisibleRect(const FloatRect&) WTF_REQUIRES_LOCK(m_lock);
-    const FloatRect& visibleRect() const WTF_REQUIRES_LOCK(m_lock);
-    void setTransformedVisibleRect(IntRect&&) WTF_REQUIRES_LOCK(m_lock);
+    void setVisibleRect(const FloatRect&);
+    void setTransformedVisibleRect(IntRect&&);
 
 #if ENABLE(SCROLLING_THREAD)
     void setScrollingNodeID(std::optional<ScrollingNodeID>) WTF_REQUIRES_LOCK(m_lock);
     const Markable<ScrollingNodeID>& scrollingNodeID() const WTF_REQUIRES_LOCK(m_lock);
 #endif
 
-    void setDrawsContent(bool) WTF_REQUIRES_LOCK(m_lock);
+    void setDrawsContent(bool);
     void setMasksToBounds(bool) WTF_REQUIRES_LOCK(m_lock);
     bool masksToBounds() const WTF_REQUIRES_LOCK(m_lock);
     void setPreserves3D(bool) WTF_REQUIRES_LOCK(m_lock);
@@ -203,7 +203,7 @@ public:
     void flushPositionChanges(const OptionSet<CompositionReason>&, bool = false);
     void flushCompositingState(const OptionSet<CompositionReason>&, bool = false);
 
-    bool hasPendingTilesCreation() const { return m_pendingTilesCreation; }
+    bool hasPendingTilesCreation() const { assertIsMainThread(); return m_pendingTilesCreation; }
     bool hasPendingBackingStoreTileUpdates() const;
     void processPendingBackingStoreTileUpdates();
     bool isCompositionRequiredOrOngoing() const;
@@ -282,13 +282,19 @@ private:
 
     const PlatformLayerIdentifier m_id;
 
-    GraphicsLayerCoordinated* m_owner { nullptr };
+    GraphicsLayerCoordinated* m_owner WTF_GUARDED_BY_CAPABILITY(mainThread) { nullptr };
     std::unique_ptr<TextureMapperLayer> m_target;
 #if USE(SKIA)
     RefPtr<SkiaCompositingLayer> m_skiaTarget;
 #endif
-    bool m_pendingTilesCreation { false };
-    bool m_needsTilesUpdate { false };
+
+    // Accessed only from the main thread.
+    bool m_drawsContent WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    bool m_pendingTilesCreation WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    bool m_needsTilesUpdate WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    FloatRect m_visibleRect WTF_GUARDED_BY_CAPABILITY(mainThread);
+    IntRect m_transformedVisibleRect WTF_GUARDED_BY_CAPABILITY(mainThread);
+    Vector<IntRect, 1> m_dirtyRegion WTF_GUARDED_BY_CAPABILITY(mainThread);
 
 #if ENABLE(DAMAGE_TRACKING)
     bool m_damagePropagationEnabled { false };
@@ -303,9 +309,6 @@ private:
     FloatPoint m_boundsOrigin WTF_GUARDED_BY_LOCK(m_lock);
     TransformationMatrix m_transform WTF_GUARDED_BY_LOCK(m_lock);
     TransformationMatrix m_childrenTransform WTF_GUARDED_BY_LOCK(m_lock);
-    FloatRect m_visibleRect WTF_GUARDED_BY_LOCK(m_lock);
-    IntRect m_transformedVisibleRect WTF_GUARDED_BY_LOCK(m_lock);
-    bool m_drawsContent WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_masksToBounds WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_preserves3D WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_backfaceVisibility WTF_GUARDED_BY_LOCK(m_lock) { true };
@@ -336,7 +339,6 @@ private:
         Path path;
         WindRule windRule;
     } m_clipPath WTF_GUARDED_BY_LOCK(m_lock);
-    Vector<IntRect, 1> m_dirtyRegion WTF_GUARDED_BY_LOCK(m_lock);
     FilterOperations m_filters WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedPlatformLayer> m_mask WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedPlatformLayer> m_replica WTF_GUARDED_BY_LOCK(m_lock);


### PR DESCRIPTION
#### 4b1174b93a43ccfb1edd0792bf636c4c12dabb4e
<pre>
[CoordinatedGraphics] Remove the lock requirement for CoordinatedPlatformLayer members that are only accessed from the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=320902">https://bugs.webkit.org/show_bug.cgi?id=320902</a>

Reviewed by Nikolas Zimmermann.

Replace the lock requirement by main thread requirement. Also remove the
visibleRect() getter, since it&apos;s only ued by CoordinatedBackingStoreProxy::updateIfNeeded()
and we can just pass the unscaled viewport size instead.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
(WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setOwner):
(WebCore::CoordinatedPlatformLayer::owner const):
(WebCore::CoordinatedPlatformLayer::didUpdateLayerTransform):
(WebCore::CoordinatedPlatformLayer::setVisibleRect):
(WebCore::CoordinatedPlatformLayer::setTransformedVisibleRect):
(WebCore::CoordinatedPlatformLayer::setContentsScale):
(WebCore::CoordinatedPlatformLayer::setDirtyRegion):
(WebCore::CoordinatedPlatformLayer::setShowRepaintCounter):
(WebCore::CoordinatedPlatformLayer::updateBackingStore):
(WebCore::CoordinatedPlatformLayer::updateContents):
(WebCore::CoordinatedPlatformLayer::paint):
(WebCore::CoordinatedPlatformLayer::record):
(WebCore::CoordinatedPlatformLayer::replay):
(WebCore::CoordinatedPlatformLayer::visibleRect const): Deleted.
(WebCore::CoordinatedPlatformLayer::setDrawsContent):
(WebCore::CoordinatedPlatformLayer::needsBackingStore const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
(WebCore::CoordinatedPlatformLayer::WTF_GUARDED_BY_CAPABILITY):
(WebCore::CoordinatedPlatformLayer::hasPendingTilesCreation const):

Canonical link: <a href="https://commits.webkit.org/318455@main">https://commits.webkit.org/318455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/352783e2cef586dce660c81e266c3cd60efff6a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139063 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41292 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39645 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151692 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39321 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36455 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44922 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43887 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190427 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51991 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148225 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52672 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147993 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27053 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42709 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124937 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119556 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51190 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14296 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50575 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->