### PR TITLE
Cherry-pick 318521@main (78f2dd93752e). https://bugs.webkit.org/show_bug.cgi?id=320961

### DIFF
--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -1935,6 +1935,54 @@
 
     "imported/w3c/webdriver/tests/classic/element_clear/clear.py": {
         "subtests": {
+            "test_contenteditable": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[date-2017-12-26-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[datetime-2017-12-26T19:48-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[datetime-local-2017-12-26T19:48-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[email-foo@example.com-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[month-2017-11-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[number-42-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[password-password-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[range-42-50]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[search-search-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[tel-999-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[text-text-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[time-19:48-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[url-https://example.com/-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_input[week-2017-W52-]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
+            "test_textarea": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
+            },
             "test_input[color-#ff0000-#000000]": {
                 "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/180645"}}
             },

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -218,6 +218,21 @@
 
     "imported/selenium/py/test/selenium/webdriver/common/interactions_tests.py": {
         "subtests": {
+            "test_can_scroll_from_element_by_amount": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_can_scroll_from_element_with_offset_by_amount": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_can_scroll_from_viewport_by_amount": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_can_scroll_from_viewport_with_offset_by_amount": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_can_scroll_to_element": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_clicking_on_form_elements": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
             },
@@ -290,8 +305,64 @@
             }
         }
     },
+    "imported/selenium/py/test/selenium/webdriver/common/interactions_with_device_tests.py": {
+        "subtests": {
+            "test_can_scroll_from_element_by_amount_with_wheel": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_can_scroll_from_element_with_offset_by_amount_with_wheel": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_can_scroll_from_viewport_by_amount_with_wheel": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_can_scroll_from_viewport_with_offset_by_amount_with_wheel": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_can_scroll_to_element_with_wheel": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_clicking_on_form_elements_with_pointer": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_context_click_with_pointer": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            }
+        }
+    },
+
     "imported/selenium/py/test/selenium/webdriver/common/typing_tests.py": {
         "subtests": {
+            "test_should_be_able_to_mix_upper_and_lower_case_letters": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_should_be_able_to_type_capital_letters": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_should_be_able_to_type_quote_marks": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_should_be_able_to_type_the_at_character": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_should_be_able_to_use_arrow_keys": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_should_type_into_input_elements_that_have_no_type_attribute": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_will_simulate_akey_down_when_entering_text_into_input_elements": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_will_simulate_akey_down_when_entering_text_into_text_areas": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_will_simulate_akey_up_when_entering_text_into_input_elements": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_will_simulate_akey_up_when_entering_text_into_text_areas": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_numeric_shift_keys": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/182333"}}
             },
@@ -559,6 +630,9 @@
 
     "imported/w3c/webdriver/tests/classic/perform_actions/pointer_contextmenu.py": {
         "subtests": {
+            "test_control_click[\\ue051-ctrlKey]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_release_control_click": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213060"}}
             }
@@ -583,6 +657,30 @@
 
     "imported/w3c/webdriver/tests/classic/perform_actions/pointer_mouse.py": {
         "subtests": {
+            "test_click_element_in_shadow_tree[inner-open]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_click_element_in_shadow_tree[outer-open]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_context_menu_at_coordinates": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_down_closes_browsing_context[with up]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_down_closes_browsing_context[without up]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_middle_click": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_move_to_origin_position_within_frame[pointer]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_move_to_origin_position_within_frame[viewport]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_click_element_in_shadow_tree[inner-closed]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
             },
@@ -594,6 +692,18 @@
 
     "imported/w3c/webdriver/tests/classic/perform_actions/pointer_pen.py": {
         "subtests": {
+            "test_pen_pointer_in_shadow_tree[inner-open]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_pen_pointer_in_shadow_tree[outer-open]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_pen_pointer_properties": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/270895"}}
+            },
+            "test_pointer_down_closes_browsing_context": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_pen_pointer_in_shadow_tree[inner-closed]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
             },
@@ -605,6 +715,33 @@
 
     "imported/w3c/webdriver/tests/classic/perform_actions/pointer_touch.py": {
         "subtests": {
+            "test_params_actions_origin_outside_viewport[element]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_params_actions_origin_outside_viewport[pointer]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_params_actions_origin_outside_viewport[viewport]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_pointer_down_closes_browsing_context": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_touch_pointer_in_shadow_tree[inner-open]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_touch_pointer_in_shadow_tree[outer-open]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_touch_pointer_properties": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/270895"}}
+            },
+            "test_touch_pointer_properties_angle_twist": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/270895"}}
+            },
+            "test_touch_pointer_properties_tilt_twist": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/270895"}}
+            },
             "test_touch_pointer_in_shadow_tree[inner-closed]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
             },
@@ -616,6 +753,15 @@
 
     "imported/w3c/webdriver/tests/classic/perform_actions/key.py": {
         "subtests": {
+            "test_element_in_shadow_tree[inner-open]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_element_in_shadow_tree[outer-open]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_key_down_closes_browsing_context": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_no_top_browsing_context": {
                 "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212950"}}
             },
@@ -630,6 +776,12 @@
 
     "imported/w3c/webdriver/tests/classic/perform_actions/key_events.py": {
         "subtests": {
+            "test_special_key_sends_keydown[CLEAR-expected4]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_special_key_sends_keydown[F11-expected16]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_modifier_key_sends_correct_events[\\ue03d-META]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
             },
@@ -771,6 +923,24 @@
 
     "imported/w3c/webdriver/tests/classic/perform_actions/wheel.py": {
         "subtests": {
+            "test_scroll_iframe": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_scroll_not_scrollable": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_scroll_scrollable_overflow": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_scroll_shadow_tree[inner-open]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_scroll_shadow_tree[outer-open]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_scroll_with_key_pressed": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_no_top_browsing_context": {
                 "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212950"}}
             },
@@ -820,10 +990,49 @@
     },
     "imported/w3c/webdriver/tests/classic/perform_actions/key_special_keys.py": {
         "subtests": {
+            "test_codepoint_keys_behave_correctly[\\U0001f604]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_codepoint_keys_behave_correctly[\\U0001f60d]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_codepoint_keys_behave_correctly[\\u0ba8\\u0bbf]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
             },
             "test_codepoint_keys_behave_correctly[\\u1100\\u1161\\u11a8]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/perform_actions/key_tentative.py": {
+        "subtests": {
+            "test_grapheme_cluster[\\U0001f937\\U0001f3fd\\u200d\\u2640\\ufe0f]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_grapheme_cluster[\\u0e01\\u0e33]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/perform_actions/pointer_modifier_click.py": {
+        "subtests": {
+            "test_modifier_click[\\ue052-altKey]": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/perform_actions/pointer_mouse_drag.py": {
+        "subtests": {
+            "test_drag_and_drop_with_draggable_element[0]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_drag_and_drop_with_draggable_element[300]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_drag_and_drop_with_draggable_element[800]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
             }
         }

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -1,4 +1,47 @@
 {
+    "imported/w3c/webdriver/tests/classic/release_actions/sequence_tentative.py": {
+        "subtests": {
+            "test_release_mouse_sequence_resets_dblclick_state[with release actions]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            },
+            "test_release_mouse_sequence_resets_dblclick_state[without release actions]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/take_screenshot/screenshot.py": {
+        "subtests": {
+            "test_no_browsing_context": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/element_click/events.py": {
+        "subtests": {
+            "test_event_mousemove": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            }
+        }
+    },
+
+    "imported/selenium/py/test/selenium/webdriver/support/event_firing_webdriver_tests.py": {
+        "subtests": {
+            "test_can_use_key_input_with_event_firing_webdriver": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            }
+        }
+    },
+
+    "imported/selenium/py/test/selenium/webdriver/common/visibility_tests.py": {
+        "subtests": {
+            "test_should_allow_the_user_to_tell_if_an_element_is_displayed_or_not": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            }
+        }
+    },
+
     "imported/w3c/webdriver/tests/classic/maximize_window/from_minimized_window.py": {
         "subtests": {
             "test_restore_from_minimized": {
@@ -98,6 +141,12 @@
 
     "imported/w3c/webdriver/tests/classic/element_clear/disabled.py": {
         "subtests": {
+            "test_fieldset_descendant": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            },
+            "test_fieldset_descendant_not_first_legend": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            },
             "test_xml": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
@@ -217,6 +266,9 @@
 
     "imported/selenium/py/test/selenium/webdriver/common/bidi_network_tests.py": {
         "subtests": {
+            "test_handler_with_data_url_request": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/281936"}}
+            },
             "test_add_intercept":  { "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288087"}}},
             "test_remove_intercept":  { "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288094"}}},
             "test_add_and_remove_request_handler":  { "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288087"}}},
@@ -282,6 +334,20 @@
 
     "imported/selenium/py/test/selenium/webdriver/common/bidi_storage_tests.py": {
         "expected": {"all": {"status": ["FAIL"], "note": ["webkit.org/b/296240", "webkit.org/b/296255"]}}
+    },
+
+    "imported/selenium/py/test/selenium/webdriver/common/bidi_tests.py": {
+        "subtests": {
+            "test_check_console_messages": {
+                "expected": {"all": {"status": ["SKIP"], "bug": "webkit.org/b/320960"}}
+            },
+            "test_check_error_console_messages": {
+                "expected": {"all": {"status": ["SKIP"], "bug": "webkit.org/b/320960"}}
+            },
+            "test_collect_js_exceptions": {
+                "expected": {"all": {"status": ["SKIP"], "bug": "webkit.org/b/320960"}}
+            }
+        }
     },
 
     "imported/selenium/py/test/selenium/webdriver/common/fedcm_tests.py": {
@@ -447,6 +513,9 @@
     },
     "imported/selenium/py/test/selenium/webdriver/common/text_handling_tests.py": {
         "subtests": {
+            "test_should_represent_ablock_level_element_as_anewline": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            },
             "test_should_be_able_to_set_more_than_one_line_of_text_in_atext_area": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/174617"}}
             },
@@ -1093,7 +1162,7 @@
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
             },
             "test_sequence_of_keydown_printable_keys_sends_events": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320476"}}
             },
             "test_sequence_of_keydown_printable_characters_sends_events": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
@@ -1177,7 +1246,7 @@
     "imported/w3c/webdriver/tests/classic/release_actions/sequence.py": {
         "subtests": {
             "test_release_char_sequence_sends_keyup_events_in_reverse": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320476"}}
             },
             "test_release_mouse_sequence_resets_dblclick_state": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
@@ -2152,6 +2221,9 @@
 
     "imported/w3c/webdriver/tests/classic/element_clear/clear.py": {
         "subtests": {
+            "test_resettable_element_does_not_satisfy_validation_constraints[month-foo]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            },
             "test_contenteditable": {
                 "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/175181"}}
             },
@@ -2776,6 +2848,9 @@
 
     "imported/w3c/webdriver/tests/classic/get_element_attribute/get.py": {
         "subtests": {
+            "test_anchor_href[relative]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            },
             "test_no_top_browsing_context": {
                 "expected": {
                     "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212950"},
@@ -2933,6 +3008,18 @@
 
     "imported/w3c/webdriver/tests/classic/get_element_text/get.py": {
         "subtests": {
+            "test_transform_capitalize[underscore]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            },
+            "test_shadow_root_slot[default outside]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320956"}}
+            },
+            "test_shadow_root_slot[default hidden]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320956"}}
+            },
+            "test_shadow_root_slot[default visible]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320956"}}
+            },
             "test_pretty_print_xml": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
@@ -3013,6 +3100,9 @@
 
     "imported/w3c/webdriver/tests/classic/is_element_enabled/enabled.py": {
         "subtests": {
+            "test_fieldset_descendant_not_first_legend[disabled]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320961"}}
+            },
             "test_xml": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
@@ -3181,6 +3271,12 @@
     },
     "imported/w3c/webdriver/tests/classic/find_element_from_shadow_root/find.py": {
         "subtests": {
+            "test_find_element[open-tag name-a]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320955"}}
+            },
+            "test_find_element[open-xpath-//a]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320955"}}
+            },
             "test_find_element[tag name-a]": {
                 "expected": { "all": { "status": ["SKIP"]}}
             },
@@ -3237,6 +3333,12 @@
     },
     "imported/w3c/webdriver/tests/classic/find_elements_from_shadow_root/find.py": {
         "subtests": {
+            "test_find_elements[open-tag name-a]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320955"}}
+            },
+            "test_find_elements[open-xpath-//a]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320955"}}
+            },
             "test_find_elements[tag name-a]": {
                 "expected": { "all": { "status": ["SKIP"]}}
             },

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -1,4 +1,109 @@
 {
+    "imported/w3c/webdriver/tests/classic/maximize_window/from_minimized_window.py": {
+        "subtests": {
+            "test_restore_from_minimized": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/277945"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/set_window_rect/from_minimized_window.py": {
+        "subtests": {
+            "test_restore_from_minimized": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/277945"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/execute_async_script/collections.py": {
+        "subtests": {
+            "test_dom_token_list": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/execute_script/collections.py": {
+        "subtests": {
+            "test_dom_token_list": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            }
+        }
+    },
+
+    "imported/selenium/py/test/selenium/webdriver/common/upload_tests.py": {
+        "subtests": {
+            "test_can_upload_two_files": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_can_upload_file": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_file_is_uploaded_to_remote_machine_on_select": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            }
+        }
+    },
+
+    "imported/selenium/py/test/selenium/webdriver/common/correct_event_firing_tests.py": {
+        "subtests": {
+            "test_sending_keys_to_an_element_should_cause_the_focus_event_to_fire": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_sending_keys_to_another_element_should_cause_the_blur_event_to_fire": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/element_click/scroll_into_view.py": {
+        "subtests": {
+            "test_scroll_into_view": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/element_clear/scroll_into_view.py": {
+        "subtests": {
+            "test_scroll_into_view": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/take_element_screenshot/scroll_into_view.py": {
+        "subtests": {
+            "test_scroll_into_view": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/get_title/iframe.py": {
+        "subtests": {
+            "test_origin[cross_origin]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/get_current_url/iframe.py": {
+        "subtests": {
+            "test_origin[cross_origin]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/element_clear/disabled.py": {
+        "subtests": {
+            "test_xml": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            }
+        }
+    },
+
     "imported/selenium/py/test/selenium/webdriver/common/alerts_tests.py": {
         "subtests": {
             "test_should_handle_alert_on_page_before_unload": {
@@ -40,6 +145,51 @@
 
     "imported/selenium/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py": {
         "subtests": {
+            "test_add_event_handler_context_created": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_add_event_handler_dom_content_loaded": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/302058"}}
+            },
+            "test_add_event_handler_download_will_begin": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288338"}}
+            },
+            "test_add_event_handler_fragment_navigated": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/287929"}}
+            },
+            "test_add_event_handler_history_updated": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/287936"}}
+            },
+            "test_add_event_handler_load": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288340"}}
+            },
+            "test_add_event_handler_navigation_committed": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/287934"}}
+            },
+            "test_add_event_handler_navigation_failed": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/287933"}}
+            },
+            "test_add_event_handler_navigation_started": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288342"}}
+            },
+            "test_add_event_handler_user_prompt_closed": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288343"}}
+            },
+            "test_add_event_handler_with_specific_contexts": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_concurrent_event_handler_registration": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_event_callback_data_consistency": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_multiple_event_handlers_same_event": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_remove_specific_event_handler_multiple_handlers": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
+            },
             "test_activate_browsing_context": { "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/296255"}}},
             "test_capture_screenshot": { "expected": { "all": { "status": ["FAIL"], "bug": ["webkit.org/b/296255", "webkit.org/b/288325"]}}},
             "test_capture_screenshot_with_parameters": { "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288325"}}},
@@ -428,7 +578,18 @@
     },
     "imported/selenium/py/test/selenium/webdriver/common/w3c_interaction_tests.py": {
         "subtests": {
-
+            "test_can_scroll_mouse_wheel": {
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_context_click": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_touch_pointer_properties": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/270895"}}
+            },
+            "test_pen_pointer_properties": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/270895"}}
+            }
         }
     },
     "imported/selenium/py/test/selenium/webdriver/common/window_switching_tests.py": {
@@ -553,6 +714,12 @@
 
     "imported/w3c/webdriver/tests/classic/back/back.py": {
         "subtests": {
+            "test_seen_nodes[https]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
+            "test_seen_nodes[https coop]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
             "test_cross_origin[capabilities0]": {
                 "expected": {"all": {"status": ["TIMEOUT"], "bug": "webkit.org/b/233391"}}
             },
@@ -590,6 +757,12 @@
 
     "imported/w3c/webdriver/tests/classic/forward/forward.py": {
         "subtests": {
+            "test_seen_nodes[https]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
+            "test_seen_nodes[https coop]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
             "test_cross_origin[capabilities0]": {
                 "expected": {"all": {"status": ["TIMEOUT"], "bug": "webkit.org/b/233391"}}
             },
@@ -1649,6 +1822,9 @@
 
     "imported/w3c/webdriver/tests/classic/close_window/user_prompts.py": {
         "subtests": {
+            "test_dismiss_and_notify[beforeunload-None]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
+            },
             "test_accept[beforeunload]": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
             },
@@ -2100,6 +2276,9 @@
     },
     "imported/w3c/webdriver/tests/classic/element_click/navigate.py": {
         "subtests": {
+            "test_link_cross_origin": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
             "test_link_cross_origin[capabilities0]": {
                 "expected": {"all": {"status": ["TIMEOUT"], "bug": "webkit.org/b/233391"}}
             },
@@ -2253,6 +2432,15 @@
     },
     "imported/w3c/webdriver/tests/classic/element_send_keys/form_controls.py": {
         "subtests": {
+            "test_textarea_insert_when_focused": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_input_insert_when_focused": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_date": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_input_append": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/182331"}}
             }
@@ -2267,6 +2455,9 @@
     },
     "imported/w3c/webdriver/tests/classic/element_send_keys/scroll_into_view.py": {
         "subtests": {
+            "test_element_outside_of_scrollable_viewport": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_option_select_container_outside_of_scrollable_viewport": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/188545"}}
             },
@@ -2277,6 +2468,9 @@
     },
     "imported/w3c/webdriver/tests/classic/element_send_keys/send_keys.py": {
         "subtests": {
+            "test_surrogates": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_no_top_browsing_context": {
                 "expected": {
                     "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212950"},
@@ -2364,6 +2558,12 @@
 
     "imported/w3c/webdriver/tests/classic/navigate_to/navigate.py": {
         "subtests": {
+            "test_seen_nodes[https coop]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
+            "test_seen_nodes[https]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
             "test_cross_origin[capabilities0]": {
                 "expected": {"all": {"status": ["TIMEOUT"], "bug": "webkit.org/b/233391"}}
             },
@@ -2471,6 +2671,9 @@
 
     "imported/w3c/webdriver/tests/classic/fullscreen_window/fullscreen.py": {
         "subtests": {
+            "test_no_browsing_context": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+            },
             "notes": "",
             "test_fullscreen_from_normal_window": {
                 "expected": {
@@ -2627,6 +2830,21 @@
 
     "imported/w3c/webdriver/tests/classic/get_element_property/get.py": {
         "subtests": {
+            "test_collection_dom_token_list": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_web_reference[element-WebElement]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_web_reference[window-WebWindow]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_web_reference[frame-WebFrame]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_web_reference[shadowRoot-ShadowRoot]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
             "test_no_top_browsing_context": {
                 "expected": {
                     "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212950"},
@@ -2715,6 +2933,9 @@
 
     "imported/w3c/webdriver/tests/classic/get_element_text/get.py": {
         "subtests": {
+            "test_pretty_print_xml": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
             "test_no_top_browsing_context": {
                 "expected": {
                     "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212950"},
@@ -2792,6 +3013,9 @@
 
     "imported/w3c/webdriver/tests/classic/is_element_enabled/enabled.py": {
         "subtests": {
+            "test_xml": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
             "test_xml_always_not_enabled": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/205923"}}
             },

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -581,10 +581,49 @@
         }
     },
 
+    "imported/w3c/webdriver/tests/classic/perform_actions/pointer_mouse.py": {
+        "subtests": {
+            "test_click_element_in_shadow_tree[inner-closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
+            },
+            "test_click_element_in_shadow_tree[outer-closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/perform_actions/pointer_pen.py": {
+        "subtests": {
+            "test_pen_pointer_in_shadow_tree[inner-closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
+            },
+            "test_pen_pointer_in_shadow_tree[outer-closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/perform_actions/pointer_touch.py": {
+        "subtests": {
+            "test_touch_pointer_in_shadow_tree[inner-closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
+            },
+            "test_touch_pointer_in_shadow_tree[outer-closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
+            }
+        }
+    },
+
     "imported/w3c/webdriver/tests/classic/perform_actions/key.py": {
         "subtests": {
             "test_no_top_browsing_context": {
                 "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212950"}}
+            },
+            "test_element_in_shadow_tree[inner-closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
+            },
+            "test_element_in_shadow_tree[outer-closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
             }
         }
     },
@@ -737,6 +776,12 @@
             },
             "test_no_browsing_context": {
                 "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212950"}}
+            },
+            "test_scroll_shadow_tree[inner-closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
+            },
+            "test_scroll_shadow_tree[outer-closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
             }
         }
     },
@@ -2643,19 +2688,22 @@
             }
         ,
             "test_find_elements[closed-css selector-#linkText]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": ["webkit.org/b/230612", "webkit.org/b/320461"]}}
             },
             "test_find_elements[closed-link text-full link text]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": ["webkit.org/b/230612", "webkit.org/b/320461"]}}
             },
             "test_find_elements[closed-partial link text-link text]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": ["webkit.org/b/230612", "webkit.org/b/320461"]}}
             },
             "test_find_elements[closed-tag name-a]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": ["webkit.org/b/230612", "webkit.org/b/320461"]}}
             },
             "test_find_elements[closed-xpath-//a]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": ["webkit.org/b/230612", "webkit.org/b/320461"]}}
+            },
+            "test_find_elements_in_nested_shadow_root[closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320461"}}
             },
             "test_invalid_shadow_root_id_argument[1]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -478,8 +478,34 @@
         }
     },
 
+    "imported/w3c/webdriver/tests/classic/add_cookie/user_prompts.py": {
+        "subtests": {
+            "test_accept[alert-None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            },
+            "test_accept[confirm-True]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            },
+            "test_accept[prompt-]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            },
+            "test_dismiss[alert-None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            },
+            "test_dismiss[confirm-False]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            },
+            "test_dismiss[prompt-None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            }
+        }
+    },
+
     "imported/w3c/webdriver/tests/classic/add_cookie/add.py": {
         "subtests": {
+            "test_add_cookie_with_expiry_in_the_future": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
+            },
             "test_add_cookie_for_ip": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
             },
@@ -1623,6 +1649,21 @@
 
     "imported/w3c/webdriver/tests/classic/close_window/user_prompts.py": {
         "subtests": {
+            "test_accept[beforeunload]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
+            },
+            "test_accept_and_notify[beforeunload-None]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
+            },
+            "test_default[beforeunload-None]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
+            },
+            "test_dismiss[beforeunload]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
+            },
+            "test_ignore[beforeunload]": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
+            },
             "test_handle_prompt_accept": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
             }
@@ -2432,13 +2473,33 @@
         "subtests": {
             "notes": "",
             "test_fullscreen_from_normal_window": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"}}
+                "expected": {
+                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             },
             "test_fullscreen_from_maximized_window": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"}}
+                "expected": {
+                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             },
+            "test_fullscreen_twice_is_idempotent": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+            },
+            "test_response_payload": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+            }
+        }
+    },
+
+    "imported/w3c/webdriver/tests/classic/fullscreen_window/from_minimized_window.py": {
+        "subtests": {
             "test_fullscreen_from_minimized_window": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/277945"}}
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"},
+                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/277945"}
+                }
             }
         }
     },
@@ -2446,23 +2507,23 @@
     "imported/w3c/webdriver/tests/classic/fullscreen_window/user_prompts.py": {
         "subtests": {
             "notes": "Some WPE tests are skipped as they trigger failure or timeout regardless of the expectation if they are run. Also, some tests expect the browser to start in non fullscreen mode, which isn't happening in the headless backend.",
-            "test_accept[capabilities0-alert-None]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+            "test_accept[alert-None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
-            "test_accept[capabilities0-confirm-True]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+            "test_accept[confirm-True]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
-            "test_accept[capabilities0-prompt-]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+            "test_accept[prompt-]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
-            "test_dismiss[capabilities0-alert-None]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+            "test_dismiss[alert-None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
-            "test_dismiss[capabilities0-confirm-False]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+            "test_dismiss[confirm-False]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
-            "test_dismiss[capabilities0-prompt-None]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+            "test_dismiss[prompt-None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             }
         }
     },
@@ -2470,19 +2531,34 @@
         "subtests": {
             "notes": "Some WPE tests are skipped as they trigger failure or timeout regardless of the expectation if they are run. Also, some tests expect the browser to start in non fullscreen mode, which isn't happening in the headless backend.",
             "test_stress[0]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+                "expected": {
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             },
             "test_stress[1]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+                "expected": {
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             },
             "test_stress[2]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+                "expected": {
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             },
             "test_stress[3]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+                "expected": {
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             },
             "test_stress[4]": {
-                "expected": {"wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}}
+                "expected": {
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                }
             }
         }
     },

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -264,6 +264,9 @@
             }
         }
     },
+    "imported/selenium/py/test/selenium/webdriver/common/print_pdf_tests.py": {
+        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/217173"}}
+    },
     "imported/selenium/py/test/selenium/webdriver/common/select_class_tests.py": {
         "subtests": {
             "test_select_by_index_multiple": {
@@ -2306,6 +2309,12 @@
         }
     },
 
+    "imported/w3c/webdriver/tests/classic/print/background.py": {
+        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/217173"}}
+    },
+    "imported/w3c/webdriver/tests/classic/print/orientation.py": {
+        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/217173"}}
+    },
     "imported/w3c/webdriver/tests/classic/print/printcmd.py": {
         "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/217173"}}
     },

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -786,6 +786,36 @@
 
     "imported/w3c/webdriver/tests/classic/perform_actions/invalid.py": {
         "subtests": {
+            "test_input_source_action_sequence_pointer_parameters_pointer_type_invalid_type[None]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/270895"}}
+            },
+            "test_input_source_action_sequence_pointer_parameters_pointer_type_invalid_type[True]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/270895"}}
+            },
+            "test_input_source_action_sequence_pointer_parameters_pointer_type_invalid_type[42]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/270895"}}
+            },
+            "test_input_source_action_sequence_pointer_parameters_pointer_type_invalid_type[value3]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/270895"}}
+            },
+            "test_input_source_action_sequence_pointer_parameters_pointer_type_invalid_type[value4]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/270895"}}
+            },
+            "test_key_action_invalid_value[fa-keyUp]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_key_action_invalid_value[\\u0ba8\\u0bbfb-keyUp]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_key_action_invalid_value[\\u0ba8\\u0bbf\\u0ba8-keyUp]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_key_action_invalid_value[\\u1100\\u1161\\u11a8c-keyUp]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
+            "test_wheel_action_scroll_origin_pointer_not_supported": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
+            },
             "test_pointer_action_common_properties_dimensions_invalid_type[None-width-pointerDown]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/270895"}}
             },

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -321,6 +321,37 @@
             }
         }
     },
+    "imported/selenium/py/test/selenium/webdriver/common/virtual_authenticator_tests.py": {
+        "subtests": {
+            "test_add_and_remove_non_resident_credentials": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/205350"}}
+            },
+            "test_add_and_remove_virtual_authenticator": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/205350"}}
+            },
+            "test_add_non_resident_credential_when_authenticator_uses_u2f_protocol": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/205350"}}
+            },
+            "test_add_resident_credential_not_supported_when_authenticator_uses_u2f_protocol": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/205350"}}
+            },
+            "test_get_credentials": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/205350"}}
+            },
+            "test_remove_all_credentials": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/205350"}}
+            },
+            "test_remove_credential_by_b64_urlId": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/205350"}}
+            },
+            "test_remove_credential_by_raw_Id": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/205350"}}
+            },
+            "test_set_user_verified": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/205350"}}
+            }
+        }
+    },
     "imported/selenium/py/test/selenium/webdriver/common/w3c_interaction_tests.py": {
         "subtests": {
 

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -1498,6 +1498,27 @@
             },
             "test_element_reference[shadow-root]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
+            "test_node_type[attribute]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_node_type[text]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_node_type[cdata]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_node_type[processing_instruction]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_node_type[comment]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_node_type[document]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_node_type[doctype]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
             }
         }
     },
@@ -1760,6 +1781,30 @@
             },
             "test_detached_shadow_root[top_context]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
+            "test_node_type[attribute]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_node_type[text]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_node_type[cdata]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_node_type[processing_instruction]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_node_type[comment]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_node_type[document]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_node_type[doctype]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
+            },
+            "test_web_reference[shadow-root]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320453"}}
             }
         }
     },

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -1314,112 +1314,112 @@
     "imported/w3c/webdriver/tests/classic/execute_async_script/arguments.py": {
         "subtests": {
             "test_element_reference[frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_element_reference[shadow-root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_element_reference[window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[42-element]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[42-frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[42-shadow_root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[42-window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[False-element]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[False-frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[False-shadow_root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[False-window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[None-element]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[None-frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[None-shadow_root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[None-window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value3-element]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value3-frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value3-shadow_root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value3-window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value4-element]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value4-frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value4-shadow_root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value4-window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_frame_for_frame_with_invalid_value": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_with_unknown_id": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_window_for_window_with_invalid_value": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_object_with_identifier_not_first_key[frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_object_with_identifier_not_first_key[window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -1427,13 +1427,13 @@
     "imported/w3c/webdriver/tests/classic/execute_async_script/node.py": {
         "subtests": {
             "test_detached_shadow_root[child_context]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_detached_shadow_root[top_context]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_element_reference[shadow-root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -1441,13 +1441,13 @@
     "imported/w3c/webdriver/tests/classic/execute_async_script/window.py": {
         "subtests": {
             "test_web_reference[frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_web_reference[window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_window_open": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -1455,118 +1455,118 @@
     "imported/w3c/webdriver/tests/classic/execute_script/arguments.py": {
         "subtests": {
             "test_detached_shadow_root_reference[child_context]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_detached_shadow_root_reference[top_context]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_element_reference[frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_element_reference[shadow-root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_element_reference[window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[42-element]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[42-frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[42-shadow_root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[42-window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[False-element]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[False-frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[False-shadow_root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[False-window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[None-element]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[None-frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[None-shadow_root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[None-window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value3-element]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value3-frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value3-shadow_root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value3-window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value4-element]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value4-frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value4-shadow_root]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_argument_for_reference_with_invalid_type[value4-window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_frame_for_frame_with_invalid_value": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_with_unknown_id": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_window_for_window_with_invalid_value": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_object_with_identifier_not_first_key[frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_object_with_identifier_not_first_key[window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -1607,19 +1607,19 @@
             }
         ,
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -1642,19 +1642,19 @@
             }
         ,
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -1692,10 +1692,10 @@
     "imported/w3c/webdriver/tests/classic/execute_script/node.py": {
         "subtests": {
             "test_detached_shadow_root[child_context]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_detached_shadow_root[top_context]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -1703,28 +1703,28 @@
     "imported/w3c/webdriver/tests/classic/execute_script/window.py": {
         "subtests": {
             "test_same_id_after_cross_origin_navigation": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_web_reference[frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_web_reference[window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_web_reference_in_array[frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_web_reference_in_array[window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_web_reference_in_object[frame]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_web_reference_in_object[window]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_window_open": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -1753,13 +1753,13 @@
             }
         ,
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_startnode_from_other_frame": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_startnode_from_other_window_handle": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -1773,13 +1773,13 @@
             }
         ,
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_startnode_from_other_frame": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_startnode_from_other_window_handle": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -1833,19 +1833,19 @@
             }
         ,
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -1856,19 +1856,19 @@
     "imported/w3c/webdriver/tests/classic/get_computed_label/get.py": {
         "subtests": {
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -1876,19 +1876,19 @@
     "imported/w3c/webdriver/tests/classic/get_computed_role/get.py": {
         "subtests": {
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2094,19 +2094,19 @@
             }
         ,
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2121,19 +2121,19 @@
             }
         ,
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2148,19 +2148,19 @@
             }
         ,
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2172,19 +2172,19 @@
             }
         ,
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2198,19 +2198,19 @@
             }
         ,
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2236,19 +2236,19 @@
             }
         ,
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2319,7 +2319,7 @@
             }
         ,
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2334,19 +2334,19 @@
             }
         ,
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_with_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2357,7 +2357,7 @@
     "imported/w3c/webdriver/tests/classic/switch_to_frame/switch_webelement.py": {
         "subtests": {
             "test_frame_id_webelement_cloned_into_iframe": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2369,7 +2369,7 @@
             }
         ,
             "test_switch_from_iframe": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2399,7 +2399,7 @@
             }
         ,
             "test_element_not_found_after_tab_switch": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2472,49 +2472,49 @@
             }
         ,
             "test_find_element[closed-css selector-#linkText]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_find_element[closed-link text-full link text]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_find_element[closed-partial link text-link text]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_find_element[closed-tag name-a]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_find_element[closed-xpath-//a]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_find_element_in_nested_shadow_root[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_shadow_root_id_argument[1]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_shadow_root_id_argument[None]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_shadow_root_id_argument[True]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_shadow_root_id_argument[shadow_root_id3]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_shadow_root_id_argument[shadow_root_id4]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_with_element": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_with_shadow_root_from_other_frame": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_with_shadow_root_from_other_window_handle": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_with_unknown_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2528,46 +2528,46 @@
             }
         ,
             "test_find_elements[closed-css selector-#linkText]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_find_elements[closed-link text-full link text]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_find_elements[closed-partial link text-link text]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_find_elements[closed-tag name-a]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_find_elements[closed-xpath-//a]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_shadow_root_id_argument[1]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_shadow_root_id_argument[None]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_shadow_root_id_argument[True]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_shadow_root_id_argument[shadow_root_id3]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_invalid_shadow_root_id_argument[shadow_root_id4]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_with_element": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_with_shadow_root_from_other_frame": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_with_shadow_root_from_other_window_handle": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_shadow_root_with_unknown_shadow_root": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
@@ -2581,16 +2581,16 @@
             }
         ,
             "test_no_such_element_from_other_frame[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_frame[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[closed]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
             "test_no_such_element_from_other_window_handle[open]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },


### PR DESCRIPTION
#### 2bd5e1d1a607ac419a33faa818f709eee484db7d
<pre>
Cherry-pick 318521@main (78f2dd93752e). <a href="https://bugs.webkit.org/show_bug.cgi?id=320961">https://bugs.webkit.org/show_bug.cgi?id=320961</a>

    [WebDriver] Gardening persistent failures July 2026 edition
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320961">https://bugs.webkit.org/show_bug.cgi?id=320961</a>

    Unreviewed test gardening.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/318521@main">https://commits.webkit.org/318521@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.44@webkitglib/2.54">https://commits.webkit.org/317695.44@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 5dddb7a18102aab57001085bf01310d5817009c2
<pre>
Cherry-pick 318430@main (77331782b1ab). <a href="https://bugs.webkit.org/show_bug.cgi?id=320862">https://bugs.webkit.org/show_bug.cgi?id=320862</a>

    [WebDriver] Gardening selenium BiDi event failures and other leftovers
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320862">https://bugs.webkit.org/show_bug.cgi?id=320862</a>

    Unreviewed test gardening.

    Alongside selenium, drive-by gardening of a number of persistent
    failures.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/318430@main">https://commits.webkit.org/318430@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.43@webkitglib/2.54">https://commits.webkit.org/317695.43@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 378bdb9c7c6147fb1451b83c1a33a645adb50e03
<pre>
Cherry-pick 318426@main (4f2ba3b3a281). <a href="https://bugs.webkit.org/show_bug.cgi?id=320859">https://bugs.webkit.org/show_bug.cgi?id=320859</a>

    [WebDriver] Gardening user-prompt failures
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320859">https://bugs.webkit.org/show_bug.cgi?id=320859</a>

    Unreviewed test gardening.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/318426@main">https://commits.webkit.org/318426@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.42@webkitglib/2.54">https://commits.webkit.org/317695.42@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### a0d647e7e97ce6410bdd07694ab1ecc54652ffd2
<pre>
Cherry-pick 318178@main (7e8a1739dde2). <a href="https://bugs.webkit.org/show_bug.cgi?id=175181">https://bugs.webkit.org/show_bug.cgi?id=175181</a>

    Web Automation: clear element should fire onchange event
    <a href="https://bugs.webkit.org/show_bug.cgi?id=175181">https://bugs.webkit.org/show_bug.cgi?id=175181</a>

    Unreviewed test gardening.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/318178@main">https://commits.webkit.org/318178@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.41@webkitglib/2.54">https://commits.webkit.org/317695.41@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### b56c0006146dc1d586d483c5cde5383e0384fa9c
<pre>
Cherry-pick 318118@main (04cd6bdd67f6). <a href="https://bugs.webkit.org/show_bug.cgi?id=184967">https://bugs.webkit.org/show_bug.cgi?id=184967</a>

    WebDriver: several tests are still failing after initial implementation of advance user interactions
    <a href="https://bugs.webkit.org/show_bug.cgi?id=184967">https://bugs.webkit.org/show_bug.cgi?id=184967</a>

    Unreviewed test gardening.

    Gardening most of the existing input/action-related failures. This
    includes a few drive-by pointer failures related to bug270895.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/318118@main">https://commits.webkit.org/318118@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.40@webkitglib/2.54">https://commits.webkit.org/317695.40@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### e29ac05071143c0241fedc143ac57e2cf58a01e6
<pre>
Cherry-pick 318070@main (f8196a94ab2f). <a href="https://bugs.webkit.org/show_bug.cgi?id=320461">https://bugs.webkit.org/show_bug.cgi?id=320461</a>

    [WebDriver] Cannot access elements inside a closed shadow tree (&quot;no such shadow root&quot;)
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320461">https://bugs.webkit.org/show_bug.cgi?id=320461</a>

    Unreviewed test gardening.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/318070@main">https://commits.webkit.org/318070@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.39@webkitglib/2.54">https://commits.webkit.org/317695.39@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 538dc9bb17a4184ff722c6eb1c4553510a73cb60
<pre>
Cherry-pick 318064@main (01c6bd3af8fe). <a href="https://bugs.webkit.org/show_bug.cgi?id=320453">https://bugs.webkit.org/show_bug.cgi?id=320453</a>

    [WebDriver] Execute Script serializes non-Element DOM nodes as element handles instead of cloning them
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320453">https://bugs.webkit.org/show_bug.cgi?id=320453</a>

    Unreviewed test gardening.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/318064@main">https://commits.webkit.org/318064@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.38@webkitglib/2.54">https://commits.webkit.org/317695.38@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 8ae844fb19ef4301b6d0c27604f8800ac33c9511
<pre>
Cherry-pick 317890@main (4d0b162f1b01). <a href="https://bugs.webkit.org/show_bug.cgi?id=270895">https://bugs.webkit.org/show_bug.cgi?id=270895</a>

    [WebDriver] Support extra attributes of pointer action
    <a href="https://bugs.webkit.org/show_bug.cgi?id=270895">https://bugs.webkit.org/show_bug.cgi?id=270895</a>

    Unreviewed test gardening.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/317890@main">https://commits.webkit.org/317890@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.37@webkitglib/2.54">https://commits.webkit.org/317695.37@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 8a4cc968c43400c48db346889014eec6bf1633ee
<pre>
Cherry-pick 317861@main (82fca03463a4). <a href="https://bugs.webkit.org/show_bug.cgi?id=217173">https://bugs.webkit.org/show_bug.cgi?id=217173</a>

    WebDriver: Implement print command
    <a href="https://bugs.webkit.org/show_bug.cgi?id=217173">https://bugs.webkit.org/show_bug.cgi?id=217173</a>

    Unreviewed test gardening.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/317861@main">https://commits.webkit.org/317861@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.36@webkitglib/2.54">https://commits.webkit.org/317695.36@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 6010aa5e69fea1f794df8baf7d155e387984d87d
<pre>
Cherry-pick 317860@main (77d3d67a5d49). <a href="https://bugs.webkit.org/show_bug.cgi?id=205350">https://bugs.webkit.org/show_bug.cgi?id=205350</a>

    [WPE][GTK] Support WebAuthn
    <a href="https://bugs.webkit.org/show_bug.cgi?id=205350">https://bugs.webkit.org/show_bug.cgi?id=205350</a>

    Unreviewed test gardening.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/317860@main">https://commits.webkit.org/317860@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.35@webkitglib/2.54">https://commits.webkit.org/317695.35@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### a56b7c43590713b1594a6afcbef37fee6467f51b
<pre>
Cherry-pick 317854@main (349a74a89c73). <a href="https://bugs.webkit.org/show_bug.cgi?id=230612">https://bugs.webkit.org/show_bug.cgi?id=230612</a>

    [WebDriver] Fix element references after tab switch or close
    <a href="https://bugs.webkit.org/show_bug.cgi?id=230612">https://bugs.webkit.org/show_bug.cgi?id=230612</a>

    Unreviewed test gardening.

    These tests were originally gardened in 316749@main for WPE, but are
    also failing on GTK.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/317854@main">https://commits.webkit.org/317854@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.34@webkitglib/2.54">https://commits.webkit.org/317695.34@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df0e704479dffb848136b7ddbada3ad849f31594

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178574 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52512 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46307 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188190 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141824 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53806 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52222 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141824 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181531 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53806 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46307 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/119678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53806 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52222 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46307 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53806 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46307 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36645 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52222 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190617 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52181 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46307 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/52862 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46307 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/148159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27087 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/52862 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119768 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51380 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46307 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50765 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51005 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50827 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->