### PR TITLE
[run-jsc-stress-tests] Print per-test execution times when the progress meter is enabled

### DIFF
--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -2999,6 +2999,14 @@ def runAndMonitorTestRunnerCommand(cmd, options={})
        didFail = {}
        blankLine = true
        prevStringLength = 0
+       printAboveProgressMeter = Proc.new {
+           | line |
+           unless blankLine
+               print("\r" + " " * prevStringLength + "\r")
+           end
+           puts line
+           blankLine = true
+       }
        IO.popen(cmd.join(' '), mode="r") {
            | inp |
            inp.each_line {
@@ -3008,15 +3016,12 @@ def runAndMonitorTestRunnerCommand(cmd, options={})
                    running[$~.post_match] = true
                elsif line =~ /^PASS: /
                    didRun[$~.post_match] = true
+                   printAboveProgressMeter.call(line) if $reportExecutionTime
                elsif line =~ /^FAIL: /
                    didRun[$~.post_match] = true
                    didFail[$~.post_match] = true
                else
-                   unless blankLine
-                       print("\r" + " " * prevStringLength + "\r")
-                   end
-                   puts line
-                   blankLine = true
+                   printAboveProgressMeter.call(line)
                end
 
                def lpad(str, chars)


### PR DESCRIPTION
#### 130cc476d2b5e73050c66b70a0b3f53c7bb1c190
<pre>
[run-jsc-stress-tests] Print per-test execution times when the progress meter is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=320911">https://bugs.webkit.org/show_bug.cgi?id=320911</a>
<a href="https://rdar.apple.com/183941218">rdar://183941218</a>

Reviewed by Yusuke Suzuki and Keith Miller.

--report-execution-time makes each test&apos;s success command echo
&quot;PASS: &lt;name&gt; &lt;N&gt;ms&quot;. But the progress meter in runAndMonitorTestRunnerCommand
matches lines beginning with &quot;PASS: &quot; and only uses them to advance its
counter, never printing them. The meter is enabled by default whenever stdout
is a TTY and verbosity is 0, so the timings were measured and then discarded.
Passing --verbose or setting JSCTEST_noProgressMeter disables the meter, which
was the only way to see them.

Print the PASS line when --report-execution-time is given, reusing the meter&apos;s
existing &quot;erase the progress line first&quot; logic so the counter still redraws
correctly around it.

* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/318568@main">https://commits.webkit.org/318568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5125b83a008c856857c00c707aca21717b650a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141670 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e666bb23-c254-43fa-ad58-b949a94cd086) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139098 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ab46e70-eda8-4374-932e-69395e9376d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119552 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/583fd930-4c53-4533-972c-743391af551c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41329 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39679 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1521 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8348 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151729 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39358 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36493 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39695 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190465 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52029 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148255 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52710 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148027 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27101 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42741 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119612 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51228 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14333 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50613 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50853 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50675 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->