### PR TITLE
testdriver-vendor.js rejects action sequences containing a pause in a key source

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2546,6 +2546,7 @@ webkit.org/b/187003 imported/w3c/web-platform-tests/infrastructure/reftest/refte
 imported/w3c/web-platform-tests/infrastructure/assumptions/ahem.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/infrastructure/assumptions/min-font-size.html [ ImageOnlyFailure ]
 webkit.org/b/197011 imported/w3c/web-platform-tests/infrastructure/testdriver [ Skip ] # largely supported; some actions need interactive window
+imported/w3c/web-platform-tests/infrastructure/testdriver/key-source-pause.html [ Pass ] # does not need an interactive window
 webkit.org/b/187093 [ Debug ] imported/w3c/web-platform-tests/infrastructure/assumptions/html-elements.html [ Skip ]
 imported/w3c/web-platform-tests/infrastructure/server/wpt-server-websocket.sub.html [ Skip ] # non deterministic URL in text dump
 

--- a/LayoutTests/imported/w3c/web-platform-tests/infrastructure/testdriver/key-source-pause-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/infrastructure/testdriver/key-source-pause-expected.txt
@@ -1,0 +1,3 @@
+
+PASS pause actions in a key source do not reject the action sequence
+

--- a/LayoutTests/imported/w3c/web-platform-tests/infrastructure/testdriver/key-source-pause.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/infrastructure/testdriver/key-source-pause.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>testdriver-vendor.js supports pause actions in a key source</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="log"></div>
+<script>
+promise_test(async () => {
+    const keys = [];
+    document.addEventListener("keydown", event => keys.push(`down:${event.key}`));
+    document.addEventListener("keyup", event => keys.push(`up:${event.key}`));
+
+    // A pause with no duration is what testdriver-actions.js inserts for a tick in
+    // which this source has no action of its own; a pause with a duration is explicit.
+    await test_driver.action_sequence([{
+        type: "key",
+        id: "key-source",
+        actions: [
+            { type: "keyDown", value: "a" },
+            { type: "pause" },
+            { type: "pause", duration: 50 },
+            { type: "keyUp", value: "a" },
+        ],
+    }]);
+
+    assert_array_equals(keys, ["down:a", "up:a"]);
+}, "pause actions in a key source do not reject the action sequence");
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8693,6 +8693,11 @@ imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.servicewor
 imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker.html [ Failure ]
 imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker.html [ Failure ]
 
+# testdriver-vendor.js dispatches key actions through a UI script that references eventSender,
+# which does not exist in the UI-script context, and uiController has no leapForward equivalent,
+# so an action sequence with a key source resolves without dispatching anything on iOS.
+imported/w3c/web-platform-tests/infrastructure/testdriver/key-source-pause.html [ Skip ]
+
 # scheduleResizeEventIfNeeded() suppresses resize events on iOS while the document is still loading,
 # since Safari on iOS resizes the window while setting up its viewport.
 imported/w3c/web-platform-tests/css/css-values/dynamic-viewport-units-rule-cache.html [ Skip ]

--- a/LayoutTests/resources/testdriver-vendor.js
+++ b/LayoutTests/resources/testdriver-vendor.js
@@ -513,8 +513,11 @@ window.test_driver_internal.action_sequence = async function(sources)
                 break;
             }
             case 'pause':
-                // FIXME: Use eventSender.leapForward.
-                throw new Error('testdriver-vendor.js for WebKit does not yet support pause key action');
+                // A tick in which the key source has no action of its own is serialized by
+                // testdriver-actions.js as a pause with no duration, so there is nothing to wait for.
+                if (action.duration > 0)
+                    events.push({type: 'leapForward', arguments: [action.duration]});
+                break;
             default:
                 throw new Error(`Unknown key action type "${action.type}" encountered in testdriver-vendor.js`);
             }


### PR DESCRIPTION
#### acdddb0cc38fddbd787d1ef56f0fb64ccd2b51bd
<pre>
testdriver-vendor.js rejects action sequences containing a pause in a key source
<a href="https://bugs.webkit.org/show_bug.cgi?id=320983">https://bugs.webkit.org/show_bug.cgi?id=320983</a>
<a href="https://rdar.apple.com/184016970">rdar://184016970</a>

Reviewed by Sam Sneddon.

window.test_driver_internal.action_sequence() threw
&quot;does not yet support pause key action&quot; for any pause action in a key source,
rejecting the whole sequence. Two kinds of pause reach that code:

- An explicit pause, from test_driver.Actions.prototype.pause(duration, &quot;key&quot;).
- An implicit one: KeySource.serialize() in testdriver-actions.js pads every
  tick in which the key source has no action of its own with
  {type: &quot;pause&quot;} and no duration. Such a pause has nothing to wait for, so
  the test never asked for a delay at all, yet the sequence was rejected.

Do what the FIXME suggested and translate a pause with a duration into an
eventSender.leapForward(), the same way pauses from the &quot;none&quot; source are
already injected below, and treat a pause with no duration as a no-op.

This matches Blink&apos;s testdriver-vendor.js, which likewise awaits the pause
rather than failing.

The test calls test_driver.action_sequence() with a hand-written source list
instead of building one with test_driver.Actions, because a padding pause
needs a second source occupying ticks and the only such combination, a key
source alongside a pointer source, is rejected earlier as unsupported: no
Actions chain in the tree reaches this code path. It covers a pause with a
duration and a padding pause without one, and fails with the rejection above
before this change. Since infrastructure/testdriver is skipped as a directory
for needing an interactive window, opt this one test back in; it does not.

Skip it on iOS: there, action_sequence() dispatches key actions from a UI
script that references eventSender, which does not exist in the UI-script
context, and uiController has no leapForward equivalent, so a key source
resolves without dispatching anything. That is pre-existing and unrelated to
this change, which is why the existing key-driven tests such as
shadow-dom/accesskey.tentative.html are already skipped there.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/infrastructure/testdriver/key-source-pause-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/infrastructure/testdriver/key-source-pause.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/resources/testdriver-vendor.js:
(window.test_driver_internal.action_sequence):

Canonical link: <a href="https://commits.webkit.org/318929@main">https://commits.webkit.org/318929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb332dcacdf878e11f43c57d0890e2f388cb289d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53839 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac06ba62-06f6-46ed-b94f-690408cbb465) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53555 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7f42d04-190e-497c-a223-72efa83fe70f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182849 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a75c231-b6c7-4567-8b39-74702d67524c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1261 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192035 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53505 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/160580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40075 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54192 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149344 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43990 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121507 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52709 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/15576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52091 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52329 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52155 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->