### PR TITLE
Describe aliasing-related semantics of WTF.BorrowedBytes

### DIFF
--- a/Source/WTF/wtf/BorrowedBytes.h
+++ b/Source/WTF/wtf/BorrowedBytes.h
@@ -63,7 +63,7 @@ using VectorUInt8 = Vector<uint8_t>;
 // This is, in effect, the Swift-crossable form of Borrow. It composes two
 // protections against two distinct failure modes:
 //
-//   - "buffer mutated/destroyed *during* the borrow": this is exactly what
+//   - "vector interior buffer destroyed *during* the borrow": this is exactly what
 //     Borrow guards, and BorrowedVectorScope gets it by holding a Borrow on the
 //     underlying Vector (engaging its CanBorrow protocol). BorrowedSpanScope
 //     has no owning container, so it cannot offer this.
@@ -77,10 +77,24 @@ using VectorUInt8 = Vector<uint8_t>;
 // of the refcount/revocation overhead. BorrowedBytes exists to carry a borrow across
 // the C++/Swift boundary.
 //
+// On the Swift side, this type confirms to various useful protocols such as
+// ContiguousBytes, DataProtocol - so this type can be passed directly to
+// various Swift APIs as a valid set of bytes.
+//
 // A ~Copyable/~Escapable C++ type (a compile-time borrow-checked alternative to this
 // reference-counted design) was tried and rejected: a non-escapable type can't be
 // usefully used in some Swift contexts (specifically CryptoKit which is the first
 // intended use of this type)
+//
+// This type aims to address lifetime safety only (including lifetime safety
+// of interior storage buffers e.g. within a vector). It does not address the
+// differences in aliasing norms between Swift and C++. In future, we may aim to
+// reflect the Swift side of this into AliasedSpans as proposed in
+// https://github.com/DougGregor/swift-evolution/blob/aliased-spans/proposals/nnnn-aliased-spans.md
+// (although that would run into the same limitations that it might not work with
+// the majority of Swift APIs.)
+// Meanwhile, users need to ensure that the actual data in the span or vector
+// does not change during a period when Swift has access.
 class BorrowedBytes : public ThreadSafeRefCounted<BorrowedBytes> {
 public:
     // Returns the borrowed data pointer, crashing cleanly if the borrow has


### PR DESCRIPTION
#### db099b025de4971e8a20542a4412e8ac3dd60568
<pre>
Describe aliasing-related semantics of WTF.BorrowedBytes
<a href="https://bugs.webkit.org/show_bug.cgi?id=320977">https://bugs.webkit.org/show_bug.cgi?id=320977</a>
<a href="https://rdar.apple.com/184009333">rdar://184009333</a>

Reviewed by Richard Robinson.

Just a comment update to make the safety properties of this type clearer.

Canonical link: <a href="https://commits.webkit.org/318547@main">https://commits.webkit.org/318547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c13254a68dfa97526f1a139e2557b8b7d9f55d54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188227 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7180b231-604b-4676-9e88-16f295334ded) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139256 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05dca9d4-48d7-415e-b467-691376e690ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119710 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3606f69f-6eb3-48e9-8a74-1444e03d7f24) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41481 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39835 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1679 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8496 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151881 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36682 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39884 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45149 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190654 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52218 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148426 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39848 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52899 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148194 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42894 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125166 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119817 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51417 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14482 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50802 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51042 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50864 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->