### PR TITLE
Crash in WidthIterator::applyTextSpacingTrimIfNeeded when a character has no glyph in any font

### DIFF
--- a/LayoutTests/fast/text/text-spacing-trim-null-font-crash-expected.txt
+++ b/LayoutTests/fast/text/text-spacing-trim-null-font-crash-expected.txt
@@ -1,0 +1,2 @@
+
+PASS if no crash or assert.

--- a/LayoutTests/fast/text/text-spacing-trim-null-font-crash.html
+++ b/LayoutTests/fast/text/text-spacing-trim-null-font-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<body style="text-spacing-trim: auto">&#x1f;<p>PASS if no crash or assert.</p></body>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -379,7 +379,7 @@ static void NODELETE updateCharacterAndSmallCapsIfNeeded(SmallCapsState& smallCa
 
 static RefPtr<Font> applyTextSpacingTrimIfNeeded(GlyphData& glyphData, char32_t character, TextSpacingTrim textSpacingTrim)
 {
-    if (textSpacingTrim.isSpaceAll())
+    if (textSpacingTrim.isSpaceAll() || !glyphData.font)
         return nullptr;
     TextSpacing::CharactersData charactersData = { .currentCharacter = character, .currentCharacterClass = TextSpacing::characterClass(character) };
     if (RefPtr halfWidthFont = TextSpacing::getHalfWidthFontIfNeeded(*protect(glyphData.font), textSpacingTrim, charactersData)) {


### PR DESCRIPTION
#### 53bedf3f8f4d917e3f0b4d95d91c139252075e5f
<pre>
Crash in WidthIterator::applyTextSpacingTrimIfNeeded when a character has no glyph in any font
<a href="https://bugs.webkit.org/show_bug.cgi?id=321023">https://bugs.webkit.org/show_bug.cgi?id=321023</a>
<a href="https://rdar.apple.com/183317081">rdar://183317081</a>

Reviewed by Vitor Roriz.

glyphDataForCharacter() can legitimately return a GlyphData with a null font (a SingleThreadWeakPtr&lt;const Font&gt;) whenever no font — including every fallback — has a glyph for the
character, which happens for code points like U+001F that no installed font maps. applyTextSpacingTrimIfNeeded() didn&apos;t account for that case: it unconditionally did
*protect(glyphData.font) to pass the font by reference into getHalfWidthFontIfNeeded(), dereferencing a null RefPtr and crashing.

The fix adds a !glyphData.font check alongside the existing isSpaceAll() early return, so the function bails out before dereferencing when there&apos;s no font to consult. This mirrors
how the equivalent code in ComplexTextController.cpp already guards the same lookup with nextFont &amp;&amp; before touching it — this path is now consistent with that sibling
implementation. Since a glyph-less character has no font whose text-spacing metrics could apply anyway, skipping the trim logic in that case is correct behavior, not just a crash
guard.

Test: fast/text/text-spacing-trim-null-font-crash.html

* LayoutTests/fast/text/text-spacing-trim-null-font-crash-expected.txt: Added.
* LayoutTests/fast/text/text-spacing-trim-null-font-crash.html: Added.
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::applyTextSpacingTrimIfNeeded):

Canonical link: <a href="https://commits.webkit.org/318619@main">https://commits.webkit.org/318619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdceccea960394a17fb169fb48a2da61b4aa61c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188447 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139441 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/729de881-6fb8-4d4d-9a7d-0c84466d84ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119895 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f2930cde-177b-418b-ba6e-258df8178383) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41679 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39674 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45370 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190875 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148630 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39893 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53119 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148395 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43091 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125386 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120060 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51637 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14657 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51022 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51262 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51084 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->