### PR TITLE
Shared/service workers don't run in same process after COOP-induced BCG switch

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -721,7 +721,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return result.autorelease();
 }
 
-+ (NSArray<_WKProcessInfo *> *)_webContentProcessInfo
+static NSArray<_WKProcessInfo *> *allWebContentProcessInfo()
 {
     RetainPtr result = adoptNS([NSMutableArray new]);
 
@@ -733,6 +733,16 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     return result.autorelease();
+}
+
++ (NSArray<_WKProcessInfo *> *)_webContentProcessInfo
+{
+    return allWebContentProcessInfo();
+}
+
++ (NSArray<_WKProcessInfo *> *)_webContentProcessInfoForTesting
+{
+    return allWebContentProcessInfo();
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -199,6 +199,7 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 + (_WKProcessInfo *)_gpuProcessInfo WK_API_AVAILABLE(macos(14.5));
 + (NSArray<_WKProcessInfo *> *)_networkingProcessInfo WK_API_AVAILABLE(macos(14.5));
 + (NSArray<_WKProcessInfo *> *)_webContentProcessInfo WK_API_AVAILABLE(macos(14.5));
++ (NSArray<_WKProcessInfo *> *)_webContentProcessInfoForTesting;
 @end
 
 @interface WKProcessPool (WKPrivateMac)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8654,6 +8654,9 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
         process->didCommitMeaningfulProvisionalLoad();
 
     if (frame->isMainFrame()) {
+        if (!protect(preferences())->siteIsolationEnabled())
+            process->didCommitMainFrameLoadWithoutSiteIsolation(request.url());
+
         m_hasUpdatedRenderingAfterDidCommitLoad = false;
 #if PLATFORM(COCOA)
         if (RefPtr drawingAreaProxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(*m_drawingArea))

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2470,6 +2470,30 @@ void WebProcessProxy::didStartProvisionalLoadForMainFrame(const URL& url)
     RELEASE_ASSERT(!isInProcessCache());
     WEBPROCESSPROXY_RELEASE_LOG(Loading, "didStartProvisionalLoadForMainFrame:");
 
+    updateSiteForMainFrameNavigation(url);
+}
+
+void WebProcessProxy::didCommitMainFrameLoadWithoutSiteIsolation(const URL& url)
+{
+    RELEASE_ASSERT(!isInProcessCache());
+
+    // We need to update site state both in didStartProvisionalLoad and didCommitMainFrameLoad when
+    // Site Isolation is disabled. For instance:
+    //
+    // - Process A starts a provisional load
+    // - Response forces a BCG switch (e.g. due to COOP response header)
+    // - Process B commits the load after the BCG switch
+    //
+    // Now both process A and B have to update the sites associated with their WebProcessProxy. This
+    // code takes care of updating the state for process B.
+    //
+    // This is not necessary when site isolation is enabled, since that goes down a different site
+    // update path even in the case of a BCG switch (didStartUsingProcessForSiteIsolation).
+    updateSiteForMainFrameNavigation(url);
+}
+
+void WebProcessProxy::updateSiteForMainFrameNavigation(const URL& url)
+{
     // This process has been used for several registrable domains already.
     if (!m_site && m_site.error() == SiteState::MultipleSites)
         return;

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -437,6 +437,7 @@ public:
     ShutdownPreventingScopeCounter::Token shutdownPreventingScope() { return m_shutdownPreventingScopeCounter.count(); }
 
     void didStartProvisionalLoadForMainFrame(const URL&);
+    void didCommitMainFrameLoadWithoutSiteIsolation(const URL&);
     void didStartUsingProcessForSiteIsolation(const std::optional<WebCore::Site>&, const WebCore::Site& mainFrameSite);
 
     // ProcessThrottlerClient
@@ -652,6 +653,8 @@ private:
     Type type() const final { return Type::WebContent; }
 
     WebProcessProxy(WebProcessPool&, WebsiteDataStore*, IsPrewarmed, WebCore::CrossOriginMode, LockdownMode, EnhancedSecurity);
+
+    void updateSiteForMainFrameNavigation(const URL&);
 
     // AuxiliaryProcessProxy
     ASCIILiteral processName() const final { return "WebContent"_s; }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -2498,6 +2498,48 @@ TEST(ServiceWorkers, LockdownModeInSharedWorkerProcess)
     runJSCheck("!!self.LockManager"_s); // WebLockManager API.
 }
 
+TEST(ServiceWorkers, SharedWorkerReusesProcessAfterCOOPProcessSwap)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/no-coop.html"_s, { "<body>Hello world!</body>"_s } },
+        { "/coop.html"_s, { {{ "Cross-Origin-Opener-Policy"_s, "same-origin"_s }}, "<script>const worker = new SharedWorker('sharedWorker.js'); worker.port.start();</script>"_s } },
+        { "/sharedWorker.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, "onconnect = e => { e.ports[0].start(); };"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Https);
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    // First page is loaded without COOP.
+    [webView loadRequest:server.request("/no-coop.html"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+    auto sourcePID = [webView _webProcessIdentifier];
+
+    // Second page is loaded with COOP, which triggers a BCG switch. This page also creates a
+    // SharedWorker.
+    [webView loadRequest:server.request("/coop.html"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+    auto coopPID = [webView _webProcessIdentifier];
+
+    // The BCG switch should result in a new process.
+    EXPECT_NE(sourcePID, coopPID);
+
+    // The SharedWorker should run in the same process as the second page.
+    EXPECT_TRUE(waitUntilEvaluatesToTrue([&]() -> bool {
+        bool foundSharedWorkerProcess = false;
+        bool sharedWorkerInPageProcess = false;
+        for (_WKWebContentProcessInfo *info in [WKProcessPool _webContentProcessInfoForTesting]) {
+            if (!info.runningSharedWorkers)
+                continue;
+            foundSharedWorkerProcess = true;
+            if (info.pid == coopPID)
+                sharedWorkerInPageProcess = true;
+        }
+        return foundSharedWorkerProcess && sharedWorkerInPageProcess;
+    }));
+}
+
 enum class UseSeparateServiceWorkerProcess : bool { No, Yes };
 void testSuspendServiceWorkerProcessBasedOnClientProcesses(UseSeparateServiceWorkerProcess useSeparateServiceWorkerProcess)
 {


### PR DESCRIPTION
#### 9eb3fbd1532c39dd1c3288a94d70e478651b8451
<pre>
Shared/service workers don&apos;t run in same process after COOP-induced BCG switch
<a href="https://bugs.webkit.org/show_bug.cgi?id=321021">https://bugs.webkit.org/show_bug.cgi?id=321021</a>
<a href="https://rdar.apple.com/182280016">rdar://182280016</a>

Reviewed by Ryosuke Niwa.

When Site Isolation is off, we sometimes don&apos;t consider the WebProcess that hosts the webpage as a
candidate for running same-origin shared and service workers. This is unintended.

This occurs because we only record the process =&gt; site association at provisional load time, not
commit time. In the case of a forced process swap due to a COOP response header:

1. Process A performs the provisional load, and records the process =&gt; site mapping.
2. We handle the COOP response header and force a BCG and process switch.
3. Process B continues the load and commits, but we never record a process =&gt; site mapping for this
new process.

To fix this, record the process =&gt; site mapping at commit time.

This only needs to occur when Site Isolation is off; when Site Isolation is on, we were already
recording the process =&gt; site mapping via a different path (in
didStartUsingProcessForSiteIsolation).

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm

* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(+[WKProcessPool _webContentProcessInfo]):
(+[WKProcessPool _webContentProcessInfoForTesting]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didStartProvisionalLoadForMainFrame):
(WebKit::WebProcessProxy::didCommitMainFrameLoadWithoutSiteIsolation):
(WebKit::WebProcessProxy::updateSiteForMainFrameNavigation):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm:
((ServiceWorkers, SharedWorkerReusesProcessAfterCOOPProcessSwap)):

Canonical link: <a href="https://commits.webkit.org/318650@main">https://commits.webkit.org/318650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97cc22cd90252e5f0c3078f385bc6d7c92999a32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188339 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88d9bedd-2314-4ff8-a39f-a7772e27701e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139351 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3f23464-8fd2-47ba-9f56-684903a31d84) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119805 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0319787d-4f30-4f9f-972f-b972375be266) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41584 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39933 "Found 1 new API test failure: TestWebKitAPI.ResourceLoadStatistics.BlockUnpartitionedThirdPartyCookies (failure)") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39593 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45262 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190767 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/178126 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52331 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148527 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39912 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53011 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148294 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42994 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125278 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119939 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51529 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14571 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50914 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51154 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50976 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->