### PR TITLE
[Custom Highlight] Implement HighlightRegistry.highlightsFromPoint() hit-testing.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-expected.txt
@@ -1,11 +1,11 @@
-0123456789 temporary
+0123456789
 
 PASS CSS.highlights.highlightsFromPoint() should throw when called with incorrect parameters.
 PASS CSS.highlights.highlightsFromPoint() should return an empty array when called with a point outside the document.
-FAIL CSS.highlights.highlightsFromPoint() returns the Highlights with their corresponding ranges present at the given point in the right order. assert_equals: CSS.highlights.highlightsFromPoint() returns exactly one HighlightHitResult when the coordinates provided point at one Highlight expected 1 but got 0
+PASS CSS.highlights.highlightsFromPoint() returns the Highlights with their corresponding ranges present at the given point in the right order.
 PASS CSS.highlights.highlightsFromPoint() returns empty array when called on a display:none iframe document.
-FAIL CSS.highlights.highlightsFromPoint() returns empty array for coordinates outside the viewport. assert_equals: highlightsFromPoint() returns the highlight at valid coordinates inside the viewport expected 1 but got 0
+PASS CSS.highlights.highlightsFromPoint() returns empty array for coordinates outside the viewport.
 PASS CSS.highlights.highlightsFromPoint() does not return highlights with only collapsed ranges.
-FAIL CSS.highlights.highlightsFromPoint() skips invalid StaticRanges. assert_equals: highlightsFromPoint() returns highlight before StaticRange is invalidated expected 1 but got 0
-FAIL CSS.highlights.highlightsFromPoint() returns all overlapping ranges within the same highlight. assert_equals: highlightsFromPoint() returns exactly one HighlightHitResult for a single highlight expected 1 but got 0
+PASS CSS.highlights.highlightsFromPoint() skips invalid StaticRanges.
+PASS CSS.highlights.highlightsFromPoint() returns all overlapping ranges within the same highlight.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-ranges-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-ranges-expected.txt
@@ -1,5 +1,5 @@
 0123456789
 0123456789
 
-FAIL CSS.highlights.highlightsFromPoint() returns HighlightHitResults with the Highlights and their corresponding Ranges and StaticRanges present at the given point in the right order on multi-line text. assert_equals: CSS.highlights.highlightsFromPoint() returns exactly one HighlightHitResult when the coordinates provided point at one Highlight expected 1 but got 0
+PASS CSS.highlights.highlightsFromPoint() returns HighlightHitResults with the Highlights and their corresponding Ranges and StaticRanges present at the given point in the right order on multi-line text.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/HighlightRegistry-highlightsFromPoint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/HighlightRegistry-highlightsFromPoint-expected.txt
@@ -1,7 +1,7 @@
 0123456789
 
 PASS CSS.highlights.highlightsFromPoint() should throw when called with nodes that are not ShadowRoot objects in options.
-FAIL CSS.highlights.highlightsFromPoint() returns Highlights present at a given point inside a shadow tree in the right order. assert_equals: CSS.highlights.highlightsFromPoint() returns exactly one Highlight when the given coordinates point at a Highlight under the shadow root provided expected 1 but got 0
-FAIL CSS.highlights.highlightsFromPoint() doesn't return Highlights that are not painted at the given coordinates even when they fall inside the Highlights' ranges assert_equals: CSS.highlights.highlightsFromPoint() returns one Highlight present at the coordinates provided expected 1 but got 0
-FAIL CSS.highlights.highlightsFromPoint() handles slotted light DOM content correctly. assert_equals: highlightsFromPoint() returns the light DOM highlight for slotted content expected 1 but got 0
+FAIL CSS.highlights.highlightsFromPoint() returns Highlights present at a given point inside a shadow tree in the right order. assert_equals: CSS.highlights.highlightsFromPoint() returns no Highlights when the coordinates provided point at one Highlight in the shadow DOM but shadowRoots provided is empty expected 0 but got 1
+FAIL CSS.highlights.highlightsFromPoint() doesn't return Highlights that are not painted at the given coordinates even when they fall inside the Highlights' ranges assert_equals: CSS.highlights.highlightsFromPoint() returns no Highlights when the given coordinates point at text under the shadow root provided even when there is a Highlight set with a Range that starts and ends in the regular DOM surrounding it, even when shadowRoots are provided expected 0 but got 1
+PASS CSS.highlights.highlightsFromPoint() handles slotted light DOM content correctly.
 

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
@@ -27,11 +27,17 @@
 #include "HighlightRegistry.h"
 
 #include "Document.h"
+#include "FloatRect.h"
 #include "HighlightHitResult.h"
 #include "HighlightsFromPointOptions.h"
 #include "IDLTypes.h"
 #include "JSDOMMapLike.h"
 #include "JSHighlight.h"
+#include "NodeDocument.h"
+#include "RenderObject.h"
+#include "SimpleRange.h"
+#include "StaticRange.h"
+#include <algorithm>
 
 namespace WebCore {
     
@@ -41,9 +47,59 @@ void HighlightRegistry::initializeMapLike(DOMMapAdapter& map)
         map.set<IDLDOMString, IDLInterface<Highlight>>(keyValue.key, keyValue.value);
 }
 
-Vector<HighlightHitResult> HighlightRegistry::highlightsFromPoint(Document&, float, float, HighlightsFromPointOptions&&)
+Vector<HighlightHitResult> HighlightRegistry::highlightsFromPoint(Document& document, float x, float y, HighlightsFromPointOptions&&)
 {
-    return { };
+    document.updateLayout();
+
+    FloatPoint point { x, y };
+
+    struct HitCandidate {
+        int priority { 0 };
+        size_t registrationIndex { 0 };
+        Vector<Ref<AbstractRange>> ranges;
+        RefPtr<Highlight> highlight;
+    };
+    Vector<HitCandidate> candidates;
+
+    for (size_t index = 0; index < m_highlightNames.size(); ++index) {
+        RefPtr highlight = m_map.get(m_highlightNames[index]);
+        if (!highlight)
+            continue;
+
+        Vector<Ref<AbstractRange>> matchingRanges;
+        auto highlightRanges = highlight->highlightRanges();
+        for (auto& highlightRange : highlightRanges) {
+            Ref abstractRange = highlightRange->range();
+            if (abstractRange->collapsed())
+                continue;
+
+            if (&abstractRange->startContainer().document() != &document)
+                continue;
+
+            if (RefPtr staticRange = dynamicDowncast<StaticRange>(abstractRange.get()); staticRange && !staticRange->computeValidity())
+                continue;
+
+            for (auto& rect : RenderObject::clientBorderAndTextRects(makeSimpleRange(abstractRange))) {
+                if (rect.contains(point)) {
+                    matchingRanges.append(WTF::move(abstractRange));
+                    break;
+                }
+            }
+        }
+
+        if (!matchingRanges.isEmpty())
+            candidates.append({ highlight->priority(), index, WTF::move(matchingRanges), WTF::move(highlight) });
+    }
+
+    std::ranges::sort(candidates, [](auto& a, auto& b) {
+        if (a.priority != b.priority)
+            return a.priority > b.priority;
+        return a.registrationIndex > b.registrationIndex;
+    });
+
+    return WTF::map(WTF::move(candidates), [](auto&& candidate) {
+        return HighlightHitResult { WTF::move(candidate.highlight), WTF::move(candidate.ranges) };
+    });
 }
 
 void HighlightRegistry::setFromMapLike(AtomString&& key, Ref<Highlight>&& value)


### PR DESCRIPTION
#### 64f73a0819df5029b12093ee88a3c8f10442b15d
<pre>
[Custom Highlight] Implement HighlightRegistry.highlightsFromPoint() hit-testing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320987">https://bugs.webkit.org/show_bug.cgi?id=320987</a>
<a href="https://rdar.apple.com/184019794">rdar://184019794</a>

Reviewed by Wenson Hsieh.

Implements the highlightsFromPoint() algorithm for light-DOM highlights. For each
registered highlight, tests the query point against the client-space rects of each
of its ranges (via RenderObject::clientBorderAndTextRects), skipping collapsed ranges
and invalidated StaticRanges, and rejecting points outside the viewport. Results are
ordered top-most first: by highlight priority descending, then by registration order
descending for equal priorities.

imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint.html
imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-ranges.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-highlightsFromPoint-ranges-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/HighlightRegistry-highlightsFromPoint-expected.txt:
* Source/WebCore/Modules/highlight/HighlightRegistry.cpp:
(WebCore::HighlightRegistry::highlightsFromPoint):

Canonical link: <a href="https://commits.webkit.org/318628@main">https://commits.webkit.org/318628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a61cb9060f24b977dd4a8e970e58b3772b59fab2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188395 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51e7430d-1cc5-4723-8423-aaec9a373e68) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139395 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05e7743c-695d-4458-bafd-e4e8b6077356) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119849 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/747f30f6-fe4f-494a-a8bb-30bb13136528) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41629 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39978 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39630 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190823 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52387 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148575 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39898 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53067 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36257 "Found 5 new test failures: http/tests/security/canvas-cors-with-two-hosts.html http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py http/tests/websocket/tests/hybi/contentextensions/block-worker.html http/tests/xmlhttprequest/abort-crash.html http/tests/xmlhttprequest/web-apps/014.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148342 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43043 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125334 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119995 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51585 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14608 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50970 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51210 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51032 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->