### PR TITLE
imagesrcset does not override href for <link rel="preload" as="image">

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/preload/preload-imagesrcset-in-markup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/preload-imagesrcset-in-markup-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Preload in markup with href and imagesrcset (w descriptors) does not fetch href assert_equals: resources/square.png?markup-w-href expected 0 but got 1
-FAIL Preload in markup with href and imagesrcset (x descriptors) does not fetch href assert_equals: resources/square.png?markup-x-href expected 0 but got 1
+PASS Preload in markup with href and imagesrcset (w descriptors) does not fetch href
+PASS Preload in markup with href and imagesrcset (x descriptors) does not fetch href
 

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -148,6 +148,15 @@ public:
             setURLToLoadAllowingReplacement(imageCandidate.string.view);
         }
 
+        // Resolve between href and imagesrcset for <link rel=preload as=image>, the same way
+        // LinkLoader::preloadIfNeeded does. Otherwise the scanner would fetch href while the
+        // link element fetches the source set candidate, downloading the image twice.
+        if (m_tagId == TagId::Link && m_linkIsPreload && !m_srcSetAttribute.isEmpty() && resourceType() == CachedResource::Type::ImageResource) {
+            auto sourceSize = SizesAttributeParser(m_sizesAttribute, m_document).effectiveSize();
+            ImageCandidate imageCandidate = bestFitSourceForImageAttributes(m_deviceScaleFactor, m_urlToLoad, m_srcSetAttribute, sourceSize);
+            setURLToLoadAllowingReplacement(imageCandidate.string.view);
+        }
+
         if (m_metaIsViewport && !m_metaContent.isNull())
             m_document->processViewport(m_metaContent, ViewportArguments::Type::ViewportMeta);
 
@@ -333,6 +342,10 @@ private:
                 m_fetchPriority = parseEnumerationFromString<RequestPriority>(attributeValue.toString()).value_or(RequestPriority::Auto);
             else if (match(attributeName, disabledAttr))
                 m_linkIsDisabled = true;
+            else if (match(attributeName, imagesrcsetAttr) && m_srcSetAttribute.isNull())
+                m_srcSetAttribute = attributeValue.toString();
+            else if (match(attributeName, imagesizesAttr) && m_sizesAttribute.isNull())
+                m_sizesAttribute = attributeValue.toString();
             break;
         case TagId::Input:
             if (match(attributeName, srcAttr))


### PR DESCRIPTION
#### eeeb01ce5ab8258304a1a878667b1b2ec548bec6
<pre>
imagesrcset does not override href for &lt;link rel=&quot;preload&quot; as=&quot;image&quot;&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=320786">https://bugs.webkit.org/show_bug.cgi?id=320786</a>
<a href="https://rdar.apple.com/183945535">rdar://183945535</a>

Reviewed by Frédéric Wang Nélar and Chris Dumez.

The preload scanner read srcset/sizes only for &lt;img&gt; and &lt;source&gt;. For
&lt;link rel=preload as=image&gt; it took href verbatim, so the speculative fetch went
to href while LinkLoader::preloadIfNeeded selected an image source from the
source set and fetched that instead — two downloads for one preload. Step 2 of
the &quot;preload&quot; algorithm [1] requires selecting from the source set when the
destination is &quot;image&quot;.

Mirror the &lt;img&gt; resolution in the link branch: buffer imagesrcset/imagesizes
(first value wins, as with srcset/sizes) and run
bestFitSourceForImageAttributes() over href + imagesrcset, gated on rel=preload
resolving to an image resource so it matches LinkLoader::preloadIfNeeded. href is
passed as the default source, so it is still selected when it legitimately joins
the source set as the 1x candidate.

dynamic-adding-preload-imagesrcset.html already passed because script-created
links never reach the scanner; preload-imagesrcset-in-markup.html goes from 2
FAIL to 2 PASS.

[1] <a href="https://html.spec.whatwg.org/multipage/links.html#preload">https://html.spec.whatwg.org/multipage/links.html#preload</a>

* LayoutTests/imported/w3c/web-platform-tests/preload/preload-imagesrcset-in-markup-expected.txt: Progression
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processAttributes):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):

Canonical link: <a href="https://commits.webkit.org/318544@main">https://commits.webkit.org/318544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfa07472cb41e0797cd910e7d7e99db4215d79d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188047 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141679 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0bbfa6fd-9c2d-4b1a-a558-cfd80ae80aa4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139107 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b4a5b13-5f4a-45a9-b8f5-8c7f7707b6dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119561 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2dd1845b-460d-47de-9c07-09011f870967) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41332 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39685 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151732 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39365 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36502 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190474 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52038 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148265 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39856 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52719 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148036 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42749 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124985 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119622 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51237 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14340 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50622 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50862 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50684 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->