### PR TITLE
REGRESSION(318407@main): Web Inspector: Canvas: swizzle recorded WebGPU object arguments

### DIFF
--- a/LayoutTests/inspector/canvas/recording-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-webgpu-expected.txt
@@ -9,6 +9,7 @@ PASS: Device actions should use the implicit device receiver.
 PASS: Setting a label should be recorded as an attribute setter.
 PASS: Getting a label should be recorded as an attribute getter.
 PASS: The recording should create a concise name for a WebGPU receiver.
+PASS: WebGPU object arguments should be swizzled as identifiers.
 PASS: The recording should identify each explicit receiver type.
 PASS: Command encoder actions should have the same receiver.
 PASS: Different command encoders should have different receivers.

--- a/LayoutTests/inspector/canvas/recording-webgpu.html
+++ b/LayoutTests/inspector/canvas/recording-webgpu.html
@@ -34,6 +34,8 @@ async function performActions() {
     device.label;
     let bindGroup = device.createBindGroup({layout: device.createBindGroupLayout({entries: []}), entries: []});
     bindGroup.label = "bindGroup";
+    let buffer = device.createBuffer({size: 4, usage: GPUBufferUsage.COPY_DST});
+    device.queue.writeBuffer(buffer, 0, new Uint8Array(4));
     await Promise.all([
         render({r: 0, g: 1, b: 0, a: 1}),
         render({r: 0, g: 0, b: 1, a: 1}),
@@ -85,6 +87,9 @@ function test() {
 
                 let bindGroupLabelAction = actions.find((action) => action.name === "label" && action.receiver === "bindGroup1");
                 InspectorTest.expectTrue(bindGroupLabelAction, "The recording should create a concise name for a WebGPU receiver.");
+
+                let writeBufferAction = actions.find((action) => action.name === "writeBuffer");
+                InspectorTest.expectEqual(typeof writeBufferAction?.parameters[0], "number", "WebGPU object arguments should be swizzled as identifiers.");
 
                 let receiverTypes = Array.from(new Set(actions.filter((action) => action.receiver).map((action) => action.receiver.replace(/\d+$/, "")))).sort();
                 InspectorTest.expectEqual(receiverTypes.join(", "), "bindGroup, commandEncoder, queue, renderPassEncoder, texture", "The recording should identify each explicit receiver type.");

--- a/Source/WebInspectorUI/UserInterface/Models/Recording.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Recording.js
@@ -516,6 +516,44 @@ WI.Recording = class Recording extends WI.Object
             return WI.unlocalizedString("WebGLVertexArrayObject");
         case WI.Recording.Swizzle.WebGLVertexArrayObjectOES:
             return WI.unlocalizedString("WebGLVertexArrayObjectOES");
+        case WI.Recording.Swizzle.GPUBindGroup:
+            return WI.unlocalizedString("GPUBindGroup");
+        case WI.Recording.Swizzle.GPUBindGroupLayout:
+            return WI.unlocalizedString("GPUBindGroupLayout");
+        case WI.Recording.Swizzle.GPUBuffer:
+            return WI.unlocalizedString("GPUBuffer");
+        case WI.Recording.Swizzle.GPUCommandBuffer:
+            return WI.unlocalizedString("GPUCommandBuffer");
+        case WI.Recording.Swizzle.GPUCommandEncoder:
+            return WI.unlocalizedString("GPUCommandEncoder");
+        case WI.Recording.Swizzle.GPUComputePassEncoder:
+            return WI.unlocalizedString("GPUComputePassEncoder");
+        case WI.Recording.Swizzle.GPUComputePipeline:
+            return WI.unlocalizedString("GPUComputePipeline");
+        case WI.Recording.Swizzle.GPUExternalTexture:
+            return WI.unlocalizedString("GPUExternalTexture");
+        case WI.Recording.Swizzle.GPUPipelineLayout:
+            return WI.unlocalizedString("GPUPipelineLayout");
+        case WI.Recording.Swizzle.GPUQuerySet:
+            return WI.unlocalizedString("GPUQuerySet");
+        case WI.Recording.Swizzle.GPUQueue:
+            return WI.unlocalizedString("GPUQueue");
+        case WI.Recording.Swizzle.GPURenderBundle:
+            return WI.unlocalizedString("GPURenderBundle");
+        case WI.Recording.Swizzle.GPURenderBundleEncoder:
+            return WI.unlocalizedString("GPURenderBundleEncoder");
+        case WI.Recording.Swizzle.GPURenderPassEncoder:
+            return WI.unlocalizedString("GPURenderPassEncoder");
+        case WI.Recording.Swizzle.GPURenderPipeline:
+            return WI.unlocalizedString("GPURenderPipeline");
+        case WI.Recording.Swizzle.GPUSampler:
+            return WI.unlocalizedString("GPUSampler");
+        case WI.Recording.Swizzle.GPUShaderModule:
+            return WI.unlocalizedString("GPUShaderModule");
+        case WI.Recording.Swizzle.GPUTexture:
+            return WI.unlocalizedString("GPUTexture");
+        case WI.Recording.Swizzle.GPUTextureView:
+            return WI.unlocalizedString("GPUTextureView");
         case WI.Recording.Swizzle.DOMPointInit:
             return WI.unlocalizedString("DOMPointInit");
         default:
@@ -693,7 +731,26 @@ WI.Recording = class Recording extends WI.Object
             || type === WI.Recording.Swizzle.WebGLTimerQueryEXT
             || type === WI.Recording.Swizzle.WebGLTransformFeedback
             || type === WI.Recording.Swizzle.WebGLVertexArrayObject
-            || type === WI.Recording.Swizzle.WebGLVertexArrayObjectOES) {
+            || type === WI.Recording.Swizzle.WebGLVertexArrayObjectOES
+            || type === WI.Recording.Swizzle.GPUBindGroup
+            || type === WI.Recording.Swizzle.GPUBindGroupLayout
+            || type === WI.Recording.Swizzle.GPUBuffer
+            || type === WI.Recording.Swizzle.GPUCommandBuffer
+            || type === WI.Recording.Swizzle.GPUCommandEncoder
+            || type === WI.Recording.Swizzle.GPUComputePassEncoder
+            || type === WI.Recording.Swizzle.GPUComputePipeline
+            || type === WI.Recording.Swizzle.GPUExternalTexture
+            || type === WI.Recording.Swizzle.GPUPipelineLayout
+            || type === WI.Recording.Swizzle.GPUQuerySet
+            || type === WI.Recording.Swizzle.GPUQueue
+            || type === WI.Recording.Swizzle.GPURenderBundle
+            || type === WI.Recording.Swizzle.GPURenderBundleEncoder
+            || type === WI.Recording.Swizzle.GPURenderPassEncoder
+            || type === WI.Recording.Swizzle.GPURenderPipeline
+            || type === WI.Recording.Swizzle.GPUSampler
+            || type === WI.Recording.Swizzle.GPUShaderModule
+            || type === WI.Recording.Swizzle.GPUTexture
+            || type === WI.Recording.Swizzle.GPUTextureView) {
             return index;
         }
 
@@ -1319,6 +1376,7 @@ WI.Recording.Swizzle = {
     WebGLSync: 22,
     WebGLTransformFeedback: 23,
     WebGLVertexArrayObject: 24,
+    DOMPointInit: 25,
     Canvas: 26,
     GPUBindGroup: 27,
     GPUBindGroupLayout: 28,

--- a/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js
@@ -104,6 +104,25 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
             case WI.Recording.Swizzle.WebGLTransformFeedback:
             case WI.Recording.Swizzle.WebGLVertexArrayObject:
             case WI.Recording.Swizzle.WebGLVertexArrayObjectOES:
+            case WI.Recording.Swizzle.GPUBindGroup:
+            case WI.Recording.Swizzle.GPUBindGroupLayout:
+            case WI.Recording.Swizzle.GPUBuffer:
+            case WI.Recording.Swizzle.GPUCommandBuffer:
+            case WI.Recording.Swizzle.GPUCommandEncoder:
+            case WI.Recording.Swizzle.GPUComputePassEncoder:
+            case WI.Recording.Swizzle.GPUComputePipeline:
+            case WI.Recording.Swizzle.GPUExternalTexture:
+            case WI.Recording.Swizzle.GPUPipelineLayout:
+            case WI.Recording.Swizzle.GPUQuerySet:
+            case WI.Recording.Swizzle.GPUQueue:
+            case WI.Recording.Swizzle.GPURenderBundle:
+            case WI.Recording.Swizzle.GPURenderBundleEncoder:
+            case WI.Recording.Swizzle.GPURenderPassEncoder:
+            case WI.Recording.Swizzle.GPURenderPipeline:
+            case WI.Recording.Swizzle.GPUSampler:
+            case WI.Recording.Swizzle.GPUShaderModule:
+            case WI.Recording.Swizzle.GPUTexture:
+            case WI.Recording.Swizzle.GPUTextureView:
                 if (!isNaN(parameter)) {
                     parameterElement.classList.add("object-handle");
                     parameterElement.textContent = WI.Recording.displayNameForReceiver([parameter, swizzleType]);
@@ -136,8 +155,11 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
         nameContainer.classList.add("name");
         nameContainer.textContent = recordingAction.name;
 
-        if (!parameterCount)
+        if (!parameterCount) {
+            if (recordingAction.isFunction)
+                titleFragment.appendChild(document.createTextNode("()"));
             return titleFragment;
+        }
 
         titleFragment.appendChild(document.createTextNode(recordingAction.isFunction ? "(" : " = "));
 


### PR DESCRIPTION
#### 27fdf13d22fd344568ddd8a2a99cc6a552c29457
<pre>
REGRESSION(318407@main): Web Inspector: Canvas: swizzle recorded WebGPU object arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=320951">https://bugs.webkit.org/show_bug.cgi?id=320951</a>

Reviewed by Mike Wyrzykowski.

* Source/WebInspectorUI/UserInterface/Models/Recording.js:
(WI.Recording.displayNameForSwizzleType):
(WI.Recording.prototype.swizzle):
(WI.Recording.Swizzle):
Pass WebGPU object identifiers through without looking them up in the recording data table.
Drive-by: add the missing `DOMPointInit` entry to keep the frontend enum synchronized with `RecordingSwizzleType`.

* Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js:
(WI.RecordingActionTreeElement._generateDOM):
Display WebGPU object arguments using the same object names as action receivers.
Drive-by: append `()` when a function has no parameters instead of displaying it like an attribute.

* LayoutTests/inspector/canvas/recording-webgpu.html:
* LayoutTests/inspector/canvas/recording-webgpu-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318545@main">https://commits.webkit.org/318545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b9f2c7b67309967b0e67db0b75fa44aae493f20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188172 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141805 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139211 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119665 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41432 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39790 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39459 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190599 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148374 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39855 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52844 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148143 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42847 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125111 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119747 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51362 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14434 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50747 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->