### PR TITLE
[JSC] Active element segment offsets are truncated for a table64

### DIFF
--- a/JSTests/wasm/stress/table64-element-offset.js
+++ b/JSTests/wasm/stress/table64-element-offset.js
@@ -1,0 +1,54 @@
+//@ skip if $addressBits <= 32
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+const options = { memory64: true };
+
+// An active element segment on a table64 has a u64 offset. Truncating it to 32
+// bits turns an out-of-bounds segment into one that silently initializes the
+// wrong slots instead of failing instantiation.
+for (const offset of ["4294967296", "4294967301", "18446744073709551615"]) {
+    await assert.throwsAsync(
+        instantiate(`
+        (module
+            (table i64 10 funcref)
+            (elem (i64.const ${offset}) $f)
+            (func $f)
+        )`, {}, options),
+        WebAssembly.RuntimeError,
+        "Element is trying to set an out of bounds table index");
+}
+
+// Same, with the offset coming from an imported i64 global.
+await assert.throwsAsync(
+    instantiate(`
+    (module
+        (import "m" "g" (global $g i64))
+        (table i64 10 funcref)
+        (elem (global.get $g) $f)
+        (func $f)
+    )`, { m: { g: new WebAssembly.Global({ value: "i64" }, 4294967296n) } }, options),
+    WebAssembly.RuntimeError,
+    "Element is trying to set an out of bounds table index");
+
+// An in-bounds offset above 2^32 is impossible, but offsets that fit must still
+// work, and an empty segment is allowed to start exactly at the table's end.
+{
+    const instance = await instantiate(`
+    (module
+        (table (export "table") i64 10 funcref)
+        (elem (i64.const 7) $f)
+        (elem (i64.const 10))
+        (type $ft (func (result i32)))
+        (func $f (result i32)
+            (i32.const 42)
+        )
+        (func (export "callAt") (param $i i64) (result i32)
+            (local.get $i)
+            (call_indirect (type $ft))
+        )
+    )`, {}, options);
+
+    assert.eq(instance.exports.callAt(7n), 42);
+    assert.eq(instance.exports.table.get(0n), null);
+}

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -846,16 +846,23 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
             // We could also evaluate the vector of expressions here, but we have nowhere safe to
             // store the resulting references so we defer that until table init.
             const auto& offset = *element.offsetIfActive;
-            uint32_t elementIndex = 0;
-            if (offset.isGlobalImport())
-                elementIndex = static_cast<uint32_t>(m_instance->loadI32Global(offset.globalImportIndex()));
-            else if (offset.isConst())
-                elementIndex = offset.constValue();
-            else {
+            const bool isTable64 = moduleInformation.table(*element.tableIndexIfActive).addressType().is64Bit();
+            uint64_t elementIndex = 0;
+            if (offset.isGlobalImport()) {
+                if (isTable64)
+                    elementIndex = static_cast<uint64_t>(m_instance->loadI64Global(offset.globalImportIndex()));
+                else
+                    elementIndex = static_cast<uint32_t>(m_instance->loadI32Global(offset.globalImportIndex()));
+            } else if (offset.isConst()) {
+                if (isTable64)
+                    elementIndex = offset.constValue();
+                else
+                    elementIndex = static_cast<uint32_t>(offset.constValue());
+            } else {
                 uint64_t result;
-                evaluateConstantExpression(globalObject, moduleInformation.constantExpressions[offset.constantExpressionIndex()], moduleInformation, Wasm::Types::I32, result);
+                evaluateConstantExpression(globalObject, moduleInformation.constantExpressions[offset.constantExpressionIndex()], moduleInformation, isTable64 ? Wasm::Types::I64 : Wasm::Types::I32, result);
                 RETURN_IF_EXCEPTION(scope, void());
-                elementIndex = static_cast<uint32_t>(result);
+                elementIndex = isTable64 ? result : static_cast<uint32_t>(result);
             }
 
             if (fn(element, *element.tableIndexIfActive, elementIndex) == IterationStatus::Done)
@@ -903,14 +910,15 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
     };
 
     // Validation of all element ranges comes before all Table and Memory initialization.
-    forEachActiveElement([&](const Wasm::Element& element, uint32_t tableIndex, uint32_t elementIndex) {
-        int64_t lastWrittenIndex = static_cast<int64_t>(elementIndex) + static_cast<int64_t>(element.initTypes.size()) - 1;
-        if (lastWrittenIndex >= m_instance->table(tableIndex)->length()) [[unlikely]] {
+    forEachActiveElement([&](const Wasm::Element& element, uint32_t tableIndex, uint64_t elementIndex) {
+        uint64_t tableLength = m_instance->table(tableIndex)->length();
+        uint64_t segmentLength = element.initTypes.size();
+        if (elementIndex > tableLength || segmentLength > tableLength - elementIndex) [[unlikely]] {
             exception = JSValue(throwException(globalObject, scope, createJSWebAssemblyRuntimeError(globalObject, vm, "Element is trying to set an out of bounds table index"_s)));
             return IterationStatus::Done;
         }
 
-        m_instance->initElementSegment(tableIndex, element, elementIndex, 0U, element.length());
+        m_instance->initElementSegment(tableIndex, element, static_cast<uint32_t>(elementIndex), 0U, element.length());
         return IterationStatus::Continue;
     });
 


### PR DESCRIPTION
#### e942b93cdaa04a323f26b3b0facbed690ca6db63
<pre>
[JSC] Active element segment offsets are truncated for a table64
<a href="https://bugs.webkit.org/show_bug.cgi?id=321008">https://bugs.webkit.org/show_bug.cgi?id=321008</a>
<a href="https://rdar.apple.com/184044756">rdar://184044756</a>

Reviewed by Cole Carley.

This is similar to 317633@main, but for table64.
forEachActiveElement is narrowing down the elementIndex to uint32_t, so
let&apos;s not do it. Also elementIndex needs to be read via i64 form in table64.

Test: JSTests/wasm/stress/table64-element-offset.js

* JSTests/wasm/stress/table64-element-offset.js: Added.
(string_appeared_here.f):
(await.assert.throwsAsync.instantiate.module.import.string_appeared_here.string_appeared_here.global.g.i64.table.i64.10.funcref.elem.global.g.f):
(g.new.WebAssembly.Global):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::evaluate):

Canonical link: <a href="https://commits.webkit.org/318590@main">https://commits.webkit.org/318590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da2d660c755b0b07015647d5512fa8dcb8c0c95c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188293 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/142436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f28fb2c1-5d54-4aa0-b77e-c81e9627413b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139312 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/142436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119766 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/556bf201-829f-4381-a2e9-c5315321d19f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41542 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39896 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1736 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8546 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39558 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39950 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45216 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190721 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52284 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148486 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52965 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148253 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27119 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42951 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125232 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119892 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51483 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14535 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50868 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51108 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50930 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->