### PR TITLE
[JSC] Cache the collator for `String#localeCompare` with a string locale

### DIFF
--- a/JSTests/microbenchmarks/locale-compare-with-locales.js
+++ b/JSTests/microbenchmarks/locale-compare-with-locales.js
@@ -1,0 +1,9 @@
+(function(a, b) {
+    var n = 200000;
+    var result = 0;
+    for (var i = 0; i < n; ++i) {
+        result += a.localeCompare(b, "en");
+    }
+    if (result != n)
+        throw "Error: bad result: " + result;
+})("yes", "no");

--- a/JSTests/stress/string-locale-compare-locales-cache.js
+++ b/JSTests/stress/string-locale-compare-locales-cache.js
@@ -1,0 +1,50 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function shouldThrow(func, errorType) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+const words = ["a", "A", "ä", "Z", "z", "ss", "ß", "ch", "cz", "資料", "10", "9", "co-op", "coop", ""];
+const locales = ["en", "de", "sv", "ja", "es", "tr", "de-u-co-phonebk", "en-US", "und"];
+
+// Repeated calls with the same string locale must keep matching a fresh Intl.Collator.
+for (const locale of locales) {
+    const collator = new Intl.Collator(locale);
+    for (let i = 0; i < 3; ++i) {
+        for (const x of words) {
+            for (const y of words)
+                shouldBe(x.localeCompare(y, locale), collator.compare(x, y));
+        }
+    }
+}
+
+// Alternating locales.
+for (let i = 0; i < 100; ++i) {
+    const locale = locales[i % locales.length];
+    shouldBe("ä".localeCompare("z", locale), new Intl.Collator(locale).compare("ä", "z"));
+}
+
+// An invalid locale must throw on every call.
+for (let i = 0; i < 3; ++i)
+    shouldThrow(() => "a".localeCompare("b", "xx-fake-INVALID!"), RangeError);
+shouldBe("a".localeCompare("b", "en"), -1);
+
+// Non-string locales and explicit options take the general path.
+shouldBe("a".localeCompare("b", ["en"]), -1);
+shouldBe("a".localeCompare("b", undefined), -1);
+shouldBe("a".localeCompare("A", "en", { sensitivity: "base" }), 0);
+shouldBe("a".localeCompare("A", "en") !== 0, true);
+
+// Rope locale string.
+const prefix = "e";
+shouldBe("a".localeCompare("b", prefix + "n"), -1);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2930,6 +2930,7 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_stringConstructor);
 
     thisObject->m_defaultCollator.visit(visitor);
+    visitor.append(thisObject->m_cachedLocaleCompareCollator);
     thisObject->m_defaultDateTimeFormat.visit(visitor);
     thisObject->m_defaultDateFormat.visit(visitor);
     thisObject->m_defaultTimeFormat.visit(visitor);
@@ -3153,6 +3154,26 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 DEFINE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE, JSGlobalObject);
+
+IntlCollator* JSGlobalObject::cachedLocaleCompareCollator(JSString* locale)
+{
+    VM& vm = this->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    String localeString = locale->value(this);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    if (m_cachedLocaleCompareCollator && m_cachedLocaleCompareCollatorLocale == localeString)
+        return m_cachedLocaleCompareCollator.get();
+
+    IntlCollator* collator = IntlCollator::create(vm, collatorStructure());
+    collator->initializeCollator(this, locale, jsUndefined());
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    m_cachedLocaleCompareCollatorLocale = WTF::move(localeString);
+    m_cachedLocaleCompareCollator.set(vm, this, collator);
+    return collator;
+}
 
 SUPPRESS_ASAN void JSGlobalObject::exposeDollarVM(VM& vm)
 {

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -299,6 +299,10 @@ public:
     LazyClassStructure m_dateTimeFormatStructure;
     LazyClassStructure m_numberFormatStructure;
 
+    // Cached collator object for String#localeCompare
+    WriteBarrier<IntlCollator> m_cachedLocaleCompareCollator;
+    String m_cachedLocaleCompareCollatorLocale;
+
     LazyClassStructure m_durationStructure;
     LazyClassStructure m_instantStructure;
     LazyClassStructure m_plainDateStructure;
@@ -786,6 +790,7 @@ public:
     JSIteratorConstructor* iteratorConstructor() const LIFETIME_BOUND { return m_iteratorConstructor.get(); }
 
     IntlCollator* defaultCollator() const LIFETIME_BOUND { return m_defaultCollator.get(this); }
+    IntlCollator* cachedLocaleCompareCollator(JSString* locale);
     bool canDoASCIIUCADUCETLocaleCompare() const { return m_canDoASCIIUCADUCETLocaleCompare; }
     IntlDateTimeFormat* defaultDateTimeFormat() const LIFETIME_BOUND { return m_defaultDateTimeFormat.get(this); }
     IntlDateTimeFormat* defaultDateFormat() const LIFETIME_BOUND { return m_defaultDateFormat.get(this); }

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1791,6 +1791,8 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncLocaleCompare, (JSGlobalObject* globalOb
     IntlCollator* collator = nullptr;
     if (locales.isUndefined() && options.isUndefined())
         collator = globalObject->defaultCollator();
+    else if (locales.isString() && options.isUndefined())
+        collator = globalObject->cachedLocaleCompareCollator(asString(locales));
     else {
         collator = IntlCollator::create(vm, globalObject->collatorStructure());
         collator->initializeCollator(globalObject, locales, options);


### PR DESCRIPTION
#### 33a5272cf9acb5e290cb58b1ec6b5a9a1ef1ee70
<pre>
[JSC] Cache the collator for `String#localeCompare` with a string locale
<a href="https://bugs.webkit.org/show_bug.cgi?id=320962">https://bugs.webkit.org/show_bug.cgi?id=320962</a>

Reviewed by Yusuke Suzuki.

`String#localeCompare(that, locale)` created a fresh IntlCollator on
every call whenever `locales` was not undefined, running full option
probing, resolveLocale and ucol_open per comparison. This makes the
common sort comparator pattern
`items.sort((a, b) =&gt; a.name.localeCompare(b.name, &quot;en&quot;))` very slow.

This patch adds a single-entry per-JSGlobalObject cache keyed by the
locale string, used when `locales` is a string and `options` is
undefined. In that case examining the arguments has no observable side
effects, so reusing the collator is not observable (V8 caches the
collator under the same condition).

                                      baseline                  patched

locale-compare-with-locales      111.1431+-2.0657     ^      2.0815+-0.0727        ^ definitely 53.3946x faster
locale-compare                     0.9404+-0.0560            0.9292+-0.0475          might be 1.0120x faster

Tests: JSTests/microbenchmarks/locale-compare-with-locales.js
       JSTests/stress/string-locale-compare-locales-cache.js

* JSTests/microbenchmarks/locale-compare-with-locales.js: Added.
* JSTests/stress/string-locale-compare-locales-cache.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::visitChildrenImpl):
(JSC::JSGlobalObject::cachedLocaleCompareCollator):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/318542@main">https://commits.webkit.org/318542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f6e5a6d0168f492e5196fc27e9f00d1702e358a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188178 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141812 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139221 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41444 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39796 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1644 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8463 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151844 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39474 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39835 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190605 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52169 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39852 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52850 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36097 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148153 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42861 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125117 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119753 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51368 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14449 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50753 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50993 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->