### PR TITLE
[Results DB] Really slow with large numbers of configurations

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
@@ -71,7 +71,7 @@ function minimumUuidForResults(results, limit) {
 
 function commitsForResults(results, limit, allCommits = true) {
     const minDisplayedUuid = minimumUuidForResults(results, limit);
-    let commits = [];
+    let commitsByUuid = new Map();
     let repositories = new Set();
     let currentCommitIndex = CommitBank.commits.length - 1;
     Object.keys(results).forEach((key) => {
@@ -83,6 +83,7 @@ function commitsForResults(results, limit, allCommits = true) {
 
                 if (!allCommits)
                     currentCommitIndex = CommitBank.commits.length - 1;
+
                 while (currentCommitIndex >= 0) {
                     if (CommitBank.commits[currentCommitIndex].uuid < result.uuid)
                         break;
@@ -90,30 +91,26 @@ function commitsForResults(results, limit, allCommits = true) {
                         candidateCommits.push(CommitBank.commits[currentCommitIndex]);
                     --currentCommitIndex;
                 }
+
                 if (candidateCommits.length === 0 || candidateCommits[candidateCommits.length - 1].uuid !== result.uuid)
                     candidateCommits.push({
                         id: '?',
                         uuid: result.uuid,
                     });
 
-                let index = 0;
                 candidateCommits.forEach(commit => {
                     if (commit.repository_id)
                         repositories.add(commit.repository_id);
-                    while (index < commits.length) {
-                        if (commit.uuid === commits[index].uuid)
-                            return;
-                        if (commit.uuid > commits[index].uuid) {
-                            commits.splice(index, 0, commit);
-                            return;
-                        }
-                        ++index;
-                    }
-                    commits.push(commit);
+                    if (!commitsByUuid.has(commit.uuid))
+                        commitsByUuid.set(commit.uuid, commit);
                 });
             });
         });
     });
+
+    let commits = [...commitsByUuid.values()];
+    commits.sort((a, b) => b.uuid - a.uuid);
+
     if (currentCommitIndex >= 0 && commits.length) {
         let trailingRepositories = new Set(repositories);
         trailingRepositories.delete(commits[commits.length - 1].repository_id);
@@ -127,26 +124,23 @@ function commitsForResults(results, limit, allCommits = true) {
         }
     }
 
-    repositories = [...repositories];
-    repositories.sort();
     return commits;
 }
 
 function scaleForCommits(commits) {
-    let scale = [];
+    let scale = Array.from({length: commits.length}, () => ({}));
     for (let i = commits.length - 1; i >= 0; --i) {
         const repository_id = commits[i].repository_id ? commits[i].repository_id : '?';
-        scale.unshift({});
-        scale[0][repository_id] = commits[i];
-        if (scale.length < 2)
+        scale[i][repository_id] = commits[i];
+        if (i === commits.length - 1)
             continue;
-        Object.keys(scale[1]).forEach((key) => {
+        Object.keys(scale[i + 1]).forEach((key) => {
             if (key === repository_id || key === '?' || key === 'uuid')
                 return;
-            scale[0][key] = scale[1][key];
+            scale[i][key] = scale[i + 1][key];
         });
-        scale[0].uuid = Math.max(...Object.keys(scale[0]).map((key) => {
-            return scale[0][key].uuid;
+        scale[i].uuid = Math.max(...Object.keys(scale[i]).map((key) => {
+            return scale[i][key].uuid;
         }));
     }
     return scale;


### PR DESCRIPTION
#### f486b35a0a3a1560336597ee9d8bcb120550b4e5
<pre>
[Results DB] Really slow with large numbers of configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=286603">https://bugs.webkit.org/show_bug.cgi?id=286603</a>
<a href="https://rdar.apple.com/144089048">rdar://144089048</a>

Reviewed by Sam Sneddon.

Two loops in the timeline were quadratic in the number of commits, which
dominates page load when many configurations are displayed.

commitsForResults() merged each candidate commit into a sorted array by
scanning from index 0, restarting that scan for every result. Collect commits
in a Map keyed by uuid and sort once at the end instead.

scaleForCommits() grew its result with unshift(), which moves every existing
element. The scale has the same length and indices as commits, so preallocate
it and fill in place.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js:
(commitsForResults):
(scaleForCommits):

Canonical link: <a href="https://commits.webkit.org/319738@main">https://commits.webkit.org/319738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7600f59113c715f57cd13de703f3c4e7c05fff79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56577 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50383 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192869 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56310 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185611 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122971 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181982 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4040 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194813 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182057 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56247 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40704 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56951 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151689 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46263 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125238 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55459 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54831 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54897 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->