### PR TITLE
[Site Isolation] Stale iframe layers are left hosted after a cross-process navigation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/draw-after-blocked-cross-origin-navigation-expected.html
+++ b/LayoutTests/http/tests/site-isolation/draw-after-blocked-cross-origin-navigation-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body { margin: 0; background: blue; }
+iframe { border: 0; width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<iframe src="about:blank"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/draw-after-blocked-cross-origin-navigation.html
+++ b/LayoutTests/http/tests/site-isolation/draw-after-blocked-cross-origin-navigation.html
@@ -1,0 +1,29 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body { margin: 0; background: blue; }
+iframe { border: 0; width: 200px; height: 200px; }
+</style>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+let subframeLoadCount = 0;
+
+function subframeLoaded() {
+    if (++subframeLoadCount < 2)
+        return;
+    // Let the compositor catch up before the result is captured.
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }));
+}
+</script>
+</head>
+<body>
+<iframe onload="subframeLoaded()" src="http://localhost:8000/site-isolation/resources/red-frame-navigating-to-x-frame-options-deny.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/red-frame-navigating-to-x-frame-options-deny.html
+++ b/LayoutTests/http/tests/site-isolation/resources/red-frame-navigating-to-x-frame-options-deny.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+html, body { margin: 0; height: 100%; background: red; }
+</style>
+</head>
+<body>
+<script>
+onload = () => {
+    setTimeout(() => {
+        // A third site is required: the frame must be hosted in a non-parent process both
+        // before and after this navigation. https is a different site from http even on the
+        // same host, so this is distinct from both the test page (http://127.0.0.1) and this
+        // frame (http://localhost).
+        location.href = "https://127.0.0.1:8443/security/XFrameOptions/resources/x-frame-options-deny.cgi";
+    }, 0);
+};
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -190,6 +190,13 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
     }
 
     if (auto contextHostedID = transaction.remoteContextHostedIdentifier(); contextHostedID && rootNode) {
+        // The hosting context identifier is reused across a cross-process navigation, so the
+        // outgoing process's root layer is still parented here. Detach it before hosting the
+        // incoming one, or it stays visible until that process exits.
+        if (auto previousLayerID = m_hostedLayers.getOptional(*contextHostedID); previousLayerID && *previousLayerID != rootNode->layerID()) {
+            if (RefPtr previousNode = nodeForID(*previousLayerID))
+                previousNode->removeFromHostingNode();
+        }
         m_hostedLayers.set(*contextHostedID, rootNode->layerID());
         m_hostedLayersInProcess.ensure(processIdentifier, [] {
             return HashSet<WebCore::PlatformLayerIdentifier>();


### PR DESCRIPTION
#### 3e31762de6b1e418d94bfc40abd088466c7d5c28
<pre>
[Site Isolation] Stale iframe layers are left hosted after a cross-process navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=321009">https://bugs.webkit.org/show_bug.cgi?id=321009</a>
<a href="https://rdar.apple.com/123701232">rdar://123701232</a>

Reviewed by Sihui Liu.

With site isolation, the UIProcess is responsible for managing rendering layers which comes
from frames in different processes. A web process will send the content that should be
rendered in its iframe. Then, it&apos;s the UIProcess&apos;s job to put the rendered content in the
right place on the screen.

On a process swap of an iframe, the UIProcess needs to receive the new content from the new
web process and replace the iframe&apos;s old content.

The bug is that the UIProcess only appends the iframe&apos;s new content without detaching the
iframe&apos;s old content.

This bug became visible when an iframe load is blocked by X-Frame-Options and DocumentLoader::loadErrorDocument()
commits an empty, transparent document. Then, the iframe&apos;s previous document
is still visible while appearing unresponsive since the old web process isn&apos;t repainting
the stale layer anymore. Usually new content is opaque, which is why I suspect this wasn&apos;t
noticed before.

This patch updates RemoteLayerTreeHost::updateLayerTree to detach any existing layer before
placing the new layer.

The regression test page is blue with a 200x200 iframe. The iframe loads a
cross-site red page from localhost, and that page then navigates itself to a URL
on web-platform.test that responds with X-Frame-Options: deny.

A blank frame is transparent, so the whole page should end up blue. The reference file is
the same page with an &lt;iframe src=&quot;about:blank&quot;&gt; instead of the real one. Without the fix
the iframe is stuck as red.

Test: http/tests/site-isolation/draw-after-blocked-cross-origin-navigation.html

* LayoutTests/http/tests/site-isolation/draw-after-blocked-cross-origin-navigation-expected.html: Added.
* LayoutTests/http/tests/site-isolation/draw-after-blocked-cross-origin-navigation.html: Added.
* LayoutTests/http/tests/site-isolation/resources/red-frame-navigating-to-x-frame-options-deny.html: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):

Canonical link: <a href="https://commits.webkit.org/318768@main">https://commits.webkit.org/318768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/304d96f243f00899f5764e1559a461963f7093ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188845 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27196264-38a7-4bc5-9fcf-f783797cb570) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139591 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9cb18e57-87c1-4592-b376-44e902d582fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160347 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120037 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f87101cc-c23e-4661-a75a-2cc654255c2e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41858 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40205 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152257 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39850 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/152 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45561 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191065 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148819 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39990 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53305 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148567 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43257 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125576 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120390 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51823 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14829 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51208 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51449 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51269 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->