### PR TITLE
AudioWorkletProcessor is torn down too early when process() returns false

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-lifetime.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-lifetime.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test AudioWorkletNode lifetime when process() returns false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-lifetime.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-lifetime.https.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      Test AudioWorkletNode's processor lifetime when process() returns false
+    </title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      // Verify that the AudioWorkletProcessor's process() method is called
+      // as long as inputs are active, even if process() returns false.
+      // And verify that it stops running once inputs become inactive.
+
+      const RENDER_QUANTUM_FRAMES = 128;
+      const sampleRate = 8000;
+      const renderLength = RENDER_QUANTUM_FRAMES * 4;
+      const channelCount = 1;
+      const filePath = 'processors/lifetime-processor.js';
+
+      promise_test(async (t) => {
+        const context =
+            new OfflineAudioContext(channelCount, renderLength, sampleRate);
+
+        await context.audioWorklet.addModule(filePath);
+
+        const testSource = new ConstantSourceNode(context, { offset: 1.0 });
+        const workletNode =
+            new AudioWorkletNode(context, 'lifetime-processor', {
+              numberOfInputs: 1,
+              numberOfOutputs: 1
+            });
+
+        testSource.connect(workletNode);
+        workletNode.connect(context.destination);
+
+        testSource.start();
+        // Stop the source node at the start of the third render quantum.
+        testSource.stop(2 * RENDER_QUANTUM_FRAMES / sampleRate);
+
+        const renderedBuffer = await context.startRendering();
+        const data = renderedBuffer.getChannelData(0);
+
+        // The first 256 frames (Quantum 1 and 2) must be 1.0.
+        const activeFrames = 2 * RENDER_QUANTUM_FRAMES;
+        assert_array_equals(
+            data.subarray(0, activeFrames),
+            new Float32Array(activeFrames).fill(1.0),
+            'First 2 quanta output (active inputs) must be 1.0');
+
+        // The remaining 256 frames (Quantum 3 and 4) must be 0.0 (silent
+        // after cleanup).
+        const silentFrames = renderLength - activeFrames;
+        assert_array_equals(
+            data.subarray(activeFrames),
+            new Float32Array(silentFrames).fill(0.0),
+            'Remaining 2 quanta output (inactive inputs) must be 0.0');
+      }, 'Test AudioWorkletNode lifetime when process() returns false');
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/processors/lifetime-processor.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/processors/lifetime-processor.js
@@ -1,0 +1,22 @@
+/**
+ * @class LifetimeProcessor
+ * @extends AudioWorkletProcessor
+ *
+ * This processor returns false from process() to verify that its lifetime
+ * is governed by active input connections when the active source flag is
+ * false.
+ */
+class LifetimeProcessor extends AudioWorkletProcessor {
+  process(inputs, outputs) {
+    // Write 1.0 to all channels of the first output.
+    const output = outputs[0];
+    for (let channel = 0; channel < output.length; ++channel) {
+      output[channel].fill(1.0);
+    }
+
+    // Returning false sets the active source flag to false.
+    return false;
+  }
+}
+
+registerProcessor('lifetime-processor', LifetimeProcessor);

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -162,6 +162,9 @@ AudioWorkletNode::~AudioWorkletNode()
             }
         }
     }
+    // The node is destroyed on the main thread, so release the rendering-thread assertion to avoid
+    // tripping its destructor check.
+    m_renderingThread = anyThreadLike;
     uninitialize();
 }
 
@@ -195,6 +198,7 @@ void AudioWorkletNode::setProcessor(RefPtr<AudioWorkletProcessor>&& processor)
         Locker locker { m_processLock };
         m_processor = WTF::move(processor);
         m_workletThread = Thread::currentSingleton();
+        m_renderingThread.reset();
     } else
         fireProcessorErrorOnMainThread(ProcessorError::ConstructorError);
 }
@@ -218,12 +222,28 @@ void AudioWorkletNode::process(size_t framesToProcess)
         zeroOutput();
         return;
     }
+    assertIsCurrent(m_renderingThread);
 
-    // If the input is not connected, pass nullptr to the processor.
+    // If the input is not connected, pass nullptr to the processor. An input is considered active
+    // as long as it is connected to a node that is still producing audio (i.e. its bus is not
+    // silent); once a source finishes playback it outputs silence.
+    bool hasActiveInputs = false;
     for (unsigned i = 0; i < numberOfInputs(); ++i) {
         CheckedPtr currentInput = input(i);
-        m_inputs[i] = currentInput->isConnected() ? &currentInput->bus() : nullptr;
+        bool connected = currentInput->isConnected();
+        m_inputs[i] = connected ? &currentInput->bus() : nullptr;
+        if (connected && !hasActiveInputs && !currentInput->bus().isSilent())
+            hasActiveInputs = true;
     }
+
+    // Once process() has returned false and the node no longer has any active inputs, the processor
+    // is done and we stop calling process().
+    if (!m_isActiveSource && !hasActiveInputs) {
+        didFinishProcessingOnRenderingThread(false);
+        zeroOutput();
+        return;
+    }
+
     for (unsigned i = 0; i < numberOfOutputs(); ++i)
         m_outputs[i] = output(i)->bus();
 
@@ -249,7 +269,8 @@ void AudioWorkletNode::process(size_t framesToProcess)
     }
 
     bool threwException = false;
-    if (!m_processor->process(m_inputs, m_outputs, m_paramValuesMap, threwException))
+    m_isActiveSource = m_processor->process(m_inputs, m_outputs, m_paramValuesMap, threwException);
+    if ((!m_isActiveSource && !hasActiveInputs) || threwException)
         didFinishProcessingOnRenderingThread(threwException);
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
@@ -34,6 +34,7 @@
 #include "AudioNode.h"
 #include <wtf/Lock.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/ThreadAssertions.h>
 
 namespace JSC {
 class JSGlobalObject;
@@ -94,17 +95,27 @@ private:
     const Ref<AudioParamMap> m_parameters;
     const Ref<MessagePort> m_port;
     Lock m_processLock;
+
+    // Bound to the rendering (worklet) thread the first time a processor is installed; guards the
+    // members below that must only be touched while rendering. Reset to anyThreadLike in the
+    // destructor since the node is destroyed on the main thread.
+    NO_UNIQUE_ADDRESS ThreadLikeAssertion m_renderingThread { noneThreadLike };
+
     RefPtr<AudioWorkletProcessor> m_processor; // Should only be used on the rendering thread.
     MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>> m_paramValuesMap;
     RefPtr<WTF::Thread> m_workletThread;
 
     // Keeps the reference of AudioBus objects from AudioNodeInput and AudioNodeOutput in order
     // to pass them to AudioWorkletProcessor.
-    Vector<RefPtr<AudioBus>> m_inputs;
-    Vector<Ref<AudioBus>> m_outputs;
+    Vector<RefPtr<AudioBus>> m_inputs WTF_GUARDED_BY_CAPABILITY(m_renderingThread);
+    Vector<Ref<AudioBus>> m_outputs WTF_GUARDED_BY_CAPABILITY(m_renderingThread);
 
     double m_tailTime { std::numeric_limits<double>::infinity() };
     bool m_wasOutputChannelCountGiven { false };
+
+    // The processor's process() method acts as an active source as long as it returns true. Once
+    // it returns false, the processor's lifetime is governed by its active inputs.
+    bool m_isActiveSource WTF_GUARDED_BY_CAPABILITY(m_renderingThread) { true };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 209f4da7d1692a001fc85e902a4df489e973e544
<pre>
AudioWorkletProcessor is torn down too early when process() returns false
<a href="https://bugs.webkit.org/show_bug.cgi?id=320973">https://bugs.webkit.org/show_bug.cgi?id=320973</a>

Reviewed by Darin Adler.

WebKit destroyed an AudioWorkletProcessor as soon as its process() method
returned false, regardless of whether the node still had active inputs. The
Web Audio spec (and Blink/Firefox) require that returning false only stops
processing once the node also has no active inputs; as long as an upstream
node is still producing audio, process() must keep being called.

This is observable when an actively-playing source feeds a worklet whose
process() returns false: the processor should keep running (and its output
reflect the processing) until the source stops, then go silent. WebKit instead
went silent one render quantum after the first process() call.

Fix this by introducing an m_isActiveSource flag, set to the return value of
process() on each render quantum (initially true). The processor is only
finished once it is no longer an active source and has no active inputs (or if
process() threw). An input is considered active while it is connected to a node
that is still producing audio, i.e. its input bus is not silent; a source that
has finished playback outputs silence.

Test: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-lifetime.https.html

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-lifetime.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-lifetime.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/processors/lifetime-processor.js: Added.
(LifetimeProcessor.prototype.process):
(LifetimeProcessor):
Import WPT test from upstream. It was failing in shipping Safari but passing
in both Firefox and Chrome.

* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::process):
(WebCore::AudioWorkletNode::~AudioWorkletNode):
(WebCore::AudioWorkletNode::setProcessor):
Track whether the node has active inputs and only finish the processor when it
is no longer an active source and has no active inputs.

* Source/WebCore/Modules/webaudio/AudioWorkletNode.h:
Add m_isActiveSource, only used on the rendering thread.

Canonical link: <a href="https://commits.webkit.org/318621@main">https://commits.webkit.org/318621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11d8007ab4305160b28c6a197c27b1ef1b7ccce7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188412 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/632d305e-4b6c-44e3-a0a2-43cb315c3aa2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139411 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e57f96a2-e54f-4766-9b8b-95a9deb5d71a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119865 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/236f14fa-1526-4f94-815b-ebd04f5058a2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41646 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39996 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1835 "Build is in progress. Recent messages:") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39641 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190840 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52404 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148594 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39896 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53084 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148361 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43060 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125351 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120012 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51602 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14620 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50987 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51227 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51049 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->