### PR TITLE
[Tools] kill-old-processes misses stuck run-webdriver-tests

### DIFF
--- a/Tools/CISupport/kill-old-processes
+++ b/Tools/CISupport/kill-old-processes
@@ -199,12 +199,20 @@ def main(user=None):
         builddir_bin = "WebKitBuild/Release/bin" if os.path.isdir("WebKitBuild/Release/bin") else "WebKitBuild/Debug/bin"
         for task in tasksToKill + taskToKillUnix + listAllWebKitPrograms(builddir_bin):
             os.system("killall -9 -v " + task)
-        os.system("ps aux | grep -P '.+/python3? .+(run_webkit_tests|run-webkit-tests|mod_pywebsocket)' | grep -v grep | awk '{print $2}' | xargs -r kill")
+        # Match on the executable name (comm) rather than the command line, so that wrappers
+        # that merely mention the script (podman run ..., bash -c '... | ...') are not killed.
+        os.system(r"ps -eo pid=,comm=,args= | grep -P '^\s*\d+\s+python3?\s' | grep -P '(run_webkit_tests|run-webkit-tests|mod_pywebsocket|run-webdriver-tests)' | grep -v grep | awk '{print $1}' | xargs -r kill")
         removeOrphanShmSegments()
 
         # Filter Xvfb instances likely spawned by our harness, skipping ones run with xvfb-run like
         # the one  used for dbus activation on the bots
         os.system("ps aux | grep -P 'Xvfb -displayfd [0-9]' | awk '{print $2}' | xargs -r kill")
+
+        # Finally, kill any SDK containers from previous jobs still running. The label is set
+        # by webkitpy/port/linux_container_sdk_utils.py on every auto-entered container.
+        if os.getenv('WEBKIT_CONTAINER_SDK_ENABLE_AUTOENTER') == '1':
+            os.system("podman ps --filter label=io.webkit.container=wkdev-build -q | xargs -r podman kill")
+
     else:
         sys.exit()
         # FIXME: Should we return an exit code based on how the kills went?


### PR DESCRIPTION
#### a089757817eb946432770ba67dd61c51cc5ac17e
<pre>
[Tools] kill-old-processes misses stuck run-webdriver-tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=320988">https://bugs.webkit.org/show_bug.cgi?id=320988</a>

Reviewed by Carlos Alberto Lopez Perez.

Recently, we had an issue where a stuck run-webdriver-tests from the
previous job was not caught by kill-old-processes, leaving its SDK
container up and affecting the subsequent runs on the same bot.

On top of that, the the current regex matching webkit commands like
run-webkit-tests expects a slash right before `python`, which is not the
case when the script uses a python executable from $PATH. As such, this
branch was in fact potentially not working at all on the bots for a
while.

Here&apos;s the list of Linux changes to avoid this in the future:

* Add run-webdriver-tests to the list of webkit commands to be killed,
  alongside the existing run-webkit-tests.
* Instead of matching on a &quot;*python&quot; command from the raw ps output, use
  its &quot;comm&quot; field, so the current bot behavior of using &quot;python&quot; from
  $PATH matches the regex and void matching commands that happen to wrap
  the actual target, like `bash -c ... | ...`.
* Also, if WEBKIT_CONTAINER_SDK_ENABLE_AUTOENTER is enabled, kill any
  still running podman SDK container matching the label set by
  linux_container_sdk_utils.py. As the bots run 1 worker per
  pod/bare-metal machine, this would not affect other workers.

* Tools/CISupport/kill-old-processes:
(main):

Canonical link: <a href="https://commits.webkit.org/318629@main">https://commits.webkit.org/318629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8461cd9e1aadf4951c5fa1a3180c8e7c1b2be19c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188304 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/142997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139325 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/142997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119779 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41553 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39904 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39563 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190732 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52295 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148499 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39902 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52976 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36189 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148265 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42963 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119903 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51494 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14540 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50879 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50941 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->