### PR TITLE
Wire up the virtual wallet mock for OpenID4VP signed and multisigned protocols

### DIFF
--- a/LayoutTests/http/wpt/identity/formats/openid4vp/openid4vp-roundtrip.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/formats/openid4vp/openid4vp-roundtrip.https-expected.txt
@@ -1,0 +1,7 @@
+
+PASS openid4vp-v1-signed request: virtual wallet response is passed through with correct protocol and data.
+PASS openid4vp-v1-multisigned request: virtual wallet response is passed through with correct protocol and data.
+PASS Mixed mdoc + openid4vp-v1-signed request: virtual wallet can respond with a specific protocol.
+PASS openid4vp-v1-signed request: virtual wallet decline rejects with NotAllowedError.
+PASS openid4vp-v1-signed request: wait + abort rejects with AbortError.
+

--- a/LayoutTests/http/wpt/identity/formats/openid4vp/openid4vp-roundtrip.https.html
+++ b/LayoutTests/http/wpt/identity/formats/openid4vp/openid4vp-roundtrip.https.html
@@ -1,0 +1,79 @@
+<!-- webkit-test-runner [ DigitalCredentialsOpenID4VPEnabled=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Digital Credential API: OpenID4VP virtual wallet roundtrip</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<link rel="author" href="mailto:pascoe@apple.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+import { makeGetOptions } from "../ISO18013/support/helper.js";
+
+async function setMockResponse(t, protocol, responseObj) {
+  await test_driver.set_virtual_wallet_behavior("respond", protocol, responseObj);
+  t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+}
+
+promise_test(async (t) => {
+  const responseData = { vp_token: { pid: ["eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ3YWxsZXQifQ.signature"] } };
+  await setMockResponse(t, "openid4vp-v1-signed", responseData);
+  await test_driver.bless("user activation");
+
+  const options = makeGetOptions({ protocol: "openid4vp-v1-signed" });
+  const result = await navigator.credentials.get(options);
+
+  assert_equals(result.type, "digital");
+  assert_equals(result.protocol, "openid4vp-v1-signed");
+  assert_array_equals(result.data.vp_token.pid, responseData.vp_token.pid);
+}, "openid4vp-v1-signed request: virtual wallet response is passed through with correct protocol and data.");
+
+promise_test(async (t) => {
+  const responseData = { vp_token: { pid: ["eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJ3YWxsZXQifQ.multisig"] } };
+  await setMockResponse(t, "openid4vp-v1-multisigned", responseData);
+  await test_driver.bless("user activation");
+
+  const options = makeGetOptions({ protocol: "openid4vp-v1-multisigned" });
+  const result = await navigator.credentials.get(options);
+
+  assert_equals(result.type, "digital");
+  assert_equals(result.protocol, "openid4vp-v1-multisigned");
+  assert_array_equals(result.data.vp_token.pid, responseData.vp_token.pid);
+}, "openid4vp-v1-multisigned request: virtual wallet response is passed through with correct protocol and data.");
+
+promise_test(async (t) => {
+  const responseData = { vp_token: { pid: ["mixed-response-token"] } };
+  await setMockResponse(t, "openid4vp-v1-signed", responseData);
+  await test_driver.bless("user activation");
+
+  const options = makeGetOptions({ protocol: ["org-iso-mdoc", "openid4vp-v1-signed"] });
+  const result = await navigator.credentials.get(options);
+
+  assert_equals(result.type, "digital");
+  assert_equals(result.protocol, "openid4vp-v1-signed");
+  assert_array_equals(result.data.vp_token.pid, ["mixed-response-token"]);
+}, "Mixed mdoc + openid4vp-v1-signed request: virtual wallet can respond with a specific protocol.");
+
+promise_test(async (t) => {
+  await test_driver.set_virtual_wallet_behavior("decline");
+  t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+  await test_driver.bless("user activation");
+
+  const options = makeGetOptions({ protocol: "openid4vp-v1-signed" });
+  await promise_rejects_dom(t, "NotAllowedError", navigator.credentials.get(options));
+}, "openid4vp-v1-signed request: virtual wallet decline rejects with NotAllowedError.");
+
+promise_test(async (t) => {
+  await test_driver.set_virtual_wallet_behavior("wait");
+  t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+  await test_driver.bless("user activation");
+
+  const controller = new AbortController();
+  const options = makeGetOptions({ protocol: "openid4vp-v1-signed", signal: controller.signal });
+  const promise = navigator.credentials.get(options);
+  controller.abort();
+  await promise_rejects_dom(t, "AbortError", promise);
+}, "openid4vp-v1-signed request: wait + abort rejects with AbortError.");
+</script>

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -149,10 +149,11 @@ void CredentialRequestCoordinator::prepareCredentialRequests(const Document& doc
 
     auto validatedCredentialRequests = validatedRequestsOrException.releaseReturnValue();
 
-    // FIXME: validatedCredentialRequests only reflects org-iso-mdoc validation, so this
-    // empty check is correct only while mdoc is the sole supported protocol; account for
-    // other protocols' surviving requests once one is added (webkit.org/b/317545).
-    if (validatedCredentialRequests.isEmpty())
+    bool hasOpenID4VPRequest = unvalidatedRequests.containsIf([](auto& request) {
+        return std::holds_alternative<OpenID4VPSignedRequest>(request)
+            || std::holds_alternative<OpenID4VPMultisignedRequest>(request);
+    });
+    if (validatedCredentialRequests.isEmpty() && !hasOpenID4VPRequest)
         return rejectTheCredentialRequestWith(Exception { ExceptionCode::TypeError, "No valid credential requests remain after validation"_s });
 
     if (signal) {

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -74,31 +74,39 @@ DigitalCredential::DigitalCredential(JSC::Strong<JSC::JSObject>&& data, DigitalC
 
 bool DigitalCredential::userAgentAllowsProtocol(const Document& document, const String& protocol)
 {
-    if (protocol == "org-iso-mdoc"_s)
+    auto parsed = digitalCredentialPresentationProtocolFromString(protocol);
+    if (!parsed)
+        return false;
+
+    using enum DigitalCredentialPresentationProtocol;
+    switch (*parsed) {
+    case OrgIsoMdoc:
         return true;
-
-    // Off by default: the API must not advertise a protocol it cannot yet fulfill.
-    if (document.settings().digitalCredentialsOpenID4VPEnabled()) {
-        return protocol == "openid4vp-v1-unsigned"_s
-            || protocol == "openid4vp-v1-signed"_s
-            || protocol == "openid4vp-v1-multisigned"_s;
+    case Openid4vpV1Unsigned:
+    case Openid4vpV1Signed:
+    case Openid4vpV1Multisigned:
+        return document.settings().digitalCredentialsOpenID4VPEnabled();
     }
-
     return false;
 }
 
 static std::optional<DigitalCredentialPresentationProtocol> convertProtocolString(const Document& document, const String& protocolString)
 {
-    if (protocolString == "org-iso-mdoc"_s)
-        return DigitalCredentialPresentationProtocol::OrgIsoMdoc;
+    auto protocol = digitalCredentialPresentationProtocolFromString(protocolString);
+    if (!protocol)
+        return std::nullopt;
 
-    if (document.settings().digitalCredentialsOpenID4VPEnabled()) {
-        if (protocolString == "openid4vp-v1-signed"_s)
-            return DigitalCredentialPresentationProtocol::Openid4vpV1Signed;
-        if (protocolString == "openid4vp-v1-multisigned"_s)
-            return DigitalCredentialPresentationProtocol::Openid4vpV1Multisigned;
+    using enum DigitalCredentialPresentationProtocol;
+    switch (*protocol) {
+    case OrgIsoMdoc:
+        return protocol;
+    case Openid4vpV1Signed:
+    case Openid4vpV1Multisigned:
+        return document.settings().digitalCredentialsOpenID4VPEnabled() ? protocol : std::nullopt;
+    case Openid4vpV1Unsigned:
+        // FIXME (webkit.org/b/320207): support once DCQL parsing lands.
+        return std::nullopt;
     }
-
     return std::nullopt;
 }
 
@@ -136,10 +144,9 @@ static ExceptionOr<std::optional<UnvalidatedDigitalCredentialRequest>> jsToCrede
             return Exception { ExceptionCode::ExistingExceptionError };
         return std::make_optional<UnvalidatedDigitalCredentialRequest>(result.releaseReturnValue());
     }
-    default:
-        // FIXME: Handle "openid4vp-v1-unsigned" once DCQL parsing lands (webkit.org/b/320207).
-        ASSERT_NOT_REACHED();
-        return Exception { ExceptionCode::TypeError, "Unsupported protocol."_s };
+    case Openid4vpV1Unsigned:
+        // FIXME (webkit.org/b/320207): support once DCQL parsing lands.
+        return std::optional<UnvalidatedDigitalCredentialRequest> { std::nullopt };
     }
 }
 

--- a/Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <optional>
+#include <wtf/text/WTFString.h>
+
 namespace WebCore {
 
 enum class DigitalCredentialPresentationProtocol : uint8_t {
@@ -33,5 +36,18 @@ enum class DigitalCredentialPresentationProtocol : uint8_t {
     Openid4vpV1Signed,
     Openid4vpV1Multisigned,
 };
+
+inline std::optional<DigitalCredentialPresentationProtocol> digitalCredentialPresentationProtocolFromString(const String& protocol)
+{
+    if (protocol == "org-iso-mdoc"_s)
+        return DigitalCredentialPresentationProtocol::OrgIsoMdoc;
+    if (protocol == "openid4vp-v1-unsigned"_s)
+        return DigitalCredentialPresentationProtocol::Openid4vpV1Unsigned;
+    if (protocol == "openid4vp-v1-signed"_s)
+        return DigitalCredentialPresentationProtocol::Openid4vpV1Signed;
+    if (protocol == "openid4vp-v1-multisigned"_s)
+        return DigitalCredentialPresentationProtocol::Openid4vpV1Multisigned;
+    return std::nullopt;
+}
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/Automation/BidiDigitalCredentialsAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiDigitalCredentialsAgent.cpp
@@ -46,6 +46,12 @@ static WebCore::DigitalCredentialPresentationProtocol toPresentationProtocol(Ins
     switch (protocol) {
     case Inspector::Protocol::BidiDigitalCredentials::DigitalCredentialProtocol::OrgIsoMdoc:
         return WebCore::DigitalCredentialPresentationProtocol::OrgIsoMdoc;
+    case Inspector::Protocol::BidiDigitalCredentials::DigitalCredentialProtocol::Openid4vpV1Unsigned:
+        return WebCore::DigitalCredentialPresentationProtocol::Openid4vpV1Unsigned;
+    case Inspector::Protocol::BidiDigitalCredentials::DigitalCredentialProtocol::Openid4vpV1Signed:
+        return WebCore::DigitalCredentialPresentationProtocol::Openid4vpV1Signed;
+    case Inspector::Protocol::BidiDigitalCredentials::DigitalCredentialProtocol::Openid4vpV1Multisigned:
+        return WebCore::DigitalCredentialPresentationProtocol::Openid4vpV1Multisigned;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiDigitalCredentials.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiDigitalCredentials.json
@@ -15,7 +15,7 @@
             "id": "DigitalCredentialProtocol",
             "type": "string",
             "description": "A digital credential presentation protocol identifier (the exchange protocol used for the synthetic response).",
-            "enum": ["org-iso-mdoc"]
+            "enum": ["org-iso-mdoc", "openid4vp-v1-unsigned", "openid4vp-v1-signed", "openid4vp-v1-multisigned"]
         }
     ],
     "commands": [

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11583,9 +11583,9 @@ void WebPageProxy::setVirtualWalletBehaviorForTesting(const String& action, cons
 
     settlePendingTestingDigitalCredentialHandler("Virtual wallet behavior replaced."_s);
 
-    // FIXME: Only org-iso-mdoc is supported, so the requested protocol is ignored (webkit.org/b/317545).
-    UNUSED_PARAM(protocol);
-    internals().testingVirtualWalletBehavior = VirtualWalletBehavior { *parsedAction, WebCore::DigitalCredentialPresentationProtocol::OrgIsoMdoc, responseJSON };
+    auto parsedProtocol = WebCore::digitalCredentialPresentationProtocolFromString(protocol).value_or(WebCore::DigitalCredentialPresentationProtocol::OrgIsoMdoc);
+
+    internals().testingVirtualWalletBehavior = VirtualWalletBehavior { *parsedAction, parsedProtocol, responseJSON };
 }
 #endif
 


### PR DESCRIPTION
#### 458076ee25d84e0dfac40742b70c9e32eebf0c5b
<pre>
Wire up the virtual wallet mock for OpenID4VP signed and multisigned protocols
<a href="https://bugs.webkit.org/show_bug.cgi?id=320919">https://bugs.webkit.org/show_bug.cgi?id=320919</a>
<a href="https://rdar.apple.com/problem/183950595">rdar://problem/183950595</a>

Reviewed by Marcos Caceres and Abrar Rahman Protyasha.

setVirtualWalletBehaviorForTesting ignored the protocol parameter
(hardcoded to org-iso-mdoc), making it impossible to test OpenID4VP
through the virtual wallet. Parse the protocol string into the correct
enum value, extend the BiDi schema with the three OpenID4VP identifiers,
and fix the coordinator empty-check that rejected OpenID4VP-only request
sets (the validator only handles mdoc, so the validated set was always
empty for OpenID4VP).

Extract digitalCredentialPresentationProtocolFromString() so the
string-to-enum mapping lives in one place. Refactor convertProtocolString
to use it, with an explicit skip for openid4vp-v1-unsigned until DCQL
parsing lands (webkit.org/b/320207).

* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::prepareCredentialRequests):
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::convertProtocolString):
* Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.h:
(WebCore::digitalCredentialPresentationProtocolFromString):
* Source/WebKit/UIProcess/Automation/BidiDigitalCredentialsAgent.cpp:
(WebKit::toPresentationProtocol):
* Source/WebKit/UIProcess/Automation/protocol/BidiDigitalCredentials.json:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setVirtualWalletBehaviorForTesting):
* LayoutTests/http/wpt/identity/formats/openid4vp/openid4vp-roundtrip.https.html: Added.
* LayoutTests/http/wpt/identity/formats/openid4vp/openid4vp-roundtrip.https-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/319055@main">https://commits.webkit.org/319055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6787f3329f23ef9c1b3ece5843e13733f8dd6af7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143158 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ef171dc-2c80-4fc2-9372-e8045156851a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139459 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96710 "2 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3eccc4e4-312c-4388-beeb-7eb8e994ae48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119913 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/461e533a-2bc3-433e-9d92-fc8626c5c433) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41696 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40052 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39705 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45389 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190894 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159715 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148649 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40163 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53137 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148413 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43110 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125405 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120083 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51655 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14674 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51040 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51280 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51102 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->