### PR TITLE
[interactive-widget] resizes-content-keyboard-scroll.html fails on iPadOS

### DIFF
--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-keyboard-scroll-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-keyboard-scroll-expected.txt
@@ -1,5 +1,4 @@
-Scrolled to 40, 1048
-PASS document.scrollingElement.scrollTop == 1048 is true
+PASS document.scrollingElement.scrollTop == window.targetScrollTop is true
 PASS document.scrollingElement.scrollLeft == 40 is true
 PASS window.visualViewport.pageTop != 0 is true
 PASS window.visualViewport.scale == 1 is true

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-keyboard-scroll.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-keyboard-scroll.html
@@ -25,14 +25,14 @@
             await UIHelper.activateElement(textField);
             await UIHelper.waitForKeyboardToShow();
 
-            window.scrollTo(40, 1048);
-            debug('Scrolled to ' + window.scrollX + ', ' + window.scrollY);
+            window.targetScrollTop = Math.floor((document.scrollingElement.scrollHeight - document.scrollingElement.clientHeight) / 2);
+            window.scrollTo(40, window.targetScrollTop);
 
             await UIHelper.ensureVisibleContentRectUpdate();
 
             window.keyboardTopInView = (await UIHelper.inputViewBoundsInWebView()).top;
 
-            shouldBeTrue('document.scrollingElement.scrollTop == 1048');
+            shouldBeTrue('document.scrollingElement.scrollTop == window.targetScrollTop');
             shouldBeTrue('document.scrollingElement.scrollLeft == 40');
             shouldBeTrue('window.visualViewport.pageTop != 0');
             shouldBeTrue('window.visualViewport.scale == 1');


### PR DESCRIPTION
#### 9d217749a9aac36b5f13deea61ac7018124c0b4a
<pre>
[interactive-widget] resizes-content-keyboard-scroll.html fails on iPadOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=321013">https://bugs.webkit.org/show_bug.cgi?id=321013</a>
<a href="https://rdar.apple.com/184051122">rdar://184051122</a>

Reviewed by Abrar Rahman Protyasha.

The test currently hardcodes the scroll y position, which fails on iPad. To
make the test device-agnostic, copy what overlays-content-keyboard-scroll.html
does and calculate the scroll y position instead.

* LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-keyboard-scroll-expected.txt:
* LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-keyboard-scroll.html:

Canonical link: <a href="https://commits.webkit.org/318582@main">https://commits.webkit.org/318582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb1a635d439ee387a9c275f253e61d407d63efdd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188309 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143002 "Build is in progress. Recent messages:") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fdf5bb1a-4e0c-495c-8348-5be8244db312) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139327 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/143002 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd467b74-4fa5-4692-bcc9-6be8ad39d979) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119781 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41555 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190737 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159592 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148501 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52981 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148267 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27114 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42966 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119908 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51499 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14550 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50884 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51124 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50946 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->