### PR TITLE
[JSC] Simplify VM teardown via specialized stopAllocationForGood

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -607,7 +607,6 @@ void Heap::lastChanceToFinalize()
         dumpHeapStatisticsAtVMDestruction();
     
     m_arrayBuffers.lastChanceToFinalize();
-    m_objectSpace.stopAllocatingForGood();
     m_objectSpace.lastChanceToFinalize();
     releaseDelayedReleasedObjects();
 

--- a/Source/JavaScriptCore/heap/LocalAllocator.cpp
+++ b/Source/JavaScriptCore/heap/LocalAllocator.cpp
@@ -89,7 +89,7 @@ LocalAllocator::~LocalAllocator()
     RELEASE_ASSERT(ok);
 }
 
-void LocalAllocator::stopAllocating()
+void LocalAllocator::stopAllocating(MarkedBlock::Handle::StopAllocatingMode mode)
 {
     ASSERT(!m_lastActiveBlock);
     if (!m_currentBlock) {
@@ -97,7 +97,7 @@ void LocalAllocator::stopAllocating()
         return;
     }
     
-    m_currentBlock->stopAllocating(m_freeList);
+    m_currentBlock->stopAllocating(m_freeList, mode);
     m_lastActiveBlock = m_currentBlock;
     m_currentBlock = nullptr;
     m_freeList.clear();
@@ -120,7 +120,7 @@ void LocalAllocator::prepareForAllocation()
 
 void LocalAllocator::stopAllocatingForGood()
 {
-    stopAllocating();
+    stopAllocating(MarkedBlock::Handle::StopAllocatingMode::ForGood);
     reset();
 }
 

--- a/Source/JavaScriptCore/heap/LocalAllocator.h
+++ b/Source/JavaScriptCore/heap/LocalAllocator.h
@@ -47,7 +47,7 @@ public:
     
     unsigned cellSize() const { return m_freeList.cellSize(); }
 
-    void stopAllocating();
+    void stopAllocating(MarkedBlock::Handle::StopAllocatingMode = MarkedBlock::Handle::StopAllocatingMode::Resumable);
     void prepareForAllocation();
     void resumeAllocating();
     void stopAllocatingForGood();

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -118,7 +118,7 @@ void MarkedBlock::Handle::unsweepWithNoNewlyAllocated()
     m_directory->didFinishUsingBlock(this);
 }
 
-void MarkedBlock::Handle::stopAllocating(const FreeList& freeList)
+void MarkedBlock::Handle::stopAllocating(const FreeList& freeList, StopAllocatingMode mode)
 {
     Locker locker { blockHeader().m_lock };
     
@@ -139,6 +139,21 @@ void MarkedBlock::Handle::stopAllocating(const FreeList& freeList)
     if (MarkedBlockInternal::verbose)
         dataLog("Free list: ", freeList, "\n");
     
+    if (mode == StopAllocatingMode::ForGood) {
+        // MarkedSpace::lastChanceToFinalize() runs next and clears the newly-allocated bitmap before
+        // sweeping, so computing it here would be wasted work. The free list still has to be zapped:
+        // the sweep runs a destructor for every cell that is not zapped.
+        if (m_attributes.destruction != DoesNotNeedDestruction) {
+            freeList.forEach(
+                [&] (HeapCell* cell) {
+                    cell->zap(HeapCell::StopAllocating);
+                });
+        }
+        m_isFreeListed = false;
+        directory()->didFinishUsingBlock(this);
+        return;
+    }
+
     // Roll back to a coherent state for Heap introspection. Cells newly
     // allocated from our free list are not currently marked, so we need another
     // way to tell what's live vs dead. 

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -167,7 +167,10 @@ public:
         // cell liveness data. To restore accurate cell liveness data, call one
         // of these functions:
         void didConsumeFreeList(); // Call this once you've allocated all the items in the free list.
-        void stopAllocating(const FreeList&);
+        // ForGood is the heap-teardown path, where the caller sweeps every block immediately
+        // afterwards and so has no use for the newly-allocated bitmap this would otherwise compute.
+        enum class StopAllocatingMode : bool { Resumable, ForGood };
+        void stopAllocating(const FreeList&, StopAllocatingMode = StopAllocatingMode::Resumable);
         void resumeAllocating(FreeList&); // Call this if you canonicalized a block for some non-collection related purpose.
             
         size_t cellSize();

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -208,6 +208,14 @@ void MarkedSpace::freeMemory()
 
 void MarkedSpace::lastChanceToFinalize()
 {
+    // Must call stopAllocatingForGood first.
+    ASSERT(!isIterating());
+    forEachDirectory(
+        [&] (BlockDirectory& directory) -> IterationStatus {
+            directory.stopAllocatingForGood();
+            return IterationStatus::Continue;
+        });
+
     forEachDirectory(
         [&] (BlockDirectory& directory) -> IterationStatus {
             directory.lastChanceToFinalize();
@@ -312,16 +320,6 @@ void MarkedSpace::stopAllocating()
     forEachDirectory(
         [&] (BlockDirectory& directory) -> IterationStatus {
             directory.stopAllocating();
-            return IterationStatus::Continue;
-        });
-}
-
-void MarkedSpace::stopAllocatingForGood()
-{
-    ASSERT(!isIterating());
-    forEachDirectory(
-        [&] (BlockDirectory& directory) -> IterationStatus {
-            directory.stopAllocatingForGood();
             return IterationStatus::Continue;
         });
 }

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -96,7 +96,7 @@ public:
     
     JSC::Heap& heap() const;
     
-    void lastChanceToFinalize(); // Must call stopAllocatingForGood first.
+    void lastChanceToFinalize();
     void freeMemory();
 
     static size_t optimalSizeFor(size_t);
@@ -115,7 +115,6 @@ public:
     void didFinishIterating();
 
     void stopAllocating();
-    void stopAllocatingForGood();
     void resumeAllocating(); // If we just stopped allocation but we didn't do a collection, we need to resume allocation.
     
     void NODELETE prepareForMarking();
@@ -189,7 +188,7 @@ private:
     friend class WeakSet;
     friend class Subspace;
     friend class IsoSubspace;
-    
+
     // Use this version when calling from within the GC where we know that the directories
     // have already been stopped.
     template<typename Functor> void forEachLiveCell(const Functor&);


### PR DESCRIPTION
#### 6bdb4f69e23bba6d8c105477da09c4edec06ffaa
<pre>
[JSC] Simplify VM teardown via specialized stopAllocationForGood
<a href="https://bugs.webkit.org/show_bug.cgi?id=321015">https://bugs.webkit.org/show_bug.cgi?id=321015</a>
<a href="https://rdar.apple.com/184053208">rdar://184053208</a>

Reviewed by Keith Miller.

This attempts to reduce VM teardown time by simplifying
MarkedSpace::lastChanceToFinalize. In MarkedBlock::Handle::stopAllocating,
we add StopAllocatingMode::ForGood mode where we do not modify
maintenance bits as we know that we will teardown the VM &amp; Heap
immediately after this call.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::lastChanceToFinalize):
* Source/JavaScriptCore/heap/LocalAllocator.cpp:
(JSC::LocalAllocator::stopAllocating):
(JSC::LocalAllocator::stopAllocatingForGood):
* Source/JavaScriptCore/heap/LocalAllocator.h:
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::stopAllocating):
* Source/JavaScriptCore/heap/MarkedBlock.h:
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::lastChanceToFinalize):
(JSC::MarkedSpace::stopAllocatingForGood): Deleted.
* Source/JavaScriptCore/heap/MarkedSpace.h:

Canonical link: <a href="https://commits.webkit.org/318597@main">https://commits.webkit.org/318597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9366b41378514922867974c1f01ee4ed8c21df77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188310 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49b869d2-a4b2-4633-9597-8b03a14b177f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139350 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f15708c1-f73c-4405-bb7b-1d3b6783494b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119804 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d72a765a-5ca7-44a3-81f1-9f1c639277d7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41564 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39909 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1774 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8564 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151964 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39576 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39967 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190738 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52301 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148507 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52982 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148273 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27122 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42974 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125249 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119909 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51500 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14554 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50885 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51125 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->