### PR TITLE
[interactive-widget] Refactor InteractiveWidget to InteractiveWidgetValue

### DIFF
--- a/Source/WebCore/dom/ViewportArguments.cpp
+++ b/Source/WebCore/dom/ViewportArguments.cpp
@@ -165,7 +165,7 @@ ViewportAttributes ViewportArguments::resolve(const FloatSize& initialViewportSi
     result.orientation = orientation;
     result.shrinkToFit = shrinkToFit;
     result.viewportFit = viewportFit;
-    result.interactiveWidget = interactiveWidget;
+    result.interactiveWidgetValue = interactiveWidgetValue;
 
     return result;
 }
@@ -312,18 +312,18 @@ static ViewportFit parseViewportFitValue(StringView key, StringView value, NOESC
     return ViewportFit::Auto;
 }
 
-static InteractiveWidget parseInteractiveWidgetValue(StringView key, StringView value, NOESCAPE const InternalViewportErrorHandler& errorHandler)
+static InteractiveWidgetValue parseInteractiveWidgetValue(StringView key, StringView value, NOESCAPE const InternalViewportErrorHandler& errorHandler)
 {
     if (equalLettersIgnoringASCIICase(value, "resizes-visual"_s))
-        return InteractiveWidget::ResizesVisual;
+        return InteractiveWidgetValue::ResizesVisual;
     if (equalLettersIgnoringASCIICase(value, "resizes-content"_s))
-        return InteractiveWidget::ResizesContent;
+        return InteractiveWidgetValue::ResizesContent;
     if (equalLettersIgnoringASCIICase(value, "overlays-content"_s))
-        return InteractiveWidget::OverlaysContent;
+        return InteractiveWidgetValue::OverlaysContent;
 
     errorHandler(ViewportErrorCode::UnrecognizedViewportArgumentValue, value, key);
 
-    return InteractiveWidget::ResizesVisual;
+    return InteractiveWidgetValue::ResizesVisual;
 }
 
 static ASCIILiteral viewportErrorMessageTemplate(ViewportErrorCode errorCode)
@@ -411,7 +411,7 @@ void setViewportFeature(ViewportArguments& arguments, StringView key, StringView
     else if (equalLettersIgnoringASCIICase(key, "viewport-fit"_s))
         arguments.viewportFit = parseViewportFitValue(key, value, internalErrorHandler);
     else if (metaViewportInteractiveWidgetEnabled && equalLettersIgnoringASCIICase(key, "interactive-widget"_s))
-        arguments.interactiveWidget = parseInteractiveWidgetValue(key, value, internalErrorHandler);
+        arguments.interactiveWidgetValue = parseInteractiveWidgetValue(key, value, internalErrorHandler);
     else
         internalErrorHandler(ViewportErrorCode::UnrecognizedViewportArgumentKey, key, { });
 }

--- a/Source/WebCore/dom/ViewportArguments.h
+++ b/Source/WebCore/dom/ViewportArguments.h
@@ -48,7 +48,7 @@ enum class ViewportFit : uint8_t {
     Cover
 };
 
-enum class InteractiveWidget : uint8_t {
+enum class InteractiveWidgetValue : uint8_t {
     ResizesVisual,
     ResizesContent,
     OverlaysContent
@@ -67,7 +67,7 @@ struct ViewportAttributes {
 
     ViewportFit viewportFit;
 
-    InteractiveWidget interactiveWidget;
+    InteractiveWidgetValue interactiveWidgetValue;
 };
 
 struct ViewportArguments {
@@ -93,7 +93,7 @@ struct ViewportArguments {
     {
     }
 
-    ViewportArguments(float width, float height, float zoom, float minZoom, float maxZoom, float userZoom, float orientation, float shrinkToFit, Type type, ViewportFit viewportFit, bool widthWasExplicit, InteractiveWidget interactiveWidget)
+    ViewportArguments(float width, float height, float zoom, float minZoom, float maxZoom, float userZoom, float orientation, float shrinkToFit, Type type, ViewportFit viewportFit, bool widthWasExplicit, InteractiveWidgetValue interactiveWidgetValue)
         : width(width)
         , height(height)
         , zoom(zoom)
@@ -105,7 +105,7 @@ struct ViewportArguments {
         , type(type)
         , viewportFit(viewportFit)
         , widthWasExplicit(widthWasExplicit)
-        , interactiveWidget(interactiveWidget)
+        , interactiveWidgetValue(interactiveWidgetValue)
     {
     }
 
@@ -123,7 +123,7 @@ struct ViewportArguments {
     Type type { Type::Implicit };
     ViewportFit viewportFit { ViewportFit::Auto };
     bool widthWasExplicit { false };
-    InteractiveWidget interactiveWidget { InteractiveWidget::ResizesVisual };
+    InteractiveWidgetValue interactiveWidgetValue { InteractiveWidgetValue::ResizesVisual };
 
     bool operator==(const ViewportArguments& other) const
     {
@@ -139,7 +139,7 @@ struct ViewportArguments {
             && shrinkToFit == other.shrinkToFit
             && viewportFit == other.viewportFit
             && widthWasExplicit == other.widthWasExplicit
-            && interactiveWidget == other.interactiveWidget;
+            && interactiveWidgetValue == other.interactiveWidgetValue;
     }
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -286,7 +286,7 @@ using WebKit::PageData::TransactionCallbackID = IPC::AsyncReplyID;
     bool viewportMetaTagCameFromImageDocument;
     bool isInStableState;
     bool hasMainThreadScrollDrivenAnimations;
-    WebCore::InteractiveWidget viewportMetaTagInteractiveWidget;
+    WebCore::InteractiveWidgetValue viewportMetaTagInteractiveWidget;
 
 #if PLATFORM(IOS_FAMILY)
     std::optional<uint64_t> dynamicViewportSizeUpdateID;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
@@ -88,7 +88,7 @@ struct MainFrameData {
     bool viewportMetaTagCameFromImageDocument { false };
     bool isInStableState { false };
     bool hasMainThreadScrollDrivenAnimations { false };
-    WebCore::InteractiveWidget viewportMetaTagInteractiveWidget { WebCore::InteractiveWidget::ResizesVisual };
+    WebCore::InteractiveWidgetValue viewportMetaTagInteractiveWidget { WebCore::InteractiveWidgetValue::ResizesVisual };
 
 #if PLATFORM(IOS_FAMILY)
     std::optional<DynamicViewportSizeUpdateID> dynamicViewportSizeUpdateID;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -440,7 +440,7 @@ enum class WebCore::ViewportFit : uint8_t {
     Cover,
 };
 
-enum class WebCore::InteractiveWidget : uint8_t {
+enum class WebCore::InteractiveWidgetValue : uint8_t {
     ResizesVisual,
     ResizesContent,
     OverlaysContent
@@ -1098,7 +1098,7 @@ struct WebCore::ViewportArguments {
     WebCore::ViewportArguments::Type type;
     WebCore::ViewportFit viewportFit;
     bool widthWasExplicit;
-    WebCore::InteractiveWidget interactiveWidget;
+    WebCore::InteractiveWidgetValue interactiveWidgetValue;
 };
 #endif // ENABLE(META_VIEWPORT)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -267,7 +267,7 @@ struct PerWebProcessState {
 
     WebKit::DynamicViewportUpdateMode dynamicViewportUpdateMode { WebKit::DynamicViewportUpdateMode::NotResizing };
 
-    WebCore::InteractiveWidget viewportMetaTagInteractiveWidget { WebCore::InteractiveWidget::ResizesVisual };
+    WebCore::InteractiveWidgetValue viewportMetaTagInteractiveWidget { WebCore::InteractiveWidgetValue::ResizesVisual };
 
     BOOL waitingForEndAnimatedResize { NO };
     BOOL waitingForCommitAfterAnimatedResize { NO };

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -174,7 +174,7 @@ enum class TapHandlingResult : uint8_t;
 - (NSString *)_contentSizeCategory;
 - (void)_dispatchSetDeviceOrientation:(WebCore::IntDegrees)deviceOrientation;
 - (WebCore::FloatSize)activeViewLayoutSize:(const CGRect&)bounds;
-- (WebCore::InteractiveWidget)_viewportMetaTagInteractiveWidget;
+- (WebCore::InteractiveWidgetValue)_viewportMetaTagInteractiveWidget;
 - (void)_updateScrollViewInsetAdjustmentBehavior;
 - (void)_resetScrollViewInsetAdjustmentBehavior;
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2556,7 +2556,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     if (!_page)
         return;
 
-    if (_perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidget::ResizesContent) {
+    if (_perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidgetValue::ResizesContent) {
         CGRect keyboardInView = [self convertRect:[self _inputViewBoundsForViewportCalculations] fromView:nil];
         if (!CGRectIsEmpty(keyboardInView)) {
             CGFloat contentTop = [self _computedObscuredInset].top;
@@ -2930,12 +2930,12 @@ static CGFloat liveResizeMinimumWidthDifference()
 
 - (CGRect)_inputViewBoundsForViewportCalculations
 {
-    if (_perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidget::OverlaysContent)
+    if (_perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidgetValue::OverlaysContent)
         return CGRectZero;
     return _inputViewBoundsInWindow;
 }
 
-- (WebCore::InteractiveWidget)_viewportMetaTagInteractiveWidget
+- (WebCore::InteractiveWidgetValue)_viewportMetaTagInteractiveWidget
 {
     return _perProcessState.viewportMetaTagInteractiveWidget;
 }
@@ -3553,8 +3553,8 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
         return [self.window convertRect:keyboardFrameInScreen fromCoordinateSpace:self.window.screen.coordinateSpace];
     })();
 
-    BOOL keyboardShouldOverlayContent = _perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidget::OverlaysContent;
-    BOOL keyboardShouldResizeContent = _perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidget::ResizesContent;
+    BOOL keyboardShouldOverlayContent = _perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidgetValue::OverlaysContent;
+    BOOL keyboardShouldResizeContent = _perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidgetValue::ResizesContent;
 
     if (adjustScrollView && !keyboardShouldOverlayContent) {
         CGFloat bottomInsetBeforeAdjustment = [_scrollView contentInset].bottom;

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -613,7 +613,7 @@ public:
     virtual void showDataDetectorsUIForPositionInformation(const InteractionInformationAtPosition&) = 0;
     virtual double minimumZoomScale() const = 0;
     virtual WebCore::FloatRect documentRect() const = 0;
-    virtual WebCore::InteractiveWidget viewportMetaTagInteractiveWidget() const = 0;
+    virtual WebCore::InteractiveWidgetValue viewportMetaTagInteractiveWidget() const = 0;
     virtual void scrollingNodeScrollViewWillStartPanGesture(WebCore::ScrollingNodeID) = 0;
     virtual void scrollingNodeScrollWillStartScroll(std::optional<WebCore::ScrollingNodeID>) = 0;
     virtual void scrollingNodeScrollDidEndScroll(std::optional<WebCore::ScrollingNodeID>) = 0;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -234,7 +234,7 @@ private:
 
     double minimumZoomScale() const override;
     WebCore::FloatRect documentRect() const override;
-    WebCore::InteractiveWidget viewportMetaTagInteractiveWidget() const override;
+    WebCore::InteractiveWidgetValue viewportMetaTagInteractiveWidget() const override;
 
     void showInspectorHighlight(const WebCore::InspectorOverlay::Highlight&) override;
     void hideInspectorHighlight() override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -418,7 +418,7 @@ WebCore::FloatRect PageClientImpl::documentRect() const
     return [contentView() bounds];
 }
 
-WebCore::InteractiveWidget PageClientImpl::viewportMetaTagInteractiveWidget() const
+WebCore::InteractiveWidgetValue PageClientImpl::viewportMetaTagInteractiveWidget() const
 {
     return [webView() _viewportMetaTagInteractiveWidget];
 }

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -260,7 +260,7 @@ WebCore::FloatRect WebPageProxy::computeLayoutViewportRect(const FloatRect& unob
         constrainedUnobscuredRect.setHeight(adjustedUnexposedMaxEdge(documentRect.maxY(), constrainedUnobscuredRect.maxY(), factor) - constrainedUnobscuredRect.y());
     }
 
-    bool resizesContent = pageClient->viewportMetaTagInteractiveWidget() == WebCore::InteractiveWidget::ResizesContent;
+    bool resizesContent = pageClient->viewportMetaTagInteractiveWidget() == WebCore::InteractiveWidgetValue::ResizesContent;
     FloatRect sizeSourceRect = resizesContent ? unobscuredContentRectRespectingInputViewBounds : unobscuredContentRect;
     FloatSize constrainedSize = isBelowMinimumScale ? constrainedUnobscuredRect.size() : sizeSourceRect.size();
     FloatRect unobscuredContentRectForViewport = isBelowMinimumScale ? constrainedUnobscuredRect : unobscuredContentRectRespectingInputViewBounds;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2378,7 +2378,7 @@ void WebPage::willCommitMainFrameData(MainFrameData& data, const TransactionID& 
     data.minimumScaleFactor = m_viewportConfiguration.minimumScale();
     data.maximumScaleFactor = m_viewportConfiguration.maximumScale();
     data.initialScaleFactor = m_viewportConfiguration.initialScale();
-    data.viewportMetaTagInteractiveWidget = m_viewportConfiguration.viewportArguments().interactiveWidget;
+    data.viewportMetaTagInteractiveWidget = m_viewportConfiguration.viewportArguments().interactiveWidgetValue;
     data.viewportMetaTagWidth = m_viewportConfiguration.viewportArguments().width;
     data.viewportMetaTagWidthWasExplicit = m_viewportConfiguration.viewportArguments().widthWasExplicit;
     data.viewportMetaTagCameFromImageDocument = m_viewportConfiguration.viewportArguments().type == ViewportArguments::Type::ImageDocument;


### PR DESCRIPTION
#### 58270b569f11642358a4a1df1f8944a594cdba47
<pre>
[interactive-widget] Refactor InteractiveWidget to InteractiveWidgetValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=320958">https://bugs.webkit.org/show_bug.cgi?id=320958</a>
<a href="https://rdar.apple.com/183986548">rdar://183986548</a>

Reviewed by Richard Robinson.

The enums resizes-visual, resizes-content, and overlays-content
are currently part of the enum class &quot;InteractiveWidget&quot;. However,
these are technically values that the interactive-widget property
can have, so naming them as InteractiveWidget is misleading in the
sense that they are not interactive widgets (such as a virtual
keyboard).

Thus to prevent confusion, rename the enum class among other variables
to &quot;InteractiveWidgetValue&quot; instead.

* Source/WebCore/dom/ViewportArguments.cpp:
(WebCore::ViewportArguments::resolve const):
(WebCore::parseInteractiveWidgetValue):
(WebCore::setViewportFeature):
* Source/WebCore/dom/ViewportArguments.h:
(WebCore::ViewportArguments::ViewportArguments):
(WebCore::ViewportArguments::operator== const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _dispatchSetViewLayoutSize:]):
(-[WKWebView _inputViewBoundsForViewportCalculations]):
(-[WKWebView _viewportMetaTagInteractiveWidget]):
(-[WKWebView _keyboardChangedWithInfo:adjustScrollView:]):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::viewportMetaTagInteractiveWidget const):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::computeLayoutViewportRect const):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::willCommitMainFrameData):

Canonical link: <a href="https://commits.webkit.org/318560@main">https://commits.webkit.org/318560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/817ff7fb9b4ad5fcd5cbe54efab4fb6fd6ac1415

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141810 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4219fa8e-de89-473d-8116-7d020c0a70b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139225 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44f8cf89-703f-482d-882f-4af0841dd032) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119679 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/673e4453-3b42-4d6d-9fb7-04f9ad7b9814) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41446 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39795 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39473 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190604 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52168 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148379 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52849 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148147 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27097 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42857 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125116 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119752 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51367 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14448 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50752 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50814 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->