### PR TITLE
[JSC] `Array#sort` without a comparator is not stable

### DIFF
--- a/JSTests/stress/array-sort-default-comparator-stability.js
+++ b/JSTests/stress/array-sort-default-comparator-stability.js
@@ -1,0 +1,29 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + ", expected: " + expected);
+}
+
+function makeEntries(count, distinct, prefix) {
+    let entries = [];
+    for (let i = 0; i < count; ++i) {
+        let key = prefix + String.fromCharCode(0x41 + ((i * 7) % distinct));
+        entries.push({ id: i, key, toString() { return this.key; } });
+    }
+    return entries;
+}
+
+function verifyStable(entries) {
+    let expected = entries.slice().sort((a, b) => a.key < b.key ? -1 : a.key > b.key ? 1 : a.id - b.id);
+    let actual = entries.slice().sort();
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < actual.length; ++i)
+        shouldBe(actual[i].id, expected[i].id);
+}
+
+for (let count = 20; count <= 40; ++count) {
+    for (let distinct of [1, 2, 3, 5])
+        verifyStable(makeEntries(count, distinct, ""));
+}
+
+for (let count of [40, 100])
+    verifyStable(makeEntries(count, 3, "0123456789012345678901234567890123456789"));

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -893,7 +893,7 @@ static ALWAYS_INLINE std::tuple<uint64_t, IndexingType, std::span<EncodedJSValue
 static unsigned sortBucketSort(std::span<EncodedJSValue> sorted, unsigned dst, SortEntryVector& bucket, unsigned depth)
 {
     if (bucket.size() < 32 || depth > 32) {
-        std::ranges::sort(bucket, WTF::codePointCompareLessThan, [](const auto& element) {
+        std::ranges::stable_sort(bucket, WTF::codePointCompareLessThan, [](const auto& element) {
             return std::get<1>(element);
         });
         for (auto& entry : bucket)


### PR DESCRIPTION
#### a011564b98ab104896256b0aaffd3ecb254d744a
<pre>
[JSC] `Array#sort` without a comparator is not stable
<a href="https://bugs.webkit.org/show_bug.cgi?id=320982">https://bugs.webkit.org/show_bug.cgi?id=320982</a>

Reviewed by Yusuke Suzuki.

The no-comparator string sort falls back to std::ranges::sort for buckets smaller
than 32 entries and past the depth cap, and std::ranges::sort is not stable. The
default sort compares ToString results, which is a consistent comparator, so the
spec requires the result to be stable [1]:

    let objects = [];
    for (let i = 0; i &lt; 30; ++i)
        objects.push({ id: i, toString() { return &quot;k&quot; + (i % 3); } });
    objects.sort(); // equal keys must keep their original order

Use std::ranges::stable_sort instead.

[1]: <a href="https://tc39.es/ecma262/#sec-sortindexedproperties">https://tc39.es/ecma262/#sec-sortindexedproperties</a>

Test: JSTests/stress/array-sort-default-comparator-stability.js

* JSTests/stress/array-sort-default-comparator-stability.js: Added.
(shouldBe):
(makeEntries):
(verifyStable):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::sortBucketSort):

Canonical link: <a href="https://commits.webkit.org/318682@main">https://commits.webkit.org/318682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76efccc643f3f0ead36e5e641736316ba28eaafa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141867 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139262 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96687 "3 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119716 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41489 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39841 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1685 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8500 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39512 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39890 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190660 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52224 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148430 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39933 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52905 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148198 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42899 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125172 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119823 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51423 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14487 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50808 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51048 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->