### PR TITLE
Implement 2-QWAC fetching

### DIFF
--- a/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
+++ b/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
@@ -123,6 +123,8 @@ CFDataRef SecKeyCopySubjectPublicKeyInfo(SecKeyRef);
 
 OSStatus SecCodeValidateFileResource(SecStaticCodeRef, CFStringRef, CFDataRef, SecCSFlags);
 
+bool SecQWACTLSBindingVerify(CFDataRef, SecTrustRef, SecTrustRef* CF_RETURNS_RETAINED, CFErrorRef*);
+
 WTF_EXTERN_C_END
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/html/LinkRelAttribute.cpp
+++ b/Source/WebCore/html/LinkRelAttribute.cpp
@@ -36,6 +36,7 @@
 #include "Document.h"
 #include "LinkIconType.h"
 #include "Settings.h"
+#include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/SortedArrayMap.h>
 #include <wtf/text/StringView.h>
 #include <wtf/text/WTFString.h>
@@ -45,7 +46,7 @@ namespace WebCore {
 // https://html.spec.whatwg.org/#linkTypes
 
 struct LinkTypeDetails {
-    bool (*isEnabled)(const Document&);
+    bool (*isEnabled)(const Document*);
     void (*updateRel)(LinkRelAttribute&);
 };
 
@@ -54,7 +55,7 @@ static constexpr SortedArrayMap linkTypes { WTF::toArray<std::pair<ComparableLet
     { "apple-touch-icon"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.iconType = LinkIconType::TouchIcon; } } },
     { "apple-touch-icon-precomposed"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.iconType = LinkIconType::TouchPrecomposedIcon; } } },
     { "compression-dictionary"_s, {
-        [](auto document) { return document.settings().compressionDictionaryEnabled(); },
+        [](auto* document) { return document && document->settings().compressionDictionaryEnabled(); },
         [](auto relAttribute) { relAttribute.isCompressionDictionary = true; } } },
     { "dns-prefetch"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isDNSPrefetch = true; } } },
     { "expect"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isInternalResourceLink = true; } } },
@@ -65,14 +66,30 @@ static constexpr SortedArrayMap linkTypes { WTF::toArray<std::pair<ComparableLet
     { "manifest"_s, { [](auto) { return false; }, [](auto) { } } },
 #endif
     { "modulepreload"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isLinkModulePreload = true; } } },
-    { "preconnect"_s, { [](auto document) { return document.settings().linkPreconnectEnabled(); }, [](auto relAttribute) { relAttribute.isLinkPreconnect = true; } } },
-    { "prefetch"_s, { [](auto document) { return document.settings().linkPrefetchEnabled(); }, [](auto relAttribute) { relAttribute.isLinkPrefetch = true; } } },
-    { "preload"_s, { [](auto document) { return document.settings().linkPreloadEnabled(); }, [](auto relAttribute) { relAttribute.isLinkPreload = true; } } },
+    { "preconnect"_s, {
+        [](auto* document) { return document && document->settings().linkPreconnectEnabled(); },
+        [](auto relAttribute) { relAttribute.isLinkPreconnect = true; } } },
+    { "prefetch"_s, {
+        [](auto* document) { return document && document->settings().linkPrefetchEnabled(); },
+        [](auto relAttribute) { relAttribute.isLinkPrefetch = true; } } },
+    { "preload"_s, {
+        [](auto* document) { return document && document->settings().linkPreloadEnabled(); },
+        [](auto relAttribute) { relAttribute.isLinkPreload = true; } } },
     { "stylesheet"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isStyleSheet = true; } } },
+    { "tls-certificate-binding"_s, {
+        [](auto) { return true; },
+        [](auto relAttribute) { relAttribute.isTLSCertificateBinding = true; } } },
 }) };
 
 LinkRelAttribute::LinkRelAttribute(Document& document, StringView rel)
+    : LinkRelAttribute(&document, rel)
 {
+}
+
+LinkRelAttribute::LinkRelAttribute(Document* document, StringView rel)
+{
+    ASSERT_WITH_MESSAGE(document || isInNetworkProcess(), "Parsing a LinkRelAttribute without a Document should only be done in the network process, and only with types that are always supported. If you're in the web process, find a Document.");
+
     if (auto linkType = linkTypes.tryGet(rel)) {
         if (linkType->isEnabled(document))
             linkType->updateRel(*this);
@@ -107,7 +124,7 @@ LinkRelAttribute::LinkRelAttribute(Document& document, StringView rel)
 bool LinkRelAttribute::isSupported(Document& document, StringView attribute)
 {
     if (auto linkType = linkTypes.tryGet(attribute))
-        return linkType->isEnabled(document);
+        return linkType->isEnabled(&document);
     return false;
 }
 

--- a/Source/WebCore/html/LinkRelAttribute.h
+++ b/Source/WebCore/html/LinkRelAttribute.h
@@ -54,8 +54,10 @@ struct LinkRelAttribute {
 #endif
     bool isInternalResourceLink : 1 { false };
     bool isCompressionDictionary : 1 { false };
+    bool isTLSCertificateBinding : 1 { false };
 
     LinkRelAttribute() = default;
+    WEBCORE_EXPORT LinkRelAttribute(Document*, StringView);
     LinkRelAttribute(Document&, StringView);
 
     friend bool operator==(const LinkRelAttribute&, const LinkRelAttribute&) = default;

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -334,3 +334,9 @@ request = "rdar://171940190"
 selectors = [
     { name = "endSessionWithCompletion:", class = "NFSession" },
 ]
+
+[[staging]]
+request = "rdar://166719636"
+symbols = [
+    "SecQWACTLSBindingVerify"
+]

--- a/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
@@ -56,14 +56,14 @@ struct NetworkLoadParameters {
     bool shouldClearReferrerOnHTTPSToHTTPRedirect { true };
     bool needsCertificateInfo { false };
     bool isMainFrameNavigation { false };
-    std::optional<NavigationActionData> mainResourceNavigationDataForAnyFrame;
-    Vector<Ref<WebCore::BlobDataFileReference>> blobFileReferences;
+    std::optional<NavigationActionData> mainResourceNavigationDataForAnyFrame { };
+    Vector<Ref<WebCore::BlobDataFileReference>> blobFileReferences { };
     PreconnectOnly shouldPreconnectOnly { PreconnectOnly::No };
-    std::optional<NetworkActivityTracker> networkActivityTracker;
+    std::optional<NetworkActivityTracker> networkActivityTracker { };
     std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain { NavigatingToAppBoundDomain::No };
     bool hadMainFrameMainResourcePrivateRelayed { false };
     bool allowPrivacyProxy { true };
-    OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections;
+    OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections { };
     bool isInitiatedByDedicatedWorker { false };
 
     uint64_t requiredCookiesVersion { 0 };

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -46,6 +46,7 @@
 #include "NetworkSession.h"
 #include "NetworkStorageManager.h"
 #include "PrivateRelayed.h"
+#include "QualifiedServerTrustFetch.h"
 #include "ResourceLoadInfo.h"
 #include "ServiceWorkerFetchTask.h"
 #include "SharedBufferReference.h"
@@ -71,6 +72,7 @@
 #include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/LegacySchemeRegistry.h>
 #include <WebCore/LinkHeader.h>
+#include <WebCore/LinkRelAttribute.h>
 #include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/OriginAccessPatterns.h>
@@ -1319,6 +1321,12 @@ void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& originalN
     if (shouldSendResourceLoadMessages())
         connectionToWebProcess().networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::ResourceLoadDidCompleteWithError(webPageProxyID(), resourceLoadInfo(), m_response, { }), 0);
 
+    // If this is done too early, we can receive the 2qwac response before the main frame main resource
+    // actually commits with all the response IPC. Since it's low priority, do it here to avoid
+    // slowing down the page load.
+    if (isMainFrameLoad())
+        checkForQualifiedServerTrust(m_response);
+
     cleanup(LoadResult::Success);
 }
 
@@ -1932,6 +1940,41 @@ void NetworkResourceLoader::didReceiveMainResourceResponse(const WebCore::Resour
         speculativeLoadManager->registerMainResourceLoadResponse(globalFrameID(), originalRequest(), response);
     if (auto& certificateInfo = response.certificateInfo(); certificateInfo && !certificateInfo->isEmpty())
         connectionToWebProcess().networkProcess().parentProcessConnection()->send(Messages::WebFrameProxyFromNetworkProcess::ReceivedMainResourceResponseWithCertificateInfo(response.url().hostAndPort(), *certificateInfo), frameID());
+}
+
+void NetworkResourceLoader::checkForQualifiedServerTrust(const WebCore::ResourceResponse& response)
+{
+    CheckedPtr session = m_connection->networkProcess().networkSession(sessionID());
+    if (!session)
+        return;
+
+    if (!response.url().protocolIs("https"_s))
+        return;
+
+    auto headerValue = response.httpHeaderField(HTTPHeaderName::Link);
+    if (headerValue.isEmpty())
+        return;
+
+    auto tlsCertificates = response.certificateInfo();
+    if (!tlsCertificates)
+        return;
+
+    LinkHeaderSet headerSet(headerValue);
+    for (const auto& header : headerSet) {
+        if (!header.valid() || header.url().isEmpty())
+            continue;
+        // From https://www.etsi.org/deliver/etsi_ts/119400_119499/11941105/02.01.01_60/ts_11941105v020101p.pdf section 6.2.2:
+        // Examine the HTTP headers included in any main frame navigation response from the server (relating to
+        // navigation by the web browser to the address as displayed in the address bar) for a HTTP 'Link' response
+        // header (as defined in IETF RFC 8288 [6]) with a rel value of tls-certificate-binding.
+        if (!WebCore::LinkRelAttribute(nullptr, header.rel()).isTLSCertificateBinding)
+            continue;
+        URL url { header.url() };
+        if (!url.isValid())
+            continue;
+        if (protocolHostAndPortAreEqual(response.url(), url))
+            return QualifiedServerTrustFetch::create(*session, url, m_parameters, *tlsCertificates);
+    }
 }
 
 void NetworkResourceLoader::initializeReportingEndpoints(const ResourceResponse& response)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -279,6 +279,8 @@ private:
     void consumeSandboxExtensions();
     void invalidateSandboxExtensions();
 
+    void checkForQualifiedServerTrust(const WebCore::ResourceResponse&);
+
 #if !RELEASE_LOG_DISABLED
     void logCookieInformation() const;
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -173,6 +173,7 @@ NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSess
     , m_testSpeedMultiplier(parameters.testSpeedMultiplier)
     , m_allowsServerPreconnect(parameters.allowsServerPreconnect)
     , m_shouldRunServiceWorkersOnMainThreadForTesting(parameters.shouldRunServiceWorkersOnMainThreadForTesting)
+    , m_qualifiedServerTrustDebugEnabledForTesting(parameters.qualifiedServerTrustDebugEnabledForTesting)
     , m_overrideServiceWorkerRegistrationCountTestingValue(parameters.overrideServiceWorkerRegistrationCountTestingValue)
     , m_inspectionForServiceWorkersAllowed(parameters.inspectionForServiceWorkersAllowed)
     , m_sharedWorkerServer([](NetworkSession& session, auto& ref) {

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -216,6 +216,7 @@ public:
     bool shouldRunServiceWorkersOnMainThreadForTesting() const { return m_shouldRunServiceWorkersOnMainThreadForTesting; }
     std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue() const { return m_overrideServiceWorkerRegistrationCountTestingValue; }
     bool isStaleWhileRevalidateEnabled() const { return m_isStaleWhileRevalidateEnabled; }
+    bool qualifiedServerTrustDebugEnabledForTesting() const { return m_qualifiedServerTrustDebugEnabledForTesting; }
 
     void lowMemoryHandler(WTF::Critical);
 
@@ -384,6 +385,7 @@ protected:
     bool m_allowsServerPreconnect { true };
     bool m_shouldRunServiceWorkersOnMainThreadForTesting { false };
     bool m_shouldSendPrivateTokenIPCForTesting { false };
+    const bool m_qualifiedServerTrustDebugEnabledForTesting { false };
     std::optional<unsigned> m_overrideServiceWorkerRegistrationCountTestingValue;
     HashSet<Ref<ServiceWorkerSoftUpdateLoader>> m_softUpdateLoaders;
     HashMap<WebCore::FetchIdentifier, WeakRef<ServiceWorkerFetchTask>> m_navigationPreloaders;

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -100,6 +100,7 @@ struct NetworkSessionCreationParameters {
     std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue;
     bool preventsSystemHTTPProxyAuthentication { false };
     bool allowsHSTSWithUntrustedRootCertificate { false };
+    bool qualifiedServerTrustDebugEnabledForTesting { false };
     String pcmMachServiceName;
     String webPushMachServiceName;
     String webPushPartitionString;

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -72,6 +72,7 @@ enum class WebKit::AllowsCellularAccess : bool;
     std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue;
     bool preventsSystemHTTPProxyAuthentication;
     bool allowsHSTSWithUntrustedRootCertificate;
+    bool qualifiedServerTrustDebugEnabledForTesting;
     String pcmMachServiceName;
     String webPushMachServiceName;
     String webPushPartitionString;

--- a/Source/WebKit/NetworkProcess/QualifiedServerTrustFetch.cpp
+++ b/Source/WebKit/NetworkProcess/QualifiedServerTrustFetch.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "QualifiedServerTrustFetch.h"
+
+#include "NetworkLoad.h"
+#include "NetworkLoadParameters.h"
+#include "NetworkProcess.h"
+#include "NetworkProcessProxyMessages.h"
+#include "NetworkResourceLoadParameters.h"
+
+#if PLATFORM(COCOA)
+#import "SecuritySoftLink.h"
+#endif
+
+namespace WebKit {
+
+using namespace WebCore;
+
+static HashMap<WebPageProxyIdentifier, Ref<QualifiedServerTrustFetch>>& globalQualifiedServerTrustFetchMap()
+{
+    static NeverDestroyed<HashMap<WebPageProxyIdentifier, Ref<QualifiedServerTrustFetch>>> map;
+    return map.get();
+}
+
+void QualifiedServerTrustFetch::keepAliveUntilCompletion(Ref<QualifiedServerTrustFetch>&& fetch)
+{
+    auto webPageID = fetch->m_webPageID;
+    if (RefPtr existingFetchForPage = globalQualifiedServerTrustFetchMap().get(webPageID))
+        existingFetchForPage->cancel();
+    ASSERT(!globalQualifiedServerTrustFetchMap().contains(webPageID));
+    globalQualifiedServerTrustFetchMap().set(webPageID, WTF::move(fetch));
+}
+
+void QualifiedServerTrustFetch::didReachCompletion(QualifiedServerTrustFetch& fetch)
+{
+    ASSERT(globalQualifiedServerTrustFetchMap().contains(fetch.m_webPageID));
+    globalQualifiedServerTrustFetchMap().remove(fetch.m_webPageID);
+}
+
+static NetworkLoadParameters qualifiedServerTrustParameters(URL&& url, const NetworkResourceLoadParameters& parameters)
+{
+    WebCore::ResourceRequest request(WTF::move(url));
+    request.setPriority(ResourceLoadPriority::VeryLow);
+    return NetworkLoadParameters {
+        parameters.webPageProxyID,
+        parameters.webPageID,
+        parameters.webFrameID,
+        parameters.topOrigin,
+        parameters.sourceOrigin,
+        parameters.parentPID,
+        WTF::move(request)
+    };
+}
+
+QualifiedServerTrustFetch::QualifiedServerTrustFetch(NetworkSession& session, const URL& url, const NetworkResourceLoadParameters& parameters, const WebCore::CertificateInfo& serverTrust)
+    : m_networkProcess(session.networkProcess())
+    , m_networkLoad(NetworkLoad::create(*this, qualifiedServerTrustParameters(URL(url), parameters), session))
+    , m_timeoutTimer(makeUnique<WebCore::Timer>(*this, &QualifiedServerTrustFetch::cancel))
+    , m_webPageID(parameters.webPageProxyID)
+    , m_debugEnabledForTesting(session.qualifiedServerTrustDebugEnabledForTesting())
+    , m_serverTrust(serverTrust)
+{
+    m_networkLoad->start();
+    m_timeoutTimer->startOneShot(60_s);
+}
+
+QualifiedServerTrustFetch::~QualifiedServerTrustFetch() = default;
+
+void QualifiedServerTrustFetch::willSendRedirectedRequest(ResourceRequest&&, ResourceRequest&&, ResourceResponse&&, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler)
+{
+    // No redirection will be followed.
+    completionHandler({ });
+}
+
+void QualifiedServerTrustFetch::didReceiveResponse(ResourceResponse&&, PrivateRelayed, ResponseCompletionHandler&& completionHandler)
+{
+    completionHandler(PolicyAction::Use);
+}
+
+void QualifiedServerTrustFetch::didReceiveBuffer(const FragmentedSharedBuffer& buffer)
+{
+    constexpr size_t maxBufferSize = 10 * MB;
+    if (m_buffer.size() > maxBufferSize)
+        return cancel();
+
+    m_buffer.append(buffer);
+}
+
+void QualifiedServerTrustFetch::didFinishLoading(const NetworkLoadMetrics&)
+{
+    WebCore::CertificateInfo qualifiedServerTrust;
+    if (m_debugEnabledForTesting) {
+        // FIXME: Once implementation of SecQWACTLSBindingVerify is available,
+        // use SecTrustSetAnchorCertificates to evaluate without verifying the root trust
+        // to get a real 2-QWAC CertificateInfo instead of reusing the TLS trust.
+        qualifiedServerTrust = m_serverTrust;
+    }
+#if PLATFORM(COCOA)
+    else if (canLoad_Security_SecQWACTLSBindingVerify()) {
+        SUPPRESS_UNRETAINED_LOCAL SecTrustRef trust { nullptr };
+        bool success = softLink_Security_SecQWACTLSBindingVerify(m_buffer.takeBuffer()->makeContiguous()->createCFData().get(), m_serverTrust.trust(), &trust, nullptr);
+        if (trust) {
+            ASSERT_UNUSED(success, success);
+            SUPPRESS_RETAINPTR_CTOR_ADOPT qualifiedServerTrust = WebCore::CertificateInfo(adoptCF(trust));
+        }
+    }
+#endif
+
+    if (RefPtr connection = m_networkProcess->parentProcessConnection())
+        connection->send(Messages::NetworkProcessProxy::ReceivedQualifiedServerTrust(m_webPageID, m_serverTrust, qualifiedServerTrust), 0);
+    didReachCompletion(*this);
+}
+
+void QualifiedServerTrustFetch::didFailLoading(const ResourceError&)
+{
+    didReachCompletion(*this);
+}
+
+void QualifiedServerTrustFetch::cancel()
+{
+    m_networkLoad->cancel();
+    didFailLoading({ });
+}
+
+void QualifiedServerTrustFetch::didSendData(uint64_t, uint64_t)
+{
+    ASSERT_NOT_REACHED();
+}
+
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/QualifiedServerTrustFetch.h
+++ b/Source/WebKit/NetworkProcess/QualifiedServerTrustFetch.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "NetworkLoadClient.h"
+#include "WebPageProxyIdentifier.h"
+#include <WebCore/CertificateInfo.h>
+#include <WebCore/SharedBuffer.h>
+#include <WebCore/Timer.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+
+class NetworkLoad;
+class NetworkProcess;
+class NetworkSession;
+
+struct NetworkResourceLoadParameters;
+
+class QualifiedServerTrustFetch final : public RefCounted<QualifiedServerTrustFetch>, public NetworkLoadClient {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(QualifiedServerTrustFetch);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(QualifiedServerTrustFetch);
+public:
+    template <typename... Args> static void create(Args&&... args)
+    {
+        keepAliveUntilCompletion(adoptRef(*new QualifiedServerTrustFetch(std::forward<Args>(args)...)));
+    }
+    ~QualifiedServerTrustFetch();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
+    QualifiedServerTrustFetch(NetworkSession&, const URL&, const NetworkResourceLoadParameters&, const WebCore::CertificateInfo& serverTrust);
+
+    static void keepAliveUntilCompletion(Ref<QualifiedServerTrustFetch>&&);
+    static void didReachCompletion(QualifiedServerTrustFetch&);
+
+    void cancel();
+
+    // NetworkLoadClient.
+    bool isSynchronous() const final { return false; }
+    bool isAllowedToAskUserForCredentials() const final { return false; }
+    void didSendData(uint64_t bytesSent, uint64_t totalBytesToBeSent) final;
+    void willSendRedirectedRequest(WebCore::ResourceRequest&&, WebCore::ResourceRequest&& redirectRequest, WebCore::ResourceResponse&& redirectResponse, CompletionHandler<void(WebCore::ResourceRequest&&)>&&) final;
+    void didReceiveResponse(WebCore::ResourceResponse&&, PrivateRelayed, ResponseCompletionHandler&&) final;
+    void didReceiveBuffer(const WebCore::FragmentedSharedBuffer&) final;
+    void didFinishLoading(const WebCore::NetworkLoadMetrics&) final;
+    void didFailLoading(const WebCore::ResourceError&) final;
+
+    const Ref<NetworkProcess> m_networkProcess;
+    const Ref<NetworkLoad> m_networkLoad;
+    const std::unique_ptr<WebCore::Timer> m_timeoutTimer;
+    const WebPageProxyIdentifier m_webPageID;
+    const bool m_debugEnabledForTesting { false };
+    const WebCore::CertificateInfo m_serverTrust;
+    RefPtr<QualifiedServerTrustFetch> m_selfReference;
+    WebCore::SharedBufferBuilder m_buffer;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/cocoa/SecuritySoftLink.h
+++ b/Source/WebKit/NetworkProcess/cocoa/SecuritySoftLink.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <wtf/SoftLinking.h>
+#import <wtf/spi/cocoa/SecuritySPI.h>
+
+SOFT_LINK_FRAMEWORK_FOR_HEADER(WebKit, Security)
+
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Security, SecQWACTLSBindingVerify, bool, (CFDataRef data, SecTrustRef trust, SecTrustRef* result, CFErrorRef* error), (data, trust, result, error));

--- a/Source/WebKit/NetworkProcess/cocoa/SecuritySoftLink.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/SecuritySoftLink.mm
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import <wtf/SoftLinking.h>
+#import <wtf/spi/cocoa/SecuritySPI.h>
+
+SOFT_LINK_FRAMEWORK_FOR_SOURCE(WebKit, Security)
+
+// FIXME: Use a compile guard instead of soft linking once systems that have rdar://182590431 exist.
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Security, SecQWACTLSBindingVerify, bool, (CFDataRef data, SecTrustRef trust, SecTrustRef* result, CFErrorRef* error), (data, trust, result, error));

--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -396,6 +396,7 @@ unset(_webkit_additional_cocoa_sources)
 list(APPEND WebKit_SOURCES
     NetworkProcess/cocoa/DeviceManagementSoftLink.mm
     NetworkProcess/cocoa/NetworkSoftLink.mm
+    NetworkProcess/cocoa/SecuritySoftLink.mm
 
     Platform/cocoa/_WKWebViewTextInputNotifications.mm
 

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -126,6 +126,7 @@ NetworkProcess/NetworkSession.cpp @cost:9
 NetworkProcess/NetworkSocketChannel.cpp
 NetworkProcess/PingLoad.cpp @cost:4
 NetworkProcess/PreconnectTask.cpp @cost:3
+NetworkProcess/QualifiedServerTrustFetch.cpp @cost:3
 
 NetworkProcess/Authentication/AuthenticationManager.cpp @cost:7
 

--- a/Source/WebKit/SourcesCMakeCocoa.txt
+++ b/Source/WebKit/SourcesCMakeCocoa.txt
@@ -37,6 +37,7 @@ NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm @nonARC
 NetworkProcess/cocoa/DeviceManagementSoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
 NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm @nonARC
 NetworkProcess/cocoa/NetworkSoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
+NetworkProcess/cocoa/SecuritySoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
 NetworkProcess/cocoa/WebSocketTaskCocoa.mm @nonARC
 
 NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm @nonARC

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -217,6 +217,13 @@ typedef NS_ENUM(NSInteger, WKFullscreenState) {
  */
 @property (nonatomic, readonly, nullable) SecTrustRef serverTrust WK_API_AVAILABLE(macos(10.12), ios(10.0));
 
+/*! @abstract A SecTrustRef with a 2-QWAC for the currently committed navigation.
+ @discussion Since a separate fetch is needed to get the 2-QWAC data, this becomes available
+ after the serverTrust.  It will only become available if the server has a valid 2-QWAC.
+ This property is key-value observing (KVO) compliant.
+ */
+@property (nonatomic, readonly, nullable) SecTrustRef qualifiedServerTrust WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 /*! @abstract A Boolean value indicating whether there is a back item in
  the back-forward list that can be navigated to.
  @discussion @link WKWebView @/link is key-value observing (KVO) compliant

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -998,6 +998,9 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
     if ([key isEqualToString:@"serverTrust"])
         return (__bridge id)[self serverTrust];
 
+    if ([key isEqualToString:@"qualifiedServerTrust"])
+        return (__bridge id)[self qualifiedServerTrust];
+
     return [super valueForUndefinedKey:key];
 }
 
@@ -1200,6 +1203,11 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
 - (SecTrustRef)serverTrust
 {
     return _page->pageLoadState().certificateInfo().trust().get();
+}
+
+- (SecTrustRef)qualifiedServerTrust
+{
+    return _page->pageLoadState().qualifiedServerTrust().trust();
 }
 
 - (void)_didAccessBackForwardList

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -116,6 +116,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic, nullable, copy) NSNumber *defaultTrackingPreventionEnabledOverride WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 @property (nonatomic, copy, setter=_setResourceMonitorThrottlerDirectory:) NSURL *_resourceMonitorThrottlerDirectory WK_API_AVAILABLE(macos(15.0), ios(18.0));
 @property (nonatomic, nullable, copy) NSURL *webContentRestrictionsConfigurationURL WK_API_AVAILABLE(macos(26.0), ios(26.0));
+@property (nonatomic) BOOL qualifiedServerTrustDebugEnabledForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 // Testing only.
 @property (nonatomic) BOOL allLoadsBlockedByDeviceManagementRestrictionsForTesting WK_API_AVAILABLE(macos(10.15), ios(13.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -967,6 +967,16 @@ static WebKit::UnifiedOriginStorageLevel NODELETE toUnifiedOriginStorageLevel(_W
     _configuration->setOverridePersistentNotificationMinimumLifetimeForTesting(lifetime);
 }
 
+- (BOOL)qualifiedServerTrustDebugEnabledForTesting
+{
+    return _configuration->qualifiedServerTrustDebugEnabledForTesting();
+}
+
+- (void)setQualifiedServerTrustDebugEnabledForTesting:(BOOL)enabled
+{
+    _configuration->setQualifiedServerTrustDebugEnabledForTesting(enabled);
+}
+
 - (NSUUID *)identifier
 {
     auto currentIdentifier = _configuration->identifier();

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -290,6 +290,15 @@ final public class WebPage {
         backingProperty(\.serverTrust, backedBy: \.serverTrust)
     }
 
+    /// The trust management object for the 2-QWAC of the currently committed navigation.
+    ///
+    /// A 2-QWAC binds a qualified website authentication certificate to the TLS certificate the webpage was
+    /// served with. Since a separate fetch is needed to get the 2-QWAC data, this value becomes available
+    /// after ``serverTrust``, and only if the server has a valid 2-QWAC.
+    public var qualifiedServerTrust: SecTrust? {
+        backingProperty(\.qualifiedServerTrust, backedBy: \.qualifiedServerTrust)
+    }
+
     /// Indicates whether the webpage loaded all resources on the page through securely encrypted connections.
     public var hasOnlySecureContent: Bool {
         backingProperty(\.hasOnlySecureContent, backedBy: \.hasOnlySecureContent)

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -207,6 +207,8 @@ private:
     void willChangeWebProcessIsResponsive() override;
     void didChangeWebProcessIsResponsive() override;
     void didSwapWebProcesses() override;
+    void willChangeQualifiedServerTrust() override;
+    void didChangeQualifiedServerTrust() override;
 
 #if USE(RUNNINGBOARD)
     void releaseNetworkActivityAfterLoadCompletion() { releaseNetworkActivity(NetworkActivityReleaseReason::LoadCompleted); }

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -1775,6 +1775,16 @@ void NavigationState::didChangeWebProcessIsResponsive()
     [webView() didChangeValueForKey:@"_webProcessIsResponsive"];
 }
 
+void NavigationState::willChangeQualifiedServerTrust()
+{
+    [webView() willChangeValueForKey:@"qualifiedServerTrust"];
+}
+
+void NavigationState::didChangeQualifiedServerTrust()
+{
+    [webView() didChangeValueForKey:@"qualifiedServerTrust"];
+}
+
 void NavigationState::didSwapWebProcesses()
 {
 #if USE(RUNNINGBOARD)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -2164,6 +2164,12 @@ void NetworkProcessProxy::flushNetworkProcessIPC(CompletionHandler<void()>&& com
     sendWithAsyncReply(Messages::NetworkProcess::FlushNetworkProcessIPC(), WTF::move(completionHandler));
 }
 
+void NetworkProcessProxy::receivedQualifiedServerTrust(WebKit::WebPageProxyIdentifier webPageID, WebCore::CertificateInfo&& serverTrust, WebCore::CertificateInfo&& qualifiedServerTrust)
+{
+    if (RefPtr page = WebPageProxy::fromIdentifier(webPageID))
+        page->receivedQualifiedServerTrust(WTF::move(serverTrust), WTF::move(qualifiedServerTrust));
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK_COMPLETION

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -287,6 +287,8 @@ public:
     void reportNetworkIssue(WebPageProxyIdentifier, const URL&);
 #endif
 
+    void receivedQualifiedServerTrust(WebKit::WebPageProxyIdentifier, WebCore::CertificateInfo&&, WebCore::CertificateInfo&&);
+
     void resourceLoadDidSendRequest(WebPageProxyIdentifier, ResourceLoadInfo&&, WebCore::ResourceRequest&&, std::optional<IPC::FormDataReference>&&);
     void resourceLoadDidPerformHTTPRedirection(WebPageProxyIdentifier, ResourceLoadInfo&&, WebCore::ResourceResponse&&, WebCore::ResourceRequest&&);
     void resourceLoadDidReceiveChallenge(WebPageProxyIdentifier, ResourceLoadInfo&&, WebCore::AuthenticationChallenge&&);

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -117,6 +117,8 @@ messages -> NetworkProcessProxy WantsDispatchMessage {
 #if ENABLE(NETWORK_ISSUE_REPORTING)
     ReportNetworkIssue(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, URL requestURL)
 #endif
+
+    ReceivedQualifiedServerTrust(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebCore::CertificateInfo serverTrust, WebCore::CertificateInfo qualifiedServerTrust)
 }
 
 }

--- a/Source/WebKit/UIProcess/PageLoadState.cpp
+++ b/Source/WebKit/UIProcess/PageLoadState.cpp
@@ -112,6 +112,7 @@ void PageLoadState::commitChanges()
     bool estimatedProgressChanged = estimatedProgress(m_committedState) != estimatedProgress(m_uncommittedState);
     bool networkRequestsInProgressChanged = m_committedState.networkRequestsInProgress != m_uncommittedState.networkRequestsInProgress;
     bool certificateInfoChanged = m_committedState.certificateInfo != m_uncommittedState.certificateInfo;
+    bool qualifiedServerTrustChanged = m_committedState.qualifiedServerTrust != m_uncommittedState.qualifiedServerTrust;
 
     if (canGoBackChanged)
         callObserverCallback(&Observer::willChangeCanGoBack);
@@ -135,12 +136,16 @@ void PageLoadState::commitChanges()
         callObserverCallback(&Observer::willChangeNetworkRequestsInProgress);
     if (certificateInfoChanged)
         callObserverCallback(&Observer::willChangeCertificateInfo);
+    if (qualifiedServerTrustChanged)
+        callObserverCallback(&Observer::willChangeQualifiedServerTrust);
 
     m_committedState = m_uncommittedState;
 
     protect(page())->isLoadingChanged();
 
     // The "did" ordering is the reverse of the "will". This is a requirement of Cocoa Key-Value Observing.
+    if (qualifiedServerTrustChanged)
+        callObserverCallback(&Observer::didChangeQualifiedServerTrust);
     if (certificateInfoChanged)
         callObserverCallback(&Observer::didChangeCertificateInfo);
     if (networkRequestsInProgressChanged)
@@ -328,6 +333,7 @@ void PageLoadState::didCommitLoad(const Transaction::Token& token, const WebCore
     m_uncommittedState.titleFromBrowsingWarning = { };
     m_uncommittedState.proxyName = proxyName;
     m_uncommittedState.source = source;
+    m_uncommittedState.qualifiedServerTrust = { };
 }
 
 void PageLoadState::didFinishLoad(const Transaction::Token& token)
@@ -485,6 +491,20 @@ void PageLoadState::callObserverCallback(void (Observer::*callback)())
 
         ((*observer).*callback)();
     }
+}
+
+void PageLoadState::receivedQualifiedServerTrust(const Transaction::Token& token, WebCore::CertificateInfo&& serverTrust, WebCore::CertificateInfo&& qualifiedServerTrust)
+{
+    ASSERT_UNUSED(token, &token.m_pageLoadState == this);
+
+#if PLATFORM(COCOA)
+    // QualifiedServerTrustFetch and IPC can take enough time that the page has navigated away.
+    // Make sure we are still exposing the server trust for which the qualifiedServerTrust is valid.
+    if (!certificatesMatch(serverTrust.trust(), this->certificateInfo().trust()))
+        return;
+#endif
+
+    m_uncommittedState.qualifiedServerTrust = WTF::move(qualifiedServerTrust);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/PageLoadState.h
+++ b/Source/WebKit/UIProcess/PageLoadState.h
@@ -81,6 +81,9 @@ public:
     virtual void willChangeWebProcessIsResponsive() = 0;
     virtual void didChangeWebProcessIsResponsive() = 0;
 
+    virtual void willChangeQualifiedServerTrust() { }
+    virtual void didChangeQualifiedServerTrust() { }
+
     virtual void didSwapWebProcesses() = 0;
 };
 
@@ -164,6 +167,8 @@ public:
 
     const WebCore::CertificateInfo& certificateInfo() const LIFETIME_BOUND { return m_committedState.certificateInfo; }
 
+    const WebCore::CertificateInfo& qualifiedServerTrust() const LIFETIME_BOUND { return m_committedState.qualifiedServerTrust; }
+
     const URL& resourceDirectoryURL() const LIFETIME_BOUND { return m_committedState.resourceDirectoryURL; }
 
     const URL& pendingAPIRequestURL() const LIFETIME_BOUND { return m_committedState.pendingAPIRequest.url; }
@@ -177,6 +182,8 @@ public:
     void didFailProvisionalLoad(const Transaction::Token&);
 
     void didCommitLoad(const Transaction::Token&, const WebCore::CertificateInfo&, bool hasInsecureContent, bool usedLegacyTLS, bool privateRelayed, const String& proxyName, const WebCore::ResourceResponseSource, const WebCore::SecurityOriginData&);
+
+    void receivedQualifiedServerTrust(const Transaction::Token&, WebCore::CertificateInfo&&, WebCore::CertificateInfo&&);
 
     void NODELETE didFinishLoad(const Transaction::Token&);
     void NODELETE didFailLoad(const Transaction::Token&);
@@ -252,6 +259,8 @@ private:
         WebCore::CertificateInfo certificateInfo;
         String proxyName;
         WebCore::ResourceResponseSource source;
+
+        WebCore::CertificateInfo qualifiedServerTrust;
     };
 
     static bool NODELETE isLoading(const Data&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -20021,6 +20021,13 @@ void WebPageProxy::updateRemoteIntersectionObserversInOtherWebProcesses(IPC::Con
     });
 }
 
+void WebPageProxy::receivedQualifiedServerTrust(WebCore::CertificateInfo&& serverTrust, WebCore::CertificateInfo&& qualifiedServerTrust)
+{
+    Ref pageLoadState = this->pageLoadState();
+    auto transaction = pageLoadState->transaction();
+    pageLoadState->receivedQualifiedServerTrust(transaction, WTF::move(serverTrust), WTF::move(qualifiedServerTrust));
+}
+
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2965,6 +2965,8 @@ public:
 
     void closeCurrentTypingCommand();
 
+    void receivedQualifiedServerTrust(WebCore::CertificateInfo&&, WebCore::CertificateInfo&&);
+
     void simulateClickOverFirstMatchingTextInViewportWithUserInteraction(String&& targetText, CompletionHandler<void(bool)>&&);
 
     void startNetworkRequestsForPageLoadTiming(WebCore::FrameIdentifier);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2307,6 +2307,7 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     networkSessionParameters.overrideServiceWorkerRegistrationCountTestingValue = m_configuration->overrideServiceWorkerRegistrationCountTestingValue();
     networkSessionParameters.preventsSystemHTTPProxyAuthentication = m_configuration->preventsSystemHTTPProxyAuthentication();
     networkSessionParameters.allowsHSTSWithUntrustedRootCertificate = m_configuration->allowsHSTSWithUntrustedRootCertificate();
+    networkSessionParameters.qualifiedServerTrustDebugEnabledForTesting = m_configuration->qualifiedServerTrustDebugEnabledForTesting();
     networkSessionParameters.pcmMachServiceName = m_configuration->pcmMachServiceName();
     networkSessionParameters.webPushMachServiceName = m_configuration->webPushMachServiceName();
     networkSessionParameters.webPushPartitionString = m_configuration->webPushPartitionString();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -172,6 +172,7 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
     copy->m_standaloneApplicationURL = this->m_standaloneApplicationURL;
     copy->m_enableInAppBrowserPrivacyForTesting = this->m_enableInAppBrowserPrivacyForTesting;
     copy->m_allowsHSTSWithUntrustedRootCertificate = this->m_allowsHSTSWithUntrustedRootCertificate;
+    copy->m_qualifiedServerTrustDebugEnabledForTesting = this->m_qualifiedServerTrustDebugEnabledForTesting;
     copy->m_pcmMachServiceName = this->m_pcmMachServiceName;
     copy->m_webPushMachServiceName = this->m_webPushMachServiceName;
     copy->m_webPushPartitionString = this->m_webPushPartitionString;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -253,6 +253,9 @@ public:
     
     bool allowsHSTSWithUntrustedRootCertificate() const { return m_allowsHSTSWithUntrustedRootCertificate; }
     void setAllowsHSTSWithUntrustedRootCertificate(bool allows) { m_allowsHSTSWithUntrustedRootCertificate = allows; }
+
+    bool qualifiedServerTrustDebugEnabledForTesting() const { return m_qualifiedServerTrustDebugEnabledForTesting; }
+    void setQualifiedServerTrustDebugEnabledForTesting(bool enabled) { m_qualifiedServerTrustDebugEnabledForTesting = enabled; }
     
     void setPCMMachServiceName(String&& name) { m_pcmMachServiceName = WTF::move(name); }
     const String& pcmMachServiceName() const LIFETIME_BOUND { return m_pcmMachServiceName; }
@@ -365,6 +368,7 @@ private:
     URL m_standaloneApplicationURL;
     bool m_enableInAppBrowserPrivacyForTesting { false };
     bool m_allowsHSTSWithUntrustedRootCertificate { false };
+    bool m_qualifiedServerTrustDebugEnabledForTesting { false };
     bool m_trackingPreventionDebugModeEnabled { false };
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     bool m_isDeclarativeWebPushEnabled { false };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2795,6 +2795,7 @@
 		FA580B4E2DA64B5F005E4965 /* UnifiedSource163.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FA580B292DA64B5F005E4965 /* UnifiedSource163.cpp */; };
 		FA5AAE9B2E6A217A00FE693D /* NetworkSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = FA5AAE992E6A217A00FE693D /* NetworkSoftLink.h */; };
 		FA5AAE9C2E6A217A00FE693D /* NetworkSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA5AAE9A2E6A217A00FE693D /* NetworkSoftLink.mm */; };
+		FA745C49302FC7FF007231F3 /* SecuritySoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA745C48302EA40D007231F3 /* SecuritySoftLink.mm */; };
 		FA84D6692E579F38004BDAA4 /* WKJSHandleRef.h in Headers */ = {isa = PBXBuildFile; fileRef = FA84D6672E579EA4004BDAA4 /* WKJSHandleRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FA8B4F6D2E46AFFC00E419CD /* WKScriptMessageRef.h in Headers */ = {isa = PBXBuildFile; fileRef = FA8B4F6B2E46A93500E419CD /* WKScriptMessageRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FA8B4F7C2E4A5F7C00E419CD /* _WKJSHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = FA8B4F792E4A5F7300E419CD /* _WKJSHandle.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -9268,6 +9269,8 @@
 		FA6DCE712BAAB3AB0043109B /* WebPagePreferencesLockdownModeObserver.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebPagePreferencesLockdownModeObserver.mm; sourceTree = "<group>"; };
 		FA6DCE722BAAB3AB0043109B /* WebPagePreferencesLockdownModeObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebPagePreferencesLockdownModeObserver.h; sourceTree = "<group>"; };
 		FA7036C32D72882A00083D04 /* RunJavaScriptParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RunJavaScriptParameters.h; sourceTree = "<group>"; };
+		FA745C47302EA40D007231F3 /* SecuritySoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SecuritySoftLink.h; sourceTree = "<group>"; };
+		FA745C48302EA40D007231F3 /* SecuritySoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SecuritySoftLink.mm; sourceTree = "<group>"; };
 		FA8262722B2193EA00BB8236 /* APINumber.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = APINumber.serialization.in; sourceTree = "<group>"; };
 		FA84D6672E579EA4004BDAA4 /* WKJSHandleRef.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKJSHandleRef.h; sourceTree = "<group>"; };
 		FA84D6682E579EA4004BDAA4 /* WKJSHandleRef.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WKJSHandleRef.cpp; sourceTree = "<group>"; };
@@ -9275,6 +9278,8 @@
 		FA87D9B42D8BDC2B00B609D4 /* FrameInfoData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameInfoData.cpp; sourceTree = "<group>"; };
 		FA894D902EB51F0500495F1F /* SharedMemoryJSBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SharedMemoryJSBuffer.h; sourceTree = "<group>"; };
 		FA894D912EB51F0500495F1F /* SharedMemoryJSBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SharedMemoryJSBuffer.cpp; sourceTree = "<group>"; };
+		FA8B24AB30212E540018413F /* QualifiedServerTrustFetch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QualifiedServerTrustFetch.h; sourceTree = "<group>"; };
+		FA8B24AC30212E540018413F /* QualifiedServerTrustFetch.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = QualifiedServerTrustFetch.cpp; sourceTree = "<group>"; };
 		FA8B4F662E4674BC00E419CD /* APIScriptMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIScriptMessage.h; sourceTree = "<group>"; };
 		FA8B4F672E4674BC00E419CD /* APIScriptMessage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = APIScriptMessage.cpp; sourceTree = "<group>"; };
 		FA8B4F6B2E46A93500E419CD /* WKScriptMessageRef.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKScriptMessageRef.h; sourceTree = "<group>"; };
@@ -14312,6 +14317,8 @@
 				1D3F2E8A99B47C6E5F7A2D13 /* PreconnectRequest.serialization.in */,
 				83A0ED331F747CC7003299EB /* PreconnectTask.cpp */,
 				83A0ED321F747CC6003299EB /* PreconnectTask.h */,
+				FA8B24AC30212E540018413F /* QualifiedServerTrustFetch.cpp */,
+				FA8B24AB30212E540018413F /* QualifiedServerTrustFetch.h */,
 				41287D4D225C161F009A3E26 /* WebSocketTask.h */,
 			);
 			path = NetworkProcess;
@@ -15256,6 +15263,8 @@
 				FA5AAE9A2E6A217A00FE693D /* NetworkSoftLink.mm */,
 				D2E2FE6D29C8C30D00023E6B /* NetworkTaskCocoa.h */,
 				D2E2FE6F29C8C4F900023E6B /* NetworkTaskCocoa.mm */,
+				FA745C47302EA40D007231F3 /* SecuritySoftLink.h */,
+				FA745C48302EA40D007231F3 /* SecuritySoftLink.mm */,
 				41287D4C225C05C5009A3E26 /* WebSocketTaskCocoa.h */,
 				41287D4B225C05C4009A3E26 /* WebSocketTaskCocoa.mm */,
 				5C2C6FA827C96FF900CCDA9E /* WKURLSessionTaskDelegate.h */,
@@ -22271,6 +22280,7 @@
 				1AF572302D690813008266F2 /* RemoteScrollingTreeCocoa.mm in Sources */,
 				7BCF70DE2615D06E00E4FB70 /* ScopedRenderingResourcesRequestCocoa.mm in Sources */,
 				9BF622542C3E8559007F7021 /* SecurityFlags.cpp in Sources */,
+				FA745C49302FC7FF007231F3 /* SecuritySoftLink.mm in Sources */,
 				E3D0A9422D62B1C90094538A /* ServiceWorkerDebuggableFrontendChannel.cpp in Sources */,
 				E3E6297F2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.cpp in Sources */,
 				93468E6D2714AF88009983E3 /* SharedFileHandleCocoa.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.h
@@ -157,6 +157,11 @@ struct HTTPResponse {
         headerFieldsFor304 = WTF::move(headerFields);
     }
 
+    void setHeaderField(String&& name, String&& value)
+    {
+        headerFields.set(WTF::move(name), WTF::move(value));
+    }
+
     enum class IncludeContentLength : bool { No, Yes };
     Vector<uint8_t> serialize(IncludeContentLength = IncludeContentLength::Yes) const;
     static Vector<uint8_t> bodyFromString(const String&);

--- a/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.swift
@@ -53,6 +53,7 @@ import struct Swift.String
 public struct Route: Sendable {
     fileprivate struct Storage: Sendable {
         let pathComponents: [String]
+        let headerFields: [String: String]
         let response: String
     }
 
@@ -62,8 +63,8 @@ public struct Route: Sendable {
         self.children = children
     }
 
-    fileprivate init(path: String, response: String) {
-        self.children = [Storage(pathComponents: [path], response: response)]
+    fileprivate init(path: String, headerFields: [String: String], response: String) {
+        self.children = [Storage(pathComponents: [path], headerFields: headerFields, response: response)]
     }
 
     /// Creates a Route from a group of child Routes.
@@ -74,7 +75,7 @@ public struct Route: Sendable {
     public init(_ path: String, @RouteBuilder _ route: () -> Route) {
         self.children = route().children
             .map {
-                Storage(pathComponents: [path] + $0.pathComponents, response: $0.response)
+                Storage(pathComponents: [path] + $0.pathComponents, headerFields: $0.headerFields, response: $0.response)
             }
     }
 
@@ -82,9 +83,10 @@ public struct Route: Sendable {
     ///
     /// - Parameters:
     ///   - path: The path of this route. If this value is non-empty, it must start with `/`.
+    ///   - headerFields: The header fields of the response.
     ///   - response: The response to be used.
-    public init(_ path: String, _ response: () -> String) {
-        self.init(path: path, response: response())
+    public init(_ path: String, headerFields: [String: String] = [:], _ response: () -> String) {
+        self.init(path: path, headerFields: headerFields, response: response())
     }
 }
 
@@ -171,7 +173,11 @@ public struct HTTPServer: ~Copyable {
         let routes = route().children
         for child in routes {
             let path = child.pathComponents.joined()
-            let response = unsafe TestWebKitAPI.HTTPResponse(WTF.String(child.response))
+            var response = unsafe TestWebKitAPI.HTTPResponse(WTF.String(child.response))
+
+            for (name, value) in child.headerFields {
+                unsafe response.setHeaderField(consuming: .init(name), consuming: .init(value))
+            }
 
             unsafe hashMapSet(&entries, consuming: .init(path), consuming: response)
         }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm
@@ -31,7 +31,10 @@
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestUIDelegate.h"
+#import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/text/MakeString.h>
 
 @interface TrustObserver : NSObject
 - (void)waitUntilServerTrustChanged;
@@ -51,6 +54,29 @@
 {
     _observedServerTrust = false;
     while (!_observedServerTrust)
+        TestWebKitAPI::Util::spinRunLoop();
+}
+
+@end
+
+@interface QualifiedServerTrustObserver : NSObject
+- (void)waitUntilQualifiedServerTrustChanged;
+@end
+
+@implementation QualifiedServerTrustObserver {
+    bool _observedQualifiedServerTrust;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    EXPECT_WK_STREQ(keyPath, "qualifiedServerTrust");
+    _observedQualifiedServerTrust = true;
+}
+
+- (void)waitUntilQualifiedServerTrustChanged
+{
+    _observedQualifiedServerTrust = false;
+    while (!_observedQualifiedServerTrust)
         TestWebKitAPI::Util::spinRunLoop();
 }
 
@@ -125,4 +151,67 @@ TEST(WKWebView, ServerTrustKVCWithCOOP)
     [webView loadHTMLString:@"<script>alert('loaded')</script>" baseURL:[NSURL URLWithString:@"https://webkit.org/path1"]];
     EXPECT_WK_STREQ([uiDelegate waitForAlert], "loaded");
     EXPECT_NULL(webView.get().serverTrust);
+}
+
+TEST(WKWebView, QualifiedServerTrustKVC)
+{
+    using namespace TestWebKitAPI;
+    constexpr auto qualifiedServerTrustBody = "This is where the 2QWAC bytes will go."_s;
+
+    HTTPServer server({ { "/2qwac"_s, { qualifiedServerTrustBody } } }, HTTPServer::Protocol::HttpsProxy);
+    auto linkHeader = [&] (ASCIILiteral rel) {
+        return makeString("<https://webkit.org/2qwac>; rel=\""_s, rel, "\""_s);
+    };
+    server.addResponse("/no-link"_s, { "hi"_s });
+    server.addResponse("/binding-link"_s, { { { "Link"_s, linkHeader("tls-certificate-binding preload"_s) } }, "hi"_s });
+    server.addResponse("/other-rel"_s, { { { "Link"_s, linkHeader("author"_s) } }, "hi"_s });
+    server.addResponse("/many-links"_s, { { { "Link"_s, makeString("<https://webkit.org/author>; rel=\"author\", "_s, linkHeader("tls-certificate-binding"_s)) } }, "hi"_s });
+    server.addResponse("/cross-origin-link"_s, { { { "Link"_s, "<https://example.com/2qwac>; rel=\"tls-certificate-binding\""_s } }, "hi"_s });
+
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setQualifiedServerTrustDebugEnabledForTesting:YES];
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    webView.get().navigationDelegate = delegate.get();
+    [delegate allowAnyTLSCertificate];
+    EXPECT_NULL([webView valueForKey:@"qualifiedServerTrust"]);
+
+    RetainPtr observer = adoptNS([QualifiedServerTrustObserver new]);
+    [webView addObserver:observer.get() forKeyPath:@"qualifiedServerTrust" options:NSKeyValueObservingOptionNew context:nil];
+
+    [webView loadURL:[NSURL URLWithString:@"https://webkit.org/binding-link"]];
+    [observer waitUntilQualifiedServerTrustChanged];
+    verifyCertificateAndPublicKey([webView qualifiedServerTrust]);
+
+    // Committing a response without a tls-certificate-binding link clears the 2QWAC.
+    [webView loadURL:[NSURL URLWithString:@"https://webkit.org/no-link"]];
+    [observer waitUntilQualifiedServerTrustChanged];
+    EXPECT_NULL([webView qualifiedServerTrust]);
+
+    // The tls-certificate-binding link is found even when it isn't the only link.
+    [webView loadURL:[NSURL URLWithString:@"https://webkit.org/many-links"]];
+    [observer waitUntilQualifiedServerTrustChanged];
+    verifyCertificateAndPublicKey([webView qualifiedServerTrust]);
+
+    // A link with a different rel is not a 2QWAC.
+    [webView loadURL:[NSURL URLWithString:@"https://webkit.org/other-rel"]];
+    [observer waitUntilQualifiedServerTrustChanged];
+    EXPECT_NULL([webView qualifiedServerTrust]);
+
+    // A cross-origin tls-certificate-binding link is ignored. The 2QWAC is already
+    // null here, so there is nothing to observe and we wait for the navigation instead.
+    [webView loadURL:[NSURL URLWithString:@"https://webkit.org/cross-origin-link"]];
+    [delegate waitForDidFinishNavigation];
+    Util::runFor(0.1_s);
+    EXPECT_NULL([webView qualifiedServerTrust]);
+
+    // Load a valid 2QWAC again to verify the checks above didn't just break the fetch entirely.
+    [webView loadURL:[NSURL URLWithString:@"https://webkit.org/binding-link"]];
+    [observer waitUntilQualifiedServerTrustChanged];
+    verifyCertificateAndPublicKey([webView qualifiedServerTrust]);
+
+    [webView removeObserver:observer.get() forKeyPath:@"qualifiedServerTrust"];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
@@ -25,11 +25,16 @@
 
 import SwiftUI
 import Observation
+import Security
 import Testing
 @_spi(CrossImportOverlay) @_spi(Private) @_spi(Testing) import WebKit
 import WebKit_Private.WKWebViewPrivate
 @_spi(Private) import _WebKit_SwiftUI
 private import TestWebKitAPILibrary
+#if ENABLE_CXX_INTEROP
+private import WebKit_Private._WKWebsiteDataStoreConfiguration
+private import WebKit_Private.WKWebsiteDataStorePrivate
+#endif
 
 // MARK: Supporting test types
 
@@ -64,6 +69,28 @@ private class TestNavigationDecider: WebPage.NavigationDeciding {
     }
 }
 
+#if ENABLE_CXX_INTEROP
+@MainActor
+private struct TrustingNavigationDecider: WebPage.NavigationDeciding {
+    mutating func decideAuthenticationChallengeDisposition(
+        for challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        (.useCredential, challenge.protectionSpace.serverTrust.map(URLCredential.init(trust:)))
+    }
+}
+
+extension WebPage.Configuration {
+    fileprivate init(_ serverConfiguration: HTTPServer.Configuration, qualifiedServerTrustDebugEnabled: Bool = false) {
+        self.init()
+
+        let storeConfiguration = _WKWebsiteDataStoreConfiguration(nonPersistentConfiguration: ())
+        storeConfiguration.httpsProxy = serverConfiguration.httpsProxy
+        storeConfiguration.qualifiedServerTrustDebugEnabledForTesting = qualifiedServerTrustDebugEnabled
+        self.websiteDataStore = WKWebsiteDataStore._store(with: storeConfiguration)
+    }
+}
+#endif // ENABLE_CXX_INTEROP
+
 // MARK: Tests
 
 @MainActor
@@ -77,6 +104,7 @@ struct WebPageTests {
         #expect(!page.isLoading)
         #expect(page.estimatedProgress == 0.0)
         #expect(page.serverTrust == nil)
+        #expect(page.qualifiedServerTrust == nil)
         #expect(!page.hasOnlySecureContent)
         #if WTF_PLATFORM_MAC || WTF_PLATFORM_IOS
         #expect(page.themeColor == nil)
@@ -84,6 +112,58 @@ struct WebPageTests {
 
         // FIXME: (283456) Make this test more comprehensive once Observation supports observing a stream of changes to properties.
     }
+
+    #if ENABLE_CXX_INTEROP
+    @Test
+    func qualifiedServerTrust() async throws {
+        var server = HTTPServer(protocol: .httpsProxy) {
+            Route("/binding-link", headerFields: ["Link": "<https://webkit.org/2qwac>; rel=\"tls-certificate-binding\""]) {
+                "hi"
+            }
+
+            Route("/2qwac") {
+                "This is where the 2QWAC bytes will go."
+            }
+
+            Route("/no-link") {
+                "hi"
+            }
+        }
+
+        try await server.run { serverConfiguration in
+            let configuration = WebPage.Configuration(serverConfiguration, qualifiedServerTrustDebugEnabled: true)
+            let page = WebPage(configuration: configuration, navigationDecider: TrustingNavigationDecider())
+
+            #expect(page.qualifiedServerTrust == nil)
+
+            let changes = Observations { page.qualifiedServerTrust != nil }
+
+            let bindingLinkURL = try #require(URL(string: "https://webkit.org/binding-link"))
+            try await page.load(bindingLinkURL).wait()
+
+            // The 2-QWAC is fetched after the navigation commits, so waiting for the navigation to finish
+            // is not enough; this waits for the property to be observed changing.
+            _ = try await #require(changes.first { @Sendable in $0 })
+
+            let qualifiedServerTrust = try #require(page.qualifiedServerTrust)
+            let serverTrust = try #require(page.serverTrust)
+
+            // With debugging enabled the 2-QWAC is the TLS trust of the 2-QWAC fetch, which was served by
+            // the same identity as the page itself.
+            let qualifiedServerTrustKey = try #require(SecTrustCopyKey(qualifiedServerTrust))
+            let serverKey = try #require(SecTrustCopyKey(serverTrust))
+            let qualifiedServerTrustKeyData = unsafe try #require(SecKeyCopyExternalRepresentation(qualifiedServerTrustKey, nil))
+            let serverKeyData = unsafe try #require(SecKeyCopyExternalRepresentation(serverKey, nil))
+            #expect(CFEqual(qualifiedServerTrustKeyData, serverKeyData))
+
+            // Committing a response without a tls-certificate-binding link clears the 2-QWAC.
+            let noLinkURL = try #require(URL(string: "https://webkit.org/no-link"))
+            try await page.load(noLinkURL).wait()
+
+            #expect(page.qualifiedServerTrust == nil)
+        }
+    }
+    #endif // ENABLE_CXX_INTEROP
 
     @Test
     func decidePolicyForNavigationActionFragment() async throws {


### PR DESCRIPTION
#### 3dfdbed8e4f07513f241af3aa56fac6a3d2b7810
<pre>
Implement 2-QWAC fetching
<a href="https://bugs.webkit.org/show_bug.cgi?id=320945">https://bugs.webkit.org/show_bug.cgi?id=320945</a>
<a href="https://rdar.apple.com/166719636">rdar://166719636</a>

Reviewed by Brady Eidson.

This is the beginning of the implementation of 2-QWACs.
See <a href="https://www.etsi.org/deliver/etsi_ts/119400_119499/11941105/02.01.01_60/ts_11941105v020101p.pdf">https://www.etsi.org/deliver/etsi_ts/119400_119499/11941105/02.01.01_60/ts_11941105v020101p.pdf</a>
This inspects the link header fields of the response to a main resource request,
and if there&apos;s a URL with a rel value of tls-certificate-binding we fetch it and evaluate the response.
If the resposne is valid, we will populate WKWebView.qualifiedServerTrust.
Since the validity check isn&apos;t implemented yet, we just reuse the TLS trust for now when testing, but as a
follow-up we&apos;ll need to do the check and populate WKWebView.qualifiedServerTrust with a trust from the
fetched response data when testing.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm

* Source/WTF/wtf/spi/cocoa/SecuritySPI.h:
* Source/WebCore/html/LinkRelAttribute.cpp:
(WebCore::LinkRelAttribute::LinkRelAttribute):
(WebCore::LinkRelAttribute::isSupported):
* Source/WebCore/html/LinkRelAttribute.h:
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/NetworkProcess/NetworkLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didFinishLoading):
(WebKit::NetworkResourceLoader::checkForQualifiedServerTrust):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::NetworkSession):
* Source/WebKit/NetworkProcess/NetworkSession.h:
(WebKit::NetworkSession::qualifiedServerTrustDebugEnabledForTesting const):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/QualifiedServerTrustFetch.cpp: Added.
(WebKit::globalQualifiedServerTrustFetchMap):
(WebKit::QualifiedServerTrustFetch::keepAliveUntilCompletion):
(WebKit::QualifiedServerTrustFetch::didReachCompletion):
(WebKit::qualifiedServerTrustParameters):
(WebKit::QualifiedServerTrustFetch::QualifiedServerTrustFetch):
(WebKit::QualifiedServerTrustFetch::willSendRedirectedRequest):
(WebKit::QualifiedServerTrustFetch::didReceiveResponse):
(WebKit::QualifiedServerTrustFetch::didReceiveBuffer):
(WebKit::QualifiedServerTrustFetch::didFinishLoading):
(WebKit::QualifiedServerTrustFetch::didFailLoading):
(WebKit::QualifiedServerTrustFetch::cancel):
(WebKit::QualifiedServerTrustFetch::didSendData):
* Source/WebKit/NetworkProcess/QualifiedServerTrustFetch.h: Added.
* Source/WebKit/NetworkProcess/cocoa/SecuritySoftLink.h: Added.
* Source/WebKit/NetworkProcess/cocoa/SecuritySoftLink.mm: Added.
* Source/WebKit/PlatformCocoa.cmake:
* Source/WebKit/Sources.txt:
* Source/WebKit/SourcesCMakeCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView valueForUndefinedKey:]):
(-[WKWebView qualifiedServerTrust]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration qualifiedServerTrustDebugEnabledForTesting]):
(-[_WKWebsiteDataStoreConfiguration setQualifiedServerTrustDebugEnabledForTesting:]):
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(qualifiedServerTrust):
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::willChangeQualifiedServerTrust):
(WebKit::NavigationState::didChangeQualifiedServerTrust):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::receivedQualifiedServerTrust):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:
* Source/WebKit/UIProcess/PageLoadState.cpp:
(WebKit::PageLoadState::commitChanges):
(WebKit::PageLoadState::didCommitLoad):
(WebKit::PageLoadState::receivedQualifiedServerTrust):
* Source/WebKit/UIProcess/PageLoadState.h:
(WebKit::PageLoadStateObserverBase::willChangeQualifiedServerTrust):
(WebKit::PageLoadStateObserverBase::didChangeQualifiedServerTrust):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedQualifiedServerTrust):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::copy const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::qualifiedServerTrustDebugEnabledForTesting const):
(WebKit::WebsiteDataStoreConfiguration::setQualifiedServerTrustDebugEnabledForTesting):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.h:
(TestWebKitAPI::HTTPResponse::setHeaderField):
* Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm:
(-[QualifiedServerTrustObserver observeValueForKeyPath:ofObject:change:context:]):
(-[QualifiedServerTrustObserver waitUntilQualifiedServerTrustChanged]):
(TEST(WKWebView, QualifiedServerTrustKVC)):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift:
(WebPageTests.observableProperties):
(WebPageTests.qualifiedServerTrust):

Canonical link: <a href="https://commits.webkit.org/319551@main">https://commits.webkit.org/319551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7edb449b3f5ce4ccc4863a8fb4d325fec5f6727b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181619 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145946 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33f4f364-62eb-4321-90f4-0c0947eba181) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141759 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184574 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45456 "Found 1 new test failure: http/tests/app-privacy-report/app-attribution-post-request.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162520 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122196 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e59ffc49-b565-418a-b291-294e3bb34cc0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44138 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42407 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4164 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10989 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154539 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42047 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3003 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42898 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193770 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55236 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151169 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55925 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38669 "Too many flaky failures: http/tests/media/reload-after-dialog.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/post-frames-goback1-uncached.html, http/tests/resourceLoadStatistics/grandfathering.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/image-blocked-alt-text.html, http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image-UpgradeMixedContent.https.html, http/tests/site-isolation/draw-after-navigation.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150871 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27616 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45460 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128208 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123898 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54438 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17042 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53820 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54059 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53885 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->