### PR TITLE
check-webkit-style --diff-files ignores the specified file paths and checks the full branch diff

### DIFF
--- a/Tools/Scripts/webkitpy/common/checkout/scm/git.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/git.py
@@ -313,6 +313,9 @@ class Git(SCM):
         else:
             command += ['HEAD']
 
+        if changed_files:
+            command += ['--'] + changed_files
+
         return self.run(command, decode_output=False, cwd=self.checkout_root)
 
     def _run_git_svn_find_rev(self, revision_or_treeish, branch=None):

--- a/Tools/Scripts/webkitpy/common/checkout/scm/scm_unittest.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/scm_unittest.py
@@ -495,6 +495,17 @@ class GitTest(SCMTest):
         self.assertIn(b'-foo', lines)
         self.assertIn(b'+bar', lines)
 
+    def test_create_patch_with_changed_files(self):
+        write_into_file_at_path('one_file', 'one')
+        write_into_file_at_path('two_file', 'two')
+        run_command(['git', 'add', 'one_file', 'two_file'])
+        scm = self.tracking_scm
+        scm.commit_locally_with_message('a new commit')
+
+        patch = scm.create_patch(changed_files=['one_file'], commit_message=False)
+        self.assertIn(b'one_file', patch)
+        self.assertNotIn(b'two_file', patch)
+
     def test_orderfile(self):
         os.mkdir("Tools")
         os.mkdir("Source")


### PR DESCRIPTION
#### 4b851b60b95111ab0376f92e4329bc6ae64c4e23
<pre>
check-webkit-style --diff-files ignores the specified file paths and checks the full branch diff
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320950">https://bugs.webkit.org/show_bug.cgi?id=320950</a>&gt;
&lt;<a href="https://rdar.apple.com/183980017">rdar://183980017</a>&gt;

Reviewed by Zak Ridouh.

`Git.create_patch()` accepts a `changed_files` argument but never uses
it, so the paths passed to `check-webkit-style --diff-files` are simply
dropped and the entire branch diff is checked instead.  A developer
narrowing a check to specific files then gets results for files they
did not name, with no warning.

Append `changed_files` as a trailing `--` pathspec, so that `git diff`
and `git format-patch`, the two command shapes `create_patch()` builds,
are limited to the requested files.

Tests: webkitpy.common.checkout.scm.scm_unittest.GitTest.test_create_patch_with_changed_files

* Tools/Scripts/webkitpy/common/checkout/scm/git.py:
(Git.create_patch):
* Tools/Scripts/webkitpy/common/checkout/scm/scm_unittest.py:
(GitTest.test_create_patch_with_changed_files): Add.

Canonical link: <a href="https://commits.webkit.org/318519@main">https://commits.webkit.org/318519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/740e86fedc0c960d711c10510d0571fd39a1bfba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188152 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ed47c1a-21fe-4fe4-875b-ae07b0a4db76) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139197 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119651 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df02ebda-9db2-480c-ae67-ea5c87aa914c) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/177859 "Found 1 webkitpy test failure: webkitpy.style.checker_unittest.GlobalVariablesTest.test_webkit_base_filter_rules") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41415 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39443 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36607 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190579 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52143 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148355 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52824 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148125 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27083 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42832 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119727 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51342 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14418 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50727 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50967 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50789 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->