### PR TITLE
[GFC] Distribute extra space up to or beyond track limits

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -419,10 +419,18 @@ static void sizeTracksToFitNonSpanningItems(const ResolveIntrinsicTrackSizesCont
     }
 }
 
+// https://drafts.csswg.org/css-grid-1/#extra-space
+// 2.2: Distribute space up to limits: UpToGrowthLimit
+// 2.3: Distribute space to non-affected tracks: UpToGrowthLimit
+// 2.4: Distribute space beyond limits: BeyondGrowthLimit
+enum class SpaceDistributionLimit : bool { UpToGrowthLimit, BeyondGrowthLimit };
+
 // Used for space distribution.
 static Vector<size_t> indexesForUnfrozenAffectedTracks(const Vector<size_t>& spannedAffectedTracks,
-    const UnsizedTracks& unsizedTracks, const Vector<LayoutUnit>& itemIncurredIncreases, ExtraSpaceDistributionTarget target)
+    const UnsizedTracks& unsizedTracks, const Vector<LayoutUnit>& itemIncurredIncreases, ExtraSpaceDistributionTarget target, SpaceDistributionLimit limit)
 {
+    if (limit == SpaceDistributionLimit::BeyondGrowthLimit)
+        return spannedAffectedTracks;
     Vector<size_t> indexes;
     for (auto trackIndex : spannedAffectedTracks) {
         if (unsizedTracks[trackIndex].affectedSize(target) + itemIncurredIncreases[trackIndex] < unsizedTracks[trackIndex].freezeLimit(target))
@@ -431,25 +439,45 @@ static Vector<size_t> indexesForUnfrozenAffectedTracks(const Vector<size_t>& spa
     return indexes;
 }
 
-// Find the item-incurred increase for each affected track by:
-// distributing the space equally among these tracks,
-// freezing a track’s item-incurred increase as its affected size + item-incurred increase
-// reaches its limit (and continuing to grow the unfrozen tracks as needed).
+// Distributes space equally among trackIndexes in successive rounds, freezing tracks (per
+// spaceDistributedToTrack, below) as needed, until space is exhausted or no tracks remain unfrozen.
 static void distributeSpaceEquallyAmongTracks(LayoutUnit& space, const Vector<size_t>& trackIndexes,
-    const UnsizedTracks& unsizedTracks, Vector<LayoutUnit>& itemIncurredIncreases, ExtraSpaceDistributionTarget target)
+    const UnsizedTracks& unsizedTracks, Vector<LayoutUnit>& itemIncurredIncreases, ExtraSpaceDistributionTarget target, SpaceDistributionLimit limit)
 {
-    auto unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(trackIndexes, unsizedTracks, itemIncurredIncreases, target);
+    auto unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(trackIndexes, unsizedTracks, itemIncurredIncreases, target, limit);
     while (!unfrozenTrackIndexes.isEmpty() && space > 0) {
         auto tracksRemainingForDistributionCount = unfrozenTrackIndexes.size();
-        for (auto trackIndex : unfrozenTrackIndexes) {
+
+        // https://drafts.csswg.org/css-grid-1/#extra-space
+        // Step 2.2, "Distribute space up to limits" (SpaceDistributionLimit::UpToGrowthLimit): "Find the
+        // item-incurred increase for each affected track by: distributing the space equally among these
+        // tracks, freezing a track's item-incurred increase as its affected size + item-incurred increase
+        // reaches its limit (and continuing to grow the unfrozen tracks as needed)."
+        // Step 2.4, "Distribute space beyond limits" (SpaceDistributionLimit::BeyondGrowthLimit): "If extra
+        // space remains at this point, unfreeze and continue to distribute space to the item-incurred
+        // increase of…"
+        auto spaceDistributedToTrack = [&](size_t trackIndex) {
+            auto spaceDistributed = space / tracksRemainingForDistributionCount;
+            if (limit == SpaceDistributionLimit::BeyondGrowthLimit)
+                return spaceDistributed;
             auto& track = unsizedTracks[trackIndex];
             auto spaceRemainingUntilLimit = track.freezeLimit(target) - (track.affectedSize(target) + itemIncurredIncreases[trackIndex]);
-            auto spaceDistributed = std::min(space / tracksRemainingForDistributionCount, spaceRemainingUntilLimit);
+            return std::min(spaceDistributed, spaceRemainingUntilLimit);
+        };
+
+        for (auto trackIndex : unfrozenTrackIndexes) {
+            auto spaceDistributed = spaceDistributedToTrack(trackIndex);
             itemIncurredIncreases[trackIndex] += spaceDistributed;
             space -= spaceDistributed;
             --tracksRemainingForDistributionCount;
         }
-        unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(trackIndexes, unsizedTracks, itemIncurredIncreases, target);
+
+        // BeyondGrowthLimit distributes without a per-track cap, so all space should be distributed.
+        if (limit == SpaceDistributionLimit::BeyondGrowthLimit) {
+            ASSERT(!space);
+            break;
+        }
+        unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(trackIndexes, unsizedTracks, itemIncurredIncreases, target, limit);
     }
 }
 
@@ -499,7 +527,7 @@ static void distributeExtraSpace(ExtraSpaceDistributionTarget spaceDistributionT
 
         // 2.2. Distribute space up to limits:
         Vector<LayoutUnit> itemIncurredIncreases(unsizedTracks.size());
-        distributeSpaceEquallyAmongTracks(spaceToDistribute, spannedAffectedTracks, unsizedTracks, itemIncurredIncreases, spaceDistributionTarget);
+        distributeSpaceEquallyAmongTracks(spaceToDistribute, spannedAffectedTracks, unsizedTracks, itemIncurredIncreases, spaceDistributionTarget, SpaceDistributionLimit::UpToGrowthLimit);
 
         // 2.3. Distribute space to non-affected tracks: if extra space remains and the item spans
         // both affected and non-affected tracks, distribute it into the non-affected tracks.


### PR DESCRIPTION
#### 763d795e62dca6e1e460b8c71e4b1b1570c2241a
<pre>
[GFC] Distribute extra space up to or beyond track limits
<a href="https://bugs.webkit.org/show_bug.cgi?id=320925">https://bugs.webkit.org/show_bug.cgi?id=320925</a>
&lt;<a href="https://rdar.apple.com/183958176">rdar://183958176</a>&gt;

Reviewed by Alan Baradlay.

This PR adds logic for space distribution beyond limits in CSS Grid §11.5.1, step 2.4

<a href="https://drafts.csswg.org/css-grid-1/#extra-space">https://drafts.csswg.org/css-grid-1/#extra-space</a>

We are adding an enum, SpaceDistributionLimit, to {finish}

indexesForUnfrozenAffectedTracks now directly returns the spannedAffectedTracks
when distribution space beyond the growth limit and skip filtering tracks based
on their freeze limit for SpaceDistributionLimit::BeyondGrowthLimit.

distributeSpaceEquallyAmongTracks also directly distributes
(space / tracksRemainingForDistributionCount) space to the affected track
instead of clamping it to the spaceRemainingUntilLimit when under
SpaceDistributionLimit::BeyondGrowthLimit.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::indexesForUnfrozenAffectedTracks):
(WebCore::Layout::distributeSpaceEquallyAmongTracks):
(WebCore::Layout::distributeExtraSpace):

Canonical link: <a href="https://commits.webkit.org/318577@main">https://commits.webkit.org/318577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4de0432eac7371368323f2f7e8633095103437d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141709 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139131 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119585 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41351 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39702 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39381 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36531 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190503 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52067 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148288 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52748 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148059 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27108 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42769 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125014 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119651 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51266 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14356 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50651 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50891 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50713 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->