### PR TITLE
Cherry-pick 318487@main (bff3814d76f7). https://bugs.webkit.org/show_bug.cgi?id=320559

### DIFF
--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -253,8 +253,8 @@ std::optional<size_t> JSString::tryFindLastOneChar(JSGlobalObject*, char16_t cha
     }
 
     const JSRopeString* rope = static_cast<const JSRopeString*>(this);
-    unsigned fiberLengths[JSRopeString::s_maxInternalRopeLength] { };
-    JSString* fibers[JSRopeString::s_maxInternalRopeLength] { };
+    std::array<unsigned, JSRopeString::s_maxInternalRopeLength> fiberLengths;
+    std::array<JSString*, JSRopeString::s_maxInternalRopeLength> fibers;
     unsigned fiberCount = 0;
     for (unsigned i = 0; i < JSRopeString::s_maxInternalRopeLength; ++i) {
         JSString* fiber = rope->fiber(i);

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1259,7 +1259,8 @@ void VM::pushCheckpointOSRSideState(std::unique_ptr<CheckpointOSRExitSideState>&
     m_checkpointSideState.append(WTF::move(payload));
 
 #if ASSERT_ENABLED
-    auto bounds = StackBounds::currentThreadStackBounds();
+    const auto& bounds = Thread::currentSingleton().stack();
+    ASSERT(bounds.contains(currentStackPointer()));
     void* previousCallFrame = bounds.end();
     for (size_t i = m_checkpointSideState.size(); i--;) {
         auto* callFrame = m_checkpointSideState[i]->associatedCallFrame;
@@ -1282,7 +1283,7 @@ std::unique_ptr<CheckpointOSRExitSideState> VM::popCheckpointOSRSideState(CallFr
 void VM::popAllCheckpointOSRSideStateUntil(CallFrame* target)
 {
     ASSERT(currentThreadIsHoldingAPILock());
-    auto bounds = StackBounds::currentThreadStackBounds().withSoftOrigin(target);
+    auto bounds = Thread::currentSingleton().stack().withSoftOrigin(target);
     ASSERT(bounds.contains(target));
 
     // We have to worry about migrating from another thread since there may be no checkpoints in our thread but one in the other threads.

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -497,9 +497,11 @@ RefPtr<Font> FontCache::similarFont(const FontDescription&, const String&)
     return nullptr;
 }
 
+#if !USE(SKIA)
 void FontCache::platformReleaseNoncriticalMemory()
 {
 }
+#endif
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -249,6 +249,9 @@ struct FontCascadeCacheKeyHashTraits : HashTraits<FontCascadeCacheKey> {
 class FontCascadeCache {
     WTF_MAKE_TZONE_ALLOCATED(FontCascadeCache);
     WTF_MAKE_NONCOPYABLE(FontCascadeCache);
+#if USE(SKIA)
+    friend class FontCache;
+#endif
 public:
     FontCascadeCache() = default;
 

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -580,6 +580,16 @@ void FontCascadeFonts::addSystemFallbackFont(Ref<Font>&& font)
     m_systemFallbackFontSet.add(WTF::move(font));
 }
 
+void FontCascadeFonts::forEachRealizedFont(NOESCAPE const Function<void(const Font&)>& function) const
+{
+    for (auto& ranges : m_realizedFallbackRanges) {
+        for (unsigned i = 0; i < ranges.size(); ++i) {
+            if (RefPtr font = ranges.rangeAt(i).font(ExternalResourceDownloadPolicy::Forbid))
+                function(*font);
+        }
+    }
+}
+
 TextShapingResultAndDisplayList* FontCascadeFonts::getOrCreateCachedShapedText(const TextRun& run, const FontCascade& fontCascade, unsigned from, std::optional<unsigned> to, ForTextEmphasis forTextEmphasis)
 {
     auto isCacheable = [&] {

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -31,6 +31,7 @@
 #include <wtf/CurrentThread.h>
 #include <wtf/EnumeratedArray.h>
 #include <wtf/Forward.h>
+#include <wtf/Function.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashTraits.h>
@@ -156,6 +157,9 @@ public:
     void pruneSystemFallbacks();
 
     void addSystemFallbackFont(Ref<Font>&&);
+
+    // Only visits fonts that have already been realized; never triggers realization/loading.
+    void forEachRealizedFont(NOESCAPE const Function<void(const Font&)>&) const;
 
 private:
     FontCascadeFonts();

--- a/Source/WebCore/platform/graphics/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontCustomPlatformData.h
@@ -95,6 +95,12 @@ public:
     WEBCORE_EXPORT FontCustomPlatformSerializedData NODELETE serializedData() const;
     WEBCORE_EXPORT static std::optional<Ref<FontCustomPlatformData>> tryMakeFromSerializationData(FontCustomPlatformSerializedData&&, bool);
 
+#if USE(SKIA)
+    sk_sp<SkTypeface> retrieveOrAddCachedTypeface(const Vector<SkFontArguments::VariationPosition::Coordinate>&);
+    void clearVariationTypefacesCache() const;
+    void clearUnusedVariationTypefacesCacheEntries() const;
+#endif
+
     static bool supportsFormat(const String&);
     static bool NODELETE supportsTechnology(const FontTechnology&);
 
@@ -106,6 +112,7 @@ public:
     RefPtr<cairo_font_face_t> m_fontFace;
 #elif USE(SKIA)
     sk_sp<SkTypeface> m_typeface;
+    mutable HashMap<unsigned, sk_sp<SkTypeface>> m_variationTypefacesCache;
 #endif
     FontPlatformData::CreationData creationData;
 

--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -55,7 +55,10 @@ FontPlatformData::FontPlatformData(const FontMetadata& metadata, const FontCusto
 {
 }
 
+#if !USE(SKIA)
 FontPlatformData::~FontPlatformData() = default;
+#endif
+
 FontPlatformData::FontPlatformData(const FontPlatformData&) = default;
 FontPlatformData& FontPlatformData::operator=(const FontPlatformData&) = default;
 

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -27,6 +27,7 @@
 #include "FontCache.h"
 
 #include "Font.h"
+#include "FontCustomPlatformData.h"
 #include "FontDescription.h"
 #include "StyleFontSizeFunctions.h"
 #include <wtf/Assertions.h>
@@ -431,6 +432,16 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
 ASCIILiteral FontCache::platformAlternateFamilyName(const String&)
 {
     return { };
+}
+
+void FontCache::platformReleaseNoncriticalMemory()
+{
+    for (auto& entry : m_fontCascadeCache.m_entries.values()) {
+        entry->fonts->forEachRealizedFont([](const Font& font) {
+            if (const auto* customPlatformData = font.platformData().customPlatformData())
+                customPlatformData->clearVariationTypefacesCache();
+        });
+    }
 }
 
 void FontCache::platformInvalidate()

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -87,12 +87,8 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
         for (auto& variation : variations)
             applyVariation(variation.tag(), variation.value());
 
-        if (!variationsToBeApplied.isEmpty()) {
-            SkFontArguments fontArgs;
-            fontArgs.setVariationDesignPosition({ variationsToBeApplied.span().data(), static_cast<int>(variationsToBeApplied.size()) });
-            if (auto variationTypeface = typeface->makeClone(fontArgs))
-                typeface = WTF::move(variationTypeface);
-        }
+        if (!variationsToBeApplied.isEmpty())
+            typeface = retrieveOrAddCachedTypeface(variationsToBeApplied);
     }
 
     auto size = description.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
@@ -174,6 +170,40 @@ std::optional<Ref<FontCustomPlatformData>> FontCustomPlatformData::tryMakeFromSe
 FontCustomPlatformSerializedData FontCustomPlatformData::serializedData() const
 {
     return FontCustomPlatformSerializedData { creationData.fontFaceData, creationData.itemInCollection, m_renderingResourceIdentifier };
+}
+
+sk_sp<SkTypeface> FontCustomPlatformData::retrieveOrAddCachedTypeface(const Vector<SkFontArguments::VariationPosition::Coordinate>& variationsToBeApplied)
+{
+    WTF::Hasher variationHasher;
+    for (auto& coordinate : variationsToBeApplied) {
+        WTF::add(variationHasher, coordinate.axis);
+        WTF::add(variationHasher, coordinate.value);
+    }
+    constexpr size_t variationTypefacesCacheMaximumSize = 8;
+    if (m_variationTypefacesCache.size() >= variationTypefacesCacheMaximumSize)
+        m_variationTypefacesCache.remove(m_variationTypefacesCache.random());
+    auto addResult = m_variationTypefacesCache.ensure(variationHasher.hash(), [&]() -> sk_sp<SkTypeface> {
+        SkFontArguments fontArgs;
+        fontArgs.setVariationDesignPosition({ variationsToBeApplied.span().data(), static_cast<int>(variationsToBeApplied.size()) });
+        if (auto variationTypeface = m_typeface->makeClone(fontArgs))
+            return variationTypeface;
+        return m_typeface;
+    });
+    if (addResult.iterator->value)
+        return addResult.iterator->value;
+    return m_typeface;
+}
+
+void FontCustomPlatformData::clearVariationTypefacesCache() const
+{
+    m_variationTypefacesCache.clear();
+}
+
+void FontCustomPlatformData::clearUnusedVariationTypefacesCacheEntries() const
+{
+    m_variationTypefacesCache.removeIf([](const auto& entry) {
+        return entry.value->unique();
+    });
 }
 
 }

--- a/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
@@ -69,6 +69,16 @@ FontPlatformData::FontPlatformData(const FontMetadata& metadata, RefPtr<FontCust
     platformDataInit();
 }
 
+FontPlatformData::~FontPlatformData()
+{
+    if (m_customPlatformData) {
+        // Dereference sk_sp<SkTypeface> used by font.
+        m_font = { };
+        // Clear sk_sp<SkTypeface> objects from cache if refcount is 1.
+        m_customPlatformData->clearUnusedVariationTypefacesCacheEntries();
+    }
+}
+
 bool FontPlatformData::skiaTypefaceHasAnySupportedColorTable(const SkTypeface& typeface)
 {
     const int tablesCount = typeface.countTables();


### PR DESCRIPTION
#### cc9be033e33e857d3c696eeb3dc0d2675bcce727
<pre>
Cherry-pick 318487@main (bff3814d76f7). <a href="https://bugs.webkit.org/show_bug.cgi?id=320559">https://bugs.webkit.org/show_bug.cgi?id=320559</a>

    [JSC][Linux] Don&apos;t re-read /proc/self/maps when handling checkpoint OSR side state
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320559">https://bugs.webkit.org/show_bug.cgi?id=320559</a>

    Reviewed by Yusuke Suzuki and Justin Michaud.

    VM::pushCheckpointOSRSideState() has an ASSERT_ENABLED block that checks
    that the side state stack remains ordered. To do so, it needs the current
    thread stack bounds.

    It obtained them using StackBounds::currentThreadStackBounds(), which does
    not cache the result. On Linux, this calls pthread_getattr_np(), which glibc
    implements for the main thread by opening and parsing /proc/self/maps.
    Each call makes the kernel generate a list of the process memory mappings
    and then makes glibc parse that list.

    While running wasm/stress/type-index-abstract-heap-types-nulls-and-casts.js
    in wasm-eager mode, profiling showed about ~45% of samples in kernel code
    generating /proc/self/maps and another ~30% in libc parsing it. The test
    opened /proc/self/maps hundreds of times through repeated calls to
    VM::pushCheckpointOSRSideState().

    Thread::m_stack is initialized using StackBounds::currentThreadStackBounds()
    and cached for the lifetime of the thread. Thread::currentSingleton().stack()
    therefore provides the cached bounds without repeating the OS query.
    logSanitizeStack() in the same file already uses this cached value.

    Switch both call sites in VM.cpp to the cached bounds. This keeps the
    relevant stack consistency assertions checks without asking the operating
    system to recalculate information that the thread already stores.

    popAllCheckpointOSRSideStateUntil() is not assertion-only: it uses the
    bounds as part of its normal operation. This change therefore also avoids
    the same cost in release builds.

    With this change, on a Release+Asserts WPE build, `run-jsc-stress-tests \
    --filter wasm.yaml/wasm/stress/type-index-abstract-heap-types` completes
    in about five minutes. Previously, it could take around one hour, and the
    tests would usually time out.

    * JSTests/wasm/stress/type-index-abstract-heap-types-concrete-vs-abstract.js:
    * JSTests/wasm/stress/type-index-abstract-heap-types-globals-and-tables.js:
    * JSTests/wasm/stress/type-index-abstract-heap-types-nulls-and-casts.js:
    * JSTests/wasm/stress/type-index-abstract-heap-types-subtype-validation.js:
    * Source/JavaScriptCore/runtime/VM.cpp:
    (JSC::VM::pushCheckpointOSRSideState):
    (JSC::VM::popAllCheckpointOSRSideStateUntil):

    Canonical link: <a href="https://commits.webkit.org/318487@main">https://commits.webkit.org/318487@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.48@webkitglib/2.54">https://commits.webkit.org/317695.48@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### b6922ca758e13f513d524f3ddd95e529fc5f544d
<pre>
Cherry-pick 318476@main (6b324fb4b79e). <a href="https://bugs.webkit.org/show_bug.cgi?id=319590">https://bugs.webkit.org/show_bug.cgi?id=319590</a>

    [Skia] Memory growth on every page load when fonts with variations are used
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319590">https://bugs.webkit.org/show_bug.cgi?id=319590</a>

    Reviewed by Carlos Garcia Campos.

    This change adds a small cache for font variation typefaces, so that
    variation-specific typefaces can be shared. This way, a lot of memory
    can be saved if font variations are used often.

    Canonical link: <a href="https://commits.webkit.org/318476@main">https://commits.webkit.org/318476@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.47@webkitglib/2.54">https://commits.webkit.org/317695.47@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### cb2788ad87c813797b9bf0d0f876c2534e8c9142
<pre>
Cherry-pick 318454@main (a5c78b4fff5c). <a href="https://bugs.webkit.org/show_bug.cgi?id=320887">https://bugs.webkit.org/show_bug.cgi?id=320887</a>

    REGRESSION(312307@main): [JSC] Clang reports unsafe buffer usage in JSStringInlines.h
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320887">https://bugs.webkit.org/show_bug.cgi?id=320887</a>

    Reviewed by Keith Miller.

    * Source/JavaScriptCore/runtime/JSStringInlines.h:
    (JSC::JSString::tryFindLastOneChar const): Change plain arrays to use
    bounds-checked std::array instances.

    Canonical link: <a href="https://commits.webkit.org/318454@main">https://commits.webkit.org/318454@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.46@webkitglib/2.54">https://commits.webkit.org/317695.46@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3811ae9b02aa92256162414a61c5af086745048

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178589 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52527 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46322 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188205 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141839 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180452 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53821 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52237 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139240 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141839 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181546 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53821 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46322 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119694 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53821 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52237 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1663 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46322 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53821 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46322 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36660 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/39862 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45127 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52237 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190632 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52196 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46322 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148408 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/52877 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46322 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148175 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27096 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/52877 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125144 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119788 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51395 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46322 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50780 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51020 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50842 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->