### PR TITLE
Cherry-pick 305413.967@safari-7624.4-branch (f1ce3d547a23). https://bugs.webkit.org/show_bug.cgi?id=317163

### DIFF
--- a/LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame-expected.html
+++ b/LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame-expected.html
@@ -1,0 +1,20 @@
+<style>
+    .box {
+        width: 100px;
+        height: 100px;
+        margin: 10px;
+        display: inline-block;
+    }
+    .image, .tainted-canvas {
+        background-color: lime;
+    }
+    .image-capture-canvas {
+        background-color: red;
+    }
+</style>
+<body>
+    <h3>The third box has to be red. It is canvas draws an image capture from another tainted canavas.</h3>
+    <div class="image box"></div>
+    <div class="tainted-canvas box"></div>
+    <div class="image-capture-canvas box"></div>
+</body>

--- a/LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame.html
+++ b/LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame.html
@@ -1,0 +1,17 @@
+<style>
+    img {
+        margin: 10px;
+        width: 100px;
+        height: 100px;
+    }
+    iframe {
+        margin: 10px;
+        width: 250px;
+        height: 100px;
+    }
+</style>
+<body>
+    <h3>The third box has to be red. It is canvas draws an image capture from another tainted canavas.</h3>
+    <img src="http://localhost:8000/canvas/resources/100x100-lime-rect.svg">
+    <iframe src="http://127.0.0.1:8000/canvas/resources/cross-origin-image-capture-video-frame.html" frameborder=0></iframe>
+</body>

--- a/LayoutTests/http/tests/canvas/resources/cross-origin-image-capture-video-frame.html
+++ b/LayoutTests/http/tests/canvas/resources/cross-origin-image-capture-video-frame.html
@@ -1,0 +1,54 @@
+<style>
+    body {
+        margin: 0;
+        padding: 0;
+        overflow: clip;
+    }
+    canvas {
+        width: 100px;
+        height: 100px;
+        margin-left: 0;
+        margin-right: 20px;
+        background: red;
+    }
+</style>
+<body>
+    <canvas id="src"></canvas>
+    <canvas id="dest"></canvas>
+    <script>
+        (async () => {
+            var srcCanvas = document.getElementById('src');
+            srcCanvas.width = 100;
+            srcCanvas.height = 100;
+
+            var destCanvas = document.getElementById('dest');
+            destCanvas.width = 100;
+            destCanvas.height = 100;
+
+            // 1. Capture the stream of the source canvas while it is still origin-clean.
+            var stream = srcCanvas.captureStream(0);
+            var track = stream.getVideoTracks()[0];
+            track.requestFrame();
+
+            // 2. Load the cross-origin image.
+            var img = new Image();
+            img.src = 'http://localhost:8000/canvas/resources/100x100-lime-rect.svg';
+            await new Promise(function(ok, fail) {
+                img.onload = ok;
+            });
+
+            // 3. Draw the the cross-origin image onto the canvas — this taints it; direct reads are now blocked.
+            var srcCtx = srcCanvas.getContext('2d');
+            srcCtx.drawImage(img, 0, 0);
+
+            // 4. grabFrame() snapshots the tainted canvas.
+            var bmp = await new ImageCapture(track).grabFrame();
+
+            // 5. Draw the frame to a fresh canvas - nothing should be drawn from the tainted canvas.
+            var destCtx = destCanvas.getContext('2d');
+            destCtx.drawImage(bmp, 0, 0);
+
+            window.parent.postMessage("onload", "*");
+        })();
+    </script>
+</body>

--- a/LayoutTests/http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe-expected.txt
@@ -1,0 +1,13 @@
+Tests that SameSite=Strict and SameSite=Lax cookies for 127.0.0.1 are not sent with a fetch() initiated from a srcdoc iframe nested inside a cross-origin iframe. The srcdoc inherits its parent's origin, so a request from the srcdoc back to the top-level origin is cross-site and must not receive SameSite-restricted cookies.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Cookies sent with cross-site fetch initiated from srcdoc iframe inside cross-origin iframe:
+PASS Do not have cookie "strict".
+PASS Do not have cookie "lax".
+PASS Has cookie "implicit-default" with value 9.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="../resources/cookie-utilities.js"></script>
+</head>
+<body>
+<script>
+window.jsTestIsAsync = true;
+
+description("Tests that SameSite=Strict and SameSite=Lax cookies for 127.0.0.1 are not sent with a fetch() initiated from a srcdoc iframe nested inside a cross-origin iframe. The srcdoc inherits its parent's origin, so a request from the srcdoc back to the top-level origin is cross-site and must not receive SameSite-restricted cookies.");
+
+const kCookieValue = "9";
+
+function checkCookies(cookies)
+{
+    debug("Cookies sent with cross-site fetch initiated from srcdoc iframe inside cross-origin iframe:");
+    if (cookies.error) {
+        testFailed(`fetch from srcdoc failed: ${cookies.error}`);
+        return;
+    }
+    if (cookies.strict === undefined)
+        testPassed('Do not have cookie "strict".');
+    else
+        testFailed(`Should not have cookie "strict". But do with value ${cookies.strict}.`);
+
+    if (cookies.lax === undefined)
+        testPassed('Do not have cookie "lax".');
+    else
+        testFailed(`Should not have cookie "lax". But do with value ${cookies.lax}.`);
+
+    if (cookies["implicit-default"] === kCookieValue)
+        testPassed(`Has cookie "implicit-default" with value ${kCookieValue}.`);
+    else
+        testFailed(`Should have cookie "implicit-default" with value ${kCookieValue}. Got ${cookies["implicit-default"]}.`);
+}
+
+async function runTest()
+{
+    await resetCookies();
+    await setCookie("strict", kCookieValue, {"SameSite": "Strict", "Max-Age": 100, "path": "/"});
+    await setCookie("lax", kCookieValue, {"SameSite": "Lax", "Max-Age": 100, "path": "/"});
+    await setCookie("implicit-default", kCookieValue, {"SameSite": null, "Max-Age": 100, "path": "/"});
+
+    let cookiesPromise = new Promise((resolve) => {
+        window.addEventListener("message", (event) => {
+            if (event.data && event.data.type === "cookies-from-srcdoc")
+                resolve(event.data.cookies);
+        }, {once: true});
+    });
+
+    let attackerIframe = document.createElement("iframe");
+    attackerIframe.src = "http://localhost:8000/cookies/same-site/resources/srcdoc-creator-inside-cross-origin-iframe.html";
+    document.body.appendChild(attackerIframe);
+
+    let cookies = await cookiesPromise;
+    checkCookies(cookies);
+
+    document.body.removeChild(attackerIframe);
+
+    await resetCookies();
+    finishJSTest();
+}
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/cookies/same-site/img-from-srcdoc-iframe-inside-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/cookies/same-site/img-from-srcdoc-iframe-inside-cross-origin-iframe-expected.txt
@@ -1,0 +1,13 @@
+Tests that SameSite=Strict and SameSite=Lax cookies for 127.0.0.1 are not sent with an <img> sub-resource request initiated from a srcdoc iframe nested inside a cross-origin iframe. The srcdoc inherits its parent's origin, so the image request back to the top-level origin is cross-site and must not receive SameSite-restricted cookies.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Cookies sent with cross-site <img> request initiated from srcdoc iframe inside cross-origin iframe:
+PASS Do not have cookie "strict".
+PASS Do not have cookie "lax".
+PASS Has cookie "implicit-default" with value 9.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/cookies/same-site/img-from-srcdoc-iframe-inside-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/cookies/same-site/img-from-srcdoc-iframe-inside-cross-origin-iframe.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="../resources/cookie-utilities.js"></script>
+</head>
+<body>
+<script>
+window.jsTestIsAsync = true;
+
+description("Tests that SameSite=Strict and SameSite=Lax cookies for 127.0.0.1 are not sent with an &lt;img&gt; sub-resource request initiated from a srcdoc iframe nested inside a cross-origin iframe. The srcdoc inherits its parent's origin, so the image request back to the top-level origin is cross-site and must not receive SameSite-restricted cookies.");
+
+const kCookieValue = "9";
+const kRecorderBase = "/cookies/same-site/resources/record-image-cookies.py";
+const kToken = "srcdoc-img-test-" + Date.now();
+
+async function fetchRecordedCookies()
+{
+    let response = await fetch(`${kRecorderBase}?mode=read&token=${encodeURIComponent(kToken)}`, {credentials: "same-origin"});
+    return response.json();
+}
+
+async function resetRecordedCookies()
+{
+    await fetch(`${kRecorderBase}?mode=reset&token=${encodeURIComponent(kToken)}`, {credentials: "same-origin"});
+}
+
+function checkCookies(cookies)
+{
+    debug("Cookies sent with cross-site &lt;img&gt; request initiated from srcdoc iframe inside cross-origin iframe:");
+    if (cookies.strict === undefined)
+        testPassed('Do not have cookie "strict".');
+    else
+        testFailed(`Should not have cookie "strict". But do with value ${cookies.strict}.`);
+
+    if (cookies.lax === undefined)
+        testPassed('Do not have cookie "lax".');
+    else
+        testFailed(`Should not have cookie "lax". But do with value ${cookies.lax}.`);
+
+    // Positive control: WebKit treats a cookie with no SameSite attribute as
+    // SameSite=None (see coreSameSitePolicy() in CookieCocoa.mm), so it must
+    // still be sent on a cross-site image request that includes credentials.
+    // Without this assertion, the negative checks above could pass simply
+    // because cookies aren't being delivered at all.
+    if (cookies["implicit-default"] === kCookieValue)
+        testPassed(`Has cookie "implicit-default" with value ${kCookieValue}.`);
+    else
+        testFailed(`Should have cookie "implicit-default" with value ${kCookieValue}. Got ${cookies["implicit-default"]}.`);
+}
+
+async function runTest()
+{
+    await resetCookies();
+    await resetRecordedCookies();
+    await setCookie("strict", kCookieValue, {"SameSite": "Strict", "Max-Age": 100, "path": "/"});
+    await setCookie("lax", kCookieValue, {"SameSite": "Lax", "Max-Age": 100, "path": "/"});
+    await setCookie("implicit-default", kCookieValue, {"SameSite": null, "Max-Age": 100, "path": "/"});
+
+    let imgLoadedPromise = new Promise((resolve, reject) => {
+        window.addEventListener("message", (event) => {
+            if (!event.data)
+                return;
+            if (event.data.type === "srcdoc-img-loaded")
+                resolve();
+            else if (event.data.type === "srcdoc-img-error")
+                reject(new Error("srcdoc <img> failed to load"));
+        }, {once: false});
+    });
+
+    let attackerIframe = document.createElement("iframe");
+    attackerIframe.src = "http://localhost:8000/cookies/same-site/resources/srcdoc-creator-img-inside-cross-origin-iframe.html?token=" + encodeURIComponent(kToken);
+    document.body.appendChild(attackerIframe);
+
+    try {
+        await imgLoadedPromise;
+    } catch (e) {
+        testFailed(String(e));
+        document.body.removeChild(attackerIframe);
+        await resetCookies();
+        finishJSTest();
+        return;
+    }
+
+    let cookies = await fetchRecordedCookies();
+    checkCookies(cookies);
+
+    document.body.removeChild(attackerIframe);
+
+    await resetRecordedCookies();
+    await resetCookies();
+    finishJSTest();
+}
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/cookies/same-site/resources/record-image-cookies.py
+++ b/LayoutTests/http/tests/cookies/same-site/resources/record-image-cookies.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#
+# Helper for img-from-srcdoc-iframe-inside-cross-origin-iframe.html
+# (rdar://175498842 / https://bugs.webkit.org/show_bug.cgi?id=313220).
+#
+# Modes:
+#   ?mode=reset&token=<id> ............ clear any previously recorded cookies for <id>
+#   ?mode=record&token=<id> ........... record incoming Cookie header to a temp file keyed by <id>; respond with a 1x1 PNG
+#   ?mode=read&token=<id> ............. respond with JSON of cookies recorded for <id>
+
+import json
+import os
+import sys
+import tempfile
+from urllib.parse import parse_qs
+
+file = __file__.split(':/cygwin')[-1]
+http_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file)))))
+sys.path.insert(0, http_root)
+
+from resources.portabilityLayer import get_cookies, get_state, set_state
+
+query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
+mode = query.get('mode', ['record'])[0]
+token = query.get('token', ['default'])[0]
+tmp_file = os.path.join(tempfile.gettempdir(), 'srcdoc-img-cookies-' + token + '.json')
+
+origin = os.environ.get('HTTP_ORIGIN', '*')
+
+if mode == 'reset':
+    set_state(tmp_file, '{}')
+    sys.stdout.write(
+        'Content-Type: text/plain\r\n'
+        'Cache-Control: no-store\r\n'
+        'Access-Control-Allow-Origin: {}\r\n'
+        'Access-Control-Allow-Credentials: true\r\n\r\n'
+        'reset'.format(origin)
+    )
+    sys.exit(0)
+
+if mode == 'read':
+    cookies_json = get_state(tmp_file, '{}')
+    sys.stdout.write(
+        'Content-Type: application/json\r\n'
+        'Cache-Control: no-store\r\n'
+        'Access-Control-Allow-Origin: {}\r\n'
+        'Access-Control-Allow-Credentials: true\r\n\r\n'
+        '{}'.format(origin, cookies_json)
+    )
+    sys.exit(0)
+
+# mode == 'record' (default): record incoming cookies and serve a 1x1 transparent PNG.
+cookies = get_cookies()
+set_state(tmp_file, json.dumps(cookies))
+
+png = bytes.fromhex(
+    '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489'
+    '0000000d4944415478da63f8ffff3f0005fe02fe2c8c5d420000000049454e44ae'
+    '426082'
+)
+sys.stdout.buffer.write(
+    ('Content-Type: image/png\r\n'
+     'Cache-Control: no-store\r\n'
+     'Content-Length: {}\r\n\r\n'.format(len(png))).encode()
+)
+sys.stdout.buffer.write(png)
+sys.exit(0)

--- a/LayoutTests/http/tests/cookies/same-site/resources/srcdoc-creator-img-inside-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/cookies/same-site/resources/srcdoc-creator-img-inside-cross-origin-iframe.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Attacker iframe (cross-origin to the top-level victim) that creates a srcdoc loading an img</title>
+</head>
+<body>
+<script>
+// Loaded at http://localhost:8000 inside an iframe of a top-level page at
+// http://127.0.0.1:8000. Creates a nested srcdoc iframe; the srcdoc loads an
+// <img> back to the top-level origin and reports load completion to the top
+// frame. The top frame then reads the cookies the image request actually saw
+// from a server-side recorder.
+//
+// rdar://175498842 / https://bugs.webkit.org/show_bug.cgi?id=313220
+
+const params = new URLSearchParams(window.location.search);
+const token = params.get("token") || "default";
+const recorderURL = "http://127.0.0.1:8000/cookies/same-site/resources/record-image-cookies.py?mode=record&token=" + encodeURIComponent(token);
+
+const srcdocContent = `<!DOCTYPE html><body><script>
+let img = new Image();
+img.onload = () => window.top.postMessage({type: "srcdoc-img-loaded"}, "*");
+img.onerror = () => window.top.postMessage({type: "srcdoc-img-error"}, "*");
+img.src = ${JSON.stringify(recorderURL)};
+<\/script></body>`;
+
+let srcdocIframe = document.createElement("iframe");
+srcdocIframe.style.display = "none";
+srcdocIframe.srcdoc = srcdocContent;
+document.body.appendChild(srcdocIframe);
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/cookies/same-site/resources/srcdoc-creator-inside-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/cookies/same-site/resources/srcdoc-creator-inside-cross-origin-iframe.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Cross-origin iframe that creates a srcdoc</title>
+</head>
+<body>
+<script>
+const fetchURL = "http://127.0.0.1:8000/cookies/resources/echo-json.py";
+const srcdocContent = `<!DOCTYPE html><body><script>
+fetch(${JSON.stringify(fetchURL)}, {credentials: "include", mode: "cors"})
+    .then((response) => response.json())
+    .then((cookies) => {
+        window.top.postMessage({type: "cookies-from-srcdoc", cookies}, "*");
+    })
+    .catch((error) => {
+        window.top.postMessage({type: "cookies-from-srcdoc", cookies: {error: String(error)}}, "*");
+    });
+<\/script></body>`;
+
+let srcdocIframe = document.createElement("iframe");
+srcdocIframe.style.display = "none";
+srcdocIframe.srcdoc = srcdocContent;
+document.body.appendChild(srcdocIframe);
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -201,6 +201,9 @@ RefPtr<VideoFrame> CanvasCaptureMediaStreamTrack::Source::grabFrame()
     if (!canvas)
         return nullptr;
 
+    if (!canvas->originClean())
+        return nullptr;
+
 #if ENABLE(WEBGL)
     if (RefPtr gl = dynamicDowncast<WebGLRenderingContextBase>(canvas->renderingContext()))
         return gl->surfaceBufferToVideoFrame(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
@@ -221,16 +224,7 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
         m_shouldEmitFrame = false;
     }
 
-    if (!canvas->originClean())
-        return;
-
-    RefPtr videoFrame = [&]() -> RefPtr<VideoFrame> {
-#if ENABLE(WEBGL)
-        if (RefPtr gl = dynamicDowncast<WebGLRenderingContextBase>(canvas->renderingContext()))
-            return gl->surfaceBufferToVideoFrame(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
-#endif
-        return canvas->toVideoFrame();
-    }();
+    RefPtr videoFrame = grabFrame();
     if (!videoFrame)
         return;
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1234,8 +1234,11 @@ void FrameLoader::setFirstPartyForCookies(const URL& url)
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*descendantFrame);
         if (!localFrame)
             continue;
-        if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(localFrame->document()->url()) || registrableDomain.matches(localFrame->document()->url()))
-            localFrame->protectedDocument()->setSiteForCookies(url);
+        if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(localFrame->document()->url())) {
+            if (RefPtr parent = dynamicDowncast<LocalFrame>(localFrame->tree().parent()))
+                protect(localFrame->document())->setSiteForCookies(parent->document()->siteForCookies());
+        } else if (registrableDomain.matches(localFrame->document()->url()))
+            protect(localFrame->document())->setSiteForCookies(url);
     }
 }
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -104,6 +104,13 @@ CacheStorageManager* CacheStorageCache::manager()
     return m_manager.get();
 }
 
+std::optional<WebCore::ClientOrigin> CacheStorageCache::origin() const
+{
+    if (RefPtr manager = m_manager.get())
+        return manager->origin();
+    return std::nullopt;
+}
+
 void CacheStorageCache::getSize(CompletionHandler<void(uint64_t)>&& callback)
 {
     assertIsOnCorrectQueue();

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
@@ -38,6 +38,10 @@ namespace IPC {
 class Connection;
 }
 
+namespace WebCore {
+struct ClientOrigin;
+}
+
 namespace WebKit {
 class CacheStorageCache;
 }
@@ -55,6 +59,7 @@ public:
     const String& name() const { return m_name; }
     const String& uniqueName() const { return m_uniqueName; }
     CacheStorageManager* manager();
+    std::optional<WebCore::ClientOrigin> origin() const;
 
     void getSize(CompletionHandler<void(uint64_t)>&&);
     void open(WebCore::DOMCacheEngine::CacheIdentifierCallback&&);

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -234,24 +234,25 @@ void CacheStorageManager::makeDirty()
     m_updateCounter = nextUpdateNumber();
 }
 
-Ref<CacheStorageManager> CacheStorageManager::create(const String& path, CacheStorageRegistry& registry, const std::optional<WebCore::ClientOrigin>& origin, QuotaCheckFunction&& quotaCheckFunction, Ref<WorkQueue>&& queue)
+Ref<CacheStorageManager> CacheStorageManager::create(const String& path, CacheStorageRegistry& registry, const WebCore::ClientOrigin& origin, ShouldWriteOriginFile shouldWriteOriginFile, QuotaCheckFunction&& quotaCheckFunction, Ref<WorkQueue>&& queue)
 {
-    return adoptRef(*new CacheStorageManager(path, registry, origin, WTF::move(quotaCheckFunction), WTF::move(queue)));
+    return adoptRef(*new CacheStorageManager(path, registry, origin, shouldWriteOriginFile, WTF::move(quotaCheckFunction), WTF::move(queue)));
 }
 
-CacheStorageManager::CacheStorageManager(const String& path, CacheStorageRegistry& registry, const std::optional<WebCore::ClientOrigin>& origin, QuotaCheckFunction&& quotaCheckFunction, Ref<WorkQueue>&& queue)
+CacheStorageManager::CacheStorageManager(const String& path, CacheStorageRegistry& registry, const WebCore::ClientOrigin& origin, ShouldWriteOriginFile shouldWriteOriginFile, QuotaCheckFunction&& quotaCheckFunction, Ref<WorkQueue>&& queue)
     : m_updateCounter(nextUpdateNumber())
     , m_path(path)
+    , m_origin(origin)
     , m_salt(readOrMakeSalt(saltFilePath(m_path)))
     , m_registry(registry)
     , m_quotaCheckFunction(WTF::move(quotaCheckFunction))
     , m_queue(WTF::move(queue))
 {
-    if (m_path.isEmpty() || !origin)
+    if (m_path.isEmpty() || shouldWriteOriginFile == ShouldWriteOriginFile::No)
         return;
 
     auto originFile = FileSystem::pathByAppendingComponent(m_path, originFileName);
-    WebCore::StorageUtilities::writeOriginToFile(originFile, *origin);
+    WebCore::StorageUtilities::writeOriginToFile(originFile, m_origin);
 }
 
 CacheStorageManager::~CacheStorageManager()

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
@@ -26,19 +26,12 @@
 #pragma once
 
 #include "Connection.h"
+#include <WebCore/ClientOrigin.h>
 #include <WebCore/DOMCacheEngine.h>
+#include <WebCore/RetrieveRecordsOptions.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebKit {
-class CacheStorageManager;
-}
-
-namespace WebCore {
-struct ClientOrigin;
-struct RetrieveRecordsOptions;
-}
 
 namespace WebKit {
 class CacheStorageCache;
@@ -47,6 +40,7 @@ class CacheStorageRegistry;
 class CacheStorageStore;
 struct CacheStorageRecord;
 
+enum class ShouldWriteOriginFile : bool { No, Yes };
 
 class CacheStorageManager : public RefCountedAndCanMakeWeakPtr<CacheStorageManager> {
     WTF_MAKE_TZONE_ALLOCATED(CacheStorageManager);
@@ -58,8 +52,9 @@ public:
     static bool hasCacheList(const String& cacheListDirectory);
 
     using QuotaCheckFunction = Function<void(uint64_t spaceRequested, CompletionHandler<void(bool)>&&)>;
-    static Ref<CacheStorageManager> create(const String& path, CacheStorageRegistry&, const std::optional<WebCore::ClientOrigin>&, QuotaCheckFunction&&, Ref<WorkQueue>&&);
+    static Ref<CacheStorageManager> create(const String& path, CacheStorageRegistry&, const WebCore::ClientOrigin&, ShouldWriteOriginFile, QuotaCheckFunction&&, Ref<WorkQueue>&&);
     ~CacheStorageManager();
+    const WebCore::ClientOrigin& origin() const { return m_origin; }
     void openCache(const String& name, WebCore::DOMCacheEngine::CacheIdentifierCallback&&);
     void removeCache(WebCore::DOMCacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&&);
     void allCaches(uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&);
@@ -81,7 +76,7 @@ public:
     void query(WebCore::RetrieveRecordsOptions&&, String&&, CompletionHandler<void(std::optional<WebCore::DOMCacheEngine::CrossThreadRecord>&&)>&&);
 
 private:
-    CacheStorageManager(const String& path, CacheStorageRegistry&, const std::optional<WebCore::ClientOrigin>&, QuotaCheckFunction&&, Ref<WorkQueue>&&);
+    CacheStorageManager(const String& path, CacheStorageRegistry&, const WebCore::ClientOrigin&, ShouldWriteOriginFile, QuotaCheckFunction&&, Ref<WorkQueue>&&);
     void makeDirty();
     bool initializeCaches();
     void removeUnusedCache(WebCore::DOMCacheIdentifier);
@@ -94,6 +89,7 @@ private:
     std::optional<uint64_t> m_size;
     std::pair<uint64_t, HashSet<WebCore::DOMCacheIdentifier>> m_pendingSize;
     String m_path;
+    WebCore::ClientOrigin m_origin;
     FileSystem::Salt m_salt;
     const Ref<CacheStorageRegistry> m_registry;
     QuotaCheckFunction m_quotaCheckFunction;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -2017,11 +2017,14 @@ void NetworkStorageManager::cacheStorageOpenCache(const WebCore::ClientOrigin& o
     checkedOriginStorageManager(origin)->protectedCacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef())->openCache(cacheName, WTF::move(callback));
 }
 
-void NetworkStorageManager::cacheStorageRemoveCache(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&& callback)
+void NetworkStorageManager::cacheStorageRemoveCache(IPC::Connection& connection, WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&& callback)
 {
     RefPtr cache = m_cacheStorageRegistry->cache(cacheIdentifier);
     if (!cache)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
+
+    auto origin = cache->origin();
+    MESSAGE_CHECK_COMPLETION(origin && isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin->topOrigin }), connection, callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal)));
 
     RefPtr cacheStorageManager = cache->manager();
     if (!cacheStorageManager)
@@ -2040,6 +2043,9 @@ void NetworkStorageManager::cacheStorageReference(IPC::Connection& connection, W
     RefPtr cache = m_cacheStorageRegistry->cache(cacheIdentifier);
     if (!cache)
         return;
+
+    auto origin = cache->origin();
+    MESSAGE_CHECK(origin && isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin->topOrigin }), connection);
 
     RefPtr cacheStorageManager = cache->manager();
     if (!cacheStorageManager)
@@ -2078,6 +2084,9 @@ void NetworkStorageManager::cacheStorageRetrieveRecords(IPC::Connection& connect
     if (!cache)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
+    auto origin = cache->origin();
+    MESSAGE_CHECK_COMPLETION(origin && isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin->topOrigin }), connection, callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal)));
+
     cache->retrieveRecords(connection, WTF::move(options), WTF::move(callback));
 }
 
@@ -2087,6 +2096,9 @@ void NetworkStorageManager::cacheStorageRemoveRecords(IPC::Connection& connectio
     if (!cache)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
+    auto origin = cache->origin();
+    MESSAGE_CHECK_COMPLETION(origin && isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin->topOrigin }), connection, callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal)));
+
     cache->removeRecords(connection, WTF::move(request), WTF::move(options), WTF::move(callback));
 }
 
@@ -2095,6 +2107,9 @@ void NetworkStorageManager::cacheStoragePutRecords(IPC::Connection& connection, 
     RefPtr cache = m_cacheStorageRegistry->cache(cacheIdentifier);
     if (!cache)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
+
+    auto origin = cache->origin();
+    MESSAGE_CHECK_COMPLETION(origin && isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin->topOrigin }), connection, callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal)));
 
     for (auto& record : records)
         MESSAGE_CHECK_COMPLETION(record.responseBodySize >= CacheStorageDiskStore::computeRealBodySizeForStorage(record.responseBody), connection, callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal)));

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -255,7 +255,7 @@ private:
 
     // Message handlers for CacheStorage.
     void cacheStorageOpenCache(const WebCore::ClientOrigin&, const String& cacheName, WebCore::DOMCacheEngine::CacheIdentifierCallback&&);
-    void cacheStorageRemoveCache(WebCore::DOMCacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&&);
+    void cacheStorageRemoveCache(IPC::Connection&, WebCore::DOMCacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&&);
     void cacheStorageAllCaches(const WebCore::ClientOrigin&, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&);
     void cacheStorageReference(IPC::Connection&, WebCore::DOMCacheIdentifier);
     void cacheStorageDereference(IPC::Connection&, WebCore::DOMCacheIdentifier);

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -248,10 +248,8 @@ IDBStorageManager& OriginStorageManager::StorageBucket::idbStorageManager(IDBSto
 CacheStorageManager& OriginStorageManager::StorageBucket::cacheStorageManager(CacheStorageRegistry& registry, const WebCore::ClientOrigin& origin, CacheStorageManager::QuotaCheckFunction&& quotaCheckFunction, Ref<WorkQueue>&& queue)
 {
     if (!m_cacheStorageManager) {
-        std::optional<WebCore::ClientOrigin> optionalOrigin;
-        if (m_level < UnifiedOriginStorageLevel::Standard)
-            optionalOrigin = origin;
-        m_cacheStorageManager = CacheStorageManager::create(resolvedCacheStoragePath(), registry, optionalOrigin, WTF::move(quotaCheckFunction), WTF::move(queue));
+        auto shouldWriteOriginFile = m_level < UnifiedOriginStorageLevel::Standard ? ShouldWriteOriginFile::Yes : ShouldWriteOriginFile::No;
+        m_cacheStorageManager = CacheStorageManager::create(resolvedCacheStoragePath(), registry, origin, shouldWriteOriginFile, WTF::move(quotaCheckFunction), WTF::move(queue));
     }
 
     return *m_cacheStorageManager;

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -41,6 +41,7 @@
 #import <pal/spi/cocoa/NetworkSPI.h>
 #import <time.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/Lock.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RobinHoodHashMap.h>
 #import <wtf/RunLoop.h>
@@ -539,6 +540,8 @@ public:
                     return;
                 }
 
+                Locker locker { listLock };
+
                 version4List().clear();
                 version6List().clear();
 
@@ -562,11 +565,12 @@ public:
         });
     }
 
-    static const TrackerAddressLookupInfo* find(const WebCore::IPAddress& address)
+    static std::optional<TrackerAddressLookupInfo> find(const WebCore::IPAddress& address)
     {
+        Locker locker { listLock };
         auto& list = address.isIPv4() ? version4List() : version6List();
         if (list.isEmpty())
-            return nullptr;
+            return std::nullopt;
 
         size_t lower = 0;
         size_t upper = list.size() - 1;
@@ -579,29 +583,31 @@ public:
                 auto middle = std::midpoint(lower, upper);
                 auto compareResult = address <=> list[middle].m_network;
                 if (is_eq(compareResult))
-                    return &list[middle];
+                    return list[middle];
                 if (is_lt(compareResult))
                     upper = middle;
                 else if (is_gt(compareResult))
                     lower = middle;
                 else {
                     ASSERT_NOT_REACHED();
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
 
         if (list[upper].contains(address))
-            return &list[upper];
+            return list[upper];
 
         if (upper != lower && list[lower].contains(address))
-            return &list[lower];
+            return list[lower];
 
-        return nullptr;
+        return std::nullopt;
     }
 
 private:
-    static Vector<TrackerAddressLookupInfo>& version4List()
+    static Lock listLock;
+
+    static Vector<TrackerAddressLookupInfo>& version4List() WTF_REQUIRES_LOCK(listLock)
     {
         static NeverDestroyed sharedList = [] {
             return Vector<TrackerAddressLookupInfo> { };
@@ -609,7 +615,7 @@ private:
         return sharedList.get();
     }
 
-    static Vector<TrackerAddressLookupInfo>& version6List()
+    static Vector<TrackerAddressLookupInfo>& version6List() WTF_REQUIRES_LOCK(listLock)
     {
         static NeverDestroyed sharedList = [] {
             return Vector<TrackerAddressLookupInfo> { };
@@ -628,6 +634,8 @@ private:
     CString m_host;
     CanBlock m_canBlock { CanBlock::No };
 };
+
+Lock TrackerAddressLookupInfo::listLock;
 
 class TrackerDomainLookupInfo {
 public:
@@ -719,7 +727,7 @@ void configureForAdvancedPrivacyProtections(NSURLSession *session)
 
     setTrackerLookupCallback(context.get(), ^(nw_endpoint_t endpoint, const char** hostName, const char** owner, bool* canBlock) {
         if (auto address = ipAddress(endpoint)) {
-            if (auto* info = TrackerAddressLookupInfo::find(*address)) {
+            if (auto info = TrackerAddressLookupInfo::find(*address)) {
                 *owner = info->owner().data();
                 *hostName = info->host().data();
                 *canBlock = info->canBlock() == TrackerAddressLookupInfo::CanBlock::Yes;

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -681,6 +681,8 @@ public:
                     return;
                 }
 
+                Locker locker { domainListLock };
+
                 for (WPTrackingDomain *domain in domains)
                     list().set(String::fromLatin1([domain.host UTF8String]), TrackerDomainLookupInfo { domain });
             }];
@@ -689,13 +691,16 @@ public:
 
     static const TrackerDomainLookupInfo find(String host)
     {
+        Locker locker { domainListLock };
         if (!list().isValidKey(host))
             return { };
         return list().get(host);
     }
 
 private:
-    static MemoryCompactRobinHoodHashMap<String, TrackerDomainLookupInfo>& list()
+    static Lock domainListLock;
+
+    static MemoryCompactRobinHoodHashMap<String, TrackerDomainLookupInfo>& list() WTF_REQUIRES_LOCK(domainListLock)
     {
         static NeverDestroyed<MemoryCompactRobinHoodHashMap<String, TrackerDomainLookupInfo>> map;
         return map.get();
@@ -704,6 +709,8 @@ private:
     CString m_owner;
     CanBlock m_canBlock { CanBlock::No };
 };
+
+Lock TrackerDomainLookupInfo::domainListLock;
 
 void configureForAdvancedPrivacyProtections(NSURLSession *session)
 {

--- a/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp
@@ -64,7 +64,8 @@ void WebStorageNamespaceProvider::decrementUseCount(const StorageNamespaceImpl::
 {
     if (auto& provider = existingStorageNameSpaceProvider()) {
         auto iterator = provider->m_sessionStorageNamespaces.find(identifier);
-        ASSERT(iterator != provider->m_sessionStorageNamespaces.end());
+        if (iterator == provider->m_sessionStorageNamespaces.end())
+            return;
         auto& sessionStorageNamespaces = iterator->value;
         ASSERT(sessionStorageNamespaces.useCount);
         if (!--sessionStorageNamespaces.useCount)


### PR DESCRIPTION
#### 3fb9798c5b49d896e1dd5682d40ffb4e805c709e
<pre>
Cherry-pick 305413.967@safari-7624.4-branch (f1ce3d547a23). <a href="https://bugs.webkit.org/show_bug.cgi?id=317163">https://bugs.webkit.org/show_bug.cgi?id=317163</a>

    Data race reading the process-global TrackerDomainLookupInfo map from the network resolver thread in WebPrivacyHelpers
    &lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=317163">https://bugs.webkit.org/show_bug.cgi?id=317163</a>&gt;
    &lt;<a href="https://rdar.apple.com/164366001">rdar://164366001</a>&gt;

    Reviewed by Charlie Wolfe.

    The tracker-lookup callback installed by
    `configureForAdvancedPrivacyProtections()` reads the process-global
    `MemoryCompactRobinHoodHashMap` returned by `list()` on a network
    resolver dispatch thread, but the `requestTrackerDomainNamesData`
    completion handler inserts into that same map on every WebPrivacy
    update from a different thread.  Nothing serializes the two, so an
    update can rehash and free the map&apos;s backing store while the resolver
    thread is reading it, leaving the resolver thread reading freed memory.

    The `find()` method already returns the matched entry by value, so no
    signature change is needed.  The lock must still cover the `list().get()`
    read because the read itself races the writer&apos;s rehash.

    No new tests since this is a data race with no deterministic
    reproduction.  The `WTF_REQUIRES_LOCK` annotation on the list accessor
    makes any access that does not hold the lock a compile error, which is
    the load-bearing guarantee that the race cannot reappear.

    * Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
    (WebKit::TrackerDomainLookupInfo::populateIfNeeded):
    (WebKit::TrackerDomainLookupInfo::find):
    (WebKit::TrackerDomainLookupInfo::list):

    Identifier: 305413.967@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/305877.1052@webkitglib/2.52">https://commits.webkit.org/305877.1052@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 29c97727c5b3f512ab8448c48f9ff57b71800913
<pre>
Cherry-pick 305413.966@safari-7624.4-branch (97c98b40f0a7). <a href="https://bugs.webkit.org/show_bug.cgi?id=317126">https://bugs.webkit.org/show_bug.cgi?id=317126</a>

    Crash reading process-global tracker address lists from the network resolver thread in WebPrivacyHelpers
    &lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=317126">https://bugs.webkit.org/show_bug.cgi?id=317126</a>&gt;
    &lt;<a href="https://rdar.apple.com/179437288">rdar://179437288</a>&gt;

    Reviewed by Charlie Wolfe.

    The tracker-lookup callback installed by
    `configureForAdvancedPrivacyProtections()` reads the process-global
    `version4List()`/`version6List()` on a network resolver dispatch thread,
    but the `requestTrackerNetworkAddresses` completion handler rebuilds
    those lists on every WebPrivacy update from a different thread.  Nothing
    serializes the two, so an update can free a list&apos;s backing buffer while
    the resolver thread is still walking it, leaving the resolver thread
    reading freed memory.

    `find()` now returns the matched entry by value because its caller reads
    the entry&apos;s members after the lookup returns.  A borrowed pointer into
    the shared buffer could not safely outlive the lock that protects it.

    No new tests since this is a data race with no deterministic
    reproduction.  The `WTF_REQUIRES_LOCK` annotations on the list accessors
    make any access that does not hold the lock a compile error, which is
    the load-bearing guarantee that the race cannot reappear.

    * Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
    (WebKit::TrackerAddressLookupInfo::populateIfNeeded):
    (WebKit::TrackerAddressLookupInfo::find):
    (WebKit::TrackerAddressLookupInfo::version4List):
    (WebKit::TrackerAddressLookupInfo::version6List):
    (WebKit::configureForAdvancedPrivacyProtections):

    Identifier: 305413.966@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/305877.1051@webkitglib/2.52">https://commits.webkit.org/305877.1051@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 1a198b8cacabfd36f55fb6b620df7f2253351610
<pre>
Cherry-pick 305413.965@safari-7624.4-branch (6254fe9499a7). <a href="https://bugs.webkit.org/show_bug.cgi?id=317082">https://bugs.webkit.org/show_bug.cgi?id=317082</a>

    REGRESSION (259876@main): Check for end iterator in WebStorageNamespaceProvider::decrementUseCount()
    &lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=317082">https://bugs.webkit.org/show_bug.cgi?id=317082</a>&gt;
    &lt;<a href="https://rdar.apple.com/179209792">rdar://179209792</a>&gt;

    Reviewed by Zak Ridouh.

    Guard against a missing entry before dereferencing the result of
    `HashMap::find()` in `decrementUseCount()`.  The function relies on
    `ASSERT(iterator != ...end())`, which compiles to nothing in release
    builds, then reads `iterator-&gt;value` unconditionally.  When the
    identifier is absent, `find()` returns `end()`, and reading
    `end()-&gt;value` accesses memory one entry past the table&apos;s backing
    buffer.

    The absent-entry case became reachable in 259876@main, which replaced
    the page-group-keyed owning map of providers with a single weakly-held
    provider (`existingStorageNameSpaceProvider()`).  The provider is now
    destroyed when the last page in a Web Content process goes away and
    recreated empty for the next page, so a `WebPage` torn down after that
    point decrements against a provider that never held its identifier.

    Return early when the iterator is `end()`, matching the existing guard
    in the sibling accessor `sessionStorageNamespace()`.  The
    `ASSERT(sessionStorageNamespaces.useCount)` is retained so debug builds
    still flag a use-count imbalance.

    No new tests since this path is reached only during web page teardown
    when the session storage namespace entry has already been removed, and
    is not directly testable through public API.

    * Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp:
    (WebKit::WebStorageNamespaceProvider::decrementUseCount):

    Identifier: 305413.965@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/305877.1050@webkitglib/2.52">https://commits.webkit.org/305877.1050@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### a806a0e40131d0352261cd7fce4bccae2bcfb3fc
<pre>
Cherry-pick 305413.948@safari-7624.4-branch (edd74642a6ef). <a href="https://bugs.webkit.org/show_bug.cgi?id=313220">https://bugs.webkit.org/show_bug.cgi?id=313220</a>

    Srcdoc iframes bypass SameSite Strict and Lax cookies
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313220">https://bugs.webkit.org/show_bug.cgi?id=313220</a>
    <a href="https://rdar.apple.com/175498842">rdar://175498842</a>

    Reviewed by Charlie Wolfe.

    When we set firstPartyForCookies on a subframe, we check if either:

    1) shouldInheritSecurityOriginFromOwner is true for the current document&apos;s URL, or
    2) if the current document&apos;s URL is same-registrable-domain as the top-level document URL

    In the case of an iframe with srcdoc, shouldInheritSecurityOriginFromOwner
    returns true (as documented), and this causes us to set the page&apos;s mainFrameURL
    as the firstPartyForCookies. We need a conditional exception for
    shouldInheritSecurityOriginFromOwner, but it should take nested iframes into
    account. This patch adjusts the logic so we inherit the ancestor frame&apos;s
    siteForCookies instead of the page&apos;s URL. The same-registrable-domain check
    remains unchanged.

    Test: http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe.html

    * LayoutTests/http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe-expected.txt: Added.
    * LayoutTests/http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe.html: Added.
    * LayoutTests/http/tests/cookies/same-site/img-from-srcdoc-iframe-inside-cross-origin-iframe-expected.txt: Added.
    * LayoutTests/http/tests/cookies/same-site/img-from-srcdoc-iframe-inside-cross-origin-iframe.html: Added.
    * LayoutTests/http/tests/cookies/same-site/resources/record-image-cookies.py: Added.
    * LayoutTests/http/tests/cookies/same-site/resources/srcdoc-creator-img-inside-cross-origin-iframe.html: Added.
    * LayoutTests/http/tests/cookies/same-site/resources/srcdoc-creator-inside-cross-origin-iframe.html: Added.
    * Source/WebCore/loader/FrameLoader.cpp:
    (WebCore::FrameLoader::setFirstPartyForCookies):

    Identifier: 305413.948@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/305877.1049@webkitglib/2.52">https://commits.webkit.org/305877.1049@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 2f804065261dfd24e934ee5c402b38c6d89a4394
<pre>
Cherry-pick 305413.944@safari-7624.4-branch (d4dc872e5bf9). <a href="https://bugs.webkit.org/show_bug.cgi?id=316594">https://bugs.webkit.org/show_bug.cgi?id=316594</a>

    Validate connection access to DOMCache with DOMCacheIdentifier
    <a href="https://rdar.apple.com/176470206">rdar://176470206</a>

    Reviewed by Chris Dumez.

    Many CacheStorage-related messages sent to NetworkStorageManager only carries DOMCacheIdentifier when asking to operate
    on DOMCache storage, and NetworkStorageManager does not check whether the sender process actually has access to
    requested cache. This lets a compromised process forge DOMCacheIdentifier and access data from other origins. To fix it,
    this patch stores the origin in CacheStorageManager and adding an origin accessor to CacheStorageCache, so that
    NetworkStorageManager can run isSiteAllowedForConnection in CacheStorage-related message handlers.

    * Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
    (WebKit::CacheStorageCache::origin const):
    * Source/WebKit/NetworkProcess/storage/CacheStorageCache.h:
    * Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
    (WebKit::CacheStorageManager::create):
    (WebKit::CacheStorageManager::CacheStorageManager):
    * Source/WebKit/NetworkProcess/storage/CacheStorageManager.h:
    (WebKit::CacheStorageManager::origin const):
    * Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
    (WebKit::NetworkStorageManager::cacheStorageRemoveCache):
    (WebKit::NetworkStorageManager::cacheStorageReference):
    (WebKit::NetworkStorageManager::cacheStorageRetrieveRecords):
    (WebKit::NetworkStorageManager::cacheStorageRemoveRecords):
    (WebKit::NetworkStorageManager::cacheStoragePutRecords):
    * Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
    * Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
    (WebKit::OriginStorageManager::StorageBucket::cacheStorageManager):

    Identifier: 305413.944@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/305877.1048@webkitglib/2.52">https://commits.webkit.org/305877.1048@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e93b64e7a179fb348dc71103c93066ff0d07ccb5
<pre>
Cherry-pick 305413.925@safari-7624.4-branch (723dbeacf061). <a href="https://bugs.webkit.org/show_bug.cgi?id=316594">https://bugs.webkit.org/show_bug.cgi?id=316594</a>

    When captured as a video frame, canvas has to be tainted if cross-origin image are drawn into it
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316594">https://bugs.webkit.org/show_bug.cgi?id=316594</a>
    <a href="https://rdar.apple.com/171846032">rdar://171846032</a>

    Reviewed by Simon Fraser.

    HTMLCanvasElement::captureStream() allows streaming a canvas&apos;s output to a &lt;video&gt;
    element. The track frames of this video is obtained from CanvasCaptureMediaStreamTrack
    ::grabFrame(). This function unconditionally gets a VideoFrame by calling
    HTMLCanvasElement::toVideoFrame().

    If cross-origin images are drawn into the canvas, this canvas has to be tainted.
    So no getImageData() can see the pixels of the cross-origin images.

    * LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame-expected.html: Added.
    * LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame.html: Added.
    * LayoutTests/http/tests/canvas/resources/cross-origin-image-capture-video-frame.html: Added.
    * Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
    (WebCore::CanvasCaptureMediaStreamTrack::Source::grabFrame):
    (WebCore::CanvasCaptureMediaStreamTrack::Source::captureCanvas):

    Identifier: 305413.925@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/305877.1047@webkitglib/2.52">https://commits.webkit.org/305877.1047@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5540b1e6f9eccd8618cc8e7d73b0659f46f699eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178758 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52696 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46491 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188374 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143067 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180621 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53990 "Build is in progress. Recent messages:") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52407 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139380 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143067 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181715 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/53990 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46491 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119834 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/53990 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52407 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46491 "The change is no longer eligible for processing.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/53990 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46491 "The change is no longer eligible for processing.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45297 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52407 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190802 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52366 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46491 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148561 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53046 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46491 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148328 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27136 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53046 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125313 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119974 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51564 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46491 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/50949 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51189 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51011 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->