### PR TITLE
[Custom Highlight] Add the highlightsFromPoint() IDL surface behind a feature flag.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-expected.txt
@@ -1,11 +1,11 @@
 0123456789 temporary
 
 PASS CSS.highlights.highlightsFromPoint() should throw when called with incorrect parameters.
-FAIL CSS.highlights.highlightsFromPoint() should return an empty array when called with a point outside the document. CSS.highlights.highlightsFromPoint is not a function. (In 'CSS.highlights.highlightsFromPoint(-1,-1)', 'CSS.highlights.highlightsFromPoint' is undefined)
-FAIL CSS.highlights.highlightsFromPoint() returns the Highlights with their corresponding ranges present at the given point in the right order. CSS.highlights.highlightsFromPoint is not a function. (In 'CSS.highlights.highlightsFromPoint(x, y)', 'CSS.highlights.highlightsFromPoint' is undefined)
-FAIL CSS.highlights.highlightsFromPoint() returns empty array when called on a display:none iframe document. iframeWindow.CSS.highlights.highlightsFromPoint is not a function. (In 'iframeWindow.CSS.highlights.highlightsFromPoint(5, 5)', 'iframeWindow.CSS.highlights.highlightsFromPoint' is undefined)
-FAIL CSS.highlights.highlightsFromPoint() returns empty array for coordinates outside the viewport. CSS.highlights.highlightsFromPoint is not a function. (In 'CSS.highlights.highlightsFromPoint(viewportWidth + 1, 5)', 'CSS.highlights.highlightsFromPoint' is undefined)
-FAIL CSS.highlights.highlightsFromPoint() does not return highlights with only collapsed ranges. CSS.highlights.highlightsFromPoint is not a function. (In 'CSS.highlights.highlightsFromPoint(x, y)', 'CSS.highlights.highlightsFromPoint' is undefined)
-FAIL CSS.highlights.highlightsFromPoint() skips invalid StaticRanges. CSS.highlights.highlightsFromPoint is not a function. (In 'CSS.highlights.highlightsFromPoint(x, y)', 'CSS.highlights.highlightsFromPoint' is undefined)
-FAIL CSS.highlights.highlightsFromPoint() returns all overlapping ranges within the same highlight. CSS.highlights.highlightsFromPoint is not a function. (In 'CSS.highlights.highlightsFromPoint(x, y)', 'CSS.highlights.highlightsFromPoint' is undefined)
+PASS CSS.highlights.highlightsFromPoint() should return an empty array when called with a point outside the document.
+FAIL CSS.highlights.highlightsFromPoint() returns the Highlights with their corresponding ranges present at the given point in the right order. assert_equals: CSS.highlights.highlightsFromPoint() returns exactly one HighlightHitResult when the coordinates provided point at one Highlight expected 1 but got 0
+PASS CSS.highlights.highlightsFromPoint() returns empty array when called on a display:none iframe document.
+FAIL CSS.highlights.highlightsFromPoint() returns empty array for coordinates outside the viewport. assert_equals: highlightsFromPoint() returns the highlight at valid coordinates inside the viewport expected 1 but got 0
+PASS CSS.highlights.highlightsFromPoint() does not return highlights with only collapsed ranges.
+FAIL CSS.highlights.highlightsFromPoint() skips invalid StaticRanges. assert_equals: highlightsFromPoint() returns highlight before StaticRange is invalidated expected 1 but got 0
+FAIL CSS.highlights.highlightsFromPoint() returns all overlapping ranges within the same highlight. assert_equals: highlightsFromPoint() returns exactly one HighlightHitResult for a single highlight expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-ranges-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-ranges-expected.txt
@@ -1,5 +1,5 @@
 0123456789
 0123456789
 
-FAIL CSS.highlights.highlightsFromPoint() returns HighlightHitResults with the Highlights and their corresponding Ranges and StaticRanges present at the given point in the right order on multi-line text. CSS.highlights.highlightsFromPoint is not a function. (In 'CSS.highlights.highlightsFromPoint(x, y)', 'CSS.highlights.highlightsFromPoint' is undefined)
+FAIL CSS.highlights.highlightsFromPoint() returns HighlightHitResults with the Highlights and their corresponding Ranges and StaticRanges present at the given point in the right order on multi-line text. assert_equals: CSS.highlights.highlightsFromPoint() returns exactly one HighlightHitResult when the coordinates provided point at one Highlight expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt
@@ -25,11 +25,11 @@ PASS HighlightRegistry interface: existence and properties of interface prototyp
 PASS HighlightRegistry interface: existence and properties of interface prototype object's "constructor" property
 PASS HighlightRegistry interface: existence and properties of interface prototype object's @@unscopables property
 PASS HighlightRegistry interface: maplike<DOMString, Highlight>
-FAIL HighlightRegistry interface: operation highlightsFromPoint(float, float, optional HighlightsFromPointOptions) assert_own_property: interface prototype object missing non-static operation expected property "highlightsFromPoint" missing
+PASS HighlightRegistry interface: operation highlightsFromPoint(float, float, optional HighlightsFromPointOptions)
 PASS HighlightRegistry must be primary interface of CSS.highlights
 PASS Stringification of CSS.highlights
-FAIL HighlightRegistry interface: CSS.highlights must inherit property "highlightsFromPoint(float, float, optional HighlightsFromPointOptions)" with the proper type assert_inherits: property "highlightsFromPoint" not found in prototype chain
-FAIL HighlightRegistry interface: calling highlightsFromPoint(float, float, optional HighlightsFromPointOptions) on CSS.highlights with too few arguments must throw TypeError assert_inherits: property "highlightsFromPoint" not found in prototype chain
+PASS HighlightRegistry interface: CSS.highlights must inherit property "highlightsFromPoint(float, float, optional HighlightsFromPointOptions)" with the proper type
+PASS HighlightRegistry interface: calling highlightsFromPoint(float, float, optional HighlightsFromPointOptions) on CSS.highlights with too few arguments must throw TypeError
 PASS CSS namespace: operation escape(CSSOMString)
 PASS CSS namespace: attribute highlights
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/HighlightRegistry-highlightsFromPoint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/HighlightRegistry-highlightsFromPoint-expected.txt
@@ -1,7 +1,7 @@
 0123456789
 
 PASS CSS.highlights.highlightsFromPoint() should throw when called with nodes that are not ShadowRoot objects in options.
-FAIL CSS.highlights.highlightsFromPoint() returns Highlights present at a given point inside a shadow tree in the right order. CSS.highlights.highlightsFromPoint is not a function. (In 'CSS.highlights.highlightsFromPoint(x, y, {shadowRoots: [shadowRoot]})', 'CSS.highlights.highlightsFromPoint' is undefined)
-FAIL CSS.highlights.highlightsFromPoint() doesn't return Highlights that are not painted at the given coordinates even when they fall inside the Highlights' ranges CSS.highlights.highlightsFromPoint is not a function. (In 'CSS.highlights.highlightsFromPoint(x, y)', 'CSS.highlights.highlightsFromPoint' is undefined)
-FAIL CSS.highlights.highlightsFromPoint() handles slotted light DOM content correctly. CSS.highlights.highlightsFromPoint is not a function. (In 'CSS.highlights.highlightsFromPoint(x, y)', 'CSS.highlights.highlightsFromPoint' is undefined)
+FAIL CSS.highlights.highlightsFromPoint() returns Highlights present at a given point inside a shadow tree in the right order. assert_equals: CSS.highlights.highlightsFromPoint() returns exactly one Highlight when the given coordinates point at a Highlight under the shadow root provided expected 1 but got 0
+FAIL CSS.highlights.highlightsFromPoint() doesn't return Highlights that are not painted at the given coordinates even when they fall inside the Highlights' ranges assert_equals: CSS.highlights.highlightsFromPoint() returns one Highlight present at the coordinates provided expected 1 but got 0
+FAIL CSS.highlights.highlightsFromPoint() handles slotted light DOM content correctly. assert_equals: highlightsFromPoint() returns the light DOM highlight for slotted content expected 1 but got 0
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3919,6 +3919,20 @@ HiddenUntilFoundEnabled:
      WebCore:
        default: true
 
+HighlightsFromPointEnabled:
+   type: bool
+   status: testable
+   category: css
+   humanReadableName: "CSS Custom Highlight API: highlightsFromPoint()"
+   humanReadableDescription: "Enable the CSS Custom Highlight API highlightsFromPoint() method"
+   defaultValue:
+     WebKitLegacy:
+       default: false
+     WebKit:
+       default: false
+     WebCore:
+       default: false
+
 HorizontalBannerViewOverlaysEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -447,7 +447,9 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/geolocation/PositionOptions.idl
 
     Modules/highlight/Highlight.idl
+    Modules/highlight/HighlightHitResult.idl
     Modules/highlight/HighlightRegistry.idl
+    Modules/highlight/HighlightsFromPointOptions.idl
 
     Modules/identity/DigitalCredential.idl
     Modules/identity/DigitalCredentialGetRequest.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -380,6 +380,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/geolocation/PositionOptions.idl \
     $(WebCore)/Modules/highlight/HighlightRegistry.idl \
     $(WebCore)/Modules/highlight/Highlight.idl \
+    $(WebCore)/Modules/highlight/HighlightHitResult.idl \
+    $(WebCore)/Modules/highlight/HighlightsFromPointOptions.idl \
     $(WebCore)/Modules/identity/DigitalCredential.idl \
     $(WebCore)/Modules/identity/DigitalCredentialGetRequest.idl \
     $(WebCore)/Modules/identity/DigitalCredentialRequestOptions.idl \

--- a/Source/WebCore/Modules/highlight/HighlightHitResult.h
+++ b/Source/WebCore/Modules/highlight/HighlightHitResult.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,12 +23,19 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://drafts.csswg.org/css-highlight-api/#highlightregistry
+#pragma once
 
-[
-    Exposed=Window
-] interface HighlightRegistry {
-    maplike<[AtomString] DOMString, Highlight>;
+#include "AbstractRange.h"
+#include "Highlight.h"
+#include <wtf/Ref.h>
+#include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
 
-    [CallWith=CurrentDocument, EnabledBySetting=HighlightsFromPointEnabled] sequence<HighlightHitResult> highlightsFromPoint(float x, float y, optional HighlightsFromPointOptions options = {});
+namespace WebCore {
+
+struct HighlightHitResult {
+    RefPtr<Highlight> highlight;
+    Vector<Ref<AbstractRange>> ranges;
 };
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/highlight/HighlightHitResult.idl
+++ b/Source/WebCore/Modules/highlight/HighlightHitResult.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,12 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://drafts.csswg.org/css-highlight-api/#highlightregistry
-
 [
-    Exposed=Window
-] interface HighlightRegistry {
-    maplike<[AtomString] DOMString, Highlight>;
-
-    [CallWith=CurrentDocument, EnabledBySetting=HighlightsFromPointEnabled] sequence<HighlightHitResult> highlightsFromPoint(float x, float y, optional HighlightsFromPointOptions options = {});
+    JSGenerateToJSObject
+] dictionary HighlightHitResult {
+    Highlight highlight;
+    sequence<AbstractRange> ranges;
 };

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "HighlightRegistry.h"
 
+#include "Document.h"
+#include "HighlightHitResult.h"
+#include "HighlightsFromPointOptions.h"
 #include "IDLTypes.h"
 #include "JSDOMMapLike.h"
 #include "JSHighlight.h"
@@ -36,6 +39,11 @@ void HighlightRegistry::initializeMapLike(DOMMapAdapter& map)
 {
     for (auto& keyValue : m_map)
         map.set<IDLDOMString, IDLInterface<Highlight>>(keyValue.key, keyValue.value);
+}
+
+Vector<HighlightHitResult> HighlightRegistry::highlightsFromPoint(Document&, float, float, HighlightsFromPointOptions&&)
+{
+    return { };
 }
 
 void HighlightRegistry::setFromMapLike(AtomString&& key, Ref<Highlight>&& value)

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.h
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.h
@@ -34,9 +34,13 @@
 namespace WebCore {
 
 class DOMMapAdapter;
+class Document;
 class DOMString;
 class Highlight;
 class StaticRange;
+
+struct HighlightHitResult;
+struct HighlightsFromPointOptions;
 
 class HighlightRegistry : public RefCounted<HighlightRegistry> {
 public:
@@ -56,6 +60,8 @@ public:
     WEBCORE_EXPORT void addAnnotationHighlightWithRange(Ref<StaticRange>&&);
     const HashMap<AtomString, Ref<Highlight>>& map() const LIFETIME_BOUND { return m_map; }
     const Vector<AtomString>& highlightNames() const LIFETIME_BOUND { return m_highlightNames; }
+
+    Vector<HighlightHitResult> highlightsFromPoint(Document&, float x, float y, HighlightsFromPointOptions&&);
     
 private:
     HighlightRegistry() = default;

--- a/Source/WebCore/Modules/highlight/HighlightsFromPointOptions.h
+++ b/Source/WebCore/Modules/highlight/HighlightsFromPointOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,12 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://drafts.csswg.org/css-highlight-api/#highlightregistry
+#pragma once
 
-[
-    Exposed=Window
-] interface HighlightRegistry {
-    maplike<[AtomString] DOMString, Highlight>;
+#include "ShadowRoot.h"
+#include <wtf/Ref.h>
+#include <wtf/Vector.h>
 
-    [CallWith=CurrentDocument, EnabledBySetting=HighlightsFromPointEnabled] sequence<HighlightHitResult> highlightsFromPoint(float x, float y, optional HighlightsFromPointOptions options = {});
+namespace WebCore {
+
+struct HighlightsFromPointOptions {
+    Vector<Ref<ShadowRoot>> shadowRoots;
 };
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/highlight/HighlightsFromPointOptions.idl
+++ b/Source/WebCore/Modules/highlight/HighlightsFromPointOptions.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,12 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://drafts.csswg.org/css-highlight-api/#highlightregistry
-
-[
-    Exposed=Window
-] interface HighlightRegistry {
-    maplike<[AtomString] DOMString, Highlight>;
-
-    [CallWith=CurrentDocument, EnabledBySetting=HighlightsFromPointEnabled] sequence<HighlightHitResult> highlightsFromPoint(float x, float y, optional HighlightsFromPointOptions options = {});
+dictionary HighlightsFromPointOptions {
+    sequence<ShadowRoot> shadowRoots = [];
 };

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4517,7 +4517,9 @@ JSHardwareAcceleration.cpp
 JSHashChangeEvent.cpp
 JSHdrMetadataType.cpp
 JSHighlight.cpp
+JSHighlightHitResult.cpp
 JSHighlightRegistry.cpp
+JSHighlightsFromPointOptions.cpp
 JSHistory.cpp
 JSHkdfParams.cpp
 JSHmacKeyParams.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1702,6 +1702,8 @@
 		441A6BE32B6C281D002A2B27 /* FragmentDirectiveGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 441A6BE22B6A0D17002A2B27 /* FragmentDirectiveGenerator.h */; };
 		4425070925829A2700C09368 /* AppHighlightStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4425070725829A1400C09368 /* AppHighlightStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4430D00B2575A83E0046D401 /* Highlight.h in Headers */ = {isa = PBXBuildFile; fileRef = 44E88E51236A5C8D009B4847 /* Highlight.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		44E88E61236A56AC009B48A2 /* HighlightHitResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 44E88E60236A56AC009B48A1 /* HighlightHitResult.h */; };
+		44E88E63236A56AC009B48A4 /* HighlightsFromPointOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 44E88E62236A56AC009B48A3 /* HighlightsFromPointOptions.h */; };
 		4430D00D2575A8A50046D401 /* HighlightRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 44E88E50236A56AC009B4847 /* HighlightRegistry.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4431EABA2AB9D54300E92FFA /* LegacyRenderSVGResourceContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 4431EAB92AB9D54300E92FFA /* LegacyRenderSVGResourceContainer.h */; };
 		44355FDA2AF29A0C001ED218 /* RenderSVGResourceMarkerInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 44355FD72AF29A0B001ED218 /* RenderSVGResourceMarkerInlines.h */; };
@@ -11856,8 +11858,12 @@
 		44E72D312B445D92009CA525 /* RenderSVGResourcePatternInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderSVGResourcePatternInlines.h; sourceTree = "<group>"; };
 		44E88E4C2369128A009B4847 /* HighlightRegistry.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = HighlightRegistry.idl; sourceTree = "<group>"; };
 		44E88E4D2369128B009B4847 /* Highlight.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Highlight.idl; sourceTree = "<group>"; };
+		44E88E64236A56AC009B48A5 /* HighlightHitResult.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = HighlightHitResult.idl; sourceTree = "<group>"; };
+		44E88E65236A56AC009B48A6 /* HighlightsFromPointOptions.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = HighlightsFromPointOptions.idl; sourceTree = "<group>"; };
 		44E88E50236A56AC009B4847 /* HighlightRegistry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HighlightRegistry.h; sourceTree = "<group>"; };
 		44E88E51236A5C8D009B4847 /* Highlight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Highlight.h; sourceTree = "<group>"; };
+		44E88E60236A56AC009B48A1 /* HighlightHitResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HighlightHitResult.h; sourceTree = "<group>"; };
+		44E88E62236A56AC009B48A3 /* HighlightsFromPointOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HighlightsFromPointOptions.h; sourceTree = "<group>"; };
 		44E88E52236A667F009B4847 /* HighlightRegistry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HighlightRegistry.cpp; sourceTree = "<group>"; };
 		44E88E54236A66A1009B4847 /* Highlight.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Highlight.cpp; sourceTree = "<group>"; };
 		44E8AB4E2AB6014D00F443A8 /* SVGSubpathData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGSubpathData.h; sourceTree = "<group>"; };
@@ -28174,9 +28180,13 @@
 				44E88E54236A66A1009B4847 /* Highlight.cpp */,
 				44E88E51236A5C8D009B4847 /* Highlight.h */,
 				44E88E4D2369128B009B4847 /* Highlight.idl */,
+				44E88E60236A56AC009B48A1 /* HighlightHitResult.h */,
+				44E88E64236A56AC009B48A5 /* HighlightHitResult.idl */,
 				44E88E52236A667F009B4847 /* HighlightRegistry.cpp */,
 				44E88E50236A56AC009B4847 /* HighlightRegistry.h */,
 				44E88E4C2369128A009B4847 /* HighlightRegistry.idl */,
+				44E88E62236A56AC009B48A3 /* HighlightsFromPointOptions.h */,
+				44E88E65236A56AC009B48A6 /* HighlightsFromPointOptions.idl */,
 				449D864D2640C9B9000122DE /* HighlightVisibility.h */,
 			);
 			path = highlight;
@@ -45824,7 +45834,9 @@
 				510A91DA24CF3D8C00BFD89C /* HIDGamepadElement.h in Headers */,
 				515BE19E1D54F6C100DD7C68 /* HIDGamepadProvider.h in Headers */,
 				4430D00B2575A83E0046D401 /* Highlight.h in Headers */,
+				44E88E61236A56AC009B48A2 /* HighlightHitResult.h in Headers */,
 				4430D00D2575A8A50046D401 /* HighlightRegistry.h in Headers */,
+				44E88E63236A56AC009B48A4 /* HighlightsFromPointOptions.h in Headers */,
 				449D864F2640C9C5000122DE /* HighlightVisibility.h in Headers */,
 				BC94D1540C275C8B006BC617 /* History.h in Headers */,
 				97DCE20210807C750057D394 /* HistoryController.h in Headers */,


### PR DESCRIPTION
#### 62c0076685e183447316868056dace66a5997a21
<pre>
[Custom Highlight API] Add the highlightsFromPoint() IDL surface behind a feature flag.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320922">https://bugs.webkit.org/show_bug.cgi?id=320922</a>
<a href="https://rdar.apple.com/183953883">rdar://183953883</a>

Reviewed by Aditya Keerthi.

Add the interface surface for HighlightRegistry.highlightsFromPoint()
(<a href="https://drafts.csswg.org/css-highlight-api-1/)">https://drafts.csswg.org/css-highlight-api-1/)</a> behind a new HighlightsFromPointEnabled setting.
This is the first of a short series of patches: it establishes the IDL, dictionaries, feature flag,
and a stub implementation, so the interface shape can be reviewed independently. The hit-testing
algorithm that returns the highlights present at a point is added in a follow-up.

LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint.html
LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-ranges.html
LayoutTests/imported/w3c/web-platform-tests/shadow-dom/HighlightRegistry-highlightsFromPoint.html
LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-ranges-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/HighlightRegistry-highlightsFromPoint-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/highlight/HighlightHitResult.h: Copied from Source/WebCore/Modules/highlight/HighlightRegistry.idl.
* Source/WebCore/Modules/highlight/HighlightHitResult.idl: Copied from Source/WebCore/Modules/highlight/HighlightRegistry.idl.
* Source/WebCore/Modules/highlight/HighlightRegistry.cpp:
(WebCore::HighlightRegistry::highlightsFromPoint):
* Source/WebCore/Modules/highlight/HighlightRegistry.h:
* Source/WebCore/Modules/highlight/HighlightRegistry.idl:
* Source/WebCore/Modules/highlight/HighlightsFromPointOptions.h: Copied from Source/WebCore/Modules/highlight/HighlightRegistry.idl.
* Source/WebCore/Modules/highlight/HighlightsFromPointOptions.idl: Copied from Source/WebCore/Modules/highlight/HighlightRegistry.idl.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/318510@main">https://commits.webkit.org/318510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa9eb57ed77153ca5338955a695f5d8236def681

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188125 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8d21ebdd-96d9-4b06-ad8b-481564f1db64) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139175 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68aed10b-838a-47bc-8aab-21adb81c1855) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119629 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/abef170b-95c4-48b2-b143-4096c035dfb4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41396 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1598 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8409 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39420 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36580 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39782 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45047 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190552 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52116 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148333 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39825 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52797 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148103 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42811 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125064 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119700 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51315 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14394 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50700 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50940 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50762 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->