### PR TITLE
[JSC] Split eager and lazy JIT thunks

### DIFF
--- a/Source/JavaScriptCore/jit/JITThunks.cpp
+++ b/Source/JavaScriptCore/jit/JITThunks.cpp
@@ -68,13 +68,26 @@ JSC_FOR_EACH_VM_INDEPENDENT_COMMON_THUNK(JSC_DEFINE_SHARED_JIT_THUNK)
     return thunks.get();
 }
 
+static ThunkGenerator generatorForLazyCommonThunk(CommonJITThunkID thunkID)
+{
+    switch (thunkID) {
+#define JSC_CASE_COMMON_JIT_THUNK(name, func) \
+    case CommonJITThunkID::name: return func;
+JSC_FOR_EACH_VM_DEPENDENT_LAZY_COMMON_THUNK(JSC_CASE_COMMON_JIT_THUNK)
+#undef JSC_CASE_COMMON_JIT_THUNK
+    default:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 void JITThunks::initialize(VM& vm)
 {
     ASSERT(!isCompilationThread());
     sharedCommonThunks();
 #define JSC_DEFINE_COMMON_JIT_THUNK(name, func) \
-    m_commonThunks[static_cast<unsigned>(CommonJITThunkID::name) - numberOfVMIndependentCommonThunkIDs] = func(vm);
-JSC_FOR_EACH_VM_DEPENDENT_COMMON_THUNK(JSC_DEFINE_COMMON_JIT_THUNK)
+    m_eagerCommonThunks[static_cast<unsigned>(CommonJITThunkID::name) - numberOfVMIndependentCommonThunkIDs] = func(vm);
+JSC_FOR_EACH_VM_DEPENDENT_EAGER_COMMON_THUNK(JSC_DEFINE_COMMON_JIT_THUNK)
 #undef JSC_DEFINE_COMMON_JIT_THUNK
 }
 
@@ -125,10 +138,10 @@ inline bool JITThunks::WeakNativeExecutableHash::equal(const Weak<NativeExecutab
     return aExecutable.function() == std::get<0>(b) && aExecutable.constructor() == std::get<1>(b) && aExecutable.implementationVisibility() == std::get<2>(b) && aExecutable.length() == std::get<3>(b) && aExecutable.name() == std::get<4>(b);
 }
 
-CodePtr<JITThunkPtrTag> JITThunks::ctiNativeCall(VM&)
+CodePtr<JITThunkPtrTag> JITThunks::ctiNativeCall(VM& vm)
 {
     ASSERT(Options::useJIT());
-    return ctiStub(CommonJITThunkID::NativeCall).code();
+    return ctiStub(vm, CommonJITThunkID::NativeCall).code();
 }
 
 CodePtr<JITThunkPtrTag> JITThunks::ctiNativeCallWithDebuggerHook(VM& vm)
@@ -137,10 +150,10 @@ CodePtr<JITThunkPtrTag> JITThunks::ctiNativeCallWithDebuggerHook(VM& vm)
     return ctiStub(vm, nativeCallWithDebuggerHookGenerator).code();
 }
 
-CodePtr<JITThunkPtrTag> JITThunks::ctiNativeConstruct(VM&)
+CodePtr<JITThunkPtrTag> JITThunks::ctiNativeConstruct(VM& vm)
 {
     ASSERT(Options::useJIT());
-    return ctiStub(CommonJITThunkID::NativeConstruct).code();
+    return ctiStub(vm, CommonJITThunkID::NativeConstruct).code();
 }
 
 CodePtr<JITThunkPtrTag> JITThunks::ctiNativeConstructWithDebuggerHook(VM& vm)
@@ -149,28 +162,28 @@ CodePtr<JITThunkPtrTag> JITThunks::ctiNativeConstructWithDebuggerHook(VM& vm)
     return ctiStub(vm, nativeConstructWithDebuggerHookGenerator).code();
 }
 
-CodePtr<JITThunkPtrTag> JITThunks::ctiNativeTailCall(VM&)
+CodePtr<JITThunkPtrTag> JITThunks::ctiNativeTailCall(VM& vm)
 {
     ASSERT(Options::useJIT());
-    return ctiStub(CommonJITThunkID::NativeTailCall).code();
+    return ctiStub(vm, CommonJITThunkID::NativeTailCall).code();
 }
 
-CodePtr<JITThunkPtrTag> JITThunks::ctiNativeTailCallWithoutSavedTags(VM&)
+CodePtr<JITThunkPtrTag> JITThunks::ctiNativeTailCallWithoutSavedTags(VM& vm)
 {
     ASSERT(Options::useJIT());
-    return ctiStub(CommonJITThunkID::NativeTailCallWithoutSavedTags).code();
+    return ctiStub(vm, CommonJITThunkID::NativeTailCallWithoutSavedTags).code();
 }
 
-CodePtr<JITThunkPtrTag> JITThunks::ctiInternalFunctionCall(VM&)
+CodePtr<JITThunkPtrTag> JITThunks::ctiInternalFunctionCall(VM& vm)
 {
     ASSERT(Options::useJIT());
-    return ctiStub(CommonJITThunkID::InternalFunctionCall).code();
+    return ctiStub(vm, CommonJITThunkID::InternalFunctionCall).code();
 }
 
-CodePtr<JITThunkPtrTag> JITThunks::ctiInternalFunctionConstruct(VM&)
+CodePtr<JITThunkPtrTag> JITThunks::ctiInternalFunctionConstruct(VM& vm)
 {
     ASSERT(Options::useJIT());
-    return ctiStub(CommonJITThunkID::InternalFunctionConstruct).code();
+    return ctiStub(vm, CommonJITThunkID::InternalFunctionConstruct).code();
 }
 
 template <typename GenerateThunk>
@@ -215,14 +228,48 @@ MacroAssemblerCodeRef<JITThunkPtrTag> JITThunks::ctiStub(VM& vm, ThunkGenerator 
     });
 }
 
-MacroAssemblerCodeRef<JITThunkPtrTag> JITThunks::ctiStub(CommonJITThunkID thunkID)
+MacroAssemblerCodeRef<JITThunkPtrTag> JITThunks::ctiStub(VM& vm, CommonJITThunkID thunkID)
 {
     unsigned index = static_cast<unsigned>(thunkID);
     if (index < numberOfVMIndependentCommonThunkIDs)
         return sharedCommonThunks()[index];
-    auto result = m_commonThunks[index - numberOfVMIndependentCommonThunkIDs];
-    ASSERT(result);
-    return result;
+    unsigned vmDependentIndex = index - numberOfVMIndependentCommonThunkIDs;
+    if (vmDependentIndex < numberOfVMDependentEagerCommonThunkIDs) {
+        auto result = m_eagerCommonThunks[vmDependentIndex];
+        ASSERT(result);
+        return result;
+    }
+    return lazyCommonThunk(vm, thunkID);
+}
+
+MacroAssemblerCodeRef<JITThunkPtrTag> JITThunks::lazyCommonThunk(VM& vm, CommonJITThunkID thunkID)
+{
+    auto& thunk = m_lazyCommonThunks[static_cast<unsigned>(thunkID) - numberOfVMIndependentCommonThunkIDs - numberOfVMDependentEagerCommonThunkIDs];
+
+    auto state = thunk.state.load(std::memory_order_acquire);
+    if (state == LazyThunkState::NotGenerated) {
+        Locker locker { thunk.lock };
+        state = thunk.state.loadRelaxed();
+        if (state == LazyThunkState::NotGenerated) {
+            thunk.codeRef = generatorForLazyCommonThunk(thunkID)(vm);
+            ASSERT(thunk.codeRef);
+            state = isCompilationThread() ? LazyThunkState::GeneratedOnCompilationThread : LazyThunkState::Generated;
+            thunk.state.store(state, std::memory_order_release);
+        }
+    }
+
+    if (state == LazyThunkState::GeneratedOnCompilationThread && !isCompilationThread()) {
+        // The main thread will issue a crossModifyingCodeFence before running
+        // any code the compiler thread generates, including any thunks that they
+        // generate. However, the main thread may grab the thunk a compiler thread
+        // generated before we've issued that crossModifyingCodeFence. Hence, we
+        // conservatively say that when the main thread grabs a thunk generated
+        // from a compiler thread for the first time, it issues a crossModifyingCodeFence.
+        WTF::crossModifyingCodeFence();
+        thunk.state.store(LazyThunkState::Generated, std::memory_order_release);
+    }
+
+    return thunk.codeRef;
 }
 
 MacroAssemblerCodeRef<JITThunkPtrTag> JITThunks::ctiSlowPathFunctionStub(VM& vm, SlowPathFunction slowPathFunction)

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -38,9 +38,11 @@
 #include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakHandleOwner.h>
 #include <tuple>
+#include <wtf/Atomics.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Hasher.h>
+#include <wtf/Lock.h>
 #include <wtf/PackedRefPtr.h>
 #include <wtf/RecursiveLockAdapter.h>
 #include <wtf/TZoneMalloc.h>
@@ -122,9 +124,11 @@ class NativeExecutable;
     macro(PutByValWithTrueKeyReplaceHandler, putByValWithTrueKeyReplaceHandler) \
     macro(PutByValWithFalseKeyReplaceHandler, putByValWithFalseKeyReplaceHandler) \
 
-// Thunks that bake VM state (topEntryFrame, topCallFrame, the VM pointer passed to operations)
-// into the generated code, so every VM needs its own copy.
-#define JSC_FOR_EACH_VM_DEPENDENT_COMMON_THUNK(macro) \
+// VM-dependent thunks that must exist before any code runs, because they are requested from
+// contexts that cannot take a lock. In particular CallLinkInfo::visitWeak runs during GC with the
+// JIT worklist threads suspended, and reaches getCTIVirtualCall; if a suspended compiler thread held
+// the lock, taking it here would deadlock.
+#define JSC_FOR_EACH_VM_DEPENDENT_EAGER_COMMON_THUNK(macro) \
     macro(HandleException, handleExceptionGenerator) \
     macro(CheckException, checkExceptionGenerator) \
     macro(NativeCall, nativeCallGenerator) \
@@ -140,6 +144,11 @@ class NativeExecutable;
     macro(VirtualThunkForRegularCall, virtualThunkForRegularCall) \
     macro(VirtualThunkForTailCall, virtualThunkForTailCall) \
     macro(VirtualThunkForConstruct, virtualThunkForConstruct) \
+
+// VM-dependent thunks generated on first use. These are only ever requested while compiling an
+// inline cache, where taking a lock is safe, and a short-lived VM never pays for the ones it does
+// not use.
+#define JSC_FOR_EACH_VM_DEPENDENT_LAZY_COMMON_THUNK(macro) \
     macro(GetByIdCustomAccessorHandler, getByIdCustomAccessorHandler) \
     macro(GetByIdCustomValueHandler, getByIdCustomValueHandler) \
     macro(GetByIdMegamorphicGetterHandler, getByIdMegamorphicGetterHandler) \
@@ -182,6 +191,10 @@ class NativeExecutable;
     macro(PutByValWithFalseKeyTransitionReallocatingHandler, putByValWithFalseKeyTransitionReallocatingHandler) \
     macro(PutByValWithFalseKeyTransitionReallocatingOutOfLineHandler, putByValWithFalseKeyTransitionReallocatingOutOfLineHandler) \
 
+#define JSC_FOR_EACH_VM_DEPENDENT_COMMON_THUNK(macro) \
+    JSC_FOR_EACH_VM_DEPENDENT_EAGER_COMMON_THUNK(macro) \
+    JSC_FOR_EACH_VM_DEPENDENT_LAZY_COMMON_THUNK(macro)
+
 // List up super common stubs so that we initialize them eagerly.
 #define JSC_FOR_EACH_COMMON_THUNK(macro) \
     JSC_FOR_EACH_VM_INDEPENDENT_COMMON_THUNK(macro) \
@@ -195,12 +208,14 @@ JSC_FOR_EACH_COMMON_THUNK(JSC_DEFINE_COMMON_JIT_THUNK_ID)
 
 #define JSC_COUNT_COMMON_JIT_THUNK_ID(name, func) + 1
 // The VM-independent thunks come first, so a CommonJITThunkID below this bound indexes the shared
-// table and one at or above it indexes a VM's own table.
+// table and one at or above it indexes a VM's own table. Within a VM's own table the eager thunks
+// come first, so an index below numberOfVMDependentEagerCommonThunkIDs is already generated and one
+// at or above it is generated on demand.
 static constexpr unsigned numberOfVMIndependentCommonThunkIDs = 0 JSC_FOR_EACH_VM_INDEPENDENT_COMMON_THUNK(JSC_COUNT_COMMON_JIT_THUNK_ID);
+static constexpr unsigned numberOfVMDependentEagerCommonThunkIDs = 0 JSC_FOR_EACH_VM_DEPENDENT_EAGER_COMMON_THUNK(JSC_COUNT_COMMON_JIT_THUNK_ID);
+static constexpr unsigned numberOfVMDependentLazyCommonThunkIDs = 0 JSC_FOR_EACH_VM_DEPENDENT_LAZY_COMMON_THUNK(JSC_COUNT_COMMON_JIT_THUNK_ID);
 static constexpr unsigned numberOfCommonThunkIDs = 0 JSC_FOR_EACH_COMMON_THUNK(JSC_COUNT_COMMON_JIT_THUNK_ID);
 #undef JSC_COUNT_COMMON_JIT_THUNK_ID
-
-static constexpr unsigned numberOfVMDependentCommonThunkIDs = numberOfCommonThunkIDs - numberOfVMIndependentCommonThunkIDs;
 
 class JITThunks final : private WeakHandleOwner {
     WTF_MAKE_TZONE_ALLOCATED(JITThunks);
@@ -217,7 +232,7 @@ public:
     CodePtr<JITThunkPtrTag> ctiInternalFunctionCall(VM&);
     CodePtr<JITThunkPtrTag> ctiInternalFunctionConstruct(VM&);
 
-    MacroAssemblerCodeRef<JITThunkPtrTag> ctiStub(CommonJITThunkID);
+    MacroAssemblerCodeRef<JITThunkPtrTag> ctiStub(VM&, CommonJITThunkID);
     MacroAssemblerCodeRef<JITThunkPtrTag> ctiStub(VM&, ThunkGenerator);
     MacroAssemblerCodeRef<JITThunkPtrTag> ctiSlowPathFunctionStub(VM&, SlowPathFunction);
 
@@ -231,8 +246,10 @@ private:
     template <typename GenerateThunk>
     MacroAssemblerCodeRef<JITThunkPtrTag> ctiStubImpl(ThunkGenerator key, GenerateThunk);
 
+    MacroAssemblerCodeRef<JITThunkPtrTag> lazyCommonThunk(VM&, CommonJITThunkID);
+
     void finalize(Handle<Unknown>, void* context) final;
-    
+
     struct Entry {
         PackedRefPtr<ExecutableMemoryHandle> handle;
         bool needsCrossModifyingCodeFence;
@@ -273,7 +290,21 @@ private:
 
     using WeakNativeExecutableSet = UncheckedKeyHashSet<Weak<NativeExecutable>, WeakNativeExecutableHash>;
 
-    MacroAssemblerCodeRef<JITThunkPtrTag> m_commonThunks[numberOfVMDependentCommonThunkIDs] { };
+    // A lazy thunk is published with a release store to its state, so a request that finds it
+    // generated reads its code with an acquire load and no lock, and each thunk's own lock keeps
+    // generating one from blocking requests for the others. GeneratedOnCompilationThread records
+    // that a thread about to run the code still owes it a crossModifyingCodeFence.
+    enum class LazyThunkState : uint8_t { NotGenerated, GeneratedOnCompilationThread, Generated };
+
+    struct LazyThunk {
+        MacroAssemblerCodeRef<JITThunkPtrTag> codeRef;
+        Atomic<LazyThunkState> state { LazyThunkState::NotGenerated };
+        Lock lock;
+    };
+
+    // Filled by initialize() before any other thread can run, so reading it needs no lock.
+    MacroAssemblerCodeRef<JITThunkPtrTag> m_eagerCommonThunks[numberOfVMDependentEagerCommonThunkIDs] { };
+    LazyThunk m_lazyCommonThunks[numberOfVMDependentLazyCommonThunkIDs];
     CTIStubMap m_ctiStubMap;
     WeakNativeExecutableSet m_nativeExecutableSet;
     WTF::RecursiveLock m_lock;

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -848,7 +848,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> VM::getCTIStub(ThunkGenerator generator)
 
 MacroAssemblerCodeRef<JITThunkPtrTag> VM::getCTIStub(CommonJITThunkID thunkID)
 {
-    return jitStubs->ctiStub(thunkID);
+    return jitStubs->ctiStub(*this, thunkID);
 }
 
 #endif // ENABLE(JIT)


### PR DESCRIPTION
#### c1b19d0128090f6cb3e12d4f967028706b37b170
<pre>
[JSC] Split eager and lazy JIT thunks
<a href="https://bugs.webkit.org/show_bug.cgi?id=320942">https://bugs.webkit.org/show_bug.cgi?id=320942</a>
<a href="https://rdar.apple.com/183974728">rdar://183974728</a>

Reviewed by Yijia Huang.

This patch splits eager and lazy JIT thunks so eager ones are commonly
used so it is created eagerly but lazy ones are created on-demand.

* Source/JavaScriptCore/jit/JITThunks.cpp:
(JSC::generatorForLazyCommonThunk):
(JSC::JITThunks::initialize):
(JSC::JITThunks::ctiNativeCall):
(JSC::JITThunks::ctiNativeConstruct):
(JSC::JITThunks::ctiNativeTailCall):
(JSC::JITThunks::ctiNativeTailCallWithoutSavedTags):
(JSC::JITThunks::ctiInternalFunctionCall):
(JSC::JITThunks::ctiInternalFunctionConstruct):
(JSC::JITThunks::ctiStub):
(JSC::JITThunks::lazyCommonThunk):
* Source/JavaScriptCore/jit/JITThunks.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::getCTIStub):

Canonical link: <a href="https://commits.webkit.org/318524@main">https://commits.webkit.org/318524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46b98ce52469ce63449f2391f9e8c752b66eb549

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178542 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188158 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7270360-e36b-441a-ba8a-8894443b388c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139203 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6442ec9-c79a-4225-b738-ead629b7440a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119657 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa0c63a7-9bec-4c97-9e85-540609bdd0e9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41423 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1626 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8438 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39449 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36613 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39815 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45080 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190585 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52149 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148364 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52830 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148133 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27086 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42839 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125097 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119733 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51348 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14424 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50733 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50973 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50795 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->