### PR TITLE
Implement the IDL changes for WebCodecsImageDecoder

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -10151,6 +10151,22 @@ WebCodecsHEVCEnabled:
       "PLATFORM(COCOA)": true
       default: false
 
+WebCodecsImageEnabled:
+  type: bool
+  status: unstable
+  category: media
+  webcoreOnChange: setNeedsRelayoutAllFrames
+  humanReadableName: "WebCodecs Image API"
+  humanReadableDescription: "Enable WebCodecs Image API"
+  condition: ENABLE(WEB_CODECS)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 WebCodecsVideoEnabled:
   type: bool
   status: mature

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -883,6 +883,10 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl
     Modules/webcodecs/WebCodecsEncodedVideoChunkType.idl
     Modules/webcodecs/WebCodecsErrorCallback.idl
+    Modules/webcodecs/WebCodecsImageDecodeResult.idl
+    Modules/webcodecs/WebCodecsImageDecoder.idl
+    Modules/webcodecs/WebCodecsImageTrack.idl
+    Modules/webcodecs/WebCodecsImageTrackList.idl
     Modules/webcodecs/WebCodecsSvcOutputMetadata.idl
     Modules/webcodecs/WebCodecsVideoDecoder.idl
     Modules/webcodecs/WebCodecsVideoDecoderConfig.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -818,6 +818,10 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunkType.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsErrorCallback.idl \
+	$(WebCore)/Modules/webcodecs/WebCodecsImageDecodeResult.idl \
+	$(WebCore)/Modules/webcodecs/WebCodecsImageDecoder.idl \
+	$(WebCore)/Modules/webcodecs/WebCodecsImageTrack.idl \
+	$(WebCore)/Modules/webcodecs/WebCodecsImageTrackList.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsSvcOutputMetadata.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsVideoDecoder.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsVideoDecoderConfig.idl \

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecodeResult.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecodeResult.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+namespace WebCore {
+
+class WebCodecsVideoFrame;
+
+struct WebCodecsImageDecodeResult {
+    Ref<WebCodecsVideoFrame> image;
+    bool complete;
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecodeResult.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecodeResult.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://w3c.github.io/webcodecs/#dictdef-imagedecoderesult
+
+[
+    Conditional=WEB_CODECS,
+    EnabledBySetting=WebCodecsImageEnabled,
+    JSGenerateToJSObject
+] dictionary WebCodecsImageDecodeResult {
+    required WebCodecsVideoFrame image;
+    required boolean complete;
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCodecsImageDecoder.h"
+
+#if ENABLE(WEB_CODECS)
+
+#include "JSDOMConvertDictionary.h"
+#include "JSDOMPromiseDeferred.h"
+#include "JSWebCodecsImageDecodeResult.h"
+#include "WebCodecsImageDecodeResult.h"
+#include "WebCodecsVideoFrame.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCodecsImageDecoder);
+
+Ref<WebCodecsImageDecoder> WebCodecsImageDecoder::create(ScriptExecutionContext& context, Init&& init)
+{
+    Ref decoder = adoptRef(*new WebCodecsImageDecoder(context, WTF::move(init)));
+    decoder->suspendIfNeeded();
+    return decoder;
+}
+
+WebCodecsImageDecoder::WebCodecsImageDecoder(ScriptExecutionContext& context, Init&&)
+    : WebCodecsBase(context)
+    , m_completedPromise(makeUniqueRef<CompletedPromise>())
+{
+}
+
+WebCodecsImageDecoder::~WebCodecsImageDecoder() = default;
+
+Ref<WebCodecsImageTrackList> WebCodecsImageDecoder::tracks() const
+{
+    if (!m_tracks)
+        m_tracks = WebCodecsImageTrackList::create({ WebCodecsImageTrack::create() });
+
+    return *m_tracks;
+}
+
+ExceptionOr<void> WebCodecsImageDecoder::decode(std::optional<DecodeOptions>&&, Ref<DeferredPromise>&&)
+{
+    return Exception { ExceptionCode::NotSupportedError };
+}
+
+ExceptionOr<void> WebCodecsImageDecoder::reset()
+{
+    return Exception { ExceptionCode::NotSupportedError };
+}
+
+ExceptionOr<void> WebCodecsImageDecoder::close()
+{
+    return Exception { ExceptionCode::NotSupportedError };
+}
+
+void WebCodecsImageDecoder::isTypeSupported(ScriptExecutionContext&, String&&, Ref<DeferredPromise>&&)
+{
+}
+
+void WebCodecsImageDecoder::suspend(ReasonForSuspension)
+{
+}
+
+void WebCodecsImageDecoder::stop()
+{
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "DOMPromiseProxy.h"
+#include "EventTargetInterfaces.h"
+#include "ExceptionOr.h"
+#include "IDLTypes.h"
+#include "JSDOMPromiseDeferredForward.h"
+#include "WebCodecsBase.h"
+#include "WebCodecsImageTrackList.h"
+#include <JavaScriptCore/ArrayBuffer.h>
+#include <JavaScriptCore/ArrayBufferView.h>
+#include <wtf/UniqueRef.h>
+
+namespace WebCore {
+
+class ReadableStream;
+class WebCodecsVideoFrame;
+
+using ImageBufferSource = Variant
+    < Ref<JSC::ArrayBuffer>
+    , Ref<JSC::ArrayBufferView>
+    , Ref<ReadableStream>
+>;
+
+class WebCodecsImageDecoder final : public WebCodecsBase {
+    WTF_MAKE_TZONE_ALLOCATED(WebCodecsImageDecoder);
+public:
+    ~WebCodecsImageDecoder();
+
+    enum class ColorSpaceConversion : bool { None, Default };
+
+    struct Init {
+        String type;
+        ImageBufferSource data;
+        ColorSpaceConversion colorSpaceConversion { ColorSpaceConversion::Default };
+        std::optional<size_t> desiredWidth;
+        std::optional<size_t> desiredHeight;
+        std::optional<bool> preferAnimation;
+    };
+
+    struct DecodeOptions {
+        size_t frameIndex { 0 };
+        bool completeFramesOnly { true };
+    };
+
+    static Ref<WebCodecsImageDecoder> create(ScriptExecutionContext&, Init&&);
+
+    String type() const { return m_type; }
+    bool complete() const { return true; }
+
+    using CompletedPromise = DOMPromiseProxy<IDLUndefined>;
+    CompletedPromise& completed() { return m_completedPromise.get(); }
+
+    Ref<WebCodecsImageTrackList> tracks() const;
+
+    ExceptionOr<void> decode(std::optional<DecodeOptions>&&, Ref<DeferredPromise>&&);
+    ExceptionOr<void> reset();
+    ExceptionOr<void> close();
+
+    static void isTypeSupported(ScriptExecutionContext&, String&& type, Ref<DeferredPromise>&&);
+
+private:
+    WebCodecsImageDecoder(ScriptExecutionContext&, Init&&);
+
+    // ActiveDOMObject.
+    void stop() final;
+    void NODELETE suspend(ReasonForSuspension) final;
+
+    // EventTarget.
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsImageDecoder; }
+
+    String m_type;
+    UniqueRef<CompletedPromise> m_completedPromise;
+    mutable RefPtr<WebCodecsImageTrackList> m_tracks;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebCodecsImageDecoder)
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.idl
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+// https://w3c.github.io/webcodecs/#imagedecoder-interface
+
+[
+    ActiveDOMObject,
+    Conditional=WEB_CODECS,
+    EnabledBySetting=WebCodecsImageEnabled,
+    ExportMacro=WEBCORE_EXPORT,
+    Exposed=(Window,DedicatedWorker),
+    InterfaceName=ImageDecoder,
+    JSCustomMarkFunction,
+    SecureContext
+] interface WebCodecsImageDecoder : EventTarget {
+    [CallWith=CurrentScriptExecutionContext] constructor(WebCodecsImageDecoderInit init);
+
+    readonly attribute DOMString type;
+    readonly attribute boolean complete;
+    readonly attribute Promise<undefined> completed;
+    readonly attribute WebCodecsImageTrackList tracks;
+
+    Promise<WebCodecsImageDecodeResult> decode(optional WebCodecsImageDecodeOptions options = {});
+    undefined reset();
+    undefined close();
+
+    [CallWith=CurrentScriptExecutionContext] static Promise<boolean> isTypeSupported(DOMString type);
+};
+
+typedef (ArrayBuffer or [AllowShared] ArrayBufferView) AllowSharedBufferSource;
+typedef (AllowSharedBufferSource or ReadableStream) ImageBufferSource;
+enum ColorSpaceConversion { "none", "default" };
+
+[
+    Conditional=WEB_CODECS,
+] dictionary WebCodecsImageDecoderInit {
+    required DOMString type;
+    required ImageBufferSource data;
+    ColorSpaceConversion colorSpaceConversion = "default";
+    [EnforceRange] unsigned long desiredWidth;
+    [EnforceRange] unsigned long desiredHeight;
+    boolean preferAnimation;
+};
+
+[
+    Conditional=WEB_CODECS,
+] dictionary WebCodecsImageDecodeOptions {
+    [EnforceRange] unsigned long frameIndex = 0;
+    boolean completeFramesOnly = true;
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageTrack.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageTrack.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCodecsImageTrack.h"
+
+#if ENABLE(WEB_CODECS)
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCodecsImageTrack);
+
+Ref<WebCodecsImageTrack> WebCodecsImageTrack::create()
+{
+    return adoptRef(*new WebCodecsImageTrack());
+}
+
+Ref<WebCodecsImageTrack> WebCodecsImageTrack::create(float repetitionCount, size_t frameCount, bool animated, bool selected)
+{
+    return adoptRef(*new WebCodecsImageTrack(repetitionCount, frameCount, animated, selected));
+}
+
+WebCodecsImageTrack::WebCodecsImageTrack(float repetitionCount, size_t frameCount, bool animated, bool selected)
+    : m_repetitionCount(repetitionCount)
+    , m_frameCount(frameCount)
+    , m_animated(animated)
+    , m_selected(selected)
+{
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageTrack.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageTrack.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,43 +25,36 @@
 
 #pragma once
 
-#include <WebCore/EventTarget.h>
-#include <WebCore/WebSocketFrame.h>
-#include <wtf/Forward.h>
-#include <wtf/ObjectIdentifier.h>
+#if ENABLE(WEB_CODECS)
+
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
 
 namespace WebCore {
 
-class Document;
-class WeakPtrImplWithEventTargetData;
-class ResourceRequest;
-class ResourceResponse;
-class WebSocketChannel;
-class WebSocketChannelInspector;
-
-using WebSocketChannelIdentifier = AtomicObjectIdentifier<WebSocketChannel>;
-
-class WEBCORE_EXPORT WebSocketChannelInspector {
+class WebCodecsImageTrack final : public RefCounted<WebCodecsImageTrack> {
+    WTF_MAKE_TZONE_ALLOCATED(WebCodecsImageTrack);
 public:
-    explicit WebSocketChannelInspector(Document&);
-    ~WebSocketChannelInspector();
+    static Ref<WebCodecsImageTrack> create();
+    static Ref<WebCodecsImageTrack> create(float repetitionCount, size_t frameCount, bool animated, bool selected);
 
-    void didCreateWebSocket(const URL&) const;
-    void willSendWebSocketHandshakeRequest(ResourceRequest&) const;
-    void didSendWebSocketHandshakeRequest(const ResourceRequest&) const;
-    void didReceiveWebSocketHandshakeResponse(const ResourceResponse&) const;
-    void didCloseWebSocket() const;
-    void didReceiveWebSocketFrame(const WebSocketFrame&) const;
-    void didSendWebSocketFrame(const WebSocketFrame&) const;
-    void didReceiveWebSocketFrameError(const String& errorMessage) const;
-    
-    WebSocketChannelIdentifier progressIdentifier() const { return m_progressIdentifier; }
+    float repetitionCount() const { return m_repetitionCount; }
+    size_t frameCount() const { return m_frameCount; }
+    bool animated() const { return m_animated; }
 
-    static WebSocketFrame createFrame(std::span<const uint8_t> data, WebSocketFrame::OpCode);
+    bool selected() const { return m_selected; }
+    void setSelected(bool selected) { m_selected = selected; }
 
 private:
-    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
-    WebSocketChannelIdentifier m_progressIdentifier;
+    WebCodecsImageTrack() = default;
+    WebCodecsImageTrack(float repetitionCount, size_t frameCount, bool animated, bool selected);
+
+    float m_repetitionCount { 1 };
+    size_t m_frameCount { 0 };
+    bool m_animated { false };
+    bool m_selected { false };
 };
 
 } // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageTrack.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageTrack.idl
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://w3c.github.io/webcodecs/#imagetrack-interface
+
+[
+    Conditional=WEB_CODECS,
+    EnabledBySetting=WebCodecsImageEnabled,
+    InterfaceName=ImageTrack,
+    Exposed=(Window,DedicatedWorker),
+    SecureContext
+] interface WebCodecsImageTrack {
+    readonly attribute boolean animated;
+    readonly attribute unsigned long frameCount;
+    readonly attribute unrestricted float repetitionCount;
+    attribute boolean selected;
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCodecsImageTrackList.h"
+
+#if ENABLE(WEB_CODECS)
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCodecsImageTrackList);
+
+Ref<WebCodecsImageTrackList> WebCodecsImageTrackList::create(Vector<Ref<WebCodecsImageTrack>>&& list)
+{
+    return adoptRef(*new WebCodecsImageTrackList(WTF::move(list)));
+}
+
+WebCodecsImageTrackList::WebCodecsImageTrackList(Vector<Ref<WebCodecsImageTrack>>&& list)
+    : m_readyPromise(makeUniqueRef<ReadyPromise>())
+    , m_list(WTF::move(list))
+{
+}
+
+RefPtr<WebCodecsImageTrack> WebCodecsImageTrackList::selectedTrack() const
+{
+    if (m_selectedIndex < 0)
+        return nullptr;
+    return item(m_selectedIndex);
+}
+
+RefPtr<WebCodecsImageTrack> WebCodecsImageTrackList::item(unsigned index) const
+{
+    if (index >= m_list.size())
+        return nullptr;
+    return m_list[index].copyRef();
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,43 +25,40 @@
 
 #pragma once
 
-#include <WebCore/EventTarget.h>
-#include <WebCore/WebSocketFrame.h>
-#include <wtf/Forward.h>
-#include <wtf/ObjectIdentifier.h>
+#if ENABLE(WEB_CODECS)
+
+#include "DOMPromiseProxy.h"
+#include "IDLTypes.h"
+#include "JSDOMPromiseDeferredForward.h"
+#include "WebCodecsImageTrack.h"
+#include <wtf/UniqueRef.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
-class Document;
-class WeakPtrImplWithEventTargetData;
-class ResourceRequest;
-class ResourceResponse;
-class WebSocketChannel;
-class WebSocketChannelInspector;
-
-using WebSocketChannelIdentifier = AtomicObjectIdentifier<WebSocketChannel>;
-
-class WEBCORE_EXPORT WebSocketChannelInspector {
+class WebCodecsImageTrackList final : public RefCounted<WebCodecsImageTrackList> {
+    WTF_MAKE_TZONE_ALLOCATED(WebCodecsImageTrackList);
 public:
-    explicit WebSocketChannelInspector(Document&);
-    ~WebSocketChannelInspector();
+    static Ref<WebCodecsImageTrackList> create(Vector<Ref<WebCodecsImageTrack>>&&);
 
-    void didCreateWebSocket(const URL&) const;
-    void willSendWebSocketHandshakeRequest(ResourceRequest&) const;
-    void didSendWebSocketHandshakeRequest(const ResourceRequest&) const;
-    void didReceiveWebSocketHandshakeResponse(const ResourceResponse&) const;
-    void didCloseWebSocket() const;
-    void didReceiveWebSocketFrame(const WebSocketFrame&) const;
-    void didSendWebSocketFrame(const WebSocketFrame&) const;
-    void didReceiveWebSocketFrameError(const String& errorMessage) const;
-    
-    WebSocketChannelIdentifier progressIdentifier() const { return m_progressIdentifier; }
+    using ReadyPromise = DOMPromiseProxy<IDLUndefined>;
+    ReadyPromise& ready() { return m_readyPromise.get(); }
 
-    static WebSocketFrame createFrame(std::span<const uint8_t> data, WebSocketFrame::OpCode);
+    size_t length() const { return m_list.size(); };
+    int selectedIndex() const { return m_selectedIndex; }
+    RefPtr<WebCodecsImageTrack> selectedTrack() const;
+
+    RefPtr<WebCodecsImageTrack> item(unsigned index) const;
+    bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
 
 private:
-    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
-    WebSocketChannelIdentifier m_progressIdentifier;
+    WebCodecsImageTrackList(Vector<Ref<WebCodecsImageTrack>>&&);
+
+    UniqueRef<ReadyPromise> m_readyPromise;
+    int m_selectedIndex { -1 };
+    Vector<Ref<WebCodecsImageTrack>> m_list;
 };
 
 } // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.idl
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://w3c.github.io/webcodecs/#imagetracklist-interface
+
+[
+    Conditional=WEB_CODECS,
+    EnabledBySetting=WebCodecsImageEnabled,
+    InterfaceName=ImageTrackList,
+    Exposed=(Window,DedicatedWorker),
+    SecureContext
+] interface WebCodecsImageTrackList {
+    getter WebCodecsImageTrack (unsigned long index);
+
+    readonly attribute Promise<undefined> ready;
+    readonly attribute unsigned long length;
+    readonly attribute long selectedIndex;
+    readonly attribute WebCodecsImageTrack? selectedTrack;
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -490,6 +490,9 @@ Modules/webcodecs/WebCodecsAudioEncoder.cpp
 Modules/webcodecs/WebCodecsBase.cpp
 Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
 Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
+Modules/webcodecs/WebCodecsImageDecoder.cpp
+Modules/webcodecs/WebCodecsImageTrack.cpp
+Modules/webcodecs/WebCodecsImageTrackList.cpp
 Modules/webcodecs/WebCodecsVideoDecoder.cpp
 Modules/webcodecs/WebCodecsVideoEncoder.cpp
 Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -800,6 +803,7 @@ bindings/js/JSUndoItemCustom.cpp
 bindings/js/JSWebAnimationCustom.cpp
 bindings/js/JSWebCodecsAudioDecoderCustom.cpp
 bindings/js/JSWebCodecsAudioEncoderCustom.cpp
+bindings/js/JSWebCodecsImageDecoderCustom.cpp
 bindings/js/JSWebCodecsVideoDecoderCustom.cpp
 bindings/js/JSWebCodecsVideoEncoderCustom.cpp
 bindings/js/JSWebGL2RenderingContextCustom.cpp
@@ -5237,6 +5241,10 @@ JSWebCodecsEncodedVideoChunkMetadata.cpp
 JSWebCodecsEncodedVideoChunkOutputCallback.cpp
 JSWebCodecsEncodedVideoChunkType.cpp
 JSWebCodecsErrorCallback.cpp
+JSWebCodecsImageDecoder.cpp
+JSWebCodecsImageDecodeResult.cpp
+JSWebCodecsImageTrack.cpp
+JSWebCodecsImageTrackList.cpp
 JSWebCodecsSvcOutputMetadata.cpp
 JSWebCodecsVideoDecoder.cpp
 JSWebCodecsVideoDecoderConfig.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -14706,6 +14706,18 @@
 		72E417621A2E8D2F004C562A /* JSEXTsRGB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSEXTsRGB.h; sourceTree = "<group>"; };
 		72E5023029B669ED00E5B8E7 /* RenderingResource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderingResource.h; sourceTree = "<group>"; };
 		72E5768A281B292600A75432 /* CopyImageOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CopyImageOptions.h; sourceTree = "<group>"; };
+		72EB157E302167B500E59EAD /* WebCodecsImageDecoder.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebCodecsImageDecoder.idl; sourceTree = "<group>"; };
+		72EB157F302167B500E59EAD /* WebCodecsImageDecodeResult.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebCodecsImageDecodeResult.idl; sourceTree = "<group>"; };
+		72EB1580302167B500E59EAD /* WebCodecsImageTrack.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebCodecsImageTrack.idl; sourceTree = "<group>"; };
+		72EB1581302167B500E59EAD /* WebCodecsImageTrackList.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebCodecsImageTrackList.idl; sourceTree = "<group>"; };
+		72EB158230216B2600E59EAD /* WebCodecsImageDecoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebCodecsImageDecoder.h; sourceTree = "<group>"; };
+		72EB158330216B2600E59EAD /* WebCodecsImageDecoder.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebCodecsImageDecoder.cpp; sourceTree = "<group>"; };
+		72EB158430216CF900E59EAD /* WebCodecsImageDecodeResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebCodecsImageDecodeResult.h; sourceTree = "<group>"; };
+		72EB158530216D5C00E59EAD /* WebCodecsImageTrack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebCodecsImageTrack.h; sourceTree = "<group>"; };
+		72EB158630216D5C00E59EAD /* WebCodecsImageTrack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebCodecsImageTrack.cpp; sourceTree = "<group>"; };
+		72EB158730216E1700E59EAD /* WebCodecsImageTrackList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = WebCodecsImageTrackList.h; sourceTree = "<group>"; };
+		72EB158830216E1700E59EAD /* WebCodecsImageTrackList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebCodecsImageTrackList.cpp; sourceTree = "<group>"; };
+		72EB15893021754500E59EAD /* JSWebCodecsImageDecoderCustom.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebCodecsImageDecoderCustom.cpp; sourceTree = "<group>"; };
 		72ECA8AB2B62FBB30094F595 /* ImageAdapter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageAdapter.cpp; sourceTree = "<group>"; };
 		72ECA8AC2B62FBB40094F595 /* ImageAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageAdapter.h; sourceTree = "<group>"; };
 		72F1AD9F1A3904C300014E18 /* EXTFragDepth.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EXTFragDepth.cpp; sourceTree = "<group>"; };
@@ -32502,6 +32514,7 @@
 				715DA5D3201BB902002EF2B0 /* JSWebAnimationCustom.cpp */,
 				45B6A3EA2C3C4FBE0062CB8A /* JSWebCodecsAudioDecoderCustom.cpp */,
 				45BA2FCA2C3C77870042DA4F /* JSWebCodecsAudioEncoderCustom.cpp */,
+				72EB15893021754500E59EAD /* JSWebCodecsImageDecoderCustom.cpp */,
 				45F4864B2C38CCE9008B9897 /* JSWebCodecsVideoDecoderCustom.cpp */,
 				45BA2FCB2C3C77870042DA4F /* JSWebCodecsVideoEncoderCustom.cpp */,
 				D3F3D3591A69A3B00059FC2B /* JSWebGL2RenderingContextCustom.cpp */,
@@ -40041,6 +40054,17 @@
 				4110A1CD28DE5B3200321D09 /* WebCodecsEncodedVideoChunkType.idl */,
 				4110A21428E3440D00321D09 /* WebCodecsErrorCallback.h */,
 				4110A20D28E3440B00321D09 /* WebCodecsErrorCallback.idl */,
+				72EB158330216B2600E59EAD /* WebCodecsImageDecoder.cpp */,
+				72EB158230216B2600E59EAD /* WebCodecsImageDecoder.h */,
+				72EB157E302167B500E59EAD /* WebCodecsImageDecoder.idl */,
+				72EB158430216CF900E59EAD /* WebCodecsImageDecodeResult.h */,
+				72EB157F302167B500E59EAD /* WebCodecsImageDecodeResult.idl */,
+				72EB158630216D5C00E59EAD /* WebCodecsImageTrack.cpp */,
+				72EB158530216D5C00E59EAD /* WebCodecsImageTrack.h */,
+				72EB1580302167B500E59EAD /* WebCodecsImageTrack.idl */,
+				72EB158830216E1700E59EAD /* WebCodecsImageTrackList.cpp */,
+				72EB158730216E1700E59EAD /* WebCodecsImageTrackList.h */,
+				72EB1581302167B500E59EAD /* WebCodecsImageTrackList.idl */,
 				419F0FCF2A39A8BF002F5972 /* WebCodecsSvcOutputMetadata.h */,
 				419F0FCE2A39A8BF002F5972 /* WebCodecsSvcOutputMetadata.idl */,
 				412524672C876E3F00A73A14 /* WebCodecsUtilities.h */,

--- a/Source/WebCore/bindings/js/JSWebCodecsImageDecoderCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebCodecsImageDecoderCustom.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Apple, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEB_CODECS)
+#include "JSWebCodecsImageDecoder.h"
+
+#include "WebCoreOpaqueRootInlines.h"
+#include <JavaScriptCore/SlotVisitor.h>
+#include <JavaScriptCore/SlotVisitorInlines.h>
+
+namespace WebCore {
+
+template <typename Visitor>
+void JSWebCodecsImageDecoder::visitAdditionalChildrenInGCThread(Visitor&)
+{
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSWebCodecsImageDecoder);
+
+}
+
+#endif

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -294,6 +294,9 @@ namespace WebCore {
     macro(ImageBitmap) \
     macro(ImageBitmapRenderingContext) \
     macro(ImageCapture) \
+    macro(ImageDecoder) \
+    macro(ImageTrack) \
+    macro(ImageTrackList) \
     macro(IdleDeadline) \
     macro(InputDeviceInfo) \
     macro(InputEvent) \

--- a/Source/WebCore/dom/EventTargetFactory.in
+++ b/Source/WebCore/dom/EventTargetFactory.in
@@ -75,6 +75,7 @@ WakeLockSentinel
 WebAnimation
 WebCodecsAudioDecoder conditional=WEB_CODECS
 WebCodecsAudioEncoder conditional=WEB_CODECS
+WebCodecsImageDecoder conditional=WEB_CODECS
 WebCodecsVideoDecoder conditional=WEB_CODECS
 WebCodecsVideoEncoder conditional=WEB_CODECS
 WebKitMediaKeySession conditional=LEGACY_ENCRYPTED_MEDIA


### PR DESCRIPTION
#### e203e1a8250fd66a933d59834fe744a3aabdf18b
<pre>
Implement the IDL changes for WebCodecsImageDecoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=320947">https://bugs.webkit.org/show_bug.cgi?id=320947</a>
<a href="https://rdar.apple.com/183978625">rdar://183978625</a>

Reviewed by Simon Fraser.

This change implements the IDL additions which are required for the WebCodecs
ImageDecoder[1]. The WebCore sources were changed just to allow compiling. New
functionalities will be filled later.

An internal feature flag for enabling WebCodecsImageDecoder is added. It is off
by default for now.

[1] <a href="https://w3c.github.io/webcodecs/#imagedecoder-interface">https://w3c.github.io/webcodecs/#imagedecoder-interface</a>

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/webcodecs/WebCodecsImageDecodeResult.h: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsImageDecodeResult.idl: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp: Added.
(WebCore::WebCodecsImageDecoder::create):
(WebCore::WebCodecsImageDecoder::WebCodecsImageDecoder):
(WebCore::WebCodecsImageDecoder::tracks const):
(WebCore::WebCodecsImageDecoder::decode):
(WebCore::WebCodecsImageDecoder::reset):
(WebCore::WebCodecsImageDecoder::close):
(WebCore::WebCodecsImageDecoder::isTypeSupported):
(WebCore::WebCodecsImageDecoder::suspend):
(WebCore::WebCodecsImageDecoder::stop):
* Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.h: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.idl: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsImageTrack.cpp: Added.
(WebCore::WebCodecsImageTrack::create):
(WebCore::WebCodecsImageTrack::WebCodecsImageTrack):
* Source/WebCore/Modules/webcodecs/WebCodecsImageTrack.h: Added.
(WebCore::WebCodecsImageTrack::animated const):
(WebCore::WebCodecsImageTrack::frameCount const):
(WebCore::WebCodecsImageTrack::repetitionCount const):
* Source/WebCore/Modules/webcodecs/WebCodecsImageTrack.idl: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.cpp: Added.
(WebCore::WebCodecsImageTrackList::create):
(WebCore::WebCodecsImageTrackList::WebCodecsImageTrackList):
(WebCore::WebCodecsImageTrackList::item):
(WebCore::WebCodecsImageTrackList::selectedTrack const):
(WebCore::WebCodecsImageTrackList::item const):
* Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.h: Added.
(WebCore::WebCodecsImageTrackList::length const):
(WebCore::WebCodecsImageTrackList::isSupportedPropertyIndex const):
* Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.idl: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSWebCodecsImageDecoderCustom.cpp: Added.
(WebCore::JSWebCodecsImageDecoder::visitAdditionalChildrenInGCThread):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/EventTargetFactory.in:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Modules/websockets/WebSocketChannelInspector.h:

Canonical link: <a href="https://commits.webkit.org/318598@main">https://commits.webkit.org/318598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1bc3680b22e03dc0c7708ba67e55ae7a095f484

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188357 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139379 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119833 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/1803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8600 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152000 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40014 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45280 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190785 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52349 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148544 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39882 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53029 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148311 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43013 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125296 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119957 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51547 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14590 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50932 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51172 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50994 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->