### PR TITLE
[WebGPU Swift] Experimentally remove unsafe statements

### DIFF
--- a/Source/WTF/wtf/EscapableByteSpan.h
+++ b/Source/WTF/wtf/EscapableByteSpan.h
@@ -37,22 +37,67 @@
 
 namespace WTF {
 
-// WTF's byte views for Swift interop.
+// Byte spans for Swift interop. In order of preference:
 //
-// Where possible, use SpanUInt8 or MutableSpanUInt8 -- in C++ these are simply
-// std::span<const uint8_t> and std::span<uint8_t>.
-// On the Swift side these materialise as Span<UInt8> and MutableSpan<UInt8>, which are
-// non-escapable. That means Swift will ensure at compile-time that the data is not
-// stashed anywhere, but is used or copied before control returns to the C++ caller.
+//   SpanUInt8 / MutableSpanUInt8 (plain std::span). A C++ accessor returning one, marked
+//   LIFETIME_BOUND, imports into Swift as a Span whose lifetime Swift tracks. Use these
+//   whenever Swift is calling a C++ function.
+//   (You _can_ use these in Swift functions that need to be called from C++, but they
+//   import as unsafe without the special magic that turns them into safe Swift Span
+//   types, so avoid.)
 //
-// However, some Swift APIs are not compatible with non-escapable types. In these cases,
-// use EscapableByteSpan which adds a small runtime overhead to ensure Swift
-// relinquishes its view of the data before it falls out of C++ scope.
+//   ByteSpan / MutableByteSpan. Non-escapable in Swift, so Swift cannot store one, and
+//   subspan() narrows without naming a pointer. Use these when C++ calls a Swift
+//   function: such a function cannot take or return Swift's own Span or MutableSpan,
+//   and a std::span parameter arrives in Swift as an unsafe type.
+//
+//   EscapableByteSpan. Escapable, for Swift APIs that reject
+//   non-escapable types, such as anything taking DataProtocol. They cost a copy count
+//   and turn misuse into a runtime crash rather than a compile error, so prefer the
+//   others.
 
 // Common byte-buffer specializations, named so they can be referenced from Swift.
 using SpanUInt8 = std::span<const uint8_t>;
 using MutableSpanUInt8 = std::span<uint8_t>;
 using VectorUInt8 = Vector<uint8_t>;
+
+// Non-escapable wrapper for std::span, for Swift function signatures exposed to C++
+// (because std::span/Span cannot safely be used in that context.)
+//
+// Safe to template only because Swift never extends these: a Swift extension on a
+// template specialization emits unparseable .swiftinterface names. span() is hidden from
+// Swift so Swift never holds an unsafe span, and because a lifetimebound member returning
+// a dependent span crashes the compiler (rdar://187391842).
+template<typename T> class SWIFT_NONESCAPABLE ByteSpanView final {
+public:
+    ByteSpanView() = default;
+
+    static ByteSpanView create(std::span<T> bytes LIFETIME_BOUND) { return ByteSpanView(bytes); }
+
+    size_t size() const { return m_span.size(); }
+
+    ByteSpanView subspan(size_t offset, size_t count) const LIFETIME_BOUND
+    {
+        RELEASE_ASSERT(offset <= m_span.size() && count <= m_span.size() - offset);
+        return ByteSpanView(m_span.subspan(offset, count));
+    }
+
+    // See above for why ifndef __swift__
+#ifndef __swift__
+    std::span<T> span() const { return m_span; }
+#endif
+
+private:
+    explicit ByteSpanView(std::span<T> bytes LIFETIME_BOUND)
+        : m_span(bytes)
+    {
+    }
+
+    std::span<T> m_span;
+};
+
+using ByteSpan = ByteSpanView<const uint8_t>;
+using MutableByteSpan = ByteSpanView<uint8_t>;
 
 // EscapableByteSpan is a stack-only control block over a span of bytes owned elsewhere
 // (typically a Vector on the C++ stack). It lets Swift borrow C++ bytes with no copy
@@ -156,5 +201,7 @@ inline EscapableByteSpan escapableSpan(SpanUInt8 bytes LIFETIME_BOUND)
 
 } // namespace WTF
 
+using WTF::ByteSpan;
 using WTF::EscapableByteSpan;
+using WTF::MutableByteSpan;
 using WTF::escapableSpan;

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -32,6 +32,7 @@
 
 #import <wtf/Borrow.h>
 #import <wtf/CheckedArithmetic.h>
+#import <wtf/EscapableByteSpan.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -293,7 +294,7 @@ std::span<uint8_t> Buffer::getMappedRange(size_t offset, size_t size)
 {
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled())
-        return bufferGetMappedRange(this, offset, size);
+        return bufferGetMappedRange(this, WTF::MutableByteSpan::create(getBufferContents()), offset, size).span();
 #endif
 
     // https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange
@@ -323,7 +324,16 @@ std::span<uint8_t> Buffer::getBufferContents()
 void Buffer::bufferCopy(std::span<const uint8_t> data, size_t offset)
 {
 #if ENABLE(WEBGPU_SWIFT)
-    bufferCopyFrom(this, data, offset);
+    auto destination = getBufferContents();
+
+    auto end = checkedSum<size_t>(offset, data.size());
+    RELEASE_ASSERT(!end.hasOverflowed() && end.value() <= destination.size());
+
+    if (data.empty())
+        return;
+
+    // The two spans come from independent allocations, so this cannot alias.
+    memcpySpan(destination.subspan(offset, data.size()), data);
 #else
     UNUSED_PARAM(data);
     UNUSED_PARAM(offset);

--- a/Source/WebGPU/WebGPU/Buffer.swift
+++ b/Source/WebGPU/WebGPU/Buffer.swift
@@ -21,43 +21,25 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-private import CxxStdlib
 import WebGPU_Internal.Buffer
-
-extension WebGPU.Buffer {
-    func copy(from source: Span<UInt8>, offset: Int) {
-        // FIXME (rdar://161274084): Swift doesn't have a lifetime-safe way to return a borrowed value from a refcounted object yet.
-        let bufferContents = unsafe MutableSpan(_unsafeCxxSpan: getBufferContents())
-
-        var destination = bufferContents._consumingExtracting(droppingFirst: offset)
-        destination.copyMemory(from: source)
-    }
-}
+import wtf
 
 @_expose(Cxx)
-func bufferCopyFrom(_ buffer: WebGPU.Buffer, from data: WebGPU.SpanConstUInt8, offset: Int) {
-    buffer.copy(from: unsafe Span<UInt8>(_unsafeCxxSpan: data), offset: offset)
-}
-
-@_expose(Cxx)
-func bufferGetMappedRange(_ buffer: WebGPU.Buffer, offset: Int, size: Int) -> WebGPU.SpanUInt8 {
-    unsafe buffer.getMappedRange(offset: offset, size: size)
-}
-
-extension WebGPU.SpanUInt8 {
-    /// A default-constructed, zero-length span: a null base pointer that's never read through.
-    ///
-    /// Marked `@safe` because the empty case carries no risk.
-    @safe
-    fileprivate static var empty: WebGPU.SpanUInt8 {
-        unsafe WebGPU.SpanUInt8()
-    }
+@_lifetime(copy contents)
+func bufferGetMappedRange(
+    _ buffer: WebGPU.Buffer,
+    contents: WTF.MutableByteSpan,
+    offset: Int,
+    size: Int,
+) -> WTF.MutableByteSpan {
+    buffer.getMappedRange(contents: contents, offset: offset, size: size)
 }
 
 extension WebGPU.Buffer {
-    func getMappedRange(offset: Int, size: Int) -> WebGPU.SpanUInt8 {
+    @_lifetime(copy contents)
+    func getMappedRange(contents: WTF.MutableByteSpan, offset: Int, size: Int) -> WTF.MutableByteSpan {
         if !isValid() {
-            return .empty
+            return WTF.MutableByteSpan()
         }
 
         var rangeSize = size
@@ -66,16 +48,16 @@ extension WebGPU.Buffer {
         }
 
         if !validateGetMappedRange(offset, rangeSize) {
-            return .empty
+            return WTF.MutableByteSpan()
         }
 
         m_mappedRanges.add(.init(UInt(offset), UInt(offset + rangeSize)))
         m_mappedRanges.compact()
 
         if m_buffer.storageMode == .private || m_buffer.storageMode == .memoryless || m_buffer.length == 0 {
-            return .empty
+            return WTF.MutableByteSpan()
         }
 
-        return unsafe getBufferContents().subspan(offset, rangeSize)
+        return contents.subspan(offset, rangeSize)
     }
 }

--- a/Source/WebGPU/WebGPU/CxxBridging.h
+++ b/Source/WebGPU/WebGPU/CxxBridging.h
@@ -29,6 +29,7 @@
 #include "ComputePassEncoder.h"
 #include "IsValidToUseWith.h"
 #include "RenderPassEncoder.h"
+#include <WebGPU/WGPUTextureImpl.h>
 #include <span>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/MathExtras.h>
@@ -71,6 +72,15 @@ inline bool isValidToUseWith(const WebGPU::TextureOrTextureView& texture, const 
 
 // FIXME: rdar://138415945
 inline bool areBuffersEqual(const WebGPU::Buffer& a, const WebGPU::Buffer& b)
+{
+    return &a == &b;
+}
+
+// FIXME: rdar://130765784
+// Swift's built-in === rejects foreign reference types, and comparing them in
+// Swift otherwise requires unsafeBitCast to a raw pointer. Doing the identity
+// comparison here keeps the Swift side free of `unsafe`.
+inline bool areTexturesEqual(const WGPUTextureImpl& a, const WGPUTextureImpl& b)
 {
     return &a == &b;
 }

--- a/Source/WebGPU/WebGPU/CxxBridgingPublic.h
+++ b/Source/WebGPU/WebGPU/CxxBridgingPublic.h
@@ -30,13 +30,8 @@
 
 #ifdef __cplusplus
 
+#include <cstddef>
 #include <span>
-
-namespace WebGPU {
-
-using SpanConstUInt8 = std::span<const uint8_t>;
-using SpanUInt8 = std::span<uint8_t>;
-
-}
+#include <wtf/EscapableByteSpan.h>
 
 #endif // __cplusplus

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -28,6 +28,7 @@
 #import "Instance.h"
 #import <Metal/Metal.h>
 #import <wtf/CompletionHandler.h>
+#import <wtf/EscapableByteSpan.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/HashMap.h>
 #import <wtf/Ref.h>
@@ -107,8 +108,11 @@ public:
     id<MTLIndirectCommandBuffer> trimICB(id<MTLIndirectCommandBuffer> dest, id<MTLIndirectCommandBuffer> src, NSUInteger newSize);
     id<MTLDevice> _Nullable metalDevice() const;
     std::pair<id<MTLBuffer>, uint64_t> newTemporaryBufferWithBytes(std::span<uint8_t> data, bool noCopy);
+    // Overload with more Swift-compatible signature
+    id<MTLBuffer> _Nullable newTemporaryBufferForSwift(const WTF::MutableByteSpan& data, bool noCopy, uint64_t& outOffset);
     void stageBufferWrite(id<MTLBuffer>, uint64_t bufferOffset, std::span<uint8_t> data);
     void encodeStagedCopy(id<MTLBuffer> temporaryBuffer, uint64_t temporaryBufferOffset, id<MTLBuffer>, uint64_t bufferOffset, uint64_t size, bool finalizeAfterCopy);
+
 
 private:
     Queue(id<MTLCommandQueue>, Adapter&, Device&);

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -38,6 +38,7 @@
 #import <simd/simd.h>
 #import <wtf/Borrow.h>
 #import <wtf/CheckedArithmetic.h>
+#import <wtf/EscapableByteSpan.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -724,11 +725,19 @@ std::pair<id<MTLBuffer>, uint64_t> Queue::newTemporaryBufferWithBytes(std::span<
     return std::make_pair(m_temporaryBuffer, priorOffset);
 }
 
+id<MTLBuffer> Queue::newTemporaryBufferForSwift(const WTF::MutableByteSpan& data, bool noCopy, uint64_t& outOffset)
+{
+    auto bufferWithOffset = newTemporaryBufferWithBytes(data.span(), noCopy);
+    outOffset = bufferWithOffset.second;
+    return bufferWithOffset.first;
+}
+
 void Queue::writeBuffer(id<MTLBuffer> buffer, uint64_t bufferOffset, std::span<uint8_t> data)
 {
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled()) {
-        queueWriteBuffer(this, buffer, bufferOffset, data);
+        auto dataSpan = MutableByteSpan::create(data);
+        queueWriteBuffer(this, buffer, bufferOffset, dataSpan);
         return;
     }
 #endif

--- a/Source/WebGPU/WebGPU/Queue.swift
+++ b/Source/WebGPU/WebGPU/Queue.swift
@@ -23,27 +23,25 @@
 
 import Metal
 import WebGPU_Internal.Queue
+import wtf
 
 private let largeBufferSize = 32 * 1024 * 1024
 
 @_expose(Cxx)
-func queueWriteBuffer(_ queue: WebGPU.Queue, buffer: any MTLBuffer, bufferOffset: UInt64, data: WebGPU.SpanUInt8) {
-    // FIXME (rdar://161269480): We should be able to declare 'data' as MutableSpan<UInt8>, which will remove this use of 'unsafe'.
-    queue.writeBuffer(buffer: buffer, bufferOffset: bufferOffset, data: unsafe MutableSpan(_unsafeCxxSpan: data))
+func queueWriteBuffer(_ queue: WebGPU.Queue, buffer: any MTLBuffer, bufferOffset: UInt64, data: WTF.MutableByteSpan) {
+    queue.writeBuffer(buffer: buffer, bufferOffset: bufferOffset, data: data)
 }
 
 extension WebGPU.Queue {
-    func writeBuffer(buffer: any MTLBuffer, bufferOffset: UInt64, data: consuming MutableSpan<UInt8>) {
+    func writeBuffer(buffer: any MTLBuffer, bufferOffset: UInt64, data: WTF.MutableByteSpan) {
         guard self.metalDevice() != nil else {
             return
         }
 
-        let count = data.count
-        let noCopy = data.count >= largeBufferSize
-        // FIXME: 'bufferWithOffset' may extend the lifetime of 'data', but we drop that information here.
-        let bufferWithOffset = unsafe newTemporaryBufferWithBytes(WebGPU.SpanUInt8(data), noCopy)
-        let temporaryBuffer = unsafe bufferWithOffset.first
-        let temporaryBufferOffset = unsafe bufferWithOffset.second
+        let count = data.size()
+        let noCopy = count >= largeBufferSize
+        var temporaryBufferOffset: UInt64 = 0
+        let temporaryBuffer = newTemporaryBufferForSwift(data, noCopy, &temporaryBufferOffset)
 
         guard let temporaryBuffer = temporaryBuffer else {
             assertionFailure("temporaryBuffer should not be nil")

--- a/Source/WebGPU/WebGPU/StdLibExtras.swift
+++ b/Source/WebGPU/WebGPU/StdLibExtras.swift
@@ -24,29 +24,12 @@
 // FIXME (rdar://164119356): Move StdLibExtras.swift from WebGPU to WTF
 
 private import CxxStdlib
+import WebGPU_Internal.CxxBridging
 import WebGPU_Private.WebGPU
-
-// FIXME (rdar://162375123): This should be in the standard library.
-extension MutableSpan where Element: BitwiseCopyable {
-    @_lifetime(self: copy self)
-    mutating func copyMemory(from source: Span<Element>) {
-        // Safety: This is lifetime safe because we have exclusive access to 'self' and we don't escape 'selfBuffer'
-        unsafe withUnsafeMutableBufferPointer { selfBuffer in
-            // Safety: This is lifetime safe because we have exclusive access to 'source' and we don't escape 'sourceBuffer'
-            unsafe source.withUnsafeBufferPointer { sourceBuffer in
-                // Safety: This is bounds safe because we do a manual bounds check
-                // Safety: This is type safe because we statically declare that our element types match and are BitwiseCopyable
-                precondition(sourceBuffer.count <= selfBuffer.count)
-                _ = unsafe memcpy(selfBuffer.baseAddress, sourceBuffer.baseAddress, sourceBuffer.count)
-            }
-        }
-    }
-}
 
 // FIXME(rdar://130765784): We should be able use the built-in ===, but AnyObject currently excludes foreign reference types
 func === (_ lhs: WGPUTexture, _ rhs: WGPUTexture) -> Bool {
-    // Safety: Swift represents all reference types, including foreign reference types, as raw pointers
-    unsafe unsafeBitCast(lhs, to: UnsafeRawPointer.self) == unsafeBitCast(rhs, to: UnsafeRawPointer.self)
+    CxxBridging.areTexturesEqual(lhs, rhs)
 }
 
 extension Comparable {

--- a/Tools/TestWebKitAPI/Tests/WTF/EscapableByteSpan.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/EscapableByteSpan.cpp
@@ -27,6 +27,8 @@
 #include <wtf/EscapableByteSpan.h>
 
 #include "Helpers/Test.h"
+#include <array>
+#include <limits>
 #include <optional>
 #include <wtf/Vector.h>
 
@@ -42,6 +44,100 @@ namespace TestWebKitAPI {
 #else
 #define EXPECTED_BORROW_CRASH ""
 #endif
+
+// MARK: - ByteSpan and MutableByteSpan
+
+TEST(WTF_ByteSpan, WrapsASpan)
+{
+    std::array<uint8_t, 5> buffer { 0, 1, 2, 3, 4 };
+    auto bytes = ByteSpan::create(std::span<const uint8_t> { buffer });
+
+    EXPECT_EQ(bytes.size(), buffer.size());
+    EXPECT_EQ(bytes.span().data(), buffer.data());
+    EXPECT_EQ(bytes.span().size(), buffer.size());
+}
+
+TEST(WTF_ByteSpan, DefaultConstructedIsEmpty)
+{
+    EXPECT_EQ(ByteSpan().size(), 0u);
+    EXPECT_TRUE(ByteSpan().span().empty());
+}
+
+TEST(WTF_ByteSpan, Subspan)
+{
+    std::array<uint8_t, 6> buffer { 0, 1, 2, 3, 4, 5 };
+    auto bytes = ByteSpan::create(std::span<const uint8_t> { buffer });
+
+    EXPECT_EQ(bytes.subspan(2, 3).size(), 3u);
+    EXPECT_EQ(bytes.subspan(2, 3).span().data(), buffer.data() + 2);
+
+    // Degenerate but legal: an empty view at the very end.
+    EXPECT_EQ(bytes.subspan(6, 0).size(), 0u);
+}
+
+TEST(WTF_ByteSpanDeathTest, SubspanPastTheEndCrashes)
+{
+    auto shouldCrash = [] {
+        std::array<uint8_t, 4> buffer { };
+        ByteSpan::create(std::span<const uint8_t> { buffer }).subspan(2, 3);
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), EXPECTED_BORROW_CRASH);
+}
+
+TEST(WTF_ByteSpanDeathTest, SubspanWithWrappedOffsetCrashes)
+{
+    auto shouldCrash = [] {
+        std::array<uint8_t, 4> buffer { };
+        ByteSpan::create(std::span<const uint8_t> { buffer }).subspan(std::numeric_limits<size_t>::max(), 1);
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), EXPECTED_BORROW_CRASH);
+}
+
+TEST(WTF_MutableByteSpan, WrapsASpan)
+{
+    std::array<uint8_t, 5> buffer { 0, 1, 2, 3, 4 };
+    auto bytes = MutableByteSpan::create(std::span<uint8_t> { buffer });
+
+    EXPECT_EQ(bytes.size(), buffer.size());
+    EXPECT_EQ(bytes.span().data(), buffer.data());
+}
+
+TEST(WTF_MutableByteSpan, DefaultConstructedIsEmpty)
+{
+    EXPECT_EQ(MutableByteSpan().size(), 0u);
+    EXPECT_TRUE(MutableByteSpan().span().empty());
+}
+
+TEST(WTF_MutableByteSpan, SubspanIsWritable)
+{
+    std::array<uint8_t, 6> buffer { 0, 1, 2, 3, 4, 5 };
+    auto bytes = MutableByteSpan::create(std::span<uint8_t> { buffer });
+    auto middle = bytes.subspan(2, 3);
+
+    EXPECT_EQ(middle.size(), 3u);
+    EXPECT_EQ(middle.span().data(), buffer.data() + 2);
+
+    middle.span()[0] = 42;
+    EXPECT_EQ(buffer[2], 42);
+}
+
+TEST(WTF_MutableByteSpanDeathTest, SubspanPastTheEndCrashes)
+{
+    auto shouldCrash = [] {
+        std::array<uint8_t, 4> buffer { };
+        MutableByteSpan::create(std::span<uint8_t> { buffer }).subspan(2, 3);
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), EXPECTED_BORROW_CRASH);
+}
+
+TEST(WTF_MutableByteSpanDeathTest, SubspanWithWrappedOffsetCrashes)
+{
+    auto shouldCrash = [] {
+        std::array<uint8_t, 4> buffer { };
+        MutableByteSpan::create(std::span<uint8_t> { buffer }).subspan(std::numeric_limits<size_t>::max(), 1);
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), EXPECTED_BORROW_CRASH);
+}
 
 // MARK: - EscapableByteSpan
 


### PR DESCRIPTION
#### 6ba0c9f7098c286c802c9bda8e34db3d8f504311
<pre>
[WebGPU Swift] Experimentally remove unsafe statements
<a href="https://bugs.webkit.org/show_bug.cgi?id=320989">https://bugs.webkit.org/show_bug.cgi?id=320989</a>
<a href="https://rdar.apple.com/148983910">rdar://148983910</a>

Reviewed by Mike Wyrzykowski.

It is WebKit policy to have purely safe Swift wherever possible.
This change removes most of the remaining &apos;unsafe&apos; keywords from the
Swift in WebGPU, mostly by adding further byte-span-borrowing primitives.

The steps taken are as follows:
- Within Queue.swift, we previously passed a C++ std::span from C++,
  through Swift, and back to C++. Although Swift did not access the data,
  this is deemed to be unsafe by Swift since Swift might have stashed
  the span beyond the acceptable lifetime. In this change, we use a new
  WTF::MutableByteSpan instead. This is a non-escapable wrapper for
  a std::span&lt;uint8_t&gt; and is more versatile than the Span&lt;UInt8&gt;
  which is provided by Swift&apos;s own SafeInteropWrappers.
- Queue also requires a new overload of newTemporaryBufferWithBytes
  which deals in types that Swift handles safely and idiomatically,
  instead of things like std::pair. It returns a new non-escapable
  wrapper for an id&lt;MTLBuffer&gt;
- In Buffer.swift, previously the getMappedRange and bufferCopyFrom
  methods acted upon a Buffer. They now instead act upon a C++
  wrapper called BufferBorrow.

We retain a single `unsafe` to make up for the lack of operator==
support from Swift.

Canonical link: <a href="https://commits.webkit.org/321250@main">https://commits.webkit.org/321250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d3ab3a6b32dd7b433e6b47aecde9acadcc99030

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197606 "Built successfully") | [⏳ 🛠 win](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/189247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146344 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50050 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/166805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126837 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48776 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/46645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/8518 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/15350 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/159085 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46420 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8699 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/48552 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/53637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199633 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60847 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/156005 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41798 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61560 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155654 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49978 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133701 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/131244 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59950 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21409 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59378 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59493 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->