### PR TITLE
Cherry-pick 318476@main (6b324fb4b79e). https://bugs.webkit.org/show_bug.cgi?id=319590

### DIFF
--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -489,9 +489,11 @@ RefPtr<Font> FontCache::similarFont(const FontDescription&, const String&)
     return nullptr;
 }
 
+#if !USE(SKIA)
 void FontCache::platformReleaseNoncriticalMemory()
 {
 }
+#endif
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -250,6 +250,9 @@ struct FontCascadeCacheKeyHashTraits : HashTraits<FontCascadeCacheKey> {
 class FontCascadeCache {
     WTF_MAKE_TZONE_ALLOCATED(FontCascadeCache);
     WTF_MAKE_NONCOPYABLE(FontCascadeCache);
+#if USE(SKIA)
+    friend class FontCache;
+#endif
 public:
     FontCascadeCache() = default;
 

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -570,6 +570,16 @@ void FontCascadeFonts::pruneSystemFallbacks()
     m_systemFallbackFontSet.clear();
 }
 
+void FontCascadeFonts::forEachRealizedFont(NOESCAPE const Function<void(const Font&)>& function) const
+{
+    for (auto& ranges : m_realizedFallbackRanges) {
+        for (unsigned i = 0; i < ranges.size(); ++i) {
+            if (RefPtr font = ranges.rangeAt(i).font(ExternalResourceDownloadPolicy::Forbid))
+                function(*font);
+        }
+    }
+}
+
 TextStream& operator<<(TextStream& ts, const FontCascadeFonts& fontCascadeFonts)
 {
     ts << "FontCascadeFonts "_s << &fontCascadeFonts << ' ' << " generation "_s << fontCascadeFonts.generation();

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -28,6 +28,7 @@
 #include <WebCore/WidthCache.h>
 #include <wtf/EnumeratedArray.h>
 #include <wtf/Forward.h>
+#include <wtf/Function.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/HashTraits.h>
 #include <wtf/MainThread.h>
@@ -80,6 +81,9 @@ public:
     WEBCORE_EXPORT const FontRanges& realizeFallbackRangesAt(const FontCascadeDescription&, FontSelector*, unsigned fallbackIndex);
 
     void pruneSystemFallbacks();
+
+    // Only visits fonts that have already been realized; never triggers realization/loading.
+    void forEachRealizedFont(NOESCAPE const Function<void(const Font&)>&) const;
 
 private:
     FontCascadeFonts();

--- a/Source/WebCore/platform/graphics/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontCustomPlatformData.h
@@ -92,6 +92,12 @@ public:
     WEBCORE_EXPORT FontCustomPlatformSerializedData serializedData() const;
     WEBCORE_EXPORT static std::optional<Ref<FontCustomPlatformData>> tryMakeFromSerializationData(FontCustomPlatformSerializedData&&, bool);
 
+#if USE(SKIA)
+    sk_sp<SkTypeface> retrieveOrAddCachedTypeface(const Vector<SkFontArguments::VariationPosition::Coordinate>&);
+    void clearVariationTypefacesCache() const;
+    void clearUnusedVariationTypefacesCacheEntries() const;
+#endif
+
     static bool supportsFormat(const String&);
     static bool supportsTechnology(const FontTechnology&);
 
@@ -103,6 +109,7 @@ public:
     RefPtr<cairo_font_face_t> m_fontFace;
 #elif USE(SKIA)
     sk_sp<SkTypeface> m_typeface;
+    mutable HashMap<unsigned, sk_sp<SkTypeface>> m_variationTypefacesCache;
 #endif
     FontPlatformData::CreationData creationData;
 

--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -56,7 +56,10 @@ FontPlatformData::FontPlatformData(float size, bool syntheticBold, bool syntheti
 {
 }
 
+#if !USE(SKIA)
 FontPlatformData::~FontPlatformData() = default;
+#endif
+
 FontPlatformData::FontPlatformData(const FontPlatformData&) = default;
 FontPlatformData& FontPlatformData::operator=(const FontPlatformData&) = default;
 

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -27,6 +27,7 @@
 #include "FontCache.h"
 
 #include "Font.h"
+#include "FontCustomPlatformData.h"
 #include "FontDescription.h"
 #include "StyleFontSizeFunctions.h"
 #include <wtf/Assertions.h>
@@ -412,6 +413,16 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
 ASCIILiteral FontCache::platformAlternateFamilyName(const String&)
 {
     return { };
+}
+
+void FontCache::platformReleaseNoncriticalMemory()
+{
+    for (auto& entry : m_fontCascadeCache.m_entries.values()) {
+        entry->fonts->forEachRealizedFont([](const Font& font) {
+            if (const auto* customPlatformData = font.platformData().customPlatformData())
+                customPlatformData->clearVariationTypefacesCache();
+        });
+    }
 }
 
 void FontCache::platformInvalidate()

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -84,12 +84,8 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
         for (auto& variation : variations)
             applyVariation(variation.tag(), variation.value());
 
-        if (!variationsToBeApplied.isEmpty()) {
-            SkFontArguments fontArgs;
-            fontArgs.setVariationDesignPosition({ variationsToBeApplied.span().data(), static_cast<int>(variationsToBeApplied.size()) });
-            if (auto variationTypeface = typeface->makeClone(fontArgs))
-                typeface = WTF::move(variationTypeface);
-        }
+        if (!variationsToBeApplied.isEmpty())
+            typeface = retrieveOrAddCachedTypeface(variationsToBeApplied);
     }
 
     auto size = description.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
@@ -170,6 +166,40 @@ std::optional<Ref<FontCustomPlatformData>> FontCustomPlatformData::tryMakeFromSe
 FontCustomPlatformSerializedData FontCustomPlatformData::serializedData() const
 {
     return FontCustomPlatformSerializedData { creationData.fontFaceData, creationData.itemInCollection, m_renderingResourceIdentifier };
+}
+
+sk_sp<SkTypeface> FontCustomPlatformData::retrieveOrAddCachedTypeface(const Vector<SkFontArguments::VariationPosition::Coordinate>& variationsToBeApplied)
+{
+    WTF::Hasher variationHasher;
+    for (auto& coordinate : variationsToBeApplied) {
+        WTF::add(variationHasher, coordinate.axis);
+        WTF::add(variationHasher, coordinate.value);
+    }
+    constexpr size_t variationTypefacesCacheMaximumSize = 8;
+    if (m_variationTypefacesCache.size() >= variationTypefacesCacheMaximumSize)
+        m_variationTypefacesCache.remove(m_variationTypefacesCache.random());
+    auto addResult = m_variationTypefacesCache.ensure(variationHasher.hash(), [&]() -> sk_sp<SkTypeface> {
+        SkFontArguments fontArgs;
+        fontArgs.setVariationDesignPosition({ variationsToBeApplied.span().data(), static_cast<int>(variationsToBeApplied.size()) });
+        if (auto variationTypeface = m_typeface->makeClone(fontArgs))
+            return variationTypeface;
+        return m_typeface;
+    });
+    if (addResult.iterator->value)
+        return addResult.iterator->value;
+    return m_typeface;
+}
+
+void FontCustomPlatformData::clearVariationTypefacesCache() const
+{
+    m_variationTypefacesCache.clear();
+}
+
+void FontCustomPlatformData::clearUnusedVariationTypefacesCacheEntries() const
+{
+    m_variationTypefacesCache.removeIf([](const auto& entry) {
+        return entry.value->unique();
+    });
 }
 
 }

--- a/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
@@ -59,6 +59,16 @@ FontPlatformData::FontPlatformData(float size, FontOrientation&& orientation, Fo
     platformDataInit();
 }
 
+FontPlatformData::~FontPlatformData()
+{
+    if (m_customPlatformData) {
+        // Dereference sk_sp<SkTypeface> used by font.
+        m_font = { };
+        // Clear sk_sp<SkTypeface> objects from cache if refcount is 1.
+        m_customPlatformData->clearUnusedVariationTypefacesCacheEntries();
+    }
+}
+
 bool FontPlatformData::skiaTypefaceHasAnySupportedColorTable(const SkTypeface& typeface)
 {
     const int tablesCount = typeface.countTables();

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteData.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteData.cpp
@@ -227,8 +227,9 @@ WebKitWebsiteDataTypes webkit_website_data_get_types(WebKitWebsiteData* websiteD
  *
  * Gets the size of the data of types @types in a #WebKitWebsiteData.
  *
- * Note that currently the data size is only known for %WEBKIT_WEBSITE_DATA_DISK_CACHE data type
- * so for all other types 0 will be returned.
+ * Note that currently the data size is only known for the %WEBKIT_WEBSITE_DATA_DISK_CACHE,
+ * %WEBKIT_WEBSITE_DATA_LOCAL_STORAGE, %WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES and
+ * %WEBKIT_WEBSITE_DATA_DOM_CACHE data types, so for all other types 0 will be returned.
  *
  * Returns: the size of @website_data for the given @types.
  *
@@ -242,9 +243,9 @@ guint64 webkit_website_data_get_size(WebKitWebsiteData* websiteData, WebKitWebsi
         return 0;
 
     guint64 totalSize = 0;
-    for (auto type : websiteData->record.size->typeSizes.keys()) {
-        if (type & types)
-            totalSize += websiteData->record.size->typeSizes.get(type);
+    for (auto [type, size] : websiteData->record.size->typeSizes) {
+        if (toWebKitWebsiteDataTypes(static_cast<WebsiteDataType>(type)) & types)
+            totalSize += size;
     }
 
     return totalSize;

--- a/Source/WebKit/WPEPlatform/wpe-platform-uninstalled.pc.in
+++ b/Source/WebKit/WPEPlatform/wpe-platform-uninstalled.pc.in
@@ -2,6 +2,7 @@ prefix=@CMAKE_BINARY_DIR@
 exec_prefix=${prefix}
 libdir=${prefix}/lib
 includedir=${prefix}
+moduledir=@WPE_PLATFORM_MODULE_DIR@
 
 Name: WPE Platform
 Description: Platform implementation for WPE WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
@@ -502,9 +502,9 @@ static void testWebsiteDataStorage(WebsiteDataTest* test, gconstpointer)
     g_assert_cmpstr(webkit_website_data_get_name(data), ==, webkit_security_origin_get_host(origin));
     webkit_security_origin_unref(origin);
     g_assert_cmpuint(webkit_website_data_get_types(data), ==, storageTypes);
-    // Storage sizes are unknown.
+    // Session storage is only kept in memory, so its size is unknown.
     g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_SESSION_STORAGE), ==, 0);
-    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_LOCAL_STORAGE), ==, 0);
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_LOCAL_STORAGE), >, 0);
 
     // Get also cached data, and clear it.
     static const WebKitWebsiteDataTypes cacheAndStorageTypes = static_cast<WebKitWebsiteDataTypes>(storageTypes | WEBKIT_WEBSITE_DATA_MEMORY_CACHE | WEBKIT_WEBSITE_DATA_DISK_CACHE);
@@ -548,8 +548,10 @@ static void testWebsiteDataDatabases(WebsiteDataTest* test, gconstpointer)
 
     test->loadURI(kServer->getURIForPath("/empty").data());
     test->waitUntilLoadFinished();
-    test->runJavaScriptAndWaitUntilFinished("window.indexedDB.open('TestDatabase');", nullptr);
+    test->runJavaScriptAndWaitUntilFinished("let idbOpened = false; window.indexedDB.open('TestDatabase').onsuccess = () => { idbOpened = true; };", nullptr);
 
+    // Wait for the database to be created on disk, so that its size can be computed.
+    test->assertJavaScriptBecomesTrue("idbOpened");
     test->wait(1);
 
     dataList = test->fetch(databaseTypes);
@@ -561,8 +563,7 @@ static void testWebsiteDataDatabases(WebsiteDataTest* test, gconstpointer)
     g_assert_cmpstr(webkit_website_data_get_name(data), ==, webkit_security_origin_get_host(origin));
     webkit_security_origin_unref(origin);
     g_assert_cmpuint(webkit_website_data_get_types(data), ==, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES);
-    // Database sizes are unknown.
-    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES), ==, 0);
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES), >, 0);
 
     test->runJavaScriptAndWaitUntilFinished("db = openDatabase(\"TestDatabase\", \"1.0\", \"TestDatabase\", 1);", nullptr);
     dataList = test->fetch(databaseTypes);
@@ -571,8 +572,7 @@ static void testWebsiteDataDatabases(WebsiteDataTest* test, gconstpointer)
     data = static_cast<WebKitWebsiteData*>(dataList->data);
     g_assert_nonnull(data);
     g_assert_cmpuint(webkit_website_data_get_types(data), ==, databaseTypes);
-    // Database sizes are unknown.
-    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES), ==, 0);
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES), >, 0);
 
     // Remove all databases at once.
     GList removeList = { data, nullptr, nullptr };
@@ -834,7 +834,7 @@ static void testWebsiteDataDOMCache(WebsiteDataTest* test, gconstpointer)
     g_assert_nonnull(dataList);
     g_assert_cmpuint(g_list_length(dataList), ==, 1);
     auto* data = static_cast<WebKitWebsiteData*>(dataList->data);
-g_assert_nonnull(data);
+    g_assert_nonnull(data);
     WebKitSecurityOrigin* origin = webkit_security_origin_new_for_uri(kServer->getURIForPath("/").data());
     g_assert_cmpstr(webkit_website_data_get_name(data), ==, webkit_security_origin_get_host(origin));
     webkit_security_origin_unref(origin);
@@ -849,6 +849,66 @@ g_assert_nonnull(data);
     static const WebKitWebsiteDataTypes caches = static_cast<WebKitWebsiteDataTypes>(WEBKIT_WEBSITE_DATA_DOM_CACHE | WEBKIT_WEBSITE_DATA_MEMORY_CACHE | WEBKIT_WEBSITE_DATA_DISK_CACHE);
     test->clear(caches, 0);
     dataList = test->fetch(caches);
+    g_assert_null(dataList);
+}
+
+static void testWebsiteDataSizes(WebsiteDataTest* test, gconstpointer)
+{
+    static const WebKitWebsiteDataTypes sizeTypes = static_cast<WebKitWebsiteDataTypes>(WEBKIT_WEBSITE_DATA_LOCAL_STORAGE | WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES | WEBKIT_WEBSITE_DATA_DOM_CACHE);
+
+    test->clear(sizeTypes, 0);
+    GList* dataList = test->fetch(sizeTypes);
+    g_assert_null(dataList);
+
+    test->loadURI(kServer->getURIForPath("/localstorage").data());
+    test->waitUntilLoadFinished();
+
+    // Local storage uses a 1 second timer to update the database.
+    test->wait(1);
+
+    dataList = test->fetch(sizeTypes);
+    g_assert_nonnull(dataList);
+    g_assert_cmpuint(g_list_length(dataList), ==, 1);
+    auto* data = static_cast<WebKitWebsiteData*>(dataList->data);
+    g_assert_nonnull(data);
+    g_assert_cmpuint(webkit_website_data_get_types(data), ==, WEBKIT_WEBSITE_DATA_LOCAL_STORAGE);
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_LOCAL_STORAGE), >, 0);
+
+    // Only the types actually present in the record contribute to the size, so the size of a
+    // type that has no data must never be reported as the size of a different type.
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES), ==, 0);
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_DOM_CACHE), ==, 0);
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_DISK_CACHE), ==, 0);
+
+    // Now add IndexedDB and DOM cache data for the same origin.
+    test->runJavaScriptAndWaitUntilFinished("let idbOpened = false; window.indexedDB.open('TestDatabase').onsuccess = () => { idbOpened = true; };", nullptr);
+    test->assertJavaScriptBecomesTrue("idbOpened");
+
+    test->runJavaScriptAndWaitUntilFinished("let domCacheFilled = false; window.caches.open('TestDOMCache').then(cache => cache.put('/domcache-entry', new Response('x'.repeat(1024)))).then(() => { domCacheFilled = true; });", nullptr);
+    test->assertJavaScriptBecomesTrue("domCacheFilled");
+
+    dataList = test->fetch(sizeTypes);
+    g_assert_nonnull(dataList);
+    g_assert_cmpuint(g_list_length(dataList), ==, 1);
+    data = static_cast<WebKitWebsiteData*>(dataList->data);
+    g_assert_nonnull(data);
+    g_assert_cmpuint(webkit_website_data_get_types(data), ==, sizeTypes);
+
+    auto localStorageSize = webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_LOCAL_STORAGE);
+    auto indexedDBSize = webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES);
+    auto domCacheSize = webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_DOM_CACHE);
+    g_assert_cmpuint(localStorageSize, >, 0);
+    g_assert_cmpuint(indexedDBSize, >, 0);
+    g_assert_cmpuint(domCacheSize, >, 0);
+
+    // Querying several types at once returns the sum of the individual sizes.
+    g_assert_cmpuint(webkit_website_data_get_size(data, sizeTypes), ==, localStorageSize + indexedDBSize + domCacheSize);
+
+    // Session storage is only kept in memory, so it never reports a size.
+    g_assert_cmpuint(webkit_website_data_get_size(data, WEBKIT_WEBSITE_DATA_SESSION_STORAGE), ==, 0);
+
+    test->clear(sizeTypes, 0);
+    dataList = test->fetch(sizeTypes);
     g_assert_null(dataList);
 }
 
@@ -907,6 +967,7 @@ void beforeAll()
     WebsiteDataTest::add("WebKitWebsiteData", "itp", testWebsiteDataITP);
     WebsiteDataTest::add("WebKitWebsiteData", "service-worker-registrations", testWebsiteDataServiceWorkerRegistrations);
     WebsiteDataTest::add("WebKitWebsiteData", "dom-cache", testWebsiteDataDOMCache);
+    WebsiteDataTest::add("WebKitWebsiteData", "sizes", testWebsiteDataSizes);
     WebsiteDataTest::add("WebKitWebsiteData", "handle-corrupted-local-storage", testWebViewHandleCorruptedLocalStorage);
     WebsiteDataTest::add("WebKitWebsiteData", "origin-and-total-storage-ratio", testWebsiteDataOriginAndTotalStorageRatio);
 }


### PR DESCRIPTION
#### 8fc3e4613a574e8b0e4e310691fb728c7efe8d1d
<pre>
Cherry-pick 318476@main (6b324fb4b79e). <a href="https://bugs.webkit.org/show_bug.cgi?id=319590">https://bugs.webkit.org/show_bug.cgi?id=319590</a>

    [Skia] Memory growth on every page load when fonts with variations are used
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319590">https://bugs.webkit.org/show_bug.cgi?id=319590</a>

    Reviewed by Carlos Garcia Campos.

    This change adds a small cache for font variation typefaces, so that
    variation-specific typefaces can be shared. This way, a lot of memory
    can be saved if font variations are used often.

    Canonical link: <a href="https://commits.webkit.org/318476@main">https://commits.webkit.org/318476@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1025@webkitglib/2.52">https://commits.webkit.org/305877.1025@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c7c0a4dba85e9ad0529eb34f6afbf22d104ca30b
<pre>
Cherry-pick 318228@main (4e9da8cb6dbb). <a href="https://bugs.webkit.org/show_bug.cgi?id=320561">https://bugs.webkit.org/show_bug.cgi?id=320561</a>

    [WPE] Missing moduledir in wpe-platform-uninstalled.pc file
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320561">https://bugs.webkit.org/show_bug.cgi?id=320561</a>

    Reviewed by Carlos Garcia Campos.

    Add a moduledir variable, like in the wpe-platform-2.0.pc file.

    * Source/WebKit/WPEPlatform/wpe-platform-uninstalled.pc.in:

    Canonical link: <a href="https://commits.webkit.org/318228@main">https://commits.webkit.org/318228@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1024@webkitglib/2.52">https://commits.webkit.org/305877.1024@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 526c8f7743097519d486cd17ef3b95b19a43cabb
<pre>
Cherry-pick 318404@main (31a2484dd863). <a href="https://bugs.webkit.org/show_bug.cgi?id=320784">https://bugs.webkit.org/show_bug.cgi?id=320784</a>

    [GLib] Fix looking up the size of various website data types
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320784">https://bugs.webkit.org/show_bug.cgi?id=320784</a>

    Reviewed by Adrian Perez de Castro and Carlos Garcia Campos.

    This was using the wrong flags to match types. Update docs
    and add tests for more types.

    Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebsiteData.cpp

    * Source/WebKit/UIProcess/API/glib/WebKitWebsiteData.cpp:
    (webkit_website_data_get_size):
    * Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebsiteData.cpp:
    (testWebsiteDataStorage):
    (testWebsiteDataDatabases):
    (testWebsiteDataDOMCache):
    (testWebsiteDataSizes):
    (beforeAll):

    Canonical link: <a href="https://commits.webkit.org/318404@main">https://commits.webkit.org/318404@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1023@webkitglib/2.52">https://commits.webkit.org/305877.1023@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/966b219c0fe2942652f32fd374a074ed165f8aaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178457 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52395 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46190 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188073 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141706 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180320 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53689 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52105 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139139 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141706 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181414 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53689 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46190 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119593 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53689 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52105 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46190 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53689 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46190 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36528 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/44995 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52105 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190500 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52064 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46190 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148295 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/52745 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46190 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148066 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27073 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/52745 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125011 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119648 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51263 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46190 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50648 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50888 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50710 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->