### PR TITLE
[GStreamer][MSE] Avoid spurious seek to 0 when seeking to end

### DIFF
--- a/LayoutTests/media/media-source/media-source-seek-to-end-doesnt-loop-expected.txt
+++ b/LayoutTests/media/media-source/media-source-seek-to-end-doesnt-loop-expected.txt
@@ -1,0 +1,28 @@
+This tests that when seeking in an audio to the end, currentTime doesn't appear to go backwards due to an accidental loop.
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(audioSourceBuffer = source.addSourceBuffer(audioLoader.type()))
+-
+Load audio sourceBuffer
+RUN(audioSourceBuffer.appendBuffer(audioLoader.initSegment()))
+RUN(audioSourceBuffer.appendBuffer(audioLoader.mediaSegment(0)))
+RUN(audioSourceBuffer.appendBuffer(audioLoader.mediaSegment(1)))
+RUN(source.endOfStream())
+RUN(savedDuration = video.duration)
+EXPECTED (savedDuration > 0 == 'true') OK
+EXPECTED (video.buffered.length == '1') OK
+-
+RUN(video.play())
+Waiting for currentTime > 0s...
+-
+Seeking to the end and waiting...
+RUN(video.currentTime = savedDuration)
+-
+Seeking, seeked and ended events happened.
+EXPECTED (video.duration == savedDuration == 'true') OK
+EXPECTED (video.currentTime == savedDuration == 'true') OK
+EXPECTED (timesSeenInTimeupdateAfterSeek.length > 0 == 'true') OK
+EXPECTED (timesSeenInTimeupdateAfterSeek.indexOf(0) == '-1') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-seek-to-end-doesnt-loop.html
+++ b/LayoutTests/media/media-source/media-source-seek-to-end-doesnt-loop.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-seek-to-end-doesnt-loop</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var loader;
+    var source;
+    var audioSourceBuffer;
+    var minBuffered;
+    var seekPromise;
+    var savedDuration;
+    const timesSeenInTimeupdateAfterSeek = [];
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    function waitForTimeupdateGreaterThan(video, refTime) {
+        return new Promise((resolve) => {
+            const listener = () => {
+                if (video.currentTime < refTime)
+                    return;
+                video.removeEventListener('timeupdate', listener);
+                resolve();
+            };
+            video.addEventListener('timeupdate', listener)
+        });
+    }
+
+    async function runTest() {
+        audioLoader = new MediaSourceLoader('content/test-48khz-manifest.json');
+        await loaderPromise(audioLoader);
+
+        findMediaElement();
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        run('audioSourceBuffer = source.addSourceBuffer(audioLoader.type())');
+        waitFor(video, 'error').then(failTest);
+
+        consoleWrite('-');
+        consoleWrite('Load audio sourceBuffer');
+        run('audioSourceBuffer.appendBuffer(audioLoader.initSegment())');
+        await waitFor(audioSourceBuffer, 'update', true);
+        for (let i = 0; i < 2; i++) {
+            run(`audioSourceBuffer.appendBuffer(audioLoader.mediaSegment(${i}))`);
+            await waitFor(audioSourceBuffer, 'update', true);
+        }
+        run('source.endOfStream()');
+        run('savedDuration = video.duration');
+        testExpected('savedDuration > 0', true);
+        testExpected('video.buffered.length', 1);
+
+        consoleWrite('-');
+        run('video.play()');
+        consoleWrite('Waiting for currentTime > 0s...');
+        await waitForTimeupdateGreaterThan(video, 0);
+
+        consoleWrite('-');
+        consoleWrite('Seeking to the end and waiting...');
+        run('video.currentTime = savedDuration');
+        video.addEventListener('timeupdate', () => {
+            timesSeenInTimeupdateAfterSeek.push(video.currentTime);
+        })
+
+        // Event logging is silenced (true) because seeked and ended can happed on any order under high load.
+        await Promise.all([
+            waitFor(video, 'seeking', true),
+            waitFor(video, 'seeked', true),
+            waitFor(video, 'ended', true),
+        ]);
+
+        consoleWrite('-');
+        consoleWrite('Seeking, seeked and ended events happened.');
+        testExpected('video.duration == savedDuration', true);
+        testExpected('video.currentTime == savedDuration', true);
+        testExpected('timesSeenInTimeupdateAfterSeek.length > 0', true);
+        testExpected('timesSeenInTimeupdateAfterSeek.indexOf(0)', -1);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    })
+    </script>
+</head>
+<body>
+    <div>
+        This tests that when seeking in an audio to the end, currentTime doesn't appear to go backwards due to an accidental loop.
+    </div>
+    <video controls muted></video>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6510,8 +6510,11 @@ void HTMLMediaElement::mediaPlayerPlaybackStateChanged()
     beginProcessingMediaPlayerCallback();
     if (playerPaused)
         pauseInternal();
-    else
+    else if (!seeking() || !isEnded()) {
+        // The extra conditions above prevent autoplay when seeking, which would start playback from 0
+        // and cause a spurious seek to 0 when seeking to the end of the media.
         playInternal();
+    }
     endProcessingMediaPlayerCallback();
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1748,6 +1748,14 @@ MediaTime MediaPlayerPrivateGStreamer::playbackPosition() const
     else if (m_canFallBackToLastFinishedSeekPosition)
         playbackPosition = m_seekTarget.time;
 
+    // Avoid exceeding the reported duration even by minuscule amounts.
+    // The multiplatform layer could degrade us to HaveMetadata if we let that happen (e.g. in MSE monitorSourceBuffers()).
+    // Don't apply this condition in the special zero duration case, since zero is a special value used when the duration
+    // is unknown, and applying the condition in that case may have undesired effects.
+    // See: MediaPlayerPrivateGStreamer::duration(), MediaPlayerPrivateGStreamerMSE::duration().
+    if (duration() != MediaTime::zeroTime() && playbackPosition > duration())
+        playbackPosition = duration();
+
     setCachedPosition(playbackPosition);
     invalidateCachedPositionOnNextIteration();
     return playbackPosition;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -313,6 +313,7 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek(const SeekTarget& target, float rate
         RefPtr self = weakThis.get();
         if (!self || !result)
             return;
+        propagateReadyStateToPlayer();
 
         // FIXME: Should m_mediaSourcePrivate run on its own WorkQueue (e.g. if MSE in a worker is enabled)
         // this should be changed for the async version of reenqueueMediaForTime.
@@ -398,7 +399,7 @@ void MediaPlayerPrivateGStreamerMSE::readyStateFromMediaSourceChanged()
 
 void MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer()
 {
-    ASSERT(m_mediaSourceReadyState < MediaPlayer::ReadyState::HaveCurrentData || !hasVideo() || !m_isWaitingForPreroll);
+    ASSERT(m_mediaSourceReadyState < MediaPlayer::ReadyState::HaveCurrentData || !hasVideo() || !m_isWaitingForPreroll || m_isSeeking);
     if (m_readyState == m_mediaSourceReadyState)
         return;
     GST_DEBUG("Propagating MediaSource readyState %s to player ready state (currently %s)",


### PR DESCRIPTION
#### 42a5b5300e3d05ac9a9274479d118958892a9508
<pre>
[GStreamer][MSE] Avoid spurious seek to 0 when seeking to end
<a href="https://bugs.webkit.org/show_bug.cgi?id=320981">https://bugs.webkit.org/show_bug.cgi?id=320981</a>

Reviewed by Xabier Rodriguez-Calvar.

On a device where a GStreamer seek operation leads to a pipeline async
state change, we may enter a flow of internal calls that cause a second
seek to zero to be executed before the first call has returned. This was
detected with Spotify when performing a seek to the asset end (duration)
right after playback has started from the beginning (position zero).
This issue does not happen if the GStreamer seek operation does not
cause a async pipeline state change.

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1645">https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1645</a>

This patch avoids automatic playback when the video has ended
(effectively helping to avoid currentTime accidentally going beyond the
duration) or when a seek is still happening (avoiding currentTime to
progress and change the conditions of the video). ReadyState is
propagated to the player when seek has completed, helping the
HTMLMediaElement algorithms to take the right decisions when seek
completes. Finally, code has been added to avoid the position to ever go
beyond the duration in order to avoid a degradation of the ReadyState to
HaveMetadata, except when the duration is zero. This is a special case
used by MediaPlayerPrivateGStreamer::duration() and
MediaPlayerPrivateGStreamerMSE::duration() when the duration is
unknown/unavailable, and we don&apos;t want to mess up with that and cause a
stream that is just being loaded to trigger unexpected effects.

Co-authored-by: Enrique Ocaña González &lt;eocanha@igalia.com&gt;

Test: media/media-source/media-source-seek-to-end-doesnt-loop.html

* LayoutTests/media/media-source/media-source-seek-to-end-doesnt-loop-expected.txt: Added.
* LayoutTests/media/media-source/media-source-seek-to-end-doesnt-loop.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerPlaybackStateChanged): Avoid automatic playback on seek or video end.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::playbackPosition const): Never allow the position to go beyond duration, except in the special case when duration is zero.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::doSeek): Propagate readyState to player on seek completion.
(WebCore::MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer): Relaxed the assert so also admit m_isSeeking as a condition to not halt execution.

Canonical link: <a href="https://commits.webkit.org/318859@main">https://commits.webkit.org/318859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/272ed49c5319b753a611f77ce658c98d2415680a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189205 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139881 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96806 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120333 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42158 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40490 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152558 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40136 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/657 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191423 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149135 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40027 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53663 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148877 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43553 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125935 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120818 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52180 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15123 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51806 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->