### PR TITLE
[JSC] Wasm table64 JS API interfaces

### DIFF
--- a/JSTests/wasm/js-api/table64-js-api.js
+++ b/JSTests/wasm/js-api/table64-js-api.js
@@ -82,9 +82,9 @@ import * as assert from "../assert.js";
 {
     const table = new WebAssembly.Table({element: "funcref", initial: 20n, maximum: 30n, address: "i64"});
     assert.eq(20n, table.grow(0n));
-    assert.eq(20, table.length);
+    assert.eq(20n, table.length);
     assert.eq(20n, table.grow(1n));
-    assert.eq(21, table.length);
+    assert.eq(21n, table.length);
 }
 
 {
@@ -99,7 +99,7 @@ import * as assert from "../assert.js";
     let called = false;
     table.grow({valueOf() { called = true; return 42n; }});
     assert.truthy(called);
-    assert.eq(62, table.length);
+    assert.eq(62n, table.length);
 }
 
 {
@@ -116,3 +116,20 @@ import * as assert from "../assert.js";
         table.set(BigInt(i), null);
 }
 
+{
+    // A delta no table could ever satisfy is a failure to grow, not a bad argument.
+    const table = new WebAssembly.Table({element: "funcref", initial: 1n, maximum: BigInt(2**64) - 1n, address: "i64"});
+    assert.throws(() => table.grow(4294967296n), RangeError, "WebAssembly.Table.prototype.grow could not grow the table");
+    assert.throws(() => table.grow(BigInt(2**64) - 1n), RangeError, "WebAssembly.Table.prototype.grow could not grow the table");
+}
+
+{
+    // length reports the same kind of value that grow() and type() do.
+    const table = new WebAssembly.Table({element: "funcref", initial: 3n, address: "i64"});
+    assert.eq(table.length, 3n);
+    assert.eq(typeof table.length, typeof table.grow(0n));
+
+    const table32 = new WebAssembly.Table({element: "funcref", initial: 3, address: "i32"});
+    assert.eq(table32.length, 3);
+    assert.eq(typeof table32.length, typeof table32.grow(0));
+}

--- a/JSTests/wasm/stress/table64-maximum.js
+++ b/JSTests/wasm/stress/table64-maximum.js
@@ -50,5 +50,5 @@ for (const maximum of ["4294967296", "4294967301", "18446744073709551615"]) {
     }
 
     assert.throws(() => instance.exports.table.grow(9999999n), RangeError, "WebAssembly.Table.prototype.grow could not grow the table");
-    assert.eq(instance.exports.table.length, 1);
+    assert.eq(instance.exports.table.length, 1n);
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
@@ -75,7 +75,7 @@ void JSWebAssemblyTable::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 DEFINE_VISIT_CHILDREN(JSWebAssemblyTable);
 
-std::optional<uint32_t> JSWebAssemblyTable::grow(JSGlobalObject* globalObject, uint32_t delta, JSValue defaultValue)
+std::optional<uint32_t> JSWebAssemblyTable::grow(JSGlobalObject* globalObject, uint64_t delta, JSValue defaultValue)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
@@ -61,7 +61,7 @@ public:
     std::optional<uint64_t> maximum() const { return m_table->maximum(); }
     uint32_t length() const { return m_table->length(); }
     uint32_t allocatedLength() const { return m_table->allocatedLength(length()); }
-    [[nodiscard]] std::optional<uint32_t> grow(JSGlobalObject*, uint32_t delta, JSValue defaultValue);
+    [[nodiscard]] std::optional<uint32_t> grow(JSGlobalObject*, uint64_t delta, JSValue defaultValue);
     JSValue get(JSGlobalObject*, uint32_t);
     void set(uint32_t, JSValue);
     void set(JSGlobalObject*, uint32_t, JSValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
@@ -81,6 +81,8 @@ JSC_DEFINE_CUSTOM_GETTER(webAssemblyTableProtoGetterLength, (JSGlobalObject* glo
 
     JSWebAssemblyTable* table = getTable(globalObject, vm, JSValue::decode(thisValue));
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
+    if (table->table()->addressType().is64Bit())
+        RELEASE_AND_RETURN(throwScope, JSValue::encode(JSBigInt::createFrom(globalObject, table->length())));
     return JSValue::encode(jsNumber(table->length()));
 }
 
@@ -93,11 +95,6 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncGrow, (JSGlobalObject* globalO
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
     uint64_t delta64 = addressValueToUint64(globalObject, callFrame->argument(0), table->table()->addressType());
-    if (delta64 > std::numeric_limits<uint32_t>::max())
-        return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.grow requires first argument to be greater than 0 and less than 2^32"_s);
-
-    uint32_t delta = delta64;
-
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
     JSValue defaultValue = jsNull();
@@ -109,7 +106,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncGrow, (JSGlobalObject* globalO
         defaultValue = callFrame->uncheckedArgument(1);
 
     uint32_t oldLength = table->length();
-    bool didGrow = !!table->grow(globalObject, delta, defaultValue);
+    bool didGrow = !!table->grow(globalObject, delta64, defaultValue);
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
     if (!didGrow)


### PR DESCRIPTION
#### b8af849be6f0d1b75cd19f82bf16ad80bcf8ddef
<pre>
[JSC] Wasm table64 JS API interfaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=321017">https://bugs.webkit.org/show_bug.cgi?id=321017</a>
<a href="https://rdar.apple.com/184053551">rdar://184053551</a>

Reviewed by Cole Carley.

We fix table64 JS API interfaces,

1. Table.length[1] is defined as AddressValue[2], so it should return
   BigInt when table is 64bit. But the current code is not doing so.
   This patch fixes it.
2. Table.grow should throw a range error when the specified delta is
   exceeding[3].

[1]: <a href="https://webassembly.github.io/spec/js-api/#tables">https://webassembly.github.io/spec/js-api/#tables</a>
[2]: <a href="https://webassembly.github.io/spec/js-api/#typedefdef-addressvalue">https://webassembly.github.io/spec/js-api/#typedefdef-addressvalue</a>
[3]: <a href="https://webassembly.github.io/spec/js-api/#dom-table-grow">https://webassembly.github.io/spec/js-api/#dom-table-grow</a>

* JSTests/wasm/js-api/table64-js-api.js:
(assert.eq.wide.type):
(assert.throws):
(table):
* JSTests/wasm/stress/table64-maximum.js:
(assert.eq.instance.exports.grow):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp:
(JSC::JSWebAssemblyTable::grow):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/318594@main">https://commits.webkit.org/318594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d449661537be2c0929671c7165b6f795b6bc2cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188353 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139362 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e522d45a-d1be-4a48-a511-0fa6b74e901b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42927 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119816 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1786 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8593 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151993 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40010 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45276 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190781 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52345 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53025 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148305 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27121 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43005 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125292 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119953 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51543 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14583 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50928 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50990 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->