### PR TITLE
[JSC] Due to IPInt, we need to ensure that wasm multi-memory does not support memory64

### DIFF
--- a/JSTests/wasm/stress/memory64-multi-memory-rejected.js
+++ b/JSTests/wasm/stress/memory64-multi-memory-rejected.js
@@ -1,0 +1,30 @@
+//@ skip if $addressBits <= 32
+import { compile } from "../wabt-wrapper.js";
+
+// A memory64 currently forces a single-memory module, because IPInt derives the address width of
+// every access from memory 0. The restriction has to hold whichever order the memories appear in.
+
+const options = { memory64: true, multi_memory: true };
+
+async function assertRejected(wat) {
+    try {
+        await compile(wat, options);
+    } catch (e) {
+        if (e instanceof WebAssembly.CompileError && e.message.includes("if using memory64 then multiple memories are illegal for now"))
+            return;
+        throw new Error(`Wrong error for ${wat}: ${e}`);
+    }
+    throw new Error(`Expected a CompileError for ${wat}`);
+}
+
+await assertRejected(`(module (memory i64 1) (memory 1))`);
+await assertRejected(`(module (memory 1) (memory i64 1))`);
+await assertRejected(`(module (memory i64 1) (memory i64 1))`);
+await assertRejected(`(module (memory i64 1) (memory 1) (memory 1))`);
+await assertRejected(`(module (import "m" "a" (memory i64 1)) (import "m" "b" (memory 1)))`);
+await assertRejected(`(module (import "m" "a" (memory 1)) (import "m" "b" (memory i64 1)))`);
+await assertRejected(`(module (import "m" "a" (memory i64 1)) (memory 1))`);
+
+// Multiple memory32s remain legal, and so does a lone memory64.
+await compile(`(module (memory 1) (memory 1))`, options);
+await compile(`(module (memory i64 1))`, options);

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -416,8 +416,8 @@ auto SectionParser::parseMemoryHelper(bool isImport) -> PartialResult
 
         // FIXME(wasm-memory64): for now IPInt checks m_cachedIsMemory64 (flag if memory 0 is 64-bit)
         // no matter which memory is being accessed
-        if (isMemory64)
-            WASM_PARSER_FAIL_IF(m_info->memoryCount(), "if using memory64 then multiple memories are illegal for now");
+        if (m_info->memoryCount())
+            WASM_PARSER_FAIL_IF(isMemory64 || m_info->memory(0).isMemory64(), "if using memory64 then multiple memories are illegal for now");
 
         initialPageCount = PageCount(initial);
 


### PR DESCRIPTION
#### d319ee7c278e6969bb9243fd5cb20f0874121cdf
<pre>
[JSC] Due to IPInt, we need to ensure that wasm multi-memory does not support memory64
<a href="https://bugs.webkit.org/show_bug.cgi?id=321038">https://bugs.webkit.org/show_bug.cgi?id=321038</a>
<a href="https://rdar.apple.com/184070346">rdar://184070346</a>

Reviewed by Cole Carley and Yijia Huang.

We would like to restrict that memory64 only has one memory. But right
now, if we define 32bit memory after 64bit memory, it passes. We should
check whether we had a 64bit memory.

Test: JSTests/wasm/stress/memory64-multi-memory-rejected.js

* JSTests/wasm/stress/memory64-multi-memory-rejected.js: Added.
(async assertRejected):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseMemoryHelper):

Canonical link: <a href="https://commits.webkit.org/318604@main">https://commits.webkit.org/318604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52dcf41427bb38d51784f4cfbafd9d8a2a8c7786

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188369 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/980a5f5c-845d-4647-9e0c-8855d7e9eb58) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139376 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b037674-e927-45f0-b046-743048ae37f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119830 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ae58649-e2c0-45df-8474-5694a7a3d4fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41606 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39960 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1800 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8603 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39615 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40026 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45292 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190797 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52361 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148557 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53041 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148324 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27126 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43019 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125308 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119969 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51559 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14593 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50944 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51184 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51006 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->