### PR TITLE
[JSC] Wasm Memory64 operands are differently decoded in unreachable code

### DIFF
--- a/JSTests/wasm/stress/memory64-unreachable-immediates.js
+++ b/JSTests/wasm/stress/memory64-unreachable-immediates.js
@@ -1,0 +1,75 @@
+//@ skip if $addressBits <= 32
+import { compile } from "../wabt-wrapper.js";
+
+// Memory immediates have to be decoded the same way in unreachable code as in reachable code: a
+// memory64 offset is a u64, and an atomic's align byte can carry a memory index. Getting this wrong
+// rejects valid modules.
+
+const options = { memory64: true, multi_memory: true, threads: true };
+
+// A memory64 atomic offset above 2^32, in unreachable code.
+await compile(`
+(module
+    (memory i64 1 1 shared)
+    (func
+        unreachable
+        (drop (i32.atomic.load offset=0x100000000 (i64.const 0)))))
+`, options);
+
+// The same offset in reachable code has always worked; keep them side by side.
+await compile(`
+(module
+    (memory i64 1 1 shared)
+    (func (result i32)
+        (i32.atomic.load offset=0x100000000 (i64.const 0))))
+`, options);
+
+// An atomic naming a non-default memory, in unreachable code.
+await compile(`
+(module
+    (memory 1 1 shared)
+    (memory $m 1 1 shared)
+    (func
+        unreachable
+        (drop (i32.atomic.load $m (i32.const 0)))))
+`, options);
+
+// memory.size and memory.grow naming a non-default memory, in unreachable code.
+await compile(`
+(module
+    (memory 1)
+    (memory $m 1)
+    (func
+        unreachable
+        (drop (memory.size $m))
+        (drop (memory.grow $m (i32.const 1)))))
+`, options);
+
+// A memory64 offset above 2^32 on a plain load in unreachable code.
+await compile(`
+(module
+    (memory i64 1)
+    (func
+        unreachable
+        (drop (i32.load offset=0x100000000 (i64.const 0)))))
+`, options);
+
+// An out-of-range memory index in unreachable code is still an error.
+async function assertRejected(wat, needle) {
+    try {
+        await compile(wat, options);
+    } catch (e) {
+        if (e instanceof WebAssembly.CompileError && e.message.includes(needle))
+            return;
+        throw new Error(`Wrong error: ${e}`);
+    }
+    throw new Error(`Expected a CompileError for ${wat}`);
+}
+
+await assertRejected(`
+(module
+    (memory 1)
+    (func
+        unreachable
+        (drop (memory.size 3))))
+`, "memory index 3 is out of range");

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/align.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/align.wast.js-expected.txt
@@ -122,8 +122,8 @@ PASS #120 Test that WebAssembly compilation fails (align.wast:891)
 PASS #121 Test that WebAssembly compilation fails (align.wast:910)
 PASS #122 Test that WebAssembly compilation fails (align.wast:929)
 PASS #123 Test that WebAssembly compilation fails (align.wast:948)
-FAIL #124 Test that WebAssembly compilation fails (align.wast:967) assert_equals: expected true but got false
-FAIL #125 Test that WebAssembly compilation fails (align.wast:986) assert_equals: expected true but got false
+PASS #124 Test that WebAssembly compilation fails (align.wast:967)
+PASS #125 Test that WebAssembly compilation fails (align.wast:986)
 PASS #126 Test that WebAssembly compilation fails (align.wast:1004)
 PASS #127 Test that WebAssembly compilation fails (align.wast:1016)
 PASS #128 Reinitialize the default imports
@@ -331,14 +331,8 @@ PASS #329 Test that WebAssembly compilation fails (align.wast:891)
 PASS #330 Test that WebAssembly compilation fails (align.wast:910)
 PASS #331 Test that WebAssembly compilation fails (align.wast:929)
 PASS #332 Test that WebAssembly compilation fails (align.wast:948)
-FAIL #333 Test that WebAssembly compilation fails (align.wast:967) assert_true: module@async_index.js:175:29
-assert_invalid@async_index.js:204:9
-align_wast_js@align.wast.js:562:17
-global code@align.wast.js:573:3 expected true got false
-FAIL #334 Test that WebAssembly compilation fails (align.wast:986) assert_true: module@async_index.js:175:29
-assert_invalid@async_index.js:204:9
-align_wast_js@align.wast.js:565:17
-global code@align.wast.js:573:3 expected true got false
+PASS #333 Test that WebAssembly compilation fails (align.wast:967)
+PASS #334 Test that WebAssembly compilation fails (align.wast:986)
 PASS #335 Test that WebAssembly compilation fails (align.wast:1004)
 PASS #336 Test that WebAssembly compilation fails (align.wast:1016)
 

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -1757,6 +1757,8 @@ auto FunctionParser<Context>::parseMemoryIndexForBulkOp(uint8_t& result) -> Part
 
 template<typename Context>
 auto FunctionParser<Context>::parseMemoryIndexAndFixupAlignment(uint32_t& alignment, uint8_t& result) -> PartialResult {
+    // memarg ::= a:u32 o:u64 (if a < 2^6) | a:u32 x:memidx o:u64 (if 2^6 <= a < 2^7)
+    WASM_PARSER_FAIL_IF(alignment >= (1 << 7), "byte alignment immediate "_s, alignment, " is too large"_s);
     bool hasMemoryIndex = alignment & (1 << 6);
     alignment = alignment & 0b111111;
     result = 0;
@@ -4566,9 +4568,9 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
 
     case GrowMemory:
     case CurrentMemory: {
-        uint8_t reserved;
-        WASM_PARSER_FAIL_IF(!parseUInt8(reserved), "can't parse reserved byte for grow_memory/current_memory"_s);
-        WASM_PARSER_FAIL_IF(reserved, "reserved byte for grow_memory/current_memory must be zero"_s);
+        WASM_PARSER_FAIL_IF(!m_info.memoryCount(), "grow_memory/current_memory is only valid if a memory is defined or imported"_s);
+        uint8_t memoryIndex;
+        WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndexForBulkOp(memoryIndex));
         return { };
     }
 
@@ -4595,10 +4597,17 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         {
             WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
             uint32_t alignment;
-            uint32_t unused;
             WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
+            uint8_t memoryIndex;
+            WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
             WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first immediate for atomic "_s, static_cast<unsigned>(op), " in unreachable context"_s);
+            if (m_info.memory(memoryIndex).isMemory64()) {
+                uint64_t unused64;
+                WASM_PARSER_FAIL_IF(!parseVarUInt64(unused64), "can't get first immediate for atomic "_s, static_cast<unsigned>(op), " in unreachable context"_s);
+            } else {
+                uint32_t unused32;
+                WASM_PARSER_FAIL_IF(!parseVarUInt32(unused32), "can't get first immediate for atomic "_s, static_cast<unsigned>(op), " in unreachable context"_s);
+            }
             break;
         }
         case ExtAtomicOpType::AtomicFence: {


### PR DESCRIPTION
#### 64153f963497bad197d2231657c2a73c2e9488a4
<pre>
[JSC] Wasm Memory64 operands are differently decoded in unreachable code
<a href="https://bugs.webkit.org/show_bug.cgi?id=321035">https://bugs.webkit.org/show_bug.cgi?id=321035</a>
<a href="https://rdar.apple.com/184068455">rdar://184068455</a>

Reviewed by Cole Carley.

Wasm unreachable code is decoding memory64 operands differently, causing
wasm parse error. Correctly handling memory64 operands in the same way
to the normal path.

* JSTests/wasm/stress/memory64-unreachable-immediates.js: Added.
(async assertRejected):
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/align.wast.js-expected.txt:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseMemoryIndexAndFixupAlignment):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):

Canonical link: <a href="https://commits.webkit.org/318605@main">https://commits.webkit.org/318605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e933f4fb70cebe62f2083fd460cba27b8e5d00ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178749 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188365 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34d67981-accb-4773-b00b-ad1eb06b8427) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139368 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62ec7767-6814-4083-ad1a-97db62c2daf7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119822 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b184acf3-272f-4a89-a1ee-dafd86387cbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41607 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39959 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1792 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8598 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152007 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39610 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40022 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45288 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190793 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52357 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148553 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53037 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148318 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27125 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43020 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125304 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119965 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51555 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14588 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50940 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51180 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51002 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->