### PR TITLE
[Site Isolation] Web Inspector: Match frame documents to owner iframe by frameId instead of URL

### DIFF
--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
@@ -37,6 +37,7 @@
 #include "DOMPatchSupport.h"
 #include "Document.h"
 #include "DocumentInlines.h"
+#include "DocumentPage.h"
 #include "DocumentType.h"
 #include "Editing.h"
 #include "ElementInlines.h"
@@ -53,6 +54,7 @@
 #include "HTMLTemplateElement.h"
 #include "InspectorDOMAgent.h"
 #include "InspectorHistory.h"
+#include "InspectorIdentifierRegistry.h"
 #include "InspectorNodeFinder.h"
 #include "InstrumentingAgents.h"
 #include "JSDOMBindingSecurity.h"
@@ -63,6 +65,8 @@
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
 #include "NodeList.h"
+#include "Page.h"
+#include "PageInspectorController.h"
 #include "PseudoElement.h"
 #include "RegisteredEventListener.h"
 #include "ScriptController.h"
@@ -79,6 +83,7 @@
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <pal/crypto/CryptoDigest.h>
 #include <pal/text/TextEncoding.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
@@ -382,8 +387,10 @@ Ref<Inspector::Protocol::DOM::Node> FrameDOMAgent::buildObjectForNode(Node* node
                 value->setPseudoElements(pseudoElements.releaseNonNull());
         }
     } else if (RefPtr document = dynamicDowncast<Document>(*node)) {
+        // The frame target alone does not tell the frontend which frame this document belongs to.
+        if (RefPtr page = m_inspectedFrame->page())
+            value->setFrameId(page->inspectorController().identifierRegistry().frameId(protect(document->frame())));
         value->setDocumentURL(InspectorDOMAgent::documentURLString(document.get()));
-        // FIXME: <https://webkit.org/b/298980> Set frameId for frame targets to enable frontend frame-to-target association.
     } else if (RefPtr doctype = dynamicDowncast<DocumentType>(*node)) {
         value->setPublicId(doctype->publicId());
         value->setSystemId(doctype->systemId());

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -118,6 +118,11 @@ WI.DOMManager = class DOMManager extends WI.Object
         if (!frameDocument || !frameDocument.documentURL)
             return;
 
+        // A frame with no owner element has no `contentDocument` slot to fill. Queueing it would
+        // strand it here and needlessly force the page body's children to load early.
+        if (frameDocument.frame && !frameDocument.frame.parentFrame)
+            return;
+
         if (this._trySpliceFrameDocumentIntoNode(frameDocument))
             return;
 
@@ -162,9 +167,8 @@ WI.DOMManager = class DOMManager extends WI.Object
         this._pageBodyChildrenRequested = true;
     }
 
-    // FIXME: <https://webkit.org/b/298980> URL-based matching is fragile (breaks with redirects,
-    // blob: URLs, about:srcdoc, query strings). Use frame identity information (frame ID or target ID)
-    // threaded through Target.targetCreated to directly look up the parent iframe element.
+    // FIXME: <https://webkit.org/b/320933> Match on the document's frameId instead. URL-based
+    // matching breaks with redirects, blob: URLs, about:srcdoc, and query strings.
     _trySpliceFrameDocumentIntoNode(frameDocument)
     {
         let frameDocURL = frameDocument.documentURL;


### PR DESCRIPTION
#### 7c631484027e48b6a845811339eb6b299a3dd434
<pre>
[Site Isolation] Web Inspector: Match frame documents to owner iframe by frameId instead of URL
<a href="https://rdar.apple.com/183966209">rdar://183966209</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320932">https://bugs.webkit.org/show_bug.cgi?id=320932</a>

Reviewed by NOBODY (OOPS!).

FrameDOMAgent never set frameId on document nodes, unlike
InspectorDOMAgent, so the frontend could not tell which frame a document
belonged to and tried to splice every frame document into the page tree.
A frame with no owner element has no contentDocument slot to fill, so
that attempt can never succeed. The document was then queued and the
frontend eagerly walked the page body&apos;s children looking for an iframe
element to match by URL. That walk cannot help such a document, and it
delivers nodes to the frontend earlier than any other request would,
which is observable.

Setting the field lets the frontend resolve the document&apos;s frame and
skip splicing when that frame has no parent frame. The condition is
written as &quot;no owner element&quot; rather than &quot;is the main frame&quot; on
purpose. It is also conservative: an unresolved frame falls back to the
previous queue-and-match path.

inspector/css/setLayoutContextTypeChangedMode.html now passes. It was
failing its first assertion because the eager walk delivered a grid
element, carrying its layout flag, before the test queried the document.
No expected results needed recollection.

Documents now carry a frameId, so the surviving URL-based matching in
DOMManager can be replaced by frame identity. Its FIXME is updated to
say so and is tracked by webkit.org/b/320933.

* Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp:
(WebCore::FrameDOMAgent::buildObjectForNode):
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.prototype._spliceFrameDocumentIntoPageTree):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c631484027e48b6a845811339eb6b299a3dd434

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141741 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139159 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96636 "2 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a83e8303-b38c-41f4-955e-af2587f4b5a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119613 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43155524-5c67-4b58-baf7-686adf2d1d18) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41383 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39733 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151783 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39404 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45030 "Found 1 new failure in inspector/agents/frame/FrameDOMAgent.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190535 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52099 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148320 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52780 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148090 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42796 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125046 "Found 1 new failure in inspector/agents/frame/FrameDOMAgent.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119683 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51298 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14379 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50683 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50923 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50745 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->