### PR TITLE
[WTF] Make StackBounds::currentThreadStackBounds() private to Thread

### DIFF
--- a/Source/WTF/wtf/StackBounds.h
+++ b/Source/WTF/wtf/StackBounds.h
@@ -59,12 +59,6 @@ public:
     // This function is only effective for newly created threads. In some platform, it returns a bogus value for the main thread.
     static StackBounds newThreadStackBounds(PlatformThreadHandle);
 #endif
-    static StackBounds currentThreadStackBounds()
-    {
-        auto result = currentThreadStackBoundsInternal();
-        result.checkConsistency();
-        return result;
-    }
 
     void* origin() const
     {
@@ -140,7 +134,16 @@ private:
         return m_bound <= m_origin;
     }
 
-    WTF_EXPORT_PRIVATE static StackBounds currentThreadStackBoundsInternal();
+    static StackBounds currentThreadStackBoundsInternal();
+
+    // Obtaining stack bounds from the OS may be slow; only Thread class should do it.
+    // Other callers should use the cached bounds via Thread::currentSingleton().stack()
+    static StackBounds currentThreadStackBounds()
+    {
+        auto result = currentThreadStackBoundsInternal();
+        result.checkConsistency();
+        return result;
+    }
 
     void checkConsistency() const
     {
@@ -155,6 +158,7 @@ private:
     void* m_bound;
 
     friend class StackStats;
+    friend class Thread;
 };
 
 } // namespace WTF


### PR DESCRIPTION
#### f6bc402b8344ad1774116fc13e7a07440ed91250
<pre>
[WTF] Make StackBounds::currentThreadStackBounds() private to Thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=320926">https://bugs.webkit.org/show_bug.cgi?id=320926</a>

Reviewed by Yusuke Suzuki.

On Linux, obtaining the main thread stack bounds can be expensive.
currentThreadStackBoundsInternal() calls pthread_getattr_np(), which may
parse the entire /proc/self/maps file to locate the main thread stack.
Calling it repeatedly can cause performance problems like the one fixed
in 318487@main.

currentThreadStackBounds() is intended to be called during thread
initialization, with the result cached in Thread::m_stack. Other code
should read the cached bounds using Thread::currentSingleton().stack().

Nothing enforced this restriction, which allowed the uncached function
to be used repeatedly. Move currentThreadStackBounds() to the private
section and make Thread a friend, preventing other callers from
accidentally bypassing the cached bounds.

* Source/WTF/wtf/StackBounds.h:
(WTF::StackBounds::currentThreadStackBounds):

Canonical link: <a href="https://commits.webkit.org/318534@main">https://commits.webkit.org/318534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13df449fab43ff5e27c7fdef7d3b2751e32a82b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141734 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139167 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119621 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41382 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39729 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1590 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8395 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39405 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36556 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39758 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190528 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52092 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148316 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39843 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52773 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148086 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42797 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125039 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119676 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51291 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14380 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50676 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->