### PR TITLE
Use default member initializers for uninitialized data members in WebCore/svg

### DIFF
--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -93,7 +93,7 @@ private:
     const UniqueRef<SVGResourcesCache> m_resourcesCache;
 
     Vector<Ref<SVGElement>> m_rebuildElements;
-    bool m_areAnimationsPaused;
+    bool m_areAnimationsPaused { false };
 
     HashMap<URL, Ref<IsolatedSVGDocumentContext>> m_externalSVGDocuments;
 };

--- a/Source/WebCore/svg/SVGPathSegListSource.cpp
+++ b/Source/WebCore/svg/SVGPathSegListSource.cpp
@@ -29,9 +29,8 @@ namespace WebCore {
 
 SVGPathSegListSource::SVGPathSegListSource(const SVGPathSegList& pathSegList)
     : m_pathSegList(pathSegList)
+    , m_itemEnd(pathSegList.size())
 {
-    m_itemCurrent = 0;
-    m_itemEnd = m_pathSegList->size();
 }
 
 bool SVGPathSegListSource::hasMoreData() const

--- a/Source/WebCore/svg/SVGPathSegListSource.h
+++ b/Source/WebCore/svg/SVGPathSegListSource.h
@@ -52,8 +52,8 @@ private:
 
     SingleThreadWeakRef<const SVGPathSegList> m_pathSegList;
     RefPtr<SVGPathSeg> m_segment;
-    size_t m_itemCurrent;
-    size_t m_itemEnd;
+    size_t m_itemCurrent { 0 };
+    size_t m_itemEnd { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGPathStringViewSource.h
+++ b/Source/WebCore/svg/SVGPathStringViewSource.h
@@ -48,7 +48,7 @@ private:
 
     template<typename Function> decltype(auto) NODELETE parse(Function&&);
 
-    bool m_is8BitSource;
+    bool m_is8BitSource { false };
     union {
         StringParsingBuffer<Latin1Character> m_buffer8;
         StringParsingBuffer<char16_t> m_buffer16;

--- a/Source/WebCore/svg/animation/SMILTime.h
+++ b/Source/WebCore/svg/animation/SMILTime.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class SMILTime {
 public:
-    SMILTime() : m_time(0) { }
+    SMILTime() = default;
     SMILTime(double time) : m_time(time) { ASSERT(!std::isnan(time)); }
     SMILTime(Seconds time) : m_time(time.value()) { ASSERT(!std::isnan(time.value())); }
     SMILTime(const SMILTime& o) : m_time(o.m_time) { }
@@ -52,7 +52,7 @@ private:
     static const double unresolvedValue;
     static const double indefiniteValue;
 
-    double m_time;
+    double m_time { 0 };
 };
 
 class SMILTimeWithOrigin {

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveFunction.h
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveFunction.h
@@ -71,9 +71,9 @@ protected:
         return number;
     }
 
-    CalcMode m_calcMode;
-    bool m_isAccumulated;
-    bool m_isAdditive;
+    CalcMode m_calcMode { CalcMode::Linear };
+    bool m_isAccumulated { false };
+    bool m_isAdditive { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 96ee85e3dabbd1fd822925d0bdcf4b59bbc9d298
<pre>
Use default member initializers for uninitialized data members in WebCore/svg
<a href="https://bugs.webkit.org/show_bug.cgi?id=320994">https://bugs.webkit.org/show_bug.cgi?id=320994</a>
<a href="https://rdar.apple.com/184027192">rdar://184027192</a>

Reviewed by Taher Ali.

Several data members in WebCore/svg rely solely on their constructors&apos;
initializer lists, leaving them indeterminate if a future constructor
forgets them. Give them default member initializers instead, and let
SVGPathSegListSource initialize m_itemEnd in its initializer list rather
than in the constructor body.

No change in behavior.

* Source/WebCore/svg/SVGDocumentExtensions.h:
* Source/WebCore/svg/SVGPathSegListSource.cpp:
(WebCore::SVGPathSegListSource::SVGPathSegListSource):
* Source/WebCore/svg/SVGPathSegListSource.h:
* Source/WebCore/svg/SVGPathStringViewSource.h:
* Source/WebCore/svg/animation/SMILTime.h:
* Source/WebCore/svg/properties/SVGAnimationAdditiveFunction.h:

Canonical link: <a href="https://commits.webkit.org/318578@main">https://commits.webkit.org/318578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e606a0bc7d76c4f75ffcdf45903d2189664b432a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141881 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac5def97-da19-4ed8-9316-164c0fbf5544) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139277 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/610e726d-7159-4791-a4fd-6010ec4c7e01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119731 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/20356126-a525-4fce-900f-d21d6897a133) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41495 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39853 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151895 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39531 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190674 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52238 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148447 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39871 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52919 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36156 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148214 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42915 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125186 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119844 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51437 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14507 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50822 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51062 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50884 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->