### PR TITLE
Update the ANGLEEnd2EndTests binary plist with the required UIApplicationSceneManifest

### DIFF
--- a/Source/ThirdParty/ANGLE/WebKit/ANGLEEnd2EndTestsAppInfo.plist
+++ b/Source/ThirdParty/ANGLE/WebKit/ANGLEEnd2EndTestsAppInfo.plist
@@ -24,6 +24,23 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>AngleUtilSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>ANGLEEnd2EndTestsAppLaunch</string>
 	<key>UIRequiresFullScreen</key>

--- a/Source/ThirdParty/ANGLE/util/ios/ios_main.mm
+++ b/Source/ThirdParty/ANGLE/util/ios/ios_main.mm
@@ -19,11 +19,19 @@ int main(int argc, char *_Nullable *_Nullable argv);
 
 @interface AngleUtilAppDelegate : UIResponder <UIApplicationDelegate>
 
+// IOSWindow.mm reaches the test's layer through the application delegate's window, so the scene
+// delegate publishes its window here once the scene connects.
 @property(nullable, nonatomic, strong) UIWindow *window;
 
 @end
 
-@implementation AngleUtilAppDelegate
+@interface AngleUtilSceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property(nullable, nonatomic, strong) UIWindow *window;
+
+@end
+
+@implementation AngleUtilSceneDelegate
 
 @synthesize window;
 
@@ -33,19 +41,32 @@ int main(int argc, char *_Nullable *_Nullable argv);
     exit(main(original_argc, original_argv));
 }
 
-- (BOOL)application:(UIApplication *_Nonnull)application
-    didFinishLaunchingWithOptions:(NSDictionary *_Nullable)launchOptions
+- (void)scene:(UIScene *_Nonnull)scene
+    willConnectToSession:(UISceneSession *_Nonnull)session
+                 options:(UISceneConnectionOptions *_Nonnull)connectionOptions
 {
-    self.window                    = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    self.window = [[UIWindow alloc] initWithWindowScene:(UIWindowScene *)scene];
     self.window.rootViewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
     [self.window makeKeyAndVisible];
-    // We need to return from this function before the app finishes launching, so call main in a
+    [UIApplication sharedApplication].delegate.window = self.window;
+    // We need to return from this function before the scene finishes connecting, so call main in a
     // timer callback afterward.
     [NSTimer scheduledTimerWithTimeInterval:0
                                      target:self
                                    selector:@selector(runMain)
                                    userInfo:nil
                                     repeats:NO];
+}
+
+@end
+
+@implementation AngleUtilAppDelegate
+
+@synthesize window;
+
+- (BOOL)application:(UIApplication *_Nonnull)application
+    didFinishLaunchingWithOptions:(NSDictionary *_Nullable)launchOptions
+{
     return YES;
 }
 


### PR DESCRIPTION
#### db35c2d759d938c8eec9af1c4069e43bdecfba0d
<pre>
Update the ANGLEEnd2EndTests binary plist with the required UIApplicationSceneManifest
<a href="https://bugs.webkit.org/show_bug.cgi?id=320996">https://bugs.webkit.org/show_bug.cgi?id=320996</a>

Reviewed by Kimmo Kinnunen.

Recent Apple SDK versions introduced a requirement for the UIApplicationSceneManifest key
in the app&apos;s plist to avoid crashing on launch. This change adds this plist key, as well
as changing the startup code to use the new scene-based design.

* Source/ThirdParty/ANGLE/WebKit/ANGLEEnd2EndTestsAppInfo.plist:
* Source/ThirdParty/ANGLE/util/ios/ios_main.mm:
(-[AngleUtilSceneDelegate scene:willConnectToSession:options:]):
(-[AngleUtilAppDelegate application:didFinishLaunchingWithOptions:]):
(-[AngleUtilAppDelegate runMain]): Deleted.

Canonical link: <a href="https://commits.webkit.org/319366@main">https://commits.webkit.org/319366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0d2262fc807ccf786872620b097d81118152731

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141896 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139287 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96696 "2 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fea6a418-376e-489c-a6d7-b6d01c65923b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119741 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ddb21da-57a5-4d85-9bf2-5f68464fbd21) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41514 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39866 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39537 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190690 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52253 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159560 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148461 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40409 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52934 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148228 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42927 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119860 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51452 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14513 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50837 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51077 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50899 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->