### PR TITLE
run-webkit-tests never finds crash logs for ServiceWorkerProcess crashes

### DIFF
--- a/Tools/Scripts/webkitpy/common/system/crashlogs.py
+++ b/Tools/Scripts/webkitpy/common/system/crashlogs.py
@@ -45,6 +45,12 @@ class CrashLogs(object):
     EXIT_PROCESS_PID_REGEX = re.compile(r'Exit process \d+:(?P<pid>\w+), code')
     DARWIN_PROCESS_REGEX = re.compile(r'^Process:\s+(?P<process_name>.*) \[(?P<pid>\d+)\]$')
 
+    # Reported crash-process name -> exact on-disk procName(s), honored only with a matching PID.
+    # The WebContent names mirror TestController::webProcessName() (device, and internal ".Development").
+    PROCESS_NAME_ALIASES = {
+        'ServiceWorkerProcess': ('com.apple.WebKit.WebContent', 'com.apple.WebKit.WebContent.Development'),
+    }
+
     def __init__(self, host, crash_log_directory, crash_logs_to_skip=[]):
         self._host = host
         if isinstance(crash_log_directory, (list, tuple, set)):
@@ -92,11 +98,19 @@ class CrashLogs(object):
         return (None, None, contents)
 
     def _find_newest_log_darwin(self, process_name, pid, include_errors, newer_than):
+        alias_names = CrashLogs.PROCESS_NAME_ALIASES.get(process_name, ()) if pid is not None else ()
+
+        def name_matches(parsed_name):
+            return parsed_name == process_name or parsed_name in alias_names
+
         def is_crash_log(fs, dirpath, basename):
             if self._crash_logs_to_skip and fs.join(dirpath, basename) in self._crash_logs_to_skip:
                 return False
-            return (basename.startswith(process_name + '_') and (basename.endswith('.crash')) or
-                    (process_name in basename and basename.endswith('.ips')))
+            if basename.endswith('.crash'):
+                return basename.startswith(process_name + '_') or any(basename.startswith(name + '_') for name in alias_names)
+            if basename.endswith('.ips'):
+                return process_name in basename or any(name in basename for name in alias_names)
+            return False
 
         logs = []
         for directory in self._crash_log_directories:
@@ -106,7 +120,7 @@ class CrashLogs(object):
             try:
                 if not newer_than or self._host.filesystem.mtime(path) > newer_than:
                     parsed_name, parsed_pid, log_contents = self._parse_darwin_crash_log(path)
-                    if parsed_name == process_name and (pid is None or parsed_pid == pid):
+                    if name_matches(parsed_name) and (pid is None or parsed_pid == pid):
                         return errors + log_contents
             except IOError as e:
                 if include_errors:

--- a/Tools/Scripts/webkitpy/common/system/crashlogs_unittest.py
+++ b/Tools/Scripts/webkitpy/common/system/crashlogs_unittest.py
@@ -383,6 +383,73 @@ class CrashLogsTest(unittest.TestCase):
         log = crash_logs.find_newest_log("DumpRenderTree", newer_than=1.0, include_errors=True)
         self.assertIn('OSError: No such file or directory', log)
 
+    def test_find_log_darwin_service_worker_process(self):
+        # A service worker runs inside a WebContent process, so WebKitTestRunner reports its
+        # crash as "ServiceWorkerProcess" while the on-disk report's procName is
+        # com.apple.WebKit.WebContent[.Development].  find_newest_log() must match such a
+        # report to "ServiceWorkerProcess" when the PID also matches.
+        if not SystemHost.get_default().platform.is_mac():
+            return
+
+        def crash_logs_for(files):
+            files = {key: string_utils.encode(value) for key, value in files.items()}
+            return CrashLogs(MockSystemHost(filesystem=MockFileSystem(files)), CrashLogsTest.DARWIN_MOCK_CRASH_DIRECTORY)
+
+        # A WebContent report matches a same-PID ServiceWorkerProcess query; a different PID does not.
+        web_content_report = make_mock_ips_crash_report_darwin('com.apple.WebKit.WebContent.Development', 4242)
+        crash_logs = crash_logs_for({
+            '/Users/mock/Library/Logs/DiagnosticReports/com.apple.WebKit.WebContent.Development-2026-08-04-085156.ips': web_content_report,
+        })
+        self.assertMultiLineEqual(crash_logs.find_newest_log('ServiceWorkerProcess', 4242), web_content_report)
+        self.assertIsNone(crash_logs.find_newest_log('ServiceWorkerProcess', 4243))
+
+        # The ".Development" suffix is optional (absent on device/release builds).
+        web_content_report_release = make_mock_ips_crash_report_darwin('com.apple.WebKit.WebContent', 4242)
+        crash_logs = crash_logs_for({
+            '/Users/mock/Library/Logs/DiagnosticReports/com.apple.WebKit.WebContent-2026-08-04-085156.ips': web_content_report_release,
+        })
+        self.assertMultiLineEqual(crash_logs.find_newest_log('ServiceWorkerProcess', 4242), web_content_report_release)
+
+        # A prefix-similar but non-WebContent procName is not matched (exact names only, not a prefix).
+        imposter_report = make_mock_ips_crash_report_darwin('com.apple.WebKit.WebContentImposter', 4242)
+        crash_logs = crash_logs_for({
+            '/Users/mock/Library/Logs/DiagnosticReports/com.apple.WebKit.WebContentImposter-2026-08-04-085156.ips': imposter_report,
+        })
+        self.assertIsNone(crash_logs.find_newest_log('ServiceWorkerProcess', 4242))
+
+        # With multiple WebContent reports, the one whose PID matches is chosen.
+        report_4243 = make_mock_ips_crash_report_darwin('com.apple.WebKit.WebContent.Development', 4243)
+        crash_logs = crash_logs_for({
+            '/Users/mock/Library/Logs/DiagnosticReports/com.apple.WebKit.WebContent.Development-2026-08-04-085156.ips': web_content_report,
+            '/Users/mock/Library/Logs/DiagnosticReports/com.apple.WebKit.WebContent.Development-2026-08-04-085200.ips': report_4243,
+        })
+        self.assertMultiLineEqual(crash_logs.find_newest_log('ServiceWorkerProcess', 4242), web_content_report)
+        self.assertMultiLineEqual(crash_logs.find_newest_log('ServiceWorkerProcess', 4243), report_4243)
+
+        # Legacy .crash reports are matched by filename prefix (procName + '_'), so an aliased
+        # WebContent .crash report must also be found for a same-PID ServiceWorkerProcess query.
+        crash_report = make_mock_crash_report_darwin('com.apple.WebKit.WebContent.Development', 4242)
+        crash_logs = crash_logs_for({
+            '/Users/mock/Library/Logs/DiagnosticReports/com.apple.WebKit.WebContent.Development_2026-08-04-085156_host.crash': crash_report,
+        })
+        self.assertMultiLineEqual(crash_logs.find_newest_log('ServiceWorkerProcess', 4242), crash_report)
+        self.assertIsNone(crash_logs.find_newest_log('ServiceWorkerProcess', 4243))
+
+        # The ".Development" suffix is optional (absent on device/release builds).
+        crash_report_release = make_mock_crash_report_darwin('com.apple.WebKit.WebContent', 4242)
+        crash_logs = crash_logs_for({
+            '/Users/mock/Library/Logs/DiagnosticReports/com.apple.WebKit.WebContent_2026-08-04-085156_host.crash': crash_report_release,
+        })
+        self.assertMultiLineEqual(crash_logs.find_newest_log('ServiceWorkerProcess', 4242), crash_report_release)
+
+        # A prefix-similar but non-WebContent procName is not matched in .crash files either:
+        # the alias filter anchors on procName + '_', so "...WebContentImposter_" is rejected.
+        imposter_crash_report = make_mock_crash_report_darwin('com.apple.WebKit.WebContentImposter', 4242)
+        crash_logs = crash_logs_for({
+            '/Users/mock/Library/Logs/DiagnosticReports/com.apple.WebKit.WebContentImposter_2026-08-04-085156_host.crash': imposter_crash_report,
+        })
+        self.assertIsNone(crash_logs.find_newest_log('ServiceWorkerProcess', 4242))
+
     def test_find_log_win(self):
         if not SystemHost.get_default().platform.is_win():
             return

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -191,6 +191,18 @@ class DarwinPort(ApplePort):
         return directories
 
     def _merge_crash_logs(self, logs, new_logs, crashed_processes):
+        def already_collected(process_name, pid):
+            # A crash report's parsed procName may be an alias of the reported crash-process
+            # name (e.g. a ServiceWorkerProcess crash is recorded under a WebContent procName).
+            # Match those the way CrashLogs._find_newest_log_darwin does, so an aliased crash
+            # already collected in the first pass is not appended again as a "new" crash.
+            for _, reported_name, reported_pid in crashed_processes:
+                if reported_pid != pid:
+                    continue
+                if process_name == reported_name or process_name in CrashLogs.PROCESS_NAME_ALIASES.get(reported_name, ()):
+                    return True
+            return False
+
         for test, crash_log in new_logs.items():
             try:
                 if test.split('-')[0] == 'Sandbox':
@@ -201,7 +213,7 @@ class DarwinPort(ApplePort):
                     pid = int(test.split('-')[1])
             except (IndexError, ValueError):
                 continue
-            if not any(entry[1] == process_name and entry[2] == pid for entry in crashed_processes):
+            if not already_collected(process_name, pid):
                 # if this is a new crash, then append the logs
                 logs[test] = crash_log
         return logs

--- a/Tools/Scripts/webkitpy/port/mac_unittest.py
+++ b/Tools/Scripts/webkitpy/port/mac_unittest.py
@@ -298,3 +298,30 @@ class MacTest(darwin_testcase.DarwinTest):
             list(port.expectations_dict().keys())[-1],
             '/mock-checkout/LayoutTests/platform/mac/TestExpectationsRosetta',
         )
+
+    def test_merge_crash_logs_service_worker_process(self):
+        # A ServiceWorkerProcess crash is recorded on disk under a WebContent procName, so
+        # look_for_new_crash_logs() collects it in its first pass keyed by the layout-test
+        # name, while find_all_logs() re-keys the same report as
+        # "com.apple.WebKit.WebContent[.Development]-<pid>".  _merge_crash_logs() must treat
+        # that WebContent procName as the same ServiceWorkerProcess crash (via
+        # CrashLogs.PROCESS_NAME_ALIASES) and not append it a second time.
+        port = self.make_port()
+        crashed_processes = [('http/tests/workers/service/basic.https', 'ServiceWorkerProcess', 4242)]
+        for procname in ('com.apple.WebKit.WebContent', 'com.apple.WebKit.WebContent.Development'):
+            merged = port._merge_crash_logs(
+                {'http/tests/workers/service/basic.https': 'first-pass-log'},
+                {'{}-4242'.format(procname): 'all-logs-log', 'FooProcess-4243': 'unrelated-log'},
+                crashed_processes,
+            )
+            # The aliased WebContent crash duplicates the ServiceWorkerProcess crash: not re-added.
+            self.assertNotIn('{}-4242'.format(procname), merged)
+            # The first-pass ServiceWorkerProcess log is preserved.
+            self.assertEqual('first-pass-log', merged['http/tests/workers/service/basic.https'])
+            # An unrelated crash is still appended.
+            self.assertEqual('unrelated-log', merged['FooProcess-4243'])
+
+        # A WebContent crash whose PID does not match the ServiceWorkerProcess PID is a
+        # genuinely new crash and is still appended.
+        merged = port._merge_crash_logs({}, {'com.apple.WebKit.WebContent-9999': 'other-pid-log'}, crashed_processes)
+        self.assertEqual('other-pid-log', merged['com.apple.WebKit.WebContent-9999'])


### PR DESCRIPTION
#### d56b981275a4256e3cfdef89249795f1c8596bf1
<pre>
run-webkit-tests never finds crash logs for ServiceWorkerProcess crashes
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=321022">https://bugs.webkit.org/show_bug.cgi?id=321022</a>&gt;
&lt;<a href="https://rdar.apple.com/184059659">rdar://184059659</a>&gt;

Reviewed by Zak Ridouh.

run-webkit-tests matches a crashed process to its on-disk crash report
by process name. A service worker runs inside a WebContent process, so
WebKitTestRunner reports its crash as &quot;ServiceWorkerProcess&quot; while the
crash report&apos;s procName is a WebContent process name. The name-based
match therefore never succeeds, so run-webkit-tests writes a &quot;No crash
log found for ServiceWorkerProcess:&lt;pid&gt;&quot; placeholder even when a
report exists.

Alias &quot;ServiceWorkerProcess&quot; to the exact WebContent process names that
TestController::webProcessName() reports on Cocoa, both
&quot;com.apple.WebKit.WebContent&quot; and its internal &quot;.Development&quot; form.
Honor the alias in both crash-report file filters (&quot;.crash&quot; and &quot;.ips&quot;)
and match a report whose procName is exactly one of those and whose PID
matches the crashed process.

Also honor the alias when merging the second-pass crash logs.
look_for_new_crash_logs() collects each crash twice -- once per crashed
process by name and PID, and once by scanning every on-disk report --
and relies on _merge_crash_logs() to drop the second-pass duplicates by
matching each report&apos;s procName against the crashed process names.
The report is stored under its WebContent procName, so without
consulting the alias there, the ServiceWorkerProcess crash already
collected in the first pass would be appended a second time.

Covered by new webkitpy unit tests.

* Tools/Scripts/webkitpy/common/system/crashlogs.py:
(CrashLogs):
- Added PROCESS_NAME_ALIASES.
(CrashLogs._find_newest_log_darwin):
* Tools/Scripts/webkitpy/common/system/crashlogs_unittest.py:
(CrashLogsTest.test_find_log_darwin_service_worker_process): Added.
* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort._merge_crash_logs):
* Tools/Scripts/webkitpy/port/mac_unittest.py:
(MacTest.test_merge_crash_logs_service_worker_process): Added.

Canonical link: <a href="https://commits.webkit.org/318611@main">https://commits.webkit.org/318611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/949169e012290524f8f5b5b416258aa2e5f32379

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52761 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46556 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188439 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d468957-1d35-4bc0-be9f-714b2d88859b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52472 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3bd5f0e0-7c4b-4a06-82e5-ff0f4513137a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181780 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/119890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64f66df6-0809-450b-ad28-88077af5d084) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178148 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190867 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52431 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/159691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53111 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148386 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27131 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43083 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120049 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51629 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/14647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51014 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51254 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51076 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->