### PR TITLE
[PDF] Alternate PDF HUD view should become visible when cursor is near it

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
@@ -29,6 +29,7 @@ import WebKit_Internal
 @_weakLinked @_spi(Private) import SwiftUI
 
 private struct Controls: View {
+    static let hoverMargin: CGFloat = 24
     private static let autoHideDelay: Duration = .seconds(3)
 
     let showSystemActions: Bool
@@ -76,6 +77,8 @@ private struct Controls: View {
         #if USE_APPLE_INTERNAL_SDK && HAVE_NSGLASSEFFECTVIEW_EFFECT_IS_INTERACTIVE
         .controlGroupStyle(.toolbar)
         #endif
+        .padding(Self.hoverMargin)
+        .contentShape(.rect)
         .onHover {
             isHovered = $0
         }
@@ -111,7 +114,7 @@ extension WKAlternatePDFHUDView {
 
         addSubview(hostingView)
         hostingView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
-        hostingView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Self.barVerticalOffset).isActive = true
+        hostingView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Self.barVerticalOffset + Controls.hoverMargin).isActive = true
     }
 
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation


### PR DESCRIPTION
#### 007542e5c99bdb8e73b8032f3608e15b8144100d
<pre>
[PDF] Alternate PDF HUD view should become visible when cursor is near it
<a href="https://bugs.webkit.org/show_bug.cgi?id=320965">https://bugs.webkit.org/show_bug.cgi?id=320965</a>
<a href="https://rdar.apple.com/183994357">rdar://183994357</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Apply a 24pt padding around the view so that the hover effect applies within that band,
while setting the content shape explicitly to avoid the padding interfering with hit testing.

The 24pt value is fairly arbitrarily chosen as to be a bit larger than the 16pt one used
for the default HUD since the view itself is a bit smaller.

* Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift:
(Controls.body):

Canonical link: <a href="https://commits.webkit.org/318529@main">https://commits.webkit.org/318529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6e0cb3c0cea02025961528a08c314889de2bbc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188197 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8cc63773-9998-4a10-ac48-6a6d235def94) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139228 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33d12d2e-01c9-4853-85ed-ea72b2ed04b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119682 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1d92f9a-11ea-4d10-a81a-6a59dbe777a0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41455 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151855 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36652 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45119 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190624 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52188 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148397 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/39837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52869 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148165 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42871 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125136 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119776 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51387 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14455 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50772 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51012 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50834 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->