### PR TITLE
[SwiftUI WebKit API] WebPage needs the WKUIDelegatePrivate attachment lifecycle callbacks (didInsertAttachment:withSource:, didRemoveAttachment:, didInvalidateDataForAttachment:)

### DIFF
--- a/Source/WebKit/Platform/unix/EnvironmentUtilities.h
+++ b/Source/WebKit/Platform/unix/EnvironmentUtilities.h
@@ -42,4 +42,4 @@ WK_EXPORT void removeValuesEndingWith(const char* environmentVariable, const cha
 
 } // namespace WebKit
 
-#endif
+#endif // __cplusplus

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2224,6 +2224,22 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 
 #endif // ENABLE(ATTACHMENT_ELEMENT)
 
+- (void)_insertAttachmentWithFileWrapperAsync:(NSFileWrapper *)fileWrapper contentType:(NSString *)contentType completion:(void(^)(_WKAttachment *))completionHandler
+{
+    THROW_IF_SUSPENDED;
+#if ENABLE(ATTACHMENT_ELEMENT)
+    auto identifier = createVersion4UUIDString();
+    auto attachment = API::Attachment::create(identifier, *_page);
+    attachment->setFileWrapperAndUpdateContentType(fileWrapper, contentType);
+    _page->insertAttachment(attachment.copyRef(), [attachment, capturedHandler = makeBlockPtr(completionHandler)] {
+        if (capturedHandler)
+            capturedHandler(wrapper(attachment));
+    });
+#else
+    capturedHandler(nil);
+#endif
+}
+
 - (id <_WKAppHighlightDelegate>)_appHighlightDelegate
 {
 #if ENABLE(APP_HIGHLIGHTS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -777,6 +777,8 @@ struct LiveResizeSnapshotState {
 
 - (BOOL)_scrollPocketInFullscreenEnabled;
 
+- (void)_insertAttachmentWithFileWrapperAsync:(NSFileWrapper *)fileWrapper contentType:(nullable NSString *)contentType completion:(void(^)(_WKAttachment *))completionHandler;
+
 @end
 
 @interface WKWebView (WKTextExtraction)

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+SPI.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+SPI.swift
@@ -24,12 +24,26 @@
 #if ENABLE_SWIFTUI
 
 import Observation
-import WebKit_Private
+import WebKit_Private.WKWebViewPrivate
 import WebKit_Internal
 
 // MARK: CrossImportOverlay SPI
 
 extension WebPage {
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(CrossImportOverlay)
+    public struct AttachmentLifecycleListeners: ~Copyable {
+        // These have to be erased to `Any` from `_WKAttachment` due to a compiler bug.
+
+        public var didRemoveAttachment: ((_ attachment: Any) -> Void)? = nil
+        public var didInsertAttachment: ((_ attachment: Any, _ source: Swift.String) -> Void)? = nil
+        public var didInvalidateDataForAttachment: ((_ attachment: Any) -> Void)? = nil
+
+        init() {
+        }
+    }
+
     #if WTF_PLATFORM_MAC
     // SPI for the cross-import overlay.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -196,6 +210,32 @@ extension WebPage.EditorStateSnapshot {
             textAlignment: NSTextAlignment(rawValue: dictionary["text-alignment"] as! Int)!,
             textColor: dictionary["text-color"] as! String
         )
+    }
+}
+
+// MARK: Experimental SPI
+
+extension WebPage {
+    /// Inserts an `<attachment>` element into the page.
+    ///
+    /// - Parameters:
+    ///   - fileWrapper: The file wrapper containing the data that the attachment represents.
+    ///   - contentType: The UTI type of the file data, like `text/html`.
+    /// - Returns: The created attachment instance.
+    /// - Note: The return type is `_WKAttachment?` but due to a compiler bug, it has to be erased as an `Any?`.
+    @_spi(Experimental)
+    public func insertAttachment(fileWrapper: FileWrapper, contentType: Swift.String?) async -> Any? {
+        await backingWebView._insertAttachment(withFileWrapperAsync: fileWrapper, contentType: contentType)
+    }
+
+    /// Returns the attachment with the specified ID, if one exists.
+    ///
+    /// - Parameter id: The identifier of an attachment to look up.
+    /// - Returns: The existing attachment instance whose identifier is `id`, or `nil` if none exists.
+    /// - Note: The return type is `_WKAttachment?` but due to a compiler bug, it has to be erased as an `Any?`.
+    @_spi(Experimental)
+    public func attachment(id: Swift.String) -> Any? {
+        backingWebView._attachment(forIdentifier: id)
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -389,6 +389,12 @@ final public class WebPage {
         return webView
     }()
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @ObservationIgnored
+    @_spi(CrossImportOverlay)
+    public var attachmentLifecycleListeners = AttachmentLifecycleListeners()
+
     // MARK: Loading functions
 
     @ObservationIgnored

--- a/Source/WebKit/UIProcess/API/cpp/WKCast.h
+++ b/Source/WebKit/UIProcess/API/cpp/WKCast.h
@@ -70,4 +70,4 @@ template<typename T, typename U> inline WKRetainPtr<T> dynamic_wk_cast(RetainPtr
 
 using WebKit::dynamic_wk_cast;
 
-#endif
+#endif // __cplusplus

--- a/Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h
+++ b/Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h
@@ -267,4 +267,4 @@ template<typename P> struct HashTraits<WKRetainPtr<P>> : SimpleClassHashTraits<W
 
 } // namespace WTF
 
-#endif
+#endif // __cplusplus

--- a/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
@@ -153,6 +153,24 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
     func _webView(_ webView: WKWebView, editorStateDidChange editorState: [AnyHashable: Any]) {
         owner?.addEditorStateUpdate(editorState)
     }
+
+    // swift-format-ignore: NoLeadingUnderscores
+    @objc(_webView:didRemoveAttachment:)
+    func _webView(_ webView: WKWebView, didRemove attachment: _WKAttachment) {
+        owner?.attachmentLifecycleListeners.didRemoveAttachment?(attachment)
+    }
+
+    // swift-format-ignore: NoLeadingUnderscores
+    @objc(_webView:didInsertAttachment:withSource:)
+    func _webView(_ webView: WKWebView, didInsert attachment: _WKAttachment, withSource source: String) {
+        owner?.attachmentLifecycleListeners.didInsertAttachment?(attachment, source)
+    }
+
+    // swift-format-ignore: NoLeadingUnderscores
+    @objc(_webView:didInvalidateDataForAttachment:)
+    func _webView(_ webView: WKWebView, didInvalidateDataFor attachment: _WKAttachment) {
+        owner?.attachmentLifecycleListeners.didInvalidateDataForAttachment?(attachment)
+    }
 }
 
 #endif

--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.h
@@ -62,4 +62,4 @@ private:
 
 }
 
-#endif
+#endif // __cplusplus

--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.h
@@ -46,4 +46,4 @@ struct FullscreenTouchSecheuristicParameters {
 
 }
 
-#endif
+#endif // __cplusplus

--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -265,6 +265,17 @@ extension View {
 
         return environment(\.webViewViewportConfiguration, configuration)
     }
+
+    /// Adds an action to perform when an attachment in the web content changes its current activity phase.
+    ///
+    /// - Parameter action: The action to perform whenever an attachment's state is updated.
+    /// - Returns: A view that calls `action` when the attachment's state is updated..
+    @_spi(Experimental)
+    public nonisolated func webViewOnAttachmentActivityPhase(
+        _ action: @escaping @MainActor (_ phase: WebView.AttachmentActivityPhase) -> Void
+    ) -> some View {
+        environment(\.webViewOnAttachmentActivityPhaseContext, .init(action: action))
+    }
 }
 
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
@@ -25,6 +25,7 @@
 
 public import SwiftUI
 @_spi(CrossImportOverlay) public import WebKit
+@_spiOnly public import WebKit_Private
 
 /// A view that displays some web content.
 ///
@@ -266,6 +267,31 @@ extension WebView {
         public static let editable = Self(storage: .editable)
 
         let storage: Storage
+    }
+
+    /// The current attachment and its state.
+    @_spi(Experimental)
+    public struct AttachmentActivityPhase {
+        /// The possible kinds of phase an attachment may be in during its lifetime.
+        @_spi(Experimental)
+        public enum Kind: Sendable {
+            /// The attachment was inserted.
+            case inserted(_ source: String)
+
+            /// The attachment was removed.
+            case removed
+
+            /// The attachment has had its data invalidated.
+            case dataInvalidated
+        }
+
+        /// The attachment this activity phase belongs to.
+        @_spi(Experimental)
+        public let attachment: _WKAttachment
+
+        /// The kind of activity this phase represents.
+        @_spi(Experimental)
+        public let kind: Kind
     }
 }
 

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
@@ -73,6 +73,9 @@ extension EnvironmentValues {
 
     @Entry
     var webViewViewportConfiguration: WebView.ViewportConfiguration_v0? = nil
+
+    @Entry
+    var webViewOnAttachmentActivityPhaseContext: OnAttachmentActivityPhaseContext? = nil
 }
 
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
@@ -59,4 +59,8 @@ struct ImmersiveEnvironmentRequestContext {
 }
 #endif
 
+struct OnAttachmentActivityPhaseContext {
+    let action: @MainActor (_ phase: WebView.AttachmentActivityPhase) -> Void
+}
+
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -148,6 +148,29 @@ struct WebViewRepresentable {
         }
         #endif // WTF_PLATFORM_IOS_FAMILY
 
+        if let onAttachmentActivityPhase = environment.webViewOnAttachmentActivityPhaseContext?.action {
+            page.attachmentLifecycleListeners.didInsertAttachment = {
+                // This is safe because it is contractually guaranteed by us to be a _WKAttachment.
+                // swift-format-ignore: NeverForceUnwrap
+                onAttachmentActivityPhase(.init(attachment: $0 as! _WKAttachment, kind: .inserted($1)))
+            }
+            page.attachmentLifecycleListeners.didRemoveAttachment = {
+                // This is safe because it is contractually guaranteed by us to be a _WKAttachment.
+                // swift-format-ignore: NeverForceUnwrap
+                onAttachmentActivityPhase(.init(attachment: $0 as! _WKAttachment, kind: .removed))
+            }
+
+            page.attachmentLifecycleListeners.didInvalidateDataForAttachment = {
+                // This is safe because it is contractually guaranteed by us to be a _WKAttachment.
+                // swift-format-ignore: NeverForceUnwrap
+                onAttachmentActivityPhase(.init(attachment: $0 as! _WKAttachment, kind: .dataInvalidated))
+            }
+        } else {
+            page.attachmentLifecycleListeners.didInsertAttachment = nil
+            page.attachmentLifecycleListeners.didRemoveAttachment = nil
+            page.attachmentLifecycleListeners.didInvalidateDataForAttachment = nil
+        }
+
         platformView.onScrollGeometryChange = environment.webViewOnScrollGeometryChange
 
         #if ENABLE_MODEL_ELEMENT_IMMERSIVE

--- a/Tools/TestWebKitAPI/Helpers/cocoa/SwiftUI+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/SwiftUI+Extras.swift
@@ -84,6 +84,14 @@ public func render(
     }
 }
 
+/// Renders a SwiftUI view.
+///
+/// - Parameter rootView: The view to render.
+@MainActor
+public func render(@ViewBuilder rootView: () -> some View) {
+    render(rootView: rootView) { () }
+}
+
 #endif // ENABLE_SWIFTUI && !WTF_PLATFORM_WATCHOS
 
 extension Font {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift
@@ -27,9 +27,11 @@ import Observation
 import SwiftUI
 import Testing
 @_spi(Testing) import WebKit
+import WebKit_Private.WKWebViewPrivate
 @_spi(Experimental) import _WebKit_SwiftUI
 private import TestWebKitAPILibrary
 import struct _Concurrency.Task
+import struct Swift.String
 #if WTF_PLATFORM_MAC
 import AppKit
 #else
@@ -39,7 +41,16 @@ import UIKit
 @Observable
 @MainActor
 private final class ViewModel {
-    let page = WebPage()
+    struct Attachments: Equatable {
+        var inserted: Set<_WKAttachment> = []
+        var removed: Set<_WKAttachment> = []
+    }
+
+    let page: WebPage = {
+        var configuration = WebPage.Configuration()
+        configuration.attachmentElementEnabled = true
+        return WebPage(configuration: configuration)
+    }()
 
     var isEditable: Bool = false
 
@@ -47,6 +58,8 @@ private final class ViewModel {
     // FIXME: Consider alternative designs to avoid this requirement.
     var viewportWidth: _WebKit_SwiftUI.WebView.ViewportConfiguration_v0.Width? = nil
     var viewportInitialScale: Float? = nil
+
+    var attachments = Attachments()
 }
 
 private struct TestView: View {
@@ -60,6 +73,21 @@ private struct TestView: View {
                 width: model.viewportWidth,
                 initialScale: model.viewportInitialScale
             )
+            .webViewOnAttachmentActivityPhase { phase in
+                switch phase.kind {
+                case .inserted(_):
+                    model.attachments.inserted.insert(phase.attachment)
+
+                case .removed:
+                    model.attachments.removed.insert(phase.attachment)
+
+                case .dataInvalidated:
+                    break
+
+                @unknown default:
+                    fatalError()
+                }
+            }
     }
 }
 
@@ -97,6 +125,52 @@ struct WebViewTests {
         await model.page.waitForNextPresentationUpdate()
 
         #expect(!(try await isContentEditable()))
+    }
+
+    @Test
+    func onAttachmentActivityPhaseAffectsListeners() async throws {
+        let html = """
+            <meta name='viewport' content='width=device-width, initial-scale=1'>
+            <script>
+            focus = () => document.body.focus()
+            </script>
+            <body onload=focus() contenteditable></body>
+            """
+
+        let model = ViewModel()
+
+        render {
+            TestView()
+                .environment(model)
+        }
+
+        try await model.page.load(html: html).wait()
+
+        let testHTMLData = try #require("<a href='#'>This is some HTML data</a>".data(using: .utf8))
+        let testImageFileURL = try #require(Bundle.testResources.url(forResource: "icon", withExtension: "png"))
+        let testImageData = try Data(contentsOf: testImageFileURL)
+
+        func insertAttachment(filename: String, contentType: String?, data: Data) async -> _WKAttachment? {
+            let fileWrapper = FileWrapper(regularFileWithContents: data)
+            fileWrapper.preferredFilename = filename
+
+            return await model.page.insertAttachment(fileWrapper: fileWrapper, contentType: contentType) as? _WKAttachment
+        }
+
+        let firstAttachment = await insertAttachment(filename: "foo", contentType: "text/html", data: testHTMLData)
+
+        #expect(model.attachments.removed == [])
+        #expect(model.attachments.inserted == [firstAttachment])
+
+        await model.page.executeEditCommand(.deleteBackward)
+
+        #expect(model.attachments.removed == [firstAttachment])
+        #expect(model.attachments.inserted == [firstAttachment])
+
+        let secondAttachment = await insertAttachment(filename: "bar.png", contentType: "text/html", data: testImageData)
+
+        #expect(model.attachments.removed == [firstAttachment])
+        #expect(model.attachments.inserted == [firstAttachment, secondAttachment])
     }
 
     #if WTF_PLATFORM_IOS_FAMILY


### PR DESCRIPTION
#### e492299027dcbe5535755c39f7cf48e6a4bfc590
<pre>
[SwiftUI WebKit API] WebPage needs the WKUIDelegatePrivate attachment lifecycle callbacks (didInsertAttachment:withSource:, didRemoveAttachment:, didInvalidateDataForAttachment:)
<a href="https://bugs.webkit.org/show_bug.cgi?id=321040">https://bugs.webkit.org/show_bug.cgi?id=321040</a>
<a href="https://rdar.apple.com/184057419">rdar://184057419</a>

Reviewed by Wenson Hsieh.

Add a few SPIs on WebView and WebPage to make dealing with attachments easier:

For handling the attachment lifecycle, a new view modifier SPI is introduced:

```
extension WebView {
    public struct AttachmentActivityPhase {
        public enum Kind: Sendable {
            case inserted(_ source: String)

            case removed

            case dataInvalidated
        }

        public var attachment: _WKAttachment { get }

        public var kind: Kind { get }
    }
}

extension View {
    public nonisolated func webViewOnAttachmentActivityPhase(
        _ action: @escaping @MainActor (_ phase: WebView.AttachmentActivityPhase) -&gt; Void
    ) -&gt; some View
}
```

On WebPage, new SPI is added to create an attachment and retrieve an attachment:

```
extension WebPage {
    public func insertAttachment(fileWrapper: FileWrapper, contentType: Swift.String?) async -&gt; _WKAttachment?

    public func attachment(id: Swift.String) -&gt; _WKAttachment?
}
```

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _insertAttachmentWithFileWrapperAsync:contentType:completion:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Swift/WebPage+SPI.swift:
(AttachmentLifecycleListeners.didRemoveAttachment):
(AttachmentLifecycleListeners.didInsertAttachment):
(AttachmentLifecycleListeners.didInvalidateDataForAttachment):
(WebPage.insertAttachment(_:contentType:)):
(WebPage.attachment(_:)):
(WebPage.setMenuBuilder(_:)): Deleted.
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
* Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift:
(WKUIDelegateAdapter._webView(_:didRemove:)):
(WKUIDelegateAdapter._webView(_:didInsert:withSource:)):
(WKUIDelegateAdapter._webView(_:didInvalidateDataFor:)):
* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:
* Source/WebKit/_WebKit_SwiftUI/API/WebView.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift:
(EnvironmentValues.webViewOnAttachmentActivityPhaseContext):
* Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):
* Tools/TestWebKitAPI/Helpers/cocoa/SwiftUI+Extras.swift:
(render(@ViewBuilder rootView: () -&gt; some View:)):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift:
(Attachments.inserted):
(Attachments.removed):
(TestView.body):
(WebViewTests.onAttachmentActivityPhaseAffectsListeners):
(ViewModel.isEditable): Deleted.
(ViewModel.viewportWidth): Deleted.
(ViewModel.viewportInitialScale): Deleted.

Canonical link: <a href="https://commits.webkit.org/318672@main">https://commits.webkit.org/318672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfe32086bc095caaad1935b0fc804d7f4e8b8f12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188817 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11c3ef2b-a1b3-4e35-a676-ad9d3d73db90) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139567 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b91242f1-5f04-41b4-bd7b-af01f485b9fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120013 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41832 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39826 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/124 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45533 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191037 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52597 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159840 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148789 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39926 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53277 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148540 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43231 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125547 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51795 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14805 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51180 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51421 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51241 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->