### PR TITLE
[JSC][Temporal] Fix constructor newTarget.prototype ordering and unify CreateTemporalX helpers

### DIFF
--- a/JSTests/stress/temporal-construct-newtarget-prototype-order.js
+++ b/JSTests/stress/temporal-construct-newtarget-prototype-order.js
@@ -1,0 +1,68 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldThrowRangeErrorNotPrototypeRead(name, C, args) {
+    const newTarget = new Proxy(function () { }, {
+        get(target, key, receiver) {
+            if (key === "prototype")
+                throw new EvalError("read newTarget.prototype before validating arguments");
+            return Reflect.get(target, key, receiver);
+        },
+    });
+
+    let error = null;
+    try {
+        Reflect.construct(C, args, newTarget);
+    } catch (e) {
+        error = e;
+    }
+
+    if (!error)
+        throw new Error(`${name}: expected a RangeError, got no exception`);
+    if (error instanceof EvalError)
+        throw new Error(`${name}: ${error.message}`);
+    if (!(error instanceof RangeError))
+        throw new Error(`${name}: expected a RangeError, got ${error}`);
+}
+
+// Each case picks arguments that fail the AO's own validity check — the one that lives inside
+// CreateTemporalX rather than in the constructor body — so the ordering is what is under test.
+shouldThrowRangeErrorNotPrototypeRead("Temporal.Duration", Temporal.Duration, [1, -1]); // IsValidDuration: mixed signs
+shouldThrowRangeErrorNotPrototypeRead("Temporal.Duration", Temporal.Duration, [Infinity]);
+shouldThrowRangeErrorNotPrototypeRead("Temporal.Instant", Temporal.Instant, [10n ** 30n]); // IsValidEpochNanoseconds
+shouldThrowRangeErrorNotPrototypeRead("Temporal.PlainDate", Temporal.PlainDate, [2020, 13, 1]); // IsValidISODate
+shouldThrowRangeErrorNotPrototypeRead("Temporal.PlainDate", Temporal.PlainDate, [300000, 1, 1]); // ISODateWithinLimits
+shouldThrowRangeErrorNotPrototypeRead("Temporal.PlainDateTime", Temporal.PlainDateTime, [2020, 13, 1]);
+shouldThrowRangeErrorNotPrototypeRead("Temporal.PlainDateTime", Temporal.PlainDateTime, [300000, 1, 1]);
+shouldThrowRangeErrorNotPrototypeRead("Temporal.PlainTime", Temporal.PlainTime, [25]); // IsValidTime
+shouldThrowRangeErrorNotPrototypeRead("Temporal.PlainYearMonth", Temporal.PlainYearMonth, [2020, 13]);
+shouldThrowRangeErrorNotPrototypeRead("Temporal.PlainYearMonth", Temporal.PlainYearMonth, [300000, 1]);
+shouldThrowRangeErrorNotPrototypeRead("Temporal.PlainMonthDay", Temporal.PlainMonthDay, [13, 1]);
+shouldThrowRangeErrorNotPrototypeRead("Temporal.ZonedDateTime", Temporal.ZonedDateTime, [10n ** 30n, "UTC"]);
+
+// The tz/calendar checks in the ZonedDateTime constructor body precede Step 11 too.
+shouldThrowRangeErrorNotPrototypeRead("Temporal.ZonedDateTime", Temporal.ZonedDateTime, [0n, "Nope/Nope"]);
+shouldThrowRangeErrorNotPrototypeRead("Temporal.ZonedDateTime", Temporal.ZonedDateTime, [0n, "UTC", "nope"]);
+
+// Subclassing must still work: with valid arguments the derived prototype is honoured.
+class MyDuration extends Temporal.Duration { }
+const derived = new MyDuration(1, 2);
+if (!(derived instanceof MyDuration) || !(derived instanceof Temporal.Duration))
+    throw new Error("subclass prototype chain broken");
+if (derived.years !== 1 || derived.months !== 2)
+    throw new Error("subclass slots not initialized");
+
+class MyPlainDate extends Temporal.PlainDate { }
+const derivedDate = new MyPlainDate(2020, 1, 1);
+if (!(derivedDate instanceof MyPlainDate) || derivedDate.toString() !== "2020-01-01")
+    throw new Error("PlainDate subclass broken");
+
+// Reflect.construct with a distinct newTarget uses that newTarget's prototype.
+const alt = { prototype: { tag: "alt" } };
+const viaReflect = Reflect.construct(Temporal.Duration, [3], Object.assign(function () { }, alt));
+if (Object.getPrototypeOf(viaReflect) !== alt.prototype)
+    throw new Error("Reflect.construct did not use newTarget.prototype");
+// `years` is an accessor on Temporal.Duration.prototype, which is deliberately NOT in this
+// object's prototype chain, so read the slot through the getter rather than as a property.
+const yearsGetter = Object.getOwnPropertyDescriptor(Temporal.Duration.prototype, "years").get;
+if (yearsGetter.call(viaReflect) !== 3)
+    throw new Error("Reflect.construct did not initialize slots");

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -31,6 +31,7 @@
 #include "DurationArithmetic.h"
 #include "FractionToDouble.h"
 #include "ISOArithmetic.h"
+#include "InternalFunction.h"
 #include "IntlObjectInlines.h"
 #include "JSCInlines.h"
 #include "PlainDateTimeCore.h"
@@ -69,19 +70,42 @@ TemporalDuration::TemporalDuration(VM& vm, Structure* structure, ISO8601::Durati
 {
 }
 
-// CreateTemporalDuration ( years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds [ , newTarget ] )
 // https://tc39.es/proposal-temporal/#sec-temporal-createtemporalduration
-TemporalDuration* TemporalDuration::tryCreateIfValid(JSGlobalObject* globalObject, ISO8601::Duration&& duration, Structure* structure)
+template<TemporalConstructTarget target>
+static TemporalDuration* createTemporalDurationImpl(JSGlobalObject* globalObject, ISO8601::Duration&& duration, TemporalNewTarget newTarget = { })
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Step 1: If IsValidDuration(...) is false, throw a RangeError exception.
     if (!ISO8601::isValidDuration(duration)) [[unlikely]] {
         throwRangeError(globalObject, scope, "Temporal.Duration properties must be finite and of consistent sign"_s);
         return { };
     }
 
-    return TemporalDuration::create(vm, structure ? structure : globalObject->durationStructure(), WTF::move(duration));
+    // Step 2: If newTarget is not present, set newTarget to %Temporal.Duration%.
+    // Step 3: Let object be ? OrdinaryCreateFromConstructor(newTarget, "%Temporal.Duration.prototype%", « ... »).
+    Structure* structure;
+    if constexpr (target == TemporalConstructTarget::Intrinsic)
+        structure = globalObject->durationStructure();
+    else {
+        ASSERT(newTarget.newTarget && newTarget.constructor);
+        structure = JSC_GET_DERIVED_STRUCTURE(vm, durationStructure, newTarget.newTarget, newTarget.constructor);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    // Steps 4-13: set [[Years]]…[[Nanoseconds]]. Step 14: Return object.
+    return TemporalDuration::create(vm, structure, WTF::move(duration));
+}
+
+TemporalDuration* createTemporalDuration(JSGlobalObject* globalObject, ISO8601::Duration&& duration)
+{
+    return createTemporalDurationImpl<TemporalConstructTarget::Intrinsic>(globalObject, WTF::move(duration));
+}
+
+TemporalDuration* createTemporalDuration(JSGlobalObject* globalObject, ISO8601::Duration&& duration, TemporalNewTarget newTarget)
+{
+    return createTemporalDurationImpl<TemporalConstructTarget::NewTarget>(globalObject, WTF::move(duration), newTarget);
 }
 
 // ToTemporalPartialDurationRecord ( temporalDurationLike )
@@ -485,7 +509,7 @@ ISO8601::Duration TemporalDuration::with(JSGlobalObject* globalObject, JSObject*
     for (size_t i = 0; i < numberOfTemporalUnits; ++i)
         result.setField(i, (*partial)[i].value_or(m_duration[i]));
 
-    // Step 24: Return ! CreateTemporalDuration(...). (Caller wraps in tryCreateIfValid.)
+    // Step 24: Return ! CreateTemporalDuration(...).
     return result;
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalDuration.h
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.h
@@ -45,7 +45,6 @@ public:
     }
 
     static TemporalDuration* create(VM&, Structure*, ISO8601::Duration&&);
-    static TemporalDuration* tryCreateIfValid(JSGlobalObject*, ISO8601::Duration&&, Structure* = nullptr);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;
@@ -87,5 +86,8 @@ private:
 
     ISO8601::Duration m_duration;
 };
+
+TemporalDuration* createTemporalDuration(JSGlobalObject*, ISO8601::Duration&&);
+TemporalDuration* createTemporalDuration(JSGlobalObject*, ISO8601::Duration&&, TemporalNewTarget);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp
@@ -86,9 +86,6 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalDuration, (JSGlobalObject* globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Step 1: NewTarget undefined check — handled by JSC's call/construct split (see callTemporalDuration).
-    JSObject* newTarget = asObject(callFrame->newTarget());
-    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, durationStructure, newTarget, callFrame->jsCallee());
-    RETURN_IF_EXCEPTION(scope, { });
 
     // Steps 2-11: For each unit X (years..nanoseconds), if X is undefined let it be 0;
     //   else ? ToIntegerIfIntegral(X). `+ 0.0` normalizes -0 → +0 (ToIntegerIfIntegral step 4).
@@ -107,8 +104,8 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalDuration, (JSGlobalObject* globalObjec
         result.setField(i, v);
     }
 
-    // Step 12: Return ? CreateTemporalDuration(...). tryCreateIfValid runs IsValidDuration.
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), structure)));
+    // Step 12: Return ? CreateTemporalDuration(..., NewTarget)
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result), { asObject(callFrame->newTarget()), callFrame->jsCallee() })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(callTemporalDuration, (JSGlobalObject* globalObject, CallFrame*))

--- a/Source/JavaScriptCore/runtime/TemporalDurationPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDurationPrototype.cpp
@@ -138,8 +138,8 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncWith, (JSGlobalObject* glo
     auto result = duration->with(globalObject, asObject(durationLike));
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Step 24: Return ! CreateTemporalDuration(...). tryCreateIfValid runs IsValidDuration.
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result))));
+    // Step 24: Return ! CreateTemporalDuration(...).
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.negated
@@ -154,7 +154,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncNegated, (JSGlobalObject* 
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.negated called on value that's not a Duration"_s);
 
     // Step 3: Return CreateNegatedTemporalDuration(duration).
-    //   Negation preserves IsValidDuration → skip tryCreateIfValid.
+    //   Negation preserves IsValidDuration → skip createTemporalDuration.
     return JSValue::encode(TemporalDuration::create(vm, globalObject->durationStructure(), TemporalCore::negateDuration(duration->duration())));
 }
 
@@ -170,7 +170,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncAbs, (JSGlobalObject* glob
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.abs called on value that's not a Duration"_s);
 
     // Step 3: Return ! CreateTemporalDuration(abs(years), ..., abs(nanoseconds)).
-    //   Per-field non-negative is stricter than IsValidDuration → skip tryCreateIfValid.
+    //   Per-field non-negative is stricter than IsValidDuration → skip createTemporalDuration.
     return JSValue::encode(TemporalDuration::create(vm, globalObject->durationStructure(), TemporalCore::absDuration(duration->duration())));
 }
 
@@ -189,7 +189,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncAdd, (JSGlobalObject* glob
     auto result = duration->addDurations<AddOrSubtract::Add>(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result))));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.subtract
@@ -207,7 +207,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncSubtract, (JSGlobalObject*
     auto result = duration->addDurations<AddOrSubtract::Subtract>(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result))));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round
@@ -230,7 +230,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncRound, (JSGlobalObject* gl
     auto result = duration->round(globalObject, options);
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result))));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.total

--- a/Source/JavaScriptCore/runtime/TemporalInstant.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.cpp
@@ -29,6 +29,7 @@
 
 #include "Error.h"
 #include "ISO8601.h"
+#include "InternalFunction.h"
 #include "JSBigInt.h"
 #include "JSCInlines.h"
 #include "JSGlobalObject.h"
@@ -41,6 +42,25 @@
 namespace JSC {
 
 const ClassInfo TemporalInstant::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TemporalInstant) };
+
+// https://tc39.es/proposal-temporal/#sec-temporal-createtemporalinstant
+TemporalInstant* createTemporalInstant(JSGlobalObject* globalObject, ISO8601::ExactTime exactTime, TemporalNewTarget newTarget)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Step 1: Assert: IsValidEpochNanoseconds(epochNanoseconds) is true.
+    ASSERT(exactTime.isValid());
+
+    // Step 2: If newTarget is not present, set newTarget to %Temporal.Instant%.
+    // Step 3: Let object be ? OrdinaryCreateFromConstructor(newTarget, "%Temporal.Instant.prototype%", « ... »).
+    ASSERT(newTarget.newTarget && newTarget.constructor);
+    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, instantStructure, newTarget.newTarget, newTarget.constructor);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 4: set [[EpochNanoseconds]]. Step 5: Return object.
+    return TemporalInstant::create(vm, structure, exactTime);
+}
 
 Structure* TemporalInstant::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {

--- a/Source/JavaScriptCore/runtime/TemporalInstant.h
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.h
@@ -72,4 +72,6 @@ private:
 
 JS_EXPORT_PRIVATE std::optional<ISO8601::ExactTime> bigIntValueToExactTime(JSGlobalObject*, JSValue bigIntValue, ASCIILiteral typeName);
 
+TemporalInstant* createTemporalInstant(JSGlobalObject*, ISO8601::ExactTime, TemporalNewTarget);
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalInstantConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstantConstructor.cpp
@@ -90,9 +90,6 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalInstant, (JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Step 1: NewTarget check done by JSC dispatch.
-    JSObject* newTarget = asObject(callFrame->newTarget());
-    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, instantStructure, newTarget, callFrame->jsCallee());
-    RETURN_IF_EXCEPTION(scope, { });
 
     // Step 2: Set epochNanoseconds to ? ToBigInt(epochNanoseconds).
     JSValue bigIntValue = callFrame->argument(0).toBigInt(globalObject);
@@ -103,8 +100,8 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalInstant, (JSGlobalObject* globalObject
     RETURN_IF_EXCEPTION(scope, { });
     ASSERT(exactTimeOpt);
 
-    // Step 4: Return ! CreateTemporalInstant(epochNanoseconds, NewTarget).
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalInstant::create(vm, structure, *exactTimeOpt)));
+    // Step 4: Return ? CreateTemporalInstant(epochNanoseconds, NewTarget).
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalInstant(globalObject, *exactTimeOpt, { asObject(callFrame->newTarget()), callFrame->jsCallee() })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(callTemporalInstant, (JSGlobalObject* globalObject, CallFrame*))

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -126,4 +126,11 @@ void throwTemporalError(JSGlobalObject*, ThrowScope&, const TemporalError&);
 
 std::optional<TimeZone> toTemporalTimeZoneIdentifier(JSGlobalObject*, JSValue);
 
+enum class TemporalConstructTarget : bool { Intrinsic, NewTarget };
+
+struct TemporalNewTarget {
+    JSObject* newTarget { nullptr };
+    JSObject* constructor { nullptr };
+};
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -31,6 +31,7 @@
 #include "CalendarICUBridge.h"
 #include "DateConstructor.h"
 #include "DurationArithmetic.h"
+#include "InternalFunction.h"
 #include "IntlObjectInlines.h"
 #include "JSCInlines.h"
 #include "Rounding.h"
@@ -130,9 +131,8 @@ ISO8601::PlainDate TemporalPlainDate::validateAndCreateISODateRecord(JSGlobalObj
     return ISO8601::PlainDate(year, month, day);
 }
 
-static bool isValidPlainDateOrThrow(JSGlobalObject* globalObject, const ISO8601::PlainDate& plainDate)
+static bool isValidPlainDateOrThrow(JSGlobalObject* globalObject, ThrowScope& scope, const ISO8601::PlainDate& plainDate)
 {
-    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     if (!ISO8601::isDateTimeWithinLimits(plainDate.year(), plainDate.month(), plainDate.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]] {
         throwRangeError(globalObject, scope, "date time is out of range of ECMAScript representation"_s);
         return false;
@@ -141,26 +141,59 @@ static bool isValidPlainDateOrThrow(JSGlobalObject* globalObject, const ISO8601:
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-createtemporaldate
-TemporalPlainDate* TemporalPlainDate::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate)
+template<TemporalConstructTarget target>
+static TemporalPlainDate* createTemporalDateImpl(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, CalendarID calendarID, TemporalNewTarget newTarget = { })
 {
-    if (!isValidPlainDateOrThrow(globalObject, plainDate))
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Step 1: If ISODateWithinLimits(isoDate) is false, throw a RangeError exception.
+    if (!isValidPlainDateOrThrow(globalObject, scope, plainDate))
         return { };
-    // Steps 2-6: OrdinaryCreateFromConstructor + [[ISODate]] + [[Calendar]].
-    return TemporalPlainDate::create(globalObject->vm(), structure, WTF::move(plainDate));
+
+    // Step 2: If newTarget is not present, set newTarget to %Temporal.PlainDate%.
+    // Step 3: Let object be ? OrdinaryCreateFromConstructor(newTarget, "%Temporal.PlainDate.prototype%", « ... »).
+    Structure* structure;
+    if constexpr (target == TemporalConstructTarget::Intrinsic)
+        structure = globalObject->plainDateStructure();
+    else {
+        ASSERT(newTarget.newTarget && newTarget.constructor);
+        structure = JSC_GET_DERIVED_STRUCTURE(vm, plainDateStructure, newTarget.newTarget, newTarget.constructor);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    // Steps 4-5: set [[ISODate]] and [[Calendar]]. Step 6: Return object.
+    return TemporalPlainDate::create(vm, structure, WTF::move(plainDate), calendarID);
 }
 
-TemporalPlainDate* TemporalPlainDate::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate, String&& calendarId)
+TemporalPlainDate* createTemporalDate(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate)
 {
-    if (!isValidPlainDateOrThrow(globalObject, plainDate))
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!isValidPlainDateOrThrow(globalObject, scope, plainDate))
         return { };
-    return TemporalPlainDate::create(globalObject->vm(), structure, WTF::move(plainDate), WTF::move(calendarId));
+    return TemporalPlainDate::create(vm, globalObject->plainDateStructure(), WTF::move(plainDate));
 }
 
-TemporalPlainDate* TemporalPlainDate::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate, CalendarID calendarID)
+TemporalPlainDate* createTemporalDate(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, String&& calendarId)
 {
-    if (!isValidPlainDateOrThrow(globalObject, plainDate))
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!isValidPlainDateOrThrow(globalObject, scope, plainDate))
         return { };
-    return TemporalPlainDate::create(globalObject->vm(), structure, WTF::move(plainDate), calendarID);
+    return TemporalPlainDate::create(vm, globalObject->plainDateStructure(), WTF::move(plainDate), WTF::move(calendarId));
+}
+
+TemporalPlainDate* createTemporalDate(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, CalendarID calendarID)
+{
+    return createTemporalDateImpl<TemporalConstructTarget::Intrinsic>(globalObject, WTF::move(plainDate), calendarID);
+}
+
+TemporalPlainDate* createTemporalDate(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, CalendarID calendarID, TemporalNewTarget newTarget)
+{
+    return createTemporalDateImpl<TemporalConstructTarget::NewTarget>(globalObject, WTF::move(plainDate), calendarID, newTarget);
 }
 
 static TemporalPlainDate* fromImpl(JSGlobalObject*, JSValue, Variant<JSObject*, TemporalOverflow>);
@@ -226,8 +259,7 @@ static TemporalPlainDate* fromImpl(JSGlobalObject* globalObject, JSValue itemVal
         }
 
         // Step 2.i: Return ! CreateTemporalDate(isoDate, calendar).
-        RELEASE_AND_RETURN(scope, TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(),
-            WTF::move(result->isoDate), result->calendarId));
+        RELEASE_AND_RETURN(scope, createTemporalDate(globalObject, WTF::move(result->isoDate), result->calendarId));
     }
 
     // String path (spec steps 3-11).
@@ -262,8 +294,8 @@ static TemporalPlainDate* fromImpl(JSGlobalObject* globalObject, JSValue itemVal
         //   spec calls are no-ops on undefined and the overflow value is unused for strings.
         // Steps 10-11: isoDate = CreateISODateRecord(...); Return ? CreateTemporalDate(isoDate, calendar).
         if (calendarId == iso8601CalendarID())
-            RELEASE_AND_RETURN(scope, TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(plainDate)));
-        RELEASE_AND_RETURN(scope, TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(plainDate), WTF::move(calendarId)));
+            RELEASE_AND_RETURN(scope, createTemporalDate(globalObject, WTF::move(plainDate)));
+        RELEASE_AND_RETURN(scope, createTemporalDate(globalObject, WTF::move(plainDate), WTF::move(calendarId)));
     }
 
     throwRangeError(globalObject, scope, "invalid date string"_s);
@@ -363,8 +395,8 @@ TemporalPlainDate* TemporalPlainDate::from(JSGlobalObject* globalObject, JSValue
 
         // Steps 10-11: isoDate = CreateISODateRecord(...); Return ? CreateTemporalDate(isoDate, calendar).
         if (calendarId == iso8601CalendarID())
-            RELEASE_AND_RETURN(scope, TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(plainDate)));
-        RELEASE_AND_RETURN(scope, TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(plainDate), WTF::move(calendarId)));
+            RELEASE_AND_RETURN(scope, createTemporalDate(globalObject, WTF::move(plainDate)));
+        RELEASE_AND_RETURN(scope, createTemporalDate(globalObject, WTF::move(plainDate), WTF::move(calendarId)));
     }
 
     // Step 4: ParseISODateTime failed → throw RangeError.

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.h
@@ -44,9 +44,6 @@ public:
     static TemporalPlainDate* create(VM&, Structure*, ISO8601::PlainDate&&);
     static TemporalPlainDate* create(VM&, Structure*, ISO8601::PlainDate&&, String&&);
     static TemporalPlainDate* create(VM&, Structure*, ISO8601::PlainDate&&, CalendarID);
-    static TemporalPlainDate* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&);
-    static TemporalPlainDate* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&, String&& calendarId);
-    static TemporalPlainDate* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&, CalendarID);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;
@@ -87,5 +84,10 @@ private:
     ISO8601::PlainDate m_plainDate;
     CalendarID m_calendarID { 0 };
 };
+
+TemporalPlainDate* createTemporalDate(JSGlobalObject*, ISO8601::PlainDate&&);
+TemporalPlainDate* createTemporalDate(JSGlobalObject*, ISO8601::PlainDate&&, String&& calendarId);
+TemporalPlainDate* createTemporalDate(JSGlobalObject*, ISO8601::PlainDate&&, CalendarID);
+TemporalPlainDate* createTemporalDate(JSGlobalObject*, ISO8601::PlainDate&&, CalendarID, TemporalNewTarget);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
@@ -87,9 +87,6 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDate, (JSGlobalObject* globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Step 1: NewTarget check done by JSC engine.
-    JSObject* newTarget = asObject(callFrame->newTarget());
-    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, plainDateStructure, newTarget, callFrame->jsCallee());
-    RETURN_IF_EXCEPTION(scope, { });
 
     // Steps 2-4: y/m/d = ? ToIntegerWithTruncation(isoYear/isoMonth/isoDay).
     //   ToIntegerWithTruncation: NaN → 0, ±Infinity → throw RangeError.
@@ -143,7 +140,8 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDate, (JSGlobalObject* globalObje
     auto plainDate = TemporalPlainDate::validateAndCreateISODateRecord(globalObject, duration);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 10: Return ? CreateTemporalDate(isoDate, calendar, NewTarget).
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, structure, WTF::move(plainDate), calendarId)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDate(globalObject, WTF::move(plainDate), calendarId,
+        { asObject(callFrame->newTarget()), callFrame->jsCallee() })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(callTemporalPlainDate, (JSGlobalObject* globalObject, CallFrame*))

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -165,15 +165,14 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainMonthDay, (JSGloba
             throwRangeError(globalObject, scope, String(resolved.error().message));
             return { };
         }
-        auto* result = TemporalPlainMonthDay::tryCreateIfValid(globalObject, globalObject->plainMonthDayStructure(), WTF::move(resolved->isoDate));
+        auto* result = createTemporalMonthDay(globalObject, WTF::move(resolved->isoDate), resolved->calendarId);
         RETURN_IF_EXCEPTION(scope, { });
-        result->setCalendarID(resolved->calendarId);
         return JSValue::encode(result);
     }
 
     // ISO: encode month-day with reference year 1972 (leap year, so Feb 29 fits).
     ISO8601::PlainDate dateToUse(1972, temporalDate->plainDate().month(), temporalDate->plainDate().day());
-    auto* mdResult = TemporalPlainMonthDay::tryCreateIfValid(globalObject, globalObject->plainMonthDayStructure(), WTF::move(dateToUse));
+    auto* mdResult = createTemporalMonthDay(globalObject, WTF::move(dateToUse));
     RETURN_IF_EXCEPTION(scope, { });
     return JSValue::encode(mdResult);
 }
@@ -203,7 +202,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainYearMonth, (JSGlob
 
     // ISO: encode year-month with day=1.
     ISO8601::PlainDate dateToUse(temporalDate->plainDate().year(), temporalDate->plainDate().month(), 1);
-    auto* ymResult = TemporalPlainYearMonth::tryCreateIfValid(globalObject, globalObject->plainYearMonthStructure(), WTF::move(dateToUse));
+    auto* ymResult = createTemporalYearMonth(globalObject, WTF::move(dateToUse));
     RETURN_IF_EXCEPTION(scope, { });
     return JSValue::encode(ymResult);
 }
@@ -226,7 +225,7 @@ static EncodedJSValue addDurationToPlainDate(JSGlobalObject* globalObject, Throw
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 8: Return ! CreateTemporalDate(result, calendar).
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(result), plainDate->calendarID())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDate(globalObject, WTF::move(result), plainDate->calendarID())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.add
@@ -310,7 +309,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncWith, (JSGlobalObject* gl
     }
 
     // Step 11: Return ! CreateTemporalDate(isoDate, calendar).
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(resolved->isoDate), calendarId)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDate(globalObject, WTF::move(resolved->isoDate), calendarId)));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.until
@@ -332,7 +331,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncUntil, (JSGlobalObject* g
     auto result = plainDate->until(globalObject, other, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), globalObject->durationStructure())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.since
@@ -353,7 +352,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncSince, (JSGlobalObject* g
     auto result = plainDate->since(globalObject, other, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), globalObject->durationStructure())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.equals
@@ -483,7 +482,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainDateTime, (JSGloba
     }
 
     // Steps 5-6: CombineISODateAndTimeRecord + CreateTemporalDateTime.
-    auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), plainDate->plainDate(), WTF::move(plainTime), plainDate->calendarID());
+    auto* result = createTemporalDateTime(globalObject, plainDate->plainDate(), WTF::move(plainTime), plainDate->calendarID());
     RETURN_IF_EXCEPTION(scope, { });
     return JSValue::encode(result);
 }

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -29,6 +29,7 @@
 #include "CalendarICUBridge.h"
 #include "DurationArithmetic.h"
 #include "ISOArithmetic.h"
+#include "InternalFunction.h"
 #include "IntlObjectInlines.h"
 #include "JSCInlines.h"
 #include "PlainDateTimeCore.h"
@@ -64,7 +65,8 @@ TemporalPlainDateTime::TemporalPlainDateTime(VM& vm, Structure* structure, ISO86
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-createtemporaldatetime
-TemporalPlainDateTime* TemporalPlainDateTime::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate, ISO8601::PlainTime&& plainTime, CalendarID calendarID)
+template<TemporalConstructTarget target>
+static TemporalPlainDateTime* createTemporalDateTimeImpl(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, ISO8601::PlainTime&& plainTime, CalendarID calendarID, TemporalNewTarget newTarget = { })
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -75,8 +77,29 @@ TemporalPlainDateTime* TemporalPlainDateTime::tryCreateIfValid(JSGlobalObject* g
         return { };
     }
 
-    // Steps 2-6: OrdinaryCreateFromConstructor + set [[ISODateTime]] and [[Calendar]] internal slots.
+    // Step 2: If newTarget is not present, set newTarget to %Temporal.PlainDateTime%.
+    // Step 3: Let object be ? OrdinaryCreateFromConstructor(newTarget, "%Temporal.PlainDateTime.prototype%", « ... »).
+    Structure* structure;
+    if constexpr (target == TemporalConstructTarget::Intrinsic)
+        structure = globalObject->plainDateTimeStructure();
+    else {
+        ASSERT(newTarget.newTarget && newTarget.constructor);
+        structure = JSC_GET_DERIVED_STRUCTURE(vm, plainDateTimeStructure, newTarget.newTarget, newTarget.constructor);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    // Steps 4-5: set [[ISODateTime]] and [[Calendar]]. Step 6: Return object.
     return TemporalPlainDateTime::create(vm, structure, WTF::move(plainDate), WTF::move(plainTime), calendarID);
+}
+
+TemporalPlainDateTime* createTemporalDateTime(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, ISO8601::PlainTime&& plainTime, CalendarID calendarID)
+{
+    return createTemporalDateTimeImpl<TemporalConstructTarget::Intrinsic>(globalObject, WTF::move(plainDate), WTF::move(plainTime), calendarID);
+}
+
+TemporalPlainDateTime* createTemporalDateTime(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, ISO8601::PlainTime&& plainTime, CalendarID calendarID, TemporalNewTarget newTarget)
+{
+    return createTemporalDateTimeImpl<TemporalConstructTarget::NewTarget>(globalObject, WTF::move(plainDate), WTF::move(plainTime), calendarID, newTarget);
 }
 
 static TemporalPlainDateTime* fromImpl(JSGlobalObject*, JSValue, JSValue);
@@ -109,7 +132,7 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
         RETURN_IF_EXCEPTION(scope, { });
 
         // Step 2.h cont.: CreateTemporalDateTime(result, calendar).
-        auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), ISO8601::PlainDate(pdt.date), ISO8601::PlainTime(pdt.time), extractedCalendarId);
+        auto* result = createTemporalDateTime(globalObject, ISO8601::PlainDate(pdt.date), ISO8601::PlainTime(pdt.time), extractedCalendarId);
         RETURN_IF_EXCEPTION(scope, { });
         return result;
     }
@@ -144,7 +167,7 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
         toTemporalOverflow(globalObject, optionsValue);
         RETURN_IF_EXCEPTION(scope, { });
         // Steps 9-13: CreateISODateRecord + CombineISODateAndTimeRecord + CreateTemporalDateTime.
-        auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), plainTimeOptional.value_or(ISO8601::PlainTime()), calendarId);
+        auto* result = createTemporalDateTime(globalObject, WTF::move(plainDate), plainTimeOptional.value_or(ISO8601::PlainTime()), calendarId);
         RETURN_IF_EXCEPTION(scope, { });
         return result;
     }

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
@@ -42,7 +42,6 @@ public:
     }
 
     static TemporalPlainDateTime* create(VM&, Structure*, ISO8601::PlainDate&&, ISO8601::PlainTime&&, CalendarID = iso8601CalendarID());
-    static TemporalPlainDateTime* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&, ISO8601::PlainTime&&, CalendarID = iso8601CalendarID());
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;
@@ -87,5 +86,8 @@ private:
     ISO8601::PlainTime m_plainTime;
     CalendarID m_calendarID { 0 };
 };
+
+TemporalPlainDateTime* createTemporalDateTime(JSGlobalObject*, ISO8601::PlainDate&&, ISO8601::PlainTime&&, CalendarID = iso8601CalendarID());
+TemporalPlainDateTime* createTemporalDateTime(JSGlobalObject*, ISO8601::PlainDate&&, ISO8601::PlainTime&&, CalendarID, TemporalNewTarget);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
@@ -90,9 +90,6 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDateTime, (JSGlobalObject* global
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Step 1: If NewTarget is undefined, throw a TypeError. (Enforced by JSC engine.)
-    JSObject* newTarget = asObject(callFrame->newTarget());
-    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, plainDateTimeStructure, newTarget, callFrame->jsCallee());
-    RETURN_IF_EXCEPTION(scope, { });
 
     // Steps 2-4: Set isoYear/isoMonth/isoDay to ? ToIntegerWithTruncation(arg).
     // Steps 5-10: For each of hour/minute/second/millisecond/microsecond/nanosecond:
@@ -136,8 +133,9 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDateTime, (JSGlobalObject* global
     auto plainTime = TemporalPlainTime::validateAndCreateTimeRecord(globalObject, duration);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Steps 18-19: CombineISODateAndTimeRecord + ? CreateTemporalDateTime.
-    auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, structure, WTF::move(plainDate), WTF::move(plainTime), calId);
+    // Steps 18-19: CombineISODateAndTimeRecord + ? CreateTemporalDateTime(isoDateTime, calendar, NewTarget).
+    auto* result = createTemporalDateTime(globalObject, WTF::move(plainDate), WTF::move(plainTime), calId,
+        { asObject(callFrame->newTarget()), callFrame->jsCallee() });
     RETURN_IF_EXCEPTION(scope, { });
     return JSValue::encode(result);
 }

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -187,7 +187,7 @@ static EncodedJSValue addDurationToPlainDateTime(JSGlobalObject* globalObject, T
     RETURN_IF_EXCEPTION(scope, { });
 
     // Steps 9-10: CombineISODateAndTimeRecord + CreateTemporalDateTime.
-    auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), WTF::move(plainTime), plainDateTime->calendarID());
+    auto* result = createTemporalDateTime(globalObject, WTF::move(plainDate), WTF::move(plainTime), plainDateTime->calendarID());
     RETURN_IF_EXCEPTION(scope, { });
     return JSValue::encode(result);
 }
@@ -290,7 +290,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWith, (JSGlobalObject
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 17: CreateTemporalDateTime.
-    auto* withResult = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), ISO8601::PlainDate(dateResult->isoDate), WTF::move(newTime), calendarId);
+    auto* withResult = createTemporalDateTime(globalObject, ISO8601::PlainDate(dateResult->isoDate), WTF::move(newTime), calendarId);
     RETURN_IF_EXCEPTION(scope, { });
     return JSValue::encode(withResult);
 }
@@ -314,7 +314,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWithPlainTime, (JSGlo
     }
 
     // Steps 4-5: CombineISODateAndTimeRecord + CreateTemporalDateTime.
-    auto* wptResult = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), plainDateTime->plainDate(), plainTime ? plainTime->plainTime() : ISO8601::PlainTime(), plainDateTime->calendarID());
+    auto* wptResult = createTemporalDateTime(globalObject, plainDateTime->plainDate(), plainTime ? plainTime->plainTime() : ISO8601::PlainTime(), plainDateTime->calendarID());
     RETURN_IF_EXCEPTION(scope, { });
     return JSValue::encode(wptResult);
 }
@@ -398,7 +398,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncRound, (JSGlobalObjec
     auto [roundedDate, roundedTime] = TemporalCore::roundISODateTime(plainDateTime->plainDate(), plainDateTime->plainTime(), incrementNs, smallestUnit, roundingMode);
 
     // Step 16: Return ? CreateTemporalDateTime(result, plainDateTime.[[Calendar]]).
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(roundedDate), WTF::move(roundedTime), plainDateTime->calendarID())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDateTime(globalObject, WTF::move(roundedDate), WTF::move(roundedTime), plainDateTime->calendarID())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.equals
@@ -861,7 +861,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncUntil, (JSGlobalObjec
     auto result = plainDateTime->differenceTemporalPlainDateTime<DifferenceOperation::Until>(globalObject, other, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), globalObject->durationStructure())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.since
@@ -882,7 +882,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncSince, (JSGlobalObjec
     auto result = plainDateTime->differenceTemporalPlainDateTime<DifferenceOperation::Since>(globalObject, other, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), globalObject->durationStructure())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
@@ -28,6 +28,7 @@
 
 #include "CalendarFields.h"
 #include "CalendarICUBridge.h"
+#include "InternalFunction.h"
 #include "IntlObjectInlines.h"
 #include "JSCInlines.h"
 #include "TemporalCalendar.h"
@@ -57,11 +58,14 @@ TemporalPlainMonthDay::TemporalPlainMonthDay(VM& vm, Structure* structure, ISO86
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-createtemporalmonthday
-TemporalPlainMonthDay* TemporalPlainMonthDay::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate)
+template<TemporalConstructTarget target>
+static TemporalPlainMonthDay* createTemporalMonthDayImpl(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, CalendarID calendarID, TemporalNewTarget newTarget = { })
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Not a step of this AO: ISO8601::PlainDate does not validate month/day, and daysInMonth()
+    // indexes a 12-entry table by month - 1 with no bounds check.
     if (!ISO8601::isValidISODate(plainDate.year(), plainDate.month(), plainDate.day())) [[unlikely]] {
         throwRangeError(globalObject, scope, "PlainMonthDay: invalid date"_s);
         return { };
@@ -73,8 +77,32 @@ TemporalPlainMonthDay* TemporalPlainMonthDay::tryCreateIfValid(JSGlobalObject* g
         return { };
     }
 
-    // Steps 2-6: OrdinaryCreateFromConstructor + set internal slots.
-    return TemporalPlainMonthDay::create(vm, structure, ISO8601::PlainMonthDay(WTF::move(plainDate)));
+    // Step 2: If newTarget is not present, set newTarget to %Temporal.PlainMonthDay%.
+    // Step 3: Let object be ? OrdinaryCreateFromConstructor(newTarget, "%Temporal.PlainMonthDay.prototype%", « ... »).
+    Structure* structure;
+    if constexpr (target == TemporalConstructTarget::Intrinsic)
+        structure = globalObject->plainMonthDayStructure();
+    else {
+        ASSERT(newTarget.newTarget && newTarget.constructor);
+        structure = JSC_GET_DERIVED_STRUCTURE(vm, plainMonthDayStructure, newTarget.newTarget, newTarget.constructor);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    // Steps 4-5: set [[ISODate]] and [[Calendar]]. Step 6: Return object.
+    auto* object = TemporalPlainMonthDay::create(vm, structure, ISO8601::PlainMonthDay(WTF::move(plainDate)));
+    if (calendarID != iso8601CalendarID())
+        object->setCalendarID(calendarID);
+    return object;
+}
+
+TemporalPlainMonthDay* createTemporalMonthDay(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, CalendarID calendarID)
+{
+    return createTemporalMonthDayImpl<TemporalConstructTarget::Intrinsic>(globalObject, WTF::move(plainDate), calendarID);
+}
+
+TemporalPlainMonthDay* createTemporalMonthDay(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, CalendarID calendarID, TemporalNewTarget newTarget)
+{
+    return createTemporalMonthDayImpl<TemporalConstructTarget::NewTarget>(globalObject, WTF::move(plainDate), calendarID, newTarget);
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-totemporalmonthday
@@ -128,7 +156,7 @@ TemporalPlainMonthDay* TemporalPlainMonthDay::from(JSGlobalObject* globalObject,
         // Step 10 (ISO path): referenceISOYear=1972 → CreateTemporalMonthDay({1972,month,day}, iso8601).
         if (calendarId == iso8601CalendarID()) {
             auto dateWithoutYear = ISO8601::PlainDate(1972, plainDate.month(), plainDate.day());
-            RELEASE_AND_RETURN(scope, TemporalPlainMonthDay::tryCreateIfValid(globalObject, globalObject->plainMonthDayStructure(), WTF::move(dateWithoutYear)));
+            RELEASE_AND_RETURN(scope, createTemporalMonthDay(globalObject, WTF::move(dateWithoutYear)));
         }
 
         // Steps 11-12 (non-ISO path): isoDate = {year,month,day}; ISODateWithinLimits check.

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
@@ -41,7 +41,6 @@ public:
     }
 
     static TemporalPlainMonthDay* create(VM&, Structure*, ISO8601::PlainMonthDay&&);
-    static TemporalPlainMonthDay* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;
@@ -77,5 +76,8 @@ private:
     ISO8601::PlainMonthDay m_plainMonthDay;
     CalendarID m_calendarID { 0 };
 };
+
+TemporalPlainMonthDay* createTemporalMonthDay(JSGlobalObject*, ISO8601::PlainDate&&, CalendarID = iso8601CalendarID());
+TemporalPlainMonthDay* createTemporalMonthDay(JSGlobalObject*, ISO8601::PlainDate&&, CalendarID, TemporalNewTarget);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
@@ -86,9 +86,6 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainMonthDay, (JSGlobalObject* global
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Step 1: NewTarget check done by JSC engine (callFrame->newTarget() is never undefined here).
-    JSObject* newTarget = asObject(callFrame->newTarget());
-    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, plainMonthDayStructure, newTarget, callFrame->jsCallee());
-    RETURN_IF_EXCEPTION(scope, { });
 
     // Step 3: m = ? ToIntegerWithTruncation(isoMonth).
     double isoMonth = callFrame->argument(0).toIntegerWithTruncation(globalObject);
@@ -127,16 +124,17 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainMonthDay, (JSGlobalObject* global
     }
 
     // Step 9: If IsValidISODate(y, m, d) is false, throw RangeError.
-    // Step 10: If ISODateWithinLimits(CreateISODateRecord(y, m, d)) is false, throw RangeError.
     if (!ISO8601::isYearWithinLimits(referenceYear)
         || !ISO8601::isValidISODate(referenceYear, isoMonth, isoDay)
         || !ISO8601::isDateTimeWithinLimits(referenceYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0)) [[unlikely]]
         return throwVMRangeError(globalObject, scope, "PlainMonthDay: date out of range of ECMAScript representation"_s);
 
-    // Step 11: Return ? CreateTemporalMonthDay(isoDate, calendar).
-    auto* result = TemporalPlainMonthDay::create(vm, structure, ISO8601::PlainMonthDay(ISO8601::PlainDate(clampTo<int32_t>(referenceYear), isoMonth, isoDay)));
-    if (result && calId != iso8601CalendarID())
-        result->setCalendarID(calId);
+    // Step 10: If ISODateWithinLimits(CreateISODateRecord(y, m, d)) is false, throw RangeError.
+    // Step 11: Return ? CreateTemporalMonthDay(isoDate, calendar, NewTarget).
+    auto* result = createTemporalMonthDay(globalObject,
+        ISO8601::PlainDate(clampTo<int32_t>(referenceYear), isoMonth, isoDay), calId,
+        { asObject(callFrame->newTarget()), callFrame->jsCallee() });
+    RETURN_IF_EXCEPTION(scope, { });
     return JSValue::encode(result);
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -254,10 +254,8 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncWith, (JSGlobalObject
     }
 
     // Step 11: Return ! CreateTemporalMonthDay(isoDate, calendar).
-    auto* withResult = TemporalPlainMonthDay::tryCreateIfValid(globalObject, globalObject->plainMonthDayStructure(), WTF::move(resolved->isoDate));
+    auto* withResult = createTemporalMonthDay(globalObject, WTF::move(resolved->isoDate), calendarId);
     RETURN_IF_EXCEPTION(scope, { });
-    if (withResult && calendarId != iso8601CalendarID())
-        withResult->setCalendarID(calendarId);
     return JSValue::encode(withResult);
 }
 
@@ -377,7 +375,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToPlainDate, (JSGloba
     }
 
     // Step 9: Return ! CreateTemporalDate(isoDate, calendar).
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(resolved->isoDate), resolved->calendarId)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDate(globalObject, WTF::move(resolved->isoDate), resolved->calendarId)));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.valueof

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -28,6 +28,7 @@
 #include "TemporalPlainTime.h"
 
 #include "DurationArithmetic.h"
+#include "InternalFunction.h"
 #include "IntlObjectInlines.h"
 #include "JSCInlines.h"
 #include "Rounding.h"
@@ -115,18 +116,19 @@ ISO8601::PlainTime TemporalPlainTime::validateAndCreateTimeRecord(JSGlobalObject
     };
 }
 
-// CreateTemporalTime ( time [ , newTarget ] )
 // https://tc39.es/proposal-temporal/#sec-temporal-createtemporaltime
-TemporalPlainTime* TemporalPlainTime::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::Duration&& duration)
+TemporalPlainTime* createTemporalTime(JSGlobalObject* globalObject, ISO8601::PlainTime&& plainTime, TemporalNewTarget newTarget)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // IsValidTime + materialize the Time Record.
-    auto plainTime = validateAndCreateTimeRecord(globalObject, duration);
+    // Step 1: If newTarget is not present, set newTarget to %Temporal.PlainTime%.
+    // Step 2: Let object be ? OrdinaryCreateFromConstructor(newTarget, "%Temporal.PlainTime.prototype%", « ... »).
+    ASSERT(newTarget.newTarget && newTarget.constructor);
+    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, plainTimeStructure, newTarget.newTarget, newTarget.constructor);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Steps 1-4: OrdinaryCreateFromConstructor + set [[Time]].
+    // Step 3: set [[Time]]. Step 4: Return object.
     return TemporalPlainTime::create(vm, structure, WTF::move(plainTime));
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.h
@@ -40,7 +40,6 @@ public:
     }
 
     static TemporalPlainTime* create(VM&, Structure*, ISO8601::PlainTime&&);
-    static TemporalPlainTime* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::Duration&&);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;
@@ -81,5 +80,7 @@ private:
 
     ISO8601::PlainTime m_plainTime;
 };
+
+TemporalPlainTime* createTemporalTime(JSGlobalObject*, ISO8601::PlainTime&&, TemporalNewTarget);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp
@@ -87,9 +87,6 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainTime, (JSGlobalObject* globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Step 1: NewTarget undefined -> TypeError (handled by JSC dispatch).
-    JSObject* newTarget = asObject(callFrame->newTarget());
-    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, plainTimeStructure, newTarget, callFrame->jsCallee());
-    RETURN_IF_EXCEPTION(scope, { });
 
     // Steps 2-7: If each arg is undefined set to 0; else ?ToIntegerWithTruncation(arg).
     ISO8601::Duration duration { };
@@ -109,8 +106,14 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainTime, (JSGlobalObject* globalObje
             return throwVMRangeError(globalObject, scope, "Temporal.PlainTime properties must be finite"_s);
         duration.setField(durationIndex, std::trunc(v));
     }
-    // Steps 8-10: IsValidTime -> CreateTimeRecord -> CreateTemporalTime.
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainTime::tryCreateIfValid(globalObject, structure, WTF::move(duration))));
+    // Steps 8-9: IsValidTime + CreateTimeRecord. Ahead of Step 10 so the observable
+    // Get(NewTarget, "prototype") inside CreateTemporalTime cannot run before validation.
+    auto plainTime = TemporalPlainTime::validateAndCreateTimeRecord(globalObject, duration);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 10: Return ? CreateTemporalTime(time, NewTarget).
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalTime(globalObject, WTF::move(plainTime),
+        { asObject(callFrame->newTarget()), callFrame->jsCallee() })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(callTemporalPlainTime, (JSGlobalObject* globalObject, CallFrame*))

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
@@ -191,7 +191,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncUntil, (JSGlobalObject* g
     auto result = plainTime->until(globalObject, other, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), globalObject->durationStructure())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.since
@@ -212,7 +212,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncSince, (JSGlobalObject* g
     auto result = plainTime->since(globalObject, other, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), globalObject->durationStructure())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.round

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
@@ -29,6 +29,7 @@
 
 #include "CalendarFields.h"
 #include "CalendarICUBridge.h"
+#include "InternalFunction.h"
 #include "IntlObjectInlines.h"
 #include "JSCInlines.h"
 #include "Rounding.h"
@@ -60,20 +61,45 @@ TemporalPlainYearMonth::TemporalPlainYearMonth(VM& vm, Structure* structure, ISO
 {
 }
 
-
-// CreateTemporalYearMonth ( isoDate, calendar [, newTarget ] )
 // https://tc39.es/proposal-temporal/#sec-temporal-createtemporalyearmonth
-TemporalPlainYearMonth* TemporalPlainYearMonth::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate)
+template<TemporalConstructTarget target>
+static TemporalPlainYearMonth* createTemporalYearMonthImpl(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, CalendarID calendarID, TemporalNewTarget newTarget = { })
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Step 1: If ISOYearMonthWithinLimits(isoDate) is false, throw a RangeError exception.
     if (!ISO8601::isYearMonthWithinLimits(plainDate.year(), plainDate.month())) [[unlikely]] {
         throwRangeError(globalObject, scope, "PlainYearMonth is out of range of ECMAScript representation"_s);
         return { };
     }
 
-    return TemporalPlainYearMonth::create(vm, structure, ISO8601::PlainYearMonth(WTF::move(plainDate)));
+    // Step 2: If newTarget is not present, set newTarget to %Temporal.PlainYearMonth%.
+    // Step 3: Let object be ? OrdinaryCreateFromConstructor(newTarget, "%Temporal.PlainYearMonth.prototype%", « ... »).
+    Structure* structure;
+    if constexpr (target == TemporalConstructTarget::Intrinsic)
+        structure = globalObject->plainYearMonthStructure();
+    else {
+        ASSERT(newTarget.newTarget && newTarget.constructor);
+        structure = JSC_GET_DERIVED_STRUCTURE(vm, plainYearMonthStructure, newTarget.newTarget, newTarget.constructor);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    // Steps 4-5: set [[ISODate]] and [[Calendar]]. Step 6: Return object.
+    auto* object = TemporalPlainYearMonth::create(vm, structure, ISO8601::PlainYearMonth(WTF::move(plainDate)));
+    if (calendarID != iso8601CalendarID())
+        object->setCalendarID(calendarID);
+    return object;
+}
+
+TemporalPlainYearMonth* createTemporalYearMonth(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, CalendarID calendarID)
+{
+    return createTemporalYearMonthImpl<TemporalConstructTarget::Intrinsic>(globalObject, WTF::move(plainDate), calendarID);
+}
+
+TemporalPlainYearMonth* createTemporalYearMonth(JSGlobalObject* globalObject, ISO8601::PlainDate&& plainDate, CalendarID calendarID, TemporalNewTarget newTarget)
+{
+    return createTemporalYearMonthImpl<TemporalConstructTarget::NewTarget>(globalObject, WTF::move(plainDate), calendarID, newTarget);
 }
 
 String TemporalPlainYearMonth::toString() const
@@ -145,22 +171,18 @@ TemporalPlainYearMonth* TemporalPlainYearMonth::from(JSGlobalObject* globalObjec
         }
 
         // Step 10: isoDate = CreateISODateRecord(year, month, day) — short form gives day=1 from the parser.
-        // Step 11: If ISOYearMonthWithinLimits(isoDate) is false, throw. (Enforced inside tryCreateIfValid.)
+        // Step 11: If ISOYearMonthWithinLimits(isoDate) is false, throw.
         // Steps 12+14+15: fields = ISODateToFields; isoDate = ? CalendarYearMonthFromFields; ! CreateTemporalYearMonth.
-        //                 Fused into plainYearMonthFromISODate + tryCreateIfValid for non-ISO; direct for ISO.
+        //                 Fused into plainYearMonthFromISODate + createTemporalYearMonth for non-ISO; direct for ISO.
         if (calendarId == iso8601CalendarID())
-            RELEASE_AND_RETURN(scope, TemporalPlainYearMonth::tryCreateIfValid(globalObject, globalObject->plainYearMonthStructure(), ISO8601::PlainDate(plainDate.year(), plainDate.month(), 1)));
+            RELEASE_AND_RETURN(scope, createTemporalYearMonth(globalObject, ISO8601::PlainDate(plainDate.year(), plainDate.month(), 1)));
 
         auto resolved = TemporalCore::plainYearMonthFromISODate(calendarId, plainDate);
         if (!resolved) [[unlikely]] {
             throwRangeError(globalObject, scope, String(resolved.error().message));
             return { };
         }
-        auto* result = TemporalPlainYearMonth::tryCreateIfValid(globalObject, globalObject->plainYearMonthStructure(), WTF::move(resolved->isoDate));
-        RETURN_IF_EXCEPTION(scope, { });
-        if (result)
-            result->setCalendarID(resolved->calendarId);
-        RELEASE_AND_RETURN(scope, result);
+        RELEASE_AND_RETURN(scope, createTemporalYearMonth(globalObject, WTF::move(resolved->isoDate), resolved->calendarId));
     }
 
     // Step 2: If item is an Object, then …

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
@@ -46,7 +46,6 @@ public:
     }
 
     static TemporalPlainYearMonth* create(VM&, Structure*, ISO8601::PlainYearMonth&&);
-    static TemporalPlainYearMonth* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;
@@ -77,5 +76,8 @@ private:
     ISO8601::PlainYearMonth m_plainYearMonth;
     CalendarID m_calendarID { 0 };
 };
+
+TemporalPlainYearMonth* createTemporalYearMonth(JSGlobalObject*, ISO8601::PlainDate&&, CalendarID = iso8601CalendarID());
+TemporalPlainYearMonth* createTemporalYearMonth(JSGlobalObject*, ISO8601::PlainDate&&, CalendarID, TemporalNewTarget);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthConstructor.cpp
@@ -85,10 +85,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainYearMonth, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: If NewTarget is undefined, throw TypeError. (Enforced by callTemporalPlainYearMonth dispatch.)
-    JSObject* newTarget = asObject(callFrame->newTarget());
-    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, plainYearMonthStructure, newTarget, callFrame->jsCallee());
-    RETURN_IF_EXCEPTION(scope, { });
+    // Step 1: If NewTarget is undefined, throw TypeError.
 
     // Step 3: Let y be ? ToIntegerWithTruncation(isoYear).
     //         Spec ToIntegerWithTruncation throws RangeError on non-finite (NaN/±Inf); JSC's helper
@@ -144,10 +141,10 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainYearMonth, (JSGlobalObject* globa
 
     // Step 10: Let isoDate be CreateISODateRecord(y, m, ref).
     // Step 11: Return ? CreateTemporalYearMonth(isoDate, calendar, NewTarget).
-    auto* result = TemporalPlainYearMonth::tryCreateIfValid(globalObject, structure, ISO8601::PlainDate(static_cast<int32_t>(isoYear), static_cast<unsigned>(isoMonth), static_cast<unsigned>(referenceDay)));
+    auto* result = createTemporalYearMonth(globalObject,
+        ISO8601::PlainDate(static_cast<int32_t>(isoYear), static_cast<unsigned>(isoMonth), static_cast<unsigned>(referenceDay)), calId,
+        { asObject(callFrame->newTarget()), callFrame->jsCallee() });
     RETURN_IF_EXCEPTION(scope, { });
-    if (result && calId != iso8601CalendarID())
-        result->setCalendarID(calId);
     return JSValue::encode(result);
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
@@ -234,10 +234,8 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncWith, (JSGlobalObjec
     }
 
     // Step 11: Return ! CreateTemporalYearMonth(isoDate, calendar).
-    auto* withResult = TemporalPlainYearMonth::tryCreateIfValid(globalObject, globalObject->plainYearMonthStructure(), WTF::move(result->isoDate));
+    auto* withResult = createTemporalYearMonth(globalObject, WTF::move(result->isoDate), yearMonth->calendarID());
     RETURN_IF_EXCEPTION(scope, { });
-    if (withResult && yearMonth->calendarID() != iso8601CalendarID())
-        withResult->setCalendarID(yearMonth->calendarID());
     return JSValue::encode(withResult);
 }
 
@@ -289,7 +287,7 @@ static JSC::EncodedJSValue differenceTemporalPlainYearMonth(JSGlobalObject* glob
 
     // Step 6: If CompareISODate(yearMonth.[[ISODate]], other.[[ISODate]]) = 0, return zero-duration.
     if (!TemporalCore::isoDateCompare(thisIsoDate, otherIsoDate))
-        RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, ISO8601::Duration(), globalObject->durationStructure())));
+        RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, ISO8601::Duration())));
 
     // Defensive: both endpoints must be within the representable date-time range before we hand
     // them to calendar arithmetic (icu4x/temporal_rs assume in-range inputs).
@@ -342,7 +340,7 @@ static JSC::EncodedJSValue differenceTemporalPlainYearMonth(JSGlobalObject* glob
         result = -result;
 
     // Step 19: Return result.
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), globalObject->durationStructure())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.until
@@ -434,7 +432,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToPlainDate, (JSGlob
             return { };
         }
         auto calIdCopy = resolved->calendarId;
-        RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(resolved->isoDate), WTF::move(calIdCopy))));
+        RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDate(globalObject, WTF::move(resolved->isoDate), WTF::move(calIdCopy))));
     }
 
     auto thisYear = yearMonth->year();
@@ -445,7 +443,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToPlainDate, (JSGlob
         return { };
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(*plainDateResult), yearMonth->calendarID())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDate(globalObject, WTF::move(*plainDateResult), yearMonth->calendarID())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tostring

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
@@ -29,6 +29,7 @@
 #include "CalendarFields.h"
 #include "CalendarICUBridge.h"
 #include "ISO8601.h"
+#include "InternalFunction.h"
 #include "IntlObject.h"
 #include "JSCInlines.h"
 #include "TemporalCalendar.h"
@@ -54,31 +55,44 @@ TemporalZonedDateTime* TemporalZonedDateTime::create(VM& vm, Structure* structur
     return object;
 }
 
-// temporal_rs: ZonedDateTime::try_new (validates epochNanoseconds range)
 // https://tc39.es/proposal-temporal/#sec-temporal-createtemporalzoneddatetime
-TemporalZonedDateTime* TemporalZonedDateTime::tryCreate(JSGlobalObject* globalObject, Structure* structure, ISO8601::ExactTime exactTime, TimeZone timeZone, CalendarID calendarID)
+template<TemporalConstructTarget target>
+static TemporalZonedDateTime* createTemporalZonedDateTimeImpl(JSGlobalObject* globalObject, ISO8601::ExactTime exactTime, TimeZone timeZone, CalendarID calendarID, TemporalNewTarget newTarget = { })
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: If IsValidEpochNanoseconds(epochNanoseconds) is false, throw RangeError.
-    if (!exactTime.isValid()) [[unlikely]] {
-        throwRangeError(globalObject, scope, "epochNanoseconds is outside of the supported range for Temporal.ZonedDateTime"_s);
-        return nullptr;
+    // Step 1: Assert: IsValidEpochNanoseconds(epochNanoseconds) is true.
+    ASSERT(exactTime.isValid());
+
+    // Step 2: If newTarget is not present, set newTarget to %Temporal.ZonedDateTime%.
+    // Step 3: Let object be ? OrdinaryCreateFromConstructor(newTarget, "%Temporal.ZonedDateTime.prototype%", « ... »).
+    Structure* structure;
+    if constexpr (target == TemporalConstructTarget::Intrinsic)
+        structure = globalObject->zonedDateTimeStructure();
+    else {
+        ASSERT(newTarget.newTarget && newTarget.constructor);
+        structure = JSC_GET_DERIVED_STRUCTURE(vm, zonedDateTimeStructure, newTarget.newTarget, newTarget.constructor);
+        RETURN_IF_EXCEPTION(scope, { });
     }
 
-    // Steps 2-5: Allocate object, set [[EpochNanoseconds]], [[TimeZone]], [[Calendar]], return.
-    return create(vm, structure, exactTime, timeZone, calendarID);
+    // Steps 4-6: set [[EpochNanoseconds]], [[TimeZone]], [[Calendar]]. Step 7: Return object.
+    return TemporalZonedDateTime::create(vm, structure, exactTime, timeZone, calendarID);
+}
+
+TemporalZonedDateTime* createTemporalZonedDateTime(JSGlobalObject* globalObject, ISO8601::ExactTime exactTime, TimeZone timeZone, CalendarID calendarID)
+{
+    return createTemporalZonedDateTimeImpl<TemporalConstructTarget::Intrinsic>(globalObject, exactTime, timeZone, calendarID);
+}
+
+TemporalZonedDateTime* createTemporalZonedDateTime(JSGlobalObject* globalObject, ISO8601::ExactTime exactTime, TimeZone timeZone, CalendarID calendarID, TemporalNewTarget newTarget)
+{
+    return createTemporalZonedDateTimeImpl<TemporalConstructTarget::NewTarget>(globalObject, exactTime, timeZone, calendarID, newTarget);
 }
 
 Structure* TemporalZonedDateTime::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {
     return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
-}
-
-TemporalZonedDateTime* TemporalZonedDateTime::withExactTime(JSGlobalObject* globalObject, ISO8601::ExactTime epochNs) const
-{
-    return tryCreate(globalObject, globalObject->zonedDateTimeStructure(), epochNs, m_timeZone, m_calendarID);
 }
 
 TemporalZonedDateTime::TemporalZonedDateTime(VM& vm, Structure* structure, ISO8601::ExactTime exactTime, TimeZone timeZone, CalendarID calendarID)
@@ -408,9 +422,7 @@ TemporalZonedDateTime* TemporalZonedDateTime::from(JSGlobalObject* globalObject,
     }
 
     // Step 12: Return ! CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar).
-    // interpretISODateTimeOffset guarantees a valid ExactTime, so create() suffices; tryCreate()
-    // adds a redundant isValid() check that acts as defense-in-depth against a buggy ICU backend.
-    RELEASE_AND_RETURN(scope, TemporalZonedDateTime::tryCreate(globalObject, globalObject->zonedDateTimeStructure(), *exactTimeResult, args->timeZone, args->calendarID));
+    RELEASE_AND_RETURN(scope, createTemporalZonedDateTime(globalObject, *exactTimeResult, args->timeZone, args->calendarID));
 }
 
 // temporal_rs: ZonedDateTime::epoch_ns (via get_epoch_nanoseconds_for)

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.h
@@ -48,7 +48,6 @@ public:
     }
 
     static TemporalZonedDateTime* create(VM&, Structure*, ISO8601::ExactTime, TimeZone, CalendarID);
-    static TemporalZonedDateTime* tryCreate(JSGlobalObject*, Structure*, ISO8601::ExactTime, TimeZone, CalendarID);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     static TemporalZonedDateTime* from(JSGlobalObject*, JSValue item);
@@ -68,8 +67,6 @@ public:
 
     static std::optional<ISO8601::ExactTime> getEpochNanosecondsFor(JSGlobalObject*, const TimeZone&, const ISO8601::PlainDate&, const ISO8601::PlainTime&, TemporalDisambiguation);
 
-    TemporalZonedDateTime* withExactTime(JSGlobalObject*, ISO8601::ExactTime epochNs) const;
-
 private:
     TemporalZonedDateTime(VM&, Structure*, ISO8601::ExactTime, TimeZone, CalendarID);
     DECLARE_DEFAULT_FINISH_CREATION;
@@ -78,5 +75,8 @@ private:
     TimeZone m_timeZone;
     CalendarID m_calendarID { 0 };
 };
+
+TemporalZonedDateTime* createTemporalZonedDateTime(JSGlobalObject*, ISO8601::ExactTime, TimeZone, CalendarID);
+TemporalZonedDateTime* createTemporalZonedDateTime(JSGlobalObject*, ISO8601::ExactTime, TimeZone, CalendarID, TemporalNewTarget);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimeConstructor.cpp
@@ -90,9 +90,6 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalZonedDateTime, (JSGlobalObject* global
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Step 1: If NewTarget is *undefined*, throw *TypeError* — handled by callTemporalZonedDateTime.
-    JSObject* newTarget = asObject(callFrame->newTarget());
-    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, zonedDateTimeStructure, newTarget, callFrame->jsCallee());
-    RETURN_IF_EXCEPTION(scope, { });
 
     // Step 2: Set _epochNanoseconds_ to ? ToBigInt(_epochNanoseconds_).
     JSValue bigIntValue = callFrame->argument(0).toBigInt(globalObject);
@@ -137,8 +134,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalZonedDateTime, (JSGlobalObject* global
     }
 
     // Step 11: Return ? CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_, NewTarget).
-    // tryCreate re-validates isValid() as a safety net (primarily for subclasses).
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalZonedDateTime::tryCreate(globalObject, structure, exactTime, *parsedTZ, calendarID)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalZonedDateTime(globalObject, exactTime, *parsedTZ, calendarID, { asObject(callFrame->newTarget()), callFrame->jsCallee() })));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
@@ -213,7 +213,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncStartOfDay, (JSGlobal
     }
 
     // Step 7: Return ! CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar).
-    RELEASE_AND_RETURN(scope, JSValue::encode(zdt->withExactTime(globalObject, *sodResult)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalZonedDateTime(globalObject, *sodResult, zdt->timeZone(), zdt->calendarID())));
 }
 
 // temporal_rs: ZonedDateTime::with_plain_time_and_provider
@@ -261,7 +261,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncWithPlainTime, (JSGlo
     }
 
     // Step 8: Return ! CreateTemporalZonedDateTime(epochNs, timeZone, calendar).
-    RELEASE_AND_RETURN(scope, JSValue::encode(zdt->withExactTime(globalObject, resultEpochNs)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalZonedDateTime(globalObject, resultEpochNs, zdt->timeZone(), zdt->calendarID())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-adddurationtozoneddatetime
@@ -278,7 +278,7 @@ static EncodedJSValue addDurationToZonedDateTime(JSGlobalObject* globalObject, T
         return { };
     }
     // Step 9: Return ! CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar).
-    RELEASE_AND_RETURN(scope, JSValue::encode(zdt->withExactTime(globalObject, *addResult)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalZonedDateTime(globalObject, *addResult, zdt->timeZone(), zdt->calendarID())));
 }
 
 // temporal_rs: ZonedDateTime::add_with_provider
@@ -383,7 +383,7 @@ static EncodedJSValue differenceTemporalZonedDateTime(JSGlobalObject* globalObje
         result = -result;
 
     // Step 12: Return result.
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), globalObject->durationStructure())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalDuration(globalObject, WTF::move(result))));
 }
 
 // temporal_rs: ZonedDateTime::until_with_provider
@@ -471,7 +471,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncRound, (JSGlobalObjec
     // Step 14: If smallestUnit is ~nanosecond~ and roundingIncrement = 1, return new ZDT.
     // Spec requires a new object even when no rounding occurs (result !== input).
     if (smallestUnit == TemporalUnit::Nanosecond && roundingIncrement == 1)
-        RELEASE_AND_RETURN(scope, JSValue::encode(zdt->withExactTime(globalObject, zdt->exactTime())));
+        RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalZonedDateTime(globalObject, zdt->exactTime(), zdt->timeZone(), zdt->calendarID())));
 
     // Steps 15-17: thisNs, timeZone, calendar.
     // Step 18: isoDateTime = GetISODateTimeFor(timeZone, thisNs).
@@ -550,7 +550,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncRound, (JSGlobalObjec
     }
 
     // Step 21: Return ! CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar).
-    RELEASE_AND_RETURN(scope, JSValue::encode(zdt->withExactTime(globalObject, ISO8601::ExactTime(resultNs))));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalZonedDateTime(globalObject, ISO8601::ExactTime(resultNs), zdt->timeZone(), zdt->calendarID())));
 }
 
 // temporal_rs: ZonedDateTime::get_time_zone_transition_with_provider
@@ -609,7 +609,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncGetTimeZoneTransition
         return JSValue::encode(jsNull());
 
     // Step 12: Return ! CreateTemporalZonedDateTime(transition, timeZone, zonedDateTime.[[Calendar]]).
-    RELEASE_AND_RETURN(scope, JSValue::encode(zdt->withExactTime(globalObject, (*transResult).value())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalZonedDateTime(globalObject, (*transResult).value(), zdt->timeZone(), zdt->calendarID())));
 }
 
 // temporal_rs: ZonedDateTime::with_with_provider
@@ -714,49 +714,22 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncWith, (JSGlobalObject
     ISO8601::PlainDate newDate = pdt.date;
     ISO8601::PlainTime newTime = pdt.time;
 
-    // Steps 24-25: InterpretISODateTimeOffset — resolve epoch nanoseconds.
-    // Step 24: newOffsetNanoseconds — use provided offset OR current offset.
-    // temporal_rs: ZonedDateTime::with_with_provider — offset always Some (either explicit or current).
+    // Step 24: newOffsetNanoseconds — the offset from the property bag, else the current one.
+    // temporal_rs: with_with_provider — offset is always Some (explicit or current).
     int64_t givenOffsetNs = pf.offsetNs.value_or(curOffsetNs);
 
-    // Steps 24-25: InterpretISODateTimeOffset.
-    // temporal_rs: ZonedDateTime::with_with_provider — is_exact=true when offset option is 'use'.
-    // offset_nanos = Some(givenOffsetNs) always.
-    if (offsetOpt == TemporalOffsetDisambiguation::Use) {
-        Int128 naiveNs = TemporalCore::getUTCEpochNanoseconds(newDate, newTime);
-        auto resultNs = naiveNs - Int128(givenOffsetNs);
-        RELEASE_AND_RETURN(scope, JSValue::encode(zdt->withExactTime(globalObject, ISO8601::ExactTime(resultNs))));
+    // Step 25: epochNanoseconds = ? InterpretISODateTimeOffset(dateTimeResult.[[ISODate]],
+    //   dateTimeResult.[[Time]], ~option~, newOffsetNanoseconds, timeZone, disambiguation, offset,
+    //   ~match-exactly~).
+    auto epochNsResult = TemporalCore::interpretISODateTimeOffset(newDate, newTime, /* useStartOfDay */ false,
+        OffsetBehaviour::Option, offsetOpt, givenOffsetNs, /* offsetHasSubMinutePrecision */ true, zdt->timeZone(), disambiguation);
+    if (!epochNsResult) [[unlikely]] {
+        throwTemporalError(globalObject, scope, epochNsResult.error());
+        return { };
     }
 
-    if (offsetOpt == TemporalOffsetDisambiguation::Prefer || offsetOpt == TemporalOffsetDisambiguation::Reject) {
-        // InterpretISODateTimeOffset step 7: CheckISODaysRange(isoDate).
-        // The local date from with() may be outside ±10^8 days even if the UTC epoch is valid.
-        if (std::abs(dateToDaysFrom1970(newDate.year(), static_cast<int>(newDate.month()) - 1, static_cast<int>(newDate.day()))) > 1e8) {
-            throwRangeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.with result is outside the supported range"_s);
-            return { };
-        }
-        // Try to find a possible instant matching the given offset (exact match).
-        auto possible = TemporalCore::getPossibleEpochNanosecondsFor(zdt->timeZone(), newDate, newTime);
-        if (!possible) [[unlikely]] {
-            throwRangeError(globalObject, scope, possible.error().message);
-            return { };
-        }
-        for (auto& candidate : TemporalCore::epochCandidates(*possible)) {
-            auto offsetResult = TemporalCore::getOffsetNanosecondsFor(zdt->timeZone(), candidate);
-            if (offsetResult && *offsetResult == givenOffsetNs)
-                RELEASE_AND_RETURN(scope, JSValue::encode(zdt->withExactTime(globalObject, candidate)));
-        }
-        if (offsetOpt == TemporalOffsetDisambiguation::Reject) {
-            throwRangeError(globalObject, scope, "ZonedDateTime.with: given offset does not match any possible instant"_s);
-            return { };
-        }
-        // Prefer: no match found, fall through to disambiguation.
-    }
-
-    auto epochNs = TemporalZonedDateTime::getEpochNanosecondsFor(globalObject, zdt->timeZone(), newDate, newTime, disambiguation);
-    RETURN_IF_EXCEPTION(scope, { });
     // Step 26: Return ! CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar).
-    RELEASE_AND_RETURN(scope, JSValue::encode(zdt->withExactTime(globalObject, *epochNs)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalZonedDateTime(globalObject, *epochNsResult, zdt->timeZone(), zdt->calendarID())));
 }
 
 // temporal_rs: ZonedDateTime::with_calendar


### PR DESCRIPTION
#### b48f01b7f1b125646d7b77e3ddcc3fe7943462cb
<pre>
[JSC][Temporal] Fix constructor newTarget.prototype ordering and unify CreateTemporalX helpers
<a href="https://bugs.webkit.org/show_bug.cgi?id=321041">https://bugs.webkit.org/show_bug.cgi?id=321041</a>
<a href="https://rdar.apple.com/184072358">rdar://184072358</a>

Reviewed by Yusuke Suzuki.

Every CreateTemporalX AO validates its slots before OrdinaryCreateFromConstructor,
whose Get(NewTarget, &quot;prototype&quot;) is observable. All eight Temporal constructors
derived their Structure on entry, so Reflect.construct with a throwing `prototype`
accessor got that error instead of the mandated RangeError.

The helpers now take a TemporalNewTarget rather than a Structure*, making the wrong
order unrepresentable, and are renamed after their AOs as free functions —
createTemporalDate, createTemporalZonedDateTime and so on. `try*` in WebKit means
&quot;returns null without throwing&quot;, the opposite of these.

Two bugs found on the way: ZonedDateTime.prototype.with open-coded
InterpretISODateTimeOffset without its CheckISODaysRange and IsValidEpochNanoseconds
steps, so an offset at the epoch boundary produced an out-of-range ZonedDateTime; and
isValidPlainDateOrThrow threw through its own ThrowScope, leaving the caller&apos;s
unchecked under --validateExceptionChecks.

Also folds CalendarID into CreateTemporalYearMonth/MonthDay, adds the missing
CreateTemporalInstant, and corrects the step annotations in all eight.

Test: JSTests/stress/temporal-construct-newtarget-prototype-order.js
Canonical link: <a href="https://commits.webkit.org/318635@main">https://commits.webkit.org/318635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fec46eadc2c1a952633f417515fcf52fdc6a7ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188383 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/790e4dce-8c3e-4ec9-a960-31bd39949c11) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139384 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/faea773d-d55f-4f2c-a8f9-b84a5a54e55c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119838 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d6e6292-4995-470e-b940-da25a490f758) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41620 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39968 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1808 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed JSC tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8609 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39621 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40040 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190811 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52375 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148566 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53055 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148333 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27150 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43028 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125322 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119983 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51573 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14599 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50958 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51198 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51020 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->