### PR TITLE
Slightly reduce unsafe in WebGPU Buffer

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.swift
+++ b/Source/WebGPU/WebGPU/Buffer.swift
@@ -44,10 +44,20 @@ func bufferGetMappedRange(_ buffer: WebGPU.Buffer, offset: Int, size: Int) -> We
     unsafe buffer.getMappedRange(offset: offset, size: size)
 }
 
+extension WebGPU.SpanUInt8 {
+    /// A default-constructed, zero-length span: a null base pointer that's never read through.
+    ///
+    /// Marked `@safe` because the empty case carries no risk.
+    @safe
+    fileprivate static var empty: WebGPU.SpanUInt8 {
+        unsafe WebGPU.SpanUInt8()
+    }
+}
+
 extension WebGPU.Buffer {
     func getMappedRange(offset: Int, size: Int) -> WebGPU.SpanUInt8 {
         if !isValid() {
-            return unsafe WebGPU.SpanUInt8()
+            return .empty
         }
 
         var rangeSize = size
@@ -56,14 +66,14 @@ extension WebGPU.Buffer {
         }
 
         if !validateGetMappedRange(offset, rangeSize) {
-            return unsafe WebGPU.SpanUInt8()
+            return .empty
         }
 
         m_mappedRanges.add(.init(UInt(offset), UInt(offset + rangeSize)))
         m_mappedRanges.compact()
 
         if m_buffer.storageMode == .private || m_buffer.storageMode == .memoryless || m_buffer.length == 0 {
-            return unsafe WebGPU.SpanUInt8()
+            return .empty
         }
 
         return unsafe getBufferContents().subspan(offset, rangeSize)


### PR DESCRIPTION
#### c3634bcc04f70159c5331ba64121399ba4237e53
<pre>
Slightly reduce unsafe in WebGPU Buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=320907">https://bugs.webkit.org/show_bug.cgi?id=320907</a>
<a href="https://rdar.apple.com/183929867">rdar://183929867</a>

Reviewed by Mike Wyrzykowski.

This change makes no functional difference but slightly reduces the number of
`unsafe` loci in the WebGPU Swift code, by centralising the construction of an
empty span.

Canonical link: <a href="https://commits.webkit.org/318478@main">https://commits.webkit.org/318478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/622649e9d83d8ae5c5fe2de958040cf7f0295acd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178397 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188013 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141645 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50ae3465-db4e-4a29-9cfc-bdb71a0fdbae) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139076 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/089d493d-ea3b-4ff6-b3a6-45e59a463a44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119531 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d3a3d5e5-eff6-409b-b0fe-bf3808a7d52d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41306 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39656 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39337 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36468 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190440 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52004 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148233 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39809 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52685 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148006 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42721 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124950 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119582 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51203 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14312 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50588 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50828 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50650 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->