### PR TITLE
Consolidate os_variant_is_basesystem() callers to a common WTF wrapper

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -176,6 +176,8 @@ WTF_EXPORT_PRIVATE void setApplicationAuditToken(audit_token_t);
 WTF_EXPORT_PRIVATE std::optional<audit_token_t> applicationAuditToken();
 #endif
 
+WTF_EXPORT_PRIVATE bool isInBaseSystem();
+
 namespace CocoaApplication {
 
 WTF_EXPORT_PRIVATE bool isAppleApplication();
@@ -261,5 +263,7 @@ using WTF::setSDKAlignedBehaviors;
 using WTF::applicationAuditToken;
 using WTF::setApplicationAuditToken;
 #endif
+
+using WTF::isInBaseSystem;
 
 #endif // PLATFORM(COCOA)

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -385,6 +385,16 @@ std::optional<audit_token_t> applicationAuditToken()
 
 #endif
 
+bool isInBaseSystem()
+{
+#if PLATFORM(MAC)
+    static bool isBaseSystem = os_variant_is_basesystem("WebKit");
+    return isBaseSystem;
+#else
+    return false;
+#endif
+}
+
 static bool applicationBundleIsEqualTo(const String& bundleIdentifierString)
 {
     return applicationBundleIdentifier() == bundleIdentifierString;

--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
@@ -28,6 +28,7 @@ public import Foundation
 import WebKit_Internal
 @_weakLinked @_spi(Private) import SwiftUI
 private import Observation
+private import wtf.Core.cocoa.RuntimeApplicationChecksCocoa
 
 @Observable
 @MainActor
@@ -145,7 +146,7 @@ extension WKAlternatePDFHUDView {
 
         super.init(frame: frame)
 
-        let controls = PDFHUDControls(showSystemActions: !isInRecoveryOS(), action: actionHandler)
+        let controls = PDFHUDControls(showSystemActions: !WTF.isInBaseSystem(), action: actionHandler)
             .environment(model)
 
         let hostingView = NSHostingView(rootView: controls)

--- a/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift
@@ -27,7 +27,7 @@ import AppKit
 public import Foundation
 internal import WebKit_Internal
 private import pal.spi.mac.NSImageSPI
-private import wtf.SPI.darwin.OSVariantSPI
+private import wtf.Core.cocoa.RuntimeApplicationChecksCocoa
 
 private let barVerticalOffset: CGFloat = 40
 private let barHorizontalPadding: CGFloat = 16
@@ -49,11 +49,6 @@ private let fadeInDuration: TimeInterval = 0.25
 private let fadeOutDuration: TimeInterval = 0.5
 private let autoHideDelay: TimeInterval = 3.0
 private let hoverInset: CGFloat = -16.0
-
-// FIXME: (rdar://164559261) understand/document/remove unsafety
-func isInRecoveryOS() -> Bool {
-    unsafe os_variant_is_basesystem("WebKit")
-}
 
 @objc
 @implementation
@@ -123,7 +118,7 @@ extension WKDefaultPDFHUDView {
         zoomGroup.alignment = .centerY
 
         self.stackView = NSStackView(views: [zoomGroup])
-        if !isInRecoveryOS() {
+        if !WTF.isInBaseSystem() {
             stackView.addArrangedSubview(separatorView)
             let fileGroup = NSStackView(views: [openInPreviewButton, saveButton])
             fileGroup.orientation = .horizontal

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -185,10 +185,10 @@
 #import <wtf/SoftLinking.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
-#import <wtf/spi/darwin/OSVariantSPI.h>
 #import <wtf/text/MakeString.h>
 
 #if ENABLE(WEB_AUTHN)
@@ -1350,7 +1350,7 @@ WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::
     [NSApp registerServicesMenuSendTypes:PasteboardTypes::forSelectionSingleton() returnTypes:PasteboardTypes::forEditingSingleton()];
 
     // Occlusion notifications are not always sent in the base system, and stale occlusion state can result in various misbehaviors.
-    if (os_variant_is_basesystem("WebKit"))
+    if (isInBaseSystem())
         setWindowOcclusionDetectionEnabled(false);
 
 #if ENABLE(TILED_CA_DRAWING_AREA)

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
@@ -36,7 +36,7 @@
 
 #if PLATFORM(COCOA)
 #include <sys/sysctl.h>
-#include <wtf/spi/darwin/OSVariantSPI.h>
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #endif
 
 #if ENABLE(MODEL_PROCESS)
@@ -47,18 +47,6 @@
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebModelPlayerProvider);
-
-#if PLATFORM(COCOA)
-static bool isRunningInRecoveryOS()
-{
-#if PLATFORM(MAC)
-    static bool isBaseSystem = os_variant_is_basesystem("WebKit");
-    return isBaseSystem;
-#else
-    return false;
-#endif
-}
-#endif
 
 Ref<WebModelPlayerProvider> WebModelPlayerProvider::create(WebPage& webPage)
 {
@@ -77,7 +65,7 @@ WebModelPlayerProvider::~WebModelPlayerProvider() = default;
 bool WebModelPlayerProvider::isAvailable() const
 {
 #if PLATFORM(COCOA)
-    return !isRunningInRecoveryOS();
+    return !isInBaseSystem();
 #else
     return true;
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -120,8 +120,8 @@
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #include <wtf/cocoa/TypeCastsCocoa.h>
-#include <wtf/spi/darwin/OSVariantSPI.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -2605,11 +2605,6 @@ auto UnifiedPDFPlugin::toContextMenuItemTag(int tagValue) -> ContextMenuItemTag
     return isKnownContextMenuItemTag ? static_cast<ContextMenuItemTag>(tagValue) : ContextMenuItemTag::Unknown;
 }
 
-static bool isInRecoveryOS()
-{
-    return os_variant_is_basesystem("WebKit");
-}
-
 std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const WebMouseEvent& contextMenuEvent) const
 {
     ASSERT(isContextMenuEvent(contextMenuEvent));
@@ -2631,13 +2626,13 @@ std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const WebMouse
     };
 
     if ([m_pdfDocument allowsCopying] && hasSelection()) {
-        bool shouldPresentLookupAndSearchOptions = !isInRecoveryOS();
+        bool shouldPresentLookupAndSearchOptions = !isInBaseSystem();
         menuItems.appendVector(selectionContextMenuItems(contextMenuEventRootViewPoint, shouldPresentLookupAndSearchOptions));
         addSeparator();
     }
 
     std::optional<int> openInDefaultViewerTag;
-    bool shouldPresentOpenWithDefaultViewerOption = !isInRecoveryOS();
+    bool shouldPresentOpenWithDefaultViewerOption = !isInBaseSystem();
     if (shouldPresentOpenWithDefaultViewerOption) {
         menuItems.append(contextMenuItem(ContextMenuItemTag::OpenWithDefaultViewer));
         openInDefaultViewerTag = std::to_underlying(ContextMenuItemTag::OpenWithDefaultViewer);


### PR DESCRIPTION
#### 939a1d177ef963c4ac1f12fc19ae350b43cf9727
<pre>
Consolidate os_variant_is_basesystem() callers to a common WTF wrapper
<a href="https://bugs.webkit.org/show_bug.cgi?id=320072">https://bugs.webkit.org/show_bug.cgi?id=320072</a>
<a href="https://rdar.apple.com/182995822">rdar://182995822</a>

Reviewed by Richard Robinson, Mike Wyrzykowski, Tim Horton, and Aditya Keerthi.

This is a second attempt at landing 318471@main, since the original
attempt was reverted after it broke macOS 26.4 Performance/ASAN builds.

`os_variant_is_basesystem(&quot;WebKit&quot;)` is found 5 times in the codebase.
Each caller needed to remember the `&quot;WebKit&quot;` magic string; the method
name is not necessarily the most intuitive, either.

This patch introduces a WTF::isInBaseSystem() wrapper, that lives in
wtf/cooca/RuntimeApplicationChecksCococa.h, providing callers an easy
and intuitive way to query if the application is running in macOS
BaseSystem.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::isInBaseSystem):
* Source/WebKit/UIProcess/PDF/WKPDFHUDView.swift:
(isInRecoveryOS): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::m_flagsChangedEventMonitorTrackingArea):
* Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp:
(WebKit::WebModelPlayerProvider::isAvailable const):
(WebKit::isRunningInRecoveryOS): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::createContextMenu const):
(WebKit::isInRecoveryOS): Deleted.

Canonical link: <a href="https://commits.webkit.org/319043@main">https://commits.webkit.org/319043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66a33e254492093ce94b7933d7e75f25ba939f51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190424 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144532 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b16a9179-0157-44ea-b02e-4a23940ff911) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140552 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41fd6927-b2d8-42cd-951e-2c87b01b9607) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121004 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8305b82-7381-444d-aa76-2d2cd7ec2f81) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42884 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41193 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2971 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9825 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40869 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1583 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41487 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192359 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53824 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149899 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54512 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149628 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27364 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44269 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126775 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121920 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53029 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15858 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52411 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52648 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52476 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->