### PR TITLE
[Site Isolation] First-party sites should not enter shared process

### DIFF
--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -191,8 +191,11 @@ UserGestureIndicator::UserGestureIndicator(std::optional<IsProcessingUserGesture
 
     if (isProcessingUserGesture && document && currentToken(vm)->processingUserGesture()) {
         document->updateLastHandledUserGestureTimestamp(currentToken(vm)->startTime());
-        if (processInteractionStyle == ProcessInteractionStyle::Immediate)
+        if (processInteractionStyle == ProcessInteractionStyle::Immediate) {
             ResourceLoadObserver::singleton().logUserInteractionWithReducedTimeResolution(*document);
+            if (RefPtr page = document->page())
+                page->didObserveFirstPartyUserGesture();
+        }
 
         if (RefPtr page = document->page()) {
             page->setUserDidInteractWithPage(true);

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -662,6 +662,7 @@ public:
     virtual void handleAutoFillButtonClick(HTMLInputElement&) { }
 
     virtual void didCompleteAutofill(HTMLInputElement&) { }
+    virtual void didObserveFirstPartyUserGesture() { }
 
     virtual void inputElementDidResignStrongPasswordAppearance(HTMLInputElement&) { }
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4186,8 +4186,11 @@ bool EventHandler::keyEvent(const PlatformKeyboardEvent& keyEvent)
             if (page)
                 page->setUserDidInteractWithPage(savedUserDidInteractWithPage);
             document->updateLastHandledUserGestureTimestamp(savedLastHandledUserGestureTimestamp);
-        } else
+        } else {
             ResourceLoadObserver::singleton().logUserInteractionWithReducedTimeResolution(*document);
+            if (page)
+                page->didObserveFirstPartyUserGesture();
+        }
     }
 
     return wasHandled;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1008,6 +1008,11 @@ const URL& Page::mainFrameURL() const
     return m_topDocumentSyncData->documentURL;
 }
 
+void Page::didObserveFirstPartyUserGesture()
+{
+    chrome().client().didObserveFirstPartyUserGesture();
+}
+
 SecurityOrigin& Page::mainFrameOrigin() const
 {
     if (!m_topDocumentSyncData->documentSecurityOrigin)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -430,6 +430,8 @@ public:
     Frame& mainFrame() const { return m_mainFrame.get(); }
     WEBCORE_EXPORT void setMainFrame(Ref<Frame>&&);
     WEBCORE_EXPORT const URL& NODELETE mainFrameURL() const LIFETIME_BOUND;
+
+    WEBCORE_EXPORT void didObserveFirstPartyUserGesture();
     SecurityOrigin& mainFrameOrigin() const;
     WEBCORE_EXPORT RefPtr<Frame> findFrameByPath(const Vector<uint64_t>& path) const;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1258,9 +1258,12 @@ struct WKWebsiteData {
     return protect(*_websiteDataStore)->hasServiceWorkerBackgroundActivityForTesting();
 }
 
--(BOOL)_isIsolatedSiteForTesting:(NSURL *)url
+- (NSNumber *)_isolatedSiteSignalsForTesting:(NSURL *)url
 {
-    return protect(*_websiteDataStore)->isIsolatedSiteForTesting(url);
+    auto signals = protect(*_websiteDataStore)->isolatedSiteSignalsForTesting(url);
+    if (!signals)
+        return nil;
+    return @(signals->toRaw());
 }
 
 - (void)_getPendingPushMessage:(void(^)(NSDictionary *))completionHandler

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -128,7 +128,7 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 - (void)_countNonDefaultSessionSets:(void(^)(uint64_t))completionHandler;
 
 -(bool)_hasServiceWorkerBackgroundActivityForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));
--(BOOL)_isIsolatedSiteForTesting:(NSURL *)url WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+-(NSNumber *)_isolatedSiteSignalsForTesting:(NSURL *)url WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0)); // IsolatedSiteStore::Signal bits, or nil if the site is not isolated.
 -(void)_getPendingPushMessage:(void(^)(NSDictionary *))completionHandler WK_API_AVAILABLE(macos(15.2), ios(18.2));
 -(void)_getPendingPushMessages:(void(^)(NSArray<NSDictionary *> *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_processPushMessage:(NSDictionary *)pushMessage completionHandler:(void(^)(bool))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8586,6 +8586,18 @@ static OptionSet<CrossSiteNavigationDataTransfer::Flag> checkIfNavigationContain
     return navigationDataTransfer;
 }
 
+void WebPageProxy::recordFirstPartyVisit(const URL& url)
+{
+    if (url.isEmpty() || url.protocolIsAbout() || url.protocolIsFile())
+        return;
+
+    Site site { url };
+    if (site.isEmpty())
+        return;
+
+    websiteDataStore().isolatedSiteStore().addSite(site, IsolatedSiteStore::Signal::FirstPartyVisit);
+}
+
 void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, std::optional<WebCore::NavigationIdentifier> navigationID, String&& mimeType, bool frameHasCustomContentProvider, FrameLoadType frameLoadType, bool usedLegacyTLS, bool wasPrivateRelayed, String&& proxyName, const WebCore::ResourceResponseSource source, bool containsPluginDocument, HasInsecureContent hasInsecureContent, MouseEventPolicy mouseEventPolicy, DocumentSecurityPolicy&& documentSecurityPolicy, HashSet<WebCore::SecurityOriginData>&& cspOriginsThatUpgradeInsecureNavigations, const UserData& userData, RestoredFromBackForwardCache restoredFromBackForwardCache, RefPtr<FrameState>&& redirectReplaceFrameState)
 {
     LOG(Loading, "(Loading) WebPageProxy %" PRIu64 " didCommitLoadForFrame in navigation %" PRIu64, identifier().toUInt64(), navigationID ? navigationID->toUInt64() : 0);
@@ -8603,8 +8615,10 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
 
     // BackForwardGoToItem is sent on the same connection ahead of this commit, so the current index
     // has already advanced; settle the cross-process traversal queue here; no-op unless a traversal is in flight.
-    if (frame->isMainFrame())
+    if (frame->isMainFrame()) {
         m_sessionHistoryTraversalQueue->traversalDidSettle();
+        recordFirstPartyVisit(request.url());
+    }
 
     if (frame->provisionalFrame()) {
         frame->commitProvisionalFrame(connection, frameID, WTF::move(frameInfo), WTF::move(request), navigationID, WTF::move(mimeType), frameHasCustomContentProvider, frameLoadType, usedLegacyTLS, wasPrivateRelayed, WTF::move(proxyName), source, containsPluginDocument, hasInsecureContent, mouseEventPolicy, WTF::move(documentSecurityPolicy), WTF::move(cspOriginsThatUpgradeInsecureNavigations), userData, restoredFromBackForwardCache, WTF::move(redirectReplaceFrameState));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3051,6 +3051,8 @@ private:
 
     void notifyProcessPoolToPrewarm();
 
+    void recordFirstPartyVisit(const URL&);
+
     bool attachmentElementEnabled();
     bool modelElementEnabled();
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2453,6 +2453,13 @@ void WebProcessProxy::didCompleteAutofill(const WebCore::Site& site)
         dataStore->isolatedSiteStore().addSite(site, IsolatedSiteStore::Signal::Autofill);
 }
 
+void WebProcessProxy::didObserveFirstPartyUserGesture(const WebCore::Site& site)
+{
+    MESSAGE_CHECK(!site.isEmpty());
+    if (RefPtr dataStore = websiteDataStore())
+        dataStore->isolatedSiteStore().addSite(site, IsolatedSiteStore::Signal::FirstPartyUserGesture);
+}
+
 void WebProcessProxy::activePagesDomainsForTesting(CompletionHandler<void(Vector<String>&&)>&& completionHandler)
 {
     sendWithAsyncReply(Messages::WebProcess::GetActivePagesOriginsForTesting(), WTF::move(completionHandler));

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -749,6 +749,7 @@ private:
     void didCollectPrewarmInformation(const WebCore::RegistrableDomain&, const WebCore::PrewarmInformation&);
 
     void didCompleteAutofill(const WebCore::Site&);
+    void didObserveFirstPartyUserGesture(const WebCore::Site&);
 
     void logDiagnosticMessageForResourceLimitTermination(const String& limitKey);
     

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -60,6 +60,8 @@ messages -> WebProcessProxy WantsDispatchMessage {
 
     DidCompleteAutofill(WebCore::Site site)
 
+    DidObserveFirstPartyUserGesture(WebCore::Site site)
+
 #if PLATFORM(COCOA)
     CacheMediaMIMETypes(Vector<String> types)
     CacheMediaSourceTypeSupported(String type, bool isSupported)

--- a/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h
@@ -36,6 +36,8 @@ class IsolatedSiteStore {
 public:
     enum class Signal : uint8_t {
         Autofill = 1 << 0,
+        FirstPartyVisit = 1 << 1,
+        FirstPartyUserGesture = 1 << 2,
     };
 
     void addSite(const WebCore::Site&, Signal);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1546,9 +1546,12 @@ void WebsiteDataStore::didHaveUserInteractionForSiteIsolation(const URL& url)
     }
 }
 
-bool WebsiteDataStore::isIsolatedSiteForTesting(const URL& url) const
+std::optional<OptionSet<IsolatedSiteStore::Signal>> WebsiteDataStore::isolatedSiteSignalsForTesting(const URL& url) const
 {
-    return m_isolatedSiteStore.contains(WebCore::Site { url });
+    WebCore::Site site { url };
+    if (!m_isolatedSiteStore.contains(site))
+        return std::nullopt;
+    return m_isolatedSiteStore.reasonsFor(site);
 }
 
 void WebsiteDataStore::logUserInteraction(const URL& url, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -233,7 +233,7 @@ public:
     void logTestingEvent(const String&);
     void didHaveUserInteractionForSiteIsolation(const URL&);
     IsolatedSiteStore& isolatedSiteStore() { return m_isolatedSiteStore; }
-    bool isIsolatedSiteForTesting(const URL&) const;
+    std::optional<OptionSet<IsolatedSiteStore::Signal>> isolatedSiteSignalsForTesting(const URL&) const;
     void logUserInteraction(const URL&, CompletionHandler<void()>&&);
     void getAllStorageAccessEntries(WebPageProxyIdentifier, CompletionHandler<void(Vector<String>&& domains)>&&);
     void hasHadUserInteraction(const URL&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -2001,6 +2001,27 @@ void WebChromeClient::didCompleteAutofill(HTMLInputElement& inputElement)
     protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebProcessProxy::DidCompleteAutofill(site), 0);
 }
 
+void WebChromeClient::didObserveFirstPartyUserGesture()
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    RefPtr corePage = page->corePage();
+    if (!corePage)
+        return;
+
+    auto site = Site { corePage->mainFrameURL() };
+    if (site.isEmpty())
+        return;
+
+    if (m_lastReportedFirstPartyUserGestureSite == site)
+        return;
+
+    m_lastReportedFirstPartyUserGestureSite = site;
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebProcessProxy::DidObserveFirstPartyUserGesture(site), 0);
+}
+
 void WebChromeClient::inputElementDidResignStrongPasswordAppearance(HTMLInputElement& inputElement)
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <WebCore/ChromeClient.h>
+#include <WebCore/Site.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
@@ -438,6 +439,7 @@ private:
     void handleAutoFillButtonClick(WebCore::HTMLInputElement&) final;
 
     void didCompleteAutofill(WebCore::HTMLInputElement&) final;
+    void didObserveFirstPartyUserGesture() final;
 
     void inputElementDidResignStrongPasswordAppearance(WebCore::HTMLInputElement&) final;
 
@@ -609,6 +611,8 @@ private:
 
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
+
+    std::optional<WebCore::Site> m_lastReportedFirstPartyUserGestureSite;
 
     WeakPtr<WebPage> m_page;
 };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8322,10 +8322,8 @@ TEST(SiteIsolation, SharedProcessAfterClick)
 TEST(SiteIsolation, SharedProcessAfterKeyDown)
 {
     HTTPServer server({
-        { "/warmup"_s, { "<iframe src='https://w3.org/w3c'></iframe>"_s } },
-        { "/example"_s, { "<iframe src='https://webkit.org/webkit'></iframe><iframe src='https://apple.com/apple'></iframe><iframe src='https://w3.org/w3c'></iframe>"_s } },
+        { "/webkit"_s, { "<iframe src='https://apple.com/apple'></iframe><iframe src='https://w3.org/w3c'></iframe>"_s } },
         { "/apple"_s, { "apple content"_s } },
-        { "/webkit"_s, { "webkit content"_s } },
         { "/w3c"_s, { "w3c content"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
 
@@ -8342,41 +8340,44 @@ TEST(SiteIsolation, SharedProcessAfterKeyDown)
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:itpDatabaseFile.path]);
 
     auto [webView, navigationDelegate] = siteIsolatedViewWithSharedProcess(server, EnableProcessCache::No, dataStoreRoot, itpRoot);
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://apple.com/warmup"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
+    // Both subframe sites are new to the user, so they share one process.
     checkFrameTreesInProcesses(webView.get(), {
         {
-            "https://apple.com"_s,
-            { { RemoteFrame } }
+            "https://webkit.org"_s,
+            { { RemoteFrame }, { RemoteFrame } }
         },
         {
             RemoteFrame,
-            { { "https://w3.org"_s } }
+            { { "https://apple.com"_s }, { "https://w3.org"_s } }
         },
     });
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://apple.com/apple"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
     [webView typeCharacter:'n'];
     [webView waitForNextPresentationUpdate];
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
+    // The user has now used apple.com as a page, so it gets a process of its own rather than joining
+    // w3.org, which it shared one with before.
     checkFrameTreesInProcesses(webView.get(), {
         {
-            "https://example.com"_s,
-            { { RemoteFrame }, { RemoteFrame }, { RemoteFrame } }
+            "https://webkit.org"_s,
+            { { RemoteFrame }, { RemoteFrame } }
         },
         {
             RemoteFrame,
-            { { "https://webkit.org"_s }, { RemoteFrame }, { RemoteFrame } }
+            { { "https://apple.com"_s }, { RemoteFrame } }
         },
         {
             RemoteFrame,
-            { { RemoteFrame }, { "https://apple.com"_s }, { "https://w3.org"_s } }
+            { { RemoteFrame }, { "https://w3.org"_s } }
         },
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
@@ -1382,7 +1382,11 @@ TEST(WKUserContentController, AutofillScriptingMarksSiteAsIsolated)
     [webView synchronouslyLoadHTMLString:@"<input id='password' type='password'>" baseURL:url];
 
     WKWebsiteDataStore *dataStore = [webView configuration].websiteDataStore;
-    EXPECT_FALSE([dataStore _isIsolatedSiteForTesting:url]);
+
+    // Loading the page has already marked the site with Signal::FirstPartyVisit, so check for the
+    // autofill signal rather than mere membership.
+    constexpr NSUInteger autofillSignal = 1 << 0; // IsolatedSiteStore::Signal::Autofill.
+    EXPECT_FALSE([[dataStore _isolatedSiteSignalsForTesting:url] unsignedIntegerValue] & autofillSignal);
 
     __block bool doneEvaluatingScript = false;
     [webView evaluateJavaScript:@"document.getElementById('password').value = 'famos'; document.getElementById('password').autofilled = true" inFrame:nil inContentWorld:autofillWorld.get() completionHandler:^(id, NSError *) {
@@ -1393,7 +1397,7 @@ TEST(WKUserContentController, AutofillScriptingMarksSiteAsIsolated)
     EXPECT_WK_STREQ("famos", [webView stringByEvaluatingJavaScript:@"document.getElementById('password').value"]);
 
     EXPECT_TRUE(TestWebKitAPI::Util::waitFor(^{
-        return (bool)[dataStore _isIsolatedSiteForTesting:url];
+        return (bool)([[dataStore _isolatedSiteSignalsForTesting:url] unsignedIntegerValue] & autofillSignal);
     }));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
@@ -2241,4 +2241,106 @@ TEST(TimeBasedEviction, PushSubscriptionOriginNotEvicted)
     EXPECT_WK_STREQ(@"example2.com", evictedDomains.get()[0]);
 }
 
+// IsolatedSiteStore::Signal.
+constexpr NSUInteger firstPartyVisitSignal = 1 << 1;
+constexpr NSUInteger firstPartyUserGestureSignal = 1 << 2;
+
+static NSUInteger isolatedSiteSignals(WKWebsiteDataStore *dataStore, NSString *urlString)
+{
+    return [[dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:urlString]] unsignedIntegerValue];
+}
+
+static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> webViewForIsolatedSiteStoreTest(const HTTPServer& server)
+{
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:server.httpsProxyConfiguration()]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
+}
+
+TEST(WKWebsiteDataStore, FirstPartyVisitMarksSiteAsIsolated)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/iframe'></iframe>"_s } },
+        { "/iframe"_s, { "iframe content"_s } },
+        { "/webkit"_s, { "webkit as a top-level page"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = webViewForIsolatedSiteStoreTest(server);
+    WKWebsiteDataStore *dataStore = [webView configuration].websiteDataStore;
+
+    EXPECT_NULL([dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://example.com/"]]);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // The top-level site is marked; the site that only appeared as a subframe is not in the store at
+    // all.
+    EXPECT_TRUE(isolatedSiteSignals(dataStore, @"https://example.com/") & firstPartyVisitSignal);
+    EXPECT_NULL([dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://webkit.org/"]]);
+
+    // Visiting that same site as a top-level page does mark it.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(isolatedSiteSignals(dataStore, @"https://webkit.org/") & firstPartyVisitSignal);
+}
+
+#if PLATFORM(MAC)
+
+TEST(WKWebsiteDataStore, FirstPartyUserGestureMarksSiteAsIsolated)
+{
+    HTTPServer server({
+        { "/example"_s, { "<body style='margin:0'><div id='target' style='width:300px;height:300px'></div></body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = webViewForIsolatedSiteStoreTest(server);
+    WKWebsiteDataStore *dataStore = [webView configuration].websiteDataStore;
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(isolatedSiteSignals(dataStore, @"https://example.com/") & firstPartyVisitSignal);
+    EXPECT_FALSE(isolatedSiteSignals(dataStore, @"https://example.com/") & firstPartyUserGestureSignal);
+
+    // A script-synthesized click constructs no UserGestureIndicator, so it is not a gesture.
+    [webView objectByEvaluatingJavaScript:@"document.getElementById('target').click(); true"];
+    [webView objectByEvaluatingJavaScript:@"true"];
+    EXPECT_FALSE(isolatedSiteSignals(dataStore, @"https://example.com/") & firstPartyUserGestureSignal);
+
+    [webView sendClickAtPoint:NSMakePoint(100, 100)];
+    [webView waitForPendingMouseEvents];
+
+    EXPECT_TRUE(Util::waitFor([&] {
+        return !!(isolatedSiteSignals(dataStore, @"https://example.com/") & firstPartyUserGestureSignal);
+    }));
+}
+
+TEST(WKWebsiteDataStore, FirstPartyUserGestureInSubframeDoesNotMarkSubframeSite)
+{
+    HTTPServer server({
+        { "/example"_s, { "<body style='margin:0'><iframe src='https://webkit.org/iframe' style='width:300px;height:300px;border:0'></iframe></body>"_s } },
+        { "/iframe"_s, { "<body style='margin:0'><div style='width:300px;height:300px'></div></body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = webViewForIsolatedSiteStoreTest(server);
+    WKWebsiteDataStore *dataStore = [webView configuration].websiteDataStore;
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // The gesture lands inside the cross-site iframe, but it is the site the user is using as a page
+    // that gets the gesture signal.
+    [webView sendClickAtPoint:NSMakePoint(100, 100)];
+    [webView waitForPendingMouseEvents];
+
+    EXPECT_TRUE(Util::waitFor([&] {
+        return !!(isolatedSiteSignals(dataStore, @"https://example.com/") & firstPartyUserGestureSignal);
+    }));
+    EXPECT_NULL([dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://webkit.org/"]]);
+}
+
+#endif // PLATFORM(MAC)
+
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewAutofillTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewAutofillTests.mm
@@ -117,7 +117,11 @@ TEST(WKWebViewAutoFillTests, AutofillMarksSiteAsIsolated)
     [webView synchronouslyLoadHTMLString:@"<input id='user' type='email'><input id='password' type='password'>" baseURL:url];
 
     WKWebsiteDataStore *dataStore = [webView configuration].websiteDataStore;
-    EXPECT_FALSE([dataStore _isIsolatedSiteForTesting:url]);
+
+    // Loading the page has already marked the site with Signal::FirstPartyVisit, so check for the
+    // autofill signal rather than mere membership.
+    constexpr NSUInteger autofillSignal = 1 << 0; // IsolatedSiteStore::Signal::Autofill.
+    EXPECT_FALSE([[dataStore _isolatedSiteSignalsForTesting:url] unsignedIntegerValue] & autofillSignal);
 
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"user.focus()"];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"password.focus()"];
@@ -128,7 +132,7 @@ TEST(WKWebViewAutoFillTests, AutofillMarksSiteAsIsolated)
     EXPECT_WK_STREQ("famos", [webView stringByEvaluatingJavaScript:@"password.value"]);
 
     EXPECT_TRUE(TestWebKitAPI::Util::waitFor(^{
-        return (bool)[dataStore _isIsolatedSiteForTesting:url];
+        return (bool)([[dataStore _isolatedSiteSignalsForTesting:url] unsignedIntegerValue] & autofillSignal);
     }));
 }
 


### PR DESCRIPTION
#### 440598309f6d34f0b5cde3e5ef519df58fc97e5c
<pre>
[Site Isolation] First-party sites should not enter shared process
<a href="https://bugs.webkit.org/show_bug.cgi?id=321033">https://bugs.webkit.org/show_bug.cgi?id=321033</a>
<a href="https://rdar.apple.com/184066679">rdar://184066679</a>

Reviewed by Ryosuke Niwa.

Site Isolation&apos;s shared process mode puts multiple cross-site frames into one WebProcess for performance, trading away
some of the process-boundary protection between the co-located sites. 318135@main introduced IsolatedSiteStore to hold
the sites that must be kept out of that process, with autofill as the first signal. This patch adds two more signals for
better coverage:
- Signal::FirstPartyVisit is recorded in WebPageProxy::didCommitLoadForFrame when the commit is for the main frame, from
the committed request&apos;s URL, skipping about: and file: URLs. This is deliberately broad: it flags every site the user
navigated to at the top level, which might create first-party cookies.
- Signal::FirstPartyUserGesture is recorded similar to where ITP records hadUserInteraction: in UserGestureIndicator&apos;s
constructor, and in EventHandler::keyEvent for a handled key event. Both recording sites are gated on
ProcessInteractionStyle::Immediate. Delayed defers recording to the caller, which records once it knows the event was
handled, and Never marks a gesture asserted programmatically rather than made by the user.

Recording the two separately lets a future eviction policy drop the visited-only sites first, and lets us measure what
narrowing to gestures would cost before deciding to narrow.

API tests: WKWebsiteDataStore.FirstPartyVisitMarksSiteAsIsolated
           WKWebsiteDataStore.FirstPartyUserGestureInSubframeDoesNotMarkSubframeSite

* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::UserGestureIndicator::UserGestureIndicator):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::didObserveFirstPartyUserGesture):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::keyEvent):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didObserveFirstPartyUserGesture):
* Source/WebCore/page/Page.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _isolatedSiteSignalsForTesting:]):
(-[WKWebsiteDataStore _isIsolatedSiteForTesting:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::recordFirstPartyVisit):
(WebKit::WebPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didObserveFirstPartyUserGesture):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::isolatedSiteSignalsForTesting const):
(WebKit::WebsiteDataStore::isIsolatedSiteForTesting const): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::didObserveFirstPartyUserGesture):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, SharedProcessAfterKeyDown)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm:
(TEST(WKUserContentController, AutofillScriptingMarksSiteAsIsolated)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm:
(TestWebKitAPI::(WKWebsiteDataStore, FirstPartyVisitMarksSiteAsIsolated)):
(TestWebKitAPI::(WKWebsiteDataStore, FirstPartyUserGestureMarksSiteAsIsolated)):
(TestWebKitAPI::(WKWebsiteDataStore, FirstPartyUserGestureInSubframeDoesNotMarkSubframeSite)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewAutofillTests.mm:
(TestWebKitAPI::TEST(WKWebViewAutoFillTests, AutofillMarksSiteAsIsolated)):

Canonical link: <a href="https://commits.webkit.org/318763@main">https://commits.webkit.org/318763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/154865cf990a588c1005c412354a776bc909d1c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189073 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139777 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120229 "Passed tests") | | ⏳ 🛠 vision-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178567 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40386 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40033 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/384 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191291 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52851 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149021 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39987 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53531 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148766 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43444 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125803 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120662 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52049 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15014 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51434 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51675 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51495 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->