### PR TITLE
[JSC] Compute builtin executable metadata in python script

### DIFF
--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Combined.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Combined.js-result
@@ -154,6 +154,12 @@ constinit const char* const s_builtinPromiseRejectPromiseCode =
 s_JSCCombinedCode + 336
 ;
 
+constinit const JSC::BuiltinSourceMetadata s_JSCBuiltinSourceMetadata[JSC::numberOfBuiltinCodes] = {
+    /* builtinPromiseFulfillPromiseCode */ { 336, 10, 2, 12, 0, 335, 333, 3, false, true },
+    /* builtinPromiseRejectPromiseCode */ { 337, 10, 2, 12, 0, 336, 334, 3, false, true },
+};
+static_assert(2 == JSC::numberOfBuiltinCodes);
+
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Combined.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Combined.js-result
@@ -192,6 +192,14 @@ constinit const char* const s_builtinPrototypeTestCode =
 s_JSCCombinedCode + 2694
 ;
 
+constinit const JSC::BuiltinSourceMetadata s_JSCBuiltinSourceMetadata[JSC::numberOfBuiltinCodes] = {
+    /* builtinPrototypeEveryCode */ { 762, 10, 1, 27, 0, 761, 759, 3, false, true },
+    /* builtinPrototypeForEachCode */ { 694, 10, 1, 23, 0, 693, 691, 3, false, true },
+    /* builtinPrototypeMatchCode */ { 1238, 10, 1, 50, 0, 1237, 1235, 3, false, true },
+    /* builtinPrototypeTestCode */ { 504, 10, 1, 26, 0, 503, 501, 3, false, true },
+};
+static_assert(4 == JSC::numberOfBuiltinCodes);
+
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Combined.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Combined.js-result
@@ -152,6 +152,12 @@ constinit const char* const s_builtinConstructorOfCode =
 s_JSCCombinedCode + 2046
 ;
 
+constinit const JSC::BuiltinSourceMetadata s_JSCBuiltinSourceMetadata[JSC::numberOfBuiltinCodes] = {
+    /* builtinConstructorFromCode */ { 2046, 10, 1, 72, 0, 2045, 2043, 3, false, true },
+    /* builtinConstructorOfCode */ { 294, 10, 0, 12, 0, 293, 291, 3, false, true },
+};
+static_assert(2 == JSC::numberOfBuiltinCodes);
+
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-InternalClashingNames-Combined.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-InternalClashingNames-Combined.js-result
@@ -153,6 +153,12 @@ constinit const char* const s_internalClashingNamesIsReadableStreamLockedCode =
 s_JSCCombinedCode + 71
 ;
 
+constinit const JSC::BuiltinSourceMetadata s_JSCBuiltinSourceMetadata[JSC::numberOfBuiltinCodes] = {
+    /* internalClashingNamesIsReadableStreamLockedCode */ { 71, 10, 1, 6, 0, 70, 68, 3, false, true },
+    /* internalClashingNamesIsReadableStreamLockedCode */ { 71, 10, 1, 6, 0, 70, 68, 3, false, true },
+};
+static_assert(2 == JSC::numberOfBuiltinCodes);
+
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_combined_implementation.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_combined_implementation.py
@@ -31,6 +31,7 @@ import string
 from string import Template
 
 from builtins_generator import BuiltinsGenerator
+from builtins_generator import compute_builtin_source_metadata
 from builtins_model import Framework, Frameworks
 from builtins_templates import BuiltinsGeneratorTemplates as Templates
 
@@ -78,12 +79,25 @@ class BuiltinsCombinedImplementationGenerator(BuiltinsGenerator):
             sections.append(self.generate_embedded_code_string_section_for_data(data))
 
         if self.model().framework is Frameworks.JavaScriptCore:
+            sections.append(self.generate_source_metadata_table(function_data))
             sections.append(Template(Templates.CombinedJSCImplementationStaticMacros).substitute(args))
         elif self.model().framework is Frameworks.WebCore:
             sections.append(Template(Templates.CombinedWebCoreImplementationStaticMacros).substitute(args))
         sections.append(Template(Templates.NamespaceBottom).substitute(args))
 
         return "\n\n".join(sections)
+
+    # Indexed by BuiltinCodeIndex. This table and the generated JSC_FOREACH_BUILTIN_CODE that the enum is
+    # built from both iterate model().all_functions(), so the two orders agree by construction.
+    def generate_source_metadata_table(self, function_data):
+        lines = []
+        lines.append("constinit const JSC::BuiltinSourceMetadata s_JSCBuiltinSourceMetadata[JSC::numberOfBuiltinCodes] = {")
+        for data in function_data:
+            entry = dict(compute_builtin_source_metadata(data['originalSource']), codeName=data['codeName'])
+            lines.append("    /* %(codeName)s */ { %(sourceLength)d, %(parametersStart)d, %(parameterCount)d, %(lineCount)d, %(endColumn)d, %(offsetOfLastNewline)d, %(positionBeforeLastNewlineLineStartOffset)d, %(closeBraceOffsetFromEnd)d, %(isAsyncFunction)s, %(isInStrictContext)s }," % entry)
+        lines.append("};")
+        lines.append("static_assert(%d == JSC::numberOfBuiltinCodes);" % len(function_data))
+        return '\n'.join(lines)
 
     def generate_secondary_header_includes(self):
         header_includes = [

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
@@ -53,6 +53,107 @@ def WK_ucfirst(str):
     str = str.replace('Svg', 'SVG')
     return str
 
+
+# Matches Lexer<Latin1Character>::isWhiteSpace, which excludes line terminators.
+def is_js_white_space(ch):
+    return ch in (' ', '\t', '\v', '\f', '\xa0')
+
+
+# Transliterated from computeBuiltinSourceMetadata, which still scans at runtime
+# for sources that have no generated entry. Change one and you must change the
+# other; keeping the two statement-for-statement alike is what makes them agree.
+def compute_builtin_source_metadata(characters):
+    regular_function_begin = "(function ("
+    async_function_begin = "(async function ("
+    assert len(characters) >= len("(function (){})")
+    is_async_function = len(characters) >= len("(async function (){})") and characters.startswith(async_function_begin)
+    assert is_async_function or characters.startswith(regular_function_begin)
+
+    async_offset = len("async ") if is_async_function else 0
+    parameters_start = len("function (") + async_offset
+    is_in_strict_context = False
+
+    i = parameters_start + 1
+    commas = 0
+    inside_curly_brackets = False
+    saw_one_param = False
+    has_rest_param = False
+    while True:
+        assert i < len(characters)
+        if characters[i] == ')':
+            break
+
+        if characters[i] == '}':
+            inside_curly_brackets = False
+        elif characters[i] == '{' or inside_curly_brackets:
+            inside_curly_brackets = True
+            i += 1
+            continue
+        elif characters[i] == ',':
+            commas += 1
+        elif not is_js_white_space(characters[i]):
+            saw_one_param = True
+
+        if i + 2 < len(characters) and characters[i:i + 3] == '...':
+            has_rest_param = True
+            i += 2
+
+        i += 1
+
+    if commas:
+        parameter_count = commas + 1
+    elif saw_one_param:
+        parameter_count = 1
+    else:
+        parameter_count = 0
+
+    if has_rest_param:
+        assert parameter_count
+        parameter_count -= 1
+
+    line_count = 0
+    end_column = 0
+    offset_of_last_newline = 0
+    offset_of_second_to_last_newline = None
+    use_strict = "use strict"
+    i = 0
+    while i < len(characters):
+        if characters[i] == '\n':
+            if line_count:
+                offset_of_second_to_last_newline = offset_of_last_newline
+            line_count += 1
+            end_column = 0
+            offset_of_last_newline = i
+        else:
+            end_column += 1
+
+        if not is_in_strict_context and characters[i] in ('"', '\''):
+            if i + 1 + len(use_strict) < len(characters) and characters.startswith(use_strict, i + 1):
+                is_in_strict_context = True
+                i += 1 + len(use_strict)
+
+        i += 1
+
+    position_before_last_newline_line_start_offset = offset_of_second_to_last_newline + 1 if offset_of_second_to_last_newline is not None else 0
+
+    close_brace_offset_from_end = 1
+    while characters[len(characters) - close_brace_offset_from_end] != '}':
+        close_brace_offset_from_end += 1
+
+    return {
+        'sourceLength': len(characters),
+        'parametersStart': parameters_start,
+        'parameterCount': parameter_count,
+        'lineCount': line_count,
+        'endColumn': end_column,
+        'offsetOfLastNewline': offset_of_last_newline,
+        'positionBeforeLastNewlineLineStartOffset': position_before_last_newline_line_start_offset,
+        'closeBraceOffsetFromEnd': close_brace_offset_from_end,
+        'isAsyncFunction': 'true' if is_async_function else 'false',
+        'isInStrictContext': 'true' if is_in_strict_context else 'false',
+    }
+
+
 class BuiltinsGenerator:
     def __init__(self, model):
         self._model = model

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -79,34 +79,26 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createDefaultConstructor(Constru
     return nullptr;
 }
 
-UnlinkedFunctionExecutable* BuiltinExecutables::createBuiltinExecutable(const SourceCode& code, const Identifier& name, ImplementationVisibility implementationVisibility, ConstructorKind constructorKind, ConstructAbility constructAbility, InlineAttribute inlineAttribute)
+UnlinkedFunctionExecutable* BuiltinExecutables::createBuiltinExecutable(const SourceCode& code, const BuiltinSourceMetadata& metadata, const Identifier& name, ImplementationVisibility implementationVisibility, ConstructorKind constructorKind, ConstructAbility constructAbility, InlineAttribute inlineAttribute)
 {
-    return createExecutable(m_vm, code, name, implementationVisibility, constructorKind, constructAbility, inlineAttribute, NeedsClassFieldInitializer::No);
+    return createExecutable(m_vm, code, metadata, name, implementationVisibility, constructorKind, constructAbility, inlineAttribute, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
 }
 
-UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const SourceCode& source, const Identifier& name, ImplementationVisibility implementationVisibility, ConstructorKind constructorKind, ConstructAbility constructAbility, InlineAttribute inlineAttribute, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement)
+// FIXME: Can we just make MetaData computation be constexpr and have the compiler do this for us?
+// https://bugs.webkit.org/show_bug.cgi?id=193272
+// Scanning by hand rather than parsing keeps us from recursing into the parser, and hence from
+// overflowing the stack on a builtin.
+static BuiltinSourceMetadata computeBuiltinSourceMetadata(std::span<const Latin1Character> characters)
 {
-    // FIXME: Can we just make MetaData computation be constexpr and have the compiler do this for us?
-    // https://bugs.webkit.org/show_bug.cgi?id=193272
-    // Someone should get mad at me for writing this code. But, it prevents us from recursing into
-    // the parser, and hence, from throwing stack overflow when parsing a builtin.
-    StringView view = source.view();
-    RELEASE_ASSERT(!view.isNull());
-    RELEASE_ASSERT(view.is8Bit());
-    auto characters = view.span8();
     auto regularFunctionBegin = "(function ("_span;
     auto asyncFunctionBegin = "(async function ("_span;
-    RELEASE_ASSERT(view.length() >= strlen("(function (){})"));
-    bool isAsyncFunction = view.length() >= strlen("(async function (){})") && spanHasPrefix(characters, asyncFunctionBegin);
+    RELEASE_ASSERT(characters.size() >= strlen("(function (){})"));
+    bool isAsyncFunction = characters.size() >= strlen("(async function (){})") && spanHasPrefix(characters, asyncFunctionBegin);
     RELEASE_ASSERT(isAsyncFunction || spanHasPrefix(characters, regularFunctionBegin));
 
     unsigned asyncOffset = isAsyncFunction ? strlen("async ") : 0;
     unsigned parametersStart = strlen("function (") + asyncOffset;
-    unsigned startColumn = parametersStart;
-    int functionKeywordStart = strlen("(");
-    int functionNameStart = parametersStart;
     bool isInStrictContext = false;
-    bool isArrowFunctionBodyExpression = false;
 
     unsigned parameterCount;
     {
@@ -116,7 +108,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
         bool sawOneParam = false;
         bool hasRestParam = false;
         while (true) {
-            ASSERT(i < view.length());
+            ASSERT(i < characters.size());
             if (characters[i] == ')')
                 break;
 
@@ -131,7 +123,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
             else if (!Lexer<Latin1Character>::isWhiteSpace(characters[i]))
                 sawOneParam = true;
 
-            if (i + 2 < view.length() && characters[i] == '.' && characters[i + 1] == '.' && characters[i + 2] == '.') {
+            if (i + 2 < characters.size() && characters[i] == '.' && characters[i + 1] == '.' && characters[i + 2] == '.') {
                 hasRestParam = true;
                 i += 2;
             }
@@ -156,7 +148,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
     unsigned endColumn = 0;
     unsigned offsetOfLastNewline = 0;
     std::optional<unsigned> offsetOfSecondToLastNewline;
-    for (unsigned i = 0; i < view.length(); ++i) {
+    for (unsigned i = 0; i < characters.size(); ++i) {
         if (characters[i] == '\n') {
             if (lineCount)
                 offsetOfSecondToLastNewline = offsetOfLastNewline;
@@ -168,7 +160,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
 
         if (!isInStrictContext && (characters[i] == '"' || characters[i] == '\'')) {
             const auto useStrict = "use strict"_span;
-            if (i + 1 + useStrict.size() < view.length()) {
+            if (i + 1 + useStrict.size() < characters.size()) {
                 if (spanHasPrefix(characters.subspan(i + 1), useStrict)) {
                     isInStrictContext = true;
                     i += 1 + useStrict.size();
@@ -181,21 +173,54 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
 
     int closeBraceOffsetFromEnd = 1;
     while (true) {
-        if (characters[view.length() - closeBraceOffsetFromEnd] == '}')
+        if (characters[characters.size() - closeBraceOffsetFromEnd] == '}')
             break;
         ++closeBraceOffsetFromEnd;
     }
 
-    JSTextPosition positionBeforeLastNewline;
-    positionBeforeLastNewline.line = lineCount;
-    positionBeforeLastNewline.offset = source.startOffset() + offsetOfLastNewline;
-    positionBeforeLastNewline.lineStartOffset = source.startOffset() + positionBeforeLastNewlineLineStartOffset;
+    BuiltinSourceMetadata result;
+    result.sourceLength = characters.size();
+    result.parametersStart = parametersStart;
+    result.parameterCount = parameterCount;
+    result.lineCount = lineCount;
+    result.endColumn = endColumn;
+    result.offsetOfLastNewline = offsetOfLastNewline;
+    result.positionBeforeLastNewlineLineStartOffset = positionBeforeLastNewlineLineStartOffset;
+    result.closeBraceOffsetFromEnd = closeBraceOffsetFromEnd;
+    result.isAsyncFunction = isAsyncFunction;
+    result.isInStrictContext = isInStrictContext;
+    return result;
+}
 
-    SourceCode newSource = source.subExpression(source.startOffset() + parametersStart, source.startOffset() + (view.length() - closeBraceOffsetFromEnd), 0, parametersStart);
+UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const SourceCode& source, const Identifier& name, ImplementationVisibility implementationVisibility, ConstructorKind constructorKind, ConstructAbility constructAbility, InlineAttribute inlineAttribute, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement)
+{
+    StringView view = source.view();
+    RELEASE_ASSERT(!view.isNull());
+    RELEASE_ASSERT(view.is8Bit());
+    return createExecutable(vm, source, computeBuiltinSourceMetadata(view.span8()), name, implementationVisibility, constructorKind, constructAbility, inlineAttribute, needsClassFieldInitializer, privateBrandRequirement);
+}
+
+UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const SourceCode& source, const BuiltinSourceMetadata& scanned, const Identifier& name, ImplementationVisibility implementationVisibility, ConstructorKind constructorKind, ConstructAbility constructAbility, InlineAttribute inlineAttribute, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement)
+{
+    StringView view = source.view();
+    RELEASE_ASSERT(scanned.sourceLength == view.length());
+
+    unsigned parametersStart = scanned.parametersStart;
+    unsigned startColumn = parametersStart;
+    int functionKeywordStart = strlen("(");
+    int functionNameStart = parametersStart;
+    bool isArrowFunctionBodyExpression = false;
+
+    JSTextPosition positionBeforeLastNewline;
+    positionBeforeLastNewline.line = scanned.lineCount;
+    positionBeforeLastNewline.offset = source.startOffset() + scanned.offsetOfLastNewline;
+    positionBeforeLastNewline.lineStartOffset = source.startOffset() + scanned.positionBeforeLastNewlineLineStartOffset;
+
+    SourceCode newSource = source.subExpression(source.startOffset() + parametersStart, source.startOffset() + (view.length() - scanned.closeBraceOffsetFromEnd), 0, parametersStart);
     bool isBuiltinDefaultClassConstructor = constructorKind != ConstructorKind::None && constructorKind != ConstructorKind::Naked;
     UnlinkedFunctionKind kind = isBuiltinDefaultClassConstructor ? UnlinkedNormalFunction : UnlinkedBuiltinFunction;
 
-    SourceParseMode parseMode = isAsyncFunction ? SourceParseMode::AsyncFunctionMode : SourceParseMode::NormalFunctionMode;
+    SourceParseMode parseMode = scanned.isAsyncFunction ? SourceParseMode::AsyncFunctionMode : SourceParseMode::NormalFunctionMode;
 
     JSTokenLocation start;
     start.line = -1;
@@ -210,9 +235,9 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
     end.endOffset = std::numeric_limits<unsigned>::max();
 
     FunctionMetadataNode metadata(
-        start, end, startColumn, endColumn, source.startOffset() + functionKeywordStart, source.startOffset() + functionNameStart, source.startOffset() + parametersStart, implementationVisibility,
-        isInStrictContext ? StrictModeLexicallyScopedFeature : NoLexicallyScopedFeatures, constructorKind, constructorKind == ConstructorKind::Extends ? SuperBinding::Needed : SuperBinding::NotNeeded,
-        parameterCount, parseMode, isArrowFunctionBodyExpression);
+        start, end, startColumn, scanned.endColumn, source.startOffset() + functionKeywordStart, source.startOffset() + functionNameStart, source.startOffset() + parametersStart, implementationVisibility,
+        scanned.isInStrictContext ? StrictModeLexicallyScopedFeature : NoLexicallyScopedFeatures, constructorKind, constructorKind == ConstructorKind::Extends ? SuperBinding::Needed : SuperBinding::NotNeeded,
+        scanned.parameterCount, parseMode, isArrowFunctionBodyExpression);
 
     metadata.finishParsing(newSource, Identifier(), FunctionMode::FunctionExpression);
     metadata.overrideName(name);
@@ -297,7 +322,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::name##Executable() \
         Identifier executableName = m_vm.propertyNames->builtinNames().functionName##PublicName();\
         if (overrideName)\
             executableName = Identifier::fromString(m_vm, overrideName);\
-        m_unlinkedExecutables[index] = createBuiltinExecutable(name##Source(), executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility, s_##name##InlineAttribute);\
+        m_unlinkedExecutables[index] = createBuiltinExecutable(name##Source(), s_JSCBuiltinSourceMetadata[index], executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility, s_##name##InlineAttribute);\
     }\
     return m_unlinkedExecutables[index];\
 }

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.h
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.h
@@ -42,9 +42,30 @@ class VM;
 #define BUILTIN_NAME_ONLY(name, functionName, overriddenName, length) name,
 enum class BuiltinCodeIndex {
     JSC_FOREACH_BUILTIN_CODE(BUILTIN_NAME_ONLY)
-    NumberOfBuiltinCodes
 };
 #undef BUILTIN_NAME_ONLY
+
+#define COUNT_BUILTIN_CODE(name, functionName, overriddenName, length) + 1
+static constexpr unsigned numberOfBuiltinCodes = 0 JSC_FOREACH_BUILTIN_CODE(COUNT_BUILTIN_CODE);
+#undef COUNT_BUILTIN_CODE
+
+// Every field is a function of the source characters alone, which is what lets the builtins generator
+// compute these at build time.
+struct BuiltinSourceMetadata {
+    unsigned sourceLength { 0 };
+    unsigned parametersStart { 0 };
+    unsigned parameterCount { 0 };
+    unsigned lineCount { 0 };
+    unsigned endColumn { 0 };
+    unsigned offsetOfLastNewline { 0 };
+    unsigned positionBeforeLastNewlineLineStartOffset { 0 };
+    int closeBraceOffsetFromEnd { 0 };
+    bool isAsyncFunction { false };
+    bool isInStrictContext { false };
+};
+
+// Emitted by the builtins generator, indexed by BuiltinCodeIndex.
+extern constinit const BuiltinSourceMetadata s_JSCBuiltinSourceMetadata[numberOfBuiltinCodes];
 
 class BuiltinExecutables {
     WTF_MAKE_TZONE_ALLOCATED(BuiltinExecutables);
@@ -70,10 +91,12 @@ SourceCode name##Source();
 private:
     VM& m_vm;
 
-    UnlinkedFunctionExecutable* createBuiltinExecutable(const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, InlineAttribute);
+    static UnlinkedFunctionExecutable* createExecutable(VM&, const SourceCode&, const BuiltinSourceMetadata&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, InlineAttribute, NeedsClassFieldInitializer, PrivateBrandRequirement);
+
+    UnlinkedFunctionExecutable* createBuiltinExecutable(const SourceCode&, const BuiltinSourceMetadata&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, InlineAttribute);
 
     const Ref<StringSourceProvider> m_combinedSourceProvider;
-    UnlinkedFunctionExecutable* m_unlinkedExecutables[static_cast<unsigned>(BuiltinCodeIndex::NumberOfBuiltinCodes)] { };
+    UnlinkedFunctionExecutable* m_unlinkedExecutables[numberOfBuiltinCodes] { };
 };
 
 }


### PR DESCRIPTION
#### 81d660ceeb2ee5a2245dfebb8d264c445ee2c05e
<pre>
[JSC] Compute builtin executable metadata in python script
<a href="https://bugs.webkit.org/show_bug.cgi?id=320968">https://bugs.webkit.org/show_bug.cgi?id=320968</a>
<a href="https://rdar.apple.com/183997090">rdar://183997090</a>

Reviewed by Yijia Huang.

This patch computes metadata information in python script when parsing
builtin JS code so that we do not need to compute them at runtime (VM
launch timing). Currently we are only applying this to JSC&apos;s JS builtin,
and planning to expand this to WebCore JS builtins too next.

* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Combined.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Combined.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Combined.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-InternalClashingNames-Combined.js-result:
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_combined_implementation.py:
(BuiltinsCombinedImplementationGenerator.generate_output):
(BuiltinsCombinedImplementationGenerator):
(BuiltinsCombinedImplementationGenerator.generate_source_metadata_table):
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py:
(WK_ucfirst):
(is_js_white_space):
(compute_builtin_source_metadata):
* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::createBuiltinExecutable):
(JSC::computeBuiltinSourceMetadata):
(JSC::BuiltinExecutables::createExecutable):
* Source/JavaScriptCore/builtins/BuiltinExecutables.h:
(JSC::BuiltinExecutables::static_cast&lt;unsigned&gt;): Deleted.

Canonical link: <a href="https://commits.webkit.org/318564@main">https://commits.webkit.org/318564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05afb0934682ddb883684ce14b9fd2df37e997ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141835 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64172c8f-61c5-4669-a852-73fd6f4b23b5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52233 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139234 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62353d1f-1123-4d95-87a7-5581451e051e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119688 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea9dfb0c-27f6-4711-a505-5ec0ffc44c2d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41460 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39813 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1657 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8474 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39485 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39858 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45123 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44055 "Found 1 new test failure: webrtc/datachannel/gather-candidates-networkprocess-crash.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190628 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52192 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148403 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52873 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36108 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148170 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27099 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42872 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125140 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119782 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51391 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14460 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50776 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51016 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50838 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->