### PR TITLE
[JSC] Move two rarely-executed code paths out of the lexer and parser hot functions

### DIFF
--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -2073,6 +2073,63 @@ void Lexer<T>::fillTokenInfo(JSToken* tokenRecord, JSTextPosition endPosition)
 }
 
 template <typename T>
+NEVER_INLINE std::optional<JSTokenType> Lexer<T>::scanSingleLineComment(JSToken* tokenRecord, bool checkForDirectives)
+{
+    if (checkForDirectives) {
+        // Script comment directives like "//# sourceURL=test.js".
+        if ((m_current == '#' || m_current == '@') && isWhiteSpace(peek(1))) [[unlikely]] {
+            shift();
+            shift();
+            parseCommentDirective();
+        }
+    }
+
+    auto endPosition = currentPosition();
+
+    using UnsignedType = SameSizeUnsignedInteger<T>;
+    constexpr auto lineFeedMask = SIMD::splat<UnsignedType>('\n');
+    constexpr auto carriageReturnMask = SIMD::splat<UnsignedType>('\r');
+    constexpr auto u2028Mask = SIMD::splat<UnsignedType>(static_cast<UnsignedType>(0x2028));
+    constexpr auto u2029Mask = SIMD::splat<UnsignedType>(static_cast<UnsignedType>(0x2029));
+    auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
+        auto lineFeed = SIMD::equal(input, lineFeedMask);
+        auto carriageReturn = SIMD::equal(input, carriageReturnMask);
+        if constexpr (std::is_same_v<T, Latin1Character>) {
+            auto mask = SIMD::bitOr(lineFeed, carriageReturn);
+            return SIMD::findFirstNonZeroIndex(mask);
+        } else {
+            auto u2028 = SIMD::equal(input, u2028Mask);
+            auto u2029 = SIMD::equal(input, u2029Mask);
+            auto mask = SIMD::bitOr(lineFeed, carriageReturn, u2028, u2029);
+            return SIMD::findFirstNonZeroIndex(mask);
+        }
+    };
+
+    auto scalarMatch = [&](auto character) ALWAYS_INLINE_LAMBDA {
+        return isLineTerminator(character);
+    };
+
+    m_code = SIMD::find(std::span { currentSourcePtr(), m_codeEnd }, vectorMatch, scalarMatch);
+    if (m_code == m_codeEnd) {
+        m_current = 0;
+        fillTokenInfo(tokenRecord, endPosition);
+        return EOFTOK;
+    }
+
+    m_current = *m_code;
+    shiftLineTerminator();
+    m_atLineStart = true;
+    m_hasLineTerminatorBeforeToken = true;
+    // The caller restarts the token scan unless a restricted keyword needs the
+    // automatic semicolon that the line terminator implies.
+    if (!isRestrKeyword(tokenRecord->m_type))
+        return std::nullopt;
+
+    fillTokenInfo(tokenRecord, endPosition);
+    return SEMICOLON;
+}
+
+template <typename T>
 JSTokenType Lexer<T>::lexWithoutClearingLineTerminator(JSToken* tokenRecord, OptionSet<LexerFlags> lexerFlags, bool strictMode)
 {
     JSTokenData* tokenData = &tokenRecord->m_data;
@@ -2168,7 +2225,9 @@ start:
         if (m_current == '!' && peek(1) == '-' && peek(2) == '-') {
             if (m_scriptMode == JSParserScriptMode::Classic) {
                 // <!-- marks the beginning of a line comment (for www usage)
-                goto inSingleLineComment;
+                if (auto result = scanSingleLineComment(tokenRecord, false))
+                    return *result;
+                goto start;
             }
         }
         if (m_current == '<') {
@@ -2229,7 +2288,9 @@ start:
             if ((m_atLineStart || m_hasLineTerminatorBeforeToken) && m_current == '>') {
                 if (m_scriptMode == JSParserScriptMode::Classic) {
                     shift();
-                    goto inSingleLineComment;
+                    if (auto result = scanSingleLineComment(tokenRecord, false))
+                        return *result;
+                    goto start;
                 }
             }
             token = (!m_hasLineTerminatorBeforeToken) ? MINUSMINUS : AUTOMINUSMINUS;
@@ -2269,7 +2330,9 @@ start:
         shift();
         if (m_current == '/') {
             shift();
-            goto inSingleLineCommentCheckForDirectives;
+            if (auto result = scanSingleLineComment(tokenRecord, true))
+                return *result;
+            goto start;
         }
         if (m_current == '*') {
             shift();
@@ -2920,7 +2983,9 @@ start:
         if (next == '!' && !currentOffset()) {
             shift();
             shift();
-            goto inSingleLineComment;
+            if (auto result = scanSingleLineComment(tokenRecord, false))
+                return *result;
+            goto start;
         }
 
         bool isValidPrivateName;
@@ -3049,62 +3114,6 @@ start:
 
     m_atLineStart = false;
     goto returnToken;
-
-inSingleLineCommentCheckForDirectives:
-    // Script comment directives like "//# sourceURL=test.js".
-    if ((m_current == '#' || m_current == '@') && isWhiteSpace(peek(1))) [[unlikely]] {
-        shift();
-        shift();
-        parseCommentDirective();
-    }
-    // Fall through to complete single line comment parsing.
-
-inSingleLineComment:
-    {
-        auto endPosition = currentPosition();
-
-        using UnsignedType = SameSizeUnsignedInteger<T>;
-        constexpr auto lineFeedMask = SIMD::splat<UnsignedType>('\n');
-        constexpr auto carriageReturnMask = SIMD::splat<UnsignedType>('\r');
-        constexpr auto u2028Mask = SIMD::splat<UnsignedType>(static_cast<UnsignedType>(0x2028));
-        constexpr auto u2029Mask = SIMD::splat<UnsignedType>(static_cast<UnsignedType>(0x2029));
-        auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
-            auto lineFeed = SIMD::equal(input, lineFeedMask);
-            auto carriageReturn = SIMD::equal(input, carriageReturnMask);
-            if constexpr (std::is_same_v<T, Latin1Character>) {
-                auto mask = SIMD::bitOr(lineFeed, carriageReturn);
-                return SIMD::findFirstNonZeroIndex(mask);
-            } else {
-                auto u2028 = SIMD::equal(input, u2028Mask);
-                auto u2029 = SIMD::equal(input, u2029Mask);
-                auto mask = SIMD::bitOr(lineFeed, carriageReturn, u2028, u2029);
-                return SIMD::findFirstNonZeroIndex(mask);
-            }
-        };
-
-        auto scalarMatch = [&](auto character) ALWAYS_INLINE_LAMBDA {
-            return isLineTerminator(character);
-        };
-
-        m_code = SIMD::find(std::span { currentSourcePtr(), m_codeEnd }, vectorMatch, scalarMatch);
-        if (m_code == m_codeEnd) {
-            m_current = 0;
-            token = EOFTOK;
-            fillTokenInfo(tokenRecord, endPosition);
-            return token;
-        }
-
-        m_current = *m_code;
-        shiftLineTerminator();
-        m_atLineStart = true;
-        m_hasLineTerminatorBeforeToken = true;
-        if (!isRestrKeyword(tokenRecord->m_type))
-            goto start;
-
-        token = SEMICOLON;
-        fillTokenInfo(tokenRecord, endPosition);
-        return token;
-    }
 
 returnToken:
     fillTokenInfo(tokenRecord, currentPosition());

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -196,6 +196,7 @@ private:
     ALWAYS_INLINE bool parseNumberAfterDecimalPoint();
     ALWAYS_INLINE bool parseNumberAfterExponentIndicator();
     ALWAYS_INLINE bool parseMultilineComment();
+    NEVER_INLINE std::optional<JSTokenType> scanSingleLineComment(JSToken*, bool checkForDirectives);
 
     ALWAYS_INLINE void parseCommentDirective();
     ALWAYS_INLINE String parseCommentDirectiveValue();

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -4275,6 +4275,63 @@ template <typename TreeBuilder> bool Parser<LexerType>::isSimpleAssignmentTarget
 }
 
 template <typename LexerType>
+template <typename TreeBuilder> TreeExpression Parser<LexerType>::parseDestructuringAssignment(TreeBuilder& context, SavePoint& savePoint, const JSTokenLocation& location, bool isPossiblePattern)
+{
+    SavePointWithError expressionErrorLocation = swapSavePointForError(context, savePoint);
+    auto pattern = tryParseDestructuringPatternExpression(context, AssignmentContext::AssignmentExpression);
+
+    // The reason why we use restoreSavePointWithError only when isPossiblePattern = true is that
+    // this can produce better error message.
+    if (isPossiblePattern && (!pattern || !match(EQUAL))) {
+        restoreSavePointWithError(context, expressionErrorLocation);
+        propagateError();
+    }
+    failIfFalse(pattern, "Cannot parse assignment pattern");
+    consumeOrFail(EQUAL, "Expected '=' following assignment pattern");
+    auto rhs = parseAssignmentExpression(context);
+    if (!rhs)
+        propagateError();
+    return context.createDestructuringAssignment(location, pattern, rhs);
+}
+
+template <typename LexerType>
+template <typename TreeBuilder> TreeExpression Parser<LexerType>::parseArrowFunctionCandidate(TreeBuilder& context, SavePoint& savePoint, const JSTokenLocation& location, bool isArrowFunctionToken, bool wasOpenParen, size_t usedVariablesSize, bool& shouldReturnResult)
+{
+    SavePointWithError errorRestorationSavePoint = swapSavePointForError(context, savePoint);
+    bool isAsync = false;
+    if (matchContextualKeyword(m_vm.propertyNames->async)) {
+        next();
+        if (!m_lexer->hasLineTerminatorBeforeToken() && (match(OPENPAREN) || matchSpecIdentifier()))
+            isAsync = true;
+        else {
+            // This is async => ... case. So this "async" is not a contextual keyword, it is parameter name.
+            restoreSavePoint(context, savePoint);
+        }
+    }
+
+    if (isArrowFunctionParameters(context)) {
+        if (wasOpenParen)
+            currentScope()->revertToPreviousUsedVariables(usedVariablesSize);
+        shouldReturnResult = true;
+        return parseArrowFunctionExpression(context, isAsync, location);
+    }
+
+    // The reason why we use propagateError only when isArrowFunctionToken = true is that
+    // this can produce better error message than restoring it to errorRestorationSavePoint.
+    if (isArrowFunctionToken && hasError()) [[unlikely]] {
+        shouldReturnResult = true;
+        return 0;
+    }
+
+    restoreSavePointWithError(context, errorRestorationSavePoint);
+    if (isArrowFunctionToken) [[unlikely]] {
+        shouldReturnResult = true;
+        failDueToUnexpectedToken();
+    }
+    return 0;
+}
+
+template <typename LexerType>
 template <typename TreeBuilder> TreeExpression Parser<LexerType>::parseAssignmentExpression(TreeBuilder& context)
 {
     ASSERT(!hasError());
@@ -4325,56 +4382,18 @@ template <typename TreeBuilder> TreeExpression Parser<LexerType>::parseAssignmen
     if (maybeValidArrowFunctionStart && !match(EOFTOK)) {
         bool isArrowFunctionToken = match(ARROWFUNCTION);
         if (!lhs || isArrowFunctionToken) {
-            SavePointWithError errorRestorationSavePoint = swapSavePointForError(context, *savePoint);
-            bool isAsync = false;
-            if (matchContextualKeyword(m_vm.propertyNames->async)) {
-                next();
-                if (!m_lexer->hasLineTerminatorBeforeToken() && (match(OPENPAREN) || matchSpecIdentifier()))
-                    isAsync = true;
-                else {
-                    // This is async => ... case. So this "async" is not a contextual keyword, it is parameter name.
-                    restoreSavePoint(context, *savePoint);
-                }
-            }
-
-            if (isArrowFunctionParameters(context)) {
-                if (wasOpenParen)
-                    currentScope()->revertToPreviousUsedVariables(usedVariablesSize);
-                return parseArrowFunctionExpression(context, isAsync, location);
-            }
-
-            // The reason why we use propagateError only when isArrowFunctionToken = true is that
-            // this can produce better error message than restoring it to errorRestorationSavePoint.
-            if (isArrowFunctionToken)
-                propagateError();
-
-            restoreSavePointWithError(context, errorRestorationSavePoint);
-            if (isArrowFunctionToken) [[unlikely]]
-                failDueToUnexpectedToken();
+            bool shouldReturnResult = false;
+            TreeExpression result = parseArrowFunctionCandidate(context, *savePoint, location, isArrowFunctionToken, wasOpenParen, usedVariablesSize, shouldReturnResult);
+            if (shouldReturnResult)
+                return result;
         }
     }
 
     if (!lhs && !maybeAssignmentPattern)
         propagateError();
 
-    if (maybeAssignmentPattern && (!lhs || (match(EQUAL) && context.isObjectOrArrayLiteral(lhs)))) {
-        bool isPossiblePattern = !lhs;
-        SavePointWithError expressionErrorLocation = swapSavePointForError(context, *savePoint);
-        auto pattern = tryParseDestructuringPatternExpression(context, AssignmentContext::AssignmentExpression);
-
-        // The reason why we use restoreSavePointWithError only when isPossiblePattern = true is that
-        // this can produce better error message.
-        if (isPossiblePattern && (!pattern || !match(EQUAL))) {
-            restoreSavePointWithError(context, expressionErrorLocation);
-            propagateError();
-        }
-        failIfFalse(pattern, "Cannot parse assignment pattern");
-        consumeOrFail(EQUAL, "Expected '=' following assignment pattern");
-        auto rhs = parseAssignmentExpression(context);
-        if (!rhs)
-            propagateError();
-        return context.createDestructuringAssignment(location, pattern, rhs);
-    }
+    if (maybeAssignmentPattern && (!lhs || (match(EQUAL) && context.isObjectOrArrayLiteral(lhs))))
+        return parseDestructuringAssignment(context, *savePoint, location, !lhs);
 
     failIfFalse(lhs, "Cannot parse expression");
     if (initialNonLHSCount != m_parserState.nonLHSCount) {

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1787,6 +1787,8 @@ private:
     template <class TreeBuilder> TreeStatement parseBlockStatement(TreeBuilder&, BlockType = BlockType::Normal);
     template <class TreeBuilder> TreeExpression parseExpression(TreeBuilder&);
     template <class TreeBuilder> TreeExpression parseAssignmentExpression(TreeBuilder&);
+    template <typename TreeBuilder> NEVER_INLINE TreeExpression parseArrowFunctionCandidate(TreeBuilder&, SavePoint&, const JSTokenLocation&, bool isArrowFunctionToken, bool wasOpenParen, size_t usedVariablesSize, bool& shouldReturnResult);
+    template <typename TreeBuilder> NEVER_INLINE TreeExpression parseDestructuringAssignment(TreeBuilder&, SavePoint&, const JSTokenLocation&, bool isPossiblePattern);
     template <class TreeBuilder> TreeExpression parseYieldExpression(TreeBuilder&);
     template <class TreeBuilder> ALWAYS_INLINE TreeExpression parseConditionalExpression(TreeBuilder&);
     template <class TreeBuilder> ALWAYS_INLINE TreeExpression parseBinaryExpression(TreeBuilder&);


### PR DESCRIPTION
#### 8aa3307b46af61b6f3f3dc7ee15df203f4146fe1
<pre>
[JSC] Move two rarely-executed code paths out of the lexer and parser hot functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=320930">https://bugs.webkit.org/show_bug.cgi?id=320930</a>
<a href="https://rdar.apple.com/183964804">rdar://183964804</a>

Reviewed by Yusuke Suzuki.

This patch moves seldom executed code out of two hot functions in Lexer and Parser,
reducing the containing functions&apos; register pressure and spill traffic and improving
performance.

Lexer::lexWithoutClearingLineTerminator: the single-line comment scanner is extracted into
the scanSingleLineComment() function.

Parser::parseAssignmentExpression(): the arrow-function candidate path and the
destructuring path are extracted as parseArrowFunctionCandidate() and
parseDestructuringAssignment().

Testing: no logic changes, covered by existing tests.

* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;T&gt;::scanSingleLineComment):
(JSC::Lexer&lt;T&gt;::lexWithoutClearingLineTerminator):
* Source/JavaScriptCore/parser/Lexer.h:
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseDestructuringAssignment):
(JSC::Parser&lt;LexerType&gt;::parseArrowFunctionCandidate):
(JSC::Parser&lt;LexerType&gt;::parseAssignmentExpression):
* Source/JavaScriptCore/parser/Parser.h:

Canonical link: <a href="https://commits.webkit.org/318507@main">https://commits.webkit.org/318507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1987b7b1fc060b01a85e84cd05b21c285d0f074

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188104 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141737 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd481f56-eaa1-4b8a-822c-4f061bcc1b6e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139155 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a61fc6bb-a766-444f-a58f-675f655e927b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119609 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0772c780-1d54-4d12-b384-a9bec082aaac) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41376 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39728 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1578 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8390 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151776 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39400 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36559 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39761 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45026 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43970 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190531 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52095 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148315 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39824 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52776 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36024 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148085 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42791 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125042 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119679 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51294 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14375 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50679 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50919 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50741 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->