### PR TITLE
[check-webkit-style] Remove dead wpt/lint/unnecessary_exclusion_in_web_features_file filter rule

### DIFF
--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -122,7 +122,6 @@ _BASE_FILTER_RULES = [
     # WebKit's importer drops some files (e.g. manual tests), causing these rules to trip
     # when such missing files are the only match for entries in a WEB_FEATURES.yml file:
     '-wpt/lint/missing_web_features_file',
-    '-wpt/lint/unnecessary_exclusion_in_web_features_file',
 
     # List Python pep8 categories last.
     #


### PR DESCRIPTION
#### 2a5ab341aa059d3059a679e3c642d79c26f0ab30
<pre>
[check-webkit-style] Remove dead wpt/lint/unnecessary_exclusion_in_web_features_file filter rule
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320964">https://bugs.webkit.org/show_bug.cgi?id=320964</a>&gt;
&lt;<a href="https://rdar.apple.com/183989096">rdar://183989096</a>&gt;

Unreviewed build fix.

Commit 318459@main (Bug 320875, <a href="https://rdar.apple.com/183894755">rdar://183894755</a>) synced WPT lint tools
from upstream and removed the `UNNECESSARY-EXCLUSION-IN-WEB-FEATURES-FILE`
lint rule.  Since `wpt_lint_categories()` derives its category set
dynamically from the installed rules, the
`wpt/lint/unnecessary_exclusion_in_web_features_file` category no
longer exists.  Keeping the dead entry in `_BASE_FILTER_RULES` causes
`test_webkit_base_filter_rules` to raise a `ValueError` in
`validate_filter_rules()`, which rejects any filter rule whose prefix
does not match a registered category name.

Covered by existing tests.

* Tools/Scripts/webkitpy/style/checker.py:
(_BASE_FILTER_RULES):

Canonical link: <a href="https://commits.webkit.org/318523@main">https://commits.webkit.org/318523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72f2731dee1cf12c9004c053bd39192fd5b9f560

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188185 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9de65c3f-6387-4928-b820-646937595fcd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52217 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/900fdde0-1a58-4940-a137-d99664caa987) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181526 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/42779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/119673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d27df85e-6994-495a-a192-57e7d004980e) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/177892 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39467 "Failed to checkout and rebase branch from PR 70836") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36640 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190612 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52176 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159491 "Failed to checkout and rebase branch from PR 70836") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52857 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148155 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27085 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42859 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51375 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14442 "Failed to checkout and rebase branch from PR 70836") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50760 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51000 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->