### PR TITLE
Unreviewed, reverting 318471@main (c17b54571809)

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -176,8 +176,6 @@ WTF_EXPORT_PRIVATE void setApplicationAuditToken(audit_token_t);
 WTF_EXPORT_PRIVATE std::optional<audit_token_t> applicationAuditToken();
 #endif
 
-WTF_EXPORT_PRIVATE bool isInBaseSystem();
-
 namespace CocoaApplication {
 
 WTF_EXPORT_PRIVATE bool isAppleApplication();
@@ -263,7 +261,5 @@ using WTF::setSDKAlignedBehaviors;
 using WTF::applicationAuditToken;
 using WTF::setApplicationAuditToken;
 #endif
-
-using WTF::isInBaseSystem;
 
 #endif // PLATFORM(COCOA)

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -385,16 +385,6 @@ std::optional<audit_token_t> applicationAuditToken()
 
 #endif
 
-bool isInBaseSystem()
-{
-#if PLATFORM(MAC)
-    static bool isBaseSystem = os_variant_is_basesystem("WebKit");
-    return isBaseSystem;
-#else
-    return false;
-#endif
-}
-
 static bool applicationBundleIsEqualTo(const String& bundleIdentifierString)
 {
     return applicationBundleIdentifier() == bundleIdentifierString;

--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
@@ -27,7 +27,6 @@ import AppKit
 public import Foundation
 import WebKit_Internal
 @_weakLinked @_spi(Private) import SwiftUI
-private import wtf.Core.cocoa.RuntimeApplicationChecksCocoa
 
 private struct Controls: View {
     private static let autoHideDelay: Duration = .seconds(3)
@@ -105,7 +104,7 @@ extension WKAlternatePDFHUDView {
 
         super.init(frame: frame)
 
-        let controls = Controls(showSystemActions: !WTF.isInBaseSystem(), action: actionHandler)
+        let controls = Controls(showSystemActions: !isInRecoveryOS(), action: actionHandler)
 
         let hostingView = NSHostingView(rootView: controls)
         hostingView.translatesAutoresizingMaskIntoConstraints = false

--- a/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift
@@ -27,7 +27,7 @@ import AppKit
 public import Foundation
 internal import WebKit_Internal
 private import pal.spi.mac.NSImageSPI
-private import wtf.Core.cocoa.RuntimeApplicationChecksCocoa
+private import wtf.SPI.darwin.OSVariantSPI
 
 private let barVerticalOffset: CGFloat = 40
 private let barHorizontalPadding: CGFloat = 16
@@ -49,6 +49,11 @@ private let fadeInDuration: TimeInterval = 0.25
 private let fadeOutDuration: TimeInterval = 0.5
 private let autoHideDelay: TimeInterval = 3.0
 private let hoverInset: CGFloat = -16.0
+
+// FIXME: (rdar://164559261) understand/document/remove unsafety
+func isInRecoveryOS() -> Bool {
+    unsafe os_variant_is_basesystem("WebKit")
+}
 
 @objc
 @implementation
@@ -101,7 +106,7 @@ extension WKDefaultPDFHUDView {
         zoomGroup.alignment = .centerY
 
         self.stackView = NSStackView(views: [zoomGroup])
-        if !WTF.isInBaseSystem() {
+        if !isInRecoveryOS() {
             stackView.addArrangedSubview(separatorView)
             let fileGroup = NSStackView(views: [openInPreviewButton, saveButton])
             fileGroup.orientation = .horizontal

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -184,10 +184,10 @@
 #import <wtf/SoftLinking.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cf/TypeCastsCF.h>
-#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
+#import <wtf/spi/darwin/OSVariantSPI.h>
 #import <wtf/text/MakeString.h>
 
 #if ENABLE(WEB_AUTHN)
@@ -1349,7 +1349,7 @@ WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::
     [NSApp registerServicesMenuSendTypes:PasteboardTypes::forSelectionSingleton() returnTypes:PasteboardTypes::forEditingSingleton()];
 
     // Occlusion notifications are not always sent in the base system, and stale occlusion state can result in various misbehaviors.
-    if (isInBaseSystem())
+    if (os_variant_is_basesystem("WebKit"))
         setWindowOcclusionDetectionEnabled(false);
 
 #if ENABLE(TILED_CA_DRAWING_AREA)

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
@@ -36,7 +36,7 @@
 
 #if PLATFORM(COCOA)
 #include <sys/sysctl.h>
-#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#include <wtf/spi/darwin/OSVariantSPI.h>
 #endif
 
 #if ENABLE(MODEL_PROCESS)
@@ -47,6 +47,18 @@
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebModelPlayerProvider);
+
+#if PLATFORM(COCOA)
+static bool isRunningInRecoveryOS()
+{
+#if PLATFORM(MAC)
+    static bool isBaseSystem = os_variant_is_basesystem("WebKit");
+    return isBaseSystem;
+#else
+    return false;
+#endif
+}
+#endif
 
 Ref<WebModelPlayerProvider> WebModelPlayerProvider::create(WebPage& webPage)
 {
@@ -65,7 +77,7 @@ WebModelPlayerProvider::~WebModelPlayerProvider() = default;
 bool WebModelPlayerProvider::isAvailable() const
 {
 #if PLATFORM(COCOA)
-    return !isInBaseSystem();
+    return !isRunningInRecoveryOS();
 #else
     return true;
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -120,8 +120,8 @@
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #include <wtf/cocoa/TypeCastsCocoa.h>
+#include <wtf/spi/darwin/OSVariantSPI.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -2555,6 +2555,11 @@ auto UnifiedPDFPlugin::toContextMenuItemTag(int tagValue) -> ContextMenuItemTag
     return isKnownContextMenuItemTag ? static_cast<ContextMenuItemTag>(tagValue) : ContextMenuItemTag::Unknown;
 }
 
+static bool isInRecoveryOS()
+{
+    return os_variant_is_basesystem("WebKit");
+}
+
 std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const WebMouseEvent& contextMenuEvent) const
 {
     ASSERT(isContextMenuEvent(contextMenuEvent));
@@ -2576,13 +2581,13 @@ std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const WebMouse
     };
 
     if ([m_pdfDocument allowsCopying] && hasSelection()) {
-        bool shouldPresentLookupAndSearchOptions = !isInBaseSystem();
+        bool shouldPresentLookupAndSearchOptions = !isInRecoveryOS();
         menuItems.appendVector(selectionContextMenuItems(contextMenuEventRootViewPoint, shouldPresentLookupAndSearchOptions));
         addSeparator();
     }
 
     std::optional<int> openInDefaultViewerTag;
-    bool shouldPresentOpenWithDefaultViewerOption = !isInBaseSystem();
+    bool shouldPresentOpenWithDefaultViewerOption = !isInRecoveryOS();
     if (shouldPresentOpenWithDefaultViewerOption) {
         menuItems.append(contextMenuItem(ContextMenuItemTag::OpenWithDefaultViewer));
         openInDefaultViewerTag = std::to_underlying(ContextMenuItemTag::OpenWithDefaultViewer);


### PR DESCRIPTION
#### ce9c9685b4d075c36c64c9ff623a53933b1ae688
<pre>
Unreviewed, reverting 318471@main (c17b54571809)
<a href="https://bugs.webkit.org/show_bug.cgi?id=320924">https://bugs.webkit.org/show_bug.cgi?id=320924</a>
<a href="https://rdar.apple.com/183951104">rdar://183951104</a>

REGRESSION(318471@main): Broke macOS 26.4 performance/ASAN builds (no such module &apos;wtf.Core.cocoa.RuntimeApplicationChecksCocoa&apos;)

Reverted change:

    Consolidate os_variant_is_basesystem() callers to a common WTF wrapper
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320072">https://bugs.webkit.org/show_bug.cgi?id=320072</a>
    <a href="https://rdar.apple.com/182995822">rdar://182995822</a>
    318471@main (c17b54571809)

Canonical link: <a href="https://commits.webkit.org/318491@main">https://commits.webkit.org/318491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9098e421506e3a449438e18d8eb6086563203ce4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178458 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52396 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188074 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2509a304-9cdc-464a-b27c-23f830c6578f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52106 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46234a7c-9a59-4a5a-a044-1bca2132237b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181415 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/42695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119582 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/1551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36529 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39731 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44996 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190501 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52746 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/148056 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27069 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/42774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125012 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51264 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->