### PR TITLE
Validation missing after 318538@main

### DIFF
--- a/LayoutTests/fast/webgpu/render-bundle-draw-indirect-offset-oob-expected.txt
+++ b/LayoutTests/fast/webgpu/render-bundle-draw-indirect-offset-oob-expected.txt
@@ -1,0 +1,11 @@
+Regression test for a GPU-process OOB read / crash: the render-bundle record-into-ICB path for drawIndirect/drawIndexedIndirect stored a WebContent-controlled indirectOffset without validating it. At executeBundles() time that offset was fed straight into the clamp/encode shaders, so an out-of-bounds offset read past the indirect buffer. Each such draw must instead raise a validation error at record time and never reach executeBundles().
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS drawIndexedIndirect out-of-bounds offset: validation error raised as expected.
+PASS drawIndirect out-of-bounds offset: validation error raised as expected.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/webgpu/render-bundle-draw-indirect-offset-oob.html
+++ b/LayoutTests/fast/webgpu/render-bundle-draw-indirect-offset-oob.html
@@ -1,0 +1,86 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<script src="../../resources/js-test.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+description("Regression test for a GPU-process OOB read / crash: the render-bundle record-into-ICB path for " +
+           "drawIndirect/drawIndexedIndirect stored a WebContent-controlled indirectOffset without validating it. " +
+           "At executeBundles() time that offset was fed straight into the clamp/encode shaders, so an " +
+           "out-of-bounds offset read past the indirect buffer. Each such draw must instead raise a validation " +
+           "error at record time and never reach executeBundles().");
+
+const format = 'rgba8unorm';
+
+async function expectValidationError(device, description, buildBundle) {
+    device.pushErrorScope('validation');
+    let bundle = buildBundle();
+
+    // Executing the (invalid) bundle must not crash the GPU process.
+    let texture = device.createTexture({ size: [1, 1], format, usage: GPUTextureUsage.RENDER_ATTACHMENT });
+    let commandEncoder = device.createCommandEncoder();
+    let pass = commandEncoder.beginRenderPass({
+        colorAttachments: [{ view: texture.createView(), loadOp: 'clear', storeOp: 'store', clearValue: { r: 1, g: 0, b: 0, a: 1 } }],
+    });
+    pass.executeBundles([bundle]);
+    pass.end();
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+
+    let error = await device.popErrorScope();
+    if (error)
+        testPassed(description + ": validation error raised as expected.");
+    else
+        testFailed(description + ": expected a validation error but none was raised.");
+}
+
+async function main() {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+
+    let module = device.createShaderModule({ code: `
+        @vertex fn vs(@builtin(vertex_index) i: u32) -> @builtin(position) vec4f {
+            var p = array(vec2f(-1, -3), vec2f(-1, 1), vec2f(3, 1));
+            return vec4f(p[i], 0, 1);
+        }
+        @fragment fn fs() -> @location(0) vec4f { return vec4f(0, 1, 0, 1); }
+    ` });
+    let pipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: { module, entryPoint: 'vs' },
+        fragment: { module, entryPoint: 'fs', targets: [{ format }] },
+        primitive: { topology: 'triangle-list' },
+    });
+
+    let indexData = new Uint16Array([0, 1, 2, 0]); // 8 bytes (uint16 index buffer must be > 4 bytes).
+    let indexBuffer = device.createBuffer({ size: indexData.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(indexBuffer, 0, indexData);
+
+    // A 20-byte indirect buffer holds exactly one MTLDrawIndexedPrimitivesIndirectArguments, so any nonzero
+    // 4-byte-aligned offset leaves fewer than sizeof(args) bytes remaining and must be rejected.
+    let argsBuffer = device.createBuffer({ size: 20, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST });
+    const oobOffset = 65536; // Far past the buffer's declared size.
+
+    await expectValidationError(device, "drawIndexedIndirect out-of-bounds offset", () => {
+        let enc = device.createRenderBundleEncoder({ colorFormats: [format] });
+        enc.setPipeline(pipeline);
+        enc.setIndexBuffer(indexBuffer, 'uint16');
+        enc.drawIndexedIndirect(argsBuffer, oobOffset);
+        return enc.finish();
+    });
+
+    await expectValidationError(device, "drawIndirect out-of-bounds offset", () => {
+        let enc = device.createRenderBundleEncoder({ colorFormats: [format] });
+        enc.setPipeline(pipeline);
+        enc.drawIndirect(argsBuffer, oobOffset);
+        return enc.finish();
+    });
+}
+
+main().catch(e => {
+    testFailed("Exception: " + e);
+}).finally(() => {
+    finishJSTest();
+});
+
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -780,6 +780,22 @@ RenderBundleEncoder::FinalizeRenderCommand RenderBundleEncoder::drawIndexedIndir
                 [renderPassEncoder->renderCommandEncoder() drawIndexedPrimitives:m_primitiveType indexType:m_indexType indexBuffer:indexBuffer indexBufferOffset:m_indexBufferOffset indirectBuffer:mtlIndirectBuffer indirectBufferOffset:modifiedIndirectOffset];
         } else if (indexBuffer.length) {
             // Record the command; its draw is encoded into this ICB slot on the GPU at executeBundles() time.
+            if (!isValidToUseWith(indirectBuffer, *this)) {
+                makeInvalid(@"drawIndexedIndirect: buffer was invalid");
+                return finalizeRenderCommand();
+            }
+
+            if (!(indirectBuffer.usage() & WGPUBufferUsage_Indirect) || (indirectOffset % 4)) {
+                makeInvalid(@"drawIndexedIndirect: validation failed");
+                return finalizeRenderCommand();
+            }
+
+            auto indirectOffsetSum = checkedSum<uint64_t>(indirectOffset, sizeof(MTLDrawIndexedPrimitivesIndirectArguments));
+            if (indirectOffsetSum.hasOverflowed() || indirectBuffer.initialSize() < indirectOffsetSum.value()) {
+                makeInvalid(@"drawIndexedIndirect: validation failed");
+                return finalizeRenderCommand();
+            }
+
             bool unusedWorkaround = false;
             auto [minVertexCount, minInstanceCount] = computeMininumVertexInstanceCount(unusedWorkaround);
             m_indirectDrawsForSlot.set(m_currentCommandIndex, IndirectDrawData {
@@ -854,6 +870,22 @@ RenderBundleEncoder::FinalizeRenderCommand RenderBundleEncoder::drawIndirect(Buf
                 [renderPassEncoder->renderCommandEncoder() drawPrimitives:m_primitiveType indirectBuffer:clampedIndirectBuffer indirectBufferOffset:indirectOffset];
         } else {
             // Record the command; its draw is encoded into this ICB slot on the GPU at executeBundles() time.
+            if (!isValidToUseWith(indirectBuffer, *this)) {
+                makeInvalid(@"drawIndirect: buffer was invalid");
+                return finalizeRenderCommand();
+            }
+
+            if (!(indirectBuffer.usage() & WGPUBufferUsage_Indirect) || (indirectOffset % 4)) {
+                makeInvalid(@"drawIndirect: validation failed");
+                return finalizeRenderCommand();
+            }
+
+            auto indirectOffsetSum = checkedSum<uint64_t>(indirectOffset, sizeof(MTLDrawPrimitivesIndirectArguments));
+            if (indirectOffsetSum.hasOverflowed() || indirectBuffer.initialSize() < indirectOffsetSum.value()) {
+                makeInvalid(@"drawIndirect: validation failed");
+                return finalizeRenderCommand();
+            }
+
             bool unusedWorkaround = false;
             auto [minVertexCount, minInstanceCount] = computeMininumVertexInstanceCount(unusedWorkaround);
             m_indirectDrawsForSlot.set(m_currentCommandIndex, IndirectDrawData {
@@ -879,7 +911,8 @@ RenderBundleEncoder::FinalizeRenderCommand RenderBundleEncoder::drawIndirect(Buf
             return finalizeRenderCommand();
         }
 
-        if (indirectBuffer.initialSize() < indirectOffset + sizeof(MTLDrawPrimitivesIndirectArguments)) {
+        auto indirectOffsetSum = checkedSum<uint64_t>(indirectOffset, sizeof(MTLDrawPrimitivesIndirectArguments));
+        if (indirectOffsetSum.hasOverflowed() || indirectBuffer.initialSize() < indirectOffsetSum.value()) {
             makeInvalid(@"drawIndirect: validation failed");
             return finalizeRenderCommand();
         }


### PR DESCRIPTION
#### 027d0dd5267bd6d2a046694c82399f61fd2bbb1a
<pre>
Validation missing after <a href="https://commits.webkit.org/318538@main">318538@main</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320997">https://bugs.webkit.org/show_bug.cgi?id=320997</a>
<a href="https://rdar.apple.com/184033420">rdar://184033420</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/318538@main">318538@main</a> didn&apos;t ensure the indirect buffer size + offset was less than
the buffer length, or divisible by four as required. Add validation.

Test: fast/webgpu/render-bundle-draw-indirect-offset-oob.html

* LayoutTests/fast/webgpu/render-bundle-draw-indirect-offset-oob-expected.txt: Added.
* LayoutTests/fast/webgpu/render-bundle-draw-indirect-offset-oob.html: Added.
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::drawIndexedIndirect):
(WebGPU::RenderBundleEncoder::drawIndirect):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/027d0dd5267bd6d2a046694c82399f61fd2bbb1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143270 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/568daefb-aa94-4bfc-b274-60eb1d0b2ea0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139545 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96732 "2 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/108f15ee-92a8-4df2-9929-24a17376e591) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119991 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3429012-d345-4ab7-8917-0f1c5468a2ca) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41809 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40155 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152208 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39803 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/97 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191010 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148765 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53250 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148517 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43208 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125520 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120349 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51768 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14781 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51153 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51394 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51214 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->