### PR TITLE
[JSC][Linux] Don't re-read /proc/self/maps when handling checkpoint OSR side state

### DIFF
--- a/JSTests/wasm/stress/type-index-abstract-heap-types-concrete-vs-abstract.js
+++ b/JSTests/wasm/stress/type-index-abstract-heap-types-concrete-vs-abstract.js
@@ -1,7 +1,5 @@
-//@ skip if $hostOS == "linux"
 //@ slow!
 // https://bugs.webkit.org/show_bug.cgi?id=247454
-// https://bugs.webkit.org/show_bug.cgi?id=320559
 import * as assert from "../assert.js";
 import { compile, instantiate } from "../gc/wast-wrapper.js";
 

--- a/JSTests/wasm/stress/type-index-abstract-heap-types-globals-and-tables.js
+++ b/JSTests/wasm/stress/type-index-abstract-heap-types-globals-and-tables.js
@@ -1,7 +1,5 @@
-//@ skip if $hostOS == "linux"
 //@ slow!
 // https://bugs.webkit.org/show_bug.cgi?id=247454
-// https://bugs.webkit.org/show_bug.cgi?id=320559
 import * as assert from "../assert.js";
 import { compile, instantiate } from "../gc/wast-wrapper.js";
 

--- a/JSTests/wasm/stress/type-index-abstract-heap-types-nulls-and-casts.js
+++ b/JSTests/wasm/stress/type-index-abstract-heap-types-nulls-and-casts.js
@@ -1,7 +1,5 @@
-//@ skip if $hostOS == "linux"
 //@ slow!
 // https://bugs.webkit.org/show_bug.cgi?id=247454
-// https://bugs.webkit.org/show_bug.cgi?id=320559
 import * as assert from "../assert.js";
 import { compile, instantiate } from "../gc/wast-wrapper.js";
 

--- a/JSTests/wasm/stress/type-index-abstract-heap-types-subtype-validation.js
+++ b/JSTests/wasm/stress/type-index-abstract-heap-types-subtype-validation.js
@@ -1,7 +1,5 @@
-//@ skip if $hostOS == "linux"
 //@ slow!
 // https://bugs.webkit.org/show_bug.cgi?id=247454
-// https://bugs.webkit.org/show_bug.cgi?id=320559
 import * as assert from "../assert.js";
 import { compile, instantiate } from "../gc/wast-wrapper.js";
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1262,7 +1262,8 @@ void VM::pushCheckpointOSRSideState(std::unique_ptr<CheckpointOSRExitSideState>&
     m_checkpointSideState.append(WTF::move(payload));
 
 #if ASSERT_ENABLED
-    auto bounds = StackBounds::currentThreadStackBounds();
+    const auto& bounds = Thread::currentSingleton().stack();
+    ASSERT(bounds.contains(currentStackPointer()));
     void* previousCallFrame = bounds.end();
     for (size_t i = m_checkpointSideState.size(); i--;) {
         auto* callFrame = m_checkpointSideState[i]->associatedCallFrame;
@@ -1285,7 +1286,7 @@ std::unique_ptr<CheckpointOSRExitSideState> VM::popCheckpointOSRSideState(CallFr
 void VM::popAllCheckpointOSRSideStateUntil(CallFrame* target)
 {
     ASSERT(currentThreadIsHoldingAPILock());
-    auto bounds = StackBounds::currentThreadStackBounds().withSoftOrigin(target);
+    auto bounds = Thread::currentSingleton().stack().withSoftOrigin(target);
     ASSERT(bounds.contains(target));
 
     // We have to worry about migrating from another thread since there may be no checkpoints in our thread but one in the other threads.


### PR DESCRIPTION
#### bff3814d76f74308c64bd502b0630afa08c8d59b
<pre>
[JSC][Linux] Don&apos;t re-read /proc/self/maps when handling checkpoint OSR side state
<a href="https://bugs.webkit.org/show_bug.cgi?id=320559">https://bugs.webkit.org/show_bug.cgi?id=320559</a>

Reviewed by Yusuke Suzuki and Justin Michaud.

VM::pushCheckpointOSRSideState() has an ASSERT_ENABLED block that checks
that the side state stack remains ordered. To do so, it needs the current
thread stack bounds.

It obtained them using StackBounds::currentThreadStackBounds(), which does
not cache the result. On Linux, this calls pthread_getattr_np(), which glibc
implements for the main thread by opening and parsing /proc/self/maps.
Each call makes the kernel generate a list of the process memory mappings
and then makes glibc parse that list.

While running wasm/stress/type-index-abstract-heap-types-nulls-and-casts.js
in wasm-eager mode, profiling showed about ~45% of samples in kernel code
generating /proc/self/maps and another ~30% in libc parsing it. The test
opened /proc/self/maps hundreds of times through repeated calls to
VM::pushCheckpointOSRSideState().

Thread::m_stack is initialized using StackBounds::currentThreadStackBounds()
and cached for the lifetime of the thread. Thread::currentSingleton().stack()
therefore provides the cached bounds without repeating the OS query.
logSanitizeStack() in the same file already uses this cached value.

Switch both call sites in VM.cpp to the cached bounds. This keeps the
relevant stack consistency assertions checks without asking the operating
system to recalculate information that the thread already stores.

popAllCheckpointOSRSideStateUntil() is not assertion-only: it uses the
bounds as part of its normal operation. This change therefore also avoids
the same cost in release builds.

With this change, on a Release+Asserts WPE build, `run-jsc-stress-tests \
--filter wasm.yaml/wasm/stress/type-index-abstract-heap-types` completes
in about five minutes. Previously, it could take around one hour, and the
tests would usually time out.

* JSTests/wasm/stress/type-index-abstract-heap-types-concrete-vs-abstract.js:
* JSTests/wasm/stress/type-index-abstract-heap-types-globals-and-tables.js:
* JSTests/wasm/stress/type-index-abstract-heap-types-nulls-and-casts.js:
* JSTests/wasm/stress/type-index-abstract-heap-types-subtype-validation.js:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::pushCheckpointOSRSideState):
(JSC::VM::popAllCheckpointOSRSideStateUntil):

Canonical link: <a href="https://commits.webkit.org/318487@main">https://commits.webkit.org/318487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccecedebba6a4b3b407a1401a58566127b359ae6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188033 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141665 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139094 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119548 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41322 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39672 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1517 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8340 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39351 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36488 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39690 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44955 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190460 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52024 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148252 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52705 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148024 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27067 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42735 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124971 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119607 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51223 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14326 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50608 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50848 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50670 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->