### PR TITLE
Accelerated convertImagePixels for PixelFormat::RGBA16F

### DIFF
--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -30,8 +30,10 @@
 #include "DestinationColorSpace.h"
 #include "IntSize.h"
 #include "Logging.h"
+#include "PixelBuffer.h"
 #include "PixelFormat.h"
 #include <array>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/TextStream.h>
@@ -46,23 +48,30 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
+#if ENABLE(PIXEL_FORMAT_RGBA16F) && !(USE(ACCELERATE) && USE(CG))
+// PixelFormat::RGBA16F is only enabled under HAVE(SUPPORT_HDR_DISPLAY), which is Cocoa-only, and
+// PLATFORM(COCOA) implies both USE(CG) and USE(ACCELERATE). RGBA16F conversions are therefore
+// handled entirely by convertImagePixelsAccelerated(), and the unaccelerated single-pixel functions
+// below only ever see 8-bits-per-component formats. If RGBA16F is ever enabled somewhere without
+// ACCELERATE or CG, those functions need to grow 16-bits-per-component variants.
+#error "PixelFormat::RGBA16F requires USE(ACCELERATE) && USE(CG)."
+#endif
+
 #if USE(ACCELERATE) && USE(CG)
 
 static inline vImage_CGImageFormat makeVImageCGImageFormat(const PixelBufferFormat& format)
 {
-    auto [bitsPerComponent, bitsPerPixel, bitmapInfo] = [] (const PixelBufferFormat& format) -> std::tuple<unsigned, unsigned, CGBitmapInfo> {
+    auto [bitsPerComponent, bitsPerPixel, bitmapInfo] = [] (const PixelBufferFormat& format) -> std::tuple<decltype(vImage_CGImageFormat::bitsPerComponent), decltype(vImage_CGImageFormat::bitsPerPixel), CGBitmapInfo> {
         switch (format.pixelFormat) {
         case PixelFormat::RGBA8:
             if (format.alphaFormat == AlphaPremultiplication::Premultiplied)
                 return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Big) | static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedLast));
-            else
-                return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Big) | static_cast<CGBitmapInfo>(kCGImageAlphaLast));
+            return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Big) | static_cast<CGBitmapInfo>(kCGImageAlphaLast));
 
         case PixelFormat::BGRA8:
             if (format.alphaFormat == AlphaPremultiplication::Premultiplied)
                 return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedFirst));
-            else
-                return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaFirst));
+            return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaFirst));
 
         case PixelFormat::BGRX8:
 #if ENABLE(PIXEL_FORMAT_RGB10)
@@ -71,13 +80,17 @@ static inline vImage_CGImageFormat makeVImageCGImageFormat(const PixelBufferForm
 #if ENABLE(PIXEL_FORMAT_RGB10A8)
         case PixelFormat::RGB10A8:
 #endif
+            break;
+
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
         case PixelFormat::RGBA16F:
+            if (format.alphaFormat == AlphaPremultiplication::Premultiplied)
+                return std::make_tuple(16u, 64u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder16Host) | static_cast<CGBitmapInfo>(kCGBitmapFloatComponents) | static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedLast));
+            return std::make_tuple(16u, 64u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder16Host) | static_cast<CGBitmapInfo>(kCGBitmapFloatComponents) | static_cast<CGBitmapInfo>(kCGImageAlphaLast));
 #endif
-            break;
         }
 
-        // We currently only support 8 bit pixel formats with alpha for these conversions.
+        // We currently only support 8- and 16-bit pixel formats with alpha for these conversions.
 
         ASSERT_NOT_REACHED();
         return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaFirst));
@@ -114,14 +127,15 @@ static void convertImagePixelsAccelerated(const ConstPixelBufferConversionView& 
     auto destinationVImageBuffer = makeVImageBuffer(destination, destinationSize);
 
     auto zeroFillDestination = [&] {
-        size_t rowFillBytes = static_cast<size_t>(destinationSize.width()) * 4;
+        size_t rowFillBytes = static_cast<size_t>(destinationSize.width()) * PixelBuffer::bytesPerPixel(destination.format.pixelFormat);
         for (int y = 0; y < destinationSize.height(); ++y)
             zeroSpan(destination.rows.subspan(static_cast<size_t>(y) * destination.bytesPerRow, rowFillBytes));
     };
 
-    if (source.format.colorSpace != destination.format.colorSpace) {
-        // FIXME: Consider using vImageConvert_AnyToAny for all conversions, not just ones that need a color space conversion,
-        // after judiciously performance testing them against each other.
+    if (source.format.colorSpace != destination.format.colorSpace
+        || PixelBuffer::bytesPerPixelComponent(source.format.pixelFormat) != PixelBuffer::bytesPerPixelComponent(destination.format.pixelFormat)) {
+        // FIXME: Consider using vImageConvert_AnyToAny for all conversions, not just ones that need a color space
+        // or component size conversion, after judiciously performance testing them against each other.
 
         auto sourceCGImageFormat = makeVImageCGImageFormat(source.format);
         auto destinationCGImageFormat = makeVImageCGImageFormat(destination.format);
@@ -146,6 +160,14 @@ static void convertImagePixelsAccelerated(const ConstPixelBufferConversionView& 
     }
 
     if (source.format.alphaFormat != destination.format.alphaFormat) {
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+        if (source.format.pixelFormat == PixelFormat::RGBA16F) {
+            if (destination.format.alphaFormat == AlphaPremultiplication::Unpremultiplied)
+                vImageUnpremultiplyData_RGBA16F(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
+            else
+                vImagePremultiplyData_RGBA16F(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
+        } else
+#endif
         if (destination.format.alphaFormat == AlphaPremultiplication::Unpremultiplied) {
             if (source.format.pixelFormat == PixelFormat::RGBA8)
                 vImageUnpremultiplyData_RGBA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
@@ -162,6 +184,8 @@ static void convertImagePixelsAccelerated(const ConstPixelBufferConversionView& 
     }
 
     if (source.format.pixelFormat != destination.format.pixelFormat) {
+        ASSERT(source.format.pixelFormat != PixelFormat::RGBA16F && destination.format.pixelFormat != PixelFormat::RGBA16F, "Conversion to/from RGBA16F should have been handled above.");
+
         // Swap pixel channels BGRA <-> RGBA.
         constexpr std::array<uint8_t, 4> map { 2, 1, 0, 3 };
         vImagePermuteChannels_ARGB8888(&sourceVImageBuffer, &destinationVImageBuffer, map.data(), kvImageNoFlags);
@@ -316,10 +340,11 @@ static void NODELETE convertImagePixelsUnaccelerated(const ConstPixelBufferConve
     }
 }
 
-#if !(USE(ACCELERATE) && USE(CG))
+#if ENABLE(PIXEL_FORMAT_RGBA16F) || !(USE(ACCELERATE) && USE(CG))
 static void copyImagePixels(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
-    size_t bytesPerRow = destinationSize.width() * 4;
+    ASSERT(source.format.pixelFormat == destination.format.pixelFormat);
+    size_t bytesPerRow = static_cast<size_t>(destinationSize.width()) * PixelBuffer::bytesPerPixel(destination.format.pixelFormat);
 
     if (bytesPerRow == source.bytesPerRow && bytesPerRow == destination.bytesPerRow) {
         memcpySpan(destination.rows, source.rows.first(bytesPerRow * destinationSize.height()));
@@ -334,179 +359,56 @@ static void copyImagePixels(const ConstPixelBufferConversionView& source, const 
 }
 #endif
 
+static bool UNUSED_FUNCTION NODELETE isSupportedConversionFormat(PixelFormat pixelFormat)
+{
+    switch (pixelFormat) {
+    case PixelFormat::RGBA8:
+    case PixelFormat::BGRA8:
+    case PixelFormat::BGRX8:
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-static Float16 NODELETE readFloat16(const std::span<const uint8_t>& span8, size_t offset)
-{
-    union {
-        Float16 float16 { };
-        std::array<uint8_t, sizeof(Float16)> bytes;
-    } float16OrBytesUnion;
-    for (size_t i = 0; i < sizeof(Float16); ++i)
-        float16OrBytesUnion.bytes[i] = span8[offset + i];
-    return float16OrBytesUnion.float16;
-}
-
-static void writeFloat16(Float16 f16, const std::span<uint8_t>& spanFloat16, size_t offset)
-{
-    union {
-        Float16 float16 { };
-        std::array<uint8_t, sizeof(Float16)> bytes;
-    } float16OrBytesUnion(f16);
-    for (size_t i = 0; i < sizeof(Float16); ++i)
-        spanFloat16[offset + i] = float16OrBytesUnion.bytes[i];
-}
-
-static void convertImagePixelsFromFloat16ToFloat16(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
-{
-    // FIXME: Float16-to-Float16 color-space conversion is unimplemented; fall through and copy
-    // verbatim. Do not early-return on a color-space mismatch: the destination is allocated
-    // uninitialized, so skipping the write would leak heap bytes through getPixelBuffer().
-
-    auto sourceBytes = source.rows.size_bytes();
-    auto sourcePixelComponents = sourceBytes / 2;
-    auto sourcePixels = sourcePixelComponents / 4;
-    auto sourceHeight = sourceBytes / source.bytesPerRow;
-    auto sourceWidth = sourcePixels / sourceHeight;
-
-    auto destinationBytes = destination.rows.size_bytes();
-    auto destinationPixelComponents = destinationBytes / 2;
-    auto destinationPixels = destinationPixelComponents / 4;
-    auto destinationHeight = destinationBytes / destination.bytesPerRow;
-    auto destinationWidth = destinationPixels / destinationHeight;
-
-    if (destinationSize.height() >= 0 && size_t(destinationSize.height()) < destinationHeight)
-        destinationHeight = size_t(destinationSize.height());
-    if (destinationSize.width() >= 0 && size_t(destinationSize.width()) < destinationWidth)
-        destinationWidth = size_t(destinationSize.width());
-
-    auto sourceRowStartOffset = 0;
-    auto destinationRowStartOffset = 0;
-    for (size_t y = 0; y < sourceHeight && y < destinationHeight; ++y) {
-        size_t offset = 0;
-        for (size_t x = 0; x < sourceWidth && x < destinationWidth; ++x) {
-            struct Pixel16 {
-                Float16 r = { };
-                Float16 g = { };
-                Float16 b = { };
-                Float16 a = { };
-            };
-            static_assert(sizeof(Float16) == 2);
-            static_assert(sizeof(Pixel16) == 4 * sizeof(Float16));
-            union {
-                Pixel16 pixel16 { };
-                std::array<uint8_t, sizeof(Pixel16)> bytes;
-            } pixel16OrBytesUnion;
-            for (size_t byte = 0; byte < sizeof(Pixel16); ++byte)
-                pixel16OrBytesUnion.bytes[byte] = source.rows[sourceRowStartOffset + offset + byte];
-            if (source.format.alphaFormat != destination.format.alphaFormat) {
-                if (source.format.alphaFormat == AlphaPremultiplication::Unpremultiplied && destination.format.alphaFormat == AlphaPremultiplication::Premultiplied) {
-                    auto fa = float(pixel16OrBytesUnion.pixel16.a);
-                    pixel16OrBytesUnion.pixel16.r = Float16(float(pixel16OrBytesUnion.pixel16.r) * fa);
-                    pixel16OrBytesUnion.pixel16.g = Float16(float(pixel16OrBytesUnion.pixel16.g) * fa);
-                    pixel16OrBytesUnion.pixel16.b = Float16(float(pixel16OrBytesUnion.pixel16.b) * fa);
-                } else if (source.format.alphaFormat == AlphaPremultiplication::Premultiplied && destination.format.alphaFormat == AlphaPremultiplication::Unpremultiplied) {
-                    if (auto fa = float(pixel16OrBytesUnion.pixel16.a)) {
-                        pixel16OrBytesUnion.pixel16.r = Float16(float(pixel16OrBytesUnion.pixel16.r) / fa);
-                        pixel16OrBytesUnion.pixel16.g = Float16(float(pixel16OrBytesUnion.pixel16.g) / fa);
-                        pixel16OrBytesUnion.pixel16.b = Float16(float(pixel16OrBytesUnion.pixel16.b) / fa);
-                    }
-                } else
-                    RELEASE_ASSERT_NOT_REACHED();
-            }
-            for (size_t byte = 0; byte < sizeof(Pixel16); ++byte)
-                destination.rows[destinationRowStartOffset + offset + byte] = pixel16OrBytesUnion.bytes[byte];
-            offset += sizeof(Pixel16);
-        }
-        sourceRowStartOffset += source.bytesPerRow;
-        destinationRowStartOffset += destination.bytesPerRow;
+    case PixelFormat::RGBA16F:
+#endif
+        return true;
+    default:
+        return false;
     }
 }
 
-static void convertImagePixelsFromFloat16(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+template<typename View> static bool NODELETE hasEnoughBytesForConversion(const View& view, const IntSize& destinationSize)
 {
-    auto pixelComponents = source.rows.size_bytes() / sizeof(Float16);
+    if (destinationSize.width() <= 0 || destinationSize.height() <= 0)
+        return true;
 
-    Vector<uint8_t> rgba8;
-    rgba8.reserveInitialCapacity(pixelComponents);
-
-    for (size_t i = 0; i < pixelComponents; ++i) {
-        auto f16 = readFloat16(source.rows, i * sizeof(Float16));
-        float f = float(f16);
-        auto u8 = (f <= 0.f) ? uint8_t(0) : ((f >= 1.f) ? uint8_t(255) : uint8_t(f * 255.f + 0.5f));
-        rgba8.append(u8);
-    }
-
-    ConstPixelBufferConversionView rgba8ConversionView {
-        .format = PixelBufferFormat {
-            .alphaFormat = source.format.alphaFormat,
-            .pixelFormat = PixelFormat::RGBA8,
-            .colorSpace = source.format.colorSpace
-        },
-        .bytesPerRow = source.bytesPerRow / unsigned(sizeof(Float16)),
-        .rows = rgba8.span()
-    };
-
-    convertImagePixels(rgba8ConversionView, destination, destinationSize);
+    CheckedSize requiredBytes = CheckedSize { static_cast<size_t>(destinationSize.height() - 1) } * view.bytesPerRow;
+    requiredBytes += CheckedSize { static_cast<size_t>(destinationSize.width()) } * PixelBuffer::bytesPerPixel(view.format.pixelFormat);
+    return !requiredBytes.hasOverflowed() && view.rows.size_bytes() >= requiredBytes.value();
 }
-
-// [[noreturn]]
-static void convertImagePixelsToFloat16(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
-{
-    auto pixelComponents = destination.rows.size_bytes() / sizeof(Float16);
-
-    Vector<uint8_t> rgba8;
-    rgba8.reserveInitialCapacity(pixelComponents);
-    rgba8.fill(uint8_t(0), pixelComponents);
-
-    PixelBufferConversionView rgba8ConversionView {
-        .format = PixelBufferFormat {
-            .alphaFormat = destination.format.alphaFormat,
-            .pixelFormat = PixelFormat::RGBA8,
-            .colorSpace = destination.format.colorSpace
-        },
-        .bytesPerRow = destination.bytesPerRow / unsigned(sizeof(Float16)),
-        .rows = rgba8.mutableSpan()
-    };
-
-    convertImagePixels(source, rgba8ConversionView, destinationSize);
-
-    for (size_t i = 0; i < pixelComponents; ++i) {
-        auto u8 = rgba8[i];
-        float f = float(u8) / 255.f;
-        Float16 f16 = f;
-        writeFloat16(f16, destination.rows, i * 2);
-    }
-
-}
-#endif // ENABLE(PIXEL_FORMAT_RGBA16F)
+#endif
 
 void convertImagePixels(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
-    auto isSourceFloat = source.format.pixelFormat == PixelFormat::RGBA16F;
-    if (isSourceFloat && destinationSize.height() > 0 && destinationSize.width() > 0) {
-        RELEASE_ASSERT((source.rows.size_bytes() - destinationSize.width() * (4 * sizeof(Float16))) / source.bytesPerRow >= size_t(destinationSize.height() - 1), "Expected source size_bytes >= (height-1) * bytesPerRow + width*4*sizeof(Float16)");
-        RELEASE_ASSERT(source.rows.size_bytes() / (4 * sizeof(Float16)) / destinationSize.width() >= size_t(destinationSize.height()), "Expected source size_bytes >= width * height * 4*sizeof(Float16)");
-    }
-    auto isDestinationFloat = destination.format.pixelFormat == PixelFormat::RGBA16F;
-    if (isDestinationFloat && destinationSize.height() > 0 && destinationSize.width() > 0) {
-        RELEASE_ASSERT((destination.rows.size_bytes() - destinationSize.width() * (4 * sizeof(Float16))) / destination.bytesPerRow >= size_t(destinationSize.height() - 1), "Expected destination size_bytes >= (height-1) * bytesPerRow + width*4*sizeof(Float16)");
-        RELEASE_ASSERT(destination.rows.size_bytes() / (4 * sizeof(Float16)) / destinationSize.width() >= size_t(destinationSize.height()), "Expected destination size_bytes >= width * height * 4*sizeof(Float16)");
-    }
-    if (isSourceFloat && isDestinationFloat)
-        return convertImagePixelsFromFloat16ToFloat16(source, destination, destinationSize);
-    if (isSourceFloat)
-        return convertImagePixelsFromFloat16(source, destination, destinationSize);
-    if (isDestinationFloat)
-        return convertImagePixelsToFloat16(source, destination, destinationSize);
-#endif // ENABLE(PIXEL_FORMAT_RGBA16F)
+    // We currently only support converting between RGBA8, BGRA8, BGRX8, and — where enabled — RGBA16F.
+    ASSERT(isSupportedConversionFormat(source.format.pixelFormat));
+    ASSERT(isSupportedConversionFormat(destination.format.pixelFormat));
 
-    // We currently only support converting between RGBA8, BGRA8, and BGRX8; and on some platforms RGBA16F (see above).
-    ASSERT(source.format.pixelFormat == PixelFormat::RGBA8 || source.format.pixelFormat == PixelFormat::BGRA8 || source.format.pixelFormat == PixelFormat::BGRX8);
-    ASSERT(destination.format.pixelFormat == PixelFormat::RGBA8 || destination.format.pixelFormat == PixelFormat::BGRA8 || destination.format.pixelFormat == PixelFormat::BGRX8);
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (source.format.pixelFormat == PixelFormat::RGBA16F)
+        RELEASE_ASSERT(hasEnoughBytesForConversion(source, destinationSize), "Source buffer is too small for the requested conversion");
+    if (destination.format.pixelFormat == PixelFormat::RGBA16F)
+        RELEASE_ASSERT(hasEnoughBytesForConversion(destination, destinationSize), "Destination buffer is too small for the requested conversion");
+#endif
 
 #if USE(ACCELERATE) && USE(CG)
-    if (source.format.alphaFormat == destination.format.alphaFormat && source.format.pixelFormat == destination.format.pixelFormat && source.format.colorSpace == destination.format.colorSpace) {
+    bool formatsAreIdentical = source.format.alphaFormat == destination.format.alphaFormat && source.format.pixelFormat == destination.format.pixelFormat && source.format.colorSpace == destination.format.colorSpace;
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    // The single-pixel functors below only handle 8 bits per component, so copy RGBA16F verbatim.
+    if (formatsAreIdentical && source.format.pixelFormat == PixelFormat::RGBA16F) {
+        copyImagePixels(source, destination, destinationSize);
+        return;
+    }
+#endif
+    if (formatsAreIdentical) {
         // FIXME: Can thes both just use per-row memcpy?
         if (source.format.alphaFormat == AlphaPremultiplication::Premultiplied)
             convertImagePixelsUnaccelerated<convertSinglePixelPremultipliedToPremultiplied<PixelFormatConversion::None>>(source, destination, destinationSize);

--- a/Tools/TestWebKitAPI/Tests/WebCore/PixelBufferConversionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PixelBufferConversionTests.cpp
@@ -27,6 +27,9 @@
 
 #include <WebCore/IntSize.h>
 #include <WebCore/PixelBufferConversion.h>
+#include <vector>
+#include <wtf/Float16.h>
+#include <wtf/StdLibExtras.h>
 
 namespace TestWebKitAPI {
 using namespace WebCore;
@@ -76,5 +79,131 @@ TEST(PixelBufferConversionTests, convertImagePixels2)
     EXPECT_EQ(convert(PixelFormat::RGBA8, PixelFormat::RGBA8), (std::vector<uint8_t> { 1, 2, 3, 4, 9, 10, 11, 12 }));
     EXPECT_EQ(convert(PixelFormat::RGBA8, PixelFormat::BGRA8), (std::vector<uint8_t> { 3, 2, 1, 4, 11, 10, 9, 12 }));
 }
+
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+
+static std::vector<uint8_t> byteVectorFromFloat16s(const std::vector<Float16>& components)
+{
+    std::vector<uint8_t> bytes(components.size() * sizeof(Float16));
+    memcpySpan(std::span { bytes }, asByteSpan(std::span { components }));
+    return bytes;
+}
+
+static std::vector<Float16> float16sFromByteVector(const std::vector<uint8_t>& bytes)
+{
+    std::vector<Float16> components(bytes.size() / sizeof(Float16));
+    memcpySpan(asMutableByteSpan(std::span { components }), std::span { bytes });
+    return components;
+}
+
+static std::vector<Float16> convertFloat16s(AlphaPremultiplication sourceAlphaFormat, DestinationColorSpace sourceColorSpace, AlphaPremultiplication destinationAlphaFormat, DestinationColorSpace destinationDestinationColorSpace, const std::vector<Float16>& components)
+{
+    RELEASE_ASSERT(!(components.size() % 4));
+    IntSize size(components.size() / 4, 1);
+    auto sourceBytes = byteVectorFromFloat16s(components);
+    unsigned bytesPerRow = sourceBytes.size();
+    std::vector<uint8_t> destinationBytes(bytesPerRow);
+    ConstPixelBufferConversionView source { PixelBufferFormat { .alphaFormat = sourceAlphaFormat, .pixelFormat = PixelFormat::RGBA16F, .colorSpace = sourceColorSpace }, bytesPerRow, sourceBytes };
+    PixelBufferConversionView destination { PixelBufferFormat { .alphaFormat = destinationAlphaFormat, .pixelFormat = PixelFormat::RGBA16F, .colorSpace = destinationDestinationColorSpace }, bytesPerRow, destinationBytes };
+
+    convertImagePixels(source, destination, size);
+
+    return float16sFromByteVector(destinationBytes);
+};
+
+// Half-float comparison with a tolerance, since color space conversions are not bit-exact.
+static void expectFloat16sNear(const std::vector<Float16>& actual, const std::vector<float>& expected, float tolerance = 1.f / 2048.f)
+{
+    ASSERT_EQ(actual.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i)
+        EXPECT_NEAR(static_cast<float>(actual[i]), expected[i], tolerance) << "component " << i;
+}
+
+TEST(PixelBufferConversionTests, convertImagePixelsFloat16Identical)
+{
+    std::vector<Float16> sourceFloat16s { 3.0, 0.5, 0.25, 1.0, 0.125, -0.25, 0.5, 1.0 };
+    EXPECT_EQ(convertFloat16s(AlphaPremultiplication::Premultiplied, DestinationColorSpace::SRGB(), AlphaPremultiplication::Premultiplied, DestinationColorSpace::SRGB(), sourceFloat16s), sourceFloat16s);
+}
+
+TEST(PixelBufferConversionTests, convertImagePixelsFloat16AlphaOnly)
+{
+    // Alpha-only changes within RGBA16F use the vImage half-float premultiply entry points.
+    auto convert = [](AlphaPremultiplication sourceAlphaFormat, AlphaPremultiplication destinationAlphaFormat, const std::vector<Float16>& components) {
+        return convertFloat16s(sourceAlphaFormat, DestinationColorSpace::SRGB(), destinationAlphaFormat, DestinationColorSpace::SRGB(), components);
+    };
+
+    expectFloat16sNear(convert(AlphaPremultiplication::Unpremultiplied, AlphaPremultiplication::Premultiplied, { 1.0, 0.5, 0.25, 0.5 }), { 0.5, 0.25, 0.125, 0.5 });
+    expectFloat16sNear(convert(AlphaPremultiplication::Premultiplied, AlphaPremultiplication::Unpremultiplied, { 0.5, 0.25, 0.125, 0.5 }), { 1.0, 0.5, 0.25, 0.5 });
+
+    // A zero alpha must not divide by zero.
+    expectFloat16sNear(convert(AlphaPremultiplication::Premultiplied, AlphaPremultiplication::Unpremultiplied, { 0.0, 0.0, 0.0, 0.0 }), { 0.0, 0.0, 0.0, 0.0 });
+}
+
+TEST(PixelBufferConversionTests, convertImagePixelsFloat16ColorSpaceConversion)
+{
+    // Orange rgb(255, 165, 0) ~ color(srgb 1 0.6471 0) -> color(display-p3 0.9497 0.6629 0.2330)
+    std::vector<Float16> sourceFloat16s { 1.0, 0.6471, 0.0, 1.0 };
+    expectFloat16sNear(convertFloat16s(AlphaPremultiplication::Premultiplied, DestinationColorSpace::SRGB(), AlphaPremultiplication::Premultiplied, DestinationColorSpace::ExtendedDisplayP3(), sourceFloat16s), { 0.9497, 0.6629, 0.2330, 1.0 });
+}
+
+TEST(PixelBufferConversionTests, convertImagePixelsFloat16ToAndFromByte)
+{
+    const auto colorSpace = DestinationColorSpace::SRGB();
+    constexpr int float16BytesPerRow = 4 * sizeof(Float16);
+    constexpr int u8BytesPerRow = 4;
+
+    // RGBA16F to BGRA8: components are scaled to [0, 255] and the channel order is swapped.
+    {
+        const auto sourceBytes = byteVectorFromFloat16s({ 1.0, 0.5, 0.0, 1.0 });
+        std::vector<uint8_t> destinationBytes(4);
+        const ConstPixelBufferConversionView source { { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA16F, colorSpace }, float16BytesPerRow, sourceBytes };
+        const PixelBufferConversionView destination { { AlphaPremultiplication::Premultiplied, PixelFormat::BGRA8, colorSpace }, u8BytesPerRow, destinationBytes };
+
+        convertImagePixels(source, destination, { 1, 1 });
+
+        EXPECT_EQ(destinationBytes[0], 0);
+        EXPECT_NEAR(destinationBytes[1], 128U, 1);
+        EXPECT_EQ(destinationBytes[2], 255);
+        EXPECT_EQ(destinationBytes[3], 255);
+    }
+
+    // BGRA8 to RGBA16F round-trips back to the same values.
+    {
+        const std::vector<uint8_t> sourceBytes { 0, 128, 255, 255 };
+        std::vector<uint8_t> destinationBytes(4 * sizeof(Float16));
+        const ConstPixelBufferConversionView source { { AlphaPremultiplication::Premultiplied, PixelFormat::BGRA8, colorSpace }, u8BytesPerRow, sourceBytes };
+        const PixelBufferConversionView destination { { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA16F, colorSpace }, float16BytesPerRow, destinationBytes };
+
+        convertImagePixels(source, destination, { 1, 1 });
+
+        expectFloat16sNear(float16sFromByteVector(destinationBytes), { 1.0, 128.0 / 255.0, 0.0, 1.0 });
+    }
+}
+
+TEST(PixelBufferConversionTests, convertImagePixelsFloat16PaddedRows)
+{
+    const auto colorSpace = DestinationColorSpace::SRGB();
+    const auto sourceBytes = byteVectorFromFloat16s({
+        1.0, 0.0, 0.0, 1.0, /* padding: */ 0.0, 0.0,
+        0.0, 1.0, 0.0, 1.0, /* padding: */ 0.0, 0.0,
+    });
+    std::vector<uint8_t> destinationBytes(2 * 6);
+    const ConstPixelBufferConversionView source { { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA16F, colorSpace }, 6 * sizeof(Float16), sourceBytes };
+    const PixelBufferConversionView destination { { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, colorSpace }, 6, destinationBytes };
+
+    convertImagePixels(source, destination, { 1, 2 });
+
+    // Row 0 is red, row 1 is green, each at the start of its (padded) row.
+    EXPECT_EQ(destinationBytes[0], 255);
+    EXPECT_EQ(destinationBytes[1], 0);
+    EXPECT_EQ(destinationBytes[2], 0);
+    EXPECT_EQ(destinationBytes[3], 255);
+    EXPECT_EQ(destinationBytes[6], 0);
+    EXPECT_EQ(destinationBytes[7], 255);
+    EXPECT_EQ(destinationBytes[8], 0);
+    EXPECT_EQ(destinationBytes[9], 255);
+}
+
+#endif // ENABLE(PIXEL_FORMAT_RGBA16F)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### e0a4c3f6764a4b74c23660affaef01c30c8afd73
<pre>
Accelerated convertImagePixels for PixelFormat::RGBA16F
<a href="https://bugs.webkit.org/show_bug.cgi?id=321147">https://bugs.webkit.org/show_bug.cgi?id=321147</a>
<a href="https://rdar.apple.com/158267620">rdar://158267620</a>

Reviewed by Mike Wyrzykowski.

Remove the long-winded and unaccelerated float16 conversion functions.
Instead, add float16 support through the accelerated path.

Note: There is no need for unaccelerated float16 functions at this time,
since PixelFormat::RGBA16F is only available on platforms where
accelerated CG functions exist and should be used.

* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::makeVImageCGImageFormat):
(WebCore::convertImagePixelsAccelerated):
(WebCore::copyImagePixels):
(WebCore::isSupportedConversionFormat):
(WebCore::hasEnoughBytesForConversion):
(WebCore::convertImagePixels):
(WebCore::readFloat16): Deleted.
(WebCore::writeFloat16): Deleted.
(WebCore::convertImagePixelsFromFloat16ToFloat16): Deleted.
(WebCore::convertImagePixelsFromFloat16): Deleted.
(WebCore::convertImagePixelsToFloat16): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/PixelBufferConversionTests.cpp:
(TestWebKitAPI::byteVectorFromFloat16s):
(TestWebKitAPI::float16sFromByteVector):
(TestWebKitAPI::convertFloat16s):
(TestWebKitAPI::expectFloat16sNear):
(TestWebKitAPI::TEST(PixelBufferConversionTests, convertImagePixelsFloat16Identical)):
(TestWebKitAPI::TEST(PixelBufferConversionTests, convertImagePixelsFloat16AlphaOnly)):
(TestWebKitAPI::TEST(PixelBufferConversionTests, convertImagePixelsFloat16ColorSpaceConversion)):
(TestWebKitAPI::TEST(PixelBufferConversionTests, convertImagePixelsFloat16ToAndFromByte)):
(TestWebKitAPI::TEST(PixelBufferConversionTests, convertImagePixelsFloat16PaddedRows)):

Canonical link: <a href="https://commits.webkit.org/318822@main">https://commits.webkit.org/318822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4344954dd1babf2e07065b444607ab693dbc9cec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188886 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143366 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d9f2b46-97b1-443f-ae4d-bd852984051a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139631 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96749 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/556eac05-d499-4ab4-a375-277af22fddfa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43227 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120077 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3dbe7eb2-1b47-4a00-808f-9d63b11bd455) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41898 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40241 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39891 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/193 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45602 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44486 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191106 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52666 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148862 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40014 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53346 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36517 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148607 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43297 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125617 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120431 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51864 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14870 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51249 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51490 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51310 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->