### PR TITLE
Cherry-pick 318283@main (9f60bad504c7). https://bugs.webkit.org/show_bug.cgi?id=320689

### DIFF
--- a/LayoutTests/platform/mac/media/webaudio-session-removed-when-frame-is-destroyed-expected.txt
+++ b/LayoutTests/platform/mac/media/webaudio-session-removed-when-frame-is-destroyed-expected.txt
@@ -1,0 +1,11 @@
+A WebAudio context in a subframe destroyed without close() must have its media session removed by AudioContext::stop(), deactivating the audio session promptly rather than leaking it until the context is garbage-collected.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS audioSessionActive is true
+PASS audioSessionDeactivated is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac/media/webaudio-session-removed-when-frame-is-destroyed.html
+++ b/LayoutTests/platform/mac/media/webaudio-session-removed-when-frame-is-destroyed.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<iframe></iframe>
+<script>
+description("A WebAudio context in a subframe destroyed without close() must have its media session removed by AudioContext::stop(), deactivating the audio session promptly rather than leaking it until the context is garbage-collected.");
+jsTestIsAsync = true;
+
+async function waitForCondition(predicate)
+{
+    for (let i = 0; i < 200; ++i) {
+        if (predicate())
+            return true;
+        await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    return false;
+}
+
+onload = async () => {
+    if (!window.internals) {
+        testFailed("This test requires the Internals API");
+        finishJSTest();
+        return;
+    }
+
+    internals.settings.setShouldDeactivateAudioSession(true);
+
+    const frame = document.querySelector("iframe");
+    await new Promise(resolve => {
+        window.onmessage = event => {
+            if (event.data === "active")
+                resolve();
+        };
+        frame.srcdoc = `<script>
+            internals.settings.setShouldDeactivateAudioSession(true);
+            internals.withUserGesture(() => {
+                window.context = new AudioContext();
+                const oscillator = context.createOscillator();
+                const gain = context.createGain();
+                gain.gain.value = 0.001;
+                oscillator.connect(gain);
+                gain.connect(context.destination);
+                oscillator.start();
+                context.resume();
+            });
+            (async () => {
+                for (let i = 0; i < 200; ++i) {
+                    if (internals.audioSessionActive()) {
+                        parent.postMessage("active", "*");
+                        return;
+                    }
+                    await new Promise(resolve => setTimeout(resolve, 10));
+                }
+                parent.postMessage("inactive", "*");
+            })();
+        <\/script>`;
+    });
+
+    audioSessionActive = internals.audioSessionActive();
+    shouldBeTrue("audioSessionActive");
+
+    // Destroy the subframe without closing its AudioContext.
+    frame.remove();
+
+    audioSessionDeactivated = await waitForCondition(() => !internals.audioSessionActive());
+    shouldBeTrue("audioSessionDeactivated");
+
+    finishJSTest();
+};
+</script>
+</body>
+</html>

--- a/ManualTests/webaudio/nocrash-audiocontext-reference-destroyed-document.html
+++ b/ManualTests/webaudio/nocrash-audiocontext-reference-destroyed-document.html
@@ -1,0 +1,274 @@
+<!-- Requries an ASAN build to reproduce crash. Crash may take a few minutes to trigger -->
+<html>
+<head>
+<style>
+feFuncB { mso-width-source: auto; grid-row-start: 0; -webkit-mask-box-image-outset: 0px; word-break: normal; border-bottom-color: red; unicode-bidi: plaintext; margin-left: auto; -webkit-border-before-style: dashed; weight: *; -webkit-box-decoration-break: clone; image-rendering: -webkit-optimize-contrast; -webkit-mask-repeat: space; -webkit-text-stroke-color: rgb(9,148,101); font-weight: lighter; -webkit-transform-style: flat; -webkit-box-sizing: border; backdrop-filter: hue-rotate(0deg); mso-width-alt: -1; box-ordinal-group: -1; marker-mid: url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7) }
+style::first-letter { border-top-left-radius: 8em 0em; border-image: fill; -webkit-animation: anim 4s alternate; right: 26vmax; -webkit-font-smoothing: none; columns: 0px; text-overflow: ellipsis; -webkit-border-after-width: 1px; rx: 1px; mso-height-source: auto; max-height: max-content; mso-background-source: auto; -webkit-animation-delay: 1s; kerning: 0; pointer-events: auto; quotes: '{' '}'; rotation-code: '\'}\''; border-style: none solid; -webkit-mask-origin: content-box; height: max-content }
+tref:nth-of-type(2) { mso-displayed-thousand-separator: '\,'; column-span: all; -webkit-box-lines: multiple; grid: auto-flow 0px/none 1px; -webkit-margin-after-collapse: discard; text-rendering: optimizelegibility; -webkit-box-orient: block-axis; -webkit-transition-duration: 0s; user-zoom: zoom; line-height: 92%; -webkit-column-rule: 0px solid; font-feature-settings: 'smcp' -1; image-orientation: from-image; -webkit-transition: opacity 42s; -webkit-flow-into: flow1; -webkit-flex: auto; box-ordinal-group: -1; grid-row-gap: 0em; -webkit-box-pack: end; shape-margin: 1px }
+#elem00001 { -webkit-animation-delay: 0s; -webkit-box-reflect: right; transition-properties: transform; -webkit-animation-name: anim; outline-offset: 10%; column-span: all; -webkit-flex-direction: column-reverse; text-justify: none; padding-top: -1vh; column-break-after: always; text-rendering: optimizeSpeed; scroll-snap-points-x: initial; -webkit-column-break-inside: avoid; -webkit-animation-duration: 1s; mso-border-top-alt: solid black .-1pt; offset-rotation: auto; -webkit-logical-height: 0px; mso-protection: locked visible; background-repeat-x: repeat-y; -webkit-border-before: 0px dashed white }
+.class6 { float: right; animation-direction: initial; font-size-adjust: 0; border-image-slice: 0 -1 4 1 fill; -webkit-tap-highlight-color: ; fill-rule: evenodd; direction: ltr; -webkit-column-span: all; -webkit-transition-delay: inherit; offset-anchor: bottom right; grid-auto-columns: 86%; min-height: 8vh; -webkit-box-flex-group: 33; min-width: 1vmin; user-select: none; -webkit-box-shadow: green 0px 1px 0px; animation-iteration-count: initial; max-height: 0vmax; cy: 0px; -webkit-border-end-color: rgb(83,226,195) }
+#elem00009 { mso-font-charset: -1; -webkit-mask-box-image-slice: 52%; stroke-opacity: 1; columns: 0; box-decoration-break: slice; -webkit-mask-image: url(#svgtmp006); -webkit-mask-box-image-width: 1px; list-style-position: outside; justify-self: center safe; margin-top: -1vmin; -webkit-margin-start: -1px; -webkit-border-start: 5px solid green; box-flex-group: -1; image-orientation: from-image; column-width: 1; motion-path: path('M 0 0 H 0 V 0 H 34 L 0 1'); text-combine-upright: inherit; background-position-x: 58%; orientation: auto; shape-outside: circle(inherit) }
+input:in-range { -webkit-user-select: ignore; list-style-image: none; -webkit-text-security: none; text-indent: 43em each-line; --cssvarc: all; caption-side: left; -webkit-transition-property: border-image-source; mso-pattern: auto; shape-margin: 47; grid-row-gap: 1px; marker-mid: url(#svgtmp005); border-image-slice: 0; transform-origin: 0 0; border-spacing: 1; max-width: 1cm; -webkit-mask-box-image-slice: 1; stop-color: rgb(140,54,146); -webkit-mask-repeat: space space; -webkit-border-before-style: dashed; whitespace: nowrap }
+.class3 { -webkit-border-bottom-right-radius: 1px 0px; text-decoration-line: none; outline-width: 1px; columns: 1px; transition-duration: inherit; float: -o-top-corner; border-right-color: transparent; -webkit-text-combine: horizontal; lighting-color: rgb(230,205,158); border-bottom: green solid; -webkit-mask-box-image-slice: 6; -webkit-line-clamp: 1; shape-outside: circle(); border-image-slice: 0; -webkit-text-fill-color: red; text-combine-upright: initial; hyphens: none; background-repeat-x: no-repeat; touch-action: pan-x pan-right; background-repeat: repeat no-repeat }
+glyph { min-width: 10vmin; background-repeat-y: repeat-y; -webkit-justify-content: space-around; stroke-linejoin: miter; list-style-type: korean-hangul-formal; -webkit-text-emphasis-style: filled; background-repeat-x: no-repeat; -webkit-padding-before: 55px; mso-border-top-alt: solid white .5pt; -webkit-mask-position: 0px 1px; right: 59px; offset-path: inherit; background-origin: content-box; grid-column-start: 10 span; -webkit-animation-name: anim; -webkit-text-emphasis-position: under; -webkit-column-rule-width: 0px; -webkit-animation: anim 0s step-start paused; -webkit-box-shadow: black 0px 44px 0px; grid-auto-rows: min-content }
+.class8, #elem00009 { border-image-slice: 0 fill; -webkit-flex-wrap: wrap; -webkit-user-select: text; background-color: rgb(148,98,116); -webkit-flow-into: progress; orphans: 1; text-decoration-style: solid; -webkit-border-before-color: ; -webkit-animation-duration: 0s; -webkit-column-rule: solid red; -ms-font-feature-settings: 'onum' 1; -webkit-logical-width: 0px; animation-name: anim; -webkit-box-shadow: white 1px 75px 1px; -webkit-background-origin: content-box; mso-border-top-alt: solid rgb(229,224,174) .-1pt; -webkit-marquee-speed: 8; caption-side: top; grid-row: span 71 middle / 1; -webkit-background-origin: content-box }
+#elem00006 { snap-height: 0px; border-bottom-left-radius: 6px 35px; padding-left: 0vw; cursor: pointer; overflow-wrap: break-word; -webkit-padding-after: 1px; -webkit-column-width: auto; box-direction: reverse; transition-duration: 0s; order: inherit; -webkit-margin-after-collapse: discard; word-break: inherit; -webkit-transition-timing-function: ease; margin: auto -1; border-image-repeat: repeat stretch; -webkit-app-region: no-drag; -webkit-flex-wrap: wrap; font-weight: inherit; list-style-image: url(#elem00004); background-blend-mode: multiply, normal }
+.class9, input:in-range, source { mso-style-id: 1; -webkit-box-flex: -1; transform: translate3d(92, -1px, 48px); kerning: 1px; flex-grow: -1; column-fill: balance; position: inherit; text-decoration-color: white; counter-increment: c; transform-origin: 0px 0px 0px; font-style: none; cy: 0px; -webkit-mask-clip: padding-box; mso-fareast-font-family: 'Times New Roman'; margin-right: -1vh; font-face: Arial; cx: 74px; -webkit-text-emphasis-position: over; -webkit-border-bottom-left-radius: 0px 0px; right: 0vw }
+.class9, #elem00004, altGlyphDef { -webkit-flex: none; -ms-flex-align: center; writing-mode: initial; scroll-behavior: auto; marker: inherit; color-profile: sRGB; -webkit-column-break-inside: avoid; -webkit-margin-after: 1px; -webkit-column-gap: 0px; text-justify: none; -webkit-tap-highlight-color: white; padding-top: 1vmin; -webkit-animation-play-state: paused; offset: none; scroll-snap-points-y: repeat(13px); -ms-user-select: none; box-decoration-break: clone; marker: inherit; -webkit-column-fill: auto; grid-auto-rows: auto }
+frame::before, #elem00004 { text-decoration-color: inherit; -webkit-ruby-position: after; -webkit-box-ordinal-group: 2; -webkit-perspective-origin-x: 0px; clip-path: url(#svgtmp005); font-vendor: any; transition-delay: 0s; padding: 0em; border-style: var(--cssvara); line-height: 0vh; -webkit-highlight: 'green'; whitespace: nowrap; shape-margin: 77%; border-top-right-radius: -1; -webkit-border-end: -1px dashed green; -webkit-font-feature-settings: 'frac' 1, 'dlig' 1; -webkit-rtl-ordering: visual; -webkit-align-self: flex-start; -webkit-animation-direction: normal, alternate; stop-opacity: 0.7696557423953793 }
+h3:only-child { mso-style-id: 0; mso-border-alt: solid white .-1pt; -webkit-text-emphasis: open; shape-outside: inset(37 9px -1px 9px); mso-data-placement: same-cell; pointer-events: bounding-box; animation-fill-mode: both; perspective-origin: top left; stroke-linejoin: miter; outline-bottom: none; justify-self: self-end; columns: 0; grid-auto-rows: min-content; break-before: page; -webkit-box-pack: justify; grid: inherit; offset-anchor: bottom right; stroke-miterlimit: 1; -webkit-column-rule-width: 7px; -webkit-tap-highlight-color: red }
+tref::first-line { scale: 1; transition-properties: transform; text-align-last: auto; border-top-width: medium; -webkit-mask-clip: content-box; mso-fareast-font-family: 'Times New Roman'; font: 0px/33 Verdana, sans-serif; cursor: help; orientation: auto; -webkit-animation: anim 1s infinite; -webkit-text-fill-color: ; mask-source-type: alpha; -webkit-transition-delay: inherit; border-bottom-right-radius: 0px 1px; -webkit-margin-end: 1px; font-variant-caps: all-small-caps; -webkit-min-logical-height: -1px; -webkit-rtl-ordering: logical; min-height: 77%; mso-number-format: General }
+.class7 { grid-column-end: 0; -webkit-align-self: center; outline-bottom: none; grid-column: -1 / auto; -webkit-app-region: no-drag; text-overflow: ellipsis; image-orientation: from-image; hyphens: none; white-space: pre-line; -webkit-text-emphasis-position: over; text-align-last: justify; outline-color: green; border-right-style: hidden; font-family: Verdana, Arial, sans-serif; font-variant-caps: petite-caps; border-style: solid none solid solid; offset-path: inherit; cellpadding: 1; -webkit-transform-style: perserve-3d; font-feature-settings: 'smcp' 1 }
+.class6 { border-left-style: solid; -webkit-backface-visibility: hidden; -webkit-align-items: center; resize: auto; -webkit-mask-clip: padding-box; motion-rotation: 0grad auto; background-size: contain, cover; -webkit-justify-content: center; letter-spacing: 0.1755605310584879pc; user-zoom: zoom; -webkit-flow-into: flow1; -webkit-border-before: 0px solid ; border-bottom-width: 0px; background-repeat-y: no-repeat; transition-property: y; list-style-image: none; --cssvard: alternate-reverse; -webkit-line-clamp: -1; -webkit-animation-play-state: paused; border-image-slice: 78% }
+
+</style>
+<script>
+
+function freememory() {
+  try { window.gc(); } catch(err) { }
+}
+
+function GetVariable(typeStore, var_type) { if(typeStore[var_type]) { return typeStore[var_type]; } else { return null; }}
+
+function SetVariable(typeStore, var_name, var_type) { typeStore[var_type] = var_name; }
+
+function runTest() {
+
+var typeStore = {};
+
+SetVariable(typeStore, window, 'Window');
+try { if (!tmp008) { tmp008 = GetVariable(typeStore, 'CSSStyleDeclaration'); } else { SetVariable(typeStore, tmp008, 'CSSStyleDeclaration');  } } catch(e) { }
+try { /* newvar{tmp011:EventHandler} */ var tmp011 = elem00035.onmousemove; } catch(e) { }
+try { if (!tmp011) { tmp011 = GetVariable(typeStore, 'EventHandler'); } else { SetVariable(typeStore, tmp011, 'EventHandler');  } } catch(e) { }
+try { /* newvar{tmp013:CustomEventInit} */ var tmp013 = {}; } catch(e) { }
+try { if (!tmp013) { tmp013 = GetVariable(typeStore, 'CustomEventInit'); } else { SetVariable(typeStore, tmp013, 'CustomEventInit'); SetVariable(typeStore, tmp013, 'EventInit');  } } catch(e) { }
+try { /* newvar{tmp012:CustomEvent} */ var tmp012 = new CustomEvent(String.fromCharCode(49, 56, 60, 122, 126, 95, 97, 37, 103, 108, 71, 59, 50, 42, 122, 83, 126, 89, 100, 106),tmp013); } catch(e) { }
+try { if (!tmp012) { tmp012 = GetVariable(typeStore, 'CustomEvent'); } else { SetVariable(typeStore, tmp012, 'CustomEvent'); SetVariable(typeStore, tmp012, 'Event');  } } catch(e) { }
+try { /* newvar{tmp014:FetchRequestCache} */ var tmp014 = "no-cache"; } catch(e) { }
+try { if (!tmp014) { tmp014 = GetVariable(typeStore, 'FetchRequestCache'); } else { SetVariable(typeStore, tmp014, 'FetchRequestCache');  } } catch(e) { }
+try { /* newvar{tmp015:FetchReferrerPolicy} */ var tmp015 = "strict-origin-when-cross-origin"; } catch(e) { }
+try { if (!tmp015) { tmp015 = GetVariable(typeStore, 'FetchReferrerPolicy'); } else { SetVariable(typeStore, tmp015, 'FetchReferrerPolicy');  } } catch(e) { }
+try { /* newvar{tmp016:HTMLButtonElement} */ var tmp016 = document.createElement("button"); } catch(e) { }
+try { if (!tmp016) { tmp016 = GetVariable(typeStore, 'HTMLButtonElement'); } else { SetVariable(typeStore, tmp016, 'HTMLButtonElement'); SetVariable(typeStore, tmp016, 'HTMLElement'); SetVariable(typeStore, tmp016, 'Element'); SetVariable(typeStore, tmp016, 'Node'); SetVariable(typeStore, tmp016, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp017:USVString} */ var tmp017 = elem00030.currentSrc; } catch(e) { }
+try { if (!tmp017) { tmp017 = GetVariable(typeStore, 'USVString'); } else { SetVariable(typeStore, tmp017, 'USVString');  } } catch(e) { }
+try { tmp016.formAction = tmp017; } catch(e) { }
+try { /* newvar{tmp023:HTMLCanvasElement} */ var tmp023 = document.createElement("canvas"); } catch(e) { }
+try { if (!tmp023) { tmp023 = GetVariable(typeStore, 'HTMLCanvasElement'); } else { SetVariable(typeStore, tmp023, 'HTMLCanvasElement'); SetVariable(typeStore, tmp023, 'HTMLElement'); SetVariable(typeStore, tmp023, 'Element'); SetVariable(typeStore, tmp023, 'Node'); SetVariable(typeStore, tmp023, 'EventTarget');  } } catch(e) { }
+try { if (!tmp038) { tmp038 = GetVariable(typeStore, 'DOMMatrix'); } else { SetVariable(typeStore, tmp038, 'DOMMatrix'); SetVariable(typeStore, tmp038, 'DOMMatrixReadOnly');  } } catch(e) { }
+try { /* newvar{tmp041:WaveShaperOptions} */ var tmp041 = {}; } catch(e) { }
+try { if (!tmp041) { tmp041 = GetVariable(typeStore, 'WaveShaperOptions'); } else { SetVariable(typeStore, tmp041, 'WaveShaperOptions'); SetVariable(typeStore, tmp041, 'AudioNodeOptions');  } } catch(e) { }
+try { /* newvar{tmp040:WaveShaperNode} */ var tmp040 = new WaveShaperNode(tmp031,tmp041); } catch(e) { }
+try { if (!tmp040) { tmp040 = GetVariable(typeStore, 'WaveShaperNode'); } else { SetVariable(typeStore, tmp040, 'WaveShaperNode'); SetVariable(typeStore, tmp040, 'AudioNode'); SetVariable(typeStore, tmp040, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp039:Float32Array} */ var tmp039 = tmp040.curve; } catch(e) { }
+try { if (!tmp039) { tmp039 = GetVariable(typeStore, 'Float32Array'); } else { SetVariable(typeStore, tmp039, 'Float32Array');  } } catch(e) { }
+try { /* newvar{tmp037:DOMMatrix} */ var tmp037 = tmp038.fromFloat32Array(tmp039); } catch(e) { }
+try { if (!tmp036) { tmp036 = GetVariable(typeStore, 'DOMMatrix'); } else { SetVariable(typeStore, tmp036, 'DOMMatrix'); SetVariable(typeStore, tmp036, 'DOMMatrixReadOnly');  } } catch(e) { }
+try { /* newvar{tmp035:DOMMatrixReadOnly} */ var tmp035 = tmp036; } catch(e) { }
+try { if (!tmp035) { tmp035 = GetVariable(typeStore, 'DOMMatrixReadOnly'); } else { SetVariable(typeStore, tmp035, 'DOMMatrixReadOnly');  } } catch(e) { }
+try { /* newvar{tmp034:Float32Array} */ var tmp034 = tmp035.toFloat32Array(); } catch(e) { }
+try { if (!tmp034) { tmp034 = GetVariable(typeStore, 'Float32Array'); } else { SetVariable(typeStore, tmp034, 'Float32Array');  } } catch(e) { }
+try { tmp029.getFrequencyResponse(tmp034,tmp039,tmp039); } catch(e) { }
+try { /* newvar{tmp049:DOMImplementation} */ var tmp049 = document.implementation; } catch(e) { }
+try { if (!tmp049) { tmp049 = GetVariable(typeStore, 'DOMImplementation'); } else { SetVariable(typeStore, tmp049, 'DOMImplementation');  } } catch(e) { }
+try { /* newvar{tmp048:DocumentType} */ var tmp048 = tmp049.createDocumentType(String.fromCharCode(52, 42, 81, 39, 116, 106, 48, 89, 50, 67, 34, 38, 74, 91, 98, 56, 45, 91, 120, 92),String.fromCodePoint(748134, 297778, 945028, 714784, 209024, 315781, 58994, 709446, 828287, 198851, 376834, 127810, 1094438, 782466, 1078270, 529743, 1112209, 953950, 585314, 242486),"elem00008"); } catch(e) { }
+try { if (!tmp048) { tmp048 = GetVariable(typeStore, 'DocumentType'); } else { SetVariable(typeStore, tmp048, 'DocumentType'); SetVariable(typeStore, tmp048, 'Node'); SetVariable(typeStore, tmp048, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp053:SVGMarkerElement} */ var tmp053 = document.createElementNS("http://www.w3.org/2000/svg", "marker"); } catch(e) { }
+try { if (!tmp053) { tmp053 = GetVariable(typeStore, 'SVGMarkerElement'); } else { SetVariable(typeStore, tmp053, 'SVGMarkerElement'); SetVariable(typeStore, tmp053, 'SVGElement'); SetVariable(typeStore, tmp053, 'Element'); SetVariable(typeStore, tmp053, 'Node'); SetVariable(typeStore, tmp053, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp052:SVGAnimatedEnumeration} */ var tmp052 = tmp053.markerUnits; } catch(e) { }
+try { if (!tmp052) { tmp052 = GetVariable(typeStore, 'SVGAnimatedEnumeration'); } else { SetVariable(typeStore, tmp052, 'SVGAnimatedEnumeration');  } } catch(e) { }
+try { /* newvar{tmp051:unsigned} */ var tmp051 = tmp052.animVal; } catch(e) { }
+try { if (!tmp051) { tmp051 = GetVariable(typeStore, 'unsigned'); } else { SetVariable(typeStore, tmp051, 'unsigned');  } } catch(e) { }
+try { /* newvar{tmp050:ChannelMergerNode} */ var tmp050 = tmp030.createChannelMerger(tmp051); } catch(e) { }
+try { if (!tmp050) { tmp050 = GetVariable(typeStore, 'ChannelMergerNode'); } else { SetVariable(typeStore, tmp050, 'ChannelMergerNode'); SetVariable(typeStore, tmp050, 'AudioNode'); SetVariable(typeStore, tmp050, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp055:DeviceMotionEvent} */ var tmp055 = document.createEvent("DeviceMotionEvent"); } catch(e) { }
+try { if (!tmp055) { tmp055 = GetVariable(typeStore, 'DeviceMotionEvent'); } else { SetVariable(typeStore, tmp055, 'DeviceMotionEvent'); SetVariable(typeStore, tmp055, 'Event');  } } catch(e) { }
+try { /* newvar{tmp054:Event} */ var tmp054 = tmp055; } catch(e) { }
+try { if (!tmp054) { tmp054 = GetVariable(typeStore, 'Event'); } else { SetVariable(typeStore, tmp054, 'Event');  } } catch(e) { }
+try { /* newvar{tmp057:ErrorEventInit} */ var tmp057 = {}; } catch(e) { }
+try { if (!tmp057) { tmp057 = GetVariable(typeStore, 'ErrorEventInit'); } else { SetVariable(typeStore, tmp057, 'ErrorEventInit'); SetVariable(typeStore, tmp057, 'EventInit');  } } catch(e) { }
+try { /* newvar{tmp056:ErrorEvent} */ var tmp056 = new ErrorEvent("elem00001",tmp057); } catch(e) { }
+try { if (!tmp056) { tmp056 = GetVariable(typeStore, 'ErrorEvent'); } else { SetVariable(typeStore, tmp056, 'ErrorEvent'); SetVariable(typeStore, tmp056, 'Event');  } } catch(e) { }
+try { /* newvar{tmp061:WebXRRigidTransform} */ var tmp061 = new WebXRRigidTransform(); } catch(e) { }
+try { if (!tmp061) { tmp061 = GetVariable(typeStore, 'WebXRRigidTransform'); } else { SetVariable(typeStore, tmp061, 'WebXRRigidTransform');  } } catch(e) { }
+try { /* newvar{tmp060:DOMPointReadOnly} */ var tmp060 = tmp061.position; } catch(e) { }
+try { if (!tmp060) { tmp060 = GetVariable(typeStore, 'DOMPointReadOnly'); } else { SetVariable(typeStore, tmp060, 'DOMPointReadOnly');  } } catch(e) { }
+try { /* newvar{tmp062:DOMPointInit} */ var tmp062 = {}; } catch(e) { }
+try { if (!tmp062) { tmp062 = GetVariable(typeStore, 'DOMPointInit'); } else { SetVariable(typeStore, tmp062, 'DOMPointInit');  } } catch(e) { }
+try { /* newvar{tmp059:DOMPointReadOnly} */ var tmp059 = tmp060.fromPoint(tmp062); } catch(e) { }
+try { if (!tmp059) { tmp059 = GetVariable(typeStore, 'DOMPointReadOnly'); } else { SetVariable(typeStore, tmp059, 'DOMPointReadOnly');  } } catch(e) { }
+try { /* newvar{tmp063:DOMMatrixInit} */ var tmp063 = {}; } catch(e) { }
+try { if (!tmp063) { tmp063 = GetVariable(typeStore, 'DOMMatrixInit'); } else { SetVariable(typeStore, tmp063, 'DOMMatrixInit'); SetVariable(typeStore, tmp063, 'DOMMatrix2DInit');  } } catch(e) { }
+try { /* newvar{tmp058:DOMPoint} */ var tmp058 = tmp059.matrixTransform(tmp063); } catch(e) { }
+try { if (!tmp058) { tmp058 = GetVariable(typeStore, 'DOMPoint'); } else { SetVariable(typeStore, tmp058, 'DOMPoint'); SetVariable(typeStore, tmp058, 'DOMPointReadOnly');  } } catch(e) { }
+try { /* newvar{tmp064:HTMLBodyElement} */ var tmp064 = document.createElement("body"); } catch(e) { }
+try { if (!tmp064) { tmp064 = GetVariable(typeStore, 'HTMLBodyElement'); } else { SetVariable(typeStore, tmp064, 'HTMLBodyElement'); SetVariable(typeStore, tmp064, 'HTMLElement'); SetVariable(typeStore, tmp064, 'Element'); SetVariable(typeStore, tmp064, 'Node'); SetVariable(typeStore, tmp064, 'EventTarget');  } } catch(e) { }
+try { tmp064.onpageshow = tmp011; } catch(e) { }
+try { /* newvar{tmp065:Location} */ var tmp065 = document.location; } catch(e) { }
+try { if (!tmp065) { tmp065 = GetVariable(typeStore, 'Location'); } else { SetVariable(typeStore, tmp065, 'Location');  } } catch(e) { }
+try { tmp065.search = tmp017; } catch(e) { }
+try { /* newvar{tmp066:boolean} */ var tmp066 = document.execCommand("justifyFull", false); } catch(e) { }
+try { tmp053.setAttribute("viewbox", "0 24 0 36"); } catch(e) { }
+try { /* newvar{tmp067:WebGL2RenderingContext} */ var tmp067 = tmp021.getContext("webgl2"); } catch(e) { }
+try { if (!tmp067) { tmp067 = GetVariable(typeStore, 'WebGL2RenderingContext'); } else { SetVariable(typeStore, tmp067, 'WebGL2RenderingContext');  } } catch(e) { }
+try { /* newvar{tmp068:GLenum} */ var tmp068 = tmp067.UNSIGNED_NORMALIZED; } catch(e) { }
+try { if (!tmp068) { tmp068 = GetVariable(typeStore, 'GLenum'); } else { SetVariable(typeStore, tmp068, 'GLenum');  } } catch(e) { }
+try { /* newvar{tmp075:SVGViewElement} */ var tmp075 = document.createElementNS("http://www.w3.org/2000/svg", "view"); } catch(e) { }
+try { if (!tmp075) { tmp075 = GetVariable(typeStore, 'SVGViewElement'); } else { SetVariable(typeStore, tmp075, 'SVGViewElement'); SetVariable(typeStore, tmp075, 'SVGElement'); SetVariable(typeStore, tmp075, 'Element'); SetVariable(typeStore, tmp075, 'Node'); SetVariable(typeStore, tmp075, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp074:SVGAnimatedRect} */ var tmp074 = tmp075.viewBox; } catch(e) { }
+try { if (!tmp074) { tmp074 = GetVariable(typeStore, 'SVGAnimatedRect'); } else { SetVariable(typeStore, tmp074, 'SVGAnimatedRect');  } } catch(e) { }
+try { /* newvar{tmp073:SVGRect} */ var tmp073 = tmp074.baseVal; } catch(e) { }
+try { if (!tmp073) { tmp073 = GetVariable(typeStore, 'SVGRect'); } else { SetVariable(typeStore, tmp073, 'SVGRect');  } } catch(e) { }
+try { /* newvar{tmp072:unrestricted} */ var tmp072 = tmp073.x; } catch(e) { }
+try { if (!tmp072) { tmp072 = GetVariable(typeStore, 'unrestricted'); } else { SetVariable(typeStore, tmp072, 'unrestricted');  } } catch(e) { }
+try { if (!tmp107) { tmp107 = GetVariable(typeStore, 'SVGLinearGradientElement'); } else { SetVariable(typeStore, tmp107, 'SVGLinearGradientElement'); SetVariable(typeStore, tmp107, 'SVGGradientElement'); SetVariable(typeStore, tmp107, 'SVGElement'); SetVariable(typeStore, tmp107, 'Element'); SetVariable(typeStore, tmp107, 'Node'); SetVariable(typeStore, tmp107, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp106:svg_url_fill} */ var tmp106 = "url(#" + tmp107.id + ")"; } catch(e) { }
+try { if (!tmp106) { tmp106 = GetVariable(typeStore, 'svg_url_fill'); } else { SetVariable(typeStore, tmp106, 'svg_url_fill');  } } catch(e) { }
+try { tmp044.setAttribute("fill", tmp106); } catch(e) { }
+try { tmp087.isPointInRange(tmp016,tmp051); } catch(e) { }
+try { elem00039.setAttribute("onwebkitfullscreenchange", "eventhandler3()"); } catch(e) { }
+try { tmp023.className = String.fromCharCode(103, 74, 39, 67, 117, 49, 35, 125, 69, 70, 123, 91, 93, 68, 40, 34, 66, 63, 50, 74); } catch(e) { }
+try { /* newvar{tmp109:AudioContext} */ var tmp109 = new AudioContext(); } catch(e) { }
+try { if (!tmp109) { tmp109 = GetVariable(typeStore, 'AudioContext'); } else { SetVariable(typeStore, tmp109, 'AudioContext'); SetVariable(typeStore, tmp109, 'BaseAudioContext'); SetVariable(typeStore, tmp109, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp108:MediaStreamAudioDestinationNode} */ var tmp108 = new MediaStreamAudioDestinationNode(tmp109,tmp041); } catch(e) { }
+try { if (!tmp108) { tmp108 = GetVariable(typeStore, 'MediaStreamAudioDestinationNode'); } else { SetVariable(typeStore, tmp108, 'MediaStreamAudioDestinationNode'); SetVariable(typeStore, tmp108, 'AudioNode'); SetVariable(typeStore, tmp108, 'EventTarget');  } } catch(e) { }
+try { tmp047.setAttribute("char", "" + String.fromCharCode(123) + ""); } catch(e) { }
+try { elem00035.setAttribute("aria-flowto", "elem00007"); } catch(e) { }
+try { tmp008.setProperty("mso-padding-alt", "0in -1pt 0in 0pt"); } catch(e) { }
+try { elem00029.setAttribute("aria-valuemin", "7"); } catch(e) { }
+try { tmp075.setAttribute("case", "second"); } catch(e) { }
+try { /* newvar{tmp110:HTMLMeterElement} */ var tmp110 = document.createElement("meter"); } catch(e) { }
+try { if (!tmp110) { tmp110 = GetVariable(typeStore, 'HTMLMeterElement'); } else { SetVariable(typeStore, tmp110, 'HTMLMeterElement'); SetVariable(typeStore, tmp110, 'HTMLElement'); SetVariable(typeStore, tmp110, 'Element'); SetVariable(typeStore, tmp110, 'Node'); SetVariable(typeStore, tmp110, 'EventTarget');  } } catch(e) { }
+try { tmp110.max = 0.8030943429875512; } catch(e) { }
+try { /* newvar{tmp111:Promise_undefined_} */ var tmp111 = elem00030.play(); } catch(e) { }
+try { if (!tmp111) { tmp111 = GetVariable(typeStore, 'Promise_undefined_'); } else { SetVariable(typeStore, tmp111, 'Promise_undefined_');  } } catch(e) { }
+try { elem00011.setAttribute("autocomplete", "on"); } catch(e) { }
+try { /* newvar{tmp112:DocumentFragment} */ var tmp112 = elem00005.content; } catch(e) { }
+try { if (!tmp112) { tmp112 = GetVariable(typeStore, 'DocumentFragment'); } else { SetVariable(typeStore, tmp112, 'DocumentFragment'); SetVariable(typeStore, tmp112, 'Node'); SetVariable(typeStore, tmp112, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp124:GLenum} */ var tmp124 = tmp067.TRIANGLE_STRIP; } catch(e) { }
+try { if (!tmp124) { tmp124 = GetVariable(typeStore, 'GLenum'); } else { SetVariable(typeStore, tmp124, 'GLenum');  } } catch(e) { }
+try { /* newvar{tmp123:WebGLShader} */ var tmp123 = tmp067.createShader(tmp124); } catch(e) { }
+try { if (!tmp123) { tmp123 = GetVariable(typeStore, 'WebGLShader'); } else { SetVariable(typeStore, tmp123, 'WebGLShader');  } } catch(e) { }
+try { /* newvar{tmp122:GLboolean} */ var tmp122 = tmp067.isShader(tmp123); } catch(e) { }
+try { if (!tmp122) { tmp122 = GetVariable(typeStore, 'GLboolean'); } else { SetVariable(typeStore, tmp122, 'GLboolean');  } } catch(e) { }
+try { /* newvar{tmp126:Float32Array} */ var tmp126 = new Float32Array(-1); } catch(e) { }
+try { if (!tmp126) { tmp126 = GetVariable(typeStore, 'Float32Array'); } else { SetVariable(typeStore, tmp126, 'Float32Array');  } } catch(e) { }
+try { /* newvar{tmp125:Float32List} */ var tmp125 = tmp126; } catch(e) { }
+try { if (!tmp125) { tmp125 = GetVariable(typeStore, 'Float32List'); } else { SetVariable(typeStore, tmp125, 'Float32List');  } } catch(e) { }
+try { tmp067.uniformMatrix4fv(tmp119,tmp122,tmp125); } catch(e) { }
+try { elem00037.setAttribute("rows", "1,-1"); } catch(e) { }
+try { tmp053.setAttribute("specularConstant", "1"); } catch(e) { }
+try { /* newvar{tmp127:Navigator} */ var tmp127 = tmp084.clientInformation; } catch(e) { }
+try { if (!tmp127) { tmp127 = GetVariable(typeStore, 'Navigator'); } else { SetVariable(typeStore, tmp127, 'Navigator');  } } catch(e) { }
+try { /* newvar{tmp131:SVGTextPathElement} */ var tmp131 = document.createElementNS("http://www.w3.org/2000/svg", "textPath"); } catch(e) { }
+try { tmp053.setAttribute("itemref", "elem00002"); } catch(e) { }
+try { /* newvar{tmp157:BinaryData} */ var tmp157 = tmp076; } catch(e) { }
+try { if (!tmp157) { tmp157 = GetVariable(typeStore, 'BinaryData'); } else { SetVariable(typeStore, tmp157, 'BinaryData');  } } catch(e) { }
+try { /* newvar{tmp156:union_DOMString1BinaryData_} */ var tmp156 = tmp157; } catch(e) { }
+try { if (!tmp156) { tmp156 = GetVariable(typeStore, 'union_DOMString1BinaryData_'); } else { SetVariable(typeStore, tmp156, 'union_DOMString1BinaryData_');  } } catch(e) { }
+try { /* newvar{tmp155:FontFace} */ var tmp155 = new FontFace("elem00001",tmp156); } catch(e) { }
+try { if (!tmp155) { tmp155 = GetVariable(typeStore, 'FontFace'); } else { SetVariable(typeStore, tmp155, 'FontFace');  } } catch(e) { }
+try { tmp131.setAttribute("patternUnits", "userSpaceOnUse"); } catch(e) { }
+try { elem00031.scrollBy(tmp114); } catch(e) { }
+try { /* newvar{tmp158:PerformanceMark} */ var tmp158 = tmp094.mark(String.fromCharCode(74, 35, 63, 39, 91, 36, 66, 126, 73, 52, 42, 61, 88, 39, 38, 60, 92, 66, 118, 79),tmp098); } catch(e) { }
+try { if (!tmp158) { tmp158 = GetVariable(typeStore, 'PerformanceMark'); } else { SetVariable(typeStore, tmp158, 'PerformanceMark'); SetVariable(typeStore, tmp158, 'PerformanceEntry');  } } catch(e) { }
+try { tmp026.setAttribute("font-stretch", "normal"); } catch(e) { }
+try { /* newvar{tmp159:eventhandler} */ var tmp159 = eventhandler3; } catch(e) { }
+try { if (!tmp159) { tmp159 = GetVariable(typeStore, 'eventhandler'); } else { SetVariable(typeStore, tmp159, 'eventhandler');  } } catch(e) { }
+try { tmp026.setAttribute("onfocusin", "tmp159"); } catch(e) { }
+try { elem00001.wrap = "elem00006"; } catch(e) { }
+try { /* newvar{tmp170:FontFaceSet} */ var tmp170 = new FontFaceSet(tmp171); } catch(e) { }
+try { if (!tmp170) { tmp170 = GetVariable(typeStore, 'FontFaceSet'); } else { SetVariable(typeStore, tmp170, 'FontFaceSet'); SetVariable(typeStore, tmp170, 'EventTarget');  } } catch(e) { }
+try { tmp170.check(String.fromCharCode(80, 86, 38, 104, 95, 91, 104, 58, 83, 44, 58, 113, 102, 89, 102, 78, 36, 101, 78, 101),"foo"); } catch(e) { }
+try { tmp144.start(0.31639910545087935,0.7836196001755922,0.566177049279381); } catch(e) { }
+try { tmp142.autocomplete = String.fromCharCode(68, 112, 38, 79, 39, 102, 78, 101, 92, 78, 92, 79, 109, 67, 49, 81, 84, 82, 102, 103); } catch(e) { }
+try { tmp008.setProperty("motion-rotation", "4turn reverse"); } catch(e) { }
+try { tmp142.width = tmp133; } catch(e) { }
+try { tmp053.setAttribute("tableValues", "9 0 19 1 0 1"); } catch(e) { }
+try { /* newvar{tmp172:HTMLVideoElement} */ var tmp172 = document.createElement("video"); } catch(e) { }
+try { if (!tmp172) { tmp172 = GetVariable(typeStore, 'HTMLVideoElement'); } else { SetVariable(typeStore, tmp172, 'HTMLVideoElement'); SetVariable(typeStore, tmp172, 'HTMLMediaElement'); SetVariable(typeStore, tmp172, 'HTMLElement'); SetVariable(typeStore, tmp172, 'Element'); SetVariable(typeStore, tmp172, 'Node'); SetVariable(typeStore, tmp172, 'EventTarget');  } } catch(e) { }
+try { tmp172.poster = "" + String.fromCharCode(46, 84, 57, 40, 78, 43, 108, 71, 106, 38, 94, 94, 103, 62, 105, 101, 85, 116, 79, 34) + ""; } catch(e) { }
+try { elem00007.longDesc = "" + String.fromCharCode(70, 60, 39, 75, 98, 35, 99, 124, 108, 109, 105, 36, 40, 95, 119, 63, 81, 83, 74, 66) + ""; } catch(e) { }
+try { elem00007.isMap = false; } catch(e) { }
+try { tmp008.setProperty("-webkit-shape-outside", "inset(0px 0px 0px 22px)"); } catch(e) { }
+try { tmp010.setAttribute("right", "23"); } catch(e) { }
+try { tmp008.setProperty("font-kerning", "auto"); } catch(e) { }
+try { tmp008.setProperty("-webkit-locale", "'zh_CN'"); } catch(e) { }
+try { elem00014.removeAttributeNS("elem00001","1"); } catch(e) { }
+try { elem00033.setSelectionRange(-1,-1,"1"); } catch(e) { }
+try { /* newvar{tmp174:XPathEvaluator} */ var tmp174 = new XPathEvaluator(); } catch(e) { }
+try { if (!tmp174) { tmp174 = GetVariable(typeStore, 'XPathEvaluator'); } else { SetVariable(typeStore, tmp174, 'XPathEvaluator');  } } catch(e) { }
+try { /* newvar{tmp173:XPathResult} */ var tmp173 = tmp174.evaluate("//button",elem00026); } catch(e) { }
+try { if (!tmp173) { tmp173 = GetVariable(typeStore, 'XPathResult'); } else { SetVariable(typeStore, tmp173, 'XPathResult');  } } catch(e) { }
+try { tmp089.setAttribute("defer", "defer"); } catch(e) { }
+try { elem00014.setAttribute("aria-autocomplete", "list"); } catch(e) { }
+try { tmp167.setAttribute("calcMode", "paced"); } catch(e) { }
+try { window.scroll(tmp161); } catch(e) { }
+try { /* newvar{tmp175:XPathResult} */ var tmp175 = tmp174.evaluate(String.fromCharCode(61, 39, 82, 59, 48, 96, 48, 35, 52, 77, 114, 58, 89, 109, 125, 52, 49, 79, 45, 112),elem00006); } catch(e) { }
+try { if (!tmp175) { tmp175 = GetVariable(typeStore, 'XPathResult'); } else { SetVariable(typeStore, tmp175, 'XPathResult');  } } catch(e) { }
+try { /* newvar{tmp176:PaymentComplete} */ var tmp176 = "unknown"; } catch(e) { }
+try { if (!tmp176) { tmp176 = GetVariable(typeStore, 'PaymentComplete'); } else { SetVariable(typeStore, tmp176, 'PaymentComplete');  } } catch(e) { }
+try { tmp142.setAttribute("scope", "row"); } catch(e) { }
+try { if (!tmp074) { tmp074 = GetVariable(typeStore, 'HTMLCanvasElement'); } else { SetVariable(typeStore, tmp074, 'HTMLCanvasElement'); SetVariable(typeStore, tmp074, 'HTMLElement'); SetVariable(typeStore, tmp074, 'Element'); SetVariable(typeStore, tmp074, 'Node'); SetVariable(typeStore, tmp074, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp073:CanvasRenderingContext2D} */ var tmp073 = tmp074.getContext("2d"); } catch(e) { }
+try { if (!tmp073) { tmp073 = GetVariable(typeStore, 'CanvasRenderingContext2D'); } else { SetVariable(typeStore, tmp073, 'CanvasRenderingContext2D');  } } catch(e) { }
+try { /* newvar{tmp072:HTMLCanvasElement} */ var tmp072 = tmp073.canvas; } catch(e) { }
+try { if (!tmp072) { tmp072 = GetVariable(typeStore, 'HTMLCanvasElement'); } else { SetVariable(typeStore, tmp072, 'HTMLCanvasElement'); SetVariable(typeStore, tmp072, 'HTMLElement'); SetVariable(typeStore, tmp072, 'Element'); SetVariable(typeStore, tmp072, 'Node'); SetVariable(typeStore, tmp072, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp071:WebGL2RenderingContext} */ var tmp071 = tmp072.getContext("webgl2"); } catch(e) { }
+try { if (!tmp071) { tmp071 = GetVariable(typeStore, 'WebGL2RenderingContext'); } else { SetVariable(typeStore, tmp071, 'WebGL2RenderingContext');  } } catch(e) { }
+try { /* newvar{tmp070:GLenum} */ var tmp070 = tmp071.FUNC_SUBTRACT; } catch(e) { }
+try { if (!tmp070) { tmp070 = GetVariable(typeStore, 'GLenum'); } else { SetVariable(typeStore, tmp070, 'GLenum');  } } catch(e) { }
+try { /* newvar{tmp077:HTMLSelectElement} */ var tmp077 = document.createElement("select"); } catch(e) { }
+try { if (!tmp077) { tmp077 = GetVariable(typeStore, 'HTMLSelectElement'); } else { SetVariable(typeStore, tmp077, 'HTMLSelectElement'); SetVariable(typeStore, tmp077, 'HTMLElement'); SetVariable(typeStore, tmp077, 'Element'); SetVariable(typeStore, tmp077, 'Node'); SetVariable(typeStore, tmp077, 'EventTarget');  } } catch(e) { }
+try { tmp077.multiple = false; } catch(e) { }
+try { elem00021.setAttribute("onended", "eventhandler5()"); } catch(e) { }
+try { tmp020.setProperty("scroll-behavior", "auto"); } catch(e) { }
+try { /* newvar{tmp078:RequestAnimationFrameCallback} */ var tmp078 = function(x){console.log("ok")}; } catch(e) { }
+try { if (!tmp078) { tmp078 = GetVariable(typeStore, 'RequestAnimationFrameCallback'); } else { SetVariable(typeStore, tmp078, 'RequestAnimationFrameCallback');  } } catch(e) { }
+var typeStore = {};
+freememory()
+
+
+}
+
+function eventhandler5() {
+
+try { /* newvar{tmp050:AudioContext} */ var tmp050 = new AudioContext(); } catch(e) { }
+try { if (!tmp050) { tmp050 = GetVariable(typeStore, 'AudioContext'); } else { SetVariable(typeStore, tmp050, 'AudioContext'); SetVariable(typeStore, tmp050, 'BaseAudioContext'); SetVariable(typeStore, tmp050, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp049:BaseAudioContext} */ var tmp049 = tmp050; } catch(e) { }
+try { if (!tmp049) { tmp049 = GetVariable(typeStore, 'BaseAudioContext'); } else { SetVariable(typeStore, tmp049, 'BaseAudioContext'); SetVariable(typeStore, tmp049, 'EventTarget');  } } catch(e) { }
+try { /* newvar{tmp063:OscillatorNode} */ var tmp063 = tmp049.createOscillator(); } catch(e) { }
+try { if (!tmp063) { tmp063 = GetVariable(typeStore, 'OscillatorNode'); } else { SetVariable(typeStore, tmp063, 'OscillatorNode'); SetVariable(typeStore, tmp063, 'AudioScheduledSourceNode'); SetVariable(typeStore, tmp063, 'AudioNode'); SetVariable(typeStore, tmp063, 'EventTarget');  } } catch(e) { }
+try { tmp028.setProperty("cellpadding", "2"); } catch(e) { }
+try { tmp028.setProperty("offset-position", "inherit"); } catch(e) { }
+try { tmp014.moveBy(tmp053); } catch(e) { }
+try { /* newvar{tmp064:Promise_undefined_} */ var tmp064 = elem00030.play(); } catch(e) { }
+try { if (!tmp079) { tmp079 = GetVariable(typeStore, 'HTMLHRElement'); } else { SetVariable(typeStore, tmp079, 'HTMLHRElement'); SetVariable(typeStore, tmp079, 'HTMLElement'); SetVariable(typeStore, tmp079, 'Element'); SetVariable(typeStore, tmp079, 'Node'); SetVariable(typeStore, tmp079, 'EventTarget');  } } catch(e) { }
+try { tmp079.size = "1"; } catch(e) { }
+try { tmp036.setAttribute("tabindex", "1"); } catch(e) { }
+try { tmp071.required = true; } catch(e) { }
+try { elem00033.selectionEnd = 0; } catch(e) { }
+try { tmp028.setProperty("border-top-color", "initial"); } catch(e) { }
+try { tmp028.setProperty("vertical-align", "inherit"); } catch(e) { }
+
+freememory()
+}
+
+</script>
+</head>
+<body onload=runTest()>
+<dialog id="elem00024" tabindex="-1" name="!IHqPDY&quot;1o(,OxmBW" tabindex="8" name="&quot;wXkCC(0~$]_k1Y?h" tabindex="0" left="0" declare="declare" expanded="true" vspace="1" layout="auto"></dialog>
+<title id="elem00025" class="class3" style="-webkit-border-after-width: 0px; flex-grow: -1; -webkit-margin-after: 0px; mso-style-next: Normal; resize: horizontal" lang="he" default="c[^e&lt;_ ~J~Y,&amp;" usemap="#elem00002" crossorigin="crossorigin" onmouseenter="eventhandler2()">nm@:VdG{F|3R%PS</title>
+<dl id="elem00026" style="-webkit-box-direction: reverse; text-rendering: optimizeSpeed; transform-origin: 9 0; grid-column-end: auto; -webkit-rtl-ordering: visual" tabindex="-1" compact="compact" tabindex="0" compact="compact" required="required" height="-1" class="class2" list="elem00005" language="javascript">
+<dt id="elem00027" style="-webkit-line-clamp: 1; mso-data-placement: same-cell; -webkit-mask-image: none; shape-margin: 1px; border-image-outset: 1" style="-webkit-mask: below none; border-bottom-width: 8px; border-bottom-left-radius: 17px; animation-iteration-count: inherit; text-combine-upright: all" lang="en-GB-wa" contenteditable="plaintext-only" title="sKsQ8S%M" row="1" scrolling="auto" type="image/jp2" expanded="true" expanded="false">c!=!xS@:mP&#x27;VB</dt>
+<dt id="elem00028" title="oq~}" tabindex="57" style="-webkit-transition-delay: 1s; white-space: pre garbage; -webkit-column-count: 0; -webkit-column-gap: -1px; -webkit-hyphenate-character: floating" style="order: inherit; -webkit-mask-box-image-repeat: stretch; -webkit-text-stroke: 1px white; lighting-color: ; shape-image-threshold: 0" dir="LTR" scrolldelay="-1" formnovalidate="formnovalidate" framespacing="0" colspan="1" min="69">
+<input id="elem00029" role="math" onblur="eventhandler2()" list="elem00001" onmouseup="eventhandler1()" default="X5Y`u" type="file" rightmargin="-1" noresize="noresize" item="GHZL7&quot;}o|$A+" enctype="multipart/form-data" async="false">
+<audio id="elem00030" preload="none" name="00=A)?Ly.id+e" onloadstart="eventhandler5()" style="border-radius: 1 1 1 0px; padding-top: 75vmin; -webkit-transition-duration: 1s; mso-border-top-alt: solid black .-1pt; border-color: " style="font-weight: inherit; border-image-outset: 1 1 10 0; -webkit-border-image: url(#elem00008) -1 1 1 1 stretch; text-justify: inter-word; -webkit-flow-into: menu" formenctype="text/plain" leftmargin="47" ontouchend="eventhandler5()" desc="*E=KNMcT." colspan="1">K{B&gt;&amp;_3k+v`</audio>
+</dt>
+<dt id="elem00031" dir="ltr" class="class4" contenteditable="plaintext-only" class="class1" dir="LTR" nowrap="nowrap" srclang="hi" layout="auto" seed="0" target="elem00006">BkDzI55TciZ-i?X[rv(c</dt>
+<dt id="elem00032" tabindex="0" class="class3" style="background: black url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7); max-zoom: auto; user-zoom: zoom; -webkit-nbsp-mode: space; box-reflect: right" title="h Mvr" lang="shi-Tfng" onmouseover="eventhandler5()" rev="contents" target="elem00005" muted="muted" code="">xKc1=yLz</dt>
+</dl>
+<textarea id="elem00033" cols="1" onerror="eventhandler4()" onselect="eventhandler5()" autofocus="autofocus" value="+#d@r[O[bV#4{&#x27;N&amp;&quot;\" profile="&amp;wU^%`" leftmargin="6" description="N(\3TJ]6duEq#&quot;Dk_5" mode="multiply" referrerpolicy="no-referrer">.4LG</textarea>
+<style id="elem00034" nonce="nonce" title="jV" onload="eventhandler5()" type="time" scoped="scoped" defer="defer" valign="baseline" cols="0" optimum="-1" itemid="bKGPH*OrvI">nma[Ql1EEgHLT&amp;%|Vp</style>
+</body>
+</html>

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1185,7 +1185,8 @@ void VM::pushCheckpointOSRSideState(std::unique_ptr<CheckpointOSRExitSideState>&
     m_checkpointSideState.append(WTF::move(payload));
 
 #if ASSERT_ENABLED
-    auto bounds = StackBounds::currentThreadStackBounds();
+    const auto& bounds = Thread::currentSingleton().stack();
+    ASSERT(bounds.contains(currentStackPointer()));
     void* previousCallFrame = bounds.end();
     for (size_t i = m_checkpointSideState.size(); i--;) {
         auto* callFrame = m_checkpointSideState[i]->associatedCallFrame;
@@ -1208,7 +1209,7 @@ std::unique_ptr<CheckpointOSRExitSideState> VM::popCheckpointOSRSideState(CallFr
 void VM::popAllCheckpointOSRSideStateUntil(CallFrame* target)
 {
     ASSERT(currentThreadIsHoldingAPILock());
-    auto bounds = StackBounds::currentThreadStackBounds().withSoftOrigin(target);
+    auto bounds = Thread::currentSingleton().stack().withSoftOrigin(target);
     ASSERT(bounds.contains(target));
 
     // We have to worry about migrating from another thread since there may be no checkpoints in our thread but one in the other threads.

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -166,8 +166,10 @@ AudioContext::~AudioContext()
 {
     m_mediaSession->invalidateClient();
 
-    if (RefPtr document = this->document())
-        document->removeAudioProducer(*this);
+    if (!isStopped()) {
+        if (RefPtr document = this->document())
+            document->removeAudioProducer(*this);
+    }
 }
 
 void AudioContext::uninitialize()
@@ -183,6 +185,13 @@ void AudioContext::uninitialize()
 #endif
 
     setState(State::Closed);
+}
+
+void AudioContext::stop()
+{
+    if (RefPtr document = this->document())
+        document->removeAudioProducer(*this);
+    BaseAudioContext::stop();
 }
 
 double AudioContext::baseLatency()

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -192,6 +192,8 @@ void AudioContext::stop()
     if (RefPtr document = this->document())
         document->removeAudioProducer(*this);
     BaseAudioContext::stop();
+
+    m_mediaSession->setActive(false);
 }
 
 double AudioContext::baseLatency()

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -159,6 +159,7 @@ private:
     void mediaCanStart(Document&) final;
 
     // ActiveDOMObject
+    void stop() final;
     void suspend(ReasonForSuspension) final;
     void resume() final;
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -265,6 +265,9 @@ protected:
     RefPtr<MediaSessionManagerInterface> mediaSessionManagerIfExists() const;
     RefPtr<MediaSessionManagerInterface> mediaSessionManager() const;
 
+    // ActiveDOMObject.
+    void stop() override;
+
 protected:
     // Only accessed when the graph lock is held.
     const Vector<AudioConnectionRef<AudioNode>>& referencedSourceNodes() const { return m_referencedSourceNodes; }
@@ -283,9 +286,6 @@ private:
     enum EventTargetInterfaceType eventTargetInterface() const final;
     void refEventTarget() override { ref(); }
     void derefEventTarget() override { deref(); }
-
-    // ActiveDOMObject.
-    void stop() override;
 
     // When the context goes away, there might still be some sources which haven't finished playing.
     // Make sure to dereference them here.


### PR DESCRIPTION
#### 4ced87c7f06e836663f66ffdec193d765be636d0
<pre>
Cherry-pick 318283@main (9f60bad504c7). <a href="https://bugs.webkit.org/show_bug.cgi?id=320689">https://bugs.webkit.org/show_bug.cgi?id=320689</a>

    [WebAudio] AudioContext leaves its media session registered after frame teardown
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320689">https://bugs.webkit.org/show_bug.cgi?id=320689</a>
    <a href="https://rdar.apple.com/183672900">rdar://183672900</a>

    Reviewed by Jean-Yves Avenard.

    AudioContext::stop() (document/frame teardown) stopped the audio thread but never removed the
    context&apos;s PlatformMediaSession -- unlike close(), it left the session registered with the manager
    until the context was garbage-collected, keeping the audio session (and NowPlaying) alive on behalf
    of a context whose frame was already gone.

    Remove the media session in stop(), mirroring close(). setActive(false) is a no-op if the context
    never activated.

    Test: platform/mac/media/webaudio-session-removed-when-frame-is-destroyed.html

    * LayoutTests/platform/mac/media/webaudio-session-removed-when-frame-is-destroyed-expected.txt: Added.
    * LayoutTests/platform/mac/media/webaudio-session-removed-when-frame-is-destroyed.html: Added.
    * Source/WebCore/Modules/webaudio/AudioContext.cpp:
    (WebCore::AudioContext::stop):

    Canonical link: <a href="https://commits.webkit.org/318283@main">https://commits.webkit.org/318283@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1028@webkitglib/2.52">https://commits.webkit.org/305877.1028@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c0d330aff5ed6562e75a220ce1de0f88809a970e
<pre>
Cherry-pick 313630@main (ed04ff40674d). <a href="https://bugs.webkit.org/show_bug.cgi?id=309708">https://bugs.webkit.org/show_bug.cgi?id=309708</a>

    Don&apos;t call document-&gt;removeAudioProducer during Document destruction
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309708">https://bugs.webkit.org/show_bug.cgi?id=309708</a>
    <a href="https://rdar.apple.com/172168772">rdar://172168772</a>

    Reviewed by Ryosuke Niwa.

    When the Document destructor is called, it is possible
    for it to take a code path where it references the document
    which is actively being destroyed. Since the Document is
    in the middle of it&apos;s destructor call, the Document is not in
    a well-defined state it may have already freed member variables, etc.

    This is the path which leads to the access of the document during
    destruction:
    - Document::~Document
    - ScriptExecutionContext::~ScriptExecutionContext
    - BaseAudioContext::deleteMarkedNodes
    - AudioContext::~AudioContext
    - Document::removeAudioProducer

    To remove the audio producers safely, this patch does so when we are certain
    the document is still alive. So, we will call this from AudioContext::stop()
    which itself gets invoked from Document::commonTeardown -&gt; ScriptExectionContext::stopActiveDOMObjects.

    To be defensive, we can also guard the call to document-&gt;removeAudioProducer in
    ~AudioContext with a check to !BaseAudioContext::isStopped().
    This ensures that we won&apos;t access the document while it is being torn down.
    During teardown, ScriptExecutionContext will stop the AudioContext by
    calling BaseAudioContext::stop which in turn sets
    BaseAudioContext::m_isStopScheduled to true and causes
    BaseAudoContext::isStopped to return true.

    Adding a manual test since the layout test can take up to a few
    minutes to trigger the bug.

    If running the manual test, test it against an ASAN build to reproduce
    the crash. On average, the test takes 49 seconds to trigger the bug.

    * ManualTests/webaudio/nocrash-audiocontext-reference-destroyed-document.html: Added.
    * Source/WebCore/Modules/webaudio/AudioContext.cpp:
    (WebCore::AudioContext::~AudioContext):
    (WebCore::AudioContext::stop):
    * Source/WebCore/Modules/webaudio/AudioContext.h:
    * Source/WebCore/Modules/webaudio/BaseAudioContext.h:

    Originally-landed-as: 305413.492@rapid/safari-7624.2.5.110-branch (72b0f61b5005). <a href="https://rdar.apple.com/176061965">rdar://176061965</a>
    Canonical link: <a href="https://commits.webkit.org/313630@main">https://commits.webkit.org/313630@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1027@webkitglib/2.52">https://commits.webkit.org/305877.1027@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3ebc4f5079f680485ce8222289a2ba8219cd42a0
<pre>
Cherry-pick 318487@main (bff3814d76f7). <a href="https://bugs.webkit.org/show_bug.cgi?id=320559">https://bugs.webkit.org/show_bug.cgi?id=320559</a>

    [JSC][Linux] Don&apos;t re-read /proc/self/maps when handling checkpoint OSR side state
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320559">https://bugs.webkit.org/show_bug.cgi?id=320559</a>

    Reviewed by Yusuke Suzuki and Justin Michaud.

    VM::pushCheckpointOSRSideState() has an ASSERT_ENABLED block that checks
    that the side state stack remains ordered. To do so, it needs the current
    thread stack bounds.

    It obtained them using StackBounds::currentThreadStackBounds(), which does
    not cache the result. On Linux, this calls pthread_getattr_np(), which glibc
    implements for the main thread by opening and parsing /proc/self/maps.
    Each call makes the kernel generate a list of the process memory mappings
    and then makes glibc parse that list.

    While running wasm/stress/type-index-abstract-heap-types-nulls-and-casts.js
    in wasm-eager mode, profiling showed about ~45% of samples in kernel code
    generating /proc/self/maps and another ~30% in libc parsing it. The test
    opened /proc/self/maps hundreds of times through repeated calls to
    VM::pushCheckpointOSRSideState().

    Thread::m_stack is initialized using StackBounds::currentThreadStackBounds()
    and cached for the lifetime of the thread. Thread::currentSingleton().stack()
    therefore provides the cached bounds without repeating the OS query.
    logSanitizeStack() in the same file already uses this cached value.

    Switch both call sites in VM.cpp to the cached bounds. This keeps the
    relevant stack consistency assertions checks without asking the operating
    system to recalculate information that the thread already stores.

    popAllCheckpointOSRSideStateUntil() is not assertion-only: it uses the
    bounds as part of its normal operation. This change therefore also avoids
    the same cost in release builds.

    With this change, on a Release+Asserts WPE build, `run-jsc-stress-tests \
    --filter wasm.yaml/wasm/stress/type-index-abstract-heap-types` completes
    in about five minutes. Previously, it could take around one hour, and the
    tests would usually time out.

    * JSTests/wasm/stress/type-index-abstract-heap-types-concrete-vs-abstract.js:
    * JSTests/wasm/stress/type-index-abstract-heap-types-globals-and-tables.js:
    * JSTests/wasm/stress/type-index-abstract-heap-types-nulls-and-casts.js:
    * JSTests/wasm/stress/type-index-abstract-heap-types-subtype-validation.js:
    * Source/JavaScriptCore/runtime/VM.cpp:
    (JSC::VM::pushCheckpointOSRSideState):
    (JSC::VM::popAllCheckpointOSRSideStateUntil):

    Canonical link: <a href="https://commits.webkit.org/318487@main">https://commits.webkit.org/318487@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1026@webkitglib/2.52">https://commits.webkit.org/305877.1026@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fab5f7e33e079be61107fb510a9be86fce5ab25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178508 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52446 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46241 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188124 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141757 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180371 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53740 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52156 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139172 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141757 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181465 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53740 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46241 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119626 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53740 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52156 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1595 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46241 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53740 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46241 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36579 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/39781 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45046 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52156 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190551 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52115 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46241 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148332 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/52796 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46241 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148102 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27090 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/52796 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125063 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119699 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51314 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46241 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50699 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50939 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50761 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->