### PR TITLE
Web Inspector: Canvas: do not treat missing `console.record()` options as present

### DIFF
--- a/LayoutTests/inspector/canvas/console-record-2d-expected.txt
+++ b/LayoutTests/inspector/canvas/console-record-2d-expected.txt
@@ -5,5 +5,5 @@ Test that CanvasManager is able to record actions made to 2D canvas contexts.
 -- Running test case: Canvas.recording2D.Console
 PASS: The recording should have the name "TEST".
 PASS: The recording should have one frame.
-PASS: The first frame should have one action.
+PASS: The first frame should have 2 actions.
 

--- a/LayoutTests/inspector/canvas/console-record-2d.html
+++ b/LayoutTests/inspector/canvas/console-record-2d.html
@@ -12,7 +12,7 @@ function test() {
         name: "Canvas.recording2D.Console",
         description: "Check that a recording can be triggered by console.record().",
         test(resolve, reject) {
-            consoleRecord(WI.Canvas.ContextType.Canvas2D, resolve, reject);
+            consoleRecord(WI.Canvas.ContextType.Canvas2D, resolve, reject, {actionCount: 2});
         },
     });
 

--- a/LayoutTests/inspector/canvas/resources/recording-2d.js
+++ b/LayoutTests/inspector/canvas/resources/recording-2d.js
@@ -413,10 +413,11 @@ function performConsoleActions() {
     console.record(ctx, {name: "TEST"});
 
     ctx.fill();
+    ctx.stroke();
 
     console.recordEnd(ctx);
 
-    ctx.stroke();
+    ctx.clip();
 }
 
 function performSavePreActions() {

--- a/LayoutTests/inspector/canvas/resources/recording-utilities.js
+++ b/LayoutTests/inspector/canvas/resources/recording-utilities.js
@@ -172,7 +172,7 @@ TestPage.registerInitializer(() => {
         CanvasAgent.startRecording(canvas.identifier, frameCount, memoryLimit).catch(reject);
     };
 
-    window.consoleRecord = function(type, resolve, reject) {
+    window.consoleRecord = function(type, resolve, reject, {actionCount = 1} = {}) {
         let canvas = getCanvas(type);
         if (!canvas) {
             reject(`Missing canvas with type "${type}".`);
@@ -188,7 +188,10 @@ TestPage.registerInitializer(() => {
 
             InspectorTest.expectEqual(recording.displayName, "TEST", "The recording should have the name \"TEST\".");
             InspectorTest.expectEqual(recording.frames.length, 1, "The recording should have one frame.");
-            InspectorTest.expectEqual(recording.frames[0].actions.length, 1, "The first frame should have one action.");
+            if (actionCount === 1)
+                InspectorTest.expectEqual(recording.frames[0].actions.length, 1, "The first frame should have one action.");
+            else
+                InspectorTest.expectEqual(recording.frames[0].actions.length, actionCount, `The first frame should have ${actionCount} actions.`);
         }).then(resolve, reject);
 
         InspectorTest.evaluateInPage(`performConsoleActions()`);

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -553,13 +553,13 @@ void InspectorCanvasAgent::consoleStartRecordingCanvas(InspectorCanvas& inspecto
     RecordingOptions recordingOptions;
     if (options) {
         JSC::VM& vm = exec.vm();
-        if (JSC::JSValue optionSingleFrame = options->get(&exec, JSC::Identifier::fromString(vm, "singleFrame"_s)))
+        if (JSC::JSValue optionSingleFrame = options->get(&exec, JSC::Identifier::fromString(vm, "singleFrame"_s)); !optionSingleFrame.isUndefined())
             recordingOptions.frameCount = optionSingleFrame.toBoolean(&exec) ? 1 : 0;
-        if (JSC::JSValue optionFrameCount = options->get(&exec, JSC::Identifier::fromString(vm, "frameCount"_s)))
+        if (JSC::JSValue optionFrameCount = options->get(&exec, JSC::Identifier::fromString(vm, "frameCount"_s)); !optionFrameCount.isUndefined())
             recordingOptions.frameCount = optionFrameCount.toNumber(&exec);
-        if (JSC::JSValue optionMemoryLimit = options->get(&exec, JSC::Identifier::fromString(vm, "memoryLimit"_s)))
+        if (JSC::JSValue optionMemoryLimit = options->get(&exec, JSC::Identifier::fromString(vm, "memoryLimit"_s)); !optionMemoryLimit.isUndefined())
             recordingOptions.memoryLimit = optionMemoryLimit.toNumber(&exec);
-        if (JSC::JSValue optionName = options->get(&exec, JSC::Identifier::fromString(vm, "name"_s)))
+        if (JSC::JSValue optionName = options->get(&exec, JSC::Identifier::fromString(vm, "name"_s)); !optionName.isUndefined())
             recordingOptions.name = optionName.toWTFString(&exec);
     }
     startRecording(inspectorCanvas, Inspector::Protocol::Recording::Initiator::Console, WTF::move(recordingOptions));


### PR DESCRIPTION
#### 7bcf4016df4a19adc8e12a597c7e4be63626fb23
<pre>
Web Inspector: Canvas: do not treat missing `console.record()` options as present
<a href="https://bugs.webkit.org/show_bug.cgi?id=320949">https://bugs.webkit.org/show_bug.cgi?id=320949</a>

Reviewed by Mike Wyrzykowski.

* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::consoleStartRecordingCanvas):
`JSC::JSValue::operator bool` only checks whether a value is empty.
An option whose value is `undefined` was treated as present and converted to `NaN`.

* LayoutTests/inspector/canvas/resources/recording-utilities.js:
* LayoutTests/inspector/canvas/resources/recording-2d.js:
* LayoutTests/inspector/canvas/console-record-2d.html:
* LayoutTests/inspector/canvas/console-record-2d-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318555@main">https://commits.webkit.org/318555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57ffd217617c6cf364564bead223905e205310bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188149 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139196 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119650 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41418 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39768 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39440 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190576 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159464 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148354 "Failure limit exceed. At least found 22 new test failures: css3/flexbox/button.html editing/caret/caret-color.html editing/deleting/4922367.html editing/deleting/5099303.html editing/deleting/5126166.html editing/selection/move-by-line-001.html editing/selection/move-by-line-002.html editing/style/4916887.html editing/style/5017613-1.html editing/style/5017613-2.html ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39862 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52821 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148124 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42830 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125088 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119724 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51339 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14415 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50724 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->