### PR TITLE
[GLib] Unreviewed gardening. Clean up expectations for tests now passing on 2.54 WPE arm64 bot

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5689,7 +5689,6 @@ webkit.org/b/220325 imported/w3c/web-platform-tests/css/css-highlight-api/highli
 # Tests need updating relating to Highlight Spec
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-logical-metrics-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-logical-metrics-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-below-selection-transparency.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-inheritance-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-inheritance-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-vertical-writing-mode-001.html [ ImageOnlyFailure ]
@@ -8087,7 +8086,6 @@ webkit.org/b/308096 imported/w3c/web-platform-tests/css/cssom-view/scrollParent.
 webkit.org/b/296130 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-4.html [ Pass Failure ]
 webkit.org/b/281267 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html [ Pass Failure ]
 
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-020.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-021.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/cookies/third-party-cookies/third-party-cookie-heuristics.tentative.https.html [ Skip ] # Timeout

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -602,7 +602,6 @@ media/media-source/media-source-inband-cea608-track.html [ Pass ]
 media/media-source/media-source-video-seek-pause.html [ Failure Pass ]
 
 # GStreamer seeks to the wrong frame
-webkit.org/b/261335 media/media-source/media-managedmse-seek.html [ ImageOnlyFailure ]
 
 # GStreamer incorrectly demux the webm and creates gaps.
 webkit.org/b/266195 media/media-source/media-managedmse-multipletracks-bufferedchange.html [ Failure ]
@@ -1483,7 +1482,7 @@ webkit.org/b/215799 imported/w3c/web-platform-tests/css/css-content/quotes-018.h
 webkit.org/b/215799 imported/w3c/web-platform-tests/css/css-content/quotes-025.html [ ImageOnlyFailure ]
 webkit.org/b/215799 imported/w3c/web-platform-tests/css/css-content/quotes-027.html [ ImageOnlyFailure ]
 
-webkit.org/b/319525 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-d.html [ ImageOnlyFailure ]
+webkit.org/b/319525 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-d.html [ Pass ]
 
 imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-style-property-013.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-style-property-013a.html [ Pass ]
@@ -4338,7 +4337,6 @@ webkit.org/b/198830 media/video-size-intrinsic-scale.html [ Failure ]
 webkit.org/b/108925 http/tests/media/video-play-stall.html [ Failure Timeout ]
 webkit.org/b/282165 http/tests/media/video-webm-stall-seek.html [ Failure ]
 
-webkit.org/b/137698 media/video-controls-drag.html [ Timeout ]
 webkit.org/b/113127 media/track/track-prefer-captions.html [ Timeout ]
 
 webkit.org/b/137311 media/video-fullscreen-only-playback.html [ Timeout ]
@@ -5486,6 +5484,17 @@ imported/w3c/web-platform-tests/webtransport/ [ Skip ]
 
 webkit.org/b/320057 imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-old-image.html [ ImageOnlyFailure Pass ]
 webkit.org/b/320056 [ Release ] imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-new-image.html [ ImageOnlyFailure Pass ]
+
+# These tests are expected to fail cross-port in LayoutTests/TestExpectations, but have
+# passed 100% of runs on all three GLib Release bots at wktesthunter depth 500 and 250.
+# Overridden here rather than removed upstream, since the Apple/Win ports were not checked.
+imported/w3c/web-platform-tests/css/css-masking/animations/clip-path-interpolation-shape-arc-direction-agnostic-radius.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-cors-001.sub.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-pseudo/marker-content-024.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-inset-009.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-inset-014.html [ Pass ]
+imported/w3c/web-platform-tests/svg/painting/reftests/gradient-external-reference.svg [ Pass ]
+imported/w3c/web-platform-tests/svg/painting/reftests/pattern-external-reference.svg [ Pass ]
 
 # End: Common failures between GTK and WPE.
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1326,3 +1326,5 @@ webkit.org/b/319319 [ Debug ] imported/w3c/web-platform-tests/css/css-contain/co
 webkit.org/b/319323 imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard-snap-interruption.html [ Failure Pass ]
 webkit.org/b/319324 inspector/canvas/create-context-webgl.html [ Failure Pass ]
 webkit.org/b/319325 fast/body-propagation/background-color/010.html [ ImageOnlyFailure Pass ]
+
+webkit.org/b/137698 media/video-controls-drag.html [ Timeout ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -159,7 +159,6 @@ webkit.org/b/212083 loader/navigation-policy/should-open-external-urls/user-gest
 webkit.org/b/212202 compositing/fixed-with-main-thread-scrolling.html [ Timeout ]
 
 # Mediastream
-webkit.org/b/213202 fast/mediastream/getUserMedia-grant-persistency3.html [ Failure ]
 webkit.org/b/235885 fast/mediastream/video-mediastream-restricted-invisible-autoplay-not-allowed.html [ Pass Timeout ]
 webkit.org/b/235885 fast/mediastream/video-mediastream-restricted-invisible-autoplay-user-click.html [ Pass Timeout ]
 
@@ -183,7 +182,6 @@ svg/hixie/viewbox/002.xml [ Failure ]
 webkit.org/b/254519 media/media-continues-playing-after-replace-source.html [ Failure Pass ]
 [ Release ] media/modern-media-controls/scrubber-support/scrubber-support-drag.html [ Pass Timeout ]
 
-webkit.org/b/264680 media/video-background-tab-playback.html [ Failure ]
 webkit.org/b/264680 [ Release ] media/no-fullscreen-when-hidden.html [ Pass Failure ]
 webkit.org/b/264680 webgl/webgl-visible-after-context-restore.html [ ImageOnlyFailure Pass ]
 
@@ -196,7 +194,6 @@ imported/w3c/web-platform-tests/fetch/metadata/generated/element-area.https.sub.
 imported/w3c/web-platform-tests/fetch/metadata/generated/window-location.https.sub.html [ Failure ]
 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/wide-gamut-canvas/2d.color.space.p3.convertToBlobp3.canvas.html [ Failure ]
 imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window.html [ Failure ]
-imported/w3c/web-platform-tests/screen-orientation/hidden_document.html [ Failure ]
 imported/w3c/web-platform-tests/storage/storagemanager-estimate.https.any.html [ Failure ]
 imported/w3c/web-platform-tests/storage/storagemanager-estimate.https.any.worker.html [ Failure ]
 imported/w3c/web-platform-tests/xhr/send-authentication-basic-setrequestheader-existing-session.htm [ Failure ]
@@ -662,12 +659,6 @@ webkit.org/b/173419 fast/events/wheel/continuous-platform-wheelevent-in-scrollin
 webkit.org/b/173419 fast/events/autoscroll-main-document.html [ Failure ]
 webkit.org/b/173419 fast/events/autoscroll-when-zoomed.html [ Failure ]
 webkit.org/b/173419 fast/events/option-tab.html [ Failure ]
-webkit.org/b/173419 fast/events/page-visibility-iframe-delete-test.html [ Timeout ]
-webkit.org/b/173419 fast/events/page-visibility-iframe-move-test.html [ Timeout ]
-webkit.org/b/173419 fast/events/page-visibility-iframe-propagation-test.html [ Timeout ]
-webkit.org/b/173419 fast/events/page-visibility-onvisibilitychange.html [ Timeout ]
-webkit.org/b/173419 fast/events/page-visibility-resize-event-order.html [ Timeout ]
-webkit.org/b/173419 fast/events/page-visibility-transition-test.html [ Timeout ]
 webkit.org/b/173419 fast/events/scroll-in-scaled-page-with-overflow-hidden.html [ Failure Timeout ]
 webkit.org/b/173419 fast/events/shadow-event-path-2.html [ Failure ]
 webkit.org/b/173419 fast/events/special-key-events-in-input-text.html [ Failure ]
@@ -813,7 +804,6 @@ webkit.org/b/143153 imported/w3c/web-platform-tests/css/css-text/text-transform/
 webkit.org/b/143153 imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-004.xht [ ImageOnlyFailure ]
 webkit.org/b/143153 imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-005.xht [ ImageOnlyFailure ]
 
-Bug(WPE) media/media-playback-page-visibility.html [ Timeout ]
 
 webkit.org/b/230277 imported/w3c/web-platform-tests/css/css-transforms/perspective-split-by-zero-w.html [ Pass ImageOnlyFailure ]
 webkit.org/b/230277 imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-006.html [ ImageOnlyFailure ]
@@ -890,7 +880,6 @@ webkit.org/b/264680 imported/w3c/web-platform-tests/webcodecs/videoFrame-constru
 webkit.org/b/266577 webgl/2.0.y/conformance2/textures/video/tex-2d-rgb16f-rgb-half_float.html [ Failure Timeout Pass ]
 
 # [WPE] Missing implementation of TestController::setHidden()
-webkit.org/b/268470 fast/mediastream/device-change-event-2.html [ Timeout ]
 
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2.html [ Failure ]
 
@@ -987,7 +976,6 @@ webkit.org/b/287572 imported/w3c/web-platform-tests/css/compositing/mix-blend-mo
 webkit.org/b/287572 imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-canvas-sibling.html [ ImageOnlyFailure ]
 webkit.org/b/287572 imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-iframe-parent.html [ ImageOnlyFailure ]
 webkit.org/b/287572 imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-iframe-sibling.html [ ImageOnlyFailure ]
-webkit.org/b/287572 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-ellipse-closest-farthest-corner.html [ ImageOnlyFailure ]
 webkit.org/b/287572 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-xywh-003.html [ ImageOnlyFailure ]
 webkit.org/b/287572 imported/w3c/web-platform-tests/css/css-scrollbars/textarea-scrollbar-width-none.html [ ImageOnlyFailure ]
 webkit.org/b/287572 imported/w3c/web-platform-tests/css/css-transforms/transform-percent-008.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 81f97cb0016db48155286f8bf1b059fb0901a8dc
<pre>
[GLib] Unreviewed gardening. Clean up expectations for tests now passing on 2.54 WPE arm64 bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=320974">https://bugs.webkit.org/show_bug.cgi?id=320974</a>

Unreviewed gardening.

The 2.54 branch bot reports ~25 constant unexpected passes. All
of them were already gardened upstream on main, but the upstream commits
do not cherry-pick cleanly onto webkitglib/2.54, so this replicates the
relevant parts of:

- d3ee002cf36d ([GTK][WPE] Gardening of tests - 2026-07-23, webkit.org/b/320068):
  glib [ Pass ] overrides for clip-path-interpolation-shape-arc-direction-agnostic-radius,
  mask-image-cors-001.sub, marker-content-024, text-decoration-inset-009/014,
  gradient-external-reference.svg, pattern-external-reference.svg.
- 9ed4a00638c1 ([GLib] LibWebRTC gardening of unexpected passing tests, webkit.org/b/320181):
  remove wpe expectations for fast/mediastream/device-change-event-2.html and
  fast/mediastream/getUserMedia-grant-persistency3.html.
- 0f106444cece (Unreviewed tests gardening of 2026-07-27):
  remove glib timeout for media/video-controls-drag.html (kept for GTK),
  remove wpe expectation for clip-path-ellipse-closest-farthest-corner.html.
- d7477ec5c605 ([GLib] Unreviewed layout test gardening, 2026-07-29):
  remove wpe timeouts for the six fast/events/page-visibility-* tests,
  media/media-playback-page-visibility.html, media/video-background-tab-playback.html,
  screen-orientation/hidden_document.html, glib media-managedmse-seek.html,
  and root custom-highlight-painting-below-selection-transparency.html;
  glib mask-mode-d.html ImageOnlyFailure -&gt; Pass.
- 1ea4cf62abc9 ([Custom Highlight] Remove stale ImageOnlyFailure expectations
  for now-passing highlight painting tests, webkit.org/b/320542):
  remove root expectation for custom-highlight-painting-020.html
  (the ios/TestExpectations part was not brought over).

* LayoutTests/TestExpectations:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/317695.45@webkitglib/2.54">https://commits.webkit.org/317695.45@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/983bb3acf00f7d65877d8afe81273bbcab5ad9e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178593 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52531 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46326 "The change is no longer eligible for processing.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188209 "Failed to checkout and rebase branch from PR 70847") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141843 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53825 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52241 "The change is no longer eligible for processing.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/188209 "Failed to checkout and rebase branch from PR 70847") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141843 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181550 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53825 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46326 "The change is no longer eligible for processing.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/188209 "Failed to checkout and rebase branch from PR 70847") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53825 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52241 "The change is no longer eligible for processing.") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/188209 "Failed to checkout and rebase branch from PR 70847") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46326 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53825 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46326 "The change is no longer eligible for processing.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/36664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52241 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190636 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52200 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46326 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/52881 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46326 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/148176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27092 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/52881 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119793 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51399 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46326 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50784 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51024 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50846 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->