### PR TITLE
Cherry-pick 316883@main (a3bb2650a027). https://bugs.webkit.org/show_bug.cgi?id=319082

### DIFF
--- a/Tools/Scripts/cross-toolchain-helper
+++ b/Tools/Scripts/cross-toolchain-helper
@@ -220,6 +220,22 @@ class YoctoCrossBuilder():
                         os.remove(candidate_cmake_cache_file)
 
     def _initialize_environment_for_target(self, no_export_environment):
+        # If running inside the SDK then clear all the jhbuild related vars which may cause issues with the cross-target environment
+        if os.environ.get('WEBKIT_CONTAINER_SDK') == '1':
+            for env_var, env_val in list(os.environ.items()):
+                if '/jhbuild/install/' in env_val:
+                    if env_var == 'PATH':
+                        os.environ['PATH'] = ':'.join(p for p in os.environ['PATH'].split(':') if '/jhbuild/install/' not in p)
+                        _log.debug(f'cross-target environment: reset variable "PATH={os.environ["PATH"]}"')
+                    else:
+                        os.environ.pop(env_var)
+                        _log.debug(f'cross-target environment: unset variable "{env_var}={env_val}"')
+        # Otherwise clear the usual suspects but in this case also warn the user
+        for env_var in ['C_INCLUDE_PATH', 'CPLUS_INCLUDE_PATH', 'GI_TYPELIB_PATH', 'LDFLAGS', 'LD_LIBRARY_PATH', 'PKG_CONFIG_PATH']:
+            if env_var in os.environ:
+                _log.warning(f'Detected environment variable "{env_var}={os.environ[env_var]}". This is problematic. Unsetting it for the cross-target environment.')
+                os.environ.pop(env_var)
+        # Now set the env vars for the target
         environment_for_target = self._targets_config.get_environment(self._target)
         if environment_for_target:
             if no_export_environment:

--- a/Tools/Scripts/cross-toolchain-helper
+++ b/Tools/Scripts/cross-toolchain-helper
@@ -30,7 +30,10 @@ import stat
 import logging
 import hashlib
 import shutil
+import shlex
+import subprocess
 import re
+import tempfile
 
 top_level_directory = os.path.realpath(os.path.join(os.path.dirname(__file__), '..', '..'))
 sys.path.insert(0, os.path.join(top_level_directory, 'Tools', 'Scripts', 'webkitpy'))
@@ -80,7 +83,7 @@ class YoctoTargetsConfig():
         # Don't automatically convert to lowercase the keys, return it literally.
         self._config_parser.optionxform = lambda option: option
         self._config_parser.read(config_file)
-        self._directory_config_file = os.path.realpath(os.path.dirname(config_file))
+        self._config_dir = os.path.realpath(os.path.dirname(config_file))
         self._available_targets = []
         self._source_files_for_hash = source_files_for_hash
         required_keys = ['repo_manifest_path', 'conf_bblayers_path', 'conf_local_path', 'image_basename', 'image_types']
@@ -102,7 +105,7 @@ class YoctoTargetsConfig():
     def _get_path(self, path):
         if os.path.isabs(path):
             return path
-        return os.path.join(self._directory_config_file, path)
+        return os.path.join(self._config_dir, path)
 
     def _get_value(self, target, key):
         if target not in self.list_target_configs_available():
@@ -141,7 +144,19 @@ class YoctoTargetsConfig():
                 environment_dic[env_key] = key_value
         return environment_dic
 
-    def get_hash_for_target(self, target):
+    def get_extra_images_fragment_file_paths(self, image_extras_file):
+        list_of_image_extras_fragments_paths = []
+        if not os.path.isfile(image_extras_file):
+            return list_of_image_extras_fragments_paths
+        with open(image_extras_file, 'r') as f:
+            image_extras_str = f.read().strip()
+        if not image_extras_str:
+            return list_of_image_extras_fragments_paths
+        for extra_image_feature in image_extras_str.strip('+').split('+'):
+            list_of_image_extras_fragments_paths.append(os.path.join(self._config_dir, 'image_extras', f'{extra_image_feature}.conf'))
+        return list_of_image_extras_fragments_paths
+
+    def get_hash_for_target(self, target, image_extras_file):
         hash_for_target = hashlib.md5()
         for key in self._config_parser[target]:
             key_value = self._get_value(target, key)
@@ -155,12 +170,16 @@ class YoctoTargetsConfig():
         for source_file in self._source_files_for_hash:
             with open(source_file, 'r', encoding='utf-8') as f:
                 hash_for_target.update(f.read().encode('utf-8', errors='ignore'))
+        # And finally add the contents of the image_extras enabled (read those from file)
+        for extra_image_fragment_file in self.get_extra_images_fragment_file_paths(image_extras_file):
+            with open(extra_image_fragment_file, 'r', encoding='utf-8') as f:
+                hash_for_target.update(f.read().encode('utf-8', errors='ignore'))
         return hash_for_target.hexdigest()
 
-    def generate_and_export_hash_version_identifier(self, target):
-        hash_version = self.get_hash_for_target(target)
-        # We use this env variable to pass the version info to a few bitbake/Yocto recipes
-        set_env_var('WEBKIT_CROSS_VERSION', '{hash_version}'.format(hash_version=hash_version))
+    def generate_and_export_hash_version_identifier(self, target, image_extras_file):
+        hash_version = self.get_hash_for_target(target, image_extras_file)
+        # We use this env var to set the version at ${meta-webkit}/conf/distro/webkitdevci.conf
+        set_env_var('WEBKIT_CROSS_VERSION', f'{hash_version}')
         return '{target_name} {hash_version}'.format(target_name=target, hash_version=hash_version)
 
     def list_target_configs_available(self):
@@ -169,8 +188,9 @@ class YoctoTargetsConfig():
 
 class YoctoCrossBuilder():
 
-    def __init__(self, targets_config, target, no_wipe, no_export_environment, skip_init):
+    def __init__(self, targets_config, target, image_extras_list, no_wipe, no_export_environment, skip_init):
         self._running_image_info_version_full_path = '/usr/share/cross-target-info-version'
+        self._running_image_info_image_extras_full_path = '/usr/share/cross-target-info-image-extras'
         self._targets_config = targets_config
         self._target = target
         self._webkit_dir = top_level_directory
@@ -180,24 +200,61 @@ class YoctoCrossBuilder():
             return
         self._workdir = os.path.join(self._webkitbuild_dir, 'CrossToolChains', target)
         self._workdir_version_file = os.path.join(self._workdir, '.target-info-version')
+        self._workdir_image_extras_file = os.path.join(self._workdir, '.image-extras')
         self._workdir_path_file = os.path.join(self._workdir, '.path')
         self._workdir_build_yoctodir = os.path.join(self._workdir, 'build')
         self._workdir_info_last_image_deployed = os.path.join(self._workdir, '.last-image-deployed-info-version')
+        self._workdir_info_last_image_extras_deployed = os.path.join(self._workdir, '.last-image-deployed-extras-info')
         self._image_directory = os.path.join(self._workdir_build_yoctodir, 'image')
         self._image_basename = targets_config.get_image_basename(self._target)
         self._image_types = targets_config.get_image_types(self._target)
         self._toolchain_directory = os.path.join(self._workdir, 'build', 'toolchain')
         self._initialize_environment_for_target(no_export_environment)
-        self._hash_version_for_current_target = targets_config.generate_and_export_hash_version_identifier(self._target)
         if skip_init:
-            _log.debug('skipping initializing the build environment because skip_init was passed.')
+            _log.debug('Skipping initializing the build environment because skip_init was passed.')
             return
+        # Track whether the workdir pre-existed, before _check_or_init_image_extras_file creates it for the .image-extras file on a fresh first run
+        self._workdir_existed = os.path.isdir(self._workdir)
+        # image_extras can affect the hash, check or initialize it before computing the hash
+        self._check_or_init_image_extras_file(image_extras_list, no_wipe)
+        # This hash can't be used when skip_init, if there a NameError then fix the caller
+        self._hash_version_for_current_target = targets_config.generate_and_export_hash_version_identifier(self._target, self._workdir_image_extras_file)
         # Initialize the workdir at __init__() time, but only when is not previously built or is built with an old configuration.
         if not self._is_workdir_initialized_at_current_version():
             if not self._initialize_workdir(no_wipe):
                 raise RuntimeError('Unable to initialize working dir for target {target}'.format(target=target))
             # Clean the build CMakeCaches.txt (if any) when the config changes as well
             self._maybe_clean_webkit_build_caches(no_wipe)
+
+    def _check_or_init_image_extras_file(self, image_extras_list, no_wipe):
+        def log_image_extras(image_extras_str):
+            if image_extras_str:
+                _log.info(f'Enabled the following image extras: {image_extras_str}')
+            else:
+                _log.info('No image extras enabled.')
+        image_extras_str = '+'.join(sorted(set(image_extras_list)))
+        if not os.path.isfile(self._workdir_image_extras_file):
+            os.makedirs(self._workdir, exist_ok=True)
+            with open(self._workdir_image_extras_file, 'w') as f:
+                f.write(image_extras_str)
+            log_image_extras(image_extras_str)
+            return
+        with open(self._workdir_image_extras_file, 'r') as f:
+            previous_image_extras_content = f.read().strip()
+        if previous_image_extras_content == image_extras_str:
+            log_image_extras(image_extras_str)
+            return
+        if not image_extras_list:
+            # This corner case is to make using this easier, as doesn't force the user to pass --image-extras every time. Passing it once is enough.
+            _log.warning(f'Reusing previously enabled image extras: "{previous_image_extras_content}" because no extras passed. To reset: rm -fr "{self._workdir}"')
+            return
+        if no_wipe:
+            _log.info(f'Image extras configuration has changed. But no-wipe has been passed, so keeping the original image extras "{previous_image_extras_content}" at "{self._workdir}"')
+            return
+        _log.warning(f'Image extras configuration has changed. Before: "{previous_image_extras_content}" Now: "{image_extras_str}". Wiping and resetting config at "{self._workdir}"')
+        shutil.rmtree(self._workdir)
+        self._workdir_existed = False
+        return self._check_or_init_image_extras_file(image_extras_list, no_wipe)
 
     def _maybe_clean_webkit_build_caches(self, no_wipe):
         target_suffix = '_' + self._target
@@ -266,19 +323,18 @@ class YoctoCrossBuilder():
             signumber = os.WTERMSIG(sys_retcode)
             _log.error('The process "{cmd}" was terminated with signal: {signal}'.format(cmd=cmd, signal=signumber))
             return abs(signumber)
-        if os.WIFSTOPPED(status):
+        if os.WIFSTOPPED(sys_retcode):
             signumber = os.WSTOPSIG(sys_retcode)
             _log.error('The process "{cmd}" was stopped with signal: {signal}'.format(cmd=cmd, signal=signumber))
             return abs(signumber)
         return max(sys_retcode, 1)
 
-
     def _add_recipe_to_include_version_file_into_image(self, local_conf_path):
         poky_meta_dir = os.path.join(self._workdir, 'sources', 'poky', 'meta')
         if not os.path.isdir(poky_meta_dir):
-            raise RuntimeError('Can not find poky meta directory at {poky_dir}'.format(poky_dir=poky_dir))
+            raise RuntimeError(f"Can't find poky meta directory at {poky_meta_dir}")
         if not os.path.isfile(local_conf_path):
-            raise RuntimeError('Can not find local.conf file at {local_conf_path}'.format(local_conf_path=local_conf_path))
+            raise RuntimeError(f"Can't find local.conf file at {local_conf_path}")
         with open(local_conf_path, 'a') as f:
             f.write('\n# This has been added automatically by cross-toolchain-helper script:\n')
             f.write('IMAGE_INSTALL:append = " wk-target-info-ver"\n')
@@ -291,12 +347,13 @@ class YoctoCrossBuilder():
             f.write('LICENSE = "MIT"\n')
             f.write('LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"\n')
             f.write('S = "${WORKDIR}"\n')
-            f.write('SRC_URI = "file://${TOPDIR}/../.target-info-version"\n')
+            f.write('SRC_URI = "file://${TOPDIR}/../.target-info-version file://${TOPDIR}/../.image-extras"\n')
             f.write('do_install() {\n')
             f.write('    mkdir -p "${D}/${datadir}"\n')
             f.write('    cp "${TOPDIR}/../.target-info-version" "${D}/' + self._running_image_info_version_full_path + '"\n')
+            f.write('    cp "${TOPDIR}/../.image-extras" "${D}/' + self._running_image_info_image_extras_full_path + '"\n')
             f.write('}\n')
-            f.write('FILES:${PN} = "' + self._running_image_info_version_full_path + '"\n')
+            f.write('FILES:${PN} = "' + self._running_image_info_version_full_path + ' ' + self._running_image_info_image_extras_full_path + '"\n')
             f.write('BBCLASSEXTEND = "native nativesdk"\n')
 
     # This is only meant to be executed once on the first run or when the configuration changes.
@@ -304,7 +361,7 @@ class YoctoCrossBuilder():
     def _initialize_workdir(self, no_wipe):
         initial_directory = os.path.realpath(os.curdir)
         try:
-            if os.path.isdir(self._workdir):
+            if self._workdir_existed and os.path.isdir(self._workdir):
                 if os.path.isfile(self._workdir_version_file) and os.path.isfile(self._workdir_path_file):
                     if no_wipe:
                         _log.info('Configuration has changed. But no-wipe has been passed, so keeping old cross builder environment at: {workdir}'.format(workdir=self._workdir))
@@ -312,14 +369,28 @@ class YoctoCrossBuilder():
                     _log.info('Configuration has changed. Deleting old cross builder environment at: {workdir}'.format(workdir=self._workdir))
                 else:
                     _log.info('Previous initialization try failed to complete. Deleting old cross builder environment at: {workdir}'.format(workdir=self._workdir))
+                # Save the extra-images file before wiping.
+                previous_image_extras_content = ""
+                if os.path.isfile(self._workdir_image_extras_file):
+                    with open(self._workdir_image_extras_file, 'r') as f:
+                        previous_image_extras_content = f.read().strip()
                 shutil.rmtree(self._workdir)
+                os.makedirs(self._workdir)
+                with open(self._workdir_image_extras_file, 'w') as f:
+                    f.write(previous_image_extras_content)
             _log.info('Initializing cross builder environment at: {workdir}'.format(workdir=self._workdir))
-            os.makedirs(self._workdir)
+            os.makedirs(self._workdir, exist_ok=True)
             # call repo clone into workdir
             conf_dir = os.path.join(self._workdir_build_yoctodir, 'conf')
             # Create confdir and copy config files
             os.makedirs(conf_dir)
-            shutil.copy2(self._targets_config.get_conf_local(self._target), os.path.join(conf_dir, 'local.conf'))
+            local_conf_path = os.path.join(conf_dir, 'local.conf')
+            shutil.copy2(self._targets_config.get_conf_local(self._target), local_conf_path)
+            # Append the extra image file fragments if specified
+            for extra_image_fragment_file in self._targets_config.get_extra_images_fragment_file_paths(self._workdir_image_extras_file):
+                with open(extra_image_fragment_file, 'rb') as src, open(local_conf_path, 'ab') as dst:
+                    dst.write(b'\n')
+                    dst.write(src.read())
             # For bblayers.conf we need to resolve the BSPDIR variable to the workdir where it is deployed
             with open(self._targets_config.get_conf_bblayers(self._target), 'r') as f:
                 bblayers_template = f.read()
@@ -376,8 +447,6 @@ class YoctoCrossBuilder():
             os.chdir(poky_dir)
             if not os.path.isfile('oe-init-build-env'):
                 raise RuntimeError('Can not find oe-init-build-env script in poky directory at {poky_dir}'.format(poky_dir=poky_dir))
-            if not os.path.isfile('oe-init-build-env'):
-                raise RuntimeError('Can not find poky init env script at: {poky_init_env_file}'.format(poky_init_env_file=poky_init_env_file))
             _log.info('Running: {command}'.format(command=command))
             if self._run_cmd('/bin/bash -c \'. oe-init-build-env "{build_directory}" ; {command}\''.format(build_directory=self._workdir_build_yoctodir, command=command)) != 0:
                 _log.error('Error running bitbake')
@@ -479,28 +548,50 @@ class YoctoCrossBuilder():
             # This does the following:
             # 1. Remove any line that exports CFLAGS/CXXFLAGS/LDFLAGS/CPPFLAGS
             # 2. On the line that exports the compiler variables (export CC, export CXX and export CPP)
-            #    remove any compiler flag that is not machine related (-m*) or is '-E' (for cpp) or is for the sysroot.
+            #    remove any compiler flag that is not machine related (-m*) or is '-E' (for cpp) or is for the sysroot/target.
+            # 3. Do not override CC/CXX with the cross-compiled GCC compiler if the user wants to use Clang, instead
+            #    set CC/CXX pointing to the cross-compiled Clang (assuming the support was built in the toolchain).
             patched_setup_env_path = original_setup_env_path + "-no-opt-flags"
-            flags_regex = re.compile('export +(C|CXX|LD|CPP)FLAGS')
-            compiler_regex = re.compile('export +C(C|XX|PP)( +)?=')
+            flags_regex = re.compile(r'export\s+(C|CXX|LD|CPP)FLAGS=')
+            gcc_compiler_regex = re.compile(r'export\s+C(C|XX|PP)=')
+            clang_compiler_regex = re.compile(r'export\s+CLANGC(C|XX|PP)=')
+            gcc_lines = []
+            clang_lines = []
             with open(original_setup_env_path, 'r') as fr:
                 with open(patched_setup_env_path, 'w') as fw:
                     for line in fr.readlines():
                         if not flags_regex.match(line):
-                            if compiler_regex.match(line):
+                            if gcc_compiler_regex.match(line) or clang_compiler_regex.match(line):
                                 newline = ""
                                 for word in line.strip().split():
                                     if word.startswith('-'):
-                                        if word.startswith('-m') or word == '-E' or word.startswith('--sysroot'):
+                                        if word == '-E' or any(word.startswith(p) for p in ['-m', '--sysroot=', '--target=']):
                                             newline += " " + word
                                     else:
                                         newline += " " + word
                                 if '="' in newline and not newline.endswith('"'):
                                     newline += '"'
                                 newline = newline.strip() + '\n'
-                                fw.write(newline)
+                                (clang_lines if clang_compiler_regex.match(line) else gcc_lines).append(newline)
                             else:
                                 fw.write(line)
+                    # The script should check the CC/CXX env var from the user, if is set to clang then export
+                    # the CLANGCC and CLANGCXX as CC/CXX, otherwise keep the default (GCC)
+                    if len(gcc_lines) != 3:
+                        raise RuntimeError('Unexpected CC/CXX/CPP parameters in setup-environment script')
+                    if clang_lines:
+                        fw.write('\nif echo "${CC} ${CXX}" | grep -qi clang; then\n')
+                        for line in clang_lines:
+                            # Remove the CLANG prefix, so for example CLANGCXX becomes CXX
+                            line = re.sub(r'(export\s+)CLANG(CC|CXX|CPP)(=)', r'\1\2\3', line)
+                            fw.write(f'    {line}')
+                        fw.write('else\n')
+                        for line in gcc_lines:
+                            fw.write(f'    {line}')
+                        fw.write('fi\n')
+                    else:
+                        for line in gcc_lines:
+                            fw.write(line)
                     # When building cog, meson tries to load the wpe headers that are on the repo from the sysroot path.
                     # That is not really a bug on meson as system libraries should be loaded from the sysroot when cross-building.
                     # Workaround the issue by creating a symlink that also resolves this WebKit repository path inside the sysroot.
@@ -559,9 +650,13 @@ class YoctoCrossBuilder():
             fw.write('echo "  Welcome to the cross dev shell"\n')
             fw.write('echo -e "Your environment is now configured\\n"\n')
             fw.write('echo "Machine target: {target}"\n'.format(target=self._target))
-            fw.write('echo "GCC version: $($CC -dumpfullversion)"\n')
-            fw.write('echo "GCC target: $($CC -dumpmachine)"\n')
-            fw.write('echo -e "##################################"\n')
+            fw.write('COMPNAME=GCC; echo "${CC} ${CXX}" | grep -qi clang && COMPNAME=Clang\n')
+            fw.write('echo "Compiler selected: ${COMPNAME}"\n')
+            fw.write('echo "${COMPNAME} version: $($CC -dumpversion)"\n')
+            fw.write('echo "${COMPNAME} target: $($CC -dumpmachine)"\n')
+            fw.write('echo -e "\\nCall the cross compiler/debugger"\n')
+            fw.write('echo "with env vars: \$CC / \$CXX / \$GDB"\n')
+            fw.write('echo "##################################"\n')
             fw.write('export PS1="(WKCrossDevShell:{target}) ${{PS1}}"\n'.format(target=self._target))
         assert (os.path.isfile(custom_rc_file))
         _log.info('Entering into cross dev shell')
@@ -577,7 +672,8 @@ class YoctoCrossBuilder():
             _log.error('Error getting the "environment-setup" script from toolchain directory')
             return 1
         _log.info('Running inside cross-toolchain env: {command}'.format(command=command))
-        return self._run_cmd('/bin/bash -c \'. {cross_setup_env_path} ; {command}\''.format(cross_setup_env_path=cross_setup_env_path, command=command))
+        inner = '. {env} ; {cmd}'.format(env=shlex.quote(cross_setup_env_path), cmd=command)
+        return self._run_cmd('/bin/bash -c {inner}'.format(inner=shlex.quote(inner)))
 
     def execute_deploy_script(self, script_path):
         if os.path.isdir(script_path) or not os.access(script_path, os.R_OK | os.X_OK):
@@ -594,6 +690,7 @@ class YoctoCrossBuilder():
             _log.info('Deploy script ended with SUCESSS. Storing current image as correctly deployed')
             with open(self._workdir_info_last_image_deployed, 'w') as f:
                 f.write('{target_ver}\n'.format(target_ver=self._hash_version_for_current_target))
+            shutil.copy2(self._workdir_image_extras_file, self._workdir_info_last_image_extras_deployed)
         else:
             _log.error('Deploy script ended with return code {retcode}'.format(retcode=retcode))
         return retcode
@@ -610,10 +707,12 @@ class YoctoCrossBuilder():
 
         if image_type == 'running':
             image_info_hash_path = self._running_image_info_version_full_path
+            image_extras_info_path = self._running_image_info_image_extras_full_path
         elif image_type == 'deployed':
             image_info_hash_path = self._workdir_info_last_image_deployed
+            image_extras_info_path = self._workdir_info_last_image_extras_deployed
         else:
-            raise NotImplementedError('Unkown image type {image_type}'.format(image_type=image_type))
+            raise NotImplementedError(f'Unknown image type {image_type}')
 
 
         _log.info('Checking if {image_type} image is updated from info file "{info}"'.format(image_type=image_type, info=image_info_hash_path))
@@ -647,7 +746,7 @@ class YoctoCrossBuilder():
         image_target = line_info_arr[0]
         image_hash = line_info_arr[1]
         if image_type == 'deployed' and image_target != self._target:
-            _log.error('The target "{target}" obtained from file at {info} does not match the passed target fron the command line {argument_target}'.format(
+            _log.error('The target "{target}" obtained from file at {info} does not match the passed target from the command line {argument_target}'.format(
                         target=image_target, info=image_info_hash_path, argument_target=self._target))
             return RETCODE_IMAGE_NOT_VALID
         if image_target not in targets_available:
@@ -655,7 +754,7 @@ class YoctoCrossBuilder():
                         target=image_target, info=image_info_hash_path, targets=', '.join(targets_available)))
             return RETCODE_IMAGE_NOT_VALID
 
-        current_hash_for_target = self._targets_config.get_hash_for_target(image_target)
+        current_hash_for_target = self._targets_config.get_hash_for_target(image_target, image_extras_info_path)
         _log.info('The current {image_type} image is valid for target: {target}'.format(image_type=image_type, target=image_target))
         _log.info('Hash obtained for current image: {hash}'.format(hash=image_hash))
         _log.info('Hash for the last image version: {hash}'.format(hash=current_hash_for_target))
@@ -667,6 +766,71 @@ class YoctoCrossBuilder():
         _log.info('Hashes match: {image_type} image is updated'.format(image_type=image_type))
         return RETCODE_IMAGE_VALID_AND_UPDATED
 
+    def check_layer_updates(self, layer_name):
+        layer_dir = os.path.join(self._workdir, 'sources', layer_name)
+        if not os.path.isdir(layer_dir):
+            raise ValueError(f'Can not find the layer directory at {layer_dir}')
+        # Get yocto version codename
+        yocto_version_codename = None
+        with tempfile.NamedTemporaryFile(mode='r', delete=True, encoding='utf-8') as ftemp:
+            if not self._do_bitbake(f'bitbake -e | grep DISTRO_CODENAME > {ftemp.name}'):
+                _log.error('Unable to get DISTRO_CODENAME from bitbake -e')
+                return 1
+            ftemp.seek(0)
+            for line in ftemp.readlines():
+                if line.startswith('DISTRO_CODENAME='):
+                    yocto_version_codename = line.strip().split('=', 1)[1].strip('\'"')
+                    break
+        if not yocto_version_codename:
+            _log.error('Could not find Yocto version codename')
+            return 1
+        initial_directory = os.path.realpath(os.curdir)
+        try:
+            os.chdir(layer_dir)
+            current_head_sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip()
+            if self._run_cmd('git fetch') != 0:
+                _log.error(f'Unable to run "git fetch" in the layer directory at "{layer_dir}"')
+                return 1
+            branch_found = None
+            git_branch_output = subprocess.check_output(['git', 'branch', '-r', '--contains', 'HEAD'], text=True)
+            for line in git_branch_output.splitlines():
+                line = line.strip()
+                # Skip 'm/*' refs (created by the 'repo' tool to track the manifest):
+                if not line or line.startswith('m/'):
+                    continue
+                if '/' in line and line.split('/', 1)[1].startswith(yocto_version_codename):
+                    branch_found = line
+                    break
+            if not branch_found:
+                _log.warning(f'Unable to find a specific branch for yocto codename {yocto_version_codename}. Trying with main/master')
+                for line in git_branch_output.splitlines():
+                    line = line.strip()
+                    if not line or line.startswith('m/'):
+                        continue
+                    if line.endswith('/main') or line.endswith('/master'):
+                        branch_found = line
+                        break
+            if not branch_found:
+                _log.error('Could not find any branch on the remote to check.')
+                return 1
+            remote_head_sha = subprocess.check_output(['git', 'rev-parse', branch_found], text=True).strip()
+            if current_head_sha == remote_head_sha:
+                _log.info(f'"{layer_name}" is at the tip of "{branch_found}" ({current_head_sha}). No update needed.')
+                return 0
+            commits_behind = subprocess.check_output(
+                ['git', 'rev-list', '--count', f'{current_head_sha}..{remote_head_sha}'],
+                text=True).strip()
+            current_committer_date = subprocess.check_output(
+                ['git', 'show', '-s', '--format=%ci', current_head_sha], text=True).strip()
+            remote_committer_date = subprocess.check_output(
+                ['git', 'show', '-s', '--format=%ci', remote_head_sha], text=True).strip()
+        finally:
+            os.chdir(initial_directory)
+        _log.info(f'"{layer_name}" is not at the tip of "{branch_found}":')
+        _log.info(f'  Current HEAD     : {current_head_sha} (committer date: {current_committer_date})')
+        _log.info(f'  Latest on remote : {remote_head_sha} (committer date: {remote_committer_date})')
+        _log.info(f'  Commits behind   : {commits_behind}')
+        return 1
 
 
 # argparse has issues parsing strings like '--'
@@ -731,6 +895,9 @@ def main(args):
                         help='Print the available targets (one per line)')
     action.add_argument('--build-image', action='store_true', dest='generate_image',
                         help='Build the image (rootfs+kernel) for the specified target.')
+    parser.add_argument('--image-extras', type=str, dest='image_extras',
+                        help='Image extra features to enable, separate the extras with a "+". '
+                             'The environment variable WEBKIT_CROSS_IMAGE_EXTRAS can be used as well to specify those.' )
     action.add_argument('--build-toolchain', action='store_true', dest='generate_toolchain',
                         help='Build the cross-toolchain for the specified target.')
     action.add_argument('--bitbake-dev-shell', action='store_true', dest='bitbake_dev_shell',
@@ -744,6 +911,8 @@ def main(args):
                         help='Pass value "running" on the board, to check if the running image is valid and updated. '
                              'Pass value "deployed" on the builder, to check if the deployed image is valid and updated. '
                              'It will return: true (zero) if the image is valid and updated, false (1) if is valid but not updated or false (2) if is not valid.')
+    action.add_argument('--check-if-layer-is-updated', type=str, dest='check_if_layer_is_updated', action='append',
+                        help='Check if a specific layer has new updates. For example: meta-browser. Parameter can be passed multiple times.')
     action.add_argument(run_cmd_key, action='store', dest='execute_inside_cross_toolchain_environment_cmd', nargs=argparse.REMAINDER,
                         help='Build the cross toolchain (only if still not built) and then execute \"command\" inside cross environment. '
                              '\033[91mIMPORTANT\033[0m: This argument is the last one, any strings after it, even if separated by spaces or quotes will be considered part of the command to be executed. '
@@ -760,9 +929,21 @@ def main(args):
         print('\n'.join(targets_config.list_target_configs_available()))
         return 0
 
+    image_extras_list = []
+    wanted_image_extras = options.image_extras if options.image_extras else os.environ.get('WEBKIT_CROSS_IMAGE_EXTRAS')
+    if wanted_image_extras:
+        image_extras_abs_path = os.path.join(top_level_directory, conf_sub_dir, 'image_extras')
+        avail_image_extras = [f[:-5] for f in os.listdir(image_extras_abs_path) if f.endswith('.conf')] if os.path.isdir(image_extras_abs_path) else []
+        for extra_feature in wanted_image_extras.strip('+').split('+'):
+            if extra_feature in avail_image_extras:
+                image_extras_list.append(extra_feature)
+            else:
+                parser.error(f'Image extra feature "{extra_feature}" not available. Available extras are: {" ".join(avail_image_extras)}')
+
     if not options.bitbake_dev_shell and not options.cross_dev_shell and not options.generate_toolchain \
        and not options.generate_image and options.execute_inside_cross_toolchain_environment_cmd is None \
-       and options.script_path is None and not options.check_if_image_is_updated:
+       and options.script_path is None and not options.check_if_image_is_updated  \
+       and options.check_if_layer_is_updated is None:
         parser.error('Need to specify an action')
 
     if options.check_if_image_is_updated == 'running':
@@ -787,7 +968,7 @@ def main(args):
     no_wipe = (options.no_wipe) or (os.environ.get('WEBKIT_CROSS_WIPE_ON_CHANGE', '1') == '0')
     no_export_environment = (options.no_export_environment) or (os.environ.get('WEBKIT_CROSS_EXPORT_ENV', '1') == '0')
     skip_init = options.check_if_image_is_updated in ['running', 'deployed']
-    builder = YoctoCrossBuilder(targets_config, options.target, no_wipe, no_export_environment, skip_init)
+    builder = YoctoCrossBuilder(targets_config, options.target, image_extras_list, no_wipe, no_export_environment, skip_init)
 
     if options.check_if_image_is_updated in ['running', 'deployed']:
         if options.bitbake_dev_shell or options.cross_dev_shell or options.generate_toolchain \
@@ -820,6 +1001,10 @@ def main(args):
 
     if options.script_path:
         retcode += builder.execute_deploy_script(options.script_path)
+
+    if options.check_if_layer_is_updated:
+        for update_layer_name in options.check_if_layer_is_updated:
+            retcode += builder.check_layer_updates(update_layer_name)
 
     return retcode
 

--- a/Tools/yocto/README.md
+++ b/Tools/yocto/README.md
@@ -143,9 +143,6 @@ This is an example on how to build and run WPE for development on the RPi:
 
 1. Build the image that will be flashed on the board:
 
-# NOTE: If you are using the **WebKit Container SDK** remember to unset the *LD_LIBRARY_PATH*
-# before building, if you don't it can cause problems with the yocto setup.
-
 ```
 user@workstation $ Tools/Scripts/cross-toolchain-helper --cross-target=rpi3-32bits-mesa --build-image
 ```

--- a/Tools/yocto/README.md
+++ b/Tools/yocto/README.md
@@ -67,18 +67,33 @@ You have there also a debugger enabled to debug binaries for the target board.
 Inside this shell, you use ```$CC``` and ```$CXX``` as compilers for the target.
 A cross-aware debugger is also enabled, you can invoke it with: ```$GDB```
 
+```
+user@workstation(WKCrossDevShell:rpi4-64bits-mesa): ~/WebKit $ $ env | grep -P '^(CC|CXX|LD|AR|GDB|.*WEBKIT.*)='
+BUILD_WEBKIT_ARGS=--no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DENABLE_SPEECH_SYNTHESIS=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+GDB=aarch64-poky-linux-gdb
+CXX=aarch64-poky-linux-clang++ --target=aarch64-poky-linux -mcpu=cortex-a72+crc -mbranch-protection=standard -mlittle-endian --sysroot=/home/igalia/webkit/WebKitBuild/CrossToolChains/rpi4-64bits-mesa/build/toolchain/sysroots/cortexa72-poky-linux
+LD=aarch64-poky-linux-ld  --sysroot=/home/igalia/webkit/WebKitBuild/CrossToolChains/rpi4-64bits-mesa/build/toolchain/sysroots/cortexa72-poky-linux
+AR=aarch64-poky-linux-ar
+CC=aarch64-poky-linux-clang --target=aarch64-poky-linux -mcpu=cortex-a72+crc -mbranch-protection=standard -mlittle-endian --sysroot=/home/igalia/webkit/WebKitBuild/CrossToolChains/rpi4-64bits-mesa/build/toolchain/sysroots/cortexa72-poky-linux
+WEBKIT_CROSS_VERSION=f2cc6d37723215008044c87e69046019
+WEBKIT_CROSS_TARGET=rpi4-64bits-mesa
+```
+
+### Using Clang
+
+It is possible to use Clang to build webkit via script `build-webkit` when
+using `cross-toolchain-helper`, or inside the `cross-dev-shell`.
+For that simply set on your environment `CC=clang` and `CXX=clang++` before
+starting the webkit build or before executing `cross-dev-shell`
+
+Example:
 
 ```
-user@workstation(WKCrossDevShell:rpi3-32bits-mesa): ~/WebKit $ env | grep -P '^(CC|CXX|LD|AR|GDB|.*WEBKIT.*)='
-BUILD_WEBKIT_ARGS=--no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_THUNDER=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland"
-GDB=arm-poky-linux-gnueabi-gdb
-CXX=arm-poky-linux-gnueabi-g++ -mthumb -mfpu=neon-vfpv4 -mfloat-abi=hard -mcpu=cortex-a7 --sysroot=/home/igalia/webkit/WebKitBuild/CrossToolChains/rpi3-32bits-mesa/build/toolchain/sysroots/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi
-LD=arm-poky-linux-gnueabi-ld  --sysroot=/home/igalia/webkit/WebKitBuild/CrossToolChains/rpi3-32bits-mesa/build/toolchain/sysroots/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi
-AR=arm-poky-linux-gnueabi-ar
-CC=arm-poky-linux-gnueabi-gcc -mthumb -mfpu=neon-vfpv4 -mfloat-abi=hard -mcpu=cortex-a7 --sysroot=/home/igalia/webkit/WebKitBuild/CrossToolChains/rpi3-32bits-mesa/build/toolchain/sysroots/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi
-WEBKIT_CROSS_TARGET=rpi3-32bits-mesa
+  CC=clang CXX=clang++ Tools/Scripts/build-webkit --cross-target=rpi4-64bits-mesa --wpe --release
+  CC=clang CXX=clang++ Tools/Scripts/cross-toolchain-helper --cross-target=rpi4-64bits-mesa --cross-dev-shell
 ```
 
+To use GCC simply unset CC or CXX (is the default).
 
 ### Using the bitbake-dev-shell
 
@@ -144,7 +159,7 @@ This is an example on how to build and run WPE for development on the RPi:
 1. Build the image that will be flashed on the board:
 
 ```
-user@workstation $ Tools/Scripts/cross-toolchain-helper --cross-target=rpi3-32bits-mesa --build-image
+user@workstation $ Tools/Scripts/cross-toolchain-helper --cross-target=rpi4-64bits-mesa --build-image
 ```
 
 2. At the end of the build it will print the path to the image, if you missed it
@@ -152,8 +167,8 @@ user@workstation $ Tools/Scripts/cross-toolchain-helper --cross-target=rpi3-32bi
    Example:
 
 ```
-user@workstation $ Tools/Scripts/cross-toolchain-helper --cross-target=rpi3-32bits-mesa --build-image
-cross-toolchain-helper INFO: Image already built at: /home/igalia/webkit/WebKitBuild/CrossToolChains/rpi3-32bits-mesa/build/image/core-image-webkit-dev-ci-tools-tests.wic.xz
+user@workstation $ Tools/Scripts/cross-toolchain-helper --cross-target=rpi4-64bits-mesa --build-image
+cross-toolchain-helper INFO: Image already built at: /home/igalia/webkit/WebKitBuild/CrossToolChains/rpi4-64bits-mesa/build/image/core-image-webkit-dev-ci-tools-tests.wic.xz
 ```
 
 3. Flash a SDCard with this image
@@ -175,7 +190,7 @@ user@workstation $ cat /path/to/core-image-webkit-dev-ci-tools-tests.wic.xz | xz
   * 3.3. Or alternatively use the script for deploying
 
 ```
-user@workstation $ DEVICESDCARD=/dev/mmcblk0 Tools/Scripts/cross-toolchain-helper --cross-target=rpi3-32bits-mesa --deploy-image-with-script Tools/yocto/deploy_image_scripts/wic-to-sdcard.sh
+user@workstation $ DEVICESDCARD=/dev/mmcblk0 Tools/Scripts/cross-toolchain-helper --cross-target=rpi4-64bits-mesa --deploy-image-with-script Tools/yocto/deploy_image_scripts/wic-to-sdcard.sh
 ```
 
 4. Grow the rootfs partition to use all the available space on the SDcard
@@ -195,21 +210,43 @@ user@workstation $ sudo resize2fs /dev/mmcblk0p2
 # Insert SDCard, boot RPi and obtain the IP address asigned via DHCP
 # NOTE: password for root is empty (no auth required)
 user@workstation $ ssh root@192.168.X.Y
-root@raspberrypi3:~# git clone https://github.com/WebKit/WebKit.git --depth 1
+root@raspberrypi4:~# git clone https://github.com/WebKit/WebKit.git --depth 1
 ````
 
-# NOTE: In the raspberrypi3 the clone can be too much, in that situation you need
-# to clone in the machine building the image and copy to the device after that.
+**TIP:** Cloning the repository from inside the board can be very slow, it is a 
+better idea to pre-clone it on the machine building the image, either inside
+the sdcard or on an external USB pen-drive.
+
+### Extra features for the image
+
+The image can be built with extra programs included like Chromium (useful for
+performance benchmark) or Netdata.
+
+To add this extra features (opt-in) into the image either pass the flag
+`--image-extras` to cross-toolchain-helper or set the env var `WEBKIT_CROSS_IMAGE_EXTRAS`
+
+Examples:
+
+```
+WEBKIT_CROSS_IMAGE_EXTRAS=netdata+chromium Tools/Scripts/cross-toolchain-helper --cross-target=rpi4-64bits-mesa --build-image
+```
+
+To check the available extra image features simply pass a random string to `cross-toolchain-helper`
+and it will error saying which ones are available.
+
+```
+Tools/Scripts/cross-toolchain-helper --cross-target=rpi4-64bits-mesa --image-extras randomstr --build-toolchain
+```
 
 ### Build WPE for the target board
 
 1. You can use the build-webkit script passing the flag --cross-target=name
 
 ```
-user@workstation $ Tools/Scripts/build-webkit --wpe --release --cross-target=rpi3-32bits-mesa
+user@workstation $ Tools/Scripts/build-webkit --wpe --release --cross-target=rpi4-64bits-mesa
 ```
 
-2. The build will be stored in a per-target directory: ```WebKitBuild/WPE/Release_rpi3-32bits-mesa```
+2. The build will be stored in a per-target directory: ```WebKitBuild/WPE/Release_rpi4-64bits-mesa```
 
 This allows to build simultaneously for different targets (and for your host system)
 from the same checkout.
@@ -217,7 +254,7 @@ from the same checkout.
 3. Generate a release.zip for copying to the target board.
 
 ```
-Tools/CISupport/built-product-archive --platform=wpe --release --cross-target=rpi3-32bits-mesa archive
+Tools/CISupport/built-product-archive --platform=wpe --release --cross-target=rpi4-64bits-mesa archive
 ```
 
 4. Copy release.zip to the board
@@ -226,6 +263,28 @@ Tools/CISupport/built-product-archive --platform=wpe --release --cross-target=rp
 scp WebKitBuild/release.zip root@192.168.X.Y:
 ```
 
+### Starting Weston (Wayland environment)
+
+Weston is configured to automatically start when any program tries to use
+the socket. You can, for example, execute `weston-simple-egl` and then
+weston should be automatically launched.
+
+So when you execute the MiniBrowser it should automatically launch weston if
+is still not launched.
+
+If for some reason it doesn't auto-launch then you can try to do that manually:
+
+```
+root@raspberrypi4:~/WebKit# systemctl start weston
+# define and export the required environment variables
+root@raspberrypi4:~/WebKit# source <(strings /proc/$(pidof weston-desktop-shell)/environ | grep -P '(XDG_RUNTIME_DIR|WAYLAND_DISPLAY)')
+root@raspberrypi4:~/WebKit# export XDG_RUNTIME_DIR
+root@raspberrypi4:~/WebKit# export WAYLAND_DISPLAY
+```
+
+Check also the config file `/etc/xdg/weston/weston.ini` that it has the
+right output entries for your screen and that the option `xwayland=true`
+is not set.
 
 ### Unpack the built product on the board and run the browser or run tests
 
@@ -235,43 +294,30 @@ scp WebKitBuild/release.zip root@192.168.X.Y:
 # cd to the webkit checkout in the board and copy release.zip inside the build directory
 user@workstation $ ssh root@192.168.X.Y
 
-root@raspberrypi3:~# cd WebKit/
-root@raspberrypi3:~/WebKit# mkdir WebKitBuild
-root@raspberrypi3:~/WebKit# cp ~/release.zip WebKitBuild/
+root@raspberrypi4:~# cd WebKit/
+root@raspberrypi4:~/WebKit# mkdir WebKitBuild
+root@raspberrypi4:~/WebKit# cp ~/release.zip WebKitBuild/
 
-root@raspberrypi3:~/WebKit# Tools/CISupport/built-product-archive --platform=wpe --release extract
+root@raspberrypi4:~/WebKit# Tools/CISupport/built-product-archive --platform=wpe --release extract
 Extracting: /home/root/WebKit/WebKitBuild/Release
 Archive:  /home/root/WebKit/WebKitBuild/release.zip
 [....]
 ```
 
-2. Now you can run the minibrowser (cog) or any type of tests.
+2. Now you can run the minibrowser or any type of tests.
 
 ```
-# [Example 1]: Run Cog over the framebuffer with KMS/DRM
-# first: ensure weston is stopped
-root@raspberrypi3:~/WebKit# systemctl stop weston
-# Run cog with platform plugin 'drm'
-root@raspberrypi3:~/WebKit# Tools/Scripts/run-minibrowser --wpe -P drm
-
-# [Example 2]: Run Cog inside Weston/Wayland
-# first: start weston
-root@raspberrypi3:~/WebKit# systemctl start weston
-# define and export the required environment variables
-root@raspberrypi3:~/WebKit# source <(strings /proc/$(pidof weston-desktop-shell)/environ | grep -P '(XDG_RUNTIME_DIR|WAYLAND_DISPLAY)')
-root@raspberrypi3:~/WebKit# export XDG_RUNTIME_DIR
-root@raspberrypi3:~/WebKit# export WAYLAND_DISPLAY
-# Run cog with platform plugin 'wl'
-root@raspberrypi3:~/WebKit# Tools/Scripts/run-minibrowser --wpe -P wl
+# [Example 1]: Run MiniBrowser
+root@raspberrypi4:~/WebKit# Tools/Scripts/run-minibrowser --wpe --release
 
 
-# [Example 3]: Run layout tests
-root@raspberrypi3:~/WebKit# Tools/Scripts/run-webkit-tests --debug-rwt-logging --no-build --wpe --release fast/css
+# [Example 2]: Run layout tests
+root@raspberrypi4:~/WebKit# Tools/Scripts/run-webkit-tests --debug-rwt-logging --no-build --wpe --release fast/css
 
 # Note: the board may be not powerful enough or have not enough ram.
 # If you see issues with tests crashing or timing out try to lower the
 # number of parallel tests and raise the timeout value for the tests.
 # [Example 4]: Run layout tests with one worker:
-root@raspberrypi3:~/WebKit# export NUMBER_OF_PROCESSORS=1
-root@raspberrypi3:~/WebKit# Tools/Scripts/run-webkit-tests --debug-rwt-logging --no-build --wpe --release fast/css
+root@raspberrypi4:~/WebKit# export NUMBER_OF_PROCESSORS=1
+root@raspberrypi4:~/WebKit# Tools/Scripts/run-webkit-tests --debug-rwt-logging --no-build --wpe --release fast/css
 ```

--- a/Tools/yocto/image_extras/chromium.conf
+++ b/Tools/yocto/image_extras/chromium.conf
@@ -1,3 +1,2 @@
 # Add chromium to image to be able to compare WPE/Chromium performance
 IMAGE_INSTALL:append = " chromium-ozone-wayland"
-CHROMIUM_EXTRA_ARGS = "--use-angle=opengles"

--- a/Tools/yocto/image_extras/chromium.conf
+++ b/Tools/yocto/image_extras/chromium.conf
@@ -1,0 +1,3 @@
+# Add chromium to image to be able to compare WPE/Chromium performance
+IMAGE_INSTALL:append = " chromium-ozone-wayland"
+CHROMIUM_EXTRA_ARGS = "--use-angle=opengles"

--- a/Tools/yocto/image_extras/netdata.conf
+++ b/Tools/yocto/image_extras/netdata.conf
@@ -1,0 +1,2 @@
+# Add netdata to automatically collect system performance metrics
+IMAGE_INSTALL:append = " netdata"

--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -772,7 +772,7 @@ index 4133ad7..2234c9b 100644
      systemd-analyze \
      unifdef \
 diff --git a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
-index 2b9b30f..d2c5fa6 100644
+index 2b9b30f..6d9c070 100644
 --- a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
 +++ b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
 @@ -132,6 +132,8 @@ RDEPENDS:packagegroup-wpewebkit-depends-core = "\
@@ -784,3 +784,35 @@ index 2b9b30f..d2c5fa6 100644
      zlib \
      libpng \
      libsoup \
+@@ -152,6 +154,7 @@ RDEPENDS:packagegroup-wpewebkit-depends-core = "\
+     wayland-protocols \
+     openjpeg \
+     libbacktrace \
++    hyphen \
+ "
+ 
+ RDEPENDS:packagegroup-wpewebkit-depends-core:append:libc-glibc = "\
+diff --git a/sources/meta-webkit/recipes-graphics/hyphen/hyphen_2.8.8.bb b/sources/meta-webkit/recipes-graphics/hyphen/hyphen_2.8.8.bb
+new file mode 100644
+index 0000000..75b3187
+--- /dev/null
++++ b/sources/meta-webkit/recipes-graphics/hyphen/hyphen_2.8.8.bb
+@@ -0,0 +1,18 @@
++SUMMARY = "A text hyphenation library"
++HOMEPAGE = "http://hunspell.sourceforge.net/"
++LICENSE = "LGPL-2.1-only | GPL-2.0-only | MPL-1.1"
++LIC_FILES_CHKSUM = " \
++    file://COPYING;md5=d45e3467790c1cae990cc9ca3293bc97 \
++    file://COPYING.LGPL;md5=d8045f3b8f929c1cb29a1e3fd737b499 \
++    file://COPYING.MPL;md5=bfe1f75d606912a4111c90743d6c7325 \
++"
++
++SRC_URI = "${SOURCEFORGE_MIRROR}/project/hunspell/Hyphen/2.8/${BPN}-${PV}.tar.gz"
++SRC_URI[md5sum] = "5ade6ae2a99bc1e9e57031ca88d36dad"
++SRC_URI[sha256sum] = "304636d4eccd81a14b6914d07b84c79ebb815288c76fe027b9ebff6ff24d5705"
++
++inherit autotools pkgconfig
++
++RDEPENDS:${PN} = "perl"
++
++BBCLASSEXTEND = "native"

--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -714,16 +714,19 @@ diff --git a/sources/meta-webkit/conf/distro/webkitdevci.conf b/sources/meta-web
 index 1f952c2..d299d1f 100644
 --- a/sources/meta-webkit/conf/distro/webkitdevci.conf
 +++ b/sources/meta-webkit/conf/distro/webkitdevci.conf
-@@ -48,5 +48,14 @@ PACKAGECONFIG:append:pn-php = " apache2"
+@@ -47,6 +47,17 @@ PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"
+ PACKAGECONFIG:append:pn-php = " apache2"
  # Disable mysql support as we don't need to build mysql/mariadb
  PACKAGECONFIG:remove:pn-php = "mysql"
- 
++# Do not kill detached screen(1)/tmux(1) sessions on logout
++PACKAGECONFIG:remove:pn-systemd-conf = "kill-user-processes"
++
 +# Disable the following services by default
 +# - Apache2: the service is not needed for the tests, the
 +#   layout test runner takes care of starting/stopping it.
 +INHERIT += "systemd-auto-enable-policy"
 +SYSTEMD_AUTOSTART_DISABLE = "apache2"
-+
+ 
  # Whitelist license from some deps.
  LICENSE_FLAGS_ACCEPTED:append = " commercial synaptics-killswitch"
 +
@@ -799,3 +802,36 @@ index bdd7fea..7005240 100644
      rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}/include/orc/
  }
  
+diff --git a/sources/poky/meta/recipes-core/systemd/systemd-conf/logind.conf b/sources/poky/meta/recipes-core/systemd/systemd-conf/logind.conf
+index bf7f692..25f01f3 100644
+--- a/sources/poky/meta/recipes-core/systemd/systemd-conf/logind.conf
++++ b/sources/poky/meta/recipes-core/systemd/systemd-conf/logind.conf
+@@ -1,2 +1,2 @@
+ [Login]
+-KillUserProcesses=yes
++KillUserProcesses=@KILL_USER_PROCESSES@
+diff --git a/sources/poky/meta/recipes-core/systemd/systemd-conf_1.0.bb b/sources/poky/meta/recipes-core/systemd/systemd-conf_1.0.bb
+index 2355936..0820dd9 100644
+--- a/sources/poky/meta/recipes-core/systemd/systemd-conf_1.0.bb
++++ b/sources/poky/meta/recipes-core/systemd/systemd-conf_1.0.bb
+@@ -10,8 +10,9 @@ REQUIRED_DISTRO_FEATURES += "usrmerge"
+ 
+ PE = "1"
+ 
+-PACKAGECONFIG ??= "dhcp-ethernet"
++PACKAGECONFIG ??= "dhcp-ethernet kill-user-processes"
+ PACKAGECONFIG[dhcp-ethernet] = ""
++PACKAGECONFIG[kill-user-processes] = ""
+ 
+ SRC_URI = "\
+     file://journald.conf \
+@@ -26,6 +27,9 @@ do_install() {
+        install -D -m0644 ${WORKDIR}/logind.conf ${D}${systemd_unitdir}/logind.conf.d/00-${PN}.conf
+        install -D -m0644 ${WORKDIR}/system.conf ${D}${systemd_unitdir}/system.conf.d/00-${PN}.conf
+ 
++        KILL_USER_PROCESSES="${@bb.utils.contains('PACKAGECONFIG', 'kill-user-processes', 'yes', 'no', d)}"
++        sed -i "s/@KILL_USER_PROCESSES@/${KILL_USER_PROCESSES}/" ${D}${systemd_unitdir}/logind.conf.d/00-${PN}.conf
++
+         if ${@bb.utils.contains('PACKAGECONFIG', 'dhcp-ethernet', 'true', 'false', d)}; then
+                install -D -m0644 ${WORKDIR}/wired.network ${D}${systemd_unitdir}/network/80-wired.network
+         fi

--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -12,94 +12,6 @@ index f4911f3..b13abad 100644
  
  [Install]
  WantedBy=multi-user.target
-diff --git a/sources/poky/meta/recipes-support/icu/icu/ICU-22813_rise_buffer_sizes_pkgdata_PR3058.patch b/sources/poky/meta/recipes-support/icu/icu/ICU-22813_rise_buffer_sizes_pkgdata_PR3058.patch
-new file mode 100644
-index 0000000..21bc060
---- /dev/null
-+++ b/sources/poky/meta/recipes-support/icu/icu/ICU-22813_rise_buffer_sizes_pkgdata_PR3058.patch
-@@ -0,0 +1,70 @@
-+From db70adaddcfa8050db6a69cdfef080a7f1423ad7 Mon Sep 17 00:00:00 2001
-+From: Carlos Alberto Lopez Perez <clopez@igalia.com>
-+Date: Mon, 1 Jul 2024 22:15:18 +0100
-+Subject: [PATCH] ICU-22813 Rise the size of the buffers used for the command
-+ strings at pkgdata
-+
-+The tool pkgdata uses snprintf() to build the strings of the commands that
-+will execute later during the install process. But the maximum size of this
-+buffers is not enough when there is a long path.
-+
-+This has caused issues on some CI systems that use very long paths, causing
-+the install process to produce a wrong result.
-+
-+The maximum path on Linux is 4096 (defined as PATH_MAX at <linux/limits.h>)
-+So the size of SMALL_BUFFER_MAX_SIZE should be 4096 to avoid errors related
-+to truncated paths.
-+
-+Upstream-Status: Submitted [https://github.com/unicode-org/icu/pull/3058]
-+---
-+ tools/pkgdata/pkgdata.cpp | 6 +++---
-+ tools/toolutil/pkg_genc.h | 5 ++---
-+ 2 files changed, 5 insertions(+), 6 deletions(-)
-+
-+diff --git a/tools/pkgdata/pkgdata.cpp b/tools/pkgdata/pkgdata.cpp
-+index c2ac112..8d08c85 100644
-+--- a/tools/pkgdata/pkgdata.cpp
-++++ b/tools/pkgdata/pkgdata.cpp
-+@@ -1134,7 +1134,7 @@ static int32_t pkg_createSymLinks(const char *targetDir, UBool specialHandling)
-+ 
-+ static int32_t pkg_installLibrary(const char *installDir, const char *targetDir, UBool noVersion) {
-+     int32_t result = 0;
-+-    char cmd[SMALL_BUFFER_MAX_SIZE];
-++    char cmd[LARGE_BUFFER_MAX_SIZE];
-+ 
-+     auto ret = snprintf(cmd,
-+             sizeof(cmd),
-+@@ -1205,7 +1205,7 @@ static int32_t pkg_installLibrary(const char *installDir, const char *targetDir,
-+ 
-+ static int32_t pkg_installCommonMode(const char *installDir, const char *fileName) {
-+     int32_t result = 0;
-+-    char cmd[SMALL_BUFFER_MAX_SIZE] = "";
-++    char cmd[LARGE_BUFFER_MAX_SIZE] = "";
-+ 
-+     if (!T_FileStream_file_exists(installDir)) {
-+         UErrorCode status = U_ZERO_ERROR;
-+@@ -1237,7 +1237,7 @@ static int32_t pkg_installCommonMode(const char *installDir, const char *fileNam
-+ #endif
-+ static int32_t pkg_installFileMode(const char *installDir, const char *srcDir, const char *fileListName) {
-+     int32_t result = 0;
-+-    char cmd[SMALL_BUFFER_MAX_SIZE] = "";
-++    char cmd[LARGE_BUFFER_MAX_SIZE] = "";
-+ 
-+     if (!T_FileStream_file_exists(installDir)) {
-+         UErrorCode status = U_ZERO_ERROR;
-+diff --git a/tools/toolutil/pkg_genc.h b/tools/toolutil/pkg_genc.h
-+index 2dd1b45..f811fe5 100644
-+--- a/tools/toolutil/pkg_genc.h
-++++ b/tools/toolutil/pkg_genc.h
-+@@ -59,9 +59,8 @@
-+ #define PKGDATA_FILE_SEP_STRING U_FILE_SEP_STRING
-+ #endif
-+ 
-+-#define LARGE_BUFFER_MAX_SIZE 2048
-+-#define SMALL_BUFFER_MAX_SIZE 512
-+-#define SMALL_BUFFER_FLAG_NAMES 32
-++#define LARGE_BUFFER_MAX_SIZE 16384
-++#define SMALL_BUFFER_MAX_SIZE 4096
-+ #define BUFFER_PADDING_SIZE 20
-+ 
-+ /** End platform defines **/
-diff --git a/sources/poky/meta/recipes-support/icu/icu_74-2.bb b/sources/poky/meta/recipes-support/icu/icu_74-2.bb
-index 8352bf2..c81cfe9 100644
---- a/sources/poky/meta/recipes-support/icu/icu_74-2.bb
-+++ b/sources/poky/meta/recipes-support/icu/icu_74-2.bb
-@@ -106,6 +106,7 @@ SRC_URI = "${BASE_SRC_URI};name=code \
-            file://filter.json \
-            file://fix-install-manx.patch \
-            file://0001-icu-Added-armeb-support.patch \
-+           file://ICU-22813_rise_buffer_sizes_pkgdata_PR3058.patch \
-            "
- 
- SRC_URI:append:class-target = "\
 diff --git a/sources/meta-openembedded/meta-gnome/recipes-gnome/libdex/libdex_0.10.1.bb b/sources/meta-openembedded/meta-gnome/recipes-gnome/libdex/libdex_0.10.1.bb
 new file mode 100644
 index 0000000000..3b83273272
@@ -784,7 +696,65 @@ index 2b9b30f..6d9c070 100644
      zlib \
      libpng \
      libsoup \
-@@ -152,6 +154,7 @@ RDEPENDS:packagegroup-wpewebkit-depends-core = "\
+diff --git a/sources/meta-webkit/classes/systemd-auto-enable-policy.bbclass b/sources/meta-webkit/classes/systemd-auto-enable-policy.bbclass
+new file mode 100644
+index 0000000..18b1f3c
+--- /dev/null
++++ b/sources/meta-webkit/classes/systemd-auto-enable-policy.bbclass
+@@ -0,0 +1,8 @@
++# Easily allow to disable specific systemd services at the distro level conf
++python __anonymous() {
++    if bb.utils.contains('DISTRO_FEATURES', 'systemd', True, False, d):
++        packages_to_disable = d.getVar('SYSTEMD_AUTOSTART_DISABLE') or ''
++        pn = d.getVar('PN')
++        if pn in packages_to_disable.split():
++            d.setVar('SYSTEMD_AUTO_ENABLE:%s' % pn, 'disable')
++}
+diff --git a/sources/meta-webkit/conf/distro/webkitdevci.conf b/sources/meta-webkit/conf/distro/webkitdevci.conf
+index 1f952c2..d299d1f 100644
+--- a/sources/meta-webkit/conf/distro/webkitdevci.conf
++++ b/sources/meta-webkit/conf/distro/webkitdevci.conf
+@@ -48,5 +48,14 @@ PACKAGECONFIG:append:pn-php = " apache2"
+ # Disable mysql support as we don't need to build mysql/mariadb
+ PACKAGECONFIG:remove:pn-php = "mysql"
+ 
++# Disable the following services by default
++# - Apache2: the service is not needed for the tests, the
++#   layout test runner takes care of starting/stopping it.
++INHERIT += "systemd-auto-enable-policy"
++SYSTEMD_AUTOSTART_DISABLE = "apache2"
++
+ # Whitelist license from some deps.
+ LICENSE_FLAGS_ACCEPTED:append = " commercial synaptics-killswitch"
++
++# Optional support for clang if meta-clang is enabled
++CLANGSDK ?= "1"
+diff --git a/sources/meta-webkit/conf/layer.conf b/sources/meta-webkit/conf/layer.conf
+index 124c13d..1a38638 100644
+--- a/sources/meta-webkit/conf/layer.conf
++++ b/sources/meta-webkit/conf/layer.conf
+@@ -9,6 +9,8 @@ BBFILES_DYNAMIC += " \
+     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bbappend \
+     webserver:${LAYERDIR}/dynamic-layers/webserver/*/*/*.bb \
+     webserver:${LAYERDIR}/dynamic-layers/webserver/*/*/*.bbappend \
++    clang-layer:${LAYERDIR}/dynamic-layers/clang-layer/*/*/*.bb \
++    clang-layer:${LAYERDIR}/dynamic-layers/clang-layer/*/*/*.bbappend \
+     "
+ 
+ BBFILE_COLLECTIONS += "webkit"
+diff --git a/sources/meta-webkit/dynamic-layers/clang-layer/recipes-core/images/webkit-dev-ci-tools.bbappend b/sources/meta-webkit/dynamic-layers/clang-layer/recipes-core/images/webkit-dev-ci-tools.bbappend
+new file mode 100644
+index 0000000..b1950a5
+--- /dev/null
++++ b/sources/meta-webkit/dynamic-layers/clang-layer/recipes-core/images/webkit-dev-ci-tools.bbappend
+@@ -0,0 +1,2 @@
++TOOLCHAIN_HOST_TASK:append = " nativesdk-clang nativesdk-compiler-rt nativesdk-compiler-rt-sanitizers"
++IMAGE_INSTALL:append = " clang compiler-rt compiler-rt-sanitizers libcxx"
+diff --git a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+index 205c058..9cf85c8 100644
+--- a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
++++ b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+@@ -154,6 +154,7 @@
      wayland-protocols \
      openjpeg \
      libbacktrace \
@@ -816,3 +786,16 @@ index 0000000..75b3187
 +RDEPENDS:${PN} = "perl"
 +
 +BBCLASSEXTEND = "native"
+diff --git a/sources/meta-clang/recipes-devtools/clang/compiler-rt-sanitizers_git.bb b/sources/meta-clang/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+index bdd7fea..7005240 100644
+--- a/sources/meta-clang/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
++++ b/sources/meta-clang/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+@@ -89,7 +89,7 @@ do_install:append () {
+         mv ${D}${libdir}/linux ${D}${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib
+     fi
+     # Already shipped with compile-rt Orc support
+-    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}/lib/linux/liborc_rt-*.a
++    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/liborc_rt-*.a
+     rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}/include/orc/
+ }
+ 

--- a/Tools/yocto/riscv/manifest.xml
+++ b/Tools/yocto/riscv/manifest.xml
@@ -8,9 +8,9 @@
 
   <!-- Yocto version: scarthgap -->
 
-  <project remote="yocto"  revision="6879650b927c96a2464224cdc2bed8245511cbf1" name="poky" path="sources/poky"/>
-  <project remote="github" revision="80e01188fa822d87d301ee71973c462d7a865493" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
-  <project remote="github" revision="d330dfe4011a873d379cdf6228fa1f243cf5a6db" name="riscv/meta-riscv" path="sources/meta-riscv"/>
+  <project remote="yocto"  revision="d4576e3c081a7ee7b57d48421c4c4f491cb4defe" name="poky" path="sources/poky"/>
+  <project remote="github" revision="ae7dfb12245c7f9b9a353499e2688015bd4e6413" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="github" revision="76727db91108f53afc8a5b72651167c4446b5fcb" name="riscv/meta-riscv" path="sources/meta-riscv"/>
   <project remote="github" revision="c2ff9fad3831a259256fc2643798f3c6829d15fc" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
 
 </manifest>

--- a/Tools/yocto/riscv/manifest.xml
+++ b/Tools/yocto/riscv/manifest.xml
@@ -3,7 +3,7 @@
   <default sync-j="4"/>
 
   <remote fetch="https://git.openembedded.org/" name="oe"/>
-  <remote fetch="https://git.yoctoproject.org/git/" name="yocto"/>
+  <remote fetch="https://git.yoctoproject.org/" name="yocto"/>
   <remote fetch="https://github.com" name="github"/>
 
   <!-- Yocto version: scarthgap -->

--- a/Tools/yocto/rpi/bblayers.conf
+++ b/Tools/yocto/rpi/bblayers.conf
@@ -19,5 +19,6 @@ BBLAYERS ?= " \
   %(BSPDIR)s/sources/meta-webkit \
   %(BSPDIR)s/sources/meta-clang \
   %(BSPDIR)s/sources/meta-browser/meta-chromium \
+  %(BSPDIR)s/sources/meta-lts-mixins \
   %(BSPDIR)s/sources/meta-raspberrypi \
   "

--- a/Tools/yocto/rpi/local-rpi3-32bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi3-32bits-mesa.conf
@@ -46,10 +46,3 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
-
-# Add netdata to automatically collect system performance metrics
-IMAGE_INSTALL:append = " netdata"
-
-# Add chromium to image to be able to compare WPE/Chromium performance
-IMAGE_INSTALL:append = " chromium-ozone-wayland"
-CHROMIUM_EXTRA_ARGS = "--use-angle=opengles"

--- a/Tools/yocto/rpi/local-rpi3-32bits-userland.conf
+++ b/Tools/yocto/rpi/local-rpi3-32bits-userland.conf
@@ -49,15 +49,3 @@ IMAGE_INSTALL:append = " gstreamer1.0-omx"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
 
-# Workarounds for buildfailures with userland graphic drivers
-# Can be removed once https://github.com/agherzan/meta-raspberrypi/pull/1118 is integrated into meta-raspberry
-PACKAGECONFIG:remove:pn-weston = "egl clients"
-# Can be removed once https://github.com/agherzan/meta-raspberrypi/pull/1119 is integrated into meta-raspberry
-PACKAGECONFIG:append:pn-mesa-gl = " gallium"
-
-# Add netdata to automatically collect system performance metrics
-IMAGE_INSTALL:append = " netdata"
-
-# Add chromium to image to be able to compare WPE/Chromium performance
-IMAGE_INSTALL:append = " chromium-ozone-wayland"
-CHROMIUM_EXTRA_ARGS = "--use-angle=opengles"

--- a/Tools/yocto/rpi/local-rpi3-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi3-64bits-mesa.conf
@@ -46,10 +46,3 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
-
-# Add netdata to automatically collect system performance metrics
-IMAGE_INSTALL:append = " netdata"
-
-# Add chromium to image to be able to compare WPE/Chromium performance
-IMAGE_INSTALL:append = " chromium-ozone-wayland"
-CHROMIUM_EXTRA_ARGS = "--use-angle=opengles"

--- a/Tools/yocto/rpi/local-rpi4-32bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi4-32bits-mesa.conf
@@ -46,10 +46,3 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
-
-# Add netdata to automatically collect system performance metrics
-IMAGE_INSTALL:append = " netdata"
-
-# Add chromium to image to be able to compare WPE/Chromium performance
-IMAGE_INSTALL:append = " chromium-ozone-wayland"
-CHROMIUM_EXTRA_ARGS = "--use-angle=opengles"

--- a/Tools/yocto/rpi/local-rpi4-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi4-64bits-mesa.conf
@@ -46,10 +46,3 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
-
-# Add netdata to automatically collect system performance metrics
-IMAGE_INSTALL:append = " netdata"
-
-# Add chromium to image to be able to compare WPE/Chromium performance
-IMAGE_INSTALL:append = " chromium-ozone-wayland"
-CHROMIUM_EXTRA_ARGS = "--use-angle=opengles"

--- a/Tools/yocto/rpi/local-rpi5-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi5-64bits-mesa.conf
@@ -46,10 +46,3 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
-
-# Add netdata to automatically collect system performance metrics
-IMAGE_INSTALL:append = " netdata"
-
-# Add chromium to image to be able to compare WPE/Chromium performance
-IMAGE_INSTALL:append = " chromium-ozone-wayland"
-CHROMIUM_EXTRA_ARGS = "--use-angle=opengles"

--- a/Tools/yocto/rpi/local-rpi5-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi5-64bits-mesa.conf
@@ -1,0 +1,55 @@
+## -------------------------------------
+## General distro settings below
+## -------------------------------------
+
+# Default help comments were removed to make this file shorter. If you are interested, check:
+# https://git.yoctoproject.org/poky/plain/meta-poky/conf/templates/default/local.conf.sample
+#
+# Check also the README.md file on this repository in the directory: Tools/yocto
+#
+
+# Distro and build base settings
+DISTRO = "webkitdevci"
+PACKAGE_CLASSES ?= "package_rpm"
+USER_CLASSES ?= "buildstats"
+PATCHRESOLVE = "noop"
+BB_DISKMON_DIRS ??= "\
+    STOPTASKS,${TMPDIR},1G,100K \
+    STOPTASKS,${DL_DIR},1G,100K \
+    STOPTASKS,${SSTATE_DIR},1G,100K \
+    STOPTASKS,/tmp,100M,100K \
+    HALT,${TMPDIR},100M,1K \
+    HALT,${DL_DIR},100M,1K \
+    HALT,${SSTATE_DIR},100M,1K \
+    HALT,/tmp,10M,1K"
+CONF_VERSION = "2"
+
+# Uncomment this to have debug symbols for libraries (-dbg packages) installed by default
+#EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+
+## -------------------------------------
+## Specific machine config options below
+## -------------------------------------
+
+## For documentation about this value and defaults suggested check:
+## https://github.com/Igalia/meta-webkit/wiki/RPi
+
+# Machine selection
+MACHINE = "raspberrypi5"
+
+# WPE Backend selection
+PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-fdo"
+
+# Enable GStreamer plugin for accelerated video decoding with RPi opens source drivers.
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
+
+# Enable opus codec support in GStreamer
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
+
+# Add netdata to automatically collect system performance metrics
+IMAGE_INSTALL:append = " netdata"
+
+# Add chromium to image to be able to compare WPE/Chromium performance
+IMAGE_INSTALL:append = " chromium-ozone-wayland"
+CHROMIUM_EXTRA_ARGS = "--use-angle=opengles"

--- a/Tools/yocto/rpi/manifest.xml
+++ b/Tools/yocto/rpi/manifest.xml
@@ -10,7 +10,7 @@
 
   <project remote="yocto"  revision="6879650b927c96a2464224cdc2bed8245511cbf1" name="poky" path="sources/poky"/>
   <project remote="github" revision="80e01188fa822d87d301ee71973c462d7a865493" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
-  <project remote="yocto"  revision="1918a27419dcd5e79954c0dc0edddcde91057a7e" name="meta-raspberrypi" path="sources/meta-raspberrypi"/>
+  <project remote="yocto"  revision="2c646d29912dcc873469a57b1c207e1549c5094d" name="meta-raspberrypi" path="sources/meta-raspberrypi"/>
   <project remote="github" revision="c2ff9fad3831a259256fc2643798f3c6829d15fc" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
   <project remote="github" revision="df21b1563910c80d7e2964971b7c5b79b5186922" name="kraj/meta-clang.git" path="sources/meta-clang"/>
   <project remote="github" revision="83cb90c618e24af9bc40fb25baab2a0acd47a560" name="OSSystems/meta-browser.git" path="sources/meta-browser"/>

--- a/Tools/yocto/rpi/manifest.xml
+++ b/Tools/yocto/rpi/manifest.xml
@@ -2,17 +2,18 @@
 <manifest>
   <default sync-j="4"/>
 
-  <remote fetch="https://git.openembedded.org/" name="oe"/>
   <remote fetch="https://git.yoctoproject.org/git/" name="yocto"/>
   <remote fetch="https://github.com" name="github"/>
 
   <!-- Yocto version: scarthgap -->
 
-  <project remote="yocto"  revision="6879650b927c96a2464224cdc2bed8245511cbf1" name="poky" path="sources/poky"/>
-  <project remote="github" revision="80e01188fa822d87d301ee71973c462d7a865493" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="yocto"  revision="d4576e3c081a7ee7b57d48421c4c4f491cb4defe" name="poky" path="sources/poky"/>
+  <project remote="github" revision="ae7dfb12245c7f9b9a353499e2688015bd4e6413" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
   <project remote="yocto"  revision="2c646d29912dcc873469a57b1c207e1549c5094d" name="meta-raspberrypi" path="sources/meta-raspberrypi"/>
   <project remote="github" revision="c2ff9fad3831a259256fc2643798f3c6829d15fc" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
-  <project remote="github" revision="df21b1563910c80d7e2964971b7c5b79b5186922" name="kraj/meta-clang.git" path="sources/meta-clang"/>
-  <project remote="github" revision="83cb90c618e24af9bc40fb25baab2a0acd47a560" name="OSSystems/meta-browser.git" path="sources/meta-browser"/>
+  <!-- for meta-clang using currently branch scarthgap-clang20 because scarthgap ships clang19 and chromium requires clang >= 20 -->
+  <project remote="github" revision="f26bab34e6c208149fe1ad04521864b663489f4d" name="kraj/meta-clang.git" path="sources/meta-clang"/>
+  <project remote="github" revision="85eeb6b50883d22c977396f5e8fe211a7961cf2e" name="OSSystems/meta-browser.git" path="sources/meta-browser"/>
+  <project remote="yocto" revision="c19b6da5a3afd3c892b3b1b44983e993ac6d5308" name="meta-lts-mixins" path="sources/meta-lts-mixins"/>
 
 </manifest>

--- a/Tools/yocto/rpi/manifest.xml
+++ b/Tools/yocto/rpi/manifest.xml
@@ -2,7 +2,7 @@
 <manifest>
   <default sync-j="4"/>
 
-  <remote fetch="https://git.yoctoproject.org/git/" name="yocto"/>
+  <remote fetch="https://git.yoctoproject.org/" name="yocto"/>
   <remote fetch="https://github.com" name="github"/>
 
   <!-- Yocto version: scarthgap -->

--- a/Tools/yocto/targets.conf
+++ b/Tools/yocto/targets.conf
@@ -80,6 +80,15 @@ image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
 environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DENABLE_SPEECH_SYNTHESIS=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
+[rpi5-64bits-mesa]
+repo_manifest_path = rpi/manifest.xml
+conf_bblayers_path = rpi/bblayers.conf
+conf_local_path = rpi/local-rpi5-64bits-mesa.conf
+image_basename = webkit-dev-ci-tools
+image_types = tar.xz wic.xz wic.bmap
+patch_file_path = meta-openembedded_and_meta-webkit.patch
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DENABLE_SPEECH_SYNTHESIS=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy -DUSE_VULKAN=OFF"
+
 [qemu-riscv64]
 repo_manifest_path = riscv/manifest.xml
 conf_bblayers_path = riscv/bblayers.conf


### PR DESCRIPTION
#### 3fa7d802a968549176b81b4a460ff073d4d4a393
<pre>
Cherry-pick 316883@main (a3bb2650a027). <a href="https://bugs.webkit.org/show_bug.cgi?id=319082">https://bugs.webkit.org/show_bug.cgi?id=319082</a>

    [WPE][cross-toolchain-helper] fatal: repository &apos;<a href="https://git.yoctoproject.org/git/poky/&apos">https://git.yoctoproject.org/git/poky/&apos</a>; not found
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319082">https://bugs.webkit.org/show_bug.cgi?id=319082</a>

    Reviewed by Nikolas Zimmermann.

    It seems the URIs <a href="https://git.yoctoproject.org/git/$repo">https://git.yoctoproject.org/git/$repo</a> are not longer valid,
    and the new valid ones have the format of <a href="https://git.yoctoproject.org/$repo">https://git.yoctoproject.org/$repo</a>

    * Tools/yocto/riscv/manifest.xml:
    * Tools/yocto/rpi/manifest.xml:

    Canonical link: <a href="https://commits.webkit.org/316883@main">https://commits.webkit.org/316883@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1037@webkitglib/2.52">https://commits.webkit.org/305877.1037@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 732b8eca42e0b114d3dc3b583e168329daed7b05
<pre>
Cherry-pick 315104@main (3e38165dc470). <a href="https://bugs.webkit.org/show_bug.cgi?id=315999">https://bugs.webkit.org/show_bug.cgi?id=315999</a>

    [WPE][cross-toolchain-helper] For the optional chromium build, do not set CHROMIUM_EXTRA_ARGS
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315999">https://bugs.webkit.org/show_bug.cgi?id=315999</a>

    Reviewed by Nikolas Zimmermann.

    The flags we were passing to Chromium are not longer valid as those switches got renamed,
    this resulted in Chromium not enabling hardware acceleration (about://gpu).

    Leave the value empty so the recipe defaults to the right values, which are defined via
    PACKAGECONFIG options, and on the current version will resolve to:

    &quot;--use-angle=gles-egl \
     --ozone-platform-hint=wayland \
     --ozone-platform=wayland
     --enable-features=AcceleratedVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL&quot;

    * Tools/yocto/image_extras/chromium.conf:

    Canonical link: <a href="https://commits.webkit.org/315104@main">https://commits.webkit.org/315104@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1036@webkitglib/2.52">https://commits.webkit.org/305877.1036@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b7c8855f77831edb7ab9221cdb7db64af89dc05d
<pre>
Cherry-pick 315103@main (06d7373045ce). <a href="https://bugs.webkit.org/show_bug.cgi?id=316989">https://bugs.webkit.org/show_bug.cgi?id=316989</a>

    [WPE][cross-toolchain-helper] Allow detached tmux/screen sessions, set logind KillUserProcesses=no
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316989">https://bugs.webkit.org/show_bug.cgi?id=316989</a>

    Reviewed by Nikolas Zimmermann.

    Configure the image with KillUserProcesses=no for logind, so it is possible
    to run detached screen or tmux sessions in the background. This is a general
    useful thing for development and matches the behaviour expected on login
    sessions from most desktop distributions.

    * Tools/yocto/meta-openembedded_and_meta-webkit.patch:

    Canonical link: <a href="https://commits.webkit.org/315103@main">https://commits.webkit.org/315103@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1035@webkitglib/2.52">https://commits.webkit.org/305877.1035@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 43059926f558bca6a6513227b8682e4397bd7e4b
<pre>
Cherry-pick 314058@main (79d8bc987197). <a href="https://bugs.webkit.org/show_bug.cgi?id=315748">https://bugs.webkit.org/show_bug.cgi?id=315748</a>

    [WPE][cross-toolchain-helper] Improve support for Clang and implement features &quot;image-extras&quot; and &quot;check-if-layer-is-updated&quot;
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315748">https://bugs.webkit.org/show_bug.cgi?id=315748</a>

    Reviewed by Nikolas Zimmermann.

    The image-extras feature allows building Chromium and Netdata optionally (opt-in),
    so this can be enabled by default on the bots but not for developers which most
    of them don&apos;t care about this, so they don&apos;t need to wait the many hours that
    takes Chromium to be built when testing locally. This will be enabled on the bots
    via env var WEBKIT_CROSS_IMAGE_EXTRAS=chromium+netdata

    The check-if-layer-is-updated feature allows to automatically detect if there are
    new layer updates on the git repository from origin/upstream for the branch that
    is currently beeing used. The idea of this will be to add a new step on the perf
    build bots that check if there are new updates on the meta-browser layer and if
    there are new updates then the step will turn red (error) without blocking the
    next build steps (haltOnFailure = False). That will make easier for bot watchers
    or gardeners to detect this and to submit a PR updating the layer to the last
    version, which should include a new Chromium version. That way we keep testing
    on the perf dashboard new versions of Chromium as those are available but we also
    keep the process of updating the layer version semi-manual, so this update gets
    registered as commit on webkit and bisection of any performance issue becomes
    possible (because the layer update can affect also libraries used by webkit).

    This patch also improves the support for Clang. Now it is possible to use
    Clang to build webkit via script build-webkit when using cross-toolchain-helper,
    or inside the cross-dev-shell. For that simply set on your environment
    CC=clang CXX=clang++ before starting the webkit build or executing cross-dev-shell.

    This also fixes an issue when parsing the cmakeargs arrguments in build-webkit
    when those contain spaces, now it uses shlex instead of manual scaping the quotes,
    which is more robust.

    And finally it updates all the layer references (but meta-webkit) to the last versions
    available for Yocto scarthgap branch, removing from the common patch those chunks that
    were already merged upstream, and adding new chunks to support this changes.

    * Tools/Scripts/cross-toolchain-helper:
    (YoctoTargetsConfig.__init__):
    (YoctoTargetsConfig._get_path):
    (YoctoTargetsConfig.get_environment):
    (YoctoTargetsConfig):
    (YoctoTargetsConfig.get_extra_images_fragment_file_paths):
    (YoctoTargetsConfig.get_hash_for_target):
    (YoctoTargetsConfig.generate_and_export_hash_version_identifier):
    (YoctoCrossBuilder):
    (YoctoCrossBuilder.__init__):
    (YoctoCrossBuilder._check_or_init_image_extras_file):
    (YoctoCrossBuilder._check_or_init_image_extras_file.log_image_extras):
    (YoctoCrossBuilder._run_cmd):
    (YoctoCrossBuilder._add_recipe_to_include_version_file_into_image):
    (YoctoCrossBuilder._initialize_workdir):
    (YoctoCrossBuilder._do_bitbake):
    (YoctoCrossBuilder.build_toolchain):
    (YoctoCrossBuilder.cross_dev_shell):
    (YoctoCrossBuilder.execute_cmd_inside_cross_toolchain_env):
    (YoctoCrossBuilder.execute_deploy_script):
    (YoctoCrossBuilder.check_if_image_is_updated):
    (YoctoCrossBuilder.check_layer_updates):
    (main):
    * Tools/yocto/README.md:
    * Tools/yocto/image_extras/chromium.conf: Added.
    * Tools/yocto/image_extras/netdata.conf: Added.
    * Tools/yocto/meta-openembedded_and_meta-webkit.patch:
    * Tools/yocto/riscv/manifest.xml:
    * Tools/yocto/rpi/bblayers.conf:
    * Tools/yocto/rpi/local-rpi3-32bits-mesa.conf:
    * Tools/yocto/rpi/local-rpi3-32bits-userland.conf:
    * Tools/yocto/rpi/local-rpi3-64bits-mesa.conf:
    * Tools/yocto/rpi/local-rpi4-32bits-mesa.conf:
    * Tools/yocto/rpi/local-rpi4-64bits-mesa.conf:
    * Tools/yocto/rpi/local-rpi5-64bits-mesa.conf:
    * Tools/yocto/rpi/manifest.xml:

    Canonical link: <a href="https://commits.webkit.org/314058@main">https://commits.webkit.org/314058@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1034@webkitglib/2.52">https://commits.webkit.org/305877.1034@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 581974808d90a298f2737fece9f18a3c116932a2
<pre>
Cherry-pick 305887@main (bfc4c6e3d42a). <a href="https://bugs.webkit.org/show_bug.cgi?id=305841">https://bugs.webkit.org/show_bug.cgi?id=305841</a>

    [WPE][cross-toolchain-helper]: libhyphen is required by default on WPE after 305816@main
    <a href="https://bugs.webkit.org/show_bug.cgi?id=305841">https://bugs.webkit.org/show_bug.cgi?id=305841</a>

    Unreviewed build fix.

    After 305816@main libhyphen is required by the default WPE build.
    However this dependency was not available on the Yocto environment
    used by the RPi4 perf bots.

    This patch adds the recipe for libhyphen and builds the dependency
    into the default image that cross-toolchain-helper generates.

    The changes are integrated here as a local patch that has been
    forwarded in another PR to the meta-webkit layer repo for review.
    Refs: <a href="https://github.com/Igalia/meta-webkit/pull/582">https://github.com/Igalia/meta-webkit/pull/582</a>

    * Tools/yocto/meta-openembedded_and_meta-webkit.patch:

    Canonical link: <a href="https://commits.webkit.org/305887@main">https://commits.webkit.org/305887@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1033@webkitglib/2.52">https://commits.webkit.org/305877.1033@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6feceb27af2c8e951870d30e1895a45169aabda6
<pre>
Cherry-pick 313500@main (fb1bf8cca1e4). <a href="https://bugs.webkit.org/show_bug.cgi?id=315079">https://bugs.webkit.org/show_bug.cgi?id=315079</a>

    [WPE][cross-toolchain-helper] Add rpi5-64bits
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315079">https://bugs.webkit.org/show_bug.cgi?id=315079</a>

    Reviewed by Carlos Alberto Lopez Perez.

    Add configuration, define target.

    Canonical link: <a href="https://commits.webkit.org/313500@main">https://commits.webkit.org/313500@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1032@webkitglib/2.52">https://commits.webkit.org/305877.1032@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### a3e2a347cac2459ffb24632d96aa347bea8cb358
<pre>
Cherry-pick 307070@main (c518b4423ada). <a href="https://bugs.webkit.org/show_bug.cgi?id=307119">https://bugs.webkit.org/show_bug.cgi?id=307119</a>

    [WPE][cross-toolchain-helper] Issues cross-building WebKit inside the SDK due to LD_LIBRARY_PATH
    <a href="https://bugs.webkit.org/show_bug.cgi?id=307119">https://bugs.webkit.org/show_bug.cgi?id=307119</a>

    Reviewed by Nikolas Zimmermann.

    Inside the SDK by default LD_LIBRARY_PATH is defined to the /jhbuild path. This seems to cause
    problems with the cross-builds via cross-toolchain-helper, because it ends producing artifacts
    for the native architecture instead for the cross-target one.

    There are also a bunch of other env vars defined on the SDK by default (related to jhbuild)
    that are potentially problematic for a cross-build environment.

    This patch ensures that this the environment variables for the cross-target build are cleaned
    automatically before starting the build.

    * Tools/Scripts/cross-toolchain-helper:
    (YoctoCrossBuilder._initialize_environment_for_target):
    * Tools/yocto/README.md:

    Canonical link: <a href="https://commits.webkit.org/307070@main">https://commits.webkit.org/307070@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1031@webkitglib/2.52">https://commits.webkit.org/305877.1031@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6db265cfad1a53c2e2c3fb0ae714210a26b91ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178717 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52655 "Build is in progress. Recent messages:") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46450 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188333 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143026 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180580 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53949 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52366 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143026 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181674 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53949 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46450 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/119800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178042 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53949 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52366 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46450 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53949 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46450 "The change is no longer eligible for processing.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45256 "Build is in progress. Recent messages:") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52366 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190761 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/178120 "Build is in progress. Recent messages:") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52325 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46450 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53005 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46450 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/148288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27113 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53005 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119933 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51523 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46450 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50908 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51148 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50970 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->