### PR TITLE
Support Live Activities for Netflix.com

### DIFF
--- a/LayoutTests/media/now-playing-info-position-without-seeking-support-expected.txt
+++ b/LayoutTests/media/now-playing-info-position-without-seeking-support-expected.txt
@@ -1,0 +1,26 @@
+
+Tests that NowPlaying reports duration and elapsed time when a site-specific quirk disables seeking support.
+
+* Adopt a domain whose site-specific quirks disable seeking support.
+RUN(internals.setTopDocumentURLForQuirks("https://www.netflix.com/"))
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(canplaythrough)
+
+* Seeking support should be disabled by the quirk.
+RUN(controlsHost = internals.controlsHostForMediaElement(video))
+EXPECTED (controlsHost.supportsSeeking == 'false') OK
+
+* Start to play, NowPlaying should become active.
+RUN(video.play())
+EVENT(playing)
+RUN(video.pause())
+
+* Duration and elapsed time should be reported anyway.
+RUN(nowPlayingState = internals.nowPlayingState)
+EXPECTED (nowPlayingState.registeredAsNowPlayingApplication == 'true') OK
+EXPECTED (isNaN(nowPlayingState.duration) == 'false') OK
+EXPECTED (nowPlayingState.duration > '0') OK
+EXPECTED (isNaN(nowPlayingState.elapsedTime) == 'false') OK
+
+END OF TEST
+

--- a/LayoutTests/media/now-playing-info-position-without-seeking-support.html
+++ b/LayoutTests/media/now-playing-info-position-without-seeking-support.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ NeedsSiteSpecificQuirks=true ] -->
+<html>
+<head>
+    <title>now-playing-info-position-without-seeking-support</title>
+    <script src=video-test.js></script>
+    <script src=media-file.js></script>
+    <script>
+
+        let nowPlayingState;
+        let controlsHost;
+
+        async function waitForAttributeToChange(attribute, expected) {
+            let start = new Date().getTime();
+            do {
+
+                if (internals.nowPlayingState[attribute] != expected)
+                    return;
+
+                await new Promise(resolve => setTimeout(resolve, 100));
+            } while (new Date().getTime() - start < 500);
+
+            failTest(`** Timed out waiting for "${attribute}" to change from "${expected}"`);
+        }
+
+        async function runTest()
+        {
+            findMediaElement();
+
+            // Adopt a domain whose site-specific quirks disable seeking support. Position
+            // must still be reported: a Now Playing client that cannot scrub can still
+            // display elapsed and remaining time. rdar://181140244
+            consoleWrite('<br>* Adopt a domain whose site-specific quirks disable seeking support.');
+            run('internals.setTopDocumentURLForQuirks("https://www.netflix.com/")');
+            run('video.src = findMediaFile("video", "content/test")');
+            await waitFor(video, 'canplaythrough');
+
+            // Guard against a vacuous pass: if the quirk failed to apply, seeking would be
+            // supported and position would be reported for the uninteresting reason.
+            consoleWrite('<br>* Seeking support should be disabled by the quirk.');
+            run('controlsHost = internals.controlsHostForMediaElement(video)');
+            testExpected('controlsHost.supportsSeeking', false);
+
+            consoleWrite('<br>* Start to play, NowPlaying should become active.');
+            runWithKeyDown(() => {
+                run('video.play()');
+            });
+
+            await waitFor(video, 'playing');
+            run('video.pause()');
+            await waitForAttributeToChange('registeredAsNowPlayingApplication', false);
+
+            consoleWrite('<br>* Duration and elapsed time should be reported anyway.');
+            run('nowPlayingState = internals.nowPlayingState');
+            testExpected('nowPlayingState.registeredAsNowPlayingApplication', true);
+            testExpected('isNaN(nowPlayingState.duration)', false);
+            testExpected('nowPlayingState.duration', '0', '>');
+            testExpected('isNaN(nowPlayingState.elapsedTime)', false);
+
+            consoleWrite('');
+        }
+
+        window.addEventListener('load', event => {
+            runTest().then(endTest).catch(failTest);
+        });
+    </script>
+</head>
+<body>
+    <video controls></video>
+    <br>
+    Tests that NowPlaying reports duration and elapsed time when a site-specific quirk disables seeking support.
+</body>
+</html>

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1546,9 +1546,10 @@ std::optional<NowPlayingInfo> MediaElementSession::computeNowPlayingInfo() const
 
     bool supportsSeeking = element->supportsSeeking();
     double rate = element->playbackRate();
-    double duration = supportsSeeking ? element->duration() : std::numeric_limits<double>::quiet_NaN();
+    // Report position independently of seekability.
+    double duration = element->duration();
     double currentTime = element->currentTime();
-    if (!std::isfinite(currentTime) || !supportsSeeking)
+    if (!std::isfinite(currentTime))
         currentTime = std::numeric_limits<double>::quiet_NaN();
     auto sourceApplicationIdentifier = element->sourceApplicationIdentifier();
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -471,7 +471,7 @@ void MediaSessionManagerCocoa::setNowPlayingInfo(bool setAsNowPlayingApplication
     auto cfIdentifier = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberLongLongType, &lastUpdatedNowPlayingInfoUniqueIdentifier));
     CFDictionarySetValue(info.get(), kMRMediaRemoteNowPlayingInfoUniqueIdentifier, cfIdentifier.get());
 
-    if (std::isfinite(nowPlayingInfo.currentTime) && !std::isnan(nowPlayingInfo.currentTime) && nowPlayingInfo.supportsSeeking) {
+    if (std::isfinite(nowPlayingInfo.currentTime) && !std::isnan(nowPlayingInfo.currentTime)) {
         auto cfCurrentTime = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &nowPlayingInfo.currentTime));
         CFDictionarySetValue(info.get(), kMRMediaRemoteNowPlayingInfoElapsedTime, cfCurrentTime.get());
     }
@@ -602,8 +602,10 @@ bool MediaSessionManagerCocoa::shouldUpdateNowPlaying(const NowPlayingInfo& nowP
 
     auto currentTime = nowPlayingInfo.currentTime;
 
-    // Always update when currentTime changes while paused.
-    if (nowPlayingInfo.supportsSeeking && !nowPlayingInfo.isPlaying) {
+    // Always update when currentTime changes while paused. This is not gated on
+    // seekability: position is reported even for non-seekable sessions, so a seek
+    // performed through the page's own controls must still refresh the elapsed time.
+    if (!nowPlayingInfo.isPlaying) {
         bool didChange = m_nowPlayingInfo->currentTime != currentTime;
         INFO_LOG_IF(didChange, LOGIDENTIFIER, "paused and current time changed");
         return didChange;
@@ -734,7 +736,7 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
 
     m_lastUpdatedNowPlayingInfoUniqueIdentifier = nowPlayingInfo->uniqueIdentifier;
 
-    if (std::isfinite(currentTime) && !std::isnan(currentTime) && nowPlayingInfo->supportsSeeking)
+    if (std::isfinite(currentTime) && !std::isnan(currentTime))
         m_lastUpdatedNowPlayingElapsedTime = currentTime;
 
     m_nowPlayingActive = nowPlayingInfo->allowsNowPlayingControlsVisibility;

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
@@ -349,7 +349,7 @@ void MediaSessionManagerGLib::updateNowPlayingInfo()
     m_lastUpdatedNowPlayingInfoUniqueIdentifier = nowPlayingInfo->uniqueIdentifier;
 
     double currentTime = nowPlayingInfo->currentTime;
-    if (std::isfinite(currentTime) && currentTime != MediaPlayer::invalidTime() && nowPlayingInfo->supportsSeeking)
+    if (std::isfinite(currentTime) && currentTime != MediaPlayer::invalidTime())
         m_lastUpdatedNowPlayingElapsedTime = currentTime;
 
     m_nowPlayingActive = nowPlayingInfo->allowsNowPlayingControlsVisibility;


### PR DESCRIPTION
#### 9323c3a2d44fe82b73da2d3feecce5ea971faa4c
<pre>
Support Live Activities for Netflix.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=321042">https://bugs.webkit.org/show_bug.cgi?id=321042</a>
&lt;<a href="https://rdar.apple.com/181140244">rdar://181140244</a>&gt;

Reviewed by Jean-Yves Avenard.

Because of the quirk added in Bug 172881, WebKit does not populate the duration and currentTime
components of the NowPlaying struct used by the Live Activities feature (e.g., see the
&quot;Now Playing&quot; widget in the control center on macOS Tahoe or newer).

We can retain the `supportsSeeking == false` behavior needed to avoid the issues that led
to the original Netflix Quirk while truthfully populating the NowPlaying struct so that
Live Activities shows the current play position.

Scrubbing in the Live Activities view (and TouchBar on relevant machine) is still disabled
for Netflix.

Test: media/now-playing-info-position-without-seeking-support.html

* LayoutTests/media/now-playing-info-position-without-seeking-support-expected.txt: Added.
* LayoutTests/media/now-playing-info-position-without-seeking-support.html: Added.
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::computeNowPlayingInfo const):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::setNowPlayingInfo):
(WebCore::MediaSessionManagerCocoa::shouldUpdateNowPlaying):
(WebCore::MediaSessionManagerCocoa::updateNowPlayingInfo):
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp:
(WebCore::MediaSessionManagerGLib::updateNowPlayingInfo):

Canonical link: <a href="https://commits.webkit.org/318992@main">https://commits.webkit.org/318992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23255631f99c3382138511c22fa1fc591ba3d50d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188789 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143269 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48da96cc-782a-4f22-ba7b-2362fc76f702) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139544 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96731 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9acb93c3-8bb0-4f23-b69a-b971ef1d1931) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119990 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41807 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40153 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152206 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39801 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/96 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191009 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148763 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40117 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53249 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148515 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43207 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125519 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120352 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51767 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14779 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51152 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51393 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51213 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->