### PR TITLE
[SwiftUI WebKit API] Expose _attachmentElementEnabled and _imageControlsEnabled  on WebPage.Configuration

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
@@ -79,6 +79,14 @@ extension WKWebViewConfiguration {
         #endif
 
         self._isControlledByAutomation = wrapped.isControlledByAutomation
+
+        #if !os(watchOS) && !os(tvOS)
+        self._attachmentElementEnabled = wrapped.attachmentElementEnabled
+        #endif
+
+        #if WTF_PLATFORM_MAC
+        self._imageControlsEnabled = wrapped.imageControlsEnabled
+        #endif
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -167,6 +167,30 @@ extension WebPage {
         public var userInterfaceDirectionPolicy: WKUserInterfaceDirectionPolicy = .content
         #endif
 
+        private var backingAttachmentElementEnabled = false
+
+        /// Determines if the non-standard `<attachment>` element may be used in web content.
+        @_spi(Experimental)
+        @available(watchOS, unavailable)
+        @available(tvOS, unavailable)
+        public var attachmentElementEnabled: Bool {
+            get { backingAttachmentElementEnabled }
+            set { backingAttachmentElementEnabled = newValue }
+        }
+
+        private var backingImageControlsEnabled = false
+
+        /// Indicates if the service controls UI appears in web content over images.
+        @_spi(Experimental)
+        @available(iOS, unavailable)
+        @available(visionOS, unavailable)
+        @available(watchOS, unavailable)
+        @available(tvOS, unavailable)
+        public var imageControlsEnabled: Bool {
+            get { backingImageControlsEnabled }
+            set { backingImageControlsEnabled = newValue }
+        }
+
         /// The process pool to use for the page, used for testing.
         @_spi(Testing)
         public var processPool: WKProcessPool? = nil


### PR DESCRIPTION
#### 4226bb9234e22fc5de2ce32add9487fb68d20e26
<pre>
[SwiftUI WebKit API] Expose _attachmentElementEnabled and _imageControlsEnabled  on WebPage.Configuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=320941">https://bugs.webkit.org/show_bug.cgi?id=320941</a>
<a href="https://rdar.apple.com/183965918">rdar://183965918</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Expose these properties as SPI on `WebPage.Configuration`

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift:

Canonical link: <a href="https://commits.webkit.org/318513@main">https://commits.webkit.org/318513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e8b64555e854b7468b79d81fce6bde06b697181

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188126 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5707493-54ca-4981-b87c-3be8f57d5cb0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139173 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96fa6deb-bb3f-4c5a-8e42-54adf96c7bfa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119627 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/97529907-b4be-4106-ad3e-f257c2a96500) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41395 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39747 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151795 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39421 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36581 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45048 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43989 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190553 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52117 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148334 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39827 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52798 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148104 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42810 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125065 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119701 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51316 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14395 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50701 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50941 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50763 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->