### PR TITLE
CSP host-source *:*/path does not work

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/source-list-wildcard-host-and-port.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/source-list-wildcard-host-and-port.https.sub-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL "*:*" with a path allows the path on the document's own origin assert_unreached: SecurityPolicyViolation event fired for https://web-platform.test:9443/content-security-policy/support/resource.py?same-origin Reached unreachable code
-FAIL "*:*" with a path allows the path on a different port assert_unreached: SecurityPolicyViolation event fired for https://web-platform.test:9444/content-security-policy/support/resource.py?other-port Reached unreachable code
-FAIL "*:*" with a path allows the path on a different host assert_unreached: SecurityPolicyViolation event fired for https://not-web-platform.test:9443/content-security-policy/support/resource.py?other-host Reached unreachable code
+PASS "*:*" with a path allows the path on the document's own origin
+PASS "*:*" with a path allows the path on a different port
+PASS "*:*" with a path allows the path on a different host
 PASS "*:*" with a path does not allow other paths
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -256,7 +256,7 @@ template<typename CharacterType> void ContentSecurityPolicySourceList::parse(Str
             // Wildcard hosts and keyword sources ('self', 'unsafe-inline',
             // etc.) aren't stored in m_list, but as attributes on the source
             // list itself.
-            if (source->scheme.isEmpty() && source->host.value.isEmpty())
+            if (source->scheme.isEmpty() && source->host.value.isEmpty() && !source->port.value && source->path.isEmpty())
                 continue;
             if (isCSPDirectiveName(source->host.value))
                 m_policy->reportDirectiveAsSourceExpression(m_directiveName, source->host.value);


### PR DESCRIPTION
#### 4a3b30232a5565ed188ca9c58633831dbd3b58ac
<pre>
CSP host-source *:*/path does not work
<a href="https://bugs.webkit.org/show_bug.cgi?id=320785">https://bugs.webkit.org/show_bug.cgi?id=320785</a>

Reviewed by Patrick Griffis.

See <a href="https://w3c.github.io/webappsec-csp/#grammardef-host-source">https://w3c.github.io/webappsec-csp/#grammardef-host-source</a>
&apos;*/path&apos;, &apos;*:80&apos; or &apos;*:*/path&apos; are valid host-source that constrain what
they match, so we shouldn&apos;t skip them.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/source-list-wildcard-host-and-port.https.sub-expected.txt: Update expectation now that the test passes.
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::ContentSecurityPolicySourceList::parse): Also take into account whether a port or path was specified.

Canonical link: <a href="https://commits.webkit.org/318612@main">https://commits.webkit.org/318612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f4b6005d68110cecf209be4265f0f6b1f32f927

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141850 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52248 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139247 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119701 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41470 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39821 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39491 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190643 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52207 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148416 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39889 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52888 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148186 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42884 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125155 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119805 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51406 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14466 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50791 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->