### PR TITLE
[EvaluationTimeZoom] Line-height units don't work correctly with zoom

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-001-expected.txt
@@ -424,27 +424,27 @@ PASS font-weight font-weight(keyword) / events
 PASS font-weight font-weight(numeric) / values
 PASS font-weight font-weight(numeric) / events
 PASS line-height number(integer) / values
-FAIL line-height number(integer) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "line-height:2s"
+PASS line-height number(integer) / events
 PASS line-height number(decimal) / values
-FAIL line-height number(decimal) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "line-height:2s"
+PASS line-height number(decimal) / events
 PASS line-height length(pt) / values
-FAIL line-height length(pt) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "line-height:2s"
+PASS line-height length(pt) / events
 PASS line-height length(pc) / values
-FAIL line-height length(pc) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "line-height:2s"
+PASS line-height length(pc) / events
 PASS line-height length(px) / values
-FAIL line-height length(px) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "line-height:2s"
+PASS line-height length(px) / events
 PASS line-height length(em) / values
-FAIL line-height length(em) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "line-height:2s"
+PASS line-height length(em) / events
 PASS line-height length(ex) / values
-FAIL line-height length(ex) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "line-height:2s"
+PASS line-height length(ex) / events
 PASS line-height length(mm) / values
-FAIL line-height length(mm) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "line-height:2s"
+PASS line-height length(mm) / events
 PASS line-height length(cm) / values
-FAIL line-height length(cm) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "line-height:2s"
+PASS line-height length(cm) / events
 PASS line-height length(in) / values
-FAIL line-height length(in) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "line-height:2s"
+PASS line-height length(in) / events
 PASS line-height percentage(%) / values
-FAIL line-height percentage(%) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "line-height:2s"
+PASS line-height percentage(%) / events
 PASS letter-spacing length(pt) / values
 PASS letter-spacing length(pt) / events
 PASS letter-spacing length(pc) / values

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/line-height-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/line-height-computed-expected.txt
@@ -1,0 +1,8 @@
+
+PASS element with px line-height
+PASS element with percentage line-height
+PASS parent with px line-height
+PASS parent with percentage line-height
+PASS root with px line-height
+PASS root with percentage line-height
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/line-height-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/line-height-computed.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<body>
+<script>
+test(() => {
+  const target1 = document.createElement("div");
+  document.body.append(target1);
+  const target2 = document.createElement("div");
+  document.body.append(target2);
+
+  try {
+    target1.style = "line-height: 20px; tab-size: 1lh;";
+    target2.style = "line-height: 20px; tab-size: 1lh; zoom: 2;";
+
+    assert_equals(getComputedStyle(target1).tabSize, getComputedStyle(target2).tabSize);
+    assert_equals(getComputedStyle(target1).tabSize, "20px");
+    assert_equals(getComputedStyle(target2).tabSize, "20px");
+  } finally {
+    target1.remove();
+    target2.remove();
+  }
+}, "element with px line-height");
+
+test(() => {
+  const target1 = document.createElement("div");
+  document.body.append(target1);
+  const target2 = document.createElement("div");
+  document.body.append(target2);
+
+  try {
+    target1.style = "font-size: 100px; line-height: 20%; tab-size: 1lh;";
+    target2.style = "font-size: 100px; line-height: 20%; tab-size: 1lh; zoom: 2;";
+
+    assert_equals(getComputedStyle(target1).tabSize, getComputedStyle(target2).tabSize);
+    assert_equals(getComputedStyle(target1).tabSize, "20px");
+    assert_equals(getComputedStyle(target2).tabSize, "20px");
+  } finally {
+    target1.remove();
+    target2.remove();
+  }
+}, "element with percentage line-height");
+
+test(() => {
+  const container1 = document.createElement("div");
+  const target1 = document.createElement("div");
+  container1.appendChild(target1);
+  document.body.append(container1);
+
+  const container2 = document.createElement("div");
+  const target2 = document.createElement("div");
+  container2.appendChild(target2);
+  document.body.append(container2);
+
+  try {
+    container1.style = "line-height: 20px;";
+    target1.style = "font-size: 1lh; line-height: 1lh;";
+
+    container2.style = "line-height: 20px; zoom: 2;";
+    target2.style = "font-size: 1lh; line-height: 1lh;";
+
+    assert_equals(getComputedStyle(target1).fontSize, getComputedStyle(target2).fontSize);
+    assert_equals(getComputedStyle(target1).lineHeight, getComputedStyle(target2).fontSize);
+
+    assert_equals(getComputedStyle(target1).fontSize, '20px');
+    assert_equals(getComputedStyle(target1).lineHeight, '20px');
+    assert_equals(getComputedStyle(target2).fontSize, '20px');
+    assert_equals(getComputedStyle(target2).lineHeight, '20px');
+  } finally {
+    container1.remove();
+    container2.remove()
+  }
+}, "parent with px line-height");
+
+test(() => {
+  const container1 = document.createElement("div");
+  const target1 = document.createElement("div");
+  container1.appendChild(target1);
+  document.body.append(container1);
+
+  const container2 = document.createElement("div");
+  const target2 = document.createElement("div");
+  container2.appendChild(target2);
+  document.body.append(container2);
+
+  try {
+    container1.style = "font-size: 100px; line-height: 20%;";
+    target1.style = "font-size: 1lh; line-height: 1lh;";
+
+    container2.style = "font-size: 100px; line-height: 20%; zoom: 2;";
+    target2.style = "font-size: 1lh; line-height: 1lh;";
+
+    assert_equals(getComputedStyle(target1).fontSize, getComputedStyle(target2).fontSize);
+    assert_equals(getComputedStyle(target1).lineHeight, getComputedStyle(target2).fontSize);
+
+    assert_equals(getComputedStyle(target1).fontSize, '20px');
+    assert_equals(getComputedStyle(target1).lineHeight, '20px');
+    assert_equals(getComputedStyle(target2).fontSize, '20px');
+    assert_equals(getComputedStyle(target2).lineHeight, '20px');
+  } finally {
+    container1.remove();
+    container2.remove()
+  }
+}, "parent with percentage line-height");
+
+test(() => {
+  const target = document.createElement("div");
+  document.body.append(target);
+
+  document.documentElement.style = "line-height: 20px;"
+
+  try {
+    target.style = "font-size: 1rlh; line-height: 1rlh;";
+
+    const unzoomedRootFontSize = getComputedStyle(target).fontSize;
+    const unzoomedRootLineHeight = getComputedStyle(target).lineHeight;
+
+    assert_equals(getComputedStyle(target).fontSize, '20px');
+    assert_equals(getComputedStyle(target).lineHeight, '20px');
+
+    document.documentElement.style = "line-height: 20px; zoom: 2";
+
+    assert_equals(getComputedStyle(target).fontSize, '20px');
+    assert_equals(getComputedStyle(target).lineHeight, '20px');
+
+    assert_equals(getComputedStyle(target).fontSize, unzoomedRootFontSize);
+    assert_equals(getComputedStyle(target).lineHeight, unzoomedRootLineHeight);
+  } finally {
+    document.documentElement.style = "";
+    target.remove();
+  }
+}, "root with px line-height");
+
+test(() => {
+  const target = document.createElement("div");
+  document.body.append(target);
+
+  document.documentElement.style = "font-size: 100px; line-height: 20%;"
+
+  try {
+    target.style = "font-size: 1rlh; line-height: 1rlh;";
+
+    const unzoomedRootFontSize = getComputedStyle(target).fontSize;
+    const unzoomedRootLineHeight = getComputedStyle(target).lineHeight;
+
+    assert_equals(getComputedStyle(target).fontSize, '20px');
+    assert_equals(getComputedStyle(target).lineHeight, '20px');
+
+    document.documentElement.style = "font-size: 100px; line-height: 20%; zoom: 2";
+
+    assert_equals(getComputedStyle(target).fontSize, '20px');
+    assert_equals(getComputedStyle(target).lineHeight, '20px');
+
+    assert_equals(getComputedStyle(target).fontSize, unzoomedRootFontSize);
+    assert_equals(getComputedStyle(target).lineHeight, unzoomedRootLineHeight);
+  } finally {
+    document.documentElement.style = "";
+    target.remove();
+  }
+}, "root with percentage line-height");
+</script>
+</body>

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -55,6 +55,7 @@ style/StyleBuilderCustom.h
 style/StyleDocumentScope.cpp
 style/StyleInvalidationFunctions.h
 style/UserAgentStyle.cpp
+style/computed/StyleComputedStyleBase.cpp
 style/computed/StyleComputedStyleBase+SettersInlines.h
 style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
 style/values/primitives/StyleLengthResolution.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5485,6 +5485,7 @@
                 {
                     "enable-if": "ENABLE_TEXT_AUTOSIZING",
                     "animation-wrapper-requires-getter": "specifiedLineHeight",
+                    "animation-wrapper-requires-setter": "setSpecifiedLineHeightFromAnimation",
                     "style-builder-custom": "All",
                     "style-extractor-custom": true,
                     "computed-style-storage-path": ["m_inheritedData"],

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -276,6 +276,23 @@ void ComputedStyleBase::setSpecifiedLineHeight(LineHeight&& lineHeight)
 
 #endif
 
+void ComputedStyleBase::setSpecifiedLineHeightFromAnimation(LineHeight&& lineHeight)
+{
+#if ENABLE(TEXT_AUTOSIZING)
+    bool specifiedLineHeightChanged = m_inheritedData->specifiedLineHeight != lineHeight;
+    bool lineHeightChanged = m_inheritedData->lineHeight != lineHeight;
+    if (specifiedLineHeightChanged || lineHeightChanged) {
+        auto& access = m_inheritedData.access();
+        if (specifiedLineHeightChanged)
+            access.specifiedLineHeight = lineHeight;
+        if (lineHeightChanged)
+            access.lineHeight = WTF::move(lineHeight);
+    }
+#else
+    SET_VAR(m_inheritedData, lineHeight, WTF::move(lineHeight));
+#endif
+}
+
 void ComputedStyleBase::setLetterSpacingFromAnimation(LetterSpacing&& value)
 {
     if (value != m_inheritedData->fontData->letterSpacing) {

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -647,6 +647,7 @@ public:
 #if ENABLE(TEXT_AUTOSIZING)
     void setSpecifiedLineHeight(LineHeight&&);
 #endif
+    void setSpecifiedLineHeightFromAnimation(LineHeight&&);
 
     void setLetterSpacingFromAnimation(LetterSpacing&&);
     void setWordSpacingFromAnimation(WordSpacing&&);

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -152,64 +152,39 @@ static double resolveIc(CSSPropertyID, const FontCascade& fontCascadeForUnit)
     return unzoomFontMetric(ideogramWidth.value(), fontDescription);
 }
 
-// Resolve the "lh" unit.
-// https://drafts.csswg.org/css-values-4/#lh
-static double resolveLh(const CSSToLengthConversionData& conversionData)
-{
-    if (conversionData.computingLineHeight() || conversionData.computingFontSize()) {
-        // Try to get the parent's computed line-height, or fall back to the initial line-height of this element's font spacing.
-        if (auto* parentStyle = conversionData.parentStyle()) {
-            return evaluate<float>(
-                parentStyle->lineHeight(),
-                LineHeightEvaluationContext {
-                    parentStyle->computedFontSize(),
-                    parentStyle->metricsOfPrimaryFont().lineSpacing()
-                },
-                parentStyle->usedZoomForLength()
-            );
-        }
-        return conversionData.fontCascadeForFontUnits().metricsOfPrimaryFont().intLineSpacing();
-    }
 
-    auto* style = conversionData.style();
-    return evaluate<float>(
-        style->lineHeight(),
-        LineHeightEvaluationContext {
-            style->fontDescription().unzoomedComputedSize(),
-            style->metricsOfPrimaryFont().lineSpacing()
-        },
-        ZoomFactor::none()
-    );
+static const ComputedStyle* styleForLineHeightUnits(const CSSToLengthConversionData& conversionData)
+{
+    if (conversionData.computingLineHeight() || conversionData.computingFontSize())
+        return conversionData.parentStyle();
+    return conversionData.style();
 }
 
-// Resolve the "rlh" unit.
-// FIXME: Share this implementation with resolveLh (as we do with other root relative units), passing in the root style.
-// https://drafts.csswg.org/css-values-4/#rlh
-static double resolveRlh(const CSSToLengthConversionData& conversionData)
+static const ComputedStyle* styleForRootLineHeightUnits(const CSSToLengthConversionData& conversionData)
 {
-    auto* rootStyle = conversionData.rootStyle();
-    if (!rootStyle)
-        return 1.0;
+    return conversionData.rootStyle();
+}
 
-    if (conversionData.computingLineHeight() || conversionData.computingFontSize()) {
+// Resolve the "lh" and "rlh" units.
+// https://drafts.csswg.org/css-values-4/#lh
+// https://drafts.csswg.org/css-values-4/#rlh
+static double resolveLh(const ComputedStyle* style, const FontCascade& fallbackFontCascadeForUnit)
+{
+    if (style) {
+        auto& fontCascade = style->fontCascade();
+        auto& fontDescription = fontCascade.fontDescription();
+
         return evaluate<float>(
-            rootStyle->specifiedLineHeight(),
+            style->specifiedLineHeight(),
             LineHeightEvaluationContext {
-                rootStyle->computedFontSize(),
-                rootStyle->metricsOfPrimaryFont().lineSpacing()
+                fontDescription.specifiedSize(),
+                static_cast<float>(unzoomFontMetric(fontCascade.metricsOfPrimaryFont().lineSpacing(), fontDescription)),
             },
-            rootStyle->usedZoomForLength()
+            ZoomFactor::none()
         );
     }
 
-    return evaluate<float>(
-        rootStyle->lineHeight(),
-        LineHeightEvaluationContext {
-            rootStyle->fontDescription().unzoomedComputedSize(),
-            rootStyle->metricsOfPrimaryFont().lineSpacing()
-        },
-        ZoomFactor::none()
-    );
+    return unzoomFontMetric(fallbackFontCascadeForUnit.metricsOfPrimaryFont().lineSpacing(), fallbackFontCascadeForUnit.fontDescription());
 }
 
 // MARK: - "viewport-percentage" resolution functions
@@ -504,7 +479,7 @@ double resolveLength(double value, CSS::LengthUnit lengthUnit, const CSSToLength
         return value * applyTextZoom(resolveIc(conversionData.propertyToCompute(), conversionData.fontCascadeForFontUnits()), conversionData);
 
     case Lh:
-        return value * applyTextZoomIf(conversionData.computingLineHeight(), resolveLh(conversionData), conversionData);
+        return value * applyTextZoomIf(conversionData.computingLineHeight(), resolveLh(styleForLineHeightUnits(conversionData), conversionData.fontCascadeForFontUnits()), conversionData);
 
     // MARK: "root font dependent" resolution
 
@@ -520,7 +495,7 @@ double resolveLength(double value, CSS::LengthUnit lengthUnit, const CSSToLength
         return value * applyTextZoom(resolveIc(conversionData.propertyToCompute(), conversionData.rootStyle() ? conversionData.rootStyle()->fontCascade() : conversionData.fontCascadeForFontUnits()), conversionData);
 
     case Rlh:
-        return value * applyTextZoomIf(conversionData.computingLineHeight(), resolveRlh(conversionData), conversionData);
+        return value * applyTextZoomIf(conversionData.computingLineHeight(), resolveLh(styleForRootLineHeightUnits(conversionData), conversionData.rootStyle() ? conversionData.rootStyle()->fontCascade() : conversionData.fontCascadeForFontUnits()), conversionData);
 
     // MARK: "viewport-percentage" resolution
 


### PR DESCRIPTION
#### badd29074be777b8d710099a0d478211333a227c
<pre>
[EvaluationTimeZoom] Line-height units don&apos;t work correctly with zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=320921">https://bugs.webkit.org/show_bug.cgi?id=320921</a>

Reviewed by Antti Koivisto.

Refactor `lh` and `rlh` unit resolution to share the same implementation
(like the other font-relative units) and to use unzoomed / specified values.

The refactor revealed that we were only setting one of the two line-height
computed style data members during animations, so this was fixed as well.

Test: imported/w3c/web-platform-tests/css/css-viewport/zoom/line-height-computed.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/line-height-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/line-height-computed.html: Added.
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:

Canonical link: <a href="https://commits.webkit.org/318558@main">https://commits.webkit.org/318558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf0a5a916b54a17062cd57c2448d2746cdc68e5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188144 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141777 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180391 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139190 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119644 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/177851 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41414 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39765 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39441 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190571 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/177931 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148348 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39865 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52816 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148118 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42829 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125083 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119719 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51334 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14416 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50719 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50781 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->