### PR TITLE
Cherry-pick 318557@main (a727aa27c537). https://bugs.webkit.org/show_bug.cgi?id=295662

### DIFF
--- a/LayoutTests/compositing/geometry/composited-bounds-with-single-axis-clip-expected.txt
+++ b/LayoutTests/compositing/geometry/composited-bounds-with-single-axis-clip-expected.txt
@@ -1,0 +1,24 @@
+Bug 295662: a backing-sharing layer whose clip comes from an ancestor that clips one axis while the other stays overflow:visible must not inflate its backing provider's bounds with that unbounded clip. Test passes if no composited layer is near-LayoutUnit::max tall.
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 8.00 86.00)
+          (bounds 50.00 50.00)
+        )
+        (GraphicsLayer
+          (position 20.00 20.00)
+          (bounds 300.00 600.00)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/geometry/composited-bounds-with-single-axis-clip.html
+++ b/LayoutTests/compositing/geometry/composited-bounds-with-single-axis-clip.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  .composited {
+      width: 50px;
+      height: 50px;
+      will-change: transform;
+  }
+
+  .provider {
+      position: absolute;
+      top: 20px;
+      left: 20px;
+      width: 300px;
+      height: 300px;
+  }
+
+  .clipper {
+      overflow-x: clip;
+      overflow-y: visible;
+      width: 300px;
+      height: 300px;
+  }
+
+  .sharing {
+      position: relative;
+      top: 50px;
+      left: 50px;
+      width: 200px;
+      height: 200px;
+      background: green;
+  }
+</style>
+</head>
+<body>
+<script>
+  if (window.testRunner) {
+      testRunner.dumpAsText();
+      testRunner.waitUntilDone();
+  }
+
+  async function runTest() {
+      if (window.testRunner) {
+          document.getElementById('layers').innerText = window.internals.layerTreeAsText(document);
+          testRunner.notifyDone();
+      }
+  }
+  window.addEventListener("load", runTest);
+</script>
+
+<p>Bug 295662: a backing-sharing layer whose clip comes from an ancestor that clips one axis while the other stays overflow:visible must not inflate its backing provider's bounds with that unbounded clip. Test passes if no composited layer is near-LayoutUnit::max tall.</p>
+<div class="composited"></div>
+<div class="provider"><div class="clipper"><div class="sharing"></div></div></div>
+<pre id="layers"></pre>
+</body>
+</html>
+

--- a/Source/WebCore/platform/graphics/LayoutRect.h
+++ b/Source/WebCore/platform/graphics/LayoutRect.h
@@ -217,10 +217,16 @@ public:
     LayoutRect transposedRect() const { return LayoutRect(m_location.transposedPoint(), m_size.transposedSize()); }
     bool isInfinite() const;
 
-    static LayoutRect infiniteRect()
+    static constexpr LayoutRect infiniteRect()
     {
         // Return a rect that is slightly smaller than the true max rect to allow pixelSnapping to round up to the nearest IntRect without overflowing.
         return LayoutRect(LayoutUnit::nearlyMin() / 2, LayoutUnit::nearlyMin() / 2, LayoutUnit::nearlyMax(), LayoutUnit::nearlyMax());
+    }
+
+    static constexpr LayoutRect renderableInfiniteRect()
+    {
+        // Return a infinite-like rect whose values are such that, when converted to float pixel values, they can reasonably represent device pixels.
+        return LayoutRect(LayoutUnit::nearlyMin() / 32, LayoutUnit::nearlyMin() / 32, LayoutUnit::nearlyMax() / 16, LayoutUnit::nearlyMax() / 16);
     }
 
     operator FloatRect() const { return FloatRect(m_location, m_size); }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5664,8 +5664,20 @@ LayoutRect RenderLayer::calculateLayerBounds(const RenderLayer* ancestorLayer, c
         const RenderLayer* clippingRootLayer = flags & UseLocalClipRectExcludingCompositingIfPossible ? this : clippingRootForPainting();
         LayoutSize offsetFromRoot = offsetFromAncestor(clippingRootLayer);
         LayoutRect clipRect = clipRectRelativeToAncestor(clippingRootLayer, offsetFromRoot, infiniteRect);
-        if (clipRect == infiniteRect)
+        if (clipRect.isInfinite())
             return infiniteRect;
+
+        auto renderableInfiniteRect = LayoutRect::renderableInfiniteRect();
+        if (clipRect.width() > renderableInfiniteRect.width() || clipRect.height() > renderableInfiniteRect.height()) {
+            // When ancestor clips only one axis, leaving the other one unbounded, clip again passing
+            // document rectangle as constraining rectangle to clipRectRelativeToAncestor(),
+            // like selfClipRect() does, to ensure we return a finite rectangle. Checking either width or
+            // height matches LayoutRect::infiniteRect doesn't work either because clipRectRelativeToAncestor()
+            // returns a rectangle that has been moved and intersected, so it's close to infinite but not exactly
+            // infinite. So, comparing to LayoutRect::renderableInfiniteRect() we make sure that we don't return
+            // a rectangle that can't be handled as layer bounds.
+            clipRect = clipRectRelativeToAncestor(clippingRootLayer, offsetFromRoot, renderer().view().documentRect());
+        }
 
         if (renderer().hasClip()) {
             if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer())) {

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3684,11 +3684,7 @@ Vector<CompositedClipData> RenderLayerCompositor::computeAncestorClippingStack(c
             return;
 
         auto infiniteRect = LayoutRect::infiniteRect();
-        auto renderableInfiniteRect = [] {
-            // Return a infinite-like rect whose values are such that, when converted to float pixel values, they can reasonably represent device pixels.
-            return LayoutRect(LayoutUnit::nearlyMin() / 32, LayoutUnit::nearlyMin() / 32, LayoutUnit::nearlyMax() / 16, LayoutUnit::nearlyMax() / 16);
-        }();
-
+        auto renderableInfiniteRect = LayoutRect::renderableInfiniteRect();
         if (clipRect.width() == infiniteRect.width()) {
             clipRect.setX(renderableInfiniteRect.x());
             clipRect.setWidth(renderableInfiniteRect.width());


### PR DESCRIPTION
#### 18428dc7a6d060f1b8c475adaa0843375dc6c3fa
<pre>
Cherry-pick 318557@main (a727aa27c537). <a href="https://bugs.webkit.org/show_bug.cgi?id=295662">https://bugs.webkit.org/show_bug.cgi?id=295662</a>

    [GTK][WPE] Content view broken on GitLab
    <a href="https://bugs.webkit.org/show_bug.cgi?id=295662">https://bugs.webkit.org/show_bug.cgi?id=295662</a>

    Reviewed by Simon Fraser.

    A layer clipped by an ancestor in one axis while the other axis stays
    overflow:visible has a semi-infinite clip rect: finite in one axis and
    unbounded (near LayoutUnit::max) in the other, produced by
    expandToInfiniteX/Y(). RenderLayer::calculateLayerBounds() was returning
    the semi-infinite rectangle that caused a wrong cover rect being
    computed in CoordinatedBackingStoreProxy::createOrDestroyTiles() for
    coordinated graphics based ports. With an empty cover rect we basically
    stopped producing new tiles for the layer, which caused that contents
    were not rendered in GitLab diff page after scrolling down a bit.

    This patch clips again passing the document rectangle as constraining
    rectangle to clipRectRelativeToAncestor(), like selfClipRect() does,
    to ensure we return a finite rectangle.

    Test: compositing/geometry/composited-bounds-with-single-axis-clip.html

    * LayoutTests/compositing/geometry/composited-bounds-with-single-axis-clip-expected.txt: Added.
    * LayoutTests/compositing/geometry/composited-bounds-with-single-axis-clip.html: Added.
    * Source/WebCore/platform/graphics/LayoutRect.h:
    (WebCore::LayoutRect::renderableInfiniteRect):
    (WebCore::LayoutRect::infiniteRect):
    * Source/WebCore/rendering/RenderLayer.cpp:
    (WebCore::RenderLayer::calculateClipRects const):
    * Source/WebCore/rendering/RenderLayerCompositor.cpp:
    (WebCore::RenderLayerCompositor::computeAncestorClippingStack const):

    Canonical link: <a href="https://commits.webkit.org/318557@main">https://commits.webkit.org/318557@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.49@webkitglib/2.54">https://commits.webkit.org/317695.49@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa9aab79c45d6cfa0b09b2e12271214847b112fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178645 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52583 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46378 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188261 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141895 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180508 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53877 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52293 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139289 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141895 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181602 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53877 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46378 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119743 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53877 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52293 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46378 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53877 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46378 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36716 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45183 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52293 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190689 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52252 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46378 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148457 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/52933 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46378 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148224 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27111 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/52933 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125200 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119859 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51451 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46378 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50836 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51076 "The change is no longer eligible for processing.") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50898 "Build is in progress. Recent messages:") | | | 
<!--EWS-Status-Bubble-End-->