### PR TITLE
[GLib] Add WEBKIT_WEBSITE_DATA_ALL_MANAGED_TYPES

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -260,18 +260,6 @@ bool NetworkStorageManager::canHandleTypes(OptionSet<WebsiteDataType> types)
     return allManagedTypes().containsAny(types);
 }
 
-OptionSet<WebsiteDataType> NetworkStorageManager::allManagedTypes()
-{
-    return {
-        WebsiteDataType::LocalStorage,
-        WebsiteDataType::SessionStorage,
-        WebsiteDataType::FileSystem,
-        WebsiteDataType::IndexedDBDatabases,
-        WebsiteDataType::DOMCache,
-        WebsiteDataType::ServiceWorkerRegistrations
-    };
-}
-
 void NetworkStorageManager::close(CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -113,7 +113,17 @@ class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver<WTF::De
 public:
     static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled, TimeBasedEvictionMode, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride, std::optional<Seconds> timeBasedEvictionIntervalOverride);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);
-    static OptionSet<WebsiteDataType> allManagedTypes();
+    static constexpr OptionSet<WebsiteDataType> allManagedTypes()
+    {
+        return {
+            WebsiteDataType::LocalStorage,
+            WebsiteDataType::SessionStorage,
+            WebsiteDataType::FileSystem,
+            WebsiteDataType::IndexedDBDatabases,
+            WebsiteDataType::DOMCache,
+            WebsiteDataType::ServiceWorkerRegistrations
+        };
+    }
 
     void startReceivingMessageFromConnection(IPC::Connection&, std::optional<HashSet<WebCore::RegistrableDomain>>&&, const SharedPreferencesForWebProcess&);
     void stopReceivingMessageFromConnection(IPC::Connection&);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteData.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteData.h.in
@@ -47,9 +47,21 @@ typedef struct _WebKitWebsiteData WebKitWebsiteData;
  * @WEBKIT_WEBSITE_DATA_SERVICE_WORKER_REGISTRATIONS: Service worker registrations.
  * @WEBKIT_WEBSITE_DATA_DOM_CACHE: DOM (CacheStorage) cache.
  * @WEBKIT_WEBSITE_DATA_FILE_SYSTEM: File system storage. Since 2.56
+ * @WEBKIT_WEBSITE_DATA_ALL_MANAGED_TYPES: All per-origin storage types. Since 2.56
  * @WEBKIT_WEBSITE_DATA_ALL: All types.
  *
  * Enum values with flags representing types of Website data.
+ *
+ * @WEBKIT_WEBSITE_DATA_ALL_MANAGED_TYPES is a subset of types that WebKit manages
+ * as the storage of an origin: session and local storage, IndexedDB databases,
+ * service worker registrations, the DOM cache and file system storage. It excludes
+ * data that is not tied to a single origin in the same way, such as cookies, the
+ * memory and disk caches, and the HSTS cache.
+ *
+ * Removing every type in this set for an origin also drops the persistent
+ * storage the origin was granted. Note that types may be added to this set in
+ * future versions, so an application built against an older version can pass a
+ * value that no longer covers all of them.
  *
  * Since: 2.16
  */
@@ -67,6 +79,12 @@ typedef enum {
     WEBKIT_WEBSITE_DATA_SERVICE_WORKER_REGISTRATIONS = 1 << 10,
     WEBKIT_WEBSITE_DATA_DOM_CACHE                    = 1 << 11,
     WEBKIT_WEBSITE_DATA_FILE_SYSTEM                  = 1 << 12,
+    WEBKIT_WEBSITE_DATA_ALL_MANAGED_TYPES            = WEBKIT_WEBSITE_DATA_SESSION_STORAGE
+                                                     | WEBKIT_WEBSITE_DATA_LOCAL_STORAGE
+                                                     | WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES
+                                                     | WEBKIT_WEBSITE_DATA_SERVICE_WORKER_REGISTRATIONS
+                                                     | WEBKIT_WEBSITE_DATA_DOM_CACHE
+                                                     | WEBKIT_WEBSITE_DATA_FILE_SYSTEM,
     WEBKIT_WEBSITE_DATA_ALL                          = (1 << 13) - 1
 } WebKitWebsiteDataTypes;
 #else
@@ -87,9 +105,21 @@ typedef enum {
  * @WEBKIT_WEBSITE_DATA_SERVICE_WORKER_REGISTRATIONS: Service worker registrations. Since 2.30
  * @WEBKIT_WEBSITE_DATA_DOM_CACHE: DOM (CacheStorage) cache. Since 2.30
  * @WEBKIT_WEBSITE_DATA_FILE_SYSTEM: File system storage. Since 2.56
+ * @WEBKIT_WEBSITE_DATA_ALL_MANAGED_TYPES: All per-origin storage types. Since 2.56
  * @WEBKIT_WEBSITE_DATA_ALL: All types.
  *
  * Enum values with flags representing types of Website data.
+ *
+ * @WEBKIT_WEBSITE_DATA_ALL_MANAGED_TYPES is a subset of types that WebKit manages
+ * as the storage of an origin: session and local storage, IndexedDB databases,
+ * service worker registrations, the DOM cache and file system storage. It excludes
+ * data that is not tied to a single origin in the same way, such as cookies, the
+ * memory and disk caches, and the HSTS cache.
+ *
+ * Removing every type in this set for an origin also drops the persistent
+ * storage the origin was granted. Note that types may be added to this set in
+ * future versions, so an application built against an older version can pass a
+ * value that no longer covers all of them.
  *
  * Since: 2.16
  */
@@ -109,6 +139,12 @@ typedef enum {
     WEBKIT_WEBSITE_DATA_SERVICE_WORKER_REGISTRATIONS = 1 << 12,
     WEBKIT_WEBSITE_DATA_DOM_CACHE                    = 1 << 13,
     WEBKIT_WEBSITE_DATA_FILE_SYSTEM                  = 1 << 14,
+    WEBKIT_WEBSITE_DATA_ALL_MANAGED_TYPES            = WEBKIT_WEBSITE_DATA_SESSION_STORAGE
+                                                     | WEBKIT_WEBSITE_DATA_LOCAL_STORAGE
+                                                     | WEBKIT_WEBSITE_DATA_INDEXEDDB_DATABASES
+                                                     | WEBKIT_WEBSITE_DATA_SERVICE_WORKER_REGISTRATIONS
+                                                     | WEBKIT_WEBSITE_DATA_DOM_CACHE
+                                                     | WEBKIT_WEBSITE_DATA_FILE_SYSTEM,
     WEBKIT_WEBSITE_DATA_ALL                          = (1 << 15) - 1
 } WebKitWebsiteDataTypes;
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
@@ -22,6 +22,7 @@
 
 #include "ITPThirdPartyData.h"
 #include "ITPThirdPartyDataForSpecificFirstParty.h"
+#include "NetworkStorageManager.h"
 #include "WebKitCookieManagerPrivate.h"
 #include "WebKitInitialize.h"
 #include "WebKitMemoryPressureSettings.h"
@@ -1152,7 +1153,7 @@ WebKitFaviconDatabase* webkit_website_data_manager_get_favicon_database(WebKitWe
 }
 #endif
 
-static OptionSet<WebsiteDataType> toWebsiteDataTypes(WebKitWebsiteDataTypes types)
+static constexpr OptionSet<WebsiteDataType> toWebsiteDataTypes(WebKitWebsiteDataTypes types)
 {
     OptionSet<WebsiteDataType> returnValue;
     if (types & WEBKIT_WEBSITE_DATA_MEMORY_CACHE)
@@ -1185,6 +1186,8 @@ static OptionSet<WebsiteDataType> toWebsiteDataTypes(WebKitWebsiteDataTypes type
         returnValue.add(WebsiteDataType::FileSystem);
     return returnValue;
 }
+
+static_assert(toWebsiteDataTypes(WEBKIT_WEBSITE_DATA_ALL_MANAGED_TYPES) == NetworkStorageManager::allManagedTypes());
 
 /**
  * webkit_website_data_manager_fetch:


### PR DESCRIPTION
#### 14838c436e0cc74210a503e338a4a64e6d5a8ba2
<pre>
[GLib] Add WEBKIT_WEBSITE_DATA_ALL_MANAGED_TYPES
<a href="https://bugs.webkit.org/show_bug.cgi?id=320928">https://bugs.webkit.org/show_bug.cgi?id=320928</a>

Reviewed by NOBODY (OOPS!).

NetworkStorageManager handles a subset of the data types, and some
of its operations act on that set as a whole rather than
on individual types, specifically unmarking an origin as persisted.

Add WEBKIT_WEBSITE_DATA_ALL_MANAGED_TYPES for it, and a static_assert that it maps
onto NetworkStorageManager::allManagedTypes() so a type cannot be added to one
without the other.

This is a preparatory change for exposing persistant-storage.

* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::allManagedTypes): Deleted.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteData.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
(toWebsiteDataTypes):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14838c436e0cc74210a503e338a4a64e6d5a8ba2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52425 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188103 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52135 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181444 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/42712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119608 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36558 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45025 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190530 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52775 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148084 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42790 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51293 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->