### PR TITLE
Add initial `portal-transform` support

### DIFF
--- a/LayoutTests/spatial-css/resources/spatial-portal-utils.js
+++ b/LayoutTests/spatial-css/resources/spatial-portal-utils.js
@@ -1,6 +1,12 @@
-const createPortal = test => {
+const createPortal = (test, { width, height, portalTransform } = {}) => {
     const portal = document.createElement("div");
     portal.className = "portal";
+    if (width)
+        portal.style.width = width;
+    if (height)
+        portal.style.height = height;
+    if (portalTransform)
+        portal.style.portalTransform = portalTransform;
     document.body.appendChild(portal);
     test.add_cleanup(() => portal.remove());
     return portal;
@@ -14,3 +20,43 @@ const appendModel = (portal, asset) => {
     model.appendChild(source);
     return model;
 };
+
+// Wraps the internals values back into a DOMMatrix.
+const resolvedPortalTransform = portal => {
+    const values = internals.spatialPortalResolvedTransform(portal);
+    return values ? new DOMMatrixReadOnly(values) : null;
+};
+
+const portalTransformsApproxEqual = (a, b) => {
+    if (!a || !b)
+        return false;
+
+    const aValues = a.toFloat64Array();
+    const bValues = b.toFloat64Array();
+    return aValues.every((value, index) => Math.abs(value - bValues[index]) <= epsilon);
+};
+
+const portalTransformScaleIsUnit = transform => {
+    return !!transform
+        && Math.abs(transform.m11 - 1) < epsilon
+        && Math.abs(transform.m22 - 1) < epsilon
+        && Math.abs(transform.m33 - 1) < epsilon;
+};
+
+const portalTransformIsResolved = transform => !!transform;
+const portalTransformIsCleared = transform => transform === null;
+
+async function waitForPortalTransform(portal, predicate, description, timeout = 5000) {
+    const startTime = Date.now();
+
+    while (true) {
+        const transform = resolvedPortalTransform(portal);
+        if (predicate(transform))
+            return transform;
+
+        if (Date.now() - startTime > timeout)
+            throw new Error(`Timeout waiting for the portal's resolved transform: ${description}`);
+
+        await sleepForSeconds(0.1);
+    }
+}

--- a/LayoutTests/spatial-css/spatial-portal-transform-auto-dynamic-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-transform-auto-dynamic-expected.txt
@@ -1,0 +1,6 @@
+
+PASS portal-transform: auto is recomputed against the merged bounds when a model is added
+PASS portal-transform: auto is recomputed when the portal is resized
+PASS portal-transform is recomputed when the property changes between auto and none
+PASS portal-transform is dropped when the model is removed and recomputed when it is reinserted
+

--- a/LayoutTests/spatial-css/spatial-portal-transform-auto-dynamic.html
+++ b/LayoutTests/spatial-css/spatial-portal-transform-auto-dynamic.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 40cm; height: 20cm; }
+</style>
+<body>
+<script>
+'use strict';
+
+internals.disableModelLoadDelaysForTesting();
+
+const flatRectangle = "flat-rectangle.usdz";
+const offsetCube = "2x2x2-at-100x50x200.usdz";
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const centered = appendModel(portal, "2x2x2-center.usdz");
+
+    await centered.ready;
+    const before = await waitForPortalTransform(portal, portalTransformIsResolved, "transform with one model");
+
+    const offset = appendModel(portal, offsetCube);
+    await offset.ready;
+    const after = await waitForPortalTransform(portal, transform => transform && !portalTransformsApproxEqual(transform, before), "transform with both models");
+
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 2, "the portal hosts both models");
+    assert_true(after.m11 < before.m11, `the merged bounds are larger, so the fit scale shrinks (${after.m11} < ${before.m11})`);
+}, `portal-transform: auto is recomputed against the merged bounds when a model is added`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, flatRectangle);
+
+    await model.ready;
+    const before = await waitForPortalTransform(portal, portalTransformIsResolved, "initial transform");
+
+    portal.style.width = "80cm"; // Double the width.
+    const after = await waitForPortalTransform(portal, transform => transform && !portalTransformsApproxEqual(transform, before), "transform after resize");
+
+    assert_3d_matrix_approx_equals(before.scale3d(2), after);
+}, `portal-transform: auto is recomputed when the portal is resized`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, flatRectangle);
+
+    await model.ready;
+    const autoTransform = await waitForPortalTransform(portal, portalTransformIsResolved, "initial auto transform");
+
+    portal.style.portalTransform = "none";
+    const noneTransform = await waitForPortalTransform(portal, transform => transform && !portalTransformsApproxEqual(transform, autoTransform), "transform after switching to none");
+    assert_true(portalTransformScaleIsUnit(noneTransform), "none yields a 1:1 CSS unit mapping");
+
+    portal.style.portalTransform = "auto";
+    const restoredTransform = await waitForPortalTransform(portal, transform => transform && !portalTransformsApproxEqual(transform, noneTransform), "transform after switching back to auto");
+    assert_3d_matrix_approx_equals(restoredTransform, autoTransform);
+}, `portal-transform is recomputed when the property changes between auto and none`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, flatRectangle);
+
+    await model.ready;
+    await waitForPortalTransform(portal, portalTransformIsResolved, "transform before removal");
+
+    model.remove();
+    await waitForPortalTransform(portal, portalTransformIsCleared, "transform after removal");
+
+    const reinsertedModel = appendModel(portal, flatRectangle);
+    await reinsertedModel.ready;
+    await waitForPortalTransform(portal, portalTransformIsResolved, "transform after reinsertion");
+}, `portal-transform is dropped when the model is removed and recomputed when it is reinserted`);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-transform-auto-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-transform-auto-expected.txt
@@ -1,0 +1,3 @@
+
+PASS portal-transform: auto scales the portal's content to fit the portal box
+

--- a/LayoutTests/spatial-css/spatial-portal-transform-auto.html
+++ b/LayoutTests/spatial-css/spatial-portal-transform-auto.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 40cm; height: 20cm; }
+</style>
+<body>
+<script>
+'use strict';
+
+internals.disableModelLoadDelaysForTesting();
+
+const flatRectangle = "flat-rectangle.usdz";
+
+promise_test(async t => {
+    const narrowPortal = createPortal(t);
+    const narrowModel = appendModel(narrowPortal, flatRectangle);
+
+    const widePortal = createPortal(t, { width: "80cm" }); // Twice as wide.
+    const wideModel = appendModel(widePortal, flatRectangle);
+
+    await narrowModel.ready;
+    await wideModel.ready;
+
+    const narrowTransform = await waitForPortalTransform(narrowPortal, portalTransformIsResolved, "narrow portal");
+    const wideTransform = await waitForPortalTransform(widePortal, portalTransformIsResolved, "wide portal");
+
+    assert_3d_matrix_approx_equals(narrowTransform.scale3d(2), wideTransform);
+}, `portal-transform: auto scales the portal's content to fit the portal box`);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-transform-none-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-transform-none-expected.txt
@@ -1,0 +1,4 @@
+
+PASS portal-transform: none is independent of the portal's size
+PASS portal-transform: none still centers the portal's content
+

--- a/LayoutTests/spatial-css/spatial-portal-transform-none.html
+++ b/LayoutTests/spatial-css/spatial-portal-transform-none.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 40cm; height: 20cm; portal-transform: none; }
+</style>
+<body>
+<script>
+'use strict';
+
+internals.disableModelLoadDelaysForTesting();
+
+const centeredCube = "2x2x2-center.usdz";
+const offsetCube = "2x2x2-at-100x50x200.usdz";
+
+promise_test(async t => {
+    const narrowPortal = createPortal(t);
+    const narrowModel = appendModel(narrowPortal, centeredCube);
+
+    const widePortal = createPortal(t, { width: "80cm" });
+    const wideModel = appendModel(widePortal, centeredCube);
+
+    await narrowModel.ready;
+    await wideModel.ready;
+
+    const narrowTransform = await waitForPortalTransform(narrowPortal, portalTransformIsResolved, "narrow portal");
+    const wideTransform = await waitForPortalTransform(widePortal, portalTransformIsResolved, "wide portal");
+
+    assert_3d_matrix_approx_equals(narrowTransform, wideTransform);
+}, `portal-transform: none is independent of the portal's size`);
+
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, offsetCube);
+
+    await model.ready;
+    const transform = await waitForPortalTransform(portal, portalTransformIsResolved, "portal");
+
+    assert_3d_matrix_approx_equals(transform, new DOMMatrixReadOnly().translate(-100, -50, -201));
+}, `portal-transform: none still centers the portal's content`);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-transform-off-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-transform-off-expected.txt
@@ -1,0 +1,3 @@
+portal-transform is supported: false
+portal-transform computed style is exposed: false
+portal-transform survives in cssText: false

--- a/LayoutTests/spatial-css/spatial-portal-transform-off.html
+++ b/LayoutTests/spatial-css/spatial-portal-transform-off.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SpatialPortalEnabled=false ] -->
+<html>
+<style>
+    #portal { spatial: portal; width: 300px; height: 150px; portal-transform: none; }
+</style>
+<body>
+<div id="portal">
+    <span id="content">Hello!</span>
+</div>
+<pre id="results"></pre>
+<script>
+    window.testRunner?.dumpAsText();
+
+    const portal = document.getElementById("portal");
+    const lines = [];
+
+    lines.push(`portal-transform is supported: ${CSS.supports("portal-transform", "auto")}`);
+    lines.push(`portal-transform computed style is exposed: ${getComputedStyle(portal).portalTransform !== undefined}`);
+
+    portal.style.portalTransform = "none";
+    lines.push(`portal-transform survives in cssText: ${portal.style.cssText.includes("portal-transform")}`);
+
+    results.textContent = lines.join("\n");
+
+    portal.remove();
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-transform-parsing-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-transform-parsing-expected.txt
@@ -1,0 +1,7 @@
+
+PASS portal-transform initial value is auto, whether or not the element establishes a portal
+PASS portal-transform accepts none and auto
+PASS portal-transform is a supported property
+PASS portal-transform ignores invalid values
+PASS portal-transform ignores not yet supported values
+

--- a/LayoutTests/spatial-css/spatial-portal-transform-parsing.html
+++ b/LayoutTests/spatial-css/spatial-portal-transform-parsing.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+'use strict';
+
+function makeElement(t, establishesPortal) {
+    const element = document.createElement("div");
+    if (establishesPortal)
+        element.style.spatial = "portal";
+    document.body.appendChild(element);
+    t.add_cleanup(() => element.remove());
+    return element;
+}
+
+test(t => {
+    assert_equals(getComputedStyle(makeElement(t, true)).portalTransform, "auto", "on a portal");
+    assert_equals(getComputedStyle(makeElement(t, false)).portalTransform, "auto", "on a non-portal");
+}, "portal-transform initial value is auto, whether or not the element establishes a portal");
+
+test(t => {
+    for (const value of ["auto", "none"]) {
+        const element = makeElement(t, true);
+        element.style.portalTransform = value;
+        assert_equals(element.style.portalTransform, value, `specified value of "${value}"`);
+        assert_equals(getComputedStyle(element).portalTransform, value, `computed value of "${value}"`);
+    }
+}, "portal-transform accepts none and auto");
+
+test(() => {
+    assert_true(CSS.supports("portal-transform", "auto"), "auto");
+    assert_true(CSS.supports("portal-transform", "none"), "none");
+}, "portal-transform is a supported property");
+
+const alwaysInvalid = ["3px", "10", "red", "auto auto", "none none", "auto none", "none auto", "auto, none"];
+
+// FIXME: rdar://182292652
+const notYetSupported = ["rotateY(45deg)", "translateZ(10px)", "scale3d(2, 2, 2)", "auto rotateY(45deg)", "rotateY(45deg) auto", "none rotateY(45deg)"];
+
+for (const [description, values] of [["invalid", alwaysInvalid], ["not yet supported", notYetSupported]]) {
+    test(t => {
+        for (const value of values) {
+            const element = makeElement(t, true);
+            element.style.portalTransform = value;
+            assert_equals(element.style.portalTransform, "", `"${value}" is not accepted`);
+            assert_equals(getComputedStyle(element).portalTransform, "auto", `"${value}" leaves the initial value in place`);
+        }
+    }, `portal-transform ignores ${description} values`);
+}
+
+</script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8404,6 +8404,7 @@ SpatialPortalEnabled:
       default: false
     WebCore:
       default: false
+  sharedPreferenceForWebProcess: true
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 SpeakerSelectionRequiresUserGesture:

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -619,6 +619,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/model-element/ModelPlayerIdentifier.h
     Modules/model-element/ModelPlayerProvider.h
     Modules/model-element/ModelPlayerTransformState.h
+    Modules/model-element/PortalTransform.h
     Modules/model-element/SpatialPortalController.h
 
     Modules/model-element/dummy/DummyModelPlayerProvider.h
@@ -3534,6 +3535,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/transforms/StylePerspective.h
     style/values/transforms/StylePerspectiveOrigin.h
+    style/values/transforms/StylePortalTransform.h
     style/values/transforms/StyleRotate.h
     style/values/transforms/StyleScale.h
     style/values/transforms/StyleTransform.h

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -272,6 +272,9 @@ private:
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
     void didUpdateEntityTransform(ModelPlayer&, NodeIdentifier, const TransformationMatrix&) final;
 #endif
+#if ENABLE(SPATIAL_PORTAL)
+    void didUpdatePortalTransform(ModelPlayer&, const TransformationMatrix&) final { }
+#endif
 #if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)
     void didUpdateBoundingBox(ModelPlayer&, NodeIdentifier, const FloatPoint3D&, const FloatPoint3D&) final;
 #endif

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -189,6 +189,14 @@ void ModelPlayer::setHasPortal(bool)
 
 #endif
 
+#if ENABLE(SPATIAL_PORTAL)
+
+void ModelPlayer::setPortalTransform(PortalTransformKind)
+{
+}
+
+#endif
+
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE)
 
 void ModelPlayer::setStageMode(StageModeOperation)

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -46,6 +46,10 @@
 #include <WebCore/StageModeOperations.h>
 #endif
 
+#if ENABLE(SPATIAL_PORTAL)
+#include <WebCore/PortalTransform.h>
+#endif
+
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
 #include <WebCore/PlatformDynamicRangeLimit.h>
 #endif
@@ -153,6 +157,10 @@ public:
 
 #if ENABLE(MODEL_ELEMENT_PORTAL)
     virtual void setHasPortal(bool);
+#endif
+
+#if ENABLE(SPATIAL_PORTAL)
+    virtual void setPortalTransform(PortalTransformKind);
 #endif
 
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE)

--- a/Source/WebCore/Modules/model-element/ModelPlayerClient.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerClient.h
@@ -61,6 +61,9 @@ public:
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
     virtual void didUpdateEntityTransform(ModelPlayer&, NodeIdentifier, const TransformationMatrix&) = 0;
 #endif
+#if ENABLE(SPATIAL_PORTAL)
+    virtual void didUpdatePortalTransform(ModelPlayer&, const TransformationMatrix&) = 0;
+#endif
 #if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)
     virtual void didUpdateBoundingBox(ModelPlayer&, NodeIdentifier, const FloatPoint3D&, const FloatPoint3D&) = 0;
 #endif

--- a/Source/WebCore/Modules/model-element/PortalTransform.h
+++ b/Source/WebCore/Modules/model-element/PortalTransform.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(SPATIAL_PORTAL)
+
+#include <cstdint>
+
+namespace WebCore {
+
+enum class PortalTransformKind : uint8_t {
+    None,
+    Auto,
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(SPATIAL_PORTAL)

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
@@ -108,6 +108,13 @@ private:
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
     void didUpdateEntityTransform(ModelPlayer&, NodeIdentifier, const TransformationMatrix&) final { }
 #endif
+#if ENABLE(SPATIAL_PORTAL)
+    void didUpdatePortalTransform(ModelPlayer& player, const TransformationMatrix& transform) final
+    {
+        if (CheckedPtr controller = m_controller.get())
+            controller->modelDidUpdatePortalTransform(player, transform);
+    }
+#endif
 #if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)
     void didUpdateBoundingBox(ModelPlayer&, NodeIdentifier, const FloatPoint3D&, const FloatPoint3D&) final { }
 #endif
@@ -323,7 +330,22 @@ ModelPlayer* SpatialPortalController::ensureModelPlayer()
         lazyInitialize(m_playerClient, PortalModelPlayerClient::create(*this));
 
     m_modelPlayer = provider->createModelPlayer(*m_playerClient);
+
+    if (m_modelPlayer)
+        m_modelPlayer->setPortalTransform(m_portalTransform);
+
     return m_modelPlayer.get();
+}
+
+void SpatialPortalController::setPortalTransform(PortalTransformKind kind)
+{
+    if (m_portalTransform == kind)
+        return;
+
+    m_portalTransform = kind;
+
+    if (RefPtr player = m_modelPlayer)
+        player->setPortalTransform(m_portalTransform);
 }
 
 void SpatialPortalController::deleteModelPlayer()
@@ -335,6 +357,9 @@ void SpatialPortalController::deleteModelPlayer()
     }
     for (auto& hostedModel : m_hostedModels.values())
         hostedModel.loadedModel = nullptr;
+
+    m_lastPushedContentSize = std::nullopt;
+    m_resolvedPortalTransform = std::nullopt;
 }
 
 void SpatialPortalController::unloadChildModel(NodeIdentifier nodeID)
@@ -382,8 +407,16 @@ void SpatialPortalController::configureGraphicsLayer(GraphicsLayer& graphicsLaye
 
 void SpatialPortalController::sizeMayHaveChanged()
 {
-    if (RefPtr player = m_modelPlayer)
-        player->sizeDidChange(portalContentSize());
+    RefPtr player = m_modelPlayer;
+    if (!player)
+        return;
+
+    auto size = portalContentSize();
+    if (m_lastPushedContentSize == size)
+        return;
+
+    m_lastPushedContentSize = size;
+    player->sizeDidChange(size);
 }
 
 void SpatialPortalController::modelDidFinishLoading(ModelPlayer&, NodeIdentifier nodeID)
@@ -423,6 +456,14 @@ void SpatialPortalController::modelDidUnload(ModelPlayer& player)
 void SpatialPortalController::modelDidUpdate(ModelPlayer&)
 {
     reconfigurePortalLayer();
+}
+
+void SpatialPortalController::modelDidUpdatePortalTransform(ModelPlayer& player, const TransformationMatrix& transform)
+{
+    if (&player != m_modelPlayer)
+        return;
+
+    m_resolvedPortalTransform = transform;
 }
 
 // Mirrors HTMLModelElement::logWarning().

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.h
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.h
@@ -29,6 +29,8 @@
 
 #include "LayoutSize.h"
 #include <WebCore/NodeIdentifier.h>
+#include <WebCore/PortalTransform.h>
+#include <WebCore/TransformationMatrix.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
@@ -70,6 +72,9 @@ public:
     void configureGraphicsLayer(GraphicsLayer&, const Color& backgroundColor);
     void sizeMayHaveChanged();
 
+    void setPortalTransform(PortalTransformKind);
+    const std::optional<TransformationMatrix>& resolvedPortalTransform() const { return m_resolvedPortalTransform; }
+
     bool isPortalVisible() const;
 
 private:
@@ -77,6 +82,7 @@ private:
     void modelDidFailLoading(ModelPlayer&, NodeIdentifier, const ResourceError&);
     void modelDidUnload(ModelPlayer&);
     void modelDidUpdate(ModelPlayer&);
+    void modelDidUpdatePortalTransform(ModelPlayer&, const TransformationMatrix&);
     void logWarning(ModelPlayer&, const String&);
     RefPtr<GraphicsLayer> portalGraphicsLayer() const;
     void viewportIntersectionChanged(bool isIntersecting);
@@ -103,6 +109,9 @@ private:
     RefPtr<ModelPlayer> m_modelPlayer;
     const RefPtr<PortalModelPlayerClient> m_playerClient;
     RefPtr<IntersectionObserver> m_intersectionObserver;
+    std::optional<LayoutSize> m_lastPushedContentSize;
+    std::optional<TransformationMatrix> m_resolvedPortalTransform;
+    PortalTransformKind m_portalTransform { PortalTransformKind::Auto };
     bool m_isIntersectingViewport { false };
 };
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3528,6 +3528,7 @@ style/values/transforms/functions/StyleSkewTransformFunction.cpp
 style/values/transforms/functions/StyleTransformFunctionBase.cpp
 style/values/transforms/functions/StyleTranslateTransformFunction.cpp
 style/values/transforms/StylePerspective.cpp
+style/values/transforms/StylePortalTransform.cpp
 style/values/transforms/StyleRotate.cpp
 style/values/transforms/StyleScale.cpp
 style/values/transforms/StyleTransform.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		02F00913A402BD5A4A68ED65 /* UnifiedSource16-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1B5C8E332AFA25F34506CCB0 /* UnifiedSource16-header-RenderStyleGetters.cpp */; };
 		030346BE5CD75A7829AD613F /* UnifiedSource40-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A756860D9AF6A2C15FCF7E3E /* UnifiedSource40-header-RenderStyleGetters.cpp */; };
 		043934662F229202E82AB23F /* UnifiedSource55-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3230252036F492BB47909DD0 /* UnifiedSource55-header-RenderStyleGetters.cpp */; };
+		053F6589A66D76BEEA136C23 /* PortalTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 329D390B53E4795024178E9D /* PortalTransform.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0562F9611573F88F0031CA16 /* PlatformLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0562F9601573F88F0031CA16 /* PlatformLayer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		056A7AC8256C4F48002F9DDC /* ShadowRootInit.h in Headers */ = {isa = PBXBuildFile; fileRef = 054E3A33256C3BD90072C5B9 /* ShadowRootInit.h */; };
 		056A7AC8256C4F48002F9DDF /* GetHTMLOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 054E3A33256C3BD90072C5BF /* GetHTMLOptions.h */; };
@@ -4789,6 +4790,7 @@
 		AED243692C939A6800E8649D /* AuthenticationResponseJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = AED243682C939A6800E8649D /* AuthenticationResponseJSON.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AEDB39B3CF27CEA5073F99DD /* UnifiedSource64-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C61AFF4898CB7897BCB412E /* UnifiedSource64-header-RenderStyleGetters.cpp */; };
 		AF53F56C6CD24319D07D951A /* SkipForward10.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = D7E7E02D100D3C3969DAEB93 /* SkipForward10.svg */; platformFilters = (macos, ); };
+		B006BDF1E82CF048027EA54E /* StylePortalTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = C7CE9CAD86C00846197AE7D5 /* StylePortalTransform.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B0358DEB688088BA80FD9DB4 /* Airplay.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = B5072BE12210266CE7E320FC /* Airplay.svg */; platformFilters = (macos, ); };
 		B10B6980140C174000BC1C26 /* WebVTTToken.h in Headers */ = {isa = PBXBuildFile; fileRef = B10B697D140C174000BC1C26 /* WebVTTToken.h */; };
 		B10B6982140C174000BC1C26 /* WebVTTTokenizer.h in Headers */ = {isa = PBXBuildFile; fileRef = B10B697F140C174000BC1C26 /* WebVTTTokenizer.h */; };
@@ -7938,6 +7940,9 @@
 		072DBC0725DC6EDA00A1350E /* JSMediaSessionCoordinator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSMediaSessionCoordinator.cpp; sourceTree = "<group>"; };
 		072F696C2E74FC2100281FC5 /* TextListParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextListParser.h; sourceTree = "<group>"; };
 		072F696E2E755BFA00281FC5 /* TextListParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextListParser.cpp; sourceTree = "<group>"; };
+		329D390B53E4795024178E9D /* PortalTransform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PortalTransform.h; sourceTree = "<group>"; };
+		B3EC871297BD15E272BE6D00 /* StylePortalTransform.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StylePortalTransform.cpp; sourceTree = "<group>"; };
+		C7CE9CAD86C00846197AE7D5 /* StylePortalTransform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StylePortalTransform.h; sourceTree = "<group>"; };
 		EDB1CA5E2E0000000000AC01 /* MediaSessionManagerClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionManagerClient.h; sourceTree = "<group>"; };
 		07307B792DA06AEC00A5EF65 /* MediaSessionManagerInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionManagerInterface.h; sourceTree = "<group>"; };
 		07307B912DA4B5C500A5EF65 /* PlatformMediaSessionInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformMediaSessionInterface.h; sourceTree = "<group>"; };
@@ -32124,6 +32129,7 @@
 				52597BB82DC412F500CAAF01 /* ModelPlayerTransformState.h */,
 				52597BE62DC6533200CAAF01 /* PlaceholderModelPlayer.cpp */,
 				52597BE52DC6533200CAAF01 /* PlaceholderModelPlayer.h */,
+				329D390B53E4795024178E9D /* PortalTransform.h */,
 				B6621298300A6EA900330D60 /* SpatialPortalController.cpp */,
 				B6621297300A6EA900330D60 /* SpatialPortalController.h */,
 			);
@@ -37995,6 +38001,8 @@
 				BC3CC1DF2DE39A910032971C /* StylePerspective.cpp */,
 				BC3CC1DE2DE38F450032971C /* StylePerspective.h */,
 				BCD9F1772E2040DC00D1C3DF /* StylePerspectiveOrigin.h */,
+				B3EC871297BD15E272BE6D00 /* StylePortalTransform.cpp */,
+				C7CE9CAD86C00846197AE7D5 /* StylePortalTransform.h */,
 				BC3CC1F42DE4CBF40032971C /* StyleRotate.cpp */,
 				BC3CC1F32DE4CBF40032971C /* StyleRotate.h */,
 				BC3CC1F02DE3ECF30032971C /* StyleScale.cpp */,
@@ -48055,6 +48063,7 @@
 				ABC128770B33AA6D00C693D5 /* PopupMenuClient.h in Headers */,
 				BC3BE12B0E98092F00835588 /* PopupMenuStyle.h in Headers */,
 				37F567CE165358F400DDE92B /* PopupOpeningObserver.h in Headers */,
+				053F6589A66D76BEEA136C23 /* PortalTransform.h in Headers */,
 				86EB71C0298C0A0F00C1DC77 /* PortIdentifier.h in Headers */,
 				93F199DE08245E59001E9ABC /* Position.h in Headers */,
 				9746AF2C14F4DDE6003E7A70 /* PositionCallback.h in Headers */,
@@ -49149,6 +49158,7 @@
 				BCD9F1782E2040DC00D1C3DF /* StylePerspectiveOrigin.h in Headers */,
 				BC4F32B82E89C4DA00F6AEC1 /* StylePerspectiveTransformFunction.h in Headers */,
 				BCB2720E2CC1F1DB00265123 /* StylePolygonFunction.h in Headers */,
+				B006BDF1E82CF048027EA54E /* StylePortalTransform.h in Headers */,
 				BCB272212CC20CAC00265123 /* StylePosition.h in Headers */,
 				BC452A502ECF9E5300FD066C /* StylePositionAnchor.h in Headers */,
 				BC452A0F2ECCF26F00FD066C /* StylePositionArea.h in Headers */,

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7928,6 +7928,26 @@
                 "url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty"
             }
         },
+        "portal-transform": {
+            "animation-type": "discrete",
+            "initial": "auto",
+            "values": [
+                "none",
+                "auto"
+            ],
+            "codegen-properties": {
+                "enable-if": "ENABLE_SPATIAL_PORTAL",
+                "settings-flag": "spatialPortalEnabled",
+                "computed-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "computed-style-storage-kind": "reference",
+                "computed-style-type": "Style::PortalTransform",
+                "parser-grammar": "<<values>>"
+            },
+            "specification": {
+                "url": "https://webkit.github.io/explainers/css-spatial/Overview.html#portals"
+            },
+            "status": "in development"
+        },
         "position": {
             "animation-type": "discrete",
             "initial": "static",

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -118,6 +118,8 @@
 #if ENABLE(SPATIAL_PORTAL)
 #include "ElementAncestorIteratorInlines.h"
 #include "HTMLModelElement.h"
+#include "SpatialPortalController.h"
+#include "StylePortalTransform.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #endif
 
@@ -387,6 +389,15 @@ static void spatialPortalStyleDidChange(Element& element)
     for (Ref model : descendantsOfType<HTMLModelElement>(element))
         model->spatialPortalContextDidChange();
 }
+
+// TODO: rdar://182292652
+static PortalTransformKind portalTransformKind(const Style::PortalTransform& portalTransform)
+{
+    return portalTransform.switchOn(
+        [](CSS::Keyword::None) { return PortalTransformKind::None; },
+        [](CSS::Keyword::Auto) { return PortalTransformKind::Auto; }
+    );
+}
 #endif
 
 void RenderBox::styleDidChange(Style::Difference diff, const Style::ComputedStyle* oldStyle)
@@ -505,10 +516,15 @@ void RenderBox::styleDidChange(Style::Difference diff, const Style::ComputedStyl
         layoutContext().invalidateAnchorDependenciesForScroller(*this);
 
 #if ENABLE(SPATIAL_PORTAL)
-    auto oldSpatial = oldStyle ? oldStyle->spatial() : SpatialType::None;
-    if (oldSpatial != newStyle.spatial()) {
-        if (RefPtr element = this->element())
+    if (RefPtr element = this->element()) {
+        auto oldSpatial = oldStyle ? oldStyle->spatial() : SpatialType::None;
+        if (oldSpatial != newStyle.spatial())
             spatialPortalStyleDidChange(*element);
+
+        if (newStyle.spatial() == SpatialType::Portal) {
+            if (CheckedPtr controller = element->spatialPortalController())
+                controller->setPortalTransform(portalTransformKind(newStyle.portalTransform()));
+        }
     }
 #endif
 }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1859,6 +1859,13 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
     if (is<RenderModel>(renderer()))
         downcast<HTMLModelElement>(renderer().element())->sizeMayHaveChanged();
 #endif
+
+#if ENABLE(SPATIAL_PORTAL)
+    if (RefPtr element = renderer().element()) {
+        if (CheckedPtr controller = element->spatialPortalController())
+            controller->sizeMayHaveChanged();
+    }
+#endif
 }
 
 void RenderLayerBacking::adjustOverflowControlsPositionRelativeToAncestor(const RenderLayer& ancestorLayer)

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -315,6 +315,7 @@ struct OverflowClipMargin;
 struct PaddingEdge;
 struct PageSize;
 struct Perspective;
+struct PortalTransform;
 struct Position;
 struct PositionAnchor;
 struct PositionArea;

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
@@ -68,6 +68,11 @@ NonInheritedRareData::NonInheritedRareData()
     , rotate(ComputedStyle::initialRotate())
     , scale(ComputedStyle::initialScale())
     , translate(ComputedStyle::initialTranslate())
+#if ENABLE(SPATIAL_PORTAL)
+    , portalTransform(ComputedStyle::initialPortalTransform())
+#else
+    , portalTransform(CSS::Keyword::Auto { })
+#endif
     , containerNames(ComputedStyle::initialContainerNames())
     , viewTransitionClasses(ComputedStyle::initialViewTransitionClasses())
     , viewTransitionName(ComputedStyle::initialViewTransitionName())
@@ -180,6 +185,7 @@ inline NonInheritedRareData::NonInheritedRareData(const NonInheritedRareData& o)
     , rotate(o.rotate)
     , scale(o.scale)
     , translate(o.translate)
+    , portalTransform(o.portalTransform)
     , containerNames(o.containerNames)
     , viewTransitionClasses(o.viewTransitionClasses)
     , viewTransitionName(o.viewTransitionName)
@@ -300,6 +306,7 @@ bool NonInheritedRareData::operator==(const NonInheritedRareData& o) const
         && rotate == o.rotate
         && scale == o.scale
         && translate == o.translate
+        && portalTransform == o.portalTransform
         && containerNames == o.containerNames
         && columnGap == o.columnGap
         && rowGap == o.rowGap
@@ -440,6 +447,7 @@ void NonInheritedRareData::dumpDifferences(TextStream& ts, const NonInheritedRar
     LOG_IF_DIFFERENT(rotate);
     LOG_IF_DIFFERENT(scale);
     LOG_IF_DIFFERENT(translate);
+    LOG_IF_DIFFERENT(portalTransform);
 
     LOG_IF_DIFFERENT(containerNames);
 

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
@@ -53,6 +53,7 @@
 #include <WebCore/StylePageSize.h>
 #include <WebCore/StylePerspective.h>
 #include <WebCore/StylePerspectiveOrigin.h>
+#include <WebCore/StylePortalTransform.h>
 #include <WebCore/StylePositionAnchor.h>
 #include <WebCore/StylePositionArea.h>
 #include <WebCore/StylePositionTryFallbacks.h>
@@ -168,6 +169,7 @@ public:
     Rotate rotate;
     Scale scale;
     Translate translate;
+    PortalTransform portalTransform;
 
     ContainerNames containerNames;
 

--- a/Source/WebCore/style/values/transforms/StylePortalTransform.cpp
+++ b/Source/WebCore/style/values/transforms/StylePortalTransform.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StylePortalTransform.h"
+
+#include "CSSKeywordValue.h"
+#include "StyleBuilderChecking.h"
+
+namespace WebCore {
+namespace Style {
+
+auto CSSValueConversion<PortalTransform>::operator()(BuilderState& state, const CSSValue& value) -> PortalTransform
+{
+    if (auto* keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
+        switch (keywordValue->valueID()) {
+        case CSSValueAuto:
+            return CSS::Keyword::Auto { };
+        case CSSValueNone:
+            return CSS::Keyword::None { };
+        default:
+            break;
+        }
+    }
+
+    state.setCurrentPropertyInvalidAtComputedValueTime();
+    return CSS::Keyword::Auto { };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/transforms/StylePortalTransform.h
+++ b/Source/WebCore/style/values/transforms/StylePortalTransform.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// TODO: rdar://182292652
+struct PortalTransform {
+    constexpr PortalTransform(CSS::Keyword::Auto)
+        : m_type { Type::Auto }
+    {
+    }
+
+    constexpr PortalTransform(CSS::Keyword::None)
+        : m_type { Type::None }
+    {
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        switch (m_type) {
+        case Type::Auto:
+            return visitor(CSS::Keyword::Auto { });
+        case Type::None:
+            return visitor(CSS::Keyword::None { });
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    constexpr bool operator==(const PortalTransform&) const = default;
+
+private:
+    enum class Type : uint8_t { Auto, None };
+    Type m_type;
+};
+
+template<> struct CSSValueConversion<PortalTransform> { PortalTransform NODELETE operator()(BuilderState&, const CSSValue&); };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::PortalTransform)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -8779,6 +8779,25 @@ bool Internals::establishesSpatialPortal(Element& element)
 {
     return element.establishesSpatialPortal();
 }
+
+// Returned as column-major values.
+std::optional<Vector<double>> Internals::spatialPortalResolvedTransform(Element& element)
+{
+    CheckedPtr controller = element.spatialPortalController();
+    if (!controller)
+        return std::nullopt;
+
+    auto& transform = controller->resolvedPortalTransform();
+    if (!transform)
+        return std::nullopt;
+
+    return Vector<double> {
+        transform->m11(), transform->m12(), transform->m13(), transform->m14(),
+        transform->m21(), transform->m22(), transform->m23(), transform->m24(),
+        transform->m31(), transform->m32(), transform->m33(), transform->m34(),
+        transform->m41(), transform->m42(), transform->m43(), transform->m44()
+    };
+}
 #endif
 
 // FIXME: Implement this method for iOS.

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1697,6 +1697,7 @@ public:
     unsigned NODELETE numberOfHostedModelsInSpatialPortal(Element&);
     unsigned NODELETE numberOfLoadedModelsInSpatialPortal(Element&);
     bool NODELETE establishesSpatialPortal(Element&);
+    std::optional<Vector<double>> NODELETE spatialPortalResolvedTransform(Element&);
 #endif
 
     ExceptionOr<void> copyImageAtLocation(int x, int y);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1554,6 +1554,7 @@ enum ContentsFormat {
     [Conditional=SPATIAL_PORTAL] unsigned long numberOfHostedModelsInSpatialPortal(Element element);
     [Conditional=SPATIAL_PORTAL] unsigned long numberOfLoadedModelsInSpatialPortal(Element element);
     [Conditional=SPATIAL_PORTAL] boolean establishesSpatialPortal(Element element);
+    [Conditional=SPATIAL_PORTAL] sequence<unrestricted double>? spatialPortalResolvedTransform(Element element);
 
     undefined copyImageAtLocation(long x, long y);
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -167,6 +167,9 @@ public:
     void setCurrentTime(WebCore::NodeIdentifier, Seconds, CompletionHandler<void()>&&) final;
     void setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data) final;
     void setHasPortal(bool) final;
+#if ENABLE(SPATIAL_PORTAL)
+    void setPortalTransform(WebCore::PortalTransformKind) final;
+#endif
     void setStageMode(WebCore::StageModeOperation) final;
     void beginStageModeTransform(const WebCore::TransformationMatrix&) final;
     void updateStageModeTransform(const WebCore::TransformationMatrix&) final;
@@ -205,7 +208,7 @@ private:
     void applyStageModeOperationToDriver();
     bool stageModeInteractionInProgress() const;
     void updateTransformSRT();
-    void notifyModelPlayerOfEntityTransformChange();
+    void notifyModelPlayerOfTransformChange();
     void applyDefaultIBL();
     void updateForCurrentStageMode();
     void setUpLoadedEntity(WKRKEntity *);
@@ -254,6 +257,9 @@ private:
 
     RefPtr<WebCore::SharedBuffer> m_transientEnvironmentMapData;
     bool m_hasPortal { true };
+#if ENABLE(SPATIAL_PORTAL)
+    WebCore::PortalTransformKind m_portalTransform { WebCore::PortalTransformKind::Auto };
+#endif
 
     // For interactions
     RetainPtr<WKStageModeInteractionDriver> m_stageModeInteractionDriver;

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -46,6 +46,9 @@ messages -> ModelProcessModelPlayerProxy {
     SetCurrentTime(WebCore::NodeIdentifier nodeID, Seconds currentTime) -> () Async
     SetEnvironmentMap(Ref<WebCore::SharedBuffer> data)
     SetHasPortal(bool hasPortal)
+#if ENABLE(SPATIAL_PORTAL)
+    [EnabledBy=SpatialPortalEnabled] SetPortalTransform(enum:uint8_t WebCore::PortalTransformKind kind)
+#endif
     SetStageMode(enum:bool WebCore::StageModeOperation stagemodeOp)
     BeginStageModeTransform(WebCore::TransformationMatrix transform)
     UpdateStageModeTransform(WebCore::TransformationMatrix transform)

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -486,6 +486,8 @@ void ModelProcessModelPlayerProxy::unloadModelTimerFired()
 
 // MARK: - RE stuff
 
+constexpr float defaultScaleFactor = 0.36f;
+
 static inline simd_float2 makeMeterSizeFromPointSize(CGSize pointSize, CGFloat pointsPerMeter)
 {
     return simd_make_float2(pointSize.width / pointsPerMeter, pointSize.height / pointsPerMeter);
@@ -550,6 +552,24 @@ static RESRT computeSRT(CALayer *layer, simd_float3 originalBoundingBoxExtents, 
     return srt;
 }
 
+#if ENABLE(SPATIAL_PORTAL)
+static RESRT computeUnfittedSRT(simd_float3 originalBoundingBoxExtents, simd_float3 originalBoundingBoxCenter, simd_quatf currentModelRotation)
+{
+    constexpr float cssUnitScale = 1.0f / defaultScaleFactor;
+
+    RESRT srt;
+    srt.scale = simd_make_float3(cssUnitScale, cssUnitScale, cssUnitScale);
+    srt.rotation = currentModelRotation;
+
+    simd_float3 boundingBoxCenter = cssUnitScale * originalBoundingBoxCenter;
+    float boundingBoxDepth = cssUnitScale * originalBoundingBoxExtents.z;
+
+    srt.translation = simd_make_float3(-boundingBoxCenter.x, -boundingBoxCenter.y, -boundingBoxCenter.z - boundingBoxDepth / 2.0f);
+
+    return srt;
+}
+#endif
+
 static CGFloat effectivePointsPerMeter(CALayer *caLayer)
 {
     constexpr CGFloat defaultPointsPerMeter = 1360;
@@ -571,8 +591,6 @@ RESRT ModelProcessModelPlayerProxy::modelStandardizedTransformSRT(RESRT original
         return originalSRT;
 #endif
 
-    constexpr float defaultScaleFactor = 0.36f;
-
     originalSRT.scale *= defaultScaleFactor;
     originalSRT.translation *= defaultScaleFactor;
 
@@ -586,8 +604,6 @@ RESRT ModelProcessModelPlayerProxy::modelLocalizedTransformSRT(RESRT originalSRT
         return originalSRT;
 #endif
 
-    constexpr float defaultScaleFactor = 0.36f;
-
     originalSRT.scale /= defaultScaleFactor;
     originalSRT.translation /= defaultScaleFactor;
 
@@ -599,10 +615,7 @@ void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
     if (m_hostedEntities.isEmpty() || !m_layer)
         return;
 
-    // The portal is fitted to every model it hosts, so the union of their bounding boxes drives the
-    // container transform.
-    // FIXME: rdar://182292321 - Models are all placed at the container origin until portal-transform
-    // and spatial positioning land, so the union is centred on that origin.
+    // TODO: Once we have spatial positioninig the union won't be centered on the origin anymore.
     simd_float3 minBound = simd_make_float3(0, 0, 0);
     simd_float3 maxBound = simd_make_float3(0, 0, 0);
     bool hasBounds = false;
@@ -626,6 +639,17 @@ void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
     simd_float3 boundingBoxExtents = maxBound - minBound;
     simd_float3 boundingBoxCenter = (maxBound + minBound) / 2;
 
+    simd_quatf currentModelRotation = setDefaultRotation ? simd_quaternion(0, simd_make_float3(1, 0, 0)) : m_transformSRT.rotation;
+
+#if ENABLE(SPATIAL_PORTAL)
+    bool skipAutoFit = m_portalTransform == WebCore::PortalTransformKind::None;
+    if (skipAutoFit) {
+        m_transformSRT = computeUnfittedSRT(boundingBoxExtents, boundingBoxCenter, currentModelRotation);
+        notifyModelPlayerOfTransformChange();
+        return;
+    }
+#endif
+
     // Each model's bounding sphere has to be reached from the merged centre, not from its own, so
     // an off-centre sibling widens the radius by its distance rather than being swallowed by it.
     float boundingRadius = 0;
@@ -637,8 +661,6 @@ void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
         boundingRadius = std::max(boundingRadius, simd_length(hostedEntity.originalBoundingBoxCenter - boundingBoxCenter) + entityRadius);
     }
 
-    // FIXME: Use the value of the 'object-fit' property here to compute an appropriate SRT.
-    simd_quatf currentModelRotation = setDefaultRotation ? simd_quaternion(0, simd_make_float3(1, 0, 0)) : m_transformSRT.rotation;
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     RESRT newSRT = computeSRT(m_layer.get(), boundingBoxExtents, boundingBoxCenter, boundingRadius, m_hasPortal, effectivePointsPerMeter(m_layer.get()), m_stageModeOperation, currentModelRotation, m_immersivePresentation);
 #else
@@ -646,17 +668,22 @@ void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
 #endif
     m_transformSRT = newSRT;
 
-    notifyModelPlayerOfEntityTransformChange();
+    notifyModelPlayerOfTransformChange();
 }
 
-void ModelProcessModelPlayerProxy::notifyModelPlayerOfEntityTransformChange()
+void ModelProcessModelPlayerProxy::notifyModelPlayerOfTransformChange()
 {
-    if (!m_nodeID)
-        return;
-
     RESRT newSRT = modelStandardizedTransformSRT(m_transformSRT);
     simd_float4x4 matrix = RESRTMatrix(newSRT);
     WebCore::TransformationMatrix transform = WebCore::TransformationMatrix(matrix);
+
+#if ENABLE(SPATIAL_PORTAL)
+    send(Messages::ModelProcessModelPlayer::DidUpdatePortalTransform(transform));
+#endif
+
+    if (!m_nodeID)
+        return;
+
     send(Messages::ModelProcessModelPlayer::DidUpdateEntityTransform(*m_nodeID, transform));
 }
 
@@ -793,7 +820,7 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
 
     if (m_entityTransformToRestore) {
         setEntityTransform(nodeID, *m_entityTransformToRestore);
-        notifyModelPlayerOfEntityTransformChange();
+        notifyModelPlayerOfTransformChange();
         m_entityTransformToRestore = std::nullopt;
     } else {
         computeTransform(true);
@@ -1319,6 +1346,21 @@ void ModelProcessModelPlayerProxy::setHasPortal(bool hasPortal)
     updateTransform();
 }
 
+#if ENABLE(SPATIAL_PORTAL)
+
+void ModelProcessModelPlayerProxy::setPortalTransform(WebCore::PortalTransformKind kind)
+{
+    if (m_portalTransform == kind)
+        return;
+
+    m_portalTransform = kind;
+
+    computeTransform(m_stageModeOperation == WebCore::StageModeOperation::None);
+    updateTransform();
+}
+
+#endif
+
 void ModelProcessModelPlayerProxy::updateForCurrentStageMode()
 {
     if (m_stageModeOperation != WebCore::StageModeOperation::None) {
@@ -1373,7 +1415,7 @@ void ModelProcessModelPlayerProxy::updateTransformSRT()
     };
 #endif
 
-    notifyModelPlayerOfEntityTransformChange();
+    notifyModelPlayerOfTransformChange();
 }
 
 #if HAVE(CORE_RE)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1391,6 +1391,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::PlaybackTargetClientContextID': ['<WebCore/PlaybackTargetClientContextIdentifier.h>'],
         'WebCore::PluginInfo': ['<WebCore/PluginData.h>'],
         'WebCore::PolicyAction': ['<WebCore/FrameLoaderTypes.h>'],
+        'WebCore::PortalTransformKind': ['<WebCore/PortalTransform.h>'],
         'WebCore::NonSerializedDataIdentifier': ['<WebCore/NonSerializedDataIdentifier.h>'],
         'WebCore::PreserveResolution': ['<WebCore/ImageBufferBackend.h>'],
         'WebCore::ProcessIdentifier': ['<WebCore/ProcessIdentifier.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6997,6 +6997,14 @@ header: <WebCore/StageModeOperations.h>
 enum class WebCore::StageModeOperation : bool;
 #endif
 
+#if ENABLE(SPATIAL_PORTAL)
+header: <WebCore/PortalTransform.h>
+enum class WebCore::PortalTransformKind : uint8_t {
+    None,
+    Auto
+};
+#endif
+
 header: <WebCore/FixedContainerEdges.h>
 enum class WebCore::PredominantColorType : uint8_t {
     None,

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -137,6 +137,17 @@ void ModelProcessModelPlayer::didUpdateEntityTransform(WebCore::NodeIdentifier n
     protect(client())->didUpdateEntityTransform(*this, nodeID, transform);
 }
 
+#if ENABLE(SPATIAL_PORTAL)
+
+void ModelProcessModelPlayer::didUpdatePortalTransform(const WebCore::TransformationMatrix& transform)
+{
+    RELEASE_ASSERT(modelProcessEnabled());
+
+    protect(client())->didUpdatePortalTransform(*this, transform);
+}
+
+#endif
+
 void ModelProcessModelPlayer::didUpdateAnimationPlaybackState(WebCore::NodeIdentifier, bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
 {
     RELEASE_ASSERT(modelProcessEnabled());
@@ -443,6 +454,19 @@ void ModelProcessModelPlayer::setHasPortal(bool hasPortal)
     m_hasPortal = hasPortal;
     send(Messages::ModelProcessModelPlayerProxy::SetHasPortal(m_hasPortal));
 }
+
+#if ENABLE(SPATIAL_PORTAL)
+
+void ModelProcessModelPlayer::setPortalTransform(WebCore::PortalTransformKind kind)
+{
+    if (m_portalTransform == kind)
+        return;
+
+    m_portalTransform = kind;
+    send(Messages::ModelProcessModelPlayerProxy::SetPortalTransform(m_portalTransform));
+}
+
+#endif
 
 void ModelProcessModelPlayer::setStageMode(WebCore::StageModeOperation stagemodeOp)
 {

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -78,6 +78,9 @@ private:
     void didConvertModelData(Ref<WebCore::SharedBuffer>&&, const String& convertedMIMEType);
     void didFailLoading(WebCore::NodeIdentifier);
     void didUpdateEntityTransform(WebCore::NodeIdentifier, const WebCore::TransformationMatrix&);
+#if ENABLE(SPATIAL_PORTAL)
+    void didUpdatePortalTransform(const WebCore::TransformationMatrix&);
+#endif
     void didUpdateAnimationPlaybackState(WebCore::NodeIdentifier, bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp);
     void didFinishEnvironmentMapLoading(bool succeeded);
 
@@ -120,6 +123,9 @@ private:
     void setCurrentTime(WebCore::NodeIdentifier, Seconds, CompletionHandler<void()>&&) final;
     void setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data) final;
     void setHasPortal(bool) final;
+#if ENABLE(SPATIAL_PORTAL)
+    void setPortalTransform(WebCore::PortalTransformKind) final;
+#endif
     void setStageMode(WebCore::StageModeOperation) final;
     void beginStageModeTransform(const WebCore::TransformationMatrix&) final;
     void updateStageModeTransform(const WebCore::TransformationMatrix&) final;
@@ -142,6 +148,9 @@ private:
     std::optional<WebCore::FloatPoint3D> m_boundingBoxCenter;
     std::optional<WebCore::FloatPoint3D> m_boundingBoxExtents;
     bool m_hasPortal { true };
+#if ENABLE(SPATIAL_PORTAL)
+    WebCore::PortalTransformKind m_portalTransform { WebCore::PortalTransformKind::Auto };
+#endif
     WebCore::StageModeOperation m_stageModeOperation { WebCore::StageModeOperation::None };
     double m_requestedPlaybackRate { 1.0 };
     std::optional<Seconds> m_pendingCurrentTime;

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
@@ -33,6 +33,9 @@ messages -> ModelProcessModelPlayer {
     DidConvertModelData(Ref<WebCore::SharedBuffer> convertedData, String convertedMIMEType)
     DidFailLoading(WebCore::NodeIdentifier nodeID)
     DidUpdateEntityTransform(WebCore::NodeIdentifier nodeID, WebCore::TransformationMatrix transform)
+#if ENABLE(SPATIAL_PORTAL)
+    [EnabledBy=SpatialPortalEnabled] DidUpdatePortalTransform(WebCore::TransformationMatrix transform)
+#endif
     DidUpdateAnimationPlaybackState(WebCore::NodeIdentifier nodeID, bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
     DidFinishEnvironmentMapLoading(bool succeeded)
     DidUnload()


### PR DESCRIPTION
#### 4dcc225071c9dad4c6d86fbb4e461f6349c91f1d
<pre>
Add initial `portal-transform` support
<a href="https://bugs.webkit.org/show_bug.cgi?id=320915">https://bugs.webkit.org/show_bug.cgi?id=320915</a>
&lt;<a href="https://rdar.apple.com/182292321">rdar://182292321</a>&gt;

Reviewed by Mike Wyrzykowski.

Add initial support `portal-transform` support to Spatial Portals. For
now just auto / none to expose the &quot;auto fit&quot; behavior.

Tests: spatial-css/spatial-portal-transform-auto-dynamic.html
       spatial-css/spatial-portal-transform-auto.html
       spatial-css/spatial-portal-transform-none.html
       spatial-css/spatial-portal-transform-off.html
       spatial-css/spatial-portal-transform-parsing.html

* LayoutTests/spatial-css/resources/spatial-portal-utils.js:
(const.createPortal):
(const.portalTransformsApproxEqual):
(async waitForPortalTransform):
* LayoutTests/spatial-css/spatial-portal-transform-auto-dynamic-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-transform-auto-dynamic.html: Added.
* LayoutTests/spatial-css/spatial-portal-transform-auto-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-transform-auto.html: Added.
* LayoutTests/spatial-css/spatial-portal-transform-none-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-transform-none.html: Added.
* LayoutTests/spatial-css/spatial-portal-transform-off-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-transform-off.html: Added.
* LayoutTests/spatial-css/spatial-portal-transform-parsing-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-transform-parsing.html: Added.
Add a new batch of tests covering the portal-transform property, dynamic
toggle and adding/removing nested models.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
Make sure we can flag the new IPC call with
`[EnabledBy=SpatialPortalEnabled]`.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/Headers.cmake:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp:
(WebCore::Style::portalTransform):
(WebCore::Style::NonInheritedRareData::NonInheritedRareData):
(WebCore::Style::NonInheritedRareData::operator== const):
(WebCore::Style::NonInheritedRareData::dumpDifferences const):
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.h:
* Source/WebCore/style/values/transforms/StylePortalTransform.cpp: Added.
(WebCore::Style::CSSValueConversion&lt;PortalTransform&gt;::operator):
* Source/WebCore/style/values/transforms/StylePortalTransform.h: Added.
(WebCore::Style::PortalTransform::PortalTransform):
(WebCore::Style::PortalTransform::switchOn const):
* Source/WebCore/Modules/model-element/PortalTransform.h: Added.
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
Add the `portal-transform` CSS property, defaults to `auto`.

* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::setPortalTransform):
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/ModelPlayerClient.h:
* Source/WebCore/Modules/model-element/SpatialPortalController.cpp:
(WebCore::SpatialPortalController::ensureModelPlayer):
(WebCore::SpatialPortalController::setPortalTransform):
(WebCore::SpatialPortalController::deleteModelPlayer):
(WebCore::SpatialPortalController::sizeMayHaveChanged):
(WebCore::SpatialPortalController::modelDidUpdatePortalTransform):
* Source/WebCore/Modules/model-element/SpatialPortalController.h:
(WebCore::SpatialPortalController::resolvedPortalTransform const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::portalTransformKind):
(WebCore::RenderBox::styleDidChange):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateGeometry):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::didUpdatePortalTransform):
(WebKit::ModelProcessModelPlayer::setPortalTransform):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in:
Wire the `portal-transform` property and formalize the portal transform
concept with its own IPC.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::computeUnfittedSRT):
(WebKit::ModelProcessModelPlayerProxy::modelStandardizedTransformSRT):
(WebKit::ModelProcessModelPlayerProxy::modelLocalizedTransformSRT):
(WebKit::ModelProcessModelPlayerProxy::computeTransform):
(WebKit::ModelProcessModelPlayerProxy::notifyModelPlayerOfTransformChange):
(WebKit::ModelProcessModelPlayerProxy::notifyModelPlayerOfEntityTransformChange): Deleted.
Renamed now that is handles entity and global transforms.
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::setPortalTransform):
(WebKit::ModelProcessModelPlayerProxy::updateTransformSRT):
In parallel of standalone model concerns (StageMode, Immersive etc...),
clearly skip the &quot;auto fit&quot; behavior on Spatial Portals when the
`spatial-transform` is set to `none`.
This keeps the model at true scale but still positions it &quot;behind the
glass&quot;.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::spatialPortalResolvedTransform):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
Expose the computed portal transform to tests. Still debating how to
expose it to Web Content in general.

Canonical link: <a href="https://commits.webkit.org/318536@main">https://commits.webkit.org/318536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0a4a3a8f83c511854080e4bf1b2e097aff5e43f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188049 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141681 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/748c3989-828e-409a-9734-95796d39ad67) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139115 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/63e79759-6ade-435e-90e8-a12eb767b0d7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42670 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159868 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119569 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/667bb0a6-c27e-43ba-b2b1-ae985e701a4f) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/177921 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41336 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39687 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1538 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8357 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39367 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36504 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39706 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190476 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159392 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148266 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39845 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52721 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148037 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42751 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124987 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119624 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51239 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14342 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50624 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50864 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50686 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->