### PR TITLE
corner-shape: fix hit testing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-hittest-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-hittest-expected.txt
@@ -1,7 +1,3 @@
 
-FAIL CSS Borders and Box Decorations 4 Test: Hit testing 'corner-shape' assert_equals: expected Element node <body><div id="target"></div>
-
-<script>
-    test(t => {
- ... but got Element node <div id="target"></div>
+PASS CSS Borders and Box Decorations 4 Test: Hit testing 'corner-shape'
 

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -36,6 +36,7 @@
 #include "CornerShapeUtilities.h"
 #include "FloatRoundedRect.h"
 #include "GraphicsContext.h"
+#include "HitTestLocation.h"
 #include "LayoutRect.h"
 #include "LayoutRoundedRect.h"
 #include "Path.h"
@@ -222,6 +223,19 @@ bool BorderShape::innerShapeContains(const LayoutRect& rect) const
 bool BorderShape::outerShapeContains(const LayoutRect& rect) const
 {
     return m_borderRect.contains(rect);
+}
+
+bool BorderShape::shapeIntersectsHitTestLocation(const HitTestLocation& hitTestLocation, float deviceScaleFactor) const
+{
+    // FIXME: This needs to handle area hit-testing
+    if (!hasNonRoundCornerShape())
+        return hitTestLocation.intersects(m_borderRect);
+
+    if (!hitTestLocation.intersects(snappedOuterRect(deviceScaleFactor)))
+        return false;
+
+    // Non-zero winding, so overlapping concave corners read as covered rather than punching a hole.
+    return pathForOuterShape(deviceScaleFactor).contains(hitTestLocation.point());
 }
 
 bool BorderShape::allCornersClippedOut(const LayoutRect& rect) const

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -41,6 +41,7 @@ namespace WebCore {
 class Color;
 class GraphicsContext;
 class FloatRect;
+class HitTestLocation;
 class Path;
 
 namespace Style {
@@ -86,6 +87,8 @@ public:
     // Returns true if the given rect is entirely inside the inner/outer shape.
     bool innerShapeContains(const LayoutRect&) const;
     bool outerShapeContains(const LayoutRect&) const;
+
+    bool shapeIntersectsHitTestLocation(const HitTestLocation&, float deviceScaleFactor) const;
 
     // Returns true if no corner regions of the outer border intersect the given rect,
     // meaning border painting can use simpler rectangular paths.

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1774,8 +1774,7 @@ bool RenderBox::hitTestBorderRadius(const HitTestLocation& hitTestLocation, cons
     borderRect.moveBy(adjustedLocation);
 
     auto borderShape = BorderShape::shapeForBorderRect(style(), borderRect);
-    // To handle non-round corners, BorderShape should do the hit-testing.
-    return hitTestLocation.intersects(borderShape.deprecatedRoundedRect());
+    return borderShape.shapeIntersectsHitTestLocation(hitTestLocation, style().deviceScaleFactor());
 }
 
 bool RenderBox::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction action)


### PR DESCRIPTION
#### 9ac9df1cb3aa8b10018ede3c59e8d0ec2d16e08e
<pre>
corner-shape: fix hit testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=321026">https://bugs.webkit.org/show_bug.cgi?id=321026</a>
<a href="https://rdar.apple.com/184061275">rdar://184061275</a>

Reviewed by Simon Fraser.

Hit testing required support to work with corner-shape

Passes existing tests

* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::outerShapeContainsPoint const):
(WebCore::BorderShape::shapeContainsPoint const):
(WebCore::BorderShape::shapeIntersectsHitTestLocation const):
* Source/WebCore/rendering/BorderShape.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::hitTestBorderRadius const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-hittest-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318637@main">https://commits.webkit.org/318637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1249af06574805bdd670f103d387668cde1b0458

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188394 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139392 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41633 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39977 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39629 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45317 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44219 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190822 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52386 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148574 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/39906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53066 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148341 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27151 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43040 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125333 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119994 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51584 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14607 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50969 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->