### PR TITLE
[Site Isolation] [iOS] Selection loupe slides in from the iframe edge in a cross-origin iframe

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -98,6 +98,7 @@
 #import "WebDataListSuggestionsDropdownIOS.h"
 #import "WebEvent.h"
 #import "WebFoundTextRange.h"
+#import "WebFrameProxy.h"
 #import "WebIOSEventFactory.h"
 #import "WebMouseEvent.h"
 #import "WebPageMessages.h"
@@ -14509,6 +14510,18 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
         Ref page = *_page;
         if (!page->editorState().hasVisualData())
             return self;
+
+        // When the selection is in a cross-origin (site-isolated) subframe, WebKit reports the
+        // selection rects in main-frame coordinates, so the selection must be contained by self (the
+        // WKContentView) rather than the subframe's overflow-scroll layer. That container's
+        // coordinate space assumes a same-process scroller, which doesn't hold across the process
+        // boundary -- using it would present the selection/loupe relative to the subframe's scrolled
+        // layer and make the loupe animate in from the iframe's edge.
+        if (auto rootFrameID = page->editorState().visualData->rootFrameID) {
+            RefPtr mainFrame = page->mainFrame();
+            if (mainFrame && mainFrame->frameID() != *rootFrameID)
+                return self;
+        }
 
         RetainPtr enclosingView = [self _viewForLayerID:page->editorState().visualData->enclosingLayerID];
         if (![enclosingView window])

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
@@ -236,6 +236,9 @@ class Color;
 @property (nonatomic, readonly) CGRect caretViewRectInContentCoordinates;
 @property (nonatomic, readonly) NSArray<NSValue *> *selectionViewRectsInContentCoordinates;
 @property (nonatomic, readonly) NSString *textForSpeakSelection;
+#if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
+@property (nonatomic, readonly) UIView *selectionHighlightView;
+#endif
 - (_WKActivatedElementInfo *)activatedElementAtPosition:(CGPoint)position;
 - (void)evaluateJavaScriptAndWaitForInputSessionToChange:(NSString *)script;
 - (void)evaluateJavaScriptAndWaitForInputSessionToChange:(NSString *)script inFrame:(WKFrameInfo *)frame;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
@@ -1583,6 +1583,11 @@ static UIWindowScene *windowScene()
     return dynamic_objc_cast<UITextSelectionDisplayInteraction>([self.textInputContentView valueForKeyPath:@"interactionAssistant._selectionViewManager"]);
 }
 
+- (UIView *)selectionHighlightView
+{
+    return self.textSelectionDisplayInteraction.highlightView;
+}
+
 #endif
 
 static WKContentView *recursiveFindWKContentView(UIView *view)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -9874,6 +9874,52 @@ TEST(SiteIsolation, SelectionBoundingRectInMainFrameIsNotOffset)
     EXPECT_LT(CGRectGetMinY(rect), 50);
 }
 
+#if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
+TEST(SiteIsolation, SelectionInCrossOriginIframeIsContainedByContentView)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe id='iframe' style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/iframe'></iframe></body>"_s } },
+        { "/iframe"_s, { "<!DOCTYPE html><body style='margin: 0'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    // The selection container is only ever the enclosing overflow-scroll layer when
+    // SelectionHonorsOverflowScrolling is enabled, so enable it to exercise the code path this test
+    // guards.
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    enableSiteIsolation(configuration.get());
+    for (_WKFeature *feature in WKPreferences._features) {
+        if ([feature.key isEqualToString:@"SelectionHonorsOverflowScrolling"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    // The container is the enclosing layer only when that layer is in a window, so host the view.
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr childFrame = [webView firstChildFrame];
+    [webView evaluateJavaScript:@"document.getElementById('iframe').focus()" completionHandler:nil];
+    while (![childFrame _isFocused])
+        childFrame = [webView firstChildFrame];
+
+    [webView _synchronouslyExecuteEditCommand:@"SelectAll" argument:nil];
+    while (![webView selectionRangeHasStartOffset:0 endOffset:4 inFrame:childFrame.get()])
+        Util::spinRunLoop();
+    [webView waitForNextPresentationUpdate];
+
+    // The selection lives in a cross-origin subframe, whose rects are reported in main-frame
+    // coordinates, so it must be contained by the WKContentView itself -- not the subframe's
+    // overflow-scroll layer (which is offset by the subframe's position and scroll). Otherwise the
+    // selection loupe/handles are positioned in the wrong coordinate space.
+    EXPECT_EQ(webView.get().selectionHighlightView.superview, webView.get().textInputContentView);
+}
+#endif // HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
+
 #endif // PLATFORM(IOS_FAMILY)
 
 #if ENABLE(IMAGE_ANALYSIS)


### PR DESCRIPTION
#### 47c187746bfd9d27268db18e105f30c6f0cdfa9e
<pre>
[Site Isolation] [iOS] Selection loupe slides in from the iframe edge in a cross-origin iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=321044">https://bugs.webkit.org/show_bug.cgi?id=321044</a>

Reviewed by Wenson Hsieh, Abrar Rahman Protyasha, and Megan Gardner.

When text is selected inside a cross-origin (site-isolated) iframe on iOS, the selection loupe
was mispositioned: instead of appearing at the caret it animated in from the top or bottom edge
of the iframe (the offset scaling with the subframe&apos;s scroll position).

When selectionHonorsOverflowScrolling is enabled, WKContentView presents the selection -- and
the loupe -- inside the enclosing overflow-scroll layer, converting the selection rects into
that container&apos;s coordinate space (see -[WKContentView _selectionContainerViewInternal] and
selectionRect:convertQuadToSelectionContainer:). For a cross-origin subframe that enclosing
layer is the subframe&apos;s remote-hosted, scrolled layer, but WebKit reports the selection rects
in main-frame (root-view) coordinates. Presenting main-frame-coordinate rects relative to the
subframe&apos;s scrolled layer positioned the loupe relative to the iframe&apos;s layer origin, so it
slid in from the iframe edge.

The overflow-scroll selection container assumes a same-process scroller whose layer the rects
are relative to, which does not hold across the site-isolation process boundary. Use the
WKContentView as the selection container when the selection&apos;s root frame is not the main frame.

Test: SiteIsolation.SelectionInCrossOriginIframeIsContainedByContentView

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _selectionContainerViewInternal]): Return self when the selection is in
a cross-origin subframe (visualData.rootFrameID is not the main frame).
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, SelectionInCrossOriginIframeIsContainedByContentView)):
* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm:
(-[TestWKWebView selectionHighlightView]): Added.

Canonical link: <a href="https://commits.webkit.org/318631@main">https://commits.webkit.org/318631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4878ef67a4e7aa85c68b544799236d7140ed0d33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188423 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cfacc247-9e60-4c43-9517-8d37c483cd6c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139419 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36f86a99-fa1d-47b5-86f7-43f0b8194a7b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119873 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73b0c1be-039a-471e-9756-7341214bbe38) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41654 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40003 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39650 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40080 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44245 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190851 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52415 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148603 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53095 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148370 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27149 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43068 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125362 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120026 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51613 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14629 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50998 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51238 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51060 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->