### PR TITLE
AudioBufferSourceNode ignores the start() offset for a negative playbackRate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt
@@ -1,0 +1,17 @@
+
+PASS AudioBufferSourceNode supports negative playbackRate (-1.0)
+PASS AudioBufferSourceNode supports high negative playbackRate (-2.0)
+PASS AudioBufferSourceNode supports high negative playbackRate (-5.0)
+PASS AudioBufferSourceNode supports fractional negative playbackRate
+PASS AudioBufferSourceNode supports very low negative playbackRate (-0.02)
+FAIL AudioBufferSourceNode enters loop backwards from offset > loopEnd assert_equals: Frame 0 should be 7 expected 7 but got 3
+PASS AudioBufferSourceNode clamps offset to loopStart for playbackRate < 0
+PASS AudioBufferSourceNode loops backwards with negative rate (offset in loop)
+FAIL AudioBufferSourceNode handles offset exactly at duration with negative rate assert_equals: Frame 1 should be 4 expected 4 but got 0
+FAIL AudioBufferSourceNode handles out-of-bounds start offset correctly assert_equals: Frame 1 should be 4.0 expected 4 but got 0
+FAIL AudioBufferSourceNode performs sub-sample interpolation backwards assert_approx_equals: Frame 0 should be approx 3.5 expected 3.5 +/- 0.0001 but got 4
+PASS AudioBufferSourceNode ran successfully with zero delta and playbackRate 0
+PASS AudioBufferSourceNode loops backwards using entire buffer when loopStart > loopEnd
+FAIL AudioBufferSourceNode loops backwards using clamped loopStart when loopStart < 0 assert_array_equals: expected property 4 to be 2 but got 4 (expected array [4, 3, 2, 1, 2, 1, 2, 1] got object "4,3,2,1,4,3,2,1")
+PASS AudioBufferSourceNode loops backwards using entire buffer when loopEnd < 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>AudioBufferSourceNode: Negative PlaybackRate Edge Cases</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+  <script>
+    /**
+     * Helper to run a test on AudioBufferSourceNode.
+     * @param {number} renderFrames - Total frames to render in
+     *     OfflineAudioContext.
+     * @param {number} bufferFrames - Number of frames in the AudioBuffer.
+     * @param {Function} setupSource - Callback to configure:
+     *     (source, sampleRate) => void
+     * @param {Function} verifyResult - Callback to verify the output:
+     *     (renderedData) => void
+     * @param {Array|null} bufferData - Optional initial buffer data. If null,
+     *     populated with 1.0, 2.0, 3.0...
+     */
+    async function runSourceNodeTest(
+      renderFrames, bufferFrames, setupSource, verifyResult,
+      bufferData = null) {
+      const sampleRate = 44100;
+      const context = new OfflineAudioContext(1, renderFrames, sampleRate);
+      const buffer = new AudioBuffer({
+        numberOfChannels: 1,
+        length: bufferFrames,
+        sampleRate: sampleRate
+      });
+      const channelData = buffer.getChannelData(0);
+
+      if (bufferData) {
+        channelData.set(bufferData);
+      } else {
+        // Populate with distinct values to easily verify interpolation.
+        for (let i = 0; i < bufferFrames; i++) {
+          channelData[i] = i + 1.0;
+        }
+      }
+
+      const source = new AudioBufferSourceNode(context, { buffer });
+      source.connect(context.destination);
+
+      setupSource(source, sampleRate);
+
+      const renderedBuffer = await context.startRendering();
+      verifyResult(renderedBuffer.getChannelData(0));
+    }
+
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -1.0;
+          source.start(0, 3 / sampleRate);
+        },
+        (renderedData) => {
+          assert_equals(renderedData[0], 4.0, 'Frame 0 should be 4.0');
+          assert_equals(renderedData[1], 3.0, 'Frame 1 should be 3.0');
+          assert_equals(renderedData[2], 2.0, 'Frame 2 should be 2.0');
+          assert_equals(renderedData[3], 1.0, 'Frame 3 should be 1.0');
+        }
+      );
+    }, 'AudioBufferSourceNode supports negative playbackRate (-1.0)');
+
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -2.0;
+          source.start(0, 3 / sampleRate);
+        },
+        (renderedData) => {
+          assert_equals(renderedData[0], 4.0, 'Frame 0 should be 4.0');
+          assert_equals(renderedData[1], 2.0, 'Frame 1 should be 2.0');
+          assert_equals(renderedData[2], 0.0, 'Frame 2 should be silence');
+          assert_equals(renderedData[3], 0.0, 'Frame 3 should be silence');
+        }
+      );
+    }, 'AudioBufferSourceNode supports high negative playbackRate (-2.0)');
+
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 8,
+        (source, sampleRate) => {
+          source.playbackRate.value = -5.0;
+          source.start(0, 7 / sampleRate);
+        },
+        (renderedData) => {
+          assert_equals(renderedData[0], 8.0, 'Frame 0 should be 8.0');
+          assert_equals(renderedData[1], 3.0, 'Frame 1 should be 3.0');
+          assert_equals(renderedData[2], 0.0, 'Frame 2 should be silence');
+          assert_equals(renderedData[3], 0.0, 'Frame 3 should be silence');
+        }
+      );
+    }, 'AudioBufferSourceNode supports high negative playbackRate (-5.0)');
+
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 2,
+        (source, sampleRate) => {
+          source.playbackRate.value = -0.5;
+          source.start(0, 1 / sampleRate);
+        },
+        (renderedData) => {
+          assert_equals(renderedData[0], 2.0, 'Frame 0 should be 2.0');
+          assert_equals(renderedData[1], 1.5, 'Frame 1 should be 1.5');
+          assert_equals(renderedData[2], 1.0, 'Frame 2 should be 1.0');
+          assert_equals(renderedData[3], 0.0, 'Frame 3 should be silence');
+        }
+      );
+    }, 'AudioBufferSourceNode supports fractional negative playbackRate');
+
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -0.02;
+          source.start(0, 3 / sampleRate);
+        },
+        (renderedData) => {
+          assert_approx_equals(renderedData[0], 4.00, 1e-4, 'Frame 0');
+          assert_approx_equals(renderedData[1], 3.98, 1e-4, 'Frame 1');
+          assert_approx_equals(renderedData[2], 3.96, 1e-4, 'Frame 2');
+          assert_approx_equals(renderedData[3], 3.94, 1e-4, 'Frame 3');
+        }
+      );
+    }, 'AudioBufferSourceNode supports very low negative playbackRate (-0.02)');
+
+    // EDGE CASE: Offset post loopEnd
+    promise_test(async () => {
+      await runSourceNodeTest(
+        6, 8,
+        (source, sampleRate) => {
+          source.loop = true;
+          source.loopStart = 2 / sampleRate;
+          source.loopEnd = 4 / sampleRate;
+          source.playbackRate.value = -1.0;
+          source.start(0, 6 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [7.0, 6.0, 5.0, 4.0, 3.0, 4.0];
+          for (let i = 0; i < expected.length; i++) {
+            assert_equals(
+              renderedData[i], expected[i],
+              `Frame ${i} should be ${expected[i]}`);
+          }
+        }
+      );
+    }, 'AudioBufferSourceNode enters loop backwards from offset > loopEnd');
+
+    // EDGE CASE: offset < loopStart
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 8,
+        (source, sampleRate) => {
+          source.loop = true;
+          source.loopStart = 4 / sampleRate;
+          source.loopEnd = 6 / sampleRate;
+          source.playbackRate.value = -1.0;
+          source.start(0, 2 / sampleRate);
+        },
+        (renderedData) => {
+          // Spec clamps offset to loopStart when playbackRate < 0.
+          const expected = [5.0, 6.0, 5.0, 6.0];
+          for (let i = 0; i < expected.length; i++) {
+            assert_equals(
+              renderedData[i], expected[i],
+              `Frame ${i} should be ${expected[i]}`);
+          }
+        }
+      );
+    }, 'AudioBufferSourceNode clamps offset to loopStart for playbackRate < 0');
+
+    // EDGE CASE: offset in loop
+    promise_test(async () => {
+      await runSourceNodeTest(
+        8, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -1.0;
+          source.loop = true;
+          source.loopStart = 1 / sampleRate;
+          source.loopEnd = 3 / sampleRate;
+          source.start(0, 2 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [3.0, 2.0, 3.0, 2.0, 3.0, 2.0, 3.0, 2.0];
+          for (let i = 0; i < expected.length; i++) {
+            assert_equals(
+              renderedData[i], expected[i],
+              `Frame ${i} should be ${expected[i]}`);
+          }
+        }
+      );
+    }, 'AudioBufferSourceNode loops backwards with negative rate ' +
+    '(offset in loop)');
+
+    // EDGE CASE: offset = buffer.duration
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -1.0;
+          source.start(0, 4 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [0.0, 4.0, 3.0, 2.0];
+          for (let i = 0; i < expected.length; i++) {
+            assert_equals(
+              renderedData[i], expected[i],
+              `Frame ${i} should be ${expected[i]}`);
+          }
+        }
+      );
+    }, 'AudioBufferSourceNode handles offset exactly at duration with ' +
+    'negative rate');
+
+    // EDGE CASE: offset > buffer.duration (out-of-bounds offset clamped)
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -1.0;
+          source.start(0, 10 / sampleRate);
+        },
+        (renderedData) => {
+          assert_equals(renderedData[0], 0.0, 'Frame 0 should be silence');
+          assert_equals(renderedData[1], 4.0, 'Frame 1 should be 4.0');
+          assert_equals(renderedData[2], 3.0, 'Frame 2 should be 3.0');
+          assert_equals(renderedData[3], 2.0, 'Frame 3 should be 2.0');
+        }
+      );
+    }, 'AudioBufferSourceNode handles out-of-bounds start offset correctly');
+
+    // Sub-sample interpolation backwards
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.playbackRate.value = -1.0;
+          source.start(0, 2.5 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [3.5, 2.5, 1.5, 0.0];
+          for (let i = 0; i < expected.length; i++) {
+            assert_approx_equals(
+              renderedData[i], expected[i], 1e-4,
+              `Frame ${i} should be approx ${expected[i]}`);
+          }
+        }
+      );
+    }, 'AudioBufferSourceNode performs sub-sample interpolation backwards');
+
+    promise_test(async () => {
+      await runSourceNodeTest(
+        4, 4,
+        (source, sampleRate) => {
+          source.loop = true;
+          source.loopStart = 2 / sampleRate;
+          source.loopEnd = 2 / sampleRate;
+          source.playbackRate.value = 0;
+          source.start(0, 2 / sampleRate);
+        },
+        (renderedData) => {
+          assert_true(true, 'Test ran successfully!');
+        }
+      );
+    }, 'AudioBufferSourceNode ran successfully with zero delta and ' +
+    'playbackRate 0');
+
+    // Negative playback rate with constraint violation:
+    // loopStart > loopEnd (expects fallback)
+    promise_test(async () => {
+      await runSourceNodeTest(
+        8, 4,
+        (source, sampleRate) => {
+          source.loop = true;
+          source.loopStart = 3 / sampleRate;
+          source.loopEnd = 1 / sampleRate;
+          source.playbackRate.value = -1.0;
+          source.start(0, 3 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [4.0, 3.0, 2.0, 1.0, 4.0, 3.0, 2.0, 1.0];
+          assert_array_equals(renderedData, expected);
+        }
+      );
+    }, 'AudioBufferSourceNode loops backwards using entire buffer when ' +
+       'loopStart > loopEnd');
+
+    // Negative playback rate with constraint violation:
+    // loopStart < 0 (expects clamping)
+    promise_test(async () => {
+      await runSourceNodeTest(
+        8, 4,
+        (source, sampleRate) => {
+          source.loop = true;
+          source.loopStart = -1 / sampleRate;
+          source.loopEnd = 2 / sampleRate;
+          source.playbackRate.value = -1.0;
+          source.start(0, 3 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [4.0, 3.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0];
+          assert_array_equals(renderedData, expected);
+        }
+      );
+    }, 'AudioBufferSourceNode loops backwards using clamped loopStart when ' +
+       'loopStart < 0');
+
+    // Negative playback rate with constraint violation:
+    // loopEnd < 0 (expects fallback)
+    promise_test(async () => {
+      await runSourceNodeTest(
+        8, 4,
+        (source, sampleRate) => {
+          source.loop = true;
+          source.loopStart = 1 / sampleRate;
+          source.loopEnd = -2 / sampleRate;
+          source.playbackRate.value = -1.0;
+          source.start(0, 3 / sampleRate);
+        },
+        (renderedData) => {
+          const expected = [4.0, 3.0, 2.0, 1.0, 4.0, 3.0, 2.0, 1.0];
+          assert_array_equals(renderedData, expected);
+        }
+      );
+    }, 'AudioBufferSourceNode loops backwards using entire buffer when ' +
+       'loopEnd < 0');
+
+  </script>
+</body>
+
+</html>

--- a/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated-loop.html
+++ b/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated-loop.html
@@ -20,7 +20,9 @@
         description:"Test looping playback at -0.75 playbackRate",
         offsetFrame:0,
         renderFrames:renderFrames,
-        expected:[104,103.25,102.5,101.75,101,100.25,102,103.75,103,102.25],
+        // Playback starts at the requested offset (loopStart), then wraps around to loopEnd,
+        // interpolating across the loop seam between loopEnd - 1 and loopStart.
+        expected:[100,103,103.5,102.75,102,101.25,100.5,101,104,103.25],
     }];
 
     function go() {

--- a/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated.html
+++ b/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated.html
@@ -30,7 +30,9 @@
 
         bufferSource.connect(context.destination);
         bufferSource.playbackRate.value = -0.75;
-        bufferSource.start(0);
+        // Start at the last sample so the whole buffer is played in reverse, since playback now
+        // starts at the requested offset rather than at the end of the buffer.
+        bufferSource.start(0, (sourceFrames - 1) / sampleRate);
 
         context.oncomplete = checkAllTests;
         context.startRendering();

--- a/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-loop.html
+++ b/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-loop.html
@@ -20,7 +20,8 @@
         description:"Test looping playback at -1 playbackRate",
         offsetFrame:0,
         renderFrames:renderFrames,
-        expected:[104, 103, 102, 101, 100, 104, 103, 102, 101, 100],
+        // Playback starts at the requested offset (loopStart), then wraps around to loopEnd.
+        expected:[100, 104, 103, 102, 101, 100, 104, 103, 102, 101],
     }];
 
     function go() {

--- a/LayoutTests/webaudio/audiobuffersource-negative-playbackrate.html
+++ b/LayoutTests/webaudio/audiobuffersource-negative-playbackrate.html
@@ -30,7 +30,9 @@
 
         bufferSource.connect(context.destination);
         bufferSource.playbackRate.value = -1;
-        bufferSource.start(0);
+        // Start at the last sample so the whole buffer is played in reverse, since playback now
+        // starts at the requested offset rather than at the end of the buffer.
+        bufferSource.start(0, (sourceFrames - 1) / sampleRate);
 
         context.oncomplete = checkAllTests;
         context.startRendering();

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -618,10 +618,9 @@ void AudioBufferSourceNode::adjustGrainParameters()
     // at a sub-sample position since it will degrade the quality.
     // When aligned to the sample-frame the playback will be identical to the PCM data stored in the buffer.
     // Since playbackRate == 1 is very common, it's worth considering quality.
-    if (playbackRate().value() < 0)
-        m_virtualReadIndex = AudioUtilities::timeToSampleFrame(m_grainOffset + m_grainDuration, m_buffer->sampleRate()) - 1;
-    else
-        m_virtualReadIndex = AudioUtilities::timeToSampleFrame(m_grainOffset, m_buffer->sampleRate());
+    // Playback starts at the requested offset regardless of the sign of the playback rate; for a
+    // negative rate we then play backwards from there.
+    m_virtualReadIndex = AudioUtilities::timeToSampleFrame(m_grainOffset, m_buffer->sampleRate());
 }
 
 double AudioBufferSourceNode::totalPitchRate()


### PR DESCRIPTION
#### b1cf6a3d1775e05a2544a94fd8a1398e43446c36
<pre>
AudioBufferSourceNode ignores the start() offset for a negative playbackRate
<a href="https://bugs.webkit.org/show_bug.cgi?id=320870">https://bugs.webkit.org/show_bug.cgi?id=320870</a>

Reviewed by NOBODY (OOPS!).

When playing an AudioBufferSourceNode backwards (negative playbackRate), the read
index was initialized to the last frame of the buffer (grainOffset +
grainDuration - 1) rather than to the requested start offset. Since grainDuration
defaults to (bufferDuration - grainOffset), that sum always collapses to the
buffer duration, so the offset passed to start() was effectively discarded for
negative rates.

Starting at the offset is what the normative playback algorithm requires. It
adjusts the offset for a negative rate only when the offset falls before the loop
start, and otherwise uses it verbatim:
<a href="https://webaudio.github.io/web-audio-api/#playback-AudioBufferSourceNode">https://webaudio.github.io/web-audio-api/#playback-AudioBufferSourceNode</a>

    if (computedPlaybackRate &lt; 0 &amp;&amp; loop &amp;&amp; offset &lt; actualLoopStart) {
        offset = actualLoopStart;
    }
    bufferTime = offset;

The Looping section says the same in prose, though that section is non-normative:
&quot;Looping does not affect the interpretation of the offset argument of start().
Playback always starts at the requested offset, and looping only begins once the
body of the loop is encountered during playback.&quot;
<a href="https://webaudio.github.io/web-audio-api/#looping-AudioBufferSourceNode">https://webaudio.github.io/web-audio-api/#looping-AudioBufferSourceNode</a>

Drop the negative-rate special case so the read index is the requested offset
regardless of the sign of the playback rate. This also matches Chrome, whose
AudioBufferSourceHandler has no such special case.

Note that the prose describing the offset argument of start() contradicts the
algorithm: &quot;If offset is greater than loopStart, playbackRate is negative, and
loop is true, playback will begin at loopStart&quot;. Read literally that would
preserve the behavior this patch removes. It appears to be a typo for &quot;less
than&quot;, mirroring the positive-rate sentence preceding it, since the normative
algorithm, Chrome and Firefox all clamp only when the offset falls before
loopStart:
<a href="https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-start">https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-start</a>

This fixes the &quot;loops backwards with negative rate (offset in loop)&quot; subtest,
which passes in both Chrome and Firefox but failed in WebKit. With loopStart at
frame 1, loopEnd at frame 3 and an offset of frame 2, no clamping applies because
the offset is not before loopStart, so playback should start at frame 2. Instead
the read index became frame 3, which is &gt;= virtualMaxFrame and was therefore
reset to loopStart, producing [2,3,2,3,...] instead of [3,2,3,2,...].

The remaining subtests of the imported WPT test still fail and are recorded as
such in the expected file. They require further changes to the reverse render
path that are out of scope here.

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt: Added.
Import the WPT test from upstream. 10 of its 15 subtests now pass, up from 9.

* LayoutTests/webaudio/audiobuffersource-negative-playbackrate.html:
* LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated.html:
These called start(0) and relied on playback beginning at the end of the buffer.
Pass the last frame as the offset so the whole buffer is still played in reverse;
their expected output is unchanged.

* LayoutTests/webaudio/audiobuffersource-negative-playbackrate-loop.html:
* LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated-loop.html:
Update the expected output. Playback now starts at the requested offset, which is
loopStart in both tests, and wraps around to loopEnd, shifting the output by one
frame.

* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::adjustGrainParameters):
Start the read index at the requested offset for a negative playback rate.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1cf6a3d1775e05a2544a94fd8a1398e43446c36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46317 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/188200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52232 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/188200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181541 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/42795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/188200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/188200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/36655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45122 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190627 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52191 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/159505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52872 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/148169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/42869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125139 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119781 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51390 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/14456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50775 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50837 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->