### PR TITLE
[JSC] BBQJIT::addTableCopy's assertion is incorrect

### DIFF
--- a/JSTests/wasm/stress/table-copy-mixed-address-types.js
+++ b/JSTests/wasm/stress/table-copy-mixed-address-types.js
@@ -1,0 +1,40 @@
+//@ skip if $addressBits <= 32
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// table.copy between tables with different address types: each offset is typed
+// by its own table, and the length by the narrower of the two.
+let wat = (dstAddressType, srcAddressType) => `
+(module
+    (table $dst (export "dst") ${dstAddressType} 8 funcref)
+    (table $src ${srcAddressType} 8 funcref)
+    (elem (table $src) (${srcAddressType}.const 1) func $f)
+    (func $f (result i32)
+        (i32.const 42)
+    )
+    (type $ft (func (result i32)))
+    (func (export "copy") (param $dstOffset ${dstAddressType}) (param $srcOffset ${srcAddressType}) (param $length ${dstAddressType === "i64" && srcAddressType === "i64" ? "i64" : "i32"})
+        (local.get $dstOffset)
+        (local.get $srcOffset)
+        (local.get $length)
+        (table.copy $dst $src)
+    )
+    (func (export "callDst") (param $i ${dstAddressType}) (result i32)
+        (local.get $i)
+        (call_indirect $dst (type $ft))
+    )
+)`;
+
+for (const dstAddressType of ["i32", "i64"]) {
+    for (const srcAddressType of ["i32", "i64"]) {
+        const instance = await instantiate(wat(dstAddressType, srcAddressType), {}, { memory64: true });
+        const dstNum = dstAddressType === "i32" ? Number : BigInt;
+        const srcNum = srcAddressType === "i32" ? Number : BigInt;
+        const lengthNum = dstAddressType === "i64" && srcAddressType === "i64" ? BigInt : Number;
+
+        for (let i = 0; i < wasmTestLoopCount; ++i) {
+            instance.exports.copy(dstNum(3), srcNum(1), lengthNum(1));
+            assert.eq(instance.exports.callDst(dstNum(3)), 42);
+        }
+    }
+}

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -962,8 +962,8 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 
 [[nodiscard]] PartialResult BBQJIT::addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, Value dstOffset, Value srcOffset, Value length)
 {
-    ASSERT(dstOffset.type() == m_info.table(srcTableIndex).addressType().asWasmTypeKind());
-    ASSERT(srcOffset.type() == m_info.table(dstTableIndex).addressType().asWasmTypeKind());
+    ASSERT(dstOffset.type() == m_info.table(dstTableIndex).addressType().asWasmTypeKind());
+    ASSERT(srcOffset.type() == m_info.table(srcTableIndex).addressType().asWasmTypeKind());
     ASSERT(m_info.table(dstTableIndex).addressType().is64Bit() && m_info.table(srcTableIndex).addressType().is64Bit() ? length.type() == TypeKind::I64 : length.type() == TypeKind::I32);
 
     Vector<Value, 8> arguments = {


### PR DESCRIPTION
#### 3c9a7dc13ae58ba3f1d38258b6af10be8325a354
<pre>
[JSC] BBQJIT::addTableCopy&apos;s assertion is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=321001">https://bugs.webkit.org/show_bug.cgi?id=321001</a>
<a href="https://rdar.apple.com/184039749">rdar://184039749</a>

Reviewed by Dan Hecht.

destination and source address type assertions are swapped.

Test: JSTests/wasm/stress/table-copy-mixed-address-types.js

* JSTests/wasm/stress/table-copy-mixed-address-types.js: Added.
(srcAddressType.module.table.dst):
(8.funcref.elem.table.src):
(string_appeared_here.string_appeared_here.const.instance.await.instantiate.wat):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableCopy):

Canonical link: <a href="https://commits.webkit.org/318574@main">https://commits.webkit.org/318574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4113811f6ce4a4afff138052f0f19e075ef84622

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188279 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/142402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64df7392-23c2-443a-9af7-435fb81009eb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139301 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/142402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1a8be92-ee3c-469a-8f9f-bcc5d49eb277) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119755 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da6ded05-a017-419b-845c-bc5095a41260) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41524 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39880 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1725 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8537 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151924 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39549 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39936 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45202 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190707 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52270 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148472 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52951 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148239 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27105 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42940 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125218 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119878 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51469 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14525 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50854 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51094 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50916 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->