### PR TITLE
Resync `scroll-animations` from WPT Upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8438,3 +8438,5 @@ imported/w3c/web-platform-tests/svg/path/distance/path-length-css-zoom.tentative
 
 # Does not generate output properly and do tree dump.
 imported/w3c/web-platform-tests/svg/linking/reftests/media-fragment-spatial-percent-zero-size.html [ Skip ]
+
+imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-on-pseudo-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: scroll-driven-animations
-  files: "**"
+rules:
+- "**": [scroll-driven-animations]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/timeline-trigger-source-starts-in-trigger-range.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/timeline-trigger-source-starts-in-trigger-range.tentative-expected.txt
@@ -1,5 +1,5 @@
 Target
 Source
 
-FAIL Already in-view source triggers animation assert_equals: expected "200px" but got "104.59375px"
+PASS Already in-view source triggers animation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt
@@ -1,6 +1,6 @@
 
-PASS Outer animation can see scroll timeline defined by :host
-PASS Outer animation can see scroll timeline defined by ::slotted
+FAIL Outer animation can not see scroll timeline defined by :host assert_equals: expected "x" but got "y"
+FAIL Outer animation can not see scroll timeline defined by ::slotted assert_equals: expected "x" but got "y"
 PASS Inner animation can see scroll timeline defined by ::part
-PASS Slotted element can see scroll timeline within the shadow
+PASS Animation inside shadow DOM can see the scroll timeline defined by the ancestor DOM
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow.html
@@ -3,6 +3,7 @@
 <link rel="help" src="https://drafts.csswg.org/scroll-animations-1/#scroll-timelines-named">
 <link rel="help" src="https://github.com/w3c/csswg-drafts/issues/8135">
 <link rel="help" src="https://github.com/w3c/csswg-drafts/issues/8192">
+<link rel="help" src="https://github.com/w3c/csswg-drafts/issues/13974">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/web-animations/testcommon.js"></script>
@@ -55,8 +56,8 @@
     assert_equals(target.getAnimations().length, 1);
     let anim = target.getAnimations()[0];
     assert_not_equals(anim.timeline, null);
-    assert_equals(anim.timeline.axis, 'y');
-  }, 'Outer animation can see scroll timeline defined by :host');
+    assert_equals(anim.timeline.axis, 'x');
+  }, 'Outer animation can not see scroll timeline defined by :host');
 </script>
 
 
@@ -93,8 +94,8 @@
     assert_equals(target.getAnimations().length, 1);
     let anim = target.getAnimations()[0];
     assert_not_equals(anim.timeline, null);
-    assert_equals(anim.timeline.axis, 'y');
-  }, 'Outer animation can see scroll timeline defined by ::slotted');
+    assert_equals(anim.timeline.axis, 'x');
+  }, 'Outer animation can not see scroll timeline defined by ::slotted');
 </script>
 
 
@@ -139,42 +140,42 @@
   }, 'Inner animation can see scroll timeline defined by ::part');
 </script>
 
-
-<template id=scroll_timeline_shadow>
+<template id=scroll_timeline_scoped_ancestor>
   <style>
-    .target {
-      animation: anim 10s linear;
-      animation-timeline: --timeline;
-    }
-    .host {
-      scroll-timeline: --timeline x;
+    .scroller {
+      scroll-timeline: --timeline;
     }
   </style>
   <div class=scroller>
-    <div class=host>
+    <div id=outer_host>
       <template shadowrootmode=open shadowrootclonable>
-        <style>
-          div {
-            scroll-timeline: --timeline y;
-          }
-        </style>
-        <div>
-          <slot></slot>
+        <div id=inner_host>
+          <template shadowrootmode=open shadowrootclonable>
+            <style>
+              /* Technically also loosely matched, but... */
+              @keyframes anim2 {
+                from { z-index: 100; }
+                to { z-index: 100; }
+              }
+
+              .target {
+                animation: anim2 10s linear;
+                animation-timeline: --timeline;
+              }
+            </style>
+            <div class=target></div>
+          </template>
         </div>
       </template>
-      <div class=target></div>
     </div>
   </div>
-  <style>
-  </style>
 </template>
 <script>
   promise_test(async (t) => {
-    inflate(t, scroll_timeline_shadow);
-    let target = main.querySelector('.target');
+    inflate(t, scroll_timeline_scoped_ancestor);
+    let target = outer_host.shadowRoot.querySelector('#inner_host').shadowRoot.querySelector('.target');
     assert_equals(target.getAnimations().length, 1);
     let anim = target.getAnimations()[0];
     assert_not_equals(anim.timeline, null);
-    assert_equals(anim.timeline.axis, 'y');
-  }, 'Slotted element can see scroll timeline within the shadow');
+  }, 'Animation inside shadow DOM can see the scroll timeline defined by the ancestor DOM');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-on-pseudo-002-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-on-pseudo-002-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-on-pseudo-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-on-pseudo-002.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Tests that scroll timeline defined by a pseudo-element can be found</title>
+<link rel="match" href="../../css/reference/ref-filled-green-100px-square.xht">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=2058585">
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#scroll-timeline-name">
+<link rel="author" name="David Shin" href="mailto:dshin@mozilla.com">
+<style>
+.container {
+  timeline-scope: --foo;
+}
+
+.red {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+
+@keyframes anim {
+  from { width: 100px; }
+  to { width: 200px; }
+}
+
+#target {
+  width: 0px;
+  height: 100px;
+  background: green;
+  animation: anim auto linear;
+  animation-timeline: --foo;
+}
+
+.st {
+  opacity: 0;
+  width: fit-content;
+  border: 1px solid;
+}
+
+.st::after {
+  display: block;
+  width: 100px;
+  height: 100px;
+  overflow: hidden;
+  content: "a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a";
+  scroll-timeline: --foo;
+}
+
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class=container>
+  <div class=red>
+    <div id=target></div>
+  </div>
+  <div class=st><div class=content></div></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt
@@ -1,6 +1,6 @@
 
-PASS Outer animation can see view timeline defined by :host
-PASS Outer animation can see view timeline defined by ::slotted
+FAIL Outer animation can not see view timeline defined by :host assert_equals: expected "x" but got "y"
+FAIL Outer animation can not see view timeline defined by ::slotted assert_equals: expected "x" but got "y"
 PASS Inner animation can see view timeline defined by ::part
-PASS Slotted element can see view timeline within the shadow
+PASS Animation inside shadow DOM can see the view timeline defined by the ancestor DOM
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow.html
@@ -3,6 +3,7 @@
 <link rel="help" src="https://drafts.csswg.org/scroll-animations-1/#view-timelines-named">
 <link rel="help" src="https://github.com/w3c/csswg-drafts/issues/8135">
 <link rel="help" src="https://github.com/w3c/csswg-drafts/issues/8192">
+<link rel="help" src="https://github.com/w3c/csswg-drafts/issues/13974">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/web-animations/testcommon.js"></script>
@@ -21,7 +22,6 @@
     to { z-index: 100; }
   }
 </style>
-
 
 <template id=view_timeline_host>
   <style>
@@ -56,8 +56,8 @@
     assert_equals(target.getAnimations().length, 1);
     let anim = target.getAnimations()[0];
     assert_not_equals(anim.timeline, null);
-    assert_equals(anim.timeline.axis, 'y');
-  }, 'Outer animation can see view timeline defined by :host');
+    assert_equals(anim.timeline.axis, 'x');
+  }, 'Outer animation can not see view timeline defined by :host');
 </script>
 
 
@@ -94,8 +94,8 @@
     assert_equals(target.getAnimations().length, 1);
     let anim = target.getAnimations()[0];
     assert_not_equals(anim.timeline, null);
-    assert_equals(anim.timeline.axis, 'y');
-  }, 'Outer animation can see view timeline defined by ::slotted');
+    assert_equals(anim.timeline.axis, 'x');
+  }, 'Outer animation can not see view timeline defined by ::slotted');
 </script>
 
 
@@ -140,42 +140,42 @@
   }, 'Inner animation can see view timeline defined by ::part');
 </script>
 
-
-<template id=view_timeline_shadow>
+<template id=view_timeline_scoped_ancestor>
   <style>
-    .target {
-      animation: anim 10s linear;
-      animation-timeline: --timeline;
-    }
-    .host {
-      view-timeline: --timeline x;
+    #outer_host {
+      view-timeline: --timeline;
     }
   </style>
   <div class=scroller>
-    <div class=host>
+    <div id=outer_host>
       <template shadowrootmode=open shadowrootclonable>
-        <style>
-          div {
-            view-timeline: --timeline y;
-          }
-        </style>
-        <div>
-          <slot></slot>
+        <div id=inner_host>
+          <template shadowrootmode=open shadowrootclonable>
+            <style>
+              /* Technically also loosely matched, but... */
+              @keyframes anim {
+                from { z-index: 100; }
+                to { z-index: 100; }
+              }
+
+              .target {
+                animation: anim 10s linear;
+                animation-timeline: --timeline;
+              }
+            </style>
+            <div class=target></div>
+          </template>
         </div>
       </template>
-      <div class=target></div>
     </div>
   </div>
-  <style>
-  </style>
 </template>
 <script>
   promise_test(async (t) => {
-    inflate(t, view_timeline_shadow);
-    let target = main.querySelector('.target');
+    inflate(t, view_timeline_scoped_ancestor);
+    let target = outer_host.shadowRoot.querySelector('#inner_host').shadowRoot.querySelector('.target');
     assert_equals(target.getAnimations().length, 1);
     let anim = target.getAnimations()[0];
     assert_not_equals(anim.timeline, null);
-    assert_equals(anim.timeline.axis, 'y');
-  }, 'Slotted element can see view timeline within the shadow');
+  }, 'Animation inside shadow DOM can see the view timeline defined by the ancestor DOM');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller-002-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller-002-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller-002.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Tests that view timeline defined by a pseudo-element can be found</title>
+<link rel="match" href="../../css/reference/ref-filled-green-100px-square.xht">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=2058585">
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#view-timeline-name">
+<link rel="author" name="David Shin" href="mailto:dshin@mozilla.com">
+<style>
+.container {
+  timeline-scope: --foo;
+}
+
+.bad {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+
+@keyframes anim {
+  from { width: 100px; }
+  to { width: 200px; }
+}
+
+#target {
+  width: 0px;
+  height: 100px;
+  background: green;
+  animation: anim auto linear;
+  animation-timeline: --foo;
+}
+
+.st {
+  width: 100px;
+  height: 100px;
+  overflow: hidden;
+  border: 1px solid;
+  opacity: 0;
+}
+
+.st::after {
+  display: block;
+  position: relative;
+  top: 100px;
+  width: 100px;
+  height: 100px;
+  content: "";
+  view-timeline: --foo;
+  background: blue;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class=container>
+  <div class=bad>
+    <div id=target></div>
+  </div>
+  <div class=st></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/w3c-import.log
@@ -86,6 +86,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-nearest-dirty.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-nearest-with-absolute-positioned-element.html
+/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-on-pseudo-002-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-on-pseudo-002.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-on-pseudo-like-part.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-on-pseudo.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-paused-animations.html
@@ -121,6 +123,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-parsing.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-paused-animations.html
+/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller-002-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller-002.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-update-reversed-animation.html

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Reflects a zero startTime as a percentage on a progress-based timeline undefined is not an object (evaluating 'actual.unit')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.tentative.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Scroll based animation: AnimationEffect.updateTiming</title>
+<!-- Adapted to progressed based scroll animations from "wpt\web-animations\interfaces\AnimationEffect\updateTiming.html" -->
+<link rel="help" href="https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+<script src="testcommon.js"></script>
+<script src="/web-animations/resources/easing-tests.js"></script>
+<script src="/web-animations/resources/timing-tests.js"></script>
+<style>
+  .scroller {
+    overflow: auto;
+    height: 100px;
+    width: 100px;
+    will-change: transform;
+  }
+  .contents {
+    height: 1000px;
+    width: 100%;
+  }
+</style>
+<body>
+<div id="log"></div>
+<script>
+'use strict';
+
+// ------------------------------
+//  startTime
+// ------------------------------
+
+// Split out from the non-'tentative' file while waiting on interop decisions.
+test(t => {
+  const anim = createScrollLinkedAnimationWithTiming(t, {duration: 1000, delay: 200})
+  anim.play();
+  // Without support for group effects, the start time of a top-level effect is
+  // always zero, expressed as 0% on a progress-based timeline.
+  assert_percents_equal(anim.effect.getComputedTiming().startTime, 0,
+                        'getComputedTiming().startTime is 0%');
+}, 'Reflects a zero startTime as a percentage on a progress-based timeline');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/w3c-import.log
@@ -38,6 +38,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/custom-property.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/duration.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.html
+/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/finish-animation.html
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/idlharness.window.js
 /LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/intrinsic-iteration-duration.tentative.html

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
@@ -2,8 +2,11 @@
 PASS View timeline with px based inset.
 PASS View timeline with percent based inset.
 PASS view timeline with inset auto.
-PASS view timeline with font relative inset.
-PASS view timeline with viewport relative insets.
-PASS view timeline inset as string
+FAIL view timeline inset as string assert_throws_js: function "() => {
+    new ViewTimeline({
+      subject: target,
+      inset: "1em 2em"
+    });
+  }" did not throw
 PASS view timeline with invalid inset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset.html
@@ -124,51 +124,6 @@
   }, 'view timeline with inset auto.');
 
 promise_test(async t => {
-  t.add_cleanup(() => {
-    target.classList.remove('big-font');
-  });
-  const anim = await runTimelineInsetTest(t, {
-    inset: [ CSS.em(1), CSS.em(2) ],
-    startOffset: 632,
-    endOffset: 884
-  });
-  verifyTimelineOffsets(anim, 632, 884);
-  target.classList.add('big-font');
-  await runTimelineBoundsTest(t, {
-    anim: anim,
-    startOffset: 640,
-    endOffset: 880,
-  }, 'Adjust for font size increase')
-      .then(anim => verifyTimelineOffsets(anim, 640, 880));
-}, 'view timeline with font relative inset.');
-
-promise_test(async t => {
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
-  const vmin = Math.min(vw, vh);
-
-  // Compute viewport-relative equivalent values from absolute inset sizes.
-  // This makes the test invariant to absolute viewport size.
-  const startInsetPx = 10;
-  const endInsetPx = 20;
-
-  const vwStart = 100 * startInsetPx / vw;
-  const vwEnd = 100 * endInsetPx / vw;
-  const vminStart = 100 * startInsetPx / vmin;
-  const vminEnd = 100 * endInsetPx / vmin;
-  await runTimelineInsetTest(t, {
-    inset: [ CSS.vw(vwStart), CSS.vw(vwEnd) ],
-    startOffset: 600 + endInsetPx,
-    endOffset: 900 - startInsetPx
-  });
-  await runTimelineInsetTest(t, {
-    inset: [ CSS.vmin(vminStart), CSS.vmin(vminEnd) ],
-    startOffset: 600 + endInsetPx,
-    endOffset: 900 - startInsetPx
-  });
-}, 'view timeline with viewport relative insets.');
-
-promise_test(async t => {
   await runTimelineInsetTest(t, {
     inset: "10px",
     startOffset: 610,
@@ -194,11 +149,22 @@ promise_test(async t => {
     startOffset: 600,
     endOffset: 900
   });
-  await runTimelineInsetTest(t, {
-    inset: "1em 2em",
-    startOffset: 632,
-    endOffset: 884
+
+  // Relative units are not allowed.
+  // https://github.com/w3c/csswg-drafts/issues/13852
+  assert_throws_js(TypeError, () => {
+    new ViewTimeline({
+      subject: target,
+      inset: "1em 2em"
+    });
   });
+  assert_throws_js(TypeError, () => {
+    new ViewTimeline({
+      subject: target,
+      inset: "1vw 2vh"
+    });
+  });
+
   assert_throws_js(TypeError, () => {
     new ViewTimeline({
       subject: target,
@@ -212,7 +178,6 @@ promise_test(async t => {
       inset: "1 2"
     });
   });
-
 }, 'view timeline inset as string');
 
 promise_test(async t => {
@@ -229,8 +194,6 @@ promise_test(async t => {
       inset: [ CSS.px(10), CSS.px(10), CSS.px(10) ]
     });
   });
-
-
 }, 'view timeline with invalid inset');
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-on-display-none-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-on-display-none-element.html
@@ -50,7 +50,9 @@ promise_test(async t => {
   t.add_cleanup(() => {
     anim.cancel();
   });
-  anim.rangeStart = "1em";
+  // We use a unit that does not require an element to resolve given:
+  // https://github.com/web-platform-tests/interop/issues/1309
+  anim.rangeStart = "10px";
   container.scrollLeft = 750;
   await waitForNextFrame();
   assert_equals(getComputedStyle(target).opacity, "1",

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-snapport.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-snapport.html
@@ -41,9 +41,9 @@
 
     // 0%
     await runAndWaitForFrameUpdate(() => {
-      container.scrollTop = 600;
+      container.scrollTop = 640;
     });
-    assert_percents_equal(anim.currentTime, -12.5);
+    assert_percents_equal(anim.currentTime, 0);
 
     // 50%
     await runAndWaitForFrameUpdate(() => {
@@ -53,7 +53,7 @@
 
     // 100%
     await runAndWaitForFrameUpdate(() => {
-      container.scrollTop = 1000;
+      container.scrollTop = 960;
     });
     assert_percents_equal(anim.currentTime, 100);
   }, 'Default ViewTimeline is affected by scroll-padding');


### PR DESCRIPTION
#### 5a991ab0a4cda96c8c3f3c53d3edac4aee7ff4ce
<pre>
Resync `scroll-animations` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=321011">https://bugs.webkit.org/show_bug.cgi?id=321011</a>
<a href="https://rdar.apple.com/184048502">rdar://184048502</a>

Reviewed by Antoine Quint.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/b318e17a2f726eeb33bf9d88275341675da28fc5">https://github.com/web-platform-tests/wpt/commit/b318e17a2f726eeb33bf9d88275341675da28fc5</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/timeline-trigger-source-starts-in-trigger-range.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-on-pseudo-002-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-on-pseudo-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller-002-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-on-display-none-element.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-snapport.html:

Canonical link: <a href="https://commits.webkit.org/318599@main">https://commits.webkit.org/318599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/535980f9757d9062a42a5d7b3b6a7c8e81340304

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178686 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188302 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/142995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ffd0edf6-4f17-4c46-a062-de1670432284) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139323 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/142995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e701f2b0-9c06-4ef6-9103-5e48e4ab5c6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119777 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0153e35-15d9-481f-ac2d-ca5e9b67556b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41550 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39902 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39562 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190730 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148496 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39883 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52974 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148263 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42962 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119901 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51492 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14539 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50877 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51117 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50939 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->