### PR TITLE
Cherry-pick 314136@main (f1c9e4d06275). https://bugs.webkit.org/show_bug.cgi?id=315783

### DIFF
--- a/Tools/Scripts/cross-toolchain-helper
+++ b/Tools/Scripts/cross-toolchain-helper
@@ -60,9 +60,9 @@ def configure_logging(selected_log_level='info'):
     elif selected_log_level == 'info':
         log_level = logging.INFO
     elif selected_log_level == 'quiet':
-        log_level = logging.NOTSET
+        log_level = logging.CRITICAL + 1
     elif selected_log_level == 'minimal':
-        log_level = logging.getLevelName(LOG_MESSAGE)
+        log_level = LOG_MESSAGE
 
     handler = LogHandler(sys.stdout)
     logger = logging.getLogger()
@@ -655,7 +655,7 @@ class YoctoCrossBuilder():
             fw.write('echo "${COMPNAME} version: $($CC -dumpversion)"\n')
             fw.write('echo "${COMPNAME} target: $($CC -dumpmachine)"\n')
             fw.write('echo -e "\\nCall the cross compiler/debugger"\n')
-            fw.write('echo "with env vars: \$CC / \$CXX / \$GDB"\n')
+            fw.write('echo "with env vars: \\$CC / \\$CXX / \\$GDB"\n')
             fw.write('echo "##################################"\n')
             fw.write('export PS1="(WKCrossDevShell:{target}) ${{PS1}}"\n'.format(target=self._target))
         assert (os.path.isfile(custom_rc_file))

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -579,11 +579,13 @@ sub determineArchitecture
             if (shouldBuildForCrossTarget()) {
                 my $helper = File::Spec->catfile(sourceDir(), "Tools", "Scripts", "cross-toolchain-helper");
                 my $target = getCrossTargetName();
-                # Pre-build the toolchain so its (potentially multi-hour) bitbake output reaches
+                # Pre-build the toolchain if needed so its (potentially multi-hour) bitbake output reaches
                 # the terminal instead of being swallowed by the pipe opened below.
-                system($helper, "--cross-target=$target", "--build-toolchain") == 0
+                # Pass --log-level=quiet here to avoid repeated info messages from the tool, those info messages
+                # would be printed later when the build is started later at runInCrossTargetEnvironment()
+                system($helper, "--log-level=quiet", "--cross-target=$target", "--build-toolchain") == 0
                     or die "cross-toolchain-helper --build-toolchain failed for $target\n";
-                $prefix = "$helper --cross-target=$target --cross-toolchain-run-cmd";
+                $prefix = "$helper --log-level=quiet --cross-target=$target --cross-toolchain-run-cmd";
             }
             if (open my $cmake_sysinfo, "$prefix cmake --system-information |") {
                 while (<$cmake_sysinfo>) {
@@ -2955,14 +2957,15 @@ sub generateBuildSystemFromCMakeProject
     # The GTK and WPE bots build and test with -DENABLE_ASSERTS=ON (both on Release and Debug).
     # Warn when the local build differs from the CI configuration.
     if (isGtk() || isWPE()) {
+        # configuration() is the name of the build config and directory, and in the case of a cross-toolchain
+        # build it is something like "Release_rpi4-64bits-mesa" (for example), so this doesn't trigger in that case.
+        # That is intentional: the CI does not enable assertions for cross-toolchain builds, so no need to warn.
         if (configuration() eq "Release") {
             my $assertsOn = grep { /^-DENABLE_ASSERTS=ON\b/i } @args;
             print STDERR "WARNING: Building Release without assertions. Pass --asserts to match the CI build.\n" unless $assertsOn;
         } elsif (configuration() eq "Debug") {
             my $assertsOff = grep { /^-DENABLE_ASSERTS=OFF\b/i } @args;
             print STDERR "WARNING: Building Debug with assertions disabled. Drop --no-asserts to match the CI build.\n" if $assertsOff;
-        } else {
-            print STDERR "WARNING: Building " . configuration() . ". This is not tested on the CI.\n";
         }
     }
 

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -581,9 +581,10 @@ sub determineArchitecture
                 my $target = getCrossTargetName();
                 # Pre-build the toolchain if needed so its (potentially multi-hour) bitbake output reaches
                 # the terminal instead of being swallowed by the pipe opened below.
-                # Pass --log-level=quiet here to avoid repeated info messages from the tool, those info messages
-                # would be printed later when the build is started later at runInCrossTargetEnvironment()
-                system($helper, "--log-level=quiet", "--cross-target=$target", "--build-toolchain") == 0
+                # The build-toolchain call runs with info log level (the default) because it is the first
+                # one to happen, so those messages are printed at the start. Next calls to cross-toolchain-helper
+                # should pass --log-level=quiet to avoid repeated messages.
+                system($helper, "--cross-target=$target", "--build-toolchain") == 0
                     or die "cross-toolchain-helper --build-toolchain failed for $target\n";
                 $prefix = "$helper --log-level=quiet --cross-target=$target --cross-toolchain-run-cmd";
             }
@@ -2537,8 +2538,10 @@ sub inFlatpakSandbox()
 sub runInCrossTargetEnvironment(@)
 {
     return if not shouldBuildForCrossTarget();
+    # Run with quiet log level to avoid repeated messages, the first run at determineArchitecture()
+    # to build the toolchain happens with log level info (the default)
     my @prefix = (File::Spec->catfile(sourceDir(), "Tools", "Scripts", "cross-toolchain-helper"),
-                  "--cross-target", getCrossTargetName(), "--cross-toolchain-run-cmd");
+                  "--log-level=quiet", "--cross-target", getCrossTargetName(), "--cross-toolchain-run-cmd");
     my @command = @_;
     exec @prefix, @command, argumentsForConfiguration(), @ARGV or die;
 }

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2952,6 +2952,20 @@ sub generateBuildSystemFromCMakeProject
     my $cmakeSourceDir = isCygwin() ? windowsSourceDir() : sourceDir();
     push @args, '"' . $cmakeSourceDir . '"';
 
+    # The GTK and WPE bots build and test with -DENABLE_ASSERTS=ON (both on Release and Debug).
+    # Warn when the local build differs from the CI configuration.
+    if (isGtk() || isWPE()) {
+        if (configuration() eq "Release") {
+            my $assertsOn = grep { /^-DENABLE_ASSERTS=ON\b/i } @args;
+            print STDERR "WARNING: Building Release without assertions. Pass --asserts to match the CI build.\n" unless $assertsOn;
+        } elsif (configuration() eq "Debug") {
+            my $assertsOff = grep { /^-DENABLE_ASSERTS=OFF\b/i } @args;
+            print STDERR "WARNING: Building Debug with assertions disabled. Drop --no-asserts to match the CI build.\n" if $assertsOff;
+        } else {
+            print STDERR "WARNING: Building " . configuration() . ". This is not tested on the CI.\n";
+        }
+    }
+
     # We call system("cmake @args") instead of system("cmake", @args) so that @args is
     # parsed for shell metacharacters.
     my $wrapper = join(" ", wrapperPrefixIfNeeded()) . " ";

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -577,9 +577,13 @@ sub determineArchitecture
             # This gets called from argumentsForConfiguration() which needs to resolve the target architecture
             # before entering into the cross-toolchain-env, so to achieve that we call the cross-target cmake.
             if (shouldBuildForCrossTarget()) {
-                $prefix = sprintf("%s --cross-target=%s --cross-toolchain-run-cmd",
-                            File::Spec->catfile(sourceDir(), "Tools", "Scripts", "cross-toolchain-helper"),
-                            getCrossTargetName());
+                my $helper = File::Spec->catfile(sourceDir(), "Tools", "Scripts", "cross-toolchain-helper");
+                my $target = getCrossTargetName();
+                # Pre-build the toolchain so its (potentially multi-hour) bitbake output reaches
+                # the terminal instead of being swallowed by the pipe opened below.
+                system($helper, "--cross-target=$target", "--build-toolchain") == 0
+                    or die "cross-toolchain-helper --build-toolchain failed for $target\n";
+                $prefix = "$helper --cross-target=$target --cross-toolchain-run-cmd";
             }
             if (open my $cmake_sysinfo, "$prefix cmake --system-information |") {
                 while (<$cmake_sysinfo>) {

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -572,15 +572,25 @@ sub determineArchitecture
             $compiler = $ENV{'CC'} if (defined($ENV{'CC'}));
             my @compiler_machine = split('-', `$compiler -dumpmachine`);
             $architecture = $compiler_machine[0];
-        } elsif (open my $cmake_sysinfo, "cmake --system-information |") {
-            while (<$cmake_sysinfo>) {
-                next unless index($_, 'CMAKE_SYSTEM_PROCESSOR') == 0;
-                if (/^CMAKE_SYSTEM_PROCESSOR \"([^"]+)\"/) {
-                    $architecture = $1;
-                    last;
-                }
+        } else {
+            my $prefix = "";
+            # This gets called from argumentsForConfiguration() which needs to resolve the target architecture
+            # before entering into the cross-toolchain-env, so to achieve that we call the cross-target cmake.
+            if (shouldBuildForCrossTarget()) {
+                $prefix = sprintf("%s --cross-target=%s --cross-toolchain-run-cmd",
+                            File::Spec->catfile(sourceDir(), "Tools", "Scripts", "cross-toolchain-helper"),
+                            getCrossTargetName());
             }
-            close $cmake_sysinfo;
+            if (open my $cmake_sysinfo, "$prefix cmake --system-information |") {
+                while (<$cmake_sysinfo>) {
+                    next unless index($_, 'CMAKE_SYSTEM_PROCESSOR') == 0;
+                    if (/^CMAKE_SYSTEM_PROCESSOR \"([^"]+)\"/) {
+                        $architecture = $1;
+                        last;
+                    }
+                }
+                close $cmake_sysinfo;
+            }
         }
     }
 

--- a/Tools/Scripts/webkitperl/FeatureList.pm
+++ b/Tools/Scripts/webkitperl/FeatureList.pm
@@ -54,6 +54,7 @@ my (
     $accessibilityIsolatedTreeSupport,
     $applePaySupport,
     $applicationManifestSupport,
+    $assertsEnabled,
     $asyncScrollingSupport,
     $attachmentElementSupport,
     $autocapitalizeSupport,
@@ -164,6 +165,10 @@ my (
 );
 
 my @features = (
+
+    { option => "asserts", desc => "Toggle assertions (CMake only). Defaults to disable on Release, enable on Debug.",
+      define => "ENABLE_ASSERTS", value => \$assertsEnabled, },
+
     { option => "fatal-warnings", desc => "Toggle warnings as errors (CMake only)",
       define => "DEVELOPER_MODE_FATAL_WARNINGS", value => \$fatalWarnings },
 


### PR DESCRIPTION
#### 0e9b63f0ca874fb42472d499e862a27c4b5b2c2b
<pre>
Cherry-pick 314136@main (f1c9e4d06275). <a href="https://bugs.webkit.org/show_bug.cgi?id=315783">https://bugs.webkit.org/show_bug.cgi?id=315783</a>

    [WPE][cross-toolchain-helper] REGRESSION(313950@main): repeated info messages and wrong warning when building webkit (v2)
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315783">https://bugs.webkit.org/show_bug.cgi?id=315783</a>

    Unreviewed follow-up patch.

    314131@main made quiet the call to build the cross-toolchain and left verbose
    the one to execute build-webkit inside the environment, but is better to do
    the other way around. Because the one to build the toolchain happens first,
    so it is less confusing to print the log messages at the start of the build
    rather than in the middle (which happens when the toolchain is not built or
    is invalidated by a config change)

    * Tools/Scripts/webkitdirs.pm:
    (determineArchitecture):
    (runInCrossTargetEnvironment):

    Canonical link: <a href="https://commits.webkit.org/314136@main">https://commits.webkit.org/314136@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1042@webkitglib/2.52">https://commits.webkit.org/305877.1042@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### f25e85f2e3a857b57c095959be85161870f77bb8
<pre>
Cherry-pick 314131@main (778e858024a4). <a href="https://bugs.webkit.org/show_bug.cgi?id=315783">https://bugs.webkit.org/show_bug.cgi?id=315783</a>

    [WPE][cross-toolchain-helper] REGRESSION(313950@main) REGRESSION(313986@main): repeated info messages and wrong warning when building WebKit
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315783">https://bugs.webkit.org/show_bug.cgi?id=315783</a>

    Reviewed by Nikolas Zimmermann.

    After 313950@main cross-toolchain-helper is called twice with output stdout
    (not captured) and each time it gets executed it prints several info messages,
    so it ends printing those info messages twice.
    Fix that by suppressing the info messages on the first run.
    And also fix a bug in the logger level of cross-toolchain-helper, because
    &quot;quiet&quot; was not working.

    After 313986@main when doing a cross-toolchain-helper it printed this:
      WARNING: Building Release_rpi4-64bits-mesa. This is not tested on the CI.
    That is wrong, so fix it also.

    * Tools/Scripts/cross-toolchain-helper:
    (configure_logging):
    (YoctoCrossBuilder.cross_dev_shell):
    * Tools/Scripts/webkitdirs.pm:
    (determineArchitecture):
    (generateBuildSystemFromCMakeProject):

    Canonical link: <a href="https://commits.webkit.org/314131@main">https://commits.webkit.org/314131@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1041@webkitglib/2.52">https://commits.webkit.org/305877.1041@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6fc54bedd0aea441417fb380e948e32310aee94e
<pre>
Cherry-pick 313986@main (b5a4cbb2ccc9). <a href="https://bugs.webkit.org/show_bug.cgi?id=315565">https://bugs.webkit.org/show_bug.cgi?id=315565</a>

    [WPE][GTK] Warn in build-webkit when building Release without assertions
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315565">https://bugs.webkit.org/show_bug.cgi?id=315565</a>

    Reviewed by Justin Michaud.

    The GTK and WPE EWS bots build and test with -DENABLE_ASSERTS=ON for
    both Release and Debug, but the default developer build does not match
    this configuration on Release (where the CMake default value disables
    assertions). This mismatch means that issues caught by assertions on
    the CI can go unnoticed when reproducing locally.

    Rather than silently changing the default for everyone, surface the
    mismatch more clearly so developers can opt in:

      * Expose ENABLE_ASSERTS as a build-webkit feature option, so
        --asserts / --no-asserts can be passed to enable or disable
        assertions explicitly (translating into -DENABLE_ASSERTS=ON|OFF
        for CMake-based builds).

      * Print a one-line warning at CMake configure time when building
        GTK or WPE without assertions enabled. On Release this warns
        unless --asserts (or an equivalent -DENABLE_ASSERTS=ON) is
        passed; on Debug it warns only when assertions have been
        explicitly disabled via --no-asserts or -DENABLE_ASSERTS=OFF.

    * Tools/Scripts/webkitdirs.pm:
    (generateBuildSystemFromCMakeProject):
    * Tools/Scripts/webkitperl/FeatureList.pm:

    Canonical link: <a href="https://commits.webkit.org/313986@main">https://commits.webkit.org/313986@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1040@webkitglib/2.52">https://commits.webkit.org/305877.1040@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 16640be16d31c4d70a9556cbdae5288c2dfc3b39
<pre>
Cherry-pick 313950@main (2959d7c8b288). <a href="https://bugs.webkit.org/show_bug.cgi?id=315634">https://bugs.webkit.org/show_bug.cgi?id=315634</a>

    [WPE][cross-toolchain-helper] REGRESSION(311591@main): bitbake builds toolchain during determineArchitecture() with no visible output
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315634">https://bugs.webkit.org/show_bug.cgi?id=315634</a>

    Reviewed by Carlos Alberto Lopez Perez.

    determineArchitecture() runs `cmake --system-information` via
    cross-toolchain-helper --cross-toolchain-run-cmd to learn the target
    architecture, with stdout piped into perl. When the cross toolchain has
    not yet been built, the helper transparently triggers a multi-hour
    `bitbake -c populate_sdk` first, and all of its progress output
    disappears into that pipe - the perl reader only keeps the single
    CMAKE_SYSTEM_PROCESSOR line, so the user sees no output for hours.

    Pre-call cross-toolchain-helper --build-toolchain with stdio inherited
    from the parent so the bitbake output reaches the terminal. The
    helper&apos;s build_toolchain() short-circuits when the toolchain already
    exists, so this adds no measurable cost on subsequent runs.

    * Tools/Scripts/webkitdirs.pm:
    (determineArchitecture):

    Canonical link: <a href="https://commits.webkit.org/313950@main">https://commits.webkit.org/313950@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1039@webkitglib/2.52">https://commits.webkit.org/305877.1039@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 1eb849cd467cf5dc5ad9b694ac9b06d38e967859
<pre>
Cherry-pick 311591@main (68c43f3fd9ec). <a href="https://bugs.webkit.org/show_bug.cgi?id=311694">https://bugs.webkit.org/show_bug.cgi?id=311694</a>

    [WPE][cross-toolchain-helper] determineArchitecture() in webkitdirs.pm doesn&apos;t handle correctly the cross-toolchain-helper case.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311694">https://bugs.webkit.org/show_bug.cgi?id=311694</a>

    Reviewed by Philippe Normand.

    When using cross-toolchain-helper determineArchitecture() in webkitdirs.pm fails
    to correctly determine the target architecture.

    The problem is that determineArchitecture() gets called before entering into the
    cross-target environment because the value of architecuture is needed to resolve
    the values of argumentsForConfiguration() which are passed when the build-webkit
    gets re-execed into the cross-target environment.

    So at that moment it can&apos;t reliable obtain the target architecture, and instead
    it obtains the host one because the CC environment variable with the cross-compiler
    is still not set.

    To fix this problem this patch detects this edge case and then calls the cmake
    binary from the cross-toolchain SDK which is configured to resolve the target
    architecture.

    * Tools/Scripts/webkitdirs.pm:
    (determineArchitecture):

    Canonical link: <a href="https://commits.webkit.org/311591@main">https://commits.webkit.org/311591@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1038@webkitglib/2.52">https://commits.webkit.org/305877.1038@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d8607dcea2ccb822ede3ea89aee5e14a60d14cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178724 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52662 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46457 "The change is no longer eligible for processing.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/188340 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143033 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180587 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/53956 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52373 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/188340 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143033 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181681 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/53956 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46457 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/188340 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/53956 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52373 "The change is no longer eligible for processing.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/188340 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (cancelled)") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46457 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/53956 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46457 "The change is no longer eligible for processing.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/39997 "The change is no longer eligible for processing.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52373 "The change is no longer eligible for processing.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/190768 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52332 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46457 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/190768 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53012 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46457 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/190768 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (cancelled)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27115 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53012 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119940 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51530 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46457 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50915 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51155 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/50977 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->