### PR TITLE
[JSC] Wasm Table index must be extended when using 64bit Table

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -841,12 +841,25 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
     return { };
 }
 
+// A runtime operation takes an address operand -- an index, offset, count, delta or length -- as 64
+// bits, so that a 64-bit address memory or table can pass one whole, and it bounds checks all 64
+// bits. The upper half of an i32 operand is don't-care everywhere else, so zero it here.
+void BBQJIT::emitZeroExtendAddressOperand(bool is64Bit, Value operand)
+{
+    if (is64Bit || operand.isConst())
+        return;
+    Location location = loadIfNecessary(operand);
+    m_jit.zeroExtend32ToWord(location.asGPR(), location.asGPR());
+}
+
 // Tables
 
 [[nodiscard]] PartialResult BBQJIT::addTableSet(unsigned tableIndex, Value index, Value value)
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
     ASSERT(index.type() == m_info.table(tableIndex).addressType().asWasmTypeKind());
+
+    emitZeroExtendAddressOperand(m_info.table(tableIndex).addressType().is64Bit(), index);
 
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -873,6 +886,8 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
     ASSERT(dstOffset.type() == m_info.table(tableIndex).addressType().asWasmTypeKind());
     ASSERT(srcOffset.type() == TypeKind::I32);
     ASSERT(length.type() == TypeKind::I32);
+
+    emitZeroExtendAddressOperand(m_info.table(tableIndex).addressType().is64Bit(), dstOffset);
 
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -925,6 +940,8 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
     auto tableAddressTypeKind = m_info.table(tableIndex).addressType().asWasmTypeKind();
     ASSERT(delta.type() == tableAddressTypeKind);
 
+    emitZeroExtendAddressOperand(m_info.table(tableIndex).addressType().is64Bit(), delta);
+
     Vector<Value, 8> arguments = {
         instanceValue(),
         Value::fromI32(tableIndex),
@@ -939,8 +956,12 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 
 [[nodiscard]] PartialResult BBQJIT::addTableFill(unsigned tableIndex, Value offset, Value fill, Value count)
 {
+    bool isTable64 = m_info.table(tableIndex).addressType().is64Bit();
     ASSERT(offset.type() == m_info.table(tableIndex).addressType().asWasmTypeKind());
     ASSERT(count.type() == m_info.table(tableIndex).addressType().asWasmTypeKind());
+
+    emitZeroExtendAddressOperand(isTable64, offset);
+    emitZeroExtendAddressOperand(isTable64, count);
 
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -962,9 +983,15 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 
 [[nodiscard]] PartialResult BBQJIT::addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, Value dstOffset, Value srcOffset, Value length)
 {
+    bool dstIsTable64 = m_info.table(dstTableIndex).addressType().is64Bit();
+    bool srcIsTable64 = m_info.table(srcTableIndex).addressType().is64Bit();
     ASSERT(dstOffset.type() == m_info.table(dstTableIndex).addressType().asWasmTypeKind());
     ASSERT(srcOffset.type() == m_info.table(srcTableIndex).addressType().asWasmTypeKind());
-    ASSERT(m_info.table(dstTableIndex).addressType().is64Bit() && m_info.table(srcTableIndex).addressType().is64Bit() ? length.type() == TypeKind::I64 : length.type() == TypeKind::I32);
+    ASSERT(dstIsTable64 && srcIsTable64 ? length.type() == TypeKind::I64 : length.type() == TypeKind::I32);
+
+    emitZeroExtendAddressOperand(dstIsTable64, dstOffset);
+    emitZeroExtendAddressOperand(srcIsTable64, srcOffset);
+    emitZeroExtendAddressOperand(dstIsTable64 && srcIsTable64, length);
 
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -1106,6 +1133,8 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
 
 [[nodiscard]] PartialResult BBQJIT::addGrowMemory(Value delta, Value& result, uint8_t memoryIndex)
 {
+    emitZeroExtendAddressOperand(m_info.memory(memoryIndex).isMemory64(), delta);
+
     Vector<Value, 8> arguments = { instanceValue(), delta, Value::fromI32(memoryIndex) };
     result = topValue(m_info.memory(memoryIndex).addressType().asWasmTypeKind());
     emitCCall(&operationGrowMemory, arguments, result);
@@ -1144,17 +1173,9 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     ASSERT(count.type() == m_info.memory(memoryIndex).addressType());
     ASSERT(targetValue.type() == TypeKind::I32);
 
-    if (!m_info.memory(memoryIndex).isMemory64()) {
-        if (!dstAddress.isConst()) {
-            Location dstLoc = loadIfNecessary(dstAddress);
-            m_jit.zeroExtend32ToWord(dstLoc.asGPR(), dstLoc.asGPR());
-        }
-
-        if (!count.isConst()) {
-            Location countLoc = loadIfNecessary(count);
-            m_jit.zeroExtend32ToWord(countLoc.asGPR(), countLoc.asGPR());
-        }
-    }
+    bool isMemory64 = m_info.memory(memoryIndex).isMemory64();
+    emitZeroExtendAddressOperand(isMemory64, dstAddress);
+    emitZeroExtendAddressOperand(isMemory64, count);
 
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -1182,26 +1203,11 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     else
         ASSERT(count.type() == TypeKind::I32);
 
-    if (!m_info.memory(dstMemoryIndex).isMemory64()) {
-        if (!dstAddress.isConst()) {
-            Location dstLoc = loadIfNecessary(dstAddress);
-            m_jit.zeroExtend32ToWord(dstLoc.asGPR(), dstLoc.asGPR());
-        }
-    }
-
-    if (!m_info.memory(srcMemoryIndex).isMemory64()) {
-        if (!srcAddress.isConst()) {
-            Location srcLoc = loadIfNecessary(srcAddress);
-            m_jit.zeroExtend32ToWord(srcLoc.asGPR(), srcLoc.asGPR());
-        }
-    }
-
-    if (!m_info.memory(srcMemoryIndex).isMemory64() || !m_info.memory(dstMemoryIndex).isMemory64()) {
-        if (!count.isConst()) {
-            Location countLoc = loadIfNecessary(count);
-            m_jit.zeroExtend32ToWord(countLoc.asGPR(), countLoc.asGPR());
-        }
-    }
+    bool dstIsMemory64 = m_info.memory(dstMemoryIndex).isMemory64();
+    bool srcIsMemory64 = m_info.memory(srcMemoryIndex).isMemory64();
+    emitZeroExtendAddressOperand(dstIsMemory64, dstAddress);
+    emitZeroExtendAddressOperand(srcIsMemory64, srcAddress);
+    emitZeroExtendAddressOperand(dstIsMemory64 && srcIsMemory64, count);
 
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -1226,12 +1232,7 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     ASSERT(srcAddress.type() == TypeKind::I32);
     ASSERT(length.type() == TypeKind::I32);
 
-    if (!m_info.memory(memoryIndex).isMemory64()) {
-        if (!dstAddress.isConst()) {
-            Location dstLoc = loadIfNecessary(dstAddress);
-            m_jit.zeroExtend32ToWord(dstLoc.asGPR(), dstLoc.asGPR());
-        }
-    }
+    emitZeroExtendAddressOperand(m_info.memory(memoryIndex).isMemory64(), dstAddress);
 
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -1344,6 +1345,8 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
 
 [[nodiscard]] PartialResult BBQJIT::atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex)
 {
+    emitZeroExtendAddressOperand(m_info.memory(memoryIndex).isMemory64(), pointer);
+
     Vector<Value, 8> arguments = {
         instanceValue(),
         pointer,
@@ -1368,6 +1371,8 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
 
 [[nodiscard]] PartialResult BBQJIT::atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex)
 {
+    emitZeroExtendAddressOperand(m_info.memory(memoryIndex).isMemory64(), pointer);
+
     Vector<Value, 8> arguments = {
         instanceValue(),
         pointer,

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1135,6 +1135,8 @@ public:
 
     [[nodiscard]] PartialResult setGlobal(uint32_t index, Value value);
 
+    void emitZeroExtendAddressOperand(bool is64Bit, Value operand);
+
     // Memory
 
     inline Location emitCheckAndPreparePointer(Value pointer, uint64_t uoffset, uint32_t sizeOfOperation, uint8_t memoryIndex)

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -166,6 +166,8 @@ Value BBQJIT::instanceValue()
     TypeKind returnType = table.wasmType().kind();
     ASSERT(typeKindSizeInBytes(returnType) == 8);
 
+    emitZeroExtendAddressOperand(table.addressType().is64Bit(), index);
+
     Vector<Value, 8> arguments = {
         instanceValue(),
         Value::fromI32(tableIndex),

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -485,6 +485,16 @@ public:
         return m_currentBlock->appendNew<Value>(m_proc, Trunc, origin(), value);
     }
 
+    // A runtime operation takes an address operand -- an index, offset, count, delta or length -- as
+    // 64 bits, so that a 64-bit address memory or table can pass one whole, and it bounds checks all
+    // 64 bits. The upper half of an i32 operand is don't-care everywhere else, so zero it here.
+    Value* addressOperand(bool is64Bit, ExpressionType operand)
+    {
+        if (is64Bit)
+            return get(operand);
+        return pointerOfInt32(get(operand));
+    }
+
     // SIMD
     void NODELETE notifyFunctionUsesSIMD() { ASSERT(m_info.usesSIMD(m_functionIndex)); }
     [[nodiscard]] PartialResult addSIMDLoad(ExpressionType pointer, uint64_t offset, ExpressionType& result, uint8_t memoryIndex);
@@ -1697,7 +1707,7 @@ auto OMGIRGenerator::addTableGet(unsigned tableIndex, ExpressionType index, Expr
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
     Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::Externref), operationGetWasmTableElement,
-        instanceValue(), constant(Int32, tableIndex), get(index));
+        instanceValue(), constant(Int32, tableIndex), addressOperand(m_info.table(tableIndex).addressType().is64Bit(), index));
     {
         result = push(resultValue);
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
@@ -1715,7 +1725,7 @@ auto OMGIRGenerator::addTableSet(unsigned tableIndex, ExpressionType index, Expr
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
     auto shouldThrow = callWasmOperation(m_currentBlock, B3::Int32, operationSetWasmTableElement,
-        instanceValue(), constant(Int32, tableIndex), get(index), get(value));
+        instanceValue(), constant(Int32, tableIndex), addressOperand(m_info.table(tableIndex).addressType().is64Bit(), index), get(value));
     {
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
             m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), shouldThrow, constant(Int32, 0)));
@@ -1757,7 +1767,7 @@ auto OMGIRGenerator::addTableInit(unsigned elementIndex, unsigned tableIndex, Ex
         instanceValue(),
         constant(Int32, elementIndex),
         constant(Int32, tableIndex),
-        get(dstOffset), get(srcOffset), get(length));
+        addressOperand(m_info.table(tableIndex).addressType().is64Bit(), dstOffset), get(srcOffset), get(length));
 
     {
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
@@ -1792,15 +1802,16 @@ auto OMGIRGenerator::addTableSize(unsigned tableIndex, ExpressionType& result) -
 auto OMGIRGenerator::addTableGrow(unsigned tableIndex, ExpressionType fill, ExpressionType delta, ExpressionType& result) -> PartialResult
 {
     result = push(callWasmOperation(m_currentBlock, toB3Type(m_info.table(tableIndex).addressType().asWasmType()), operationWasmTableGrow,
-        instanceValue(), constant(Int32, tableIndex), get(fill), get(delta)));
+        instanceValue(), constant(Int32, tableIndex), get(fill), addressOperand(m_info.table(tableIndex).addressType().is64Bit(), delta)));
 
     return { };
 }
 
 auto OMGIRGenerator::addTableFill(unsigned tableIndex, ExpressionType offset, ExpressionType fill, ExpressionType count) -> PartialResult
 {
+    bool isTable64 = m_info.table(tableIndex).addressType().is64Bit();
     Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmTableFill,
-        instanceValue(), constant(Int32, tableIndex), get(offset), get(fill), get(count));
+        instanceValue(), constant(Int32, tableIndex), addressOperand(isTable64, offset), get(fill), addressOperand(isTable64, count));
 
     {
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
@@ -1816,12 +1827,14 @@ auto OMGIRGenerator::addTableFill(unsigned tableIndex, ExpressionType offset, Ex
 
 auto OMGIRGenerator::addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length) -> PartialResult
 {
+    bool dstIsTable64 = m_info.table(dstTableIndex).addressType().is64Bit();
+    bool srcIsTable64 = m_info.table(srcTableIndex).addressType().is64Bit();
     Value* resultValue = callWasmOperation(
         m_currentBlock, toB3Type(Types::I32), operationWasmTableCopy,
         instanceValue(),
         constant(Int32, dstTableIndex),
         constant(Int32, srcTableIndex),
-        get(dstOffset), get(srcOffset), get(length));
+        addressOperand(dstIsTable64, dstOffset), addressOperand(srcIsTable64, srcOffset), addressOperand(dstIsTable64 && srcIsTable64, length));
 
     {
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
@@ -2067,7 +2080,7 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
 auto OMGIRGenerator::addGrowMemory(ExpressionType delta, ExpressionType& result, uint8_t memoryIndex) -> PartialResult
 {
     result = push(callWasmOperation(m_currentBlock, m_info.memory(memoryIndex).addressType().asB3TypeKind(), operationGrowMemory,
-        instanceValue(), get(delta), constant(Int32, memoryIndex)));
+        instanceValue(), addressOperand(m_info.memory(memoryIndex).isMemory64(), delta), constant(Int32, memoryIndex)));
 
     restoreWebAssemblyGlobalState(m_info.memories, instanceValue(), m_currentBlock);
 
@@ -2101,13 +2114,9 @@ auto OMGIRGenerator::addCurrentMemory(ExpressionType& result, uint8_t memoryInde
 
 auto OMGIRGenerator::addMemoryFill(ExpressionType dstAddress, ExpressionType target, ExpressionType count, uint8_t memoryIndex) -> PartialResult
 {
-    auto* dstAddressValue = m_info.memory(memoryIndex).isMemory64()
-        ? get(dstAddress)
-        : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(dstAddress));
+    auto* dstAddressValue = addressOperand(m_info.memory(memoryIndex).isMemory64(), dstAddress);
     auto* targetValue = get(target);
-    auto* countValue = m_info.memory(memoryIndex).isMemory64()
-        ? get(count)
-        : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(count));
+    auto* countValue = addressOperand(m_info.memory(memoryIndex).isMemory64(), count);
 
     if (!memoryIndex) {
         auto* memorySize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfCachedMemory0Size()));
@@ -2145,16 +2154,12 @@ auto OMGIRGenerator::addMemoryFill(ExpressionType dstAddress, ExpressionType tar
 
 auto OMGIRGenerator::addMemoryInit(unsigned dataSegmentIndex, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length, uint8_t memoryIndex) -> PartialResult
 {
-    auto dstAddressValue = m_info.memory(memoryIndex).isMemory64()
-        ? get(dstAddress)
-        : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(dstAddress));
-
-    auto srcAddressValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(srcAddress));
+    auto dstAddressValue = addressOperand(m_info.memory(memoryIndex).isMemory64(), dstAddress);
 
     Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmMemoryInit,
         instanceValue(),
         constant(Int32, dataSegmentIndex),
-        dstAddressValue, srcAddressValue, get(length), constant(Int32, memoryIndex));
+        dstAddressValue, get(srcAddress), get(length), constant(Int32, memoryIndex));
 
     {
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
@@ -2170,15 +2175,9 @@ auto OMGIRGenerator::addMemoryInit(unsigned dataSegmentIndex, ExpressionType dst
 
 auto OMGIRGenerator::addMemoryCopy(ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex) -> PartialResult
 {
-    auto* dstAddressValue = m_info.memory(dstMemoryIndex).isMemory64()
-        ? get(dstAddress)
-        : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(dstAddress));
-    auto* srcAddressValue = m_info.memory(srcMemoryIndex).isMemory64()
-        ? get(srcAddress)
-        : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(srcAddress));
-    auto* countValue = m_info.memory(srcMemoryIndex).isMemory64() && m_info.memory(dstMemoryIndex).isMemory64()
-        ? get(count)
-        : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(count));
+    auto* dstAddressValue = addressOperand(m_info.memory(dstMemoryIndex).isMemory64(), dstAddress);
+    auto* srcAddressValue = addressOperand(m_info.memory(srcMemoryIndex).isMemory64(), srcAddress);
+    auto* countValue = addressOperand(m_info.memory(srcMemoryIndex).isMemory64() && m_info.memory(dstMemoryIndex).isMemory64(), count);
 
     if (!dstMemoryIndex && !srcMemoryIndex) {
         auto* memorySize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfCachedMemory0Size()));
@@ -3214,7 +3213,7 @@ auto OMGIRGenerator::atomicCompareExchange(ExtAtomicOpType op, Type valueType, E
 
 auto OMGIRGenerator::atomicWait(ExtAtomicOpType op, ExpressionType pointerVar, ExpressionType valueVar, ExpressionType timeoutVar, ExpressionType& result, uint64_t offset, uint8_t memoryIndex) -> PartialResult
 {
-    Value* pointer = get(pointerVar);
+    Value* pointer = addressOperand(m_info.memory(memoryIndex).isMemory64(), pointerVar);
     Value* value = get(valueVar);
     Value* timeout = get(timeoutVar);
     Value* resultValue = nullptr;
@@ -3242,7 +3241,7 @@ auto OMGIRGenerator::atomicWait(ExtAtomicOpType op, ExpressionType pointerVar, E
 auto OMGIRGenerator::atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint64_t offset, uint8_t memoryIndex) -> PartialResult
 {
     Value* resultValue = callWasmOperation(m_currentBlock, Int32, operationMemoryAtomicNotify,
-        instanceValue(), get(pointer), constant(Int64, offset), get(count), constant(Int32, memoryIndex));
+        instanceValue(), addressOperand(m_info.memory(memoryIndex).isMemory64(), pointer), constant(Int64, offset), get(count), constant(Int32, memoryIndex));
     {
         result = push(resultValue);
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),


### PR DESCRIPTION
#### 02cdfb795a84a346ef15c69f1ad3fed82d401216
<pre>
[JSC] Wasm Table index must be extended when using 64bit Table
<a href="https://bugs.webkit.org/show_bug.cgi?id=321031">https://bugs.webkit.org/show_bug.cgi?id=321031</a>
<a href="https://rdar.apple.com/184064205">rdar://184064205</a>

Reviewed by Cole Carley.

In Table64, index should be represented as i64. As a result, operation
are taking uint64_t, but we are not zero-extending the passed i32 index
appropriately. This patch fixes them.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitZeroExtendAddressOperand):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableInit):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableGrow):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableCopy):
(JSC::Wasm::BBQJITImpl::BBQJIT::addGrowMemory):
(JSC::Wasm::BBQJITImpl::BBQJIT::addMemoryFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addMemoryCopy):
(JSC::Wasm::BBQJITImpl::BBQJIT::addMemoryInit):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicWait):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicNotify):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableGet):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addressOperand):
(JSC::Wasm::OMGIRGenerator::addTableGet):
(JSC::Wasm::OMGIRGenerator::addTableSet):
(JSC::Wasm::OMGIRGenerator::addTableInit):
(JSC::Wasm::OMGIRGenerator::addTableGrow):
(JSC::Wasm::OMGIRGenerator::addTableFill):
(JSC::Wasm::OMGIRGenerator::addTableCopy):
(JSC::Wasm::OMGIRGenerator::addGrowMemory):
(JSC::Wasm::OMGIRGenerator::addMemoryFill):
(JSC::Wasm::OMGIRGenerator::addMemoryInit):
(JSC::Wasm::OMGIRGenerator::addMemoryCopy):
(JSC::Wasm::OMGIRGenerator::atomicWait):
(JSC::Wasm::OMGIRGenerator::atomicNotify):

Canonical link: <a href="https://commits.webkit.org/318603@main">https://commits.webkit.org/318603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28a6979f3d684612441ea68bbbae171442a3de43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188355 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139360 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119814 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41596 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39944 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1784 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8595 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39607 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40012 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190783 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52347 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148540 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53027 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148307 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43011 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125294 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119955 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51545 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14585 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50930 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51170 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50992 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->