### PR TITLE
[JSC] Do not truncate table64 maximum size to uint32_t

### DIFF
--- a/JSTests/wasm/js-api/table64-js-api.js
+++ b/JSTests/wasm/js-api/table64-js-api.js
@@ -71,6 +71,15 @@ import * as assert from "../assert.js";
 }
 
 {
+    // A maximum above 2^32 must be reflected in full, not truncated.
+    const table = new WebAssembly.Table({initial: 1n, maximum: 4294967301n, element: "funcref", address: "i64"});
+    assert.eq(table.type().maximum, 4294967301n);
+
+    const wide = new WebAssembly.Table({initial: 1n, maximum: BigInt(2**64) - 1n, element: "funcref", address: "i64"});
+    assert.eq(wide.type().maximum, 18446744073709551615n);
+}
+
+{
     const table = new WebAssembly.Table({element: "funcref", initial: 20n, maximum: 30n, address: "i64"});
     assert.eq(20n, table.grow(0n));
     assert.eq(20, table.length);

--- a/JSTests/wasm/stress/table64-growable-import.js
+++ b/JSTests/wasm/stress/table64-growable-import.js
@@ -1,0 +1,50 @@
+//@ skip if $addressBits <= 32
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// A module whose imported table declares initial == maximum is compiled on the
+// assumption that the table can never be resized: BBQ and OMG fold its length
+// into a constant and treat its function buffer as immutable. Comparing the
+// declared and the provided maximum as u32 let a table64 whose real maximum is
+// above 2^32 satisfy such an import and then grow underneath compiled code.
+{
+    const table = new WebAssembly.Table({ element: "funcref", initial: 5n, maximum: 5n, address: "i64" });
+    const growable = new WebAssembly.Table({ element: "funcref", initial: 5n, maximum: 4294967301n, address: "i64" });
+    const wat = `
+    (module
+        (import "m" "t" (table $t i64 5 5 funcref))
+    )`;
+
+    await instantiate(wat, { m: { t: table } }, { memory64: true });
+    await assert.throwsAsync(
+        instantiate(wat, { m: { t: growable } }, { memory64: true }),
+        WebAssembly.LinkError,
+        "Imported Table m:t 'maximum' is larger than the module's expected 'maximum'");
+}
+
+// A table whose maximum genuinely matches the declared one stays resizable, and
+// every tier must see the length it grew to rather than the declared minimum.
+{
+    const helper = await instantiate(`
+    (module
+        (func (export "f") (result i32)
+            (i32.const 42)
+        )
+    )`, {}, {});
+
+    const table = new WebAssembly.Table({ element: "funcref", initial: 5n, maximum: 4294967301n, address: "i64" });
+    const instance = await instantiate(`
+    (module
+        (import "m" "t" (table $t i64 5 4294967301 funcref))
+        (type $ft (func (result i32)))
+        (func (export "callAt") (param $i i64) (result i32)
+            (local.get $i)
+            (call_indirect $t (type $ft))
+        )
+    )`, { m: { t: table } }, { memory64: true });
+
+    table.grow(5n);
+    table.set(7n, helper.exports.f);
+    for (let i = 0; i < wasmTestLoopCount; ++i)
+        assert.eq(instance.exports.callAt(7n), 42);
+}

--- a/JSTests/wasm/stress/table64-maximum.js
+++ b/JSTests/wasm/stress/table64-maximum.js
@@ -1,0 +1,54 @@
+//@ skip if $addressBits <= 32
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// A table64's maximum is a u64. Narrowing it to 32 bits leaves the table unable
+// to grow, and when the narrowed value lands below the initial size it also
+// breaks Wasm::Table's maximum >= length invariant.
+for (const maximum of ["4294967296", "4294967301", "18446744073709551615"]) {
+    const instance = await instantiate(`
+    (module
+        (table (export "table") i64 1 ${maximum} funcref)
+        (func (export "size") (result i64)
+            (table.size 0)
+        )
+        (func (export "grow") (param $delta i64) (result i64)
+            (ref.null func)
+            (local.get $delta)
+            (table.grow 0)
+        )
+    )`, {}, { memory64: true });
+
+    assert.eq(instance.exports.size(), 1n);
+    assert.eq(instance.exports.grow(9n), 1n);
+    assert.eq(instance.exports.size(), 10n);
+    assert.eq(instance.exports.grow(0n), 10n);
+}
+
+// However large the declared maximum is, growth is still bounded by the number of
+// entries a table may hold (Wasm::Table::isValidLength, maxTableEntries). Only
+// rejected grows are exercised here; reaching that bound would allocate 10M entries.
+{
+    const instance = await instantiate(`
+    (module
+        (table (export "table") i64 1 18446744073709551615 funcref)
+        (func (export "size") (result i64)
+            (table.size 0)
+        )
+        (func (export "grow") (param $delta i64) (result i64)
+            (ref.null func)
+            (local.get $delta)
+            (table.grow 0)
+        )
+    )`, {}, { memory64: true });
+
+    // 9999999 lands exactly on the bound, 10000000 just past it, and the last delta
+    // overflows the u64 length computation.
+    for (const delta of [9999999n, 10000000n, 18446744073709551615n]) {
+        assert.eq(instance.exports.grow(delta), -1n);
+        assert.eq(instance.exports.size(), 1n);
+    }
+
+    assert.throws(() => instance.exports.table.grow(9999999n), RangeError, "WebAssembly.Table.prototype.grow could not grow the table");
+    assert.eq(instance.exports.table.length, 1);
+}

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -794,7 +794,7 @@ public:
         ASSERT(!*this);
     }
 
-    TableInformation(uint32_t initial, std::optional<uint32_t> maximum, bool isImport, TableElementType type, Type wasmType, InitializationType initType, uint64_t initialBitsOrImportNumber, bool isTable64)
+    TableInformation(uint32_t initial, std::optional<uint64_t> maximum, bool isImport, TableElementType type, Type wasmType, InitializationType initType, uint64_t initialBitsOrImportNumber, bool isTable64)
         : m_wasmType(wasmType)
         , m_maximum(maximum)
         , m_initialBitsOrImportNumber(initialBitsOrImportNumber)
@@ -811,7 +811,7 @@ public:
     explicit operator bool() const { return m_isValid; }
     bool isImport() const { return m_isImport; }
     uint32_t initial() const { return m_initial; }
-    std::optional<uint32_t> maximum() const { return m_maximum; }
+    std::optional<uint64_t> maximum() const { return m_maximum; }
     TableElementType type() const { return m_type; }
     Type wasmType() const { return m_wasmType; }
     InitializationType initType() const { return m_initType; }
@@ -820,7 +820,7 @@ public:
 
 private:
     Type m_wasmType;
-    std::optional<uint32_t> m_maximum;
+    std::optional<uint64_t> m_maximum;
     uint64_t m_initialBitsOrImportNumber;
     uint32_t m_initial;
     TableElementType m_type;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
@@ -163,10 +163,10 @@ JSObject* JSWebAssemblyTable::type(JSGlobalObject* globalObject)
     }
 
     JSObject* result;
-    auto numberOrBigInt = [&](uint32_t value) {
+    auto numberOrBigInt = [&](uint64_t value) {
         return m_table->addressType().is64Bit()
             ? JSBigInt::createFrom(globalObject, value)
-            : jsNumber(value);
+            : jsNumber(static_cast<double>(value));
     };
 
     auto maximum = m_table->maximum();

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
@@ -58,7 +58,7 @@ public:
     DECLARE_VISIT_CHILDREN;
 
     static bool isValidLength(uint32_t length) { return Wasm::Table::isValidLength(length); }
-    std::optional<uint32_t> maximum() const { return m_table->maximum(); }
+    std::optional<uint64_t> maximum() const { return m_table->maximum(); }
     uint32_t length() const { return m_table->length(); }
     uint32_t allocatedLength() const { return m_table->allocatedLength(length()); }
     [[nodiscard]] std::optional<uint32_t> grow(JSGlobalObject*, uint32_t delta, JSValue defaultValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
@@ -171,10 +171,10 @@ static JSObject* createTypeReflectionObject(JSGlobalObject* globalObject, JSWebA
             throwException(globalObject, throwScope, createTypeError(globalObject, errorMessage));
             return nullptr;
         }
-        std::optional<uint32_t> maximum = table.maximum();
+        std::optional<uint64_t> maximum = table.maximum();
         if (maximum) {
             typeObj = constructEmptyObject(globalObject, globalObject->objectPrototype(), 3);
-            typeObj->putDirect(vm, Identifier::fromString(vm, "maximum"_s), jsNumber(maximum.value()));
+            typeObj->putDirect(vm, Identifier::fromString(vm, "maximum"_s), jsNumber(static_cast<double>(maximum.value())));
         } else
             typeObj = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
         typeObj->putDirect(vm, Identifier::fromString(vm, "minimum"_s), jsNumber(table.initial()));

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -444,8 +444,8 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
             if (actualInitial < expectedInitial)
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Table import"_s, "provided an 'initial' that is too small"_s)));
 
-            if (std::optional<uint32_t> expectedMaximum = moduleInformation.tables[import.kindIndex].maximum()) {
-                std::optional<uint32_t> actualMaximum = table->maximum();
+            if (std::optional<uint64_t> expectedMaximum = moduleInformation.tables[import.kindIndex].maximum()) {
+                std::optional<uint64_t> actualMaximum = table->maximum();
                 if (!actualMaximum)
                     return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Table import"_s, "does not have a 'maximum' but the module requires that it does"_s)));
                 if (*actualMaximum > *expectedMaximum)


### PR DESCRIPTION
#### b91045c99b1bf34920bb033d7af8d4b2a1a82a20
<pre>
[JSC] Do not truncate table64 maximum size to uint32_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=321000">https://bugs.webkit.org/show_bug.cgi?id=321000</a>
<a href="https://rdar.apple.com/184038951">rdar://184038951</a>

Reviewed by Keith Miller.

We are silently truncating the maximum value to uint32_t. This patch
fixes it.

Test: JSTests/wasm/stress/table64-maximum.js

* JSTests/wasm/js-api/table64-js-api.js:
* JSTests/wasm/stress/table64-growable-import.js: Added.
(await.assert.throwsAsync.instantiate):
* JSTests/wasm/stress/table64-maximum.js: Added.
(string_appeared_here.funcref.func.export.string_appeared_here.result.i64.table.size.0.func.export.string_appeared_here.param.delta.i64.result.i64.ref.null.func.local.delta):
(assert.eq.instance.exports.grow):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::TableInformation::TableInformation):
(JSC::Wasm::TableInformation::maximum const):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp:
(JSC::JSWebAssemblyTable::type):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp:
(JSC::createTypeReflectionObject):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):

Canonical link: <a href="https://commits.webkit.org/318575@main">https://commits.webkit.org/318575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e0b31d963ce89246ee7ed50f592b73a72203dfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52612 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188290 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/142428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52322 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139309 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/142428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5deca6c1-15c1-417c-847a-789e88abc219) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42872 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119763 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d3bd2dd-4b94-4ab2-b742-1c4c3da922c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41538 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39892 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1733 "Passed tests") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/8558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151938 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39947 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45213 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190718 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52281 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/159593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148483 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52962 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148250 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27106 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42952 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125229 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119889 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51480 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/14547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50865 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51105 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50927 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->