### PR TITLE
Re-import content-security-policy/script-src

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module-expected.txt
@@ -1,0 +1,7 @@
+A modulepreloaded parser-inserted external module script is allowed with `strict-dynamic` in the script-src directive.
+
+
+PASS Parser-inserted external module script that is also `modulepreload`ed is allowed with `strict-dynamic`.
+PASS Parser-inserted external module script with only a `<link rel=preload as=script>` is not allowed with `strict-dynamic`.
+PASS A `modulepreload` for a different URL does not allow a parser-inserted external module script with `strict-dynamic`.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html
@@ -1,0 +1,73 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>A modulepreloaded parser-inserted external module script is allowed with `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+    <link rel="modulepreload" href="simpleSourcedModule.js?modulepreloaded-module">
+    <link rel="preload" as="script" href="simpleSourcedModule.js?preload-as-script">
+    <link rel="modulepreload" href="simpleSourcedModule.js?modulepreloaded-other">
+</head>
+
+<body>
+    <h1>A modulepreloaded parser-inserted external module script is allowed with `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'modulepreloaded-module') {
+                    t.done();
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (!violation.blockedURI.includes('simpleSourcedModule.js?modulepreloaded-module')) {
+                    return;
+                }
+                assert_unreached('A modulepreloaded parser-inserted external module script is allowed with `strict-dynamic`.');
+            }));
+        }, 'Parser-inserted external module script that is also `modulepreload`ed is allowed with `strict-dynamic`.');
+    </script>
+    <script type="module" src="simpleSourcedModule.js?modulepreloaded-module"></script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'preload-as-script') {
+                    assert_unreached('A generic `<link rel=preload as=script>` must not allow a parser-inserted module script with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (!violation.blockedURI.includes('simpleSourcedModule.js?preload-as-script')) {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src-elem');
+                t.done();
+            }));
+        }, 'Parser-inserted external module script with only a `<link rel=preload as=script>` is not allowed with `strict-dynamic`.');
+    </script>
+    <script type="module" src="simpleSourcedModule.js?preload-as-script"></script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'url-mismatch') {
+                    assert_unreached('A `modulepreload` for a different URL must not allow a parser-inserted module script with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (!violation.blockedURI.includes('simpleSourcedModule.js?url-mismatch')) {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src-elem');
+                t.done();
+            }));
+        }, 'A `modulepreload` for a different URL does not allow a parser-inserted external module script with `strict-dynamic`.');
+    </script>
+    <script type="module" src="simpleSourcedModule.js?url-mismatch"></script>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module_empty_hash-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module_empty_hash-expected.txt
@@ -1,0 +1,5 @@
+Parser-inserted external module scripts do not match the empty-string hash with `strict-dynamic` in the script-src directive.
+
+
+PASS Parser-inserted external module script in markup does not match the empty-string hash with `strict-dynamic`.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module_empty_hash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module_empty_hash.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Parser-inserted external module scripts do not match the empty-string hash with `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' (the SHA-256 of the empty string) -->
+</head>
+
+<body>
+    <h1>Parser-inserted external module scripts do not match the empty-string hash with `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'markup-module') {
+                    assert_unreached('Parser-inserted external module script in markup must not match the empty-string hash with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (!violation.blockedURI.includes('simpleSourcedModule.js?markup-module')) {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src-elem');
+                t.done();
+            }));
+        }, 'Parser-inserted external module script in markup does not match the empty-string hash with `strict-dynamic`.');
+    </script>
+    <script type="module" src="simpleSourcedModule.js?markup-module"></script>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module_empty_hash.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module_empty_hash.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/w3c-import.log
@@ -77,6 +77,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_javascript_uri.html.headers
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_meta_tag.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_meta_tag.html.headers
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html.headers
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_new_function.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_new_function.html.headers
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted.html
@@ -91,6 +93,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_correct_nonce.html.headers
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module.html.headers
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module_empty_hash.html
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module_empty_hash.html.headers
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_worker-importScripts.https.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_worker.https.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_DedicatedWorker.html


### PR DESCRIPTION
#### 8764cb879c75d1249f8c9cf139116b157cef6351
<pre>
Re-import content-security-policy/script-src
<a href="https://bugs.webkit.org/show_bug.cgi?id=321010">https://bugs.webkit.org/show_bug.cgi?id=321010</a>
<a href="https://rdar.apple.com/184046305">rdar://184046305</a>

Reviewed by Ryan Reno.

Re-import a pair of tests accidentally removed from WebKit&apos;s repo from a larger csp
test resync commit: <a href="https://commits.webkit.org/318528@main">https://commits.webkit.org/318528@main</a>

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module_empty_hash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module_empty_hash.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module_empty_hash-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/318596@main">https://commits.webkit.org/318596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd3eada9927b2e45f9d1b3d57374cb3f57fa6409

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188325 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/609a65c9-831d-442f-8c78-1a28c91fabe4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139335 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48cfd293-9b60-4740-aa99-dab6e0495cc6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160081 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119789 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8906d85-a266-4138-8cf2-30c8dcda7ebe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41567 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39918 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151967 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39581 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190753 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148511 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39878 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52997 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148277 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42977 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119925 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51515 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14559 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50900 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51140 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50962 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->