### PR TITLE
[CoordinatedGraphics] Move CoordinatedAnimatedBackingStoreClient ownership to CoordinatedBackingStoreProxy

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.cpp
@@ -37,14 +37,9 @@
 
 namespace WebCore {
 
-Ref<CoordinatedAnimatedBackingStoreClient> CoordinatedAnimatedBackingStoreClient::create(GraphicsLayer& layer)
+Ref<CoordinatedAnimatedBackingStoreClient> CoordinatedAnimatedBackingStoreClient::create()
 {
-    return adoptRef(*new CoordinatedAnimatedBackingStoreClient(layer));
-}
-
-CoordinatedAnimatedBackingStoreClient::CoordinatedAnimatedBackingStoreClient(GraphicsLayer& layer)
-    : m_layer(&layer)
-{
+    return adoptRef(*new CoordinatedAnimatedBackingStoreClient());
 }
 
 void CoordinatedAnimatedBackingStoreClient::invalidate()
@@ -53,9 +48,11 @@ void CoordinatedAnimatedBackingStoreClient::invalidate()
     m_layer = nullptr;
 }
 
-void CoordinatedAnimatedBackingStoreClient::update(const FloatRect& visibleRect, const FloatRect& coverRect, const FloatSize& size, float contentsScale)
+void CoordinatedAnimatedBackingStoreClient::update(GraphicsLayer* layer, const FloatRect& visibleRect, const FloatRect& coverRect, const FloatSize& size, float contentsScale)
 {
     ASSERT(isMainThread());
+    ASSERT(layer);
+    m_layer = layer;
     m_visibleRect = visibleRect;
     m_coverRect = coverRect;
     m_size = size;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h
@@ -38,15 +38,15 @@ class TransformationMatrix;
 
 class CoordinatedAnimatedBackingStoreClient final : public ThreadSafeRefCounted<CoordinatedAnimatedBackingStoreClient> {
 public:
-    static Ref<CoordinatedAnimatedBackingStoreClient> create(GraphicsLayer&);
+    static Ref<CoordinatedAnimatedBackingStoreClient> create();
     ~CoordinatedAnimatedBackingStoreClient() = default;
 
     void invalidate();
-    void update(const FloatRect& visibleRect, const FloatRect& coverRect, const FloatSize&, float contentsScale);
+    void update(GraphicsLayer*, const FloatRect& visibleRect, const FloatRect& coverRect, const FloatSize&, float contentsScale);
     void requestBackingStoreUpdateIfNeeded(const TransformationMatrix&);
 
 private:
-    explicit CoordinatedAnimatedBackingStoreClient(GraphicsLayer&);
+    CoordinatedAnimatedBackingStoreClient() = default;
 
     GraphicsLayer* m_layer { nullptr };
     FloatRect m_visibleRect;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
@@ -21,8 +21,10 @@
 #include "CoordinatedBackingStoreProxy.h"
 
 #if USE(COORDINATED_GRAPHICS)
+#include "CoordinatedAnimatedBackingStoreClient.h"
 #include "CoordinatedPlatformLayer.h"
 #include "CoordinatedTileBuffer.h"
+#include "GraphicsLayerCoordinated.h"
 #include "PlatformDisplay.h"
 #include "ProcessCapabilities.h"
 #include <wtf/CheckedArithmetic.h>
@@ -97,13 +99,36 @@ Ref<CoordinatedBackingStoreProxy> CoordinatedBackingStoreProxy::create()
     return adoptRef(*new CoordinatedBackingStoreProxy());
 }
 
-OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStoreProxy::updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, const IntSize& unscaledViewportSize, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>& dirtyRegion, Damage& damage, CoordinatedPlatformLayer& layer)
+CoordinatedBackingStoreProxy::~CoordinatedBackingStoreProxy()
+{
+    ASSERT(!m_animatedBackingStoreClient);
+}
+
+void CoordinatedBackingStoreProxy::invalidate()
+{
+    setAffectedByTransformAnimation(false);
+}
+
+void CoordinatedBackingStoreProxy::setAffectedByTransformAnimation(bool affectedByTransformAnimation)
+{
+    if (affectedByTransformAnimation && !m_animatedBackingStoreClient)
+        m_animatedBackingStoreClient = CoordinatedAnimatedBackingStoreClient::create();
+    else if (!affectedByTransformAnimation && m_animatedBackingStoreClient) {
+        m_animatedBackingStoreClient->invalidate();
+        m_animatedBackingStoreClient = nullptr;
+    }
+}
+
+OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStoreProxy::updateIfNeeded(const IntRect& unscaledVisibleRect, const FloatSize& unscaledSize, const FloatRect& unscaledViewportRect, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>& dirtyRegion, Damage& damage, CoordinatedPlatformLayer& layer)
 {
     assertIsHeld(layer.lock());
     Vector<uint32_t> tilesToCreate;
     Vector<uint32_t> tilesToRemove;
     if (shouldCreateAndDestroyTiles)
-        createOrDestroyTiles(unscaledVisibleRect, unscaledContentsRect, unscaledViewportSize, contentsScale, layer.maxTextureSize(), damage, tilesToCreate, tilesToRemove);
+        createOrDestroyTiles(unscaledVisibleRect, IntRect { { }, IntSize(unscaledSize) }, enclosingIntRect(unscaledViewportRect).size(), contentsScale, layer.maxTextureSize(), damage, tilesToCreate, tilesToRemove);
+
+    if (m_animatedBackingStoreClient)
+        m_animatedBackingStoreClient->update(layer.owner(), unscaledViewportRect, m_coverRect, unscaledSize, contentsScale);
 
     if (!m_tiles.isEmpty())
         invalidateRegion(dirtyRegion);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -31,6 +31,7 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
+class CoordinatedAnimatedBackingStoreClient;
 class CoordinatedPlatformLayer;
 class CoordinatedTileBuffer;
 class Damage;
@@ -40,11 +41,14 @@ class CoordinatedBackingStoreProxy final : public ThreadSafeRefCounted<Coordinat
     WTF_MAKE_TZONE_ALLOCATED(CoordinatedBackingStoreProxy);
 public:
     static Ref<CoordinatedBackingStoreProxy> create();
-    ~CoordinatedBackingStoreProxy() = default;
+    ~CoordinatedBackingStoreProxy();
 
     static constexpr int s_defaultCPUTileSize = 256;
 
-    const IntRect& coverRect() const LIFETIME_BOUND { return m_coverRect; }
+    void setAffectedByTransformAnimation(bool);
+    CoordinatedAnimatedBackingStoreClient* animatedBackingStoreClient() const { return m_animatedBackingStoreClient.get(); }
+
+    void invalidate();
 
     class Update {
         WTF_MAKE_NONCOPYABLE(Update);
@@ -81,7 +85,7 @@ public:
         TilesPending = 1 << 1,
         TilesChanged = 1 << 2
     };
-    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, const IntSize& unscaledViewportSize, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>&, Damage&, CoordinatedPlatformLayer&);
+    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const FloatSize& unscaledSize, const FloatRect& unscaledViewportRect, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>&, Damage&, CoordinatedPlatformLayer&);
     Update takePendingUpdate();
 
     void waitUntilPaintingComplete();
@@ -151,6 +155,7 @@ private:
     IntRect m_coverRect;
     IntRect m_keepRect;
     HashMap<IntPoint, Tile> m_tiles;
+    RefPtr<CoordinatedAnimatedBackingStoreClient> m_animatedBackingStoreClient;
     struct {
         Lock lock;
         Update pending WTF_GUARDED_BY_LOCK(lock);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -854,15 +854,12 @@ void CoordinatedPlatformLayer::updateBackingStore()
         return;
 
     Damage damage(m_size, Damage::Mode::Rectangles);
-    IntRect contentsRect(IntPoint::zero(), IntSize(m_size));
-    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRect, contentsRect, enclosingIntRect(m_visibleRect).size(), m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
+    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRect, m_size, m_visibleRect, m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
     m_needsTilesUpdate = false;
 #if ENABLE(DAMAGE_TRACKING)
     addDamage(WTF::move(damage));
 #endif
     m_dirtyRegion.clear();
-    if (m_animatedBackingStoreClient)
-        m_animatedBackingStoreClient->update(m_visibleRect, m_backingStoreProxy->coverRect(), m_size, m_contentsScale);
 
     if (updateResult.contains(CoordinatedBackingStoreProxy::UpdateResult::TilesChanged)) {
         if (m_repaintCount != -1 && updateResult.contains(CoordinatedBackingStoreProxy::UpdateResult::BuffersChanged)) {
@@ -883,28 +880,20 @@ void CoordinatedPlatformLayer::updateContents(bool affectedByTransformAnimation)
     if (needsBackingStore()) {
         if (!m_backingStoreProxy) {
             m_backingStoreProxy = CoordinatedBackingStoreProxy::create();
+            m_backingStoreProxy->setAffectedByTransformAnimation(affectedByTransformAnimation);
             m_needsTilesUpdate = true;
             m_pendingChanges.add(Change::BackingStore);
-        }
-
-        if (affectedByTransformAnimation) {
-            if (!m_animatedBackingStoreClient) {
-                m_animatedBackingStoreClient = CoordinatedAnimatedBackingStoreClient::create(*m_owner);
+        } else {
+            bool wasAffectedByTransformAnimation = !!m_backingStoreProxy->animatedBackingStoreClient();
+            if (wasAffectedByTransformAnimation != affectedByTransformAnimation) {
+                m_backingStoreProxy->setAffectedByTransformAnimation(affectedByTransformAnimation);
                 m_pendingChanges.add(Change::BackingStore);
             }
-        } else if (m_animatedBackingStoreClient) {
-            m_animatedBackingStoreClient->invalidate();
-            m_animatedBackingStoreClient = nullptr;
-            m_pendingChanges.add(Change::BackingStore);
         }
     } else {
         if (m_backingStoreProxy) {
+            m_backingStoreProxy->invalidate();
             m_backingStoreProxy = nullptr;
-            m_pendingChanges.add(Change::BackingStore);
-        }
-        if (m_animatedBackingStoreClient) {
-            m_animatedBackingStoreClient->invalidate();
-            m_animatedBackingStoreClient = nullptr;
             m_pendingChanges.add(Change::BackingStore);
         }
     }
@@ -918,10 +907,9 @@ void CoordinatedPlatformLayer::updateContents(bool affectedByTransformAnimation)
 void CoordinatedPlatformLayer::purgeBackingStores()
 {
     Locker locker { m_lock };
-    m_backingStoreProxy = nullptr;
-    if (m_animatedBackingStoreClient) {
-        m_animatedBackingStoreClient->invalidate();
-        m_animatedBackingStoreClient = nullptr;
+    if (m_backingStoreProxy) {
+        m_backingStoreProxy->invalidate();
+        m_backingStoreProxy = nullptr;
     }
     m_imageBackingStore.current = nullptr;
     if (shouldReleaseBuffer(m_contentsBuffer.pending.get()))
@@ -1170,8 +1158,8 @@ void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<Com
                     m_backingStore = CoordinatedBackingStore::create();
                 layer.setBackingStore(m_backingStore.get());
 
-                if (m_animatedBackingStoreClient)
-                    layer.setAnimatedBackingStoreClient(m_animatedBackingStoreClient.get());
+                if (auto* animatedBackingStoreClient = m_backingStoreProxy->animatedBackingStoreClient())
+                    layer.setAnimatedBackingStoreClient(animatedBackingStoreClient);
             } else {
                 layer.setBackingStore(nullptr);
                 layer.setAnimatedBackingStoreClient(nullptr);
@@ -1364,7 +1352,7 @@ void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet
         }
 
         if (m_pendingChanges.contains(Change::BackingStore)) {
-            layer.setUseBackingStore(!!m_backingStoreProxy, m_backingStoreProxy && m_animatedBackingStoreClient ? m_animatedBackingStoreClient.get() : nullptr);
+            layer.setUseBackingStore(!!m_backingStoreProxy, m_backingStoreProxy ? m_backingStoreProxy->animatedBackingStoreClient() : nullptr);
             m_pendingChanges.remove(Change::BackingStore);
         }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -47,7 +47,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 namespace WebCore {
-class CoordinatedAnimatedBackingStoreClient;
 class CoordinatedBackingStore;
 class CoordinatedBackingStoreProxy;
 class CoordinatedImageBackingStore;
@@ -325,7 +324,6 @@ private:
     float m_contentsScale WTF_GUARDED_BY_LOCK(m_lock) { 1. };
     RefPtr<CoordinatedBackingStoreProxy> m_backingStoreProxy WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedBackingStore> m_backingStore WTF_GUARDED_BY_LOCK(m_lock);
-    RefPtr<CoordinatedAnimatedBackingStoreClient> m_animatedBackingStoreClient WTF_GUARDED_BY_LOCK(m_lock);
     struct {
         RefPtr<CoordinatedImageBackingStore> current;
         RefPtr<CoordinatedImageBackingStore> committed;


### PR DESCRIPTION
#### 0f25453ee003c74b1042030c0bb1b2fcfe5fb4b5
<pre>
[CoordinatedGraphics] Move CoordinatedAnimatedBackingStoreClient ownership to CoordinatedBackingStoreProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=320970">https://bugs.webkit.org/show_bug.cgi?id=320970</a>

Reviewed by Nikolas Zimmermann.

A CoordinatedAnimatedBackingStoreClient can only exist when the layer
has a CoordinatedBackingStoreProxy, and the client is updated with the
cover rect computed by CoordinatedBackingStoreProxy so it&apos;s simpler to
make CoordinatedBackingStoreProxy own the CoordinatedAnimatedBackingStoreClient.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.cpp:
(WebCore::CoordinatedAnimatedBackingStoreClient::create):
(WebCore::CoordinatedAnimatedBackingStoreClient::update):
(WebCore::CoordinatedAnimatedBackingStoreClient::CoordinatedAnimatedBackingStoreClient): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
(WebCore::CoordinatedBackingStoreProxy::~CoordinatedBackingStoreProxy):
(WebCore::CoordinatedBackingStoreProxy::invalidate):
(WebCore::CoordinatedBackingStoreProxy::setAffectedByTransformAnimation):
(WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::updateBackingStore):
(WebCore::CoordinatedPlatformLayer::updateContents):
(WebCore::CoordinatedPlatformLayer::purgeBackingStores):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnTarget):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:

Canonical link: <a href="https://commits.webkit.org/318535@main">https://commits.webkit.org/318535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac22080f86940a852728b9bddea2499fc1222a81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52524 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46319 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188202 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52234 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139236 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42796 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119690 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41462 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151862 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36657 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45124 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190629 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52193 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/159512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148404 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52874 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148171 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27091 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42875 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125141 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119784 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51392 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/14463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50777 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->