### PR TITLE
Cherry-pick 318534@main (f6bc402b8344). https://bugs.webkit.org/show_bug.cgi?id=320926

### DIFF
--- a/Source/WTF/wtf/StackBounds.h
+++ b/Source/WTF/wtf/StackBounds.h
@@ -59,12 +59,6 @@ public:
     // This function is only effective for newly created threads. In some platform, it returns a bogus value for the main thread.
     static StackBounds newThreadStackBounds(PlatformThreadHandle);
 #endif
-    static StackBounds currentThreadStackBounds()
-    {
-        auto result = currentThreadStackBoundsInternal();
-        result.checkConsistency();
-        return result;
-    }
 
     void* origin() const
     {
@@ -140,7 +134,16 @@ private:
         return m_bound <= m_origin;
     }
 
-    WTF_EXPORT_PRIVATE static StackBounds currentThreadStackBoundsInternal();
+    static StackBounds currentThreadStackBoundsInternal();
+
+    // Obtaining stack bounds from the OS may be slow; only Thread class should do it.
+    // Other callers should use the cached bounds via Thread::currentSingleton().stack()
+    static StackBounds currentThreadStackBounds()
+    {
+        auto result = currentThreadStackBoundsInternal();
+        result.checkConsistency();
+        return result;
+    }
 
     void checkConsistency() const
     {
@@ -155,6 +158,7 @@ private:
     void* m_bound;
 
     friend class StackStats;
+    friend class Thread;
 };
 
 } // namespace WTF


### PR DESCRIPTION
#### cc61ff0b6aba13f7dbd5c6a5917179728575d4e7
<pre>
Cherry-pick 318534@main (f6bc402b8344). <a href="https://bugs.webkit.org/show_bug.cgi?id=320926">https://bugs.webkit.org/show_bug.cgi?id=320926</a>

    [WTF] Make StackBounds::currentThreadStackBounds() private to Thread
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320926">https://bugs.webkit.org/show_bug.cgi?id=320926</a>

    Reviewed by Yusuke Suzuki.

    On Linux, obtaining the main thread stack bounds can be expensive.
    currentThreadStackBoundsInternal() calls pthread_getattr_np(), which may
    parse the entire /proc/self/maps file to locate the main thread stack.
    Calling it repeatedly can cause performance problems like the one fixed
    in 318487@main.

    currentThreadStackBounds() is intended to be called during thread
    initialization, with the result cached in Thread::m_stack. Other code
    should read the cached bounds using Thread::currentSingleton().stack().

    Nothing enforced this restriction, which allowed the uncached function
    to be used repeatedly. Move currentThreadStackBounds() to the private
    section and make Thread a friend, preventing other callers from
    accidentally bypassing the cached bounds.

    * Source/WTF/wtf/StackBounds.h:
    (WTF::StackBounds::currentThreadStackBounds):

    Canonical link: <a href="https://commits.webkit.org/318534@main">https://commits.webkit.org/318534@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.53@webkitglib/2.54">https://commits.webkit.org/317695.53@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c03aeeaa5d3421326630e0963f8126531eb58af0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178865 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52803 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46598 "The change is no longer eligible for processing.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/188481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143174 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54097 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52514 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/188481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143174 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181822 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54097 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46598 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/188481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54097 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52514 "The change is no longer eligible for processing.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/188481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46598 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54097 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46598 "The change is no longer eligible for processing.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/40138 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45405 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52514 "The change is no longer eligible for processing.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/190911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52473 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46598 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/190911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53153 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46598 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/190911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27139 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53153 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125421 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120108 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51671 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46598 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51056 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51296 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51118 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->