### PR TITLE
[ews] Add validation for git author email address

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='7.0.3',
+    version='7.0.5',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     long_description_content_type='text/markdown',

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -50,7 +50,7 @@ except ImportError:
         "See https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy"
     )
 
-version = Version(7, 0, 4)
+version = Version(7, 0, 5)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('markupsafe', Version(3, 0, 3), pypi_name='MarkupSafe', wheel=True))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
@@ -179,7 +179,7 @@ class Commit(object):
         hash=None,
         revision=None,
         identifier=None, branch=None, branch_point=None,
-        timestamp=None, author=None, message=None, order=None, repository_id=None
+        timestamp=None, author=None, message=None, order=None, repository_id=None, committer=None
     ):
         self.hash = self._parse_hash(hash, do_assert=True)
         self.revision = self._parse_revision(revision, do_assert=True)
@@ -235,6 +235,18 @@ class Commit(object):
             raise TypeError("Expected 'author' to be of type {}, got '{}'".format(Contributor, author))
         else:
             self.author = author
+
+        if committer and isinstance(committer, dict) and committer.get('name'):
+            emails = committer.get('emails', [])
+            if committer.get('email'):
+                emails.append(committer.get('email'))
+            self.committer = Contributor(committer.get('name'), emails)
+        elif committer and isinstance(committer, string_utils.basestring) and '@' in committer:
+            self.committer = Contributor(committer, [committer])
+        elif committer and not isinstance(committer, Contributor):
+            raise TypeError("Expected 'committer' to be of type {}, got '{}'".format(Contributor, committer))
+        else:
+            self.committer = committer
 
         if message and not isinstance(message, string_utils.basestring):
             raise ValueError("Expected 'message' to be a string, got '{}'".format(message))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -952,10 +952,13 @@ class Git(Scm):
         # Parse git log output, handling both normal and merge commits (which have an extra 'Merge:' line)
         log_lines = log.stdout.splitlines()
         author_line = None
+        committer_line = None
         message_start_index = None
         for i, line in enumerate(log_lines):
             if line.startswith('Author:'):
                 author_line = line
+            if line.startswith('Commit:'):
+                committer_line = line
             # The message starts after the first blank line following the header
             if message_start_index is None and not line.strip() and i > 0:
                 message_start_index = i + 1
@@ -1005,11 +1008,13 @@ class Git(Scm):
             timestamp=timestamp,
             order=order,
             author=Contributor.from_scm_log(author_line, self.contributors),
+            committer=Contributor.from_scm_log(committer_line.replace('Commit:', 'Author:', 1), self.contributors) if committer_line else None,
             message=logcontent if include_log else None,
         )
 
     def _args_from_content(self, content, include_log=True):
         author = None
+        committer = None
         timestamp = None
 
         # Parse header lines dynamically to handle merge commits (which have an extra 'Merge:' line)
@@ -1019,6 +1024,8 @@ class Git(Scm):
             split = line.split(': ')
             if split[0] == 'Author':
                 author = Contributor.from_scm_log(line.lstrip(), self.contributors)
+            elif split[0] == 'Commit':
+                committer = Contributor.from_scm_log(line.replace('Commit:', 'Author:', 1).lstrip(), self.contributors)
             elif split[0] == 'CommitDate':
                 timestamp = int(line.split(' ')[-1])
             # The message starts after the first blank line following the header
@@ -1037,6 +1044,7 @@ class Git(Scm):
         return dict(
             revision=int(matches[-1].split('@')[0]) if matches else None,
             author=author,
+            committer=committer,
             timestamp=timestamp,
             message=message.rstrip() if include_log else None,
         )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -372,12 +372,13 @@ nothing to commit, working tree clean
                         'commit {hash}\n'
                         'Author:     {author} <{email}>\n'
                         'AuthorDate: {date}\n'
-                        'Commit:     {author} <{email}>\n'
+                        'Commit:     {committer}\n'
                         'CommitDate: {date}\n'
                         '\n{log}\n'.format(
                             hash=commit.hash,
                             author=commit.author.name,
                             email=commit.author.email,
+                            committer=getattr(commit, 'committer', None) or commit.author,
                             date=commit.timestamp,
                             log='\n'.join(
                                 [

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -480,6 +480,30 @@ class PullRequest(Command):
             sys.stderr.write("'{}' is not a remote in this repository\n".format(source_remote))
             return 1
 
+        # Check identities before rebasing, a rebase resets the committer of every commit it rewrites
+        mismatched = [
+            commit for commit in repository.commits(begin=dict(hash=branch_point.hash), end=dict(branch=repository.branch))
+            if commit.author and commit.committer and commit.author.email != commit.committer.email
+        ]
+        if mismatched:
+            for commit in mismatched:
+                log.warning("Commit {} was authored by '{}' but committed by '{}'".format(commit.hash[:12], commit.author, commit.committer))
+            if not args.defaults:
+                try:
+                    response = Terminal.choose(
+                        '{} in this pull request {} a committer which differs from the author\nDo you want to continue?'.format(
+                            string_utils.pluralize(len(mismatched), 'commit'),
+                            'has' if len(mismatched) == 1 else 'have',
+                        ), default='Yes', options=('Yes', 'No'),
+                    )
+                except EOFError:
+                    log.warning('Prompting is impossible, continuing despite the committer mismatch')
+                    response = 'Yes'
+                if response == 'No':
+                    sys.stderr.write('User declined to create a pull request with mismatched author and committer\n')
+                    sys.stderr.write('`git commit --amend --no-edit` refreshes the committer of the current commit from your git configuration\n')
+                    return 1
+
         rebasing = args.rebase if args.rebase is not None else repository.config().get(
             'webkitscmpy.auto-rebase-branch',
             repository.config().get('pull.rebase', 'true'),

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -443,6 +443,44 @@ Rebased 'eng/pr-branch' on 'main!'
 Running pre-PR checks...
 No pre-PR checks to run""")
 
+    def _pull_request_with_mismatched_committer(self, response):
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
+            repo.modified['modified.txt'] = 'diff'
+            self.assertEqual(1, program.main(
+                args=('pull-request', '-i', 'pr-branch', '-v'),
+                path=self.path,
+            ))
+            repo.head.committer = Contributor('test', ['test@test'])
+            with MockTerminal.input(response):
+                self.assertEqual(1, program.main(
+                    args=('pull-request', '-v'),
+                    path=self.path,
+                ))
+
+        self.assertIn(
+            "was authored by 'Tim Apple <tapple@webkit.org>' but committed by 'test <test@test>'",
+            captured.root.log.getvalue(),
+        )
+        self.assertIn('1 commit in this pull request has a committer which differs from the author', captured.stdout.getvalue())
+        return captured
+
+    def test_committer_mismatch_decline(self):
+        captured = self._pull_request_with_mismatched_committer('n')
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            "'{}' doesn't have a recognized remote\n"
+            'User declined to create a pull request with mismatched author and committer\n'
+            '`git commit --amend --no-edit` refreshes the committer of the current commit from your git configuration\n'.format(self.path),
+        )
+
+    def test_committer_mismatch_accept(self):
+        captured = self._pull_request_with_mismatched_committer('y')
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            "'{path}' doesn't have a recognized remote\n"
+            "'{path}' doesn't have a recognized remote\n".format(path=self.path),
+        )
+
     def test_github(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
             self.path, remote='https://{}'.format(remote.remote),


### PR DESCRIPTION
#### 5761defbc62064bddf9edf28ec5338e6a7bf0b5e
<pre>
[ews] Add validation for git author email address
<a href="https://bugs.webkit.org/show_bug.cgi?id=319096">https://bugs.webkit.org/show_bug.cgi?id=319096</a>

Reviewed by NOBODY (OOPS!).

Make `git-webkit pr` warn about every commit in the pull request whose
committer differs from its author and ask a single confirmation question.
Uploads on behalf of someone else remain possible, the identity just becomes
visible at the point where the mistake used to be invisible. The check runs
before the automatic rebase, because a rebase resets the committer of every
commit it rewrites to the current user. With --defaults, or when prompting is
impossible, the check only logs warnings so non-interactive callers keep
working.

Also bump setup.py to match webkitscmpy/__init__.py.

* Tools/Scripts/libraries/webkitscmpy/setup.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py:
(Commit.__init__):
(Commit):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.commit):
(Git._args_from_content):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_pull_request):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5761defbc62064bddf9edf28ec5338e6a7bf0b5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178436 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/188052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180299 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/188052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181393 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/188052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/177759 "Found 1 webkitpy test failure: webkitpy.style.checker_unittest.GlobalVariablesTest.test_webkit_base_filter_rules") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/188052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/36507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190479 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/177839 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/52724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/148040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/52724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->