### PR TITLE
Promote -[WKWebView _getMainResourceDataWithCompletionHandler:] SPI to fetchMainResourceDataWithCompletionHandler: API

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -463,6 +463,12 @@ The uniform type identifier kUTTypeWebArchive can be used get the related pasteb
 */
 - (void)createWebArchiveDataWithCompletionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData * _Nullable, NSError * _Nullable))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
 
+/*! @abstract Fetch data representing the main resource of the current web content in the WKWebView.
+ @param completionHandler A block to invoke when the main resource data is ready.
+ @discussion Main resource data represents the raw response data of the main frame's resource.
+ */
+- (void)fetchMainResourceDataWithCompletionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData * _Nullable mainResourceData, NSError * _Nullable error))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 /*! @abstract A Boolean value indicating whether horizontal swipe gestures
  will trigger back-forward list navigations.
  @discussion The default value is NO.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2325,6 +2325,14 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
     });
 }
 
+- (void)fetchMainResourceDataWithCompletionHandler:(void (^)(NSData *, NSError *))completionHandler
+{
+    THROW_IF_SUSPENDED;
+    _page->getMainResourceDataOfFrame(protect(_page->mainFrame()), [completionHandler = makeBlockPtr(completionHandler)](API::Data* data) {
+        completionHandler(protect(wrapper(data)).get(), nil);
+    });
+}
+
 static RetainPtr<NSDictionary> dictionaryRepresentationForEditorState(const WebKit::EditorState& state)
 {
     if (!state.hasPostLayoutData())
@@ -6003,9 +6011,7 @@ static inline OptionSet<WebCore::LayoutMilestone> NODELETE layoutMilestones(_WKR
 - (void)_getMainResourceDataWithCompletionHandler:(void (^)(NSData *, NSError *))completionHandler
 {
     THROW_IF_SUSPENDED;
-    _page->getMainResourceDataOfFrame(protect(_page->mainFrame()), [completionHandler = makeBlockPtr(completionHandler)](API::Data* data) {
-        completionHandler(protect(wrapper(data)).get(), nil);
-    });
+    [self fetchMainResourceDataWithCompletionHandler:completionHandler];
 }
 
 - (void)_getWebArchiveDataWithCompletionHandler:(void (^)(NSData *, NSError *))completionHandler

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -363,7 +363,7 @@ for this property.
 
 - (void)_saveResources:(NSURL *)directory suggestedFileName:(NSString *)name completionHandler:(void (^)(NSError *error))completionHandler WK_API_AVAILABLE(macos(14.4), ios(17.4), visionos(1.1));
 - (void)_archiveWithConfiguration:(_WKArchiveConfiguration*)configuration completionHandler:(void (^)(NSError *error))completionHandler WK_API_AVAILABLE(macos(14.4), ios(17.4), visionos(1.1));
-- (void)_getMainResourceDataWithCompletionHandler:(void (^)(NSData *, NSError *))completionHandler;
+- (void)_getMainResourceDataWithCompletionHandler:(void (^)(NSData *, NSError *))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("fetchMainResourceDataWithCompletionHandler:", macos(WK_MAC_TBA, WK_MAC_TBA), ios(WK_IOS_TBA, WK_IOS_TBA));
 - (void)_getWebArchiveDataWithCompletionHandler:(void (^)(NSData *, NSError *))completionHandler;
 - (void)_createWebArchiveForFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSData *, NSError *))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 - (void)_createWebArchiveForFrames:(NSArray<WKFrameInfo *> *)frames rootFrame:(WKFrameInfo *)rootFrame completionHandler:(void (^)(NSData *, NSError *))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetResourceData.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetResourceData.mm
@@ -26,7 +26,7 @@
 #import "config.h"
 #import <WebKit/WKFoundation.h>
 
-#if PLATFORM(MAC)
+#if PLATFORM(COCOA)
 
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
@@ -41,8 +41,8 @@ TEST(WebKit, GetPDFResourceData)
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     __block bool isDone;
-    [webView _getMainResourceDataWithCompletionHandler:^(NSData *data, NSError *error) {
-        EXPECT_NULL(data);
+    [webView fetchMainResourceDataWithCompletionHandler:^(NSData *data, NSError *error) {
+        EXPECT_TRUE(!data || !data.length);
         isDone = true;
     }];
     TestWebKitAPI::Util::run(&isDone);
@@ -53,7 +53,7 @@ TEST(WebKit, GetPDFResourceData)
 
     [webView _test_waitForDidFinishNavigation];
 
-    [webView _getMainResourceDataWithCompletionHandler:^(NSData *data, NSError *error) {
+    [webView fetchMainResourceDataWithCompletionHandler:^(NSData *data, NSError *error) {
         EXPECT_EQ(data.length, 10820UL);
         isDone = true;
     }];
@@ -72,10 +72,12 @@ TEST(WebKit, GetPDFResourceDataInUnparentedWebView)
     [webView _test_waitForDidFinishNavigation];
 
     __block bool isDone;
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [webView _getMainResourceDataWithCompletionHandler:^(NSData *data, NSError *error) {
         EXPECT_EQ(data.length, 10820UL);
         isDone = true;
     }];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     TestWebKitAPI::Util::run(&isDone);
 }


### PR DESCRIPTION
#### 3f7c2260209879bce0c9633e3d621d4b3a0bf966
<pre>
Promote -[WKWebView _getMainResourceDataWithCompletionHandler:] SPI to fetchMainResourceDataWithCompletionHandler: API
<a href="https://bugs.webkit.org/show_bug.cgi?id=226509">https://bugs.webkit.org/show_bug.cgi?id=226509</a>

Reviewed by NOBODY (OOPS!).

Promote the private SPI -[WKWebView _getMainResourceDataWithCompletionHandler:] to the public API -[WKWebView fetchMainResourceDataWithCompletionHandler:]. This method allows WebKit clients to retrieve the raw response data of the main frame resource.
The private SPI is deprecated with a replacement recommendation and now forwards directly to the public API for backwards compatibility.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetResourceData.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView fetchMainResourceDataWithCompletionHandler:]):
(-[WKWebView _getMainResourceDataWithCompletionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetResourceData.mm:
(TEST(WebKit, GetPDFResourceData)):
(TEST(WebKit, GetPDFResourceDataInUnparentedWebView)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f7c2260209879bce0c9633e3d621d4b3a0bf966

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188232 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141866 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139264 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96686 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119718 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41486 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39839 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39513 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190659 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52223 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148429 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52904 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148197 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42902 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125171 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119822 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51422 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14488 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51047 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->