### PR TITLE
Model computed value line-height more closely to how its specified

### DIFF
--- a/LayoutTests/fast/css/line-height-get-computed-style-expected.txt
+++ b/LayoutTests/fast/css/line-height-get-computed-style-expected.txt
@@ -1,13 +1,13 @@
 
-PASS with font-size: 10px, #target.style['line-height'] = 1e+26 should result in a used line-height of 999999914697178458896728064px
+PASS with font-size: 10px, #target.style['line-height'] = 1e+26 should result in a used line-height of 1000000062271131048573140992px
 PASS with font-size: 10px, #target.style['line-height'] = 2.53821 should result in a used line-height of 25.382099px
-PASS with font-size: 10px, #target.style['line-height'] = 2.6666667 should result in a used line-height of 26.666664px
+PASS with font-size: 10px, #target.style['line-height'] = 2.6666667 should result in a used line-height of 26.666668px
 PASS with font-size: 10px, #target.style['line-height'] = 2.123456789123457 should result in a used line-height of 21.234568px
 PASS with font-size: 10px, #target.style['line-height'] = 2.5 should result in a used line-height of 25px
 PASS with font-size: 10px, #target.style['line-height'] = 2 should result in a used line-height of 20px
 PASS with font-size: 10px, #target.style['line-height'] = 1.05 should result in a used line-height of 10.5px
 PASS with font-size: 10px, #target.style['line-height'] = 1.049 should result in a used line-height of 10.49px
-PASS with font-size: 10px, #target.style['line-height'] = 1.0491 should result in a used line-height of 10.491001px
+PASS with font-size: 10px, #target.style['line-height'] = 1.0491 should result in a used line-height of 10.491px
 PASS with font-size: 10px, #target.style['line-height'] = 0 should result in a used line-height of 0px
 PASS with font-size: 10px, #target.style['line-height'] = 1 should result in a used line-height of 10px
 

--- a/LayoutTests/fast/css/line-height-get-computed-style.html
+++ b/LayoutTests/fast/css/line-height-get-computed-style.html
@@ -23,18 +23,18 @@
         }, `with font-size: 10px, #target.style['line-height'] = ${line_height_percent} should result in a used line-height of ${expected_line_height}`)
     }
     
-    test_line_height(1e+26, '999999914697178458896728064px')
+    test_line_height(1e+26, '1000000062271131048573140992px')
     
     // Per spec, CSS numbers shouldn't serialize with more than 6 decimal places.
     test_line_height(2.53821, '25.382099px')
-    test_line_height(2.6666667, '26.666664px')
+    test_line_height(2.6666667, '26.666668px')
     // 20 decimals.
     test_line_height(2.12345678912345678912, '21.234568px')
     test_line_height(2.5, '25px')
     test_line_height(2, '20px')
     test_line_height(1.05, '10.5px')
     test_line_height(1.049, '10.49px')
-    test_line_height(1.0491, '10.491001px')
+    test_line_height(1.0491, '10.491px')
     test_line_height(0, '0px')
     test_line_height(1, '10px')
     

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -207,6 +207,12 @@ template<typename Numeric, Range range = Numeric::range, typename T = typename N
     return clampToRange<range, T, U>(value);
 }
 
+// Clamps a value to within `range` of the specified numeric type.
+template<typename Numeric, Range range = Numeric::range, typename T = typename Numeric::ResolvedValueType, typename U> constexpr Numeric clampingToRangeOf(U value)
+{
+    return Numeric { clampToRange<range, T, U>(value) };
+}
+
 // Checks if a floating point value is within `range`.
 template<Range range, std::floating_point T> constexpr bool isWithinRange(T value)
 {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -197,14 +197,11 @@ inline InlineLayoutUnit InlineLevelBox::preferredLineHeight() const
         [&](const CSS::Keyword::Normal&) -> InlineLayoutUnit {
             return 0;
         },
-        [&](const WebCore::Style::LineHeight::Fixed& fixed) -> InlineLayoutUnit {
-            return WebCore::Style::evaluate<InlineLayoutUnit>(fixed, m_style.zoomFactor);
+        [&](const WebCore::Style::LineHeight::Length& length) -> InlineLayoutUnit {
+            return WebCore::Style::evaluate<InlineLayoutUnit>(length, m_style.zoomFactor);
         },
-        [&](const WebCore::Style::LineHeight::Percentage& percentage) -> InlineLayoutUnit {
-            return WebCore::Style::evaluate<LayoutUnit>(percentage, LayoutUnit { fontSize() });
-        },
-        [&](const WebCore::Style::LineHeight::Calc& calc) -> InlineLayoutUnit {
-            return WebCore::Style::evaluate<LayoutUnit>(calc, LayoutUnit { fontSize() }, m_style.zoomFactor);
+        [&](const WebCore::Style::LineHeight::Number& number) -> InlineLayoutUnit {
+            return LayoutUnit { number.value * LayoutUnit { fontSize() } };
         }
     );
 }
@@ -215,5 +212,5 @@ inline bool InlineLevelBox::hasLineBoxRelativeAlignment() const
         || WTF::holdsAlternative<CSS::Keyword::Bottom>(m_style.verticalAlignment);
 }
 
-}
-}
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -403,14 +403,11 @@ String PrintContext::pageProperty(LocalFrame* frame, const String& propertyName,
             [&](const CSS::Keyword::Normal&) -> String {
                 return "0"_s;
             },
-            [&](const Style::LineHeight::Fixed& fixed) -> String {
-                return makeString(fixed.resolveZoom(style->usedZoomForLength()));
+            [&](const Style::LineHeight::Length& length) -> String {
+                return makeString(length.resolveZoom(style->usedZoomForLength()));
             },
-            [&](const Style::LineHeight::Percentage& percentage) -> String {
-                return makeString(percentage.value);
-            },
-            [&](const Style::LineHeight::Calc&) -> String {
-                return "0"_s;
+            [&](const Style::LineHeight::Number& number) -> String {
+                return makeString(number.value);
             }
         );
     }

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -256,24 +256,21 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
             [&](const CSS::Keyword::Normal&) {
                 return 0;
             },
-            [&](const Style::LineHeight::Fixed& fixed) {
-                return Style::evaluate<LayoutUnit>(fixed, Style::ZoomFactor { 1.0f }).toInt();
+            [&](const Style::LineHeight::Length& length) {
+                return Style::evaluate<LayoutUnit>(length, Style::ZoomFactor::none()).toInt();
             },
-            [&](const Style::LineHeight::Percentage& percentage) {
-                return Style::evaluate<LayoutUnit>(percentage, LayoutUnit { fontDescription.specifiedSize() }).toInt();
-            },
-            [&](const Style::LineHeight::Calc&) {
-                return 0;
+            [&](const Style::LineHeight::Number& number) {
+                return LayoutUnit { number.value * LayoutUnit { fontDescription.specifiedSize() } }.toInt();
             }
         );
 
         // This calculation matches the line-height computed size calculation in StyleBuilderCustom::applyValueLineHeight().
         int lineHeight = specifiedLineHeight * scaleChange;
-        if (auto fixedLineHeight = lineHeightLength.tryFixed(); fixedLineHeight && fixedLineHeight->resolveZoom(Style::ZoomFactor { 1.0f }) == lineHeight)
+        if (auto fixedLineHeight = lineHeightLength.tryLength(); fixedLineHeight && fixedLineHeight->resolveZoom(Style::ZoomFactor::none()) == lineHeight)
             continue;
 
         auto newParentStyle = cloneRenderStyleWithState(parentStyle);
-        newParentStyle.setLineHeight(lineHeightLength.isNormal() ? Style::LineHeight { lineHeightLength } : Style::LineHeight { Style::LineHeight::Fixed { static_cast<float>(lineHeight) } });
+        newParentStyle.setLineHeight(lineHeightLength.isNormal() ? Style::LineHeight { lineHeightLength } : Style::LineHeight { Style::LineHeight::Length { static_cast<float>(lineHeight) } });
         newParentStyle.setSpecifiedLineHeight(Style::LineHeight { lineHeightLength });
         newParentStyle.setFontDescription(WTF::move(fontDescription));
         parentRenderer->setStyle(WTF::move(newParentStyle));

--- a/Source/WebCore/rendering/style/AutosizeStatus.cpp
+++ b/Source/WebCore/rendering/style/AutosizeStatus.cpp
@@ -144,10 +144,10 @@ auto AutosizeStatus::isIdempotentTextAutosizingCandidate(const Style::ComputedSt
 
 bool AutosizeStatus::probablyContainsASmallFixedNumberOfLines(const Style::ComputedStyle& style)
 {
-    auto& lineHeightAsLength = style.specifiedLineHeight();
-    auto lineHeightAsFixed = lineHeightAsLength.tryFixed();
-    auto lineHeightAsPercentage = lineHeightAsLength.tryPercentage();
-    if (!lineHeightAsFixed && !lineHeightAsPercentage)
+    auto& specifiedLineHeight = style.specifiedLineHeight();
+    auto lineHeightAsLength = specifiedLineHeight.tryLength();
+    auto lineHeightAsNumber = specifiedLineHeight.tryNumber();
+    if (!lineHeightAsLength && !lineHeightAsNumber)
         return false;
 
     auto zoomFactor = style.usedZoomForLength();
@@ -165,7 +165,7 @@ bool AutosizeStatus::probablyContainsASmallFixedNumberOfLines(const Style::Compu
     if (heightOrMaxHeight <= 0)
         return false;
 
-    float approximateLineHeight = lineHeightAsPercentage ? lineHeightAsPercentage->value * style.specifiedFontSize() / 100 : lineHeightAsFixed->resolveZoom(zoomFactor);
+    float approximateLineHeight = lineHeightAsNumber ? lineHeightAsNumber->value * style.specifiedFontSize() : lineHeightAsLength->resolveZoom(zoomFactor);
     if (approximateLineHeight <= 0)
         return false;
 

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -758,26 +758,14 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyLineHeight> {
             [&](const CSS::Keyword::Normal& keyword) {
                 return functor(keyword);
             },
-            [&](const LineHeight::Fixed& fixed) {
+            [&](const LineHeight::Length& fixed) {
                 return functor(fixed);
             },
-            [&](const LineHeight::Percentage& percentage) {
-                // CSSValueConversion<LineHeight> will convert a percentage value to a fixed value,
-                // and a number value to a percentage value. To be able to roundtrip a number value, we thus
-                // look for a percent value and convert it back to a number.
+            [&](const LineHeight::Number& number) {
                 if (state.valueType == ExtractorState::PropertyValueType::Computed)
-                    return functor(Number<CSS::Nonnegative> { percentage.value / 100 });
+                    return functor(number);
 
-                // This is imperfect, because it doesn't include the zoom factor and the real computation
-                // for how high to be in pixels does include things like minimum font size and the zoom factor.
-                // On the other hand, since font-size doesn't include the zoom factor, we really can't do
-                // that here either.
-                return functor(Length<CSS::Nonnegative> { percentage.value * state.style.fontDescription().unzoomedComputedSize() / 100 });
-            },
-            [&](const LineHeight::Calc& calc) {
-                // FIXME: We pass ZoomFactor::none() but it really is not clear why we are even evaluating calc
-                // here. We should probably revisit this and figure out another way to do this.
-                return functor(Length<CSS::Nonnegative> { evaluate<float>(calc, 0.0f, ZoomFactor::none()) });
+                return functor(LineHeight::Length { number.value * state.style.fontDescription().unzoomedComputedSize() });
             }
         );
     }

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -57,44 +57,45 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSVa
         .cssToLengthConversionData()
         .copyForLineHeight();
 
-    auto zoomFactor = Style::ZoomFactor { state.zoomWithTextZoomFactor() };
-
-    auto percentageBasis = [&] {
-        return state.style().fontDescription().unzoomedComputedSize();
-    };
-
-    using StyleSpecified = typename LineHeight::Specified;
-    using CSSRaw = typename StyleSpecified::CSS::Raw;
+    using StyleLengthPercentage = LengthPercentage<CSS::Nonnegative>;
+    using CSSRaw = typename StyleLengthPercentage::CSS::Raw;
     using CSSDimensionRaw = typename CSSRaw::Dimension;
     using CSSPercentageRaw = typename CSSRaw::Percentage;
 
     using StyleNumber = Number<CSS::Nonnegative>;
     using CSSNumberRaw = typename StyleNumber::CSS::Raw;;
 
-    auto handleFixed = [&](const StyleSpecified::Dimension& fixed) {
-        return LineHeight::Fixed { CSS::clampToRangeOf<LineHeight::Fixed>(fixed.unresolvedValue() * multiplier) };
+    auto handleLength = [&](const auto& length) {
+        return CSS::clampingToRangeOf<LineHeight::Length>(
+            length.unresolvedValue() * multiplier
+        );
     };
 
-    auto handlePercentage = [&](const StyleSpecified::Percentage& percentage) {
-        // Line-height percentages need to inherit as if they were pixel values. In the example:
-        // <div style="font-size: 10px; line-height: 150%;"><div style="font-size: 100px;"></div></div>
-        // the inner element should have line-height of 15px. However, in this example:
-        // <div style="font-size: 10px; line-height: 1.5;"><div style="font-size: 100px;"></div></div>
-        // the inner element should have a line-height of 150px. Therefore, we map percentages to Fixed
-        // values and raw numbers to percentages.
+    auto handlePercentage = [&](const auto& percentage) {
+        auto textZoomFactor = ZoomFactor { state.zoomWithTextZoomFactor() };
+        auto percentageBasis = state.style().fontDescription().unzoomedComputedSize();
 
         // FIXME: percentage should not be restricted to an integer here.
         auto percentageValue = static_cast<int>(percentage.value);
 
-        return LineHeight::Fixed { CSS::clampToRangeOf<LineHeight::Fixed>((percentageValue * percentageBasis() * zoomFactor.value) / 100.0) };
+        return CSS::clampingToRangeOf<LineHeight::Length>(
+            (percentageValue * percentageBasis * textZoomFactor.value) / 100.0
+        );
     };
 
-    auto handleCalc = [&](const StyleSpecified::Calc& calc) {
-        return LineHeight::Fixed { CSS::clampToRangeOf<LineHeight::Fixed>(calc.evaluate(percentageBasis(), zoomFactor) * multiplier) };
+    auto handleCalc = [&](const auto& calc) {
+        auto textZoomFactor = ZoomFactor { state.zoomWithTextZoomFactor() };
+        auto percentageBasis = state.style().fontDescription().unzoomedComputedSize();
+
+        return CSS::clampingToRangeOf<LineHeight::Length>(
+            evaluate<float>(calc, percentageBasis, textZoomFactor) * multiplier
+        );
     };
 
-    auto handleNumber = [&](const StyleNumber& number) {
-        return LineHeight::Percentage { CSS::clampToRangeOf<LineHeight::Percentage>(number.value * 100.0) };
+    auto handleNumber = [&](const auto& number) {
+        return CSS::clampingToRangeOf<LineHeight::Number>(
+            number.value
+        );
     };
 
     return WTF::switchOn(*primitiveValue,
@@ -109,13 +110,13 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSVa
 
             auto convertedCalc = toStyle(CSS::UnevaluatedCalc<CSSRaw> { calc }, conversionData);
             return WTF::switchOn(convertedCalc,
-                [&](const StyleSpecified::Dimension& fixed) {
-                    return handleFixed(fixed);
+                [&](const StyleLengthPercentage::Dimension& length) {
+                    return handleLength(length);
                 },
-                [&](const StyleSpecified::Percentage& percentage) {
+                [&](const StyleLengthPercentage::Percentage& percentage) {
                     return handlePercentage(percentage);
                 },
-                [&](const StyleSpecified::Calc& calc) {
+                [&](const StyleLengthPercentage::Calc& calc) {
                     return handleCalc(calc);
                 }
             );
@@ -128,7 +129,7 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSVa
                 return handlePercentage(toStyle(CSSPercentageRaw(*unit, raw.value), conversionData));
 
             if (auto unit = CSSDimensionRaw::UnitTraits::validate(raw.unit))
-                return handleFixed(toStyle(CSSDimensionRaw(*unit, raw.value), conversionData));
+                return handleLength(toStyle(CSSDimensionRaw(*unit, raw.value), conversionData));
 
             state.setCurrentPropertyInvalidAtComputedValueTime();
             return CSS::Keyword::Normal { };
@@ -140,20 +141,27 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSVa
 
 auto Blending<LineHeight>::canBlend(const LineHeight& a, const LineHeight& b) -> bool
 {
-    return a.hasSameType(b) || (a.isCalculated() && b.isNumeric()) || (b.isCalculated() && a.isNumeric());
+    return a.hasSameType(b) && a.isNumeric() && b.isNumeric();
 }
 
 auto Blending<LineHeight>::requiresInterpolationForAccumulativeIteration(const LineHeight& a, const LineHeight& b) -> bool
 {
-    return !a.hasSameType(b) || a.isCalculated() || b.isCalculated();
+    return !a.hasSameType(b);
 }
 
 auto Blending<LineHeight>::blend(const LineHeight& a, const LineHeight& b, const BlendingContext& context) -> LineHeight
 {
-    if (!a.isNumeric() || !b.isNumeric())
+    if (!a.hasSameType(b) || !a.isNumeric() || !b.isNumeric())
         return context.progress < 0.5 ? a : b;
 
-    return Style::blend(get<LineHeight::Numeric>(a), get<LineHeight::Numeric>(b), context);
+    return WTF::visit(WTF::makeVisitor(
+        [&]<typename T>(const T& a, const T& b) -> LineHeight {
+            return LineHeight { WebCore::Style::blend(a, b, context) };
+        },
+        [](const auto&, const auto&) -> LineHeight {
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    ), a.m_value, b.m_value);
 }
 
 // MARK: - Evaluation
@@ -162,17 +170,14 @@ auto Evaluation<LineHeight, float>::operator()(
     const LineHeight& lineHeight, LineHeightEvaluationContext context, ZoomFactor zoom) -> float
 {
     return WTF::switchOn(lineHeight,
-        [&](const LineHeight::Fixed& fixed) {
-            return evaluate<LayoutUnit>(fixed, zoom).toFloat();
-        },
-        [&](const LineHeight::Percentage& percentage) {
-            return evaluate<LayoutUnit>(percentage, LayoutUnit { context.computedFontSize }).toFloat();
-        },
-        [&](const LineHeight::Calc& calc) {
-            return evaluate<LayoutUnit>(calc, LayoutUnit { context.computedFontSize }, zoom).toFloat();
-        },
         [&](const CSS::Keyword::Normal&) {
             return context.lineSpacing;
+        },
+        [&](const LineHeight::Length& length) {
+            return evaluate<LayoutUnit>(length, zoom).toFloat();
+        },
+        [&](const LineHeight::Number& number) {
+            return LayoutUnit { number.value * LayoutUnit { context.computedFontSize } }.toFloat();
         }
     );
 }

--- a/Source/WebCore/style/values/inline/StyleLineHeight.h
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.h
@@ -24,29 +24,64 @@
 
 #pragma once
 
-#include <WebCore/StylePrimitiveNumericOrKeyword.h>
+#include <WebCore/StylePrimitiveNumeric.h>
 #include <wtf/Hasher.h>
 
 namespace WebCore {
 namespace Style {
 
 // <'line-height'> = normal | <number [0,∞]> | <length-percentage [0,∞]>
-// NOTE: <number [0,∞]> gets converted to <length-percentage [0,∞]>.
+// NOTE: <length-percentage [0,∞]> gets converted to <length [0,∞]> at style building time by resolving any percentages against `font-size`.
 // https://drafts.csswg.org/css-inline/#propdef-line-height
-struct LineHeight : PrimitiveNumericOrKeyword<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Normal> {
-    using Base::Base;
+struct LineHeight {
+    using Number = Style::Number<CSS::Nonnegative, float>;
+    using Length = Style::Length<CSS::Nonnegative, float>;
 
-    bool isNormal() const { return holdsAlternative<CSS::Keyword::Normal>(); }
+    constexpr LineHeight(CSS::Keyword::Normal keyword) : m_value { keyword } { }
+    constexpr LineHeight(Number number) : m_value { number } { }
+    constexpr LineHeight(Length length) : m_value { length } { }
 
-    unsigned valueForHash() const
+    constexpr bool isNormal() const { return holdsAlternative<CSS::Keyword::Normal>(); }
+    constexpr bool isNumeric() const { return !holdsAlternative<CSS::Keyword::Normal>(); }
+
+    constexpr std::optional<Length> tryLength() const { return holdsAlternative<Length>() ? std::optional { get<Length>(m_value) } : std::nullopt; }
+    constexpr std::optional<Number> tryNumber() const { return holdsAlternative<Number>() ? std::optional { get<Number>(m_value) } : std::nullopt; }
+
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
+    {
+        return WTF::switchOn(m_value, std::forward<F>(f)...);
+    }
+
+    template<typename U> constexpr bool holdsAlternative() const
+    {
+        return WTF::holdsAlternative<U>(m_value);
+    }
+
+    constexpr unsigned valueForHash() const
     {
         return switchOn(
             [&](const CSS::Keyword::Normal&) -> unsigned { return computeHash(0); },
-            [&](const Fixed& fixed) -> unsigned { return computeHash(1, fixed.unresolvedValue()); },
-            [&](const Percentage& percentage) -> unsigned { return computeHash(2, percentage.value); },
-            [&](const Calc&) -> unsigned { return computeHash(3); }
+            [&](const Number& number) -> unsigned { return computeHash(1, number.value); },
+            [&](const Length& length) -> unsigned { return computeHash(2, length.unresolvedValue()); }
         );
     }
+
+    constexpr bool hasSameType(const LineHeight& other) const
+    {
+        return m_value.index() == other.m_value.index();
+    }
+
+    constexpr bool operator==(const LineHeight&) const = default;
+
+    // Legacy name support
+    using Fixed = Length;
+    constexpr std::optional<Length> tryFixed() const { return tryLength(); }
+    constexpr bool isFixed() const { return holdsAlternative<Length>(); }
+
+private:
+    friend struct Blending<LineHeight>;
+
+    Variant<CSS::Keyword::Normal, Number, Length> m_value;
 };
 
 // MARK: - Conversion


### PR DESCRIPTION
#### acfe18ce0f1cb3f287d6f1730bd6179e8e7fa808
<pre>
Model computed value line-height more closely to how its specified
<a href="https://bugs.webkit.org/show_bug.cgi?id=320995">https://bugs.webkit.org/show_bug.cgi?id=320995</a>

Reviewed by Darin Adler.

Replaces awkward modeling of `line-height` computed value using LengthPercentage
with one that mirrors the spec. This removes the unused `calc` term and makes
things a bit more clear to the reader.

The removal of an unnecessary multiplication by 100 then later division by 100
that happened due to converting from storing as Percentage to storing as a
Number caused a small precision change in line-height-get-computed-style.html.

To avoid other precision changes issues, the evaluation functions have been
carefully constructed to retain the same set of conversions to LayoutUnit as
the older code.

* LayoutTests/fast/css/line-height-get-computed-style-expected.txt:
* LayoutTests/fast/css/line-height-get-computed-style.html:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
* Source/WebCore/page/PrintContext.cpp:
* Source/WebCore/rendering/TextAutoSizing.cpp:
* Source/WebCore/rendering/style/AutosizeStatus.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/values/inline/StyleLineHeight.cpp:
* Source/WebCore/style/values/inline/StyleLineHeight.h:

Canonical link: <a href="https://commits.webkit.org/318710@main">https://commits.webkit.org/318710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d47e7d8108f1357f547309f6b80a609bc1a9f3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188733 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139505 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41755 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40100 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39750 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/40 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190953 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148710 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39951 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53193 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148462 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43157 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125463 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120187 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51711 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14728 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51096 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->