### PR TITLE
Sync `tools/metadata` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/meta/tests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/meta/tests/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/metadata/meta/tests/__init__.py

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/meta/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/meta/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/metadata/meta/__init__.py

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/tests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/tests/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/metadata/tests/__init__.py

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/metadata/__init__.py

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/schema.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/schema.py
@@ -1,8 +1,7 @@
 from enum import Enum
 from dataclasses import dataclass
 from fnmatch import fnmatchcase
-from functools import cached_property
-from typing import Any, Dict, Sequence, Union
+from typing import Any, Dict, List, Sequence, Union
 
 from ..schema import SchemaValue, validate_dict
 
@@ -11,32 +10,13 @@ YAML filename for meta files
 """
 WEB_FEATURES_YML_FILENAME = "WEB_FEATURES.yml"
 
-# File prefix to indicate that this FeatureFile should run in EXCLUDE mode.
-EXCLUSION_PREFIX = "!"
-
 
 class SpecialFileEnum(Enum):
     """All files recursively"""
     RECURSIVE = "**"
 
 
-class FileMatchingMode(Enum):
-    """Defines how a FeatureFile pattern is used for matching."""
-    INCLUDE = 1  # Include files that match the pattern
-    EXCLUDE = 2  # Exclude files that match the pattern
-
 class FeatureFile(str):
-    @cached_property
-    def matching_mode(self) -> FileMatchingMode:
-        """Determines if the pattern should include or exclude matches."""
-        return FileMatchingMode.EXCLUDE if self.startswith(EXCLUSION_PREFIX) else FileMatchingMode.INCLUDE
-
-    @cached_property
-    def processed_filename(self) -> str:
-        """Removes the exclusion prefix "!" from the pattern."""
-        # TODO. After moving to Python3.9, use: return self.removeprefix(EXCLUSION_PREFIX)
-        return self[len(EXCLUSION_PREFIX):] if self.startswith(EXCLUSION_PREFIX) else self
-
     def match_files(self, base_filenames: Sequence[str]) -> Sequence[str]:
         """
         Given the input base file names, returns the subset of base file names
@@ -52,40 +32,51 @@ class FeatureFile(str):
         # If our file name contains a wildcard, use fnmatch
         if "*" in self:
             for base_filename in base_filenames:
-                if fnmatchcase(base_filename, self.processed_filename):
+                if fnmatchcase(base_filename, self):
                     result.append(base_filename)
-        elif self.processed_filename in base_filenames:
-            result.append(self.processed_filename)
+        elif self in base_filenames:
+            result.append(self)
         return result
 
 
 @dataclass
 class FeatureEntry:
-    files: Union[Sequence[FeatureFile], SpecialFileEnum]
+    file: Union[FeatureFile, SpecialFileEnum]
     """The web-features key"""
-    name: str
+    feature_ids: List[str]
 
-    _required_keys = {"files", "name"}
+    _required_keys = {"ids"}
 
-    def __init__(self, obj: Dict[str, Any]):
+    def __init__(self, obj: Dict[str, Union[List[str], Dict[str, List[str]]]]):
         """
         Converts the provided dictionary to an instance of FeatureEntry
         :param obj: The object that will be converted to a FeatureEntry.
         :return: An instance of FeatureEntry
         :raises ValueError: If there are unexpected keys or missing required keys.
         """
-        validate_dict(obj, FeatureEntry._required_keys)
-        self.files = SchemaValue.from_union([
-            lambda x: SchemaValue.from_list(SchemaValue.from_class(FeatureFile), x),
-            SpecialFileEnum], obj.get("files"))
-        self.name = SchemaValue.from_str(obj.get("name"))
-        # If "**" is used, it should be the only item. Not in a list.
-        if isinstance(self.files, list) and SpecialFileEnum.RECURSIVE.value in self.files:
-            raise ValueError(f'Feature {self.name} contains "**" in a list. It should be `files: "**"`')
+        if len(obj) == 0:
+            raise ValueError(f"Input value {obj} contains zero keys")
 
+        if len(obj) > 1:
+            raise ValueError(f"Input value {obj} contains more than one key")
+        key = list(obj)[0]
+        self.file = SchemaValue.from_union([
+            SpecialFileEnum,
+            SchemaValue.from_class(FeatureFile)
+        ], key)
+
+        value = obj[key]
+        if isinstance(value, list):
+            self.feature_ids = value
+        else:
+            validate_dict(value, FeatureEntry._required_keys)
+            self.feature_ids = value["ids"]
+
+    def __str__(self) -> str:
+        return '{}: {}'.format(self.file, self.feature_ids)
 
     def does_feature_apply_recursively(self) -> bool:
-        if isinstance(self.files, SpecialFileEnum) and self.files == SpecialFileEnum.RECURSIVE:
+        if isinstance(self.file, SpecialFileEnum) and self.file == SpecialFileEnum.RECURSIVE:
             return True
         return False
 
@@ -93,9 +84,9 @@ class FeatureEntry:
 @dataclass
 class WebFeaturesFile:
     """List of features"""
-    features: Sequence[FeatureEntry]
+    rules: Sequence[FeatureEntry]
 
-    _required_keys = {"features"}
+    _required_keys = {"rules"}
 
     def __init__(self, obj: Dict[str, Any]):
         """
@@ -105,5 +96,5 @@ class WebFeaturesFile:
         :raises ValueError: If there are unexpected keys or missing required keys.
         """
         validate_dict(obj, WebFeaturesFile._required_keys)
-        self.features = SchemaValue.from_list(
-            lambda raw_feature: FeatureEntry(SchemaValue.from_dict(raw_feature)), obj.get("features"))
+        self.rules = SchemaValue.from_list(
+            lambda raw_feature: FeatureEntry(SchemaValue.from_dict(raw_feature)), obj.get("rules"))

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/tests/test_schema.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/tests/test_schema.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from dataclasses import asdict
-from ..schema import FileMatchingMode, WebFeaturesFile, FeatureEntry, SpecialFileEnum, FeatureFile
+from ..schema import WebFeaturesFile, FeatureEntry, SpecialFileEnum, FeatureFile
 
 import pytest
 import re
@@ -11,18 +11,24 @@ import re
     [
         (
             {
-                "features": [
+                "rules": [
                     {
-                        "name": "feature1",
-                        "files": ["file1", "file2"],
+                        "file1": ["feature1"]
+                    },
+                    {
+                        "file2": ["feature1"]
                     }
                 ]
             },
             {
-                "features": [
+                "rules": [
                     {
-                        "name": "feature1",
-                        "files": ["file1", "file2"],
+                        "feature_ids": ["feature1"],
+                        "file": "file1"
+                    },
+                    {
+                        "feature_ids": ["feature1"],
+                        "file": "file2"
                     }
                 ]
             },
@@ -31,52 +37,38 @@ import re
         ),
         (
             {
-                "features": [
+                "rules": [
                     {
-                        "name": "feature1",
-                        "files": "**",
+                        "**": ["feature1"]
                     }
                 ]
             },
             {
-                "features": [
+                "rules": [
                     {
-                        "name": "feature1",
-                        "files": SpecialFileEnum.RECURSIVE,
+                        "feature_ids": ["feature1"],
+                        "file": SpecialFileEnum.RECURSIVE,
                     }
                 ]
             },
             None,
             None
-        ),
-        (
-            {
-                "features": [
-                    {
-                        "name": "feature1",
-                        "files": ["**"],
-                    }
-                ]
-            },
-            None,
-            ValueError,
-            "Feature feature1 contains \"**\" in a list. It should be `files: \"**\"`"
         ),
         (
             {},
             None,
             ValueError,
-            "Object missing required keys: ['features']"
+            "Object missing required keys: ['rules']"
         ),
         (
             {
-                "features": [
+                "rules": [
                     {}
                 ]
             },
             None,
             ValueError,
-            "Object missing required keys: ['files', 'name']"
+            "Input value {} contains zero keys"
         ),
     ])
 def test_web_features_file(input, expected_result, expected_exception_type, exception_message):
@@ -90,11 +82,11 @@ def test_web_features_file(input, expected_result, expected_exception_type, exce
     "input,expected_result",
     [
         (
-            FeatureEntry({"name": "test1", "files":["file1"]}),
+            FeatureEntry({"file1": ["test1"]}),
             False
         ),
         (
-            FeatureEntry({"name": "test2", "files": SpecialFileEnum.RECURSIVE}),
+            FeatureEntry({SpecialFileEnum.RECURSIVE.value: ["test2"]}),
             True
         ),
     ])
@@ -102,39 +94,23 @@ def test_does_feature_apply_recursively(input, expected_result):
     assert input.does_feature_apply_recursively() == expected_result
 
 @pytest.mark.parametrize(
-    "input_feature,input_files,expected_result,expected_match_mode",
+    "input_feature,input_files,expected_result",
     [
         (
             FeatureFile("*"),
             ["test.html", "TEST.HTML"],
             ["test.html", "TEST.HTML"],
-            FileMatchingMode.INCLUDE,
         ),
         (
             FeatureFile("test.html"),
             ["test.html", "TEST.HTML"],
             ["test.html"],
-            FileMatchingMode.INCLUDE,
-        ),
-        (
-            FeatureFile("!test.html"),
-            ["test.html", "TEST.HTML"],
-            ["test.html"],
-            FileMatchingMode.EXCLUDE,
         ),
         (
             FeatureFile("test*.html"),
             ["test.html", "test1.html", "TEST1.HTML", "test2.html", "test-2.html", "foo.html"],
             ["test.html", "test1.html", "test2.html", "test-2.html"],
-            FileMatchingMode.INCLUDE,
-        ),
-        (
-            FeatureFile("!test*.html"),
-            ["test.html", "test1.html", "TEST1.HTML", "test2.html", "test-2.html", "foo.html"],
-            ["test.html", "test1.html", "test2.html", "test-2.html"],
-            FileMatchingMode.EXCLUDE,
         ),
     ])
-def test_feature_file_match_files(input_feature, input_files, expected_result, expected_match_mode):
+def test_feature_file_match_files(input_feature, input_files, expected_result):
     assert input_feature.match_files(input_files) == expected_result
-    assert input_feature.matching_mode == expected_match_mode

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/tests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/tests/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/tests/__init__.py

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/__init__.py

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/yaml/tests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/yaml/tests/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/metadata/yaml/tests/__init__.py

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/yaml/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/metadata/yaml/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/tools/metadata/yaml/__init__.py


### PR DESCRIPTION
#### dfb69ad177362ed9391d034a855b7fcbeb216121
<pre>
Sync `tools/metadata` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=320954">https://bugs.webkit.org/show_bug.cgi?id=320954</a>
<a href="https://rdar.apple.com/183984515">rdar://183984515</a>

Reviewed by NOBODY (OOPS!).

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/97e0cab6df9622d4e0d105ce3e0215b7197b7648">https://github.com/web-platform-tests/wpt/commit/97e0cab6df9622d4e0d105ce3e0215b7197b7648</a>

* LayoutTests/imported/w3c/web-platform-tests/tools/metadata/meta/tests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/metadata/meta/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/metadata/tests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/metadata/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/schema.py:
(SpecialFileEnum):
(FeatureFile):
(FeatureFile.match_files):
(FeatureEntry):
(FeatureEntry.__init__):
(FeatureEntry.__str__):
(FeatureEntry.does_feature_apply_recursively):
(WebFeaturesFile):
(WebFeaturesFile.__init__):
(FileMatchingMode): Deleted.
(FeatureFile.matching_mode): Deleted.
(FeatureFile.processed_filename): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/tests/test_schema.py:
(test_feature_file_match_files):
* LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/tests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/metadata/webfeatures/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/metadata/yaml/tests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/tools/metadata/yaml/w3c-import.log:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfb69ad177362ed9391d034a855b7fcbeb216121

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188161 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141794 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/146edb40-98d0-4a6b-ba44-ec4506af9430) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139204 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4336a852-6127-41c3-89ac-fb6b1e62f8bd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119658 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e9dea25-f0da-490b-9ed9-e89279f9dfbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41427 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39781 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39453 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190588 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52152 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148365 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52833 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148134 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42843 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119736 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51351 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14428 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50736 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50976 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50798 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->