### PR TITLE
[JSC] `String#localeCompare` collator cache goes stale across language changes

### DIFF
--- a/JSTests/stress/string-locale-compare-locales-cache-language-change.js
+++ b/JSTests/stress/string-locale-compare-locales-cache-language-change.js
@@ -1,0 +1,27 @@
+//@ runDefault("--useDollarVM=1")
+
+if (typeof $vm === "undefined" || typeof $vm.setUserPreferredLanguages !== "function")
+    quit();
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: bad value: ${actual}, expected: ${expected}`);
+}
+
+// "xx" is structurally valid but not an available locale, so it resolves via the default locale.
+// The cached String#localeCompare collator must not survive a default-locale change.
+$vm.setUserPreferredLanguages(["en-US"]);
+
+setTimeout(() => {
+    for (let i = 0; i < 3; ++i)
+        shouldBe("ö".localeCompare("z", "xx"), new Intl.Collator("xx").compare("ö", "z"), "en-US");
+    shouldBe("ö".localeCompare("z", "xx") < 0, true, "en-US ordering");
+
+    $vm.setUserPreferredLanguages(["sv-SE"]);
+
+    setTimeout(() => {
+        shouldBe(new Intl.Collator("xx").compare("ö", "z") > 0, true, "sv-SE ordering via fresh collator");
+        for (let i = 0; i < 3; ++i)
+            shouldBe("ö".localeCompare("z", "xx"), new Intl.Collator("xx").compare("ö", "z"), "sv-SE");
+    }, 0);
+}, 0);

--- a/Source/JavaScriptCore/runtime/IntlCache.h
+++ b/Source/JavaScriptCore/runtime/IntlCache.h
@@ -79,6 +79,7 @@ public:
     }
 
     void clearForTimeZoneChange() { clearDateTimeFormatImplCache(); }
+    uint64_t languagesEpoch() const { return m_lastSeenLanguagesEpoch; }
     bool hasLanguageChange() const { return m_lastSeenLanguagesEpoch != s_languagesEpoch.load(std::memory_order_acquire); }
     void clearForLanguageChange()
     {

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -88,6 +88,7 @@
 #include "GlobalObjectMethodTable.h"
 #include "HeapIterationScope.h"
 #include "ImportMap.h"
+#include "IntlCache.h"
 #include "IntlCollator.h"
 #include "IntlCollatorPrototype.h"
 #include "IntlDateTimeFormat.h"
@@ -3163,7 +3164,7 @@ IntlCollator* JSGlobalObject::cachedLocaleCompareCollator(JSString* locale)
     String localeString = locale->value(this);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    if (m_cachedLocaleCompareCollator && m_cachedLocaleCompareCollatorLocale == localeString)
+    if (m_cachedLocaleCompareCollator && m_cachedLocaleCompareCollatorLanguagesEpoch == vm.intlCache().languagesEpoch() && m_cachedLocaleCompareCollatorLocale == localeString)
         return m_cachedLocaleCompareCollator.get();
 
     IntlCollator* collator = IntlCollator::create(vm, collatorStructure());
@@ -3171,6 +3172,7 @@ IntlCollator* JSGlobalObject::cachedLocaleCompareCollator(JSString* locale)
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     m_cachedLocaleCompareCollatorLocale = WTF::move(localeString);
+    m_cachedLocaleCompareCollatorLanguagesEpoch = vm.intlCache().languagesEpoch();
     m_cachedLocaleCompareCollator.set(vm, this, collator);
     return collator;
 }

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -302,6 +302,7 @@ public:
     // Cached collator object for String#localeCompare
     WriteBarrier<IntlCollator> m_cachedLocaleCompareCollator;
     String m_cachedLocaleCompareCollatorLocale;
+    uint64_t m_cachedLocaleCompareCollatorLanguagesEpoch { 0 };
 
     LazyClassStructure m_durationStructure;
     LazyClassStructure m_instantStructure;


### PR DESCRIPTION
#### 7d0200e4e6ed21a62e502459658984fe341dcf61
<pre>
[JSC] `String#localeCompare` collator cache goes stale across language changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=321039">https://bugs.webkit.org/show_bug.cgi?id=321039</a>

Reviewed by Yusuke Suzuki.

318542@main added a per-JSGlobalObject collator cache for
`String#localeCompare(that, locale)` keyed only by the locale string.
An unavailable-but-well-formed locale (e.g. &quot;xx&quot;) resolves via
DefaultLocale(), which follows the user preferred languages, so the same
locale string can produce a different collator after a language change.
The cache is not wired into IntlCache&apos;s languages epoch, so
`&quot;ö&quot;.localeCompare(&quot;z&quot;, &quot;xx&quot;)` keeps the pre-change ordering.

Record the languages epoch observed by IntlCache when caching, and treat
a mismatch as a cache miss.

    $vm.setUserPreferredLanguages([&quot;en-US&quot;]);
    // &quot;ö&quot;.localeCompare(&quot;z&quot;, &quot;xx&quot;) -&gt; -1
    $vm.setUserPreferredLanguages([&quot;sv-SE&quot;]);
    // &quot;ö&quot;.localeCompare(&quot;z&quot;, &quot;xx&quot;) -&gt; still -1, expected 1

Test: JSTests/stress/string-locale-compare-locales-cache-language-change.js

* JSTests/stress/string-locale-compare-locales-cache-language-change.js: Added.
(shouldBe):
(setTimeout):
* Source/JavaScriptCore/runtime/IntlCache.h:
(JSC::IntlCache::languagesEpoch const):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::cachedLocaleCompareCollator):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:

Canonical link: <a href="https://commits.webkit.org/318616@main">https://commits.webkit.org/318616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaaaba6a1858afb03f05c93dbb399615567d0ac2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188372 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139389 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119843 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41618 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39964 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1813 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8610 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152018 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39622 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40029 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190800 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52364 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148567 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39894 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53044 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148334 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43034 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125311 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119972 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51562 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14600 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50947 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->