### PR TITLE
[JSC][Temporal] Guard PlainDate construction against out-of-range years; consolidate CalendarResolveFields

### DIFF
--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -987,10 +987,7 @@ static std::optional<PlainDate> NODELETE parseDate(StringParsingBuffer<Character
     auto day = parseDateDay(buffer, *year, *month);
     if (!day)
         return std::nullopt;
-    int32_t y = *year;
-    if (!isYearWithinLimits(y)) [[unlikely]]
-        y = outOfRangeYear;
-    return PlainDate(y, *month, *day);
+    return PlainDate(*year, *month, *day);
 }
 
 // DateSpecYearMonth ::: DateYear DateSeparator[?Extended] DateMonth   (YYYY-MM or YYYYMM)
@@ -1005,10 +1002,7 @@ static std::optional<PlainDate> NODELETE parseDateSpecYearMonth(StringParsingBuf
     auto month = parseDateMonth(buffer);
     if (!month)
         return std::nullopt;
-    int32_t y = *year;
-    if (!isYearWithinLimits(y)) [[unlikely]]
-        y = outOfRangeYear;
-    return PlainDate(y, *month, 1);
+    return PlainDate(*year, *month, 1);
 }
 
 // DateSpecMonthDay :::
@@ -2077,13 +2071,6 @@ bool isValidISODate(double year, double month, double day)
     if (day < 1 || day > daysInMonth1)
         return false;
     return true;
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal-create-iso-date-record
-PlainDate createISODateRecord(double year, double month, double day)
-{
-    ASSERT(isValidISODate(year, month, day));
-    return PlainDate(year, month, day);
 }
 
 // temporal_rs: TimeZone::try_from_str (src/builtins/core/time_zone.rs)

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -338,6 +338,11 @@ constexpr bool isYearWithinLimits(int32_t year)
     return year >= minYear && year <= maxYear;
 }
 
+constexpr bool isYearWithinLimits(int64_t year)
+{
+    return year >= minYear && year <= maxYear;
+}
+
 // https://tc39.es/proposal-temporal/#sec-temporal-isoyearmonthwithinlimits
 constexpr bool isYearMonthWithinLimits(int32_t year, int32_t month)
 {
@@ -367,7 +372,21 @@ public:
         , m_month(month)
         , m_day(day)
     {
-        ASSERT(isYearWithinLimits(year) || year == outOfRangeYear);
+        // month/day are kept as-is even when year is out of range; use sentinel() if
+        // month/day might be garbage too (e.g. computed alongside year).
+        if (!isYearWithinLimits(year)) [[unlikely]]
+            m_year = outOfRangeYear;
+    }
+
+    constexpr PlainDate(int64_t year, unsigned month, unsigned day)
+        : PlainDate(isYearWithinLimits(year) ? static_cast<int32_t>(year) : outOfRangeYear, month, day)
+    {
+    }
+
+    // Placeholder for "no valid date": year is outOfRangeYear, month/day are 1, 1.
+    static constexpr PlainDate sentinel()
+    {
+        return PlainDate(outOfRangeYear, 1, 1);
     }
 
     friend bool operator==(const PlainDate&, const PlainDate&) = default;
@@ -539,7 +558,6 @@ String monthCode(uint32_t);
 
 bool NODELETE isValidDuration(const Duration&);
 bool NODELETE isValidISODate(double, double, double);
-PlainDate NODELETE createISODateRecord(double, double, double);
 
 std::optional<ParsedMonthCode> NODELETE parseMonthCode(StringView);
 std::optional<TimeZone> JS_EXPORT_PRIVATE parseTemporalTimeZoneIdentifier(StringView);

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -84,38 +84,6 @@ CalendarID getTemporalCalendarIdentifierWithISODefault(JSGlobalObject* globalObj
     RELEASE_AND_RETURN(scope, toTemporalCalendarIdentifier(globalObject, calendarLike));
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal-calendarresolvefields
-static void calendarResolveFields(JSGlobalObject* globalObject, std::optional<int32_t> year, unsigned month, std::optional<ParsedMonthCode> monthCode, TemporalDateFormat format, CalendarID calendarId)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    bool isISO = calendarId == iso8601CalendarID();
-
-    if ((format == TemporalDateFormat::Date || format == TemporalDateFormat::YearMonth)
-        && !year) [[unlikely]] {
-        throwTypeError(globalObject, scope, "year must be supplied for this Temporal type"_s);
-        return;
-    }
-    if (monthCode) {
-        if (isISO) {
-            if (monthCode->isLeapMonth) [[unlikely]] {
-                throwRangeError(globalObject, scope, "iso8601 calendar does not have leap months"_s);
-                return;
-            }
-            if (monthCode->monthNumber > 12) [[unlikely]] {
-                throwRangeError(globalObject, scope, "month must be <= 12 with iso8601 calendar"_s);
-                return;
-            }
-            if (month != monthCode->monthNumber) [[unlikely]] {
-                throwRangeError(globalObject, scope, "month does not match month code"_s);
-                return;
-            }
-        }
-        // For non-ISO calendars, monthCode validation is handled by the ICU calendar.
-    }
-}
-
 // temporal_rs: CalendarFields::from_prop_bag
 // https://tc39.es/proposal-temporal/#sec-temporal-preparecalendarfields
 template<FieldSetType type>
@@ -433,54 +401,6 @@ std::optional<ParsedMonthCode> parseMonthCode(JSGlobalObject* globalObject, JSVa
         return { };
     }
     return parsed;
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal-isodatefromfields
-ISO8601::PlainDate isoDateFromFields(JSGlobalObject* globalObject, TemporalDateFormat format, int32_t year, uint32_t month, uint32_t day, std::optional<ParsedMonthCode> monthCode, TemporalOverflow overflow, CalendarID calendarId)
-{
-
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    calendarResolveFields(globalObject, year, month, monthCode, format, calendarId);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    ASSERT(month > 0);
-    ASSERT(day > 0);
-
-    if (calendarId != iso8601CalendarID()) {
-        auto result = TemporalCore::nonISOCalendarDateToISO(calendarId, std::optional<int32_t>(year), static_cast<uint8_t>(month), static_cast<uint8_t>(day), monthCode, overflow);
-        if (!result) [[unlikely]] {
-            throwRangeError(globalObject, scope, String(result.error().message));
-            return { };
-        }
-        return *result;
-    }
-
-    if (overflow == TemporalOverflow::Constrain) {
-        month = std::min<uint32_t>(month, 12);
-        day = std::min<uint32_t>(day, ISO8601::daysInMonth(year, month));
-    }
-
-    auto plainDate = TemporalPlainDate::validateAndCreateISODateRecord(globalObject, ISO8601::Duration(year, month, 0LL, day, 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0)));
-    RETURN_IF_EXCEPTION(scope, { });
-
-    bool valid = true;
-    switch (format) {
-    case TemporalDateFormat::YearMonth:
-        valid = ISO8601::isYearMonthWithinLimits(plainDate.year(), plainDate.month());
-        break;
-    default:
-        valid = ISO8601::isDateTimeWithinLimits(plainDate.year(), plainDate.month(), plainDate.day(), 12, 0, 0, 0, 0, 0);
-        break;
-    }
-
-    if (!valid) [[unlikely]] {
-        throwRangeError(globalObject, scope, "date time is out of range of ECMAScript representation"_s);
-        return { };
-    }
-
-    return plainDate;
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-interprettemporaldatetimefields

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.h
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.h
@@ -45,8 +45,6 @@ CalendarID getTemporalCalendarIdentifierWithISODefault(JSGlobalObject*, JSObject
 
 std::optional<ParsedMonthCode> parseMonthCode(JSGlobalObject*, JSValue argument);
 
-ISO8601::PlainDate isoDateFromFields(JSGlobalObject*, TemporalDateFormat, int32_t, uint32_t, uint32_t, std::optional<ParsedMonthCode>, TemporalOverflow, CalendarID = iso8601CalendarID());
-
 ISO8601::PlainDateTime interpretTemporalDateTimeFields(JSGlobalObject*, CalendarID, const TemporalCore::CalendarFieldsIn&, const TemporalCore::TimeFieldsIn&, TemporalOverflow);
 
 ISO8601::PlainDate isoDateAdd(JSGlobalObject*, const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -122,12 +122,6 @@ CalendarID toTemporalCalendarIdentifier(JSGlobalObject*, JSValue);
 TemporalDisambiguation toTemporalDisambiguation(JSGlobalObject*, JSObject*);
 TemporalOffsetDisambiguation toTemporalOffset(JSGlobalObject*, JSObject*, TemporalOffsetDisambiguation fallback);
 
-enum class TemporalDateFormat : uint8_t {
-    Date,
-    YearMonth,
-    MonthDay
-};
-
 enum class TemporalAnyProperties : bool {
     None,
     Some,

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -320,8 +320,20 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncWith, (JSGlobalObject* gl
             return throwVMTypeError(globalObject, scope, "Object must contain at least one Temporal date property"_s);
 
         // Step 10: isoDate = ? CalendarDateFromFields(calendar, fields, overflow).
-        result = isoDateFromFields(globalObject, TemporalDateFormat::Date, y, m, d, optionalMonthCode, overflow, calendarId);
-        RETURN_IF_EXCEPTION(scope, { });
+        TemporalCore::CalendarFieldsIn fields;
+        fields.year = y;
+        fields.month = m;
+        fields.monthCode = optionalMonthCode;
+        fields.day = static_cast<uint8_t>(d);
+        auto resolved = TemporalCore::dateFromFields(calendarId, fields, overflow);
+        if (!resolved) [[unlikely]] {
+            if (resolved.error().kind == TemporalErrorKind::TypeError)
+                throwTypeError(globalObject, scope, String(resolved.error().message));
+            else
+                throwRangeError(globalObject, scope, String(resolved.error().message));
+            return { };
+        }
+        result = resolved->isoDate;
     }
 
     // Step 11: Return ! CreateTemporalDate(isoDate, calendar).

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
@@ -31,6 +31,7 @@
 #include "TemporalCalendar.h"
 #include "TemporalPlainMonthDay.h"
 #include "TemporalPlainMonthDayPrototype.h"
+#include <wtf/MathExtras.h>
 
 namespace JSC {
 
@@ -133,7 +134,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainMonthDay, (JSGlobalObject* global
         return throwVMRangeError(globalObject, scope, "PlainMonthDay: date out of range of ECMAScript representation"_s);
 
     // Step 11: Return ? CreateTemporalMonthDay(isoDate, calendar).
-    auto* result = TemporalPlainMonthDay::create(vm, structure, ISO8601::PlainMonthDay(ISO8601::PlainDate(referenceYear, isoMonth, isoDay)));
+    auto* result = TemporalPlainMonthDay::create(vm, structure, ISO8601::PlainMonthDay(ISO8601::PlainDate(clampTo<int32_t>(referenceYear), isoMonth, isoDay)));
     if (result && calId != iso8601CalendarID())
         result->setCalendarID(calId);
     return JSValue::encode(result);

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
@@ -39,6 +39,8 @@
 #include "TemporalPlainDateTime.h"
 #include "TemporalPlainTime.h"
 #include "TemporalPlainYearMonth.h"
+#include <wtf/MathExtras.h>
+
 namespace JSC {
 
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncAdd);
@@ -415,10 +417,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToPlainDate, (JSGlob
             return throwVMRangeError(globalObject, scope, "day property must be finite"_s);
         if (doubleDay <= 0) [[unlikely]]
             return throwVMRangeError(globalObject, scope, "day property must be a positive integer"_s);
-        if (!isInBounds<int32_t>(doubleDay)) [[unlikely]]
-            itemDay = ISO8601::outOfRangeYear; // Later resolve step will report the range error.
-        else
-            itemDay = static_cast<int32_t>(doubleDay);
+        itemDay = clampTo<int32_t>(doubleDay);
     }
     if (!itemDay) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.toPlainDate: item does not have a day field"_s);

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
@@ -29,6 +29,7 @@
 #include "CalendarArithmetic.h"
 #include "CalendarICUBridge.h"
 #include "ISO8601.h"
+#include "ISOArithmetic.h"
 #include "IntlObject.h"
 #include "JSCInlines.h"
 #include "TemporalCalendar.h"
@@ -84,73 +85,38 @@ struct ResolvedISOFields {
     uint8_t day;
 };
 
-// resolveISOFields — internal helper; implements the ISO path of three spec AOs, parameterized by ISOResolveType:
-//   Date -> ISODateFromFields (#sec-temporal-isodatefromfields)
-//   YearMonth -> ISOYearMonthFromFields (#sec-temporal-isoyearmonthfromfields)
-//   MonthDay -> ISOMonthDayFromFields (#sec-temporal-isomonthdayfromfields)
-// temporal_rs: types.rs ResolvedIsoFields::try_from_fields
-static TemporalResult<ResolvedISOFields> resolveISOFields(const CalendarFieldsIn& fields, TemporalOverflow overflow, ISOResolveType type)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendarresolvefields
+static TemporalResult<void> calendarResolveFields(CalendarID calendarId, CalendarFieldsIn& fields, ResolveType type)
 {
-    auto rangeCheck = checkYearRange(fields);
-    if (!rangeCheck)
-        return makeUnexpected(rangeCheck.error());
-
-    // Resolve year: MonthDay uses reference year; others require explicit year field.
-    int32_t year;
-    if (type == ISOResolveType::MonthDay)
-        year = isoMonthDayReferenceLeapYear;
-    else {
-        if (!fields.year)
+    if (calendarIsISO(calendarId)) {
+        // Steps 1.a-1.d: needsYear/needsDay.
+        bool needsYear = type == ResolveType::Date || type == ResolveType::YearMonth;
+        bool needsDay = type == ResolveType::Date || type == ResolveType::MonthDay;
+        // Step 1.e: needsYear + year unset.
+        if (needsYear && !fields.year)
             return makeUnexpected(typeError("year property must be present"_s));
-        year = *fields.year;
-    }
-
-    // Resolve day: YearMonth uses day=1; others require explicit day field.
-    uint8_t day;
-    if (type == ISOResolveType::YearMonth)
-        day = 1;
-    else {
-        if (!fields.day)
+        // Step 1.f: needsDay + day unset.
+        if (needsDay && !fields.day)
             return makeUnexpected(typeError("day property must be present"_s));
-        day = *fields.day;
+        // Step 1.g: month and monthCode both unset.
+        if (!fields.month && !fields.monthCode)
+            return makeUnexpected(typeError("month or monthCode property must be present"_s));
+        // Step 1.h: monthCode validation + consistency with month.
+        if (fields.monthCode) {
+            auto& mc = *fields.monthCode;
+            if (mc.isLeapMonth)
+                return makeUnexpected(rangeError("iso8601 calendar does not have leap months"_s));
+            if (mc.monthNumber < 1 || mc.monthNumber > 12)
+                return makeUnexpected(rangeError("month must be 1-12 for iso8601 calendar"_s));
+            uint8_t codeMonth = static_cast<uint8_t>(mc.monthNumber);
+            if (fields.month && *fields.month != codeMonth)
+                return makeUnexpected(rangeError("month does not match monthCode"_s));
+            fields.month = codeMonth;
+        }
+        return { };
     }
-
-    // Resolve month: prefer month over monthCode; validate consistency if both present.
-    uint32_t month;
-    if (fields.month && !fields.monthCode) {
-        month = clampTo<uint8_t>(*fields.month);
-    } else if (fields.monthCode) {
-        auto& mc = *fields.monthCode;
-        if (mc.isLeapMonth)
-            return makeUnexpected(rangeError("iso8601 calendar does not have leap months"_s));
-        if (mc.monthNumber < 1 || mc.monthNumber > 12)
-            return makeUnexpected(rangeError("month must be 1-12 for iso8601 calendar"_s));
-        uint8_t codeMonth = static_cast<uint8_t>(mc.monthNumber);
-        if (fields.month && *fields.month != codeMonth)
-            return makeUnexpected(rangeError("month does not match monthCode"_s));
-        month = codeMonth;
-    } else if (!fields.month)
-        return makeUnexpected(typeError("month or monthCode property must be present"_s));
-    else
-        month = clampTo<uint8_t>(*fields.month);
-
-    // Constrain or reject month and day per overflow.
-    if (month < 1 || month > 12) {
-        if (overflow == TemporalOverflow::Constrain)
-            month = clampTo<uint8_t>(month, 1, 12);
-        else
-            return makeUnexpected(rangeError("month is out of range"_s));
-    }
-
-    uint8_t maxDay = ISO8601::daysInMonth(year, month);
-    if (day < 1 || day > maxDay) {
-        if (overflow == TemporalOverflow::Constrain)
-            day = clampTo<uint8_t>(day, 1, maxDay);
-        else
-            return makeUnexpected(rangeError("day is out of range"_s));
-    }
-
-    return ResolvedISOFields { year, static_cast<uint8_t>(month), day };
+    // Step 2: NonISOResolveFields.
+    return nonISOResolveFields(calendarId, fields, type);
 }
 
 // https://tc39.es/proposal-intl-era-monthcode/#sup-temporal-nonisoresolvefields
@@ -256,6 +222,39 @@ TemporalResult<void> nonISOResolveFields(CalendarID calendarId, CalendarFieldsIn
     return { };
 }
 
+// https://tc39.es/proposal-temporal/#sec-temporal-calendardatetoiso
+static TemporalResult<ResolvedISOFields> calendarDateToISO(CalendarID calendarId, const CalendarFieldsIn& fields, TemporalOverflow overflow, ISOResolveType type)
+{
+    // Step 1: If calendar is "iso8601", then
+    if (calendarIsISO(calendarId)) {
+        // Step 1.a: Assert: fields.[[Year]], fields.[[Month]], and fields.[[Day]] are not unset.
+        ASSERT(fields.year.has_value());
+        ASSERT(fields.month.has_value());
+        ASSERT(type == ISOResolveType::YearMonth || fields.day.has_value());
+        int32_t year = *fields.year;
+        uint8_t day = type == ISOResolveType::YearMonth ? 1 : *fields.day;
+        uint32_t month = *fields.month;
+
+        // Step 1.b: Return ? RegulateISODate(fields.[[Year]], fields.[[Month]], fields.[[Day]], overflow).
+        auto regulated = regulateISODate(year, clampTo<int32_t>(month), day, overflow);
+        if (!regulated)
+            return makeUnexpected(regulated.error());
+        return ResolvedISOFields { regulated->year(), regulated->month(), regulated->day() };
+    }
+
+    // Step 2: Return ? NonISOCalendarDateToISO(calendar, fields, overflow).
+    uint8_t month = 1;
+    if (fields.month)
+        month = clampTo<uint8_t>(*fields.month);
+    else if (fields.monthCode)
+        month = static_cast<uint8_t>(fields.monthCode->monthNumber);
+    uint8_t day = type == ISOResolveType::YearMonth ? 1 : *fields.day;
+    auto result = nonISOCalendarDateToISO(calendarId, fields.year, month, day, fields.monthCode, overflow);
+    if (!result)
+        return makeUnexpected(result.error());
+    return ResolvedISOFields { result->year(), result->month(), result->day() };
+}
+
 // CalendarDateFromFields — temporal_rs: Calendar::date_from_fields (src/builtins/core/calendar.rs)
 // https://tc39.es/proposal-temporal/#sec-temporal-calendardatefromfields
 // Implements steps 1-4; PrepareCalendarFields done by JS-layer caller.
@@ -263,47 +262,30 @@ TemporalResult<ResolvedCalendarDate> dateFromFields(CalendarID calendarId, const
 {
     bool isISO = calendarIsISO(calendarId);
 
-    if (isISO) {
-        // Step 1 (ISO): CalendarResolveFields + Step 2 CalendarDateToISO — fused into resolveISOFields.
-        auto resolved = resolveISOFields(fields, overflow, ISOResolveType::Date);
-        if (!resolved)
-            return makeUnexpected(resolved.error());
-
-        // Step 3: If ISODateWithinLimits(result) is false, throw RangeError.
-        if (!ISO8601::isDateTimeWithinLimits(resolved->year, resolved->month, resolved->day, 12, 0, 0, 0, 0, 0))
-            return makeUnexpected(rangeError("Date is not within representable range"_s));
-
-        // Step 4: Return result.
-        auto isoDate = ISO8601::PlainDate(resolved->year, resolved->month, resolved->day);
-        return ResolvedCalendarDate { isoDate, iso8601CalendarID() };
-    }
-
-    // Step 1 (non-ISO): CalendarResolveFields → nonISOResolveFields.
     CalendarFieldsIn resolved = fields;
-    if (auto validated = nonISOResolveFields(calendarId, resolved, ResolveType::Date); !validated)
+    if (isISO) {
+        auto rangeCheck = checkYearRange(resolved);
+        if (!rangeCheck)
+            return makeUnexpected(rangeCheck.error());
+    }
+    // Step 1: CalendarResolveFields.
+    if (auto validated = calendarResolveFields(calendarId, resolved, ResolveType::Date); !validated)
         return makeUnexpected(validated.error());
 
-    // Resolve month from month/monthCode
-    uint8_t month = 1;
-    if (resolved.month)
-        month = clampTo<uint8_t>(*resolved.month);
-    else if (resolved.monthCode)
-        month = static_cast<uint8_t>(resolved.monthCode->monthNumber);
-
-    // nonISOResolveFields has already derived the arithmetic year and erased era/eraYear.
-    // Step 2 (non-ISO): CalendarDateToISO → nonISOCalendarDateToISO.
-    auto result = nonISOCalendarDateToISO(calendarId, resolved.year, month, *resolved.day, resolved.monthCode, overflow);
-    if (!result)
-        return makeUnexpected(result.error());
-    if (auto consistencyCheck = checkLunisolarMonthConsistency(calendarId, fields, *result); !consistencyCheck)
+    // Step 2: CalendarDateToISO.
+    auto resolvedIso = calendarDateToISO(calendarId, resolved, overflow, ISOResolveType::Date);
+    if (!resolvedIso)
+        return makeUnexpected(resolvedIso.error());
+    auto isoDate = ISO8601::PlainDate(resolvedIso->year, resolvedIso->month, resolvedIso->day);
+    if (auto consistencyCheck = checkLunisolarMonthConsistency(calendarId, fields, isoDate); !consistencyCheck)
         return makeUnexpected(consistencyCheck.error());
 
     // Step 3: If ISODateWithinLimits(result) is false, throw RangeError.
-    if (!ISO8601::isDateTimeWithinLimits(result->year(), result->month(), result->day(), 12, 0, 0, 0, 0, 0))
+    if (!ISO8601::isDateTimeWithinLimits(resolvedIso->year, resolvedIso->month, resolvedIso->day, 12, 0, 0, 0, 0, 0))
         return makeUnexpected(rangeError("Date is not within representable range"_s));
 
     // Step 4: Return result.
-    return ResolvedCalendarDate { *result, calendarId };
+    return ResolvedCalendarDate { isoDate, isISO ? iso8601CalendarID() : calendarId };
 }
 
 // CalendarYearMonthFromFields — temporal_rs: Calendar::year_month_from_fields (src/builtins/core/calendar.rs)
@@ -312,83 +294,69 @@ TemporalResult<ResolvedCalendarDate> yearMonthFromFields(CalendarID calendarId, 
 {
     bool isISO = calendarIsISO(calendarId);
 
-    // Steps 1-2 (ISO): set [[Day]]=1 + CalendarResolveFields + Step 3 CalendarDateToISO — fused into resolveISOFields.
+    // Step 1: Set fields.[[Day]] to 1.
+    CalendarFieldsIn resolved = fields;
+    resolved.day = 1;
+
     if (isISO) {
-        auto resolved = resolveISOFields(fields, overflow, ISOResolveType::YearMonth);
-        if (!resolved)
-            return makeUnexpected(resolved.error());
-
-        // Step 4: If ISOYearMonthWithinLimits(result) is false, throw RangeError.
-        if (!ISO8601::isYearMonthWithinLimits(resolved->year, resolved->month))
-            return makeUnexpected(rangeError("YearMonth is not within representable range"_s));
-
-        // Step 5: Return result.
-        auto isoDate = ISO8601::PlainDate(resolved->year, resolved->month, resolved->day);
-        return ResolvedCalendarDate { isoDate, iso8601CalendarID() };
+        auto rangeCheck = checkYearRange(resolved);
+        if (!rangeCheck)
+            return makeUnexpected(rangeCheck.error());
     }
 
-    // Steps 1-2 (non-ISO): set [[Day]]=1 + CalendarResolveFields → nonISOResolveFields.
-    CalendarFieldsIn resolved = fields;
-    if (auto validated = nonISOResolveFields(calendarId, resolved, ResolveType::YearMonth); !validated)
+    // Step 2: CalendarResolveFields. (non-ISO: nonISOResolveFields does its own checkYearRange
+    // interleaved with its presence/consistency checks — do not range-check again here.)
+    if (auto validated = calendarResolveFields(calendarId, resolved, ResolveType::YearMonth); !validated)
         return makeUnexpected(validated.error());
 
-    uint8_t month = 1;
-    if (resolved.month)
-        month = clampTo<uint8_t>(*resolved.month);
-    else if (resolved.monthCode)
-        month = static_cast<uint8_t>(resolved.monthCode->monthNumber);
-
-    // nonISOResolveFields has already derived the arithmetic year and erased era/eraYear.
-    // Step 3 (non-ISO): CalendarDateToISO → nonISOCalendarDateToISO.
-    auto result = nonISOCalendarDateToISO(calendarId, resolved.year, month, 1, resolved.monthCode, overflow);
-    if (!result)
-        return makeUnexpected(result.error());
-    if (auto consistencyCheck = checkLunisolarMonthConsistency(calendarId, fields, *result); !consistencyCheck)
+    // Step 3: CalendarDateToISO.
+    auto resolvedIso = calendarDateToISO(calendarId, resolved, overflow, ISOResolveType::YearMonth);
+    if (!resolvedIso)
+        return makeUnexpected(resolvedIso.error());
+    auto isoDate = ISO8601::PlainDate(resolvedIso->year, resolvedIso->month, resolvedIso->day);
+    if (auto consistencyCheck = checkLunisolarMonthConsistency(calendarId, fields, isoDate); !consistencyCheck)
         return makeUnexpected(consistencyCheck.error());
 
     // Step 4: If ISOYearMonthWithinLimits(result) is false, throw RangeError.
-    if (!ISO8601::isYearMonthWithinLimits(result->year(), result->month()))
+    if (!ISO8601::isYearMonthWithinLimits(resolvedIso->year, resolvedIso->month))
         return makeUnexpected(rangeError("YearMonth is not within representable range"_s));
 
     // Step 5: Return result.
-    return ResolvedCalendarDate { *result, calendarId };
+    return ResolvedCalendarDate { isoDate, isISO ? iso8601CalendarID() : calendarId };
 }
 
 // CalendarMonthDayFromFields — temporal_rs: Calendar::month_day_from_fields (src/builtins/core/calendar.rs)
 // https://tc39.es/proposal-temporal/#sec-temporal-calendarmonthdayfromfields
+// calendarDateToISO is not reused here: it stores whatever year it's given, but this always
+// stores the fixed reference year isoMonthDayReferenceLeapYear instead.
 TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, const CalendarFieldsIn& fields, TemporalOverflow overflow)
 {
     bool isISO = calendarIsISO(calendarId);
 
-    // Steps 1-2: CalendarResolveFields + CalendarMonthDayToISOReferenceDate — fused inline (ISO path).
+    // Steps 1-2: CalendarResolveFields + CalendarMonthDayToISOReferenceDate (ISO path).
     if (isISO) {
         // temporal_rs: if year is provided, validate day against that year first,
         // then use reference year 1972 for the stored date.
         // Per spec: the year is ONLY used for overflow (leap year check), NOT for range validation.
+        int32_t yearForOverflow = isoMonthDayReferenceLeapYear;
         if (fields.year) {
             // Substitute a proxy year with the same leap-year property to avoid range errors.
             // This matches the spec requirement that year is not range-checked for PlainMonthDay.
-            CalendarFieldsIn fieldsForOverflow = fields;
             int32_t yr = *fields.year;
             // Determine leap year status: divisible by 4, except centuries unless also by 400.
             bool isLeap = !(yr % 400) || (!(yr % 4) && yr % 100);
-            fieldsForOverflow.year = isLeap ? isoMonthDayReferenceLeapYear : isoMonthDayReferenceNonLeapYear;
-            auto resolved = resolveISOFields(fieldsForOverflow, overflow, ISOResolveType::Date);
-            if (!resolved)
-                return makeUnexpected(resolved.error());
-            // Step 3: Assert: ISODateWithinLimits(result) — always holds for reference year 1972.
-            ASSERT(ISO8601::isDateTimeWithinLimits(isoMonthDayReferenceLeapYear, resolved->month, resolved->day, 12, 0, 0, 0, 0, 0));
-            auto isoDate = ISO8601::PlainDate(isoMonthDayReferenceLeapYear, resolved->month, resolved->day);
-            // Step 4: Return result.
-            return ResolvedCalendarDate { isoDate, iso8601CalendarID() };
+            yearForOverflow = isLeap ? isoMonthDayReferenceLeapYear : isoMonthDayReferenceNonLeapYear;
         }
-        auto resolved = resolveISOFields(fields, overflow, ISOResolveType::MonthDay);
-        if (!resolved)
-            return makeUnexpected(resolved.error());
-
-        auto isoDate = ISO8601::PlainDate(isoMonthDayReferenceLeapYear, resolved->month, resolved->day);
+        CalendarFieldsIn resolvedFields = fields;
+        resolvedFields.year = yearForOverflow;
+        if (auto validated = calendarResolveFields(calendarId, resolvedFields, ResolveType::MonthDay); !validated)
+            return makeUnexpected(validated.error());
+        auto regulated = regulateISODate(yearForOverflow, clampTo<int32_t>(*resolvedFields.month), *resolvedFields.day, overflow);
+        if (!regulated)
+            return makeUnexpected(regulated.error());
         // Step 3: Assert: ISODateWithinLimits(result) — always holds for reference year 1972.
-        ASSERT(ISO8601::isDateTimeWithinLimits(isoMonthDayReferenceLeapYear, resolved->month, resolved->day, 12, 0, 0, 0, 0, 0));
+        ASSERT(ISO8601::isDateTimeWithinLimits(isoMonthDayReferenceLeapYear, regulated->month(), regulated->day(), 12, 0, 0, 0, 0, 0));
+        auto isoDate = ISO8601::PlainDate(isoMonthDayReferenceLeapYear, regulated->month(), regulated->day());
         // Step 4: Return result.
         return ResolvedCalendarDate { isoDate, iso8601CalendarID() };
     }

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -2539,8 +2539,6 @@ static TemporalResult<void> validateRejectMode(UCalendar* cal, CalendarID calend
 TemporalResult<ISO8601::PlainDate> nonISOCalendarDateToISO(CalendarID calendarId, std::optional<int32_t> year, uint8_t month, uint8_t day, std::optional<ParsedMonthCode> monthCode, TemporalOverflow overflow)
 {
     if (year && calendarUsesISOFallbackForExtremeYear(calendarId, *year)) {
-        if (*year < ISO8601::minYear || *year > ISO8601::maxYear) [[unlikely]]
-            return ISO8601::PlainDate { ISO8601::outOfRangeYear, 1, 1 };
         int32_t isoYear = *year;
         if (month > 12) {
             if (overflow == TemporalOverflow::Reject) [[unlikely]]
@@ -2597,8 +2595,6 @@ TemporalResult<ISO8601::PlainDate> nonISOCalendarDateToISO(CalendarID calendarId
                 return makeUnexpected(rangeError("month is out of range"_s));
             ASSERT(year);
             int32_t isoYear = gregorianStructuredCalendarISOYear(calendarId, *year);
-            if (!ISO8601::isYearWithinLimits(isoYear)) [[unlikely]]
-                return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
             uint8_t resolvedMonth = month;
             if (month > 12) {
                 if (overflow == TemporalOverflow::Reject) [[unlikely]]

--- a/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
@@ -51,21 +51,17 @@ ISO8601::PlainYearMonth balanceISOYearMonth(int64_t year, int64_t month)
     // 2. Set month to ((month - 1) modulo 12) + 1.
     month = newM0 + 1;
     // 3. Return ISO Year-Month Record { [[Year]]: year, [[Month]]: month }.
-    // NOTE: clamp year to representable range (outOfRangeYear sentinel); callers check.
-    if (year < ISO8601::minYear || year > ISO8601::maxYear) [[unlikely]]
-        year = ISO8601::outOfRangeYear;
-    return ISO8601::PlainYearMonth(static_cast<int32_t>(year), static_cast<unsigned>(month));
+    return ISO8601::PlainYearMonth(ISO8601::PlainDate(year, static_cast<unsigned>(month), 1));
 }
 
 // AddDaysToISODate — temporal_rs: IsoDate::balance (with implicit day fold-in)
 // https://tc39.es/proposal-temporal/#sec-temporal-adddaystoisodate
-// NOTE: Returns { outOfRangeYear, 1, 1 } for out-of-bounds dates instead of throwing (callers check).
 ISO8601::PlainDate addDaysToISODate(const ISO8601::PlainDate& date, int64_t days)
 {
     int32_t year = date.year();
     int32_t month = static_cast<int32_t>(date.month());
     if (year == ISO8601::outOfRangeYear) [[unlikely]]
-        return ISO8601::PlainDate { ISO8601::outOfRangeYear, 1, 1 };
+        return ISO8601::PlainDate::sentinel();
 
     // PlainDate's month invariant (set by regulateISODate / balanceISOYearMonth at every
     // construction site reachable from public Temporal entry points) is [1, 12]. We rely
@@ -86,11 +82,11 @@ ISO8601::PlainDate addDaysToISODate(const ISO8601::PlainDate& date, int64_t days
     double ms = makeDate(epochDays, 0);
     double daysToUse = msToDays(ms);
     if (!isInBounds<int32_t>(daysToUse)) [[unlikely]]
-        return ISO8601::PlainDate { ISO8601::outOfRangeYear, 1, 1 };
+        return ISO8601::PlainDate::sentinel();
     // 3. Return CreateISODateRecord(EpochTimeToEpochYear(ms), EpochTimeToMonthInYear(ms) + 1, EpochTimeToDate(ms)).
     auto [y, m, d] = WTF::yearMonthDayFromDays(static_cast<int32_t>(daysToUse));
     if (!ISO8601::isYearWithinLimits(y)) [[unlikely]]
-        return ISO8601::PlainDate { ISO8601::outOfRangeYear, 1, 1 };
+        return ISO8601::PlainDate::sentinel();
     return ISO8601::PlainDate { y, static_cast<unsigned>(m + 1), static_cast<unsigned>(d) };
 }
 


### PR DESCRIPTION
#### 89c1884e15a927c5dd681311418d44b66cf8012e
<pre>
[JSC][Temporal] Guard PlainDate construction against out-of-range years; consolidate CalendarResolveFields
<a href="https://bugs.webkit.org/show_bug.cgi?id=320927">https://bugs.webkit.org/show_bug.cgi?id=320927</a>
<a href="https://rdar.apple.com/183960408">rdar://183960408</a>

Reviewed by Yusuke Suzuki.

PlainDate&apos;s constructor now sanitizes `year` itself instead of asserting and
trusting every caller to check first — this was crashing on debug builds
(e.g. indianSakaToISO, huge duration arithmetic) and silently wrapping
values incorrectly in a couple of places. Added an int64_t overload and a
sentinel() factory for callers whose month/day may be equally untrustworthy.

Also fixed PlainYearMonth.prototype.toPlainDate misusing the year sentinel
as a day poison value (wrong clamp direction under overflow:constrain), and
a possible UB static_cast in the PlainMonthDay constructor.

Consolidated CalendarResolveFields/CalendarDateToISO into single
implementations in CalendarFields.cpp, removing a second undocumented
duplicate in TemporalCalendar.cpp and monthDayFromFields&apos;s own internal
duplication.

Canonical link: <a href="https://commits.webkit.org/318504@main">https://commits.webkit.org/318504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b9699fade59631f6099081672c14853e55376f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141720 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5960089a-20e2-4f68-8382-5e2518625695) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180334 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139138 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4673f12-7d86-4d28-a632-41c2e0cef948) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119592 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dfd0fedc-1e0d-4891-9fc5-c3d0129feee6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41367 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39714 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1561 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8379 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151767 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39389 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Skipped layout-tests; 343 new passes 13 flakes 1 failures; Uploaded test results; 343 new passes 8 flakes 1 failures; 343 new passes 3 flakes 2 failures; Passed layout tests with flaky tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36542 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39744 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45009 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190514 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/177874 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52078 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148297 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52759 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148068 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27078 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42778 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125025 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119662 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51277 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14364 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50662 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50902 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->