### PR TITLE
Widen JS Temporal time zone cache in TimeZoneICUBridge.cpp

### DIFF
--- a/JSTests/microbenchmarks/temporal-zoned-date-time-time-zone-cache.js
+++ b/JSTests/microbenchmarks/temporal-zoned-date-time-time-zone-cache.js
@@ -1,0 +1,19 @@
+//@ requireOptions("--useTemporal=1")
+
+// Guards the UCalendar TinyLRUCache in TimeZoneICUBridge.cpp (timeZoneCacheEntry,
+// capacity 16). Cycling 12 named zones fits the cache; a smaller capacity evicts
+// before reuse and pays ucal_open (~900ns) on every access.
+const zones = [
+    "America/Vancouver", "America/Denver", "America/Chicago", "America/New_York",
+    "America/Sao_Paulo", "Europe/London", "Europe/Paris", "Africa/Cairo",
+    "Asia/Kolkata", "Asia/Tokyo", "Australia/Sydney", "Pacific/Auckland",
+];
+const instant = Temporal.Instant.fromEpochMilliseconds(1750000000000); // 2025-06-15T15:06:40Z
+const zdts = zones.map(zone => instant.toZonedDateTimeISO(zone));
+
+let acc = 0;
+for (var i = 0; i < 2400000; ++i)
+    acc += zdts[i % zdts.length].offsetNanoseconds / 900e9; // ICU offset lookup per iteration
+
+if (acc !== 14000000)
+    throw "Bad result: " + acc;

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -61,7 +61,7 @@ struct TimeZoneLRUCachePolicy {
 static RefPtr<TimeZoneCacheEntry> timeZoneCacheEntry(const TimeZone& timeZone)
 {
     static Lock cacheLock;
-    static LazyNeverDestroyed<TinyLRUCache<TimeZone, RefPtr<TimeZoneCacheEntry>, 8, TimeZoneLRUCachePolicy>> cache;
+    static LazyNeverDestroyed<TinyLRUCache<TimeZone, RefPtr<TimeZoneCacheEntry>, 16, TimeZoneLRUCachePolicy>> cache;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         cache.construct();


### PR DESCRIPTION
#### 8776c95a1b0ab0ff7361f3cbf66b4efc625328ee
<pre>
Widen JS Temporal time zone cache in TimeZoneICUBridge.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=320917">https://bugs.webkit.org/show_bug.cgi?id=320917</a>
<a href="https://rdar.apple.com/183947401">rdar://183947401</a>

Reviewed by Yusuke Suzuki.

Proposal test durationtotal was slightly below V8 with the original
cache size 8, and raising the size to 16 brings it to parity.

                                                     ToT                      Change
temporal-zoned-date-time-time-zone-cache      242.0512+-4.0773          241.3375+-4.3303
&lt;geometric&gt;                                   242.0512+-4.0773          241.3375+-4.3303          might be 1.0030x faster

Test: JSTests/microbenchmarks/temporal-zoned-date-time-time-zone-cache.js

* JSTests/microbenchmarks/temporal-zoned-date-time-time-zone-cache.js: Added.
* Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp:
(JSC::TemporalCore::timeZoneCacheEntry):

Canonical link: <a href="https://commits.webkit.org/318588@main">https://commits.webkit.org/318588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c0eabb90c02716b8608a1ac20eb6d45e014f377

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141729 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ea36239-039b-490a-9e13-a29bfafd72fc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139148 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/701bcbfa-8fac-4727-8a52-8c30dee11f0d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42709 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119602 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4de368f-7979-4328-b8ad-d99b21c11337) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41375 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39721 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1571 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8388 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39398 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36551 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39753 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190523 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52087 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148304 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/39826 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52768 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36022 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148075 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27118 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42789 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125034 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119671 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51286 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14373 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50671 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50911 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50733 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->