### PR TITLE
[JSC] `Function#bind` strength reduction in DFG should accept method structures

### DIFF
--- a/JSTests/microbenchmarks/function-bind-method.js
+++ b/JSTests/microbenchmarks/function-bind-method.js
@@ -1,0 +1,20 @@
+class Component {
+    constructor(seed) { this.state = seed | 0; }
+    handleClick(e) { return this.state + e; }
+    onScroll(x) { return this.state - x; }
+    render() {
+        const onClick = this.handleClick.bind(this);
+        const onScr = this.onScroll.bind(this, 2);
+        return onClick(1) + onScr();
+    }
+}
+
+var shorthand = {
+    handle(e) { return e; },
+};
+
+var component = new Component(3);
+for (var i = 0; i < 1e5; ++i) {
+    component.render();
+    shorthand.handle.bind(shorthand);
+}

--- a/JSTests/stress/bound-function-strength-reduction-method.js
+++ b/JSTests/stress/bound-function-strength-reduction-method.js
@@ -1,0 +1,78 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+// Class methods (strict, no "prototype" property) and object-literal shorthand methods
+// use dedicated method structures. Function#bind on them should be strength-reduced
+// to NewBoundFunction with lazily materialized .name/.length, and stay correct.
+class Component {
+    constructor() { this.state = 40; }
+    handleClick(a, b) { return this.state + a + b; }
+}
+
+var sloppyHolder = {
+    handle(a, b, c) { return this === sloppyHolder ? a + b + c : -1; },
+};
+
+var component = new Component();
+
+function bindClassMethod() {
+    return component.handleClick.bind(component, 1);
+}
+noInline(bindClassMethod);
+
+function bindShorthandMethod() {
+    return sloppyHolder.handle.bind(sloppyHolder);
+}
+noInline(bindShorthandMethod);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var f = bindClassMethod();
+    shouldBe(f(1), 42);
+    shouldBe(f.name, "bound handleClick");
+    shouldBe(f.length, 1);
+
+    var g = bindShorthandMethod();
+    shouldBe(g(1, 2, 3), 6);
+    shouldBe(g.name, "bound handle");
+    shouldBe(g.length, 3);
+}
+
+// Methods are not constructors, and neither are their bound versions.
+shouldThrow(() => new (bindClassMethod())(), "TypeError: function is not a constructor (evaluating 'new (bindClassMethod())()')");
+shouldThrow(() => new (bindShorthandMethod())(), "TypeError: function is not a constructor (evaluating 'new (bindShorthandMethod())()')");
+
+// Once .name/.length are reified (the structure transitions), bind must observe the modified values.
+class Modified {
+    method(a, b) { return a; }
+}
+var modified = new Modified();
+Object.defineProperty(modified.method, "name", { value: "renamed" });
+Object.defineProperty(modified.method, "length", { value: 7 });
+
+function bindModifiedMethod() {
+    return modified.method.bind(null, 0);
+}
+noInline(bindModifiedMethod);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var h = bindModifiedMethod();
+    shouldBe(h.name, "bound renamed");
+    shouldBe(h.length, 6);
+}

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
@@ -409,7 +409,11 @@ bool JSBoundFunction::canSkipNameAndLengthMaterialization(JSGlobalObject* global
         return true;
     if (structure == globalObject->strictFunctionStructure(true) || structure == globalObject->strictFunctionStructure(false))
         return true;
+    if (structure == globalObject->strictMethodStructure(true) || structure == globalObject->strictMethodStructure(false))
+        return true;
     if (structure == globalObject->sloppyFunctionStructure(true) || structure == globalObject->sloppyFunctionStructure(false))
+        return true;
+    if (structure == globalObject->sloppyMethodStructure(true) || structure == globalObject->sloppyMethodStructure(false))
         return true;
     // Plain host functions now use the lazy reify path for length/name (mirroring JS function and
     // builtin behavior), so an untransitioned hostFunctionStructure means length/name are still


### PR DESCRIPTION
#### 2af38faaec709b9af4ffb54373d691d5a894e22a
<pre>
[JSC] `Function#bind` strength reduction in DFG should accept method structures
<a href="https://bugs.webkit.org/show_bug.cgi?id=320959">https://bugs.webkit.org/show_bug.cgi?id=320959</a>

Reviewed by Yusuke Suzuki.

296674@main split JSFunction structures for functions without a &quot;prototype&quot; property
(class methods, object-literal shorthand methods, accessors) into strictMethodStructure /
sloppyMethodStructure, but JSBoundFunction::canSkipNameAndLengthMaterialization() was not
updated. So `this.handleClick.bind(this)` on a class method no longer folds FunctionBind
into NewBoundFunction and always calls operationFunctionBind. This patch adds the two
method structures to the whitelist; they are created from the same createStructure() calls
as their function counterparts, so the lazy .name/.length materialization invariant holds.

                            baseline                  patched

function-bind-method    11.5201+-0.1138     ^      2.5012+-0.0493        ^ definitely 4.6058x faster

Tests: JSTests/microbenchmarks/function-bind-method.js
       JSTests/stress/bound-function-strength-reduction-method.js

* JSTests/microbenchmarks/function-bind-method.js: Added.
(Component):
(Component.prototype.handleClick):
(Component.prototype.onScroll):
(Component.prototype.render):
(shorthand.handle):
* JSTests/stress/bound-function-strength-reduction-method.js: Added.
(shouldBe):
(shouldThrow):
(prototype.handleClick):
(sloppyHolder.handle):
(bindClassMethod):
(bindShorthandMethod):
(Modified.prototype.method):
(Modified):
(bindModifiedMethod):
* Source/JavaScriptCore/runtime/JSBoundFunction.cpp:
(JSC::JSBoundFunction::canSkipNameAndLengthMaterialization):

Canonical link: <a href="https://commits.webkit.org/318527@main">https://commits.webkit.org/318527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b171afa0b768afa0543dce65f08671234ba380b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188174 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139213 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119667 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41434 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1636 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8453 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39464 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36629 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39831 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45096 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190601 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52165 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148376 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39836 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52846 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148145 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42848 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125113 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119749 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51364 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14439 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50749 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50811 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->