### PR TITLE
Add animation forwarding to child models in spatial portals

### DIFF
--- a/LayoutTests/spatial-css/resources/spatial-portal-utils.js
+++ b/LayoutTests/spatial-css/resources/spatial-portal-utils.js
@@ -46,6 +46,17 @@ const portalTransformScaleIsUnit = transform => {
 const portalTransformIsResolved = transform => !!transform;
 const portalTransformIsCleared = transform => transform === null;
 
+async function waitFor(predicate, description, timeout = 5000) {
+    const startTime = Date.now();
+
+    while (!predicate()) {
+        if (Date.now() - startTime > timeout)
+            throw new Error(`Timeout waiting for ${description}`);
+
+        await sleepForSeconds(0.05);
+    }
+}
+
 async function waitForPortalTransform(portal, predicate, description, timeout = 5000) {
     const startTime = Date.now();
 

--- a/LayoutTests/spatial-css/spatial-portal-animation-currenttime-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-animation-currenttime-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Setting currentTime is ignored on a <model> nested in a spatial portal that has no animation
+PASS Setting currentTime on a <model> nested in a spatial portal seeks its animation
+PASS Siblings in a spatial portal seek independently
+

--- a/LayoutTests/spatial-css/spatial-portal-animation-currenttime.html
+++ b/LayoutTests/spatial-css/spatial-portal-animation-currenttime.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<meta charset="utf-8">
+<title>&lt;model> animation currentTime inside a spatial portal</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, "cube.usdz");
+
+    await model.ready;
+
+    assert_equals(model.currentTime, 0);
+    model.currentTime = 30;
+    assert_equals(model.currentTime, 0, "currentTime is ignored on a child model that has no animation");
+}, "Setting currentTime is ignored on a <model> nested in a spatial portal that has no animation");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, "stopwatch-60s.usdz");
+
+    await model.ready;
+
+    assert_equals(model.currentTime, 0);
+
+    model.currentTime = 30;
+    assert_approx_equals(model.currentTime, 30, 0.1, "currentTime should be around 30s");
+
+    model.currentTime = -5;
+    assert_equals(model.currentTime, 0, "currentTime should be clamped to 0");
+
+    model.currentTime = 90;
+    assert_approx_equals(model.currentTime, 60, 0.1, "currentTime should be clamped to duration");
+}, "Setting currentTime on a <model> nested in a spatial portal seeks its animation");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const first = appendModel(portal, "stopwatch-60s.usdz");
+    const second = appendModel(portal, "stopwatch-60s.usdz");
+
+    await Promise.all([first.ready, second.ready]);
+
+    first.currentTime = 10;
+    second.currentTime = 40;
+
+    assert_approx_equals(first.currentTime, 10, 0.1, "seeking the first child does not disturb it");
+    assert_approx_equals(second.currentTime, 40, 0.1, "each child seeks its own animation");
+}, "Siblings in a spatial portal seek independently");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-animation-dynamic-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-animation-dynamic-expected.txt
@@ -1,0 +1,5 @@
+
+PASS <model autoplay> added to a rendering spatial portal plays its animation
+PASS playbackRate set before a <model> joins a rendering spatial portal is applied
+PASS loop set before a <model> joins a rendering spatial portal is applied
+

--- a/LayoutTests/spatial-css/spatial-portal-animation-dynamic.html
+++ b/LayoutTests/spatial-css/spatial-portal-animation-dynamic.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<meta charset="utf-8">
+<title>&lt;model> animation playback for a late addition to a spatial portal</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+// A child added to a portal that is already rendering finds a ModelPlayer that already exists, so
+// its playback state reaches the model process by a different route than its siblings' did.
+promise_test(async t => {
+    const portal = createPortal(t);
+    const first = appendModel(portal, "stopwatch-60s.usdz");
+    await first.ready;
+
+    const late = appendModel(portal, "stopwatch-60s.usdz");
+    late.autoplay = true;
+    await late.ready;
+
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 2, "the portal hosts both models");
+    assert_approx_equals(late.duration, 60, 0.1, "the late model reports its animation duration");
+    assert_false(late.paused, "a late model with autoplay starts playing");
+    assert_true(first.paused, "the model that was already loaded does not start playing");
+}, "<model autoplay> added to a rendering spatial portal plays its animation");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const first = appendModel(portal, "stopwatch-60s.usdz");
+    await first.ready;
+
+    const late = appendModel(portal, "stopwatch-60s.usdz");
+    late.playbackRate = 10;
+    await late.ready;
+
+    await Promise.all([first.play(), late.play()]);
+    await sleepForSeconds(0.5);
+
+    assert_greater_than(late.currentTime, first.currentTime, "the late model advances at its own playbackRate");
+}, "playbackRate set before a <model> joins a rendering spatial portal is applied");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const first = appendModel(portal, "stopwatch-60s.usdz");
+    await first.ready;
+
+    const late = appendModel(portal, "stopwatch-60s.usdz");
+    late.autoplay = true;
+    late.loop = true;
+    await late.ready;
+
+    late.currentTime = late.duration - 0.01;
+    await sleepForSeconds(0.2);
+
+    assert_false(late.paused, "the late looping model keeps playing past its duration");
+}, "loop set before a <model> joins a rendering spatial portal is applied");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-animation-independent-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-animation-independent-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Siblings in a spatial portal advance at their own playbackRate
+PASS Pausing one <model> in a spatial portal does not pause its siblings
+PASS Looping is applied per <model> in a spatial portal
+

--- a/LayoutTests/spatial-css/spatial-portal-animation-independent.html
+++ b/LayoutTests/spatial-css/spatial-portal-animation-independent.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<meta charset="utf-8">
+<title>Independent &lt;model> animation playback inside a spatial portal</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+// The children of a spatial portal share one ModelPlayer, so playback state has to be addressed per
+// model rather than per player.
+promise_test(async t => {
+    const portal = createPortal(t);
+    const slow = appendModel(portal, "stopwatch-60s.usdz");
+    const fast = appendModel(portal, "stopwatch-60s.usdz");
+
+    slow.playbackRate = 1;
+    fast.playbackRate = 10;
+
+    await Promise.all([slow.ready, fast.ready]);
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 2, "the portal hosts both models");
+
+    await Promise.all([slow.play(), fast.play()]);
+    await sleepForSeconds(0.5);
+
+    assert_false(slow.paused, "the slower model is playing");
+    assert_false(fast.paused, "the faster model is playing");
+    assert_greater_than(fast.currentTime, slow.currentTime, "the model with the higher playbackRate advances further");
+}, "Siblings in a spatial portal advance at their own playbackRate");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const playing = appendModel(portal, "stopwatch-60s.usdz");
+    const paused = appendModel(portal, "stopwatch-60s.usdz");
+
+    await Promise.all([playing.ready, paused.ready]);
+
+    await playing.play();
+    assert_false(playing.paused, "the first model is playing");
+    assert_true(paused.paused, "pausing state is not shared with its sibling");
+
+    await paused.play();
+    await paused.pause();
+    assert_false(playing.paused, "pausing a sibling does not pause the first model");
+    assert_true(paused.paused, "the second model is paused");
+}, "Pausing one <model> in a spatial portal does not pause its siblings");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const looping = appendModel(portal, "stopwatch-60s.usdz");
+    const notLooping = appendModel(portal, "stopwatch-60s.usdz");
+
+    looping.loop = true;
+
+    await Promise.all([looping.ready, notLooping.ready]);
+    await Promise.all([looping.play(), notLooping.play()]);
+
+    looping.currentTime = looping.duration - 0.01;
+    notLooping.currentTime = notLooping.duration - 0.01;
+    await sleepForSeconds(0.2);
+
+    assert_false(looping.paused, "the looping model keeps playing past its duration");
+    assert_true(notLooping.paused, "its non-looping sibling stops at its duration");
+}, "Looping is applied per <model> in a spatial portal");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-model-animations-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-model-animations-expected.txt
@@ -1,0 +1,7 @@
+
+PASS <model autoplay> nested in a spatial portal plays its animation
+PASS play() and pause() control a <model> nested in a spatial portal
+PASS <model autoplay loop> nested in a spatial portal loops its animation
+PASS <model autoplay> nested in a spatial portal stops after reaching its duration
+PASS Re-adding a <model> to a spatial portal does not reuse the playback state it had before
+

--- a/LayoutTests/spatial-css/spatial-portal-model-animations.html
+++ b/LayoutTests/spatial-css/spatial-portal-model-animations.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<meta charset="utf-8">
+<title>&lt;model> animation playback inside a spatial portal</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, "stopwatch-60s.usdz");
+    model.autoplay = true;
+
+    await model.ready;
+
+    assert_approx_equals(model.duration, 60, 0.1, "the child model reports its animation duration");
+    assert_false(model.paused, "a child model with autoplay starts playing");
+}, "<model autoplay> nested in a spatial portal plays its animation");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, "stopwatch-60s.usdz");
+
+    await model.ready;
+
+    assert_true(model.paused, "a child model without autoplay does not start playing");
+
+    await model.play();
+    assert_false(model.paused, "play() starts the child model's animation");
+
+    await model.pause();
+    assert_true(model.paused, "pause() stops the child model's animation");
+}, "play() and pause() control a <model> nested in a spatial portal");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, "stopwatch-60s.usdz");
+    model.autoplay = true;
+    model.loop = true;
+
+    await model.ready;
+
+    model.currentTime = model.duration - 0.01;
+    await sleepForSeconds(0.2);
+    assert_false(model.paused, "a looping child model keeps playing past its duration");
+}, "<model autoplay loop> nested in a spatial portal loops its animation");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, "stopwatch-60s.usdz");
+    model.autoplay = true;
+
+    await model.ready;
+
+    model.currentTime = model.duration - 0.01;
+    await sleepForSeconds(0.2);
+    assert_true(model.paused, "a non-looping child model stops at its duration");
+}, "<model autoplay> nested in a spatial portal stops after reaching its duration");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, "stopwatch-60s.usdz");
+    model.autoplay = true;
+
+    await model.ready;
+    assert_false(model.paused, "the child model starts playing");
+
+    model.remove();
+    assert_equals(model.duration, 0, "the removed child model no longer reports playback state");
+
+    model.autoplay = false;
+    portal.appendChild(model);
+    await waitFor(() => model.duration > 0, "the re-added child model to report its duration");
+
+    assert_true(model.paused, "the re-added child model does not inherit the earlier autoplay");
+}, "Re-adding a <model> to a spatial portal does not reuse the playback state it had before");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -821,9 +821,7 @@ void HTMLModelElement::createModelPlayer()
     auto nodeID = nodeIdentifier();
 
 #if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
-    modelPlayer->setAutoplay(nodeID, autoplay());
-    modelPlayer->setLoop(nodeID, loop());
-    modelPlayer->setPlaybackRate(nodeID, m_playbackRate, [](double) { });
+    applyInitialAnimationState(*modelPlayer);
 #endif
 
 #if ENABLE(MODEL_ELEMENT_PORTAL)
@@ -1444,6 +1442,27 @@ void HTMLModelElement::setCamera(HTMLModelElementCamera camera, DOMPromiseDeferr
 
 #if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
 
+ModelPlayer* HTMLModelElement::modelPlayerForAnimation() const
+{
+    if (m_modelPlayer)
+        return m_modelPlayer.get();
+
+#if ENABLE(SPATIAL_PORTAL)
+    if (CheckedPtr controller = m_lastRegisteredPortalController.get())
+        return controller->modelPlayer();
+#endif
+
+    return nullptr;
+}
+
+void HTMLModelElement::applyInitialAnimationState(ModelPlayer& modelPlayer)
+{
+    auto nodeID = nodeIdentifier();
+    modelPlayer.setAutoplay(nodeID, autoplay());
+    modelPlayer.setLoop(nodeID, loop());
+    modelPlayer.setPlaybackRate(nodeID, m_playbackRate, [](double) { });
+}
+
 void HTMLModelElement::setPlaybackRate(double playbackRate)
 {
     if (m_playbackRate == playbackRate)
@@ -1451,18 +1470,20 @@ void HTMLModelElement::setPlaybackRate(double playbackRate)
 
     m_playbackRate = playbackRate;
 
-    if (m_modelPlayer)
-        m_modelPlayer->setPlaybackRate(nodeIdentifier(), playbackRate, [](double) { });
+    if (RefPtr modelPlayer = modelPlayerForAnimation())
+        modelPlayer->setPlaybackRate(nodeIdentifier(), playbackRate, [](double) { });
 }
 
 double HTMLModelElement::duration() const
 {
-    return m_modelPlayer ? m_modelPlayer->duration(nodeIdentifier()) : 0;
+    RefPtr modelPlayer = modelPlayerForAnimation();
+    return modelPlayer ? modelPlayer->duration(nodeIdentifier()) : 0;
 }
 
 bool HTMLModelElement::paused() const
 {
-    return m_modelPlayer ? m_modelPlayer->paused(nodeIdentifier()) : true;
+    RefPtr modelPlayer = modelPlayerForAnimation();
+    return modelPlayer ? modelPlayer->paused(nodeIdentifier()) : true;
 }
 
 void HTMLModelElement::play(DOMPromiseDeferred<void>&& promise)
@@ -1477,12 +1498,13 @@ void HTMLModelElement::pause(DOMPromiseDeferred<void>&& promise)
 
 void HTMLModelElement::setPaused(bool paused, DOMPromiseDeferred<void>&& promise)
 {
-    if (!m_modelPlayer) {
+    RefPtr modelPlayer = modelPlayerForAnimation();
+    if (!modelPlayer) {
         promise.reject();
         return;
     }
 
-    m_modelPlayer->setPaused(nodeIdentifier(), paused, [promise = WTF::move(promise)] (bool succeeded) mutable {
+    modelPlayer->setPaused(nodeIdentifier(), paused, [promise = WTF::move(promise)] (bool succeeded) mutable {
         if (succeeded)
             promise.resolve();
         else
@@ -1497,8 +1519,8 @@ bool HTMLModelElement::autoplay() const
 
 void HTMLModelElement::updateAutoplay()
 {
-    if (m_modelPlayer)
-        m_modelPlayer->setAutoplay(nodeIdentifier(), autoplay());
+    if (RefPtr modelPlayer = modelPlayerForAnimation())
+        modelPlayer->setAutoplay(nodeIdentifier(), autoplay());
 }
 
 bool HTMLModelElement::loop() const
@@ -1508,19 +1530,20 @@ bool HTMLModelElement::loop() const
 
 void HTMLModelElement::updateLoop()
 {
-    if (m_modelPlayer)
-        m_modelPlayer->setLoop(nodeIdentifier(), loop());
+    if (RefPtr modelPlayer = modelPlayerForAnimation())
+        modelPlayer->setLoop(nodeIdentifier(), loop());
 }
 
 double HTMLModelElement::currentTime() const
 {
-    return m_modelPlayer ? m_modelPlayer->currentTime(nodeIdentifier()).seconds() : 0;
+    RefPtr modelPlayer = modelPlayerForAnimation();
+    return modelPlayer ? modelPlayer->currentTime(nodeIdentifier()).seconds() : 0;
 }
 
 void HTMLModelElement::setCurrentTime(double currentTime)
 {
-    if (m_modelPlayer)
-        m_modelPlayer->setCurrentTime(nodeIdentifier(), Seconds(currentTime), [] { });
+    if (RefPtr modelPlayer = modelPlayerForAnimation())
+        modelPlayer->setCurrentTime(nodeIdentifier(), Seconds(currentTime), [] { });
 }
 
 #endif

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -180,6 +180,7 @@ public:
     void setPaused(bool, DOMPromiseDeferred<void>&&);
     double currentTime() const;
     void setCurrentTime(double);
+    void applyInitialAnimationState(ModelPlayer&);
 #endif
 
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE)
@@ -319,6 +320,8 @@ private:
     void updateAutoplay();
     bool loop() const;
     void updateLoop();
+    // A <model> inside a spatial portal has no player of its own; the portal owns one.
+    ModelPlayer* modelPlayerForAnimation() const;
 #endif
 
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
@@ -210,8 +210,11 @@ void SpatialPortalController::unregisterChildModel(HTMLModelElement& model)
     if (hostedModelElement(nodeID) != &model)
         return;
 
-    unloadChildModel(nodeID);
     m_hostedModels.remove(nodeID);
+
+    // Unconditional, unlike unloadChildModel(): the player also tracks nodes that never loaded.
+    if (RefPtr player = m_modelPlayer)
+        player->unload(nodeID);
 
     if (m_hostedModels.isEmpty())
         deleteModelPlayer();
@@ -266,6 +269,10 @@ void SpatialPortalController::loadChildModelIfReady(HTMLModelElement& model)
         return;
 
     it->value.loadedModel = modelData;
+
+#if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
+    model.applyInitialAnimationState(*player);
+#endif
     player->load(nodeID, *modelData, portalContentSize(), false);
 }
 
@@ -330,9 +337,10 @@ ModelPlayer* SpatialPortalController::ensureModelPlayer()
         lazyInitialize(m_playerClient, PortalModelPlayerClient::create(*this));
 
     m_modelPlayer = provider->createModelPlayer(*m_playerClient);
+    if (!m_modelPlayer)
+        return nullptr;
 
-    if (m_modelPlayer)
-        m_modelPlayer->setPortalTransform(m_portalTransform);
+    m_modelPlayer->setPortalTransform(m_portalTransform);
 
     return m_modelPlayer.get();
 }

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -82,6 +82,7 @@ public:
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -121,7 +122,7 @@ public:
     void unloadModelTimerFired();
     void updateTransformAfterLayout();
     void updateOpacity();
-    void animationPlaybackStateDidUpdate();
+    void animationPlaybackStateDidUpdate(WKRKEntity *);
 
     // Messages
     void createLayer();
@@ -191,14 +192,21 @@ public:
 private:
     ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&, const std::optional<String>&, std::optional<int>, std::optional<int>);
 
-    struct HostedModelEntity {
+    struct TrackedModel {
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(TrackedModel);
+
         RefPtr<WebCore::REModelLoader> loader;
         RetainPtr<WKRKEntity> entity;
         simd_float3 originalEntityScale { simd_make_float3(1, 1, 1) };
         simd_float3 originalBoundingBoxCenter { simd_make_float3(0, 0, 0) };
         simd_float3 originalBoundingBoxExtents { simd_make_float3(0, 0, 0) };
+
+        bool autoplay { false };
+        bool loop { false };
+        double playbackRate { 1.0 };
+        std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore;
     };
-    using HostedModelEntityMap = HashMap<WebCore::NodeIdentifier, HostedModelEntity>;
+    using TrackedModelMap = HashMap<WebCore::NodeIdentifier, UniqueRef<TrackedModel>>;
 
     RESRT modelStandardizedTransformSRT(RESRT originalSRT);
     RESRT modelLocalizedTransformSRT(RESRT originalSRT);
@@ -211,10 +219,15 @@ private:
     void notifyModelPlayerOfTransformChange();
     void applyDefaultIBL();
     void updateForCurrentStageMode();
-    void setUpLoadedEntity(WKRKEntity *);
+    void setUpLoadedEntity(WebCore::NodeIdentifier, WKRKEntity *);
     simd_float3 reportingModelScale() const;
     void clearReportingModelIfNeeded(WebCore::NodeIdentifier);
-    HostedModelEntityMap::iterator findHostedEntityForLoader(const WebCore::REModelLoader&);
+    TrackedModel& ensureTrackedModel(WebCore::NodeIdentifier);
+    TrackedModel* trackedModel(WebCore::NodeIdentifier);
+    const TrackedModel* trackedModel(WebCore::NodeIdentifier) const;
+    TrackedModelMap::iterator findTrackedModelForLoader(const WebCore::REModelLoader&);
+    TrackedModelMap::iterator findTrackedModelForEntity(WKRKEntity *);
+    RetainPtr<WKRKEntity> entityForNode(WebCore::NodeIdentifier) const;
     void cancelAllLoaders();
 #if HAVE(CORE_RE)
     void ensurePortalEntityHierarchy();
@@ -232,10 +245,9 @@ private:
     std::unique_ptr<LayerHostingContext> m_layerHostingContext;
     RetainPtr<WKModelProcessModelLayer> m_layer;
 
-    HostedModelEntityMap m_hostedEntities;
+    TrackedModelMap m_trackedModels;
 
-    // The first model loaded reports animation playback state for the portal until that is
-    // generalized: rdar://182292543 (Child model animation forwarding).
+    // FIXME: rdar://182292380 - The first model loaded; it receives the portal's environment map.
     RetainPtr<WKRKEntity> m_modelRKEntity;
 #if HAVE(CORE_RE)
     REPtr<RESceneRef> m_scene;
@@ -251,10 +263,6 @@ private:
     bool m_transformNeedsUpdateAfterNextLayout { false };
     bool m_entityTransformSetByScript { false };
 
-    bool m_autoplay { false };
-    bool m_loop { false };
-    double m_playbackRate { 1.0 };
-
     RefPtr<WebCore::SharedBuffer> m_transientEnvironmentMapData;
     bool m_hasPortal { true };
 #if ENABLE(SPATIAL_PORTAL)
@@ -269,7 +277,6 @@ private:
     std::optional<int> m_debugEntityMemoryLimit;
     std::optional<int> m_debugImmersiveEntityMemoryLimit;
     std::optional<WebCore::TransformationMatrix> m_entityTransformToRestore;
-    std::optional<WebCore::ModelPlayerAnimationState> m_animationStateToRestore;
     RunLoop::Timer m_unloadModelTimer;
 
     // For testing

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -92,9 +92,9 @@
     return self;
 }
 
-- (void)entityAnimationPlaybackStateDidUpdate:(id)entity
+- (void)entityAnimationPlaybackStateDidUpdate:(WKRKEntity *)entity
 {
-    _modelProcessModelPlayerProxy->animationPlaybackStateDidUpdate();
+    _modelProcessModelPlayerProxy->animationPlaybackStateDidUpdate(entity);
 }
 
 #if HAVE(CORE_RE)
@@ -312,6 +312,7 @@ void RKUSDModelLoadScheduler::loadNextModel()
 #endif // HAVE(CORE_RE)
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelProcessModelPlayerProxy);
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(ModelProcessModelPlayerProxy::TrackedModel);
 
 uint64_t ModelProcessModelPlayerProxy::gObjectCountForTesting = 0;
 
@@ -411,6 +412,9 @@ void ModelProcessModelPlayerProxy::loadModel(WebCore::NodeIdentifier nodeID, Ref
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
 
+    if (auto* tracked = trackedModel(nodeID))
+        tracked->animationStateToRestore = std::nullopt;
+
 #if HAVE(CORE_RE)
     if (model->mimeType() != usdzMIMEType) {
         Ref<WebCore::SharedBuffer> modelData = model->data();
@@ -442,13 +446,15 @@ void ModelProcessModelPlayerProxy::loadModel(WebCore::NodeIdentifier nodeID, Ref
 void ModelProcessModelPlayerProxy::reloadModel(WebCore::NodeIdentifier nodeID, Ref<WebCore::Model>&& model, WebCore::LayoutSize layoutSize, std::optional<WebCore::TransformationMatrix> entityTransformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore)
 {
     m_entityTransformToRestore = WTF::move(entityTransformToRestore);
-    m_animationStateToRestore = WTF::move(animationStateToRestore);
-    if (m_animationStateToRestore) {
-        m_autoplay = m_animationStateToRestore->autoplay();
-        m_loop = m_animationStateToRestore->loop();
-        if (auto playbackRate = m_animationStateToRestore->effectivePlaybackRate())
-            m_playbackRate = *playbackRate;
+
+    auto& tracked = ensureTrackedModel(nodeID);
+    if (animationStateToRestore) {
+        tracked.autoplay = animationStateToRestore->autoplay();
+        tracked.loop = animationStateToRestore->loop();
+        if (auto playbackRate = animationStateToRestore->effectivePlaybackRate())
+            tracked.playbackRate = *playbackRate;
     }
+    tracked.animationStateToRestore = WTF::move(animationStateToRestore);
 
     bool isForImmersive = false;
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
@@ -612,7 +618,7 @@ RESRT ModelProcessModelPlayerProxy::modelLocalizedTransformSRT(RESRT originalSRT
 
 void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
 {
-    if (m_hostedEntities.isEmpty() || !m_layer)
+    if (m_trackedModels.isEmpty() || !m_layer)
         return;
 
     // TODO: Once we have spatial positioninig the union won't be centered on the origin anymore.
@@ -620,13 +626,13 @@ void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
     simd_float3 maxBound = simd_make_float3(0, 0, 0);
     bool hasBounds = false;
 
-    for (auto& hostedEntity : m_hostedEntities.values()) {
-        if (!hostedEntity.entity)
+    for (UniqueRef<TrackedModel>& tracked : m_trackedModels.values()) {
+        if (!tracked->entity)
             continue;
 
-        simd_float3 halfExtents = hostedEntity.originalBoundingBoxExtents / 2;
-        simd_float3 entityMin = hostedEntity.originalBoundingBoxCenter - halfExtents;
-        simd_float3 entityMax = hostedEntity.originalBoundingBoxCenter + halfExtents;
+        simd_float3 halfExtents = tracked->originalBoundingBoxExtents / 2;
+        simd_float3 entityMin = tracked->originalBoundingBoxCenter - halfExtents;
+        simd_float3 entityMax = tracked->originalBoundingBoxCenter + halfExtents;
 
         minBound = hasBounds ? simd_min(minBound, entityMin) : entityMin;
         maxBound = hasBounds ? simd_max(maxBound, entityMax) : entityMax;
@@ -653,12 +659,12 @@ void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
     // Each model's bounding sphere has to be reached from the merged centre, not from its own, so
     // an off-centre sibling widens the radius by its distance rather than being swallowed by it.
     float boundingRadius = 0;
-    for (auto& hostedEntity : m_hostedEntities.values()) {
-        if (!hostedEntity.entity)
+    for (UniqueRef<TrackedModel>& tracked : m_trackedModels.values()) {
+        if (!tracked->entity)
             continue;
 
-        float entityRadius = [hostedEntity.entity boundingRadius] * hostedEntity.originalEntityScale.x;
-        boundingRadius = std::max(boundingRadius, simd_length(hostedEntity.originalBoundingBoxCenter - boundingBoxCenter) + entityRadius);
+        float entityRadius = [tracked->entity boundingRadius] * tracked->originalEntityScale.x;
+        boundingRadius = std::max(boundingRadius, simd_length(tracked->originalBoundingBoxCenter - boundingBoxCenter) + entityRadius);
     }
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
@@ -698,9 +704,9 @@ void ModelProcessModelPlayerProxy::updateTransform()
 
     // The container owns the global transforms (stagemode, portal-transform) and each model sits beneath with only its original scale applied.
     [m_containerEntityWrapper setTransform:WKEntityTransform({ m_transformSRT.scale, m_transformSRT.rotation, m_transformSRT.translation })];
-    for (auto& hostedEntity : m_hostedEntities.values()) {
-        if (hostedEntity.entity)
-            [hostedEntity.entity setTransform:WKEntityTransform({ hostedEntity.originalEntityScale, simd_quaternion(0, simd_make_float3(1, 0, 0)), simd_make_float3(0, 0, 0) })];
+    for (UniqueRef<TrackedModel>& tracked : m_trackedModels.values()) {
+        if (tracked->entity)
+            [tracked->entity setTransform:WKEntityTransform({ tracked->originalEntityScale, simd_quaternion(0, simd_make_float3(1, 0, 0)), simd_make_float3(0, 0, 0) })];
     }
 #else
     RetainPtr reportingEntity = m_modelRKEntity;
@@ -732,21 +738,22 @@ void ModelProcessModelPlayerProxy::updateOpacity()
     if (!m_layer)
         return;
 
-    for (auto& hostedEntity : m_hostedEntities.values())
-        [hostedEntity.entity setOpacity:[m_layer opacity]];
+    for (UniqueRef<TrackedModel>& tracked : m_trackedModels.values())
+        [tracked->entity setOpacity:[m_layer opacity]];
 }
 
-void ModelProcessModelPlayerProxy::animationPlaybackStateDidUpdate()
+void ModelProcessModelPlayerProxy::animationPlaybackStateDidUpdate(WKRKEntity *entity)
 {
-    if (!m_nodeID)
+    auto it = findTrackedModelForEntity(entity);
+    if (it == m_trackedModels.end())
         return;
 
-    auto nodeID = *m_nodeID;
-    bool isPaused = paused(nodeID);
-    float playbackRate = [m_modelRKEntity playbackRate];
-    NSTimeInterval duration = this->duration(nodeID);
-    NSTimeInterval currentTime = this->currentTime(nodeID).seconds();
-    RELEASE_LOG_DEBUG(ModelElement, "%p - ModelProcessModelPlayerProxy: did update animation playback state: paused: %d, playbackRate: %f, duration: %f, currentTime: %f", this, isPaused, playbackRate, duration, currentTime);
+    auto nodeID = it->key;
+    bool isPaused = [entity paused];
+    float playbackRate = [entity playbackRate];
+    NSTimeInterval duration = [entity duration];
+    NSTimeInterval currentTime = [entity currentTime];
+    RELEASE_LOG_DEBUG(ModelElement, "%p - ModelProcessModelPlayerProxy: did update animation playback state for nodeID=%" PRIu64 ": paused: %d, playbackRate: %f, duration: %f, currentTime: %f", this, nodeID.toUInt64(), isPaused, playbackRate, duration, currentTime);
     send(Messages::ModelProcessModelPlayer::DidUpdateAnimationPlaybackState(nodeID, isPaused, playbackRate, Seconds(duration), Seconds(currentTime), MonotonicTime::now()));
 }
 
@@ -763,12 +770,12 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
 
-    auto it = findHostedEntityForLoader(loader);
-    if (it == m_hostedEntities.end())
+    auto it = findTrackedModelForLoader(loader);
+    if (it == m_trackedModels.end())
         return;
 
     auto nodeID = it->key;
-    it->value.loader = nullptr;
+    it->value->loader = nullptr;
 
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy finished loading model nodeID=%" PRIu64 " id=%" PRIu64, this, nodeID.toUInt64(), m_id.toUInt64());
 
@@ -783,17 +790,19 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
     loadedEntity = model->rootRKEntity();
 #endif
 
-    it->value.entity = loadedEntity;
+    it->value->entity = loadedEntity;
+    // Every entity gets a delegate, since playback is reported per node.
+    [loadedEntity setDelegate:m_objCAdapter.get()];
 
     // The entity's bounding box is relative to its own coordinate space, so the original scale
     // still has to be applied.
     WKEntityTransform originalTransform = [loadedEntity transform];
-    it->value.originalEntityScale = originalTransform.scale;
-    it->value.originalBoundingBoxExtents = [loadedEntity boundingBoxExtents] * it->value.originalEntityScale;
-    it->value.originalBoundingBoxCenter = [loadedEntity boundingBoxCenter] * it->value.originalEntityScale;
+    it->value->originalEntityScale = originalTransform.scale;
+    it->value->originalBoundingBoxExtents = [loadedEntity boundingBoxExtents] * it->value->originalEntityScale;
+    it->value->originalBoundingBoxCenter = [loadedEntity boundingBoxCenter] * it->value->originalEntityScale;
 
-    simd_float3 boundingBoxCenter = it->value.originalBoundingBoxCenter;
-    simd_float3 boundingBoxExtents = it->value.originalBoundingBoxExtents;
+    simd_float3 boundingBoxCenter = it->value->originalBoundingBoxCenter;
+    simd_float3 boundingBoxExtents = it->value->originalBoundingBoxExtents;
 
 #if HAVE(CORE_RE)
     ensurePortalEntityHierarchy();
@@ -805,13 +814,11 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
         RENetworkMarkEntityMetadataDirty(model->rootEntity());
 #endif // HAVE(CORE_RE)
 
-    // The first model loaded reports animation playback state for the portal and receives its
-    // environment map: rdar://182292543 (Child model animation forwarding).
+    // The first model loaded receives the portal's environment map.
     bool isReportingModel = !m_nodeID || *m_nodeID == nodeID;
     if (isReportingModel) {
         m_nodeID = nodeID;
         m_modelRKEntity = loadedEntity;
-        [loadedEntity setDelegate:m_objCAdapter.get()];
     }
 
 #if HAVE(CORE_RE)
@@ -832,13 +839,7 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
 #endif // HAVE(CORE_RE)
 
     updateOpacity();
-    setUpLoadedEntity(loadedEntity.get());
-
-    if (m_animationStateToRestore) {
-        [loadedEntity setPaused:m_animationStateToRestore->paused()];
-        [loadedEntity setCurrentTime:m_animationStateToRestore->currentTime().seconds()];
-        m_animationStateToRestore = std::nullopt;
-    }
+    setUpLoadedEntity(nodeID, loadedEntity.get());
 
     if (isReportingModel) {
         applyEnvironmentMapDataAndRelease([weakThis = WeakPtr { *this }] () mutable {
@@ -857,7 +858,7 @@ void ModelProcessModelPlayerProxy::didFailLoading(WebCore::REModelLoader& loader
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
 
-    auto it = findHostedEntityForLoader(loader);
+    auto it = findTrackedModelForLoader(loader);
 
     RELEASE_LOG_ERROR(ModelElement, "%p - ModelProcessModelPlayerProxy failed to load model id=%" PRIu64 " error=\"%@\"", this, m_id.toUInt64(), error.nsError().localizedDescription);
 
@@ -865,11 +866,11 @@ void ModelProcessModelPlayerProxy::didFailLoading(WebCore::REModelLoader& loader
     triggerModelLoadedCallbacks(false);
 #endif
 
-    if (it == m_hostedEntities.end())
+    if (it == m_trackedModels.end())
         return;
 
     auto nodeID = it->key;
-    m_hostedEntities.remove(it);
+    m_trackedModels.remove(it);
     clearReportingModelIfNeeded(nodeID);
 
     send(Messages::ModelProcessModelPlayer::DidFailLoading(nodeID));
@@ -916,15 +917,14 @@ void ModelProcessModelPlayerProxy::load(WebCore::NodeIdentifier nodeID, WebCore:
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
 
-    auto& hostedEntity = m_hostedEntities.ensure(nodeID, [] {
-        return HostedModelEntity { };
-    }).iterator->value;
-    if (RefPtr previousLoader = std::exchange(hostedEntity.loader, nullptr))
+    auto& tracked = ensureTrackedModel(nodeID);
+    if (RefPtr previousLoader = std::exchange(tracked.loader, nullptr))
         previousLoader->cancel();
 
-    auto previousEntity = std::exchange(hostedEntity.entity, nullptr);
+    RetainPtr previousEntity = std::exchange(tracked.entity, nullptr);
     if (previousEntity) {
         clearReportingModelIfNeeded(nodeID);
+        [previousEntity setDelegate:nil];
         [previousEntity removeFromParentEntity];
     }
 
@@ -957,16 +957,16 @@ void ModelProcessModelPlayerProxy::load(WebCore::NodeIdentifier nodeID, WebCore:
         else
             loader = WebCore::loadREModel(model.get(), *this);
 
-        auto it = m_hostedEntities.find(nodeID);
-        if (it == m_hostedEntities.end()) {
+        auto it = m_trackedModels.find(nodeID);
+        if (it == m_trackedModels.end()) {
             loader->cancel();
             return;
         }
-        it->value.loader = WTF::move(loader);
+        it->value->loader = WTF::move(loader);
     });
 #else
     auto loader = SimpleModelLoader::create();
-    hostedEntity.loader = loader.ptr();
+    tracked.loader = loader.ptr();
 
     RetainPtr<NSData> modelData = model.data()->createNSData();
     [getWKRKEntityClassSingleton() loadFromData:modelData.get() withAttributionTaskID:nil entityMemoryLimit:0 completionHandler:makeBlockPtr([weakThis = WeakPtr { *this }, loader = WTF::move(loader)] (WKRKEntity *entity) mutable {
@@ -991,20 +991,23 @@ void ModelProcessModelPlayerProxy::unloadModel(WebCore::NodeIdentifier nodeID)
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
 
-    auto it = m_hostedEntities.find(nodeID);
-    if (it == m_hostedEntities.end())
+    auto it = m_trackedModels.find(nodeID);
+    if (it == m_trackedModels.end())
         return;
 
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::unloadModel nodeID=%" PRIu64 " id=%" PRIu64, this, nodeID.toUInt64(), m_id.toUInt64());
 
-    auto hostedEntity = WTF::move(it->value);
-    m_hostedEntities.remove(it);
+    RefPtr loader = it->value->loader;
+    RetainPtr entity = it->value->entity;
+    m_trackedModels.remove(it);
 
-    if (RefPtr loader = hostedEntity.loader)
+    if (loader)
         loader->cancel();
 
-    if (hostedEntity.entity)
-        [hostedEntity.entity removeFromParentEntity];
+    if (entity) {
+        [entity setDelegate:nil];
+        [entity removeFromParentEntity];
+    }
 
     clearReportingModelIfNeeded(nodeID);
 
@@ -1029,34 +1032,82 @@ simd_float3 ModelProcessModelPlayerProxy::reportingModelScale() const
     if (!m_nodeID)
         return simd_make_float3(1, 1, 1);
 
-    auto it = m_hostedEntities.find(*m_nodeID);
-    return it == m_hostedEntities.end() ? simd_make_float3(1, 1, 1) : it->value.originalEntityScale;
+    auto it = m_trackedModels.find(*m_nodeID);
+    return it == m_trackedModels.end() ? simd_make_float3(1, 1, 1) : it->value->originalEntityScale;
 }
 
-ModelProcessModelPlayerProxy::HostedModelEntityMap::iterator ModelProcessModelPlayerProxy::findHostedEntityForLoader(const WebCore::REModelLoader& loader)
+ModelProcessModelPlayerProxy::TrackedModelMap::iterator ModelProcessModelPlayerProxy::findTrackedModelForLoader(const WebCore::REModelLoader& loader)
 {
-    return std::ranges::find_if(m_hostedEntities, [&](auto& entry) {
-        return entry.value.loader.get() == &loader;
+    return std::ranges::find_if(m_trackedModels, [&](auto& entry) {
+        return entry.value->loader.get() == &loader;
     });
+}
+
+ModelProcessModelPlayerProxy::TrackedModelMap::iterator ModelProcessModelPlayerProxy::findTrackedModelForEntity(WKRKEntity *entity)
+{
+    if (!entity)
+        return m_trackedModels.end();
+
+    return std::ranges::find_if(m_trackedModels, [&](auto& entry) {
+        return entry.value->entity.get() == entity;
+    });
+}
+
+RetainPtr<WKRKEntity> ModelProcessModelPlayerProxy::entityForNode(WebCore::NodeIdentifier nodeID) const
+{
+    if (auto* tracked = trackedModel(nodeID))
+        return tracked->entity;
+
+    return nil;
+}
+
+ModelProcessModelPlayerProxy::TrackedModel& ModelProcessModelPlayerProxy::ensureTrackedModel(WebCore::NodeIdentifier nodeID)
+{
+    return m_trackedModels.ensure(nodeID, [] {
+        return makeUniqueRef<TrackedModel>();
+    }).iterator->value.get();
+}
+
+ModelProcessModelPlayerProxy::TrackedModel* ModelProcessModelPlayerProxy::trackedModel(WebCore::NodeIdentifier nodeID)
+{
+    auto it = m_trackedModels.find(nodeID);
+    if (it == m_trackedModels.end())
+        return nullptr;
+
+    return it->value.ptr();
+}
+
+const ModelProcessModelPlayerProxy::TrackedModel* ModelProcessModelPlayerProxy::trackedModel(WebCore::NodeIdentifier nodeID) const
+{
+    auto it = m_trackedModels.find(nodeID);
+    if (it == m_trackedModels.end())
+        return nullptr;
+
+    return it->value.ptr();
 }
 
 void ModelProcessModelPlayerProxy::cancelAllLoaders()
 {
-    for (auto& hostedEntity : m_hostedEntities.values()) {
-        if (RefPtr loader = std::exchange(hostedEntity.loader, nullptr))
+    for (UniqueRef<TrackedModel>& tracked : m_trackedModels.values()) {
+        if (RefPtr loader = std::exchange(tracked->loader, nullptr))
             loader->cancel();
     }
 }
 
-// FIXME: rdar://182292543 - Playback state should be per model.
-void ModelProcessModelPlayerProxy::setUpLoadedEntity(WKRKEntity *entity)
+void ModelProcessModelPlayerProxy::setUpLoadedEntity(WebCore::NodeIdentifier nodeID, WKRKEntity *entity)
 {
-    if (!entity || !m_layer)
+    auto* tracked = trackedModel(nodeID);
+    if (!tracked || !entity || !m_layer)
         return;
 
-    [entity setUpAnimationWithAutoPlay:m_autoplay];
-    [entity setLoop:m_loop];
-    [entity setPlaybackRate:m_playbackRate];
+    [entity setUpAnimationWithAutoPlay:tracked->autoplay];
+    [entity setLoop:tracked->loop];
+    [entity setPlaybackRate:tracked->playbackRate];
+
+    if (auto animationStateToRestore = std::exchange(tracked->animationStateToRestore, std::nullopt)) {
+        [entity setPaused:animationStateToRestore->paused()];
+        [entity setCurrentTime:animationStateToRestore->currentTime().seconds()];
+    }
 }
 
 void ModelProcessModelPlayerProxy::sizeDidChange(WebCore::LayoutSize layoutSize)
@@ -1072,7 +1123,7 @@ void ModelProcessModelPlayerProxy::sizeDidChange(WebCore::LayoutSize layoutSize)
 
     auto width = layoutSize.width().toDouble();
     auto height = layoutSize.height().toDouble();
-    if (!m_transformNeedsUpdateAfterNextLayout && !m_hostedEntities.isEmpty() && m_layer)
+    if (!m_transformNeedsUpdateAfterNextLayout && !m_trackedModels.isEmpty() && m_layer)
         m_transformNeedsUpdateAfterNextLayout = width != CGRectGetWidth([m_layer frame]) || height != CGRectGetHeight([m_layer frame]);
     [m_layer setFrame:CGRectMake(0, 0, width, height)];
 }
@@ -1174,48 +1225,66 @@ WebCore::ModelPlayerAccessibilityChildren ModelProcessModelPlayerProxy::accessib
     return { };
 }
 
-void ModelProcessModelPlayerProxy::setAutoplay(WebCore::NodeIdentifier, bool autoplay)
+void ModelProcessModelPlayerProxy::setAutoplay(WebCore::NodeIdentifier nodeID, bool autoplay)
 {
-    m_autoplay = autoplay;
+    ensureTrackedModel(nodeID).autoplay = autoplay;
 }
 
-void ModelProcessModelPlayerProxy::setLoop(WebCore::NodeIdentifier, bool loop)
+void ModelProcessModelPlayerProxy::setLoop(WebCore::NodeIdentifier nodeID, bool loop)
 {
-    m_loop = loop;
-    [m_modelRKEntity setLoop:m_loop];
+    auto& tracked = ensureTrackedModel(nodeID);
+    tracked.loop = loop;
+
+    if (RetainPtr entity = tracked.entity)
+        [entity setLoop:loop];
 }
 
-void ModelProcessModelPlayerProxy::setPlaybackRate(WebCore::NodeIdentifier, double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
+void ModelProcessModelPlayerProxy::setPlaybackRate(WebCore::NodeIdentifier nodeID, double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
 {
-    m_playbackRate = playbackRate;
-    [m_modelRKEntity setPlaybackRate:m_playbackRate];
-    completionHandler(m_modelRKEntity ? [m_modelRKEntity playbackRate] : 1.0);
+    auto& tracked = ensureTrackedModel(nodeID);
+    tracked.playbackRate = playbackRate;
+
+    RetainPtr entity = tracked.entity;
+    if (!entity)
+        return completionHandler(playbackRate);
+
+    [entity setPlaybackRate:playbackRate];
+    completionHandler([entity playbackRate]);
 }
 
-double ModelProcessModelPlayerProxy::duration(WebCore::NodeIdentifier) const
+double ModelProcessModelPlayerProxy::duration(WebCore::NodeIdentifier nodeID) const
 {
-    return [m_modelRKEntity duration];
+    RetainPtr entity = entityForNode(nodeID);
+    return entity ? [entity duration] : 0;
 }
 
-bool ModelProcessModelPlayerProxy::paused(WebCore::NodeIdentifier) const
+bool ModelProcessModelPlayerProxy::paused(WebCore::NodeIdentifier nodeID) const
 {
-    return [m_modelRKEntity paused];
+    RetainPtr entity = entityForNode(nodeID);
+    return entity ? [entity paused] : true;
 }
 
-void ModelProcessModelPlayerProxy::setPaused(WebCore::NodeIdentifier, bool paused, CompletionHandler<void(bool succeeded)>&& completionHandler)
+void ModelProcessModelPlayerProxy::setPaused(WebCore::NodeIdentifier nodeID, bool paused, CompletionHandler<void(bool succeeded)>&& completionHandler)
 {
-    [m_modelRKEntity setPaused:paused];
-    completionHandler(paused == [m_modelRKEntity paused]);
+    RetainPtr entity = entityForNode(nodeID);
+    if (!entity)
+        return completionHandler(false);
+
+    [entity setPaused:paused];
+    completionHandler(paused == [entity paused]);
 }
 
-Seconds ModelProcessModelPlayerProxy::currentTime(WebCore::NodeIdentifier) const
+Seconds ModelProcessModelPlayerProxy::currentTime(WebCore::NodeIdentifier nodeID) const
 {
-    return Seconds([m_modelRKEntity currentTime]);
+    RetainPtr entity = entityForNode(nodeID);
+    return entity ? Seconds([entity currentTime]) : 0_s;
 }
 
-void ModelProcessModelPlayerProxy::setCurrentTime(WebCore::NodeIdentifier, Seconds currentTime, CompletionHandler<void()>&& completionHandler)
+void ModelProcessModelPlayerProxy::setCurrentTime(WebCore::NodeIdentifier nodeID, Seconds currentTime, CompletionHandler<void()>&& completionHandler)
 {
-    [m_modelRKEntity setCurrentTime:currentTime.seconds()];
+    if (RetainPtr entity = entityForNode(nodeID))
+        [entity setCurrentTime:currentTime.seconds()];
+
     completionHandler();
 }
 
@@ -1501,7 +1570,14 @@ void ModelProcessModelPlayerProxy::applyDefaultIBL()
 void ModelProcessModelPlayerProxy::teardownEntity()
 {
     cancelAllLoaders();
-    m_hostedEntities.clear();
+
+    // Keeps each map entry, because captureStateForReload() has just recorded playback state there
+    // and the caller reloads immediately afterwards. Releasing the entity is what frees the memory.
+    for (UniqueRef<TrackedModel>& tracked : m_trackedModels.values()) {
+        tracked->loader = nullptr;
+        [tracked->entity setDelegate:nil];
+        tracked->entity = nullptr;
+    }
 #if HAVE(CORE_RE)
     if (m_containerEntity.get())
         REEntityRemoveFromSceneOrParent(m_containerEntity.get());
@@ -1521,10 +1597,12 @@ void ModelProcessModelPlayerProxy::teardownEntity()
 
 void ModelProcessModelPlayerProxy::captureStateForReload()
 {
-    if (m_modelRKEntity && m_nodeID) {
-        auto nodeID = *m_nodeID;
-        m_animationStateToRestore = WebCore::ModelPlayerAnimationState(m_autoplay, m_loop, paused(nodeID), Seconds(duration(nodeID)),
-            std::optional<double> { m_playbackRate }, std::optional<Seconds> { Seconds(currentTime(nodeID)) }, std::optional<MonotonicTime> { MonotonicTime::now() });
+    for (UniqueRef<TrackedModel>& tracked : m_trackedModels.values()) {
+        if (!tracked->entity)
+            continue;
+
+        tracked->animationStateToRestore = WebCore::ModelPlayerAnimationState { tracked->autoplay, tracked->loop, [tracked->entity paused], Seconds([tracked->entity duration]),
+            std::optional<double> { tracked->playbackRate }, std::optional<Seconds> { Seconds([tracked->entity currentTime]) }, std::optional<MonotonicTime> { MonotonicTime::now() } };
     }
 
     // Re-stage the env map for the post-reload entity. Entity transform is intentionally NOT captured:
@@ -1538,8 +1616,8 @@ void ModelProcessModelPlayerProxy::captureStateForReload()
 void ModelProcessModelPlayerProxy::ensureImmersivePresentation(CompletionHandler<void(std::optional<WebCore::LayerHostingContextIdentifier>)>&& completion)
 {
     // FIXME: Add immersive presentation for spatial portal
-    if (m_hostedEntities.size() > 1) {
-        RELEASE_LOG_ERROR(ModelElement, "%p - ModelProcessModelPlayerProxy::ensureImmersivePresentation: unsupported for %u hosted models id=%" PRIu64, this, m_hostedEntities.size(), m_id.toUInt64());
+    if (m_trackedModels.size() > 1) {
+        RELEASE_LOG_ERROR(ModelElement, "%p - ModelProcessModelPlayerProxy::ensureImmersivePresentation: unsupported for %u hosted models id=%" PRIu64, this, m_trackedModels.size(), m_id.toUInt64());
         return completion(std::nullopt);
     }
 
@@ -1551,7 +1629,7 @@ void ModelProcessModelPlayerProxy::ensureImmersivePresentation(CompletionHandler
 
     setImmersivePresentation(true);
 
-    if (m_nodeID && m_currentModel && !m_hostedEntities.isEmpty() && !atTargetLimit) {
+    if (m_nodeID && m_currentModel && !m_trackedModels.isEmpty() && !atTargetLimit) {
         RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::ensureImmersivePresentation: reloading at %dMB id=%" PRIu64, this, targetLimit, m_id.toUInt64());
         teardownEntity();
         load(*m_nodeID, *m_currentModel, m_layoutSize, true);
@@ -1581,7 +1659,7 @@ void ModelProcessModelPlayerProxy::exitImmersivePresentation(CompletionHandler<v
 
     setImmersivePresentation(false);
 
-    if (m_nodeID && m_currentModel && !m_hostedEntities.isEmpty() && !atTargetLimit) {
+    if (m_nodeID && m_currentModel && !m_trackedModels.isEmpty() && !atTargetLimit) {
         RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::exitImmersivePresentation: reloading at %dMB id=%" PRIu64, this, targetLimit, m_id.toUInt64());
         teardownEntity();
         load(*m_nodeID, *m_currentModel, m_layoutSize, false);

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -87,6 +87,31 @@ bool ModelProcessModelPlayer::modelProcessEnabled() const
     return strongPage && strongPage->corePage() && strongPage->corePage()->settings().modelElementEnabled() && strongPage->corePage()->settings().modelProcessEnabled();
 }
 
+ModelProcessModelPlayer::NodeAnimationState& ModelProcessModelPlayer::ensureAnimationState(WebCore::NodeIdentifier nodeID)
+{
+    return m_animationStates.ensure(nodeID, [] {
+        return NodeAnimationState { };
+    }).iterator->value;
+}
+
+const ModelProcessModelPlayer::NodeAnimationState* ModelProcessModelPlayer::animationStateIfExists(WebCore::NodeIdentifier nodeID) const
+{
+    auto it = m_animationStates.find(nodeID);
+    if (it == m_animationStates.end())
+        return nullptr;
+
+    return &it->value;
+}
+
+ModelProcessModelPlayer::NodeAnimationState* ModelProcessModelPlayer::animationStateIfExists(WebCore::NodeIdentifier nodeID)
+{
+    auto it = m_animationStates.find(nodeID);
+    if (it == m_animationStates.end())
+        return nullptr;
+
+    return &it->value;
+}
+
 // MARK: - Messages
 
 void ModelProcessModelPlayer::didCreateLayer(WebCore::LayerHostingContextIdentifier identifier)
@@ -124,6 +149,8 @@ void ModelProcessModelPlayer::didFailLoading(WebCore::NodeIdentifier nodeID)
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer didFailLoading id=%" PRIu64, this, m_id.toUInt64());
     RELEASE_ASSERT(modelProcessEnabled());
 
+    m_animationStates.remove(nodeID);
+
     protect(client())->didFailLoading(*this, nodeID, WebCore::ResourceError { WebCore::errorDomainWebKitInternal, 0, { }, "Failed to load model data"_s });
 }
 
@@ -148,14 +175,19 @@ void ModelProcessModelPlayer::didUpdatePortalTransform(const WebCore::Transforma
 
 #endif
 
-void ModelProcessModelPlayer::didUpdateAnimationPlaybackState(WebCore::NodeIdentifier, bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
+void ModelProcessModelPlayer::didUpdateAnimationPlaybackState(WebCore::NodeIdentifier nodeID, bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
 {
     RELEASE_ASSERT(modelProcessEnabled());
 
-    m_animationState.setPaused(isPaused);
-    m_animationState.setDuration(duration);
-    m_animationState.setPlaybackRate(playbackRate);
-    m_animationState.setCurrentTime(currentTime, clockTimestamp);
+    auto* nodeAnimationState = animationStateIfExists(nodeID);
+    if (!nodeAnimationState)
+        return;
+
+    auto& animationState = nodeAnimationState->playbackState;
+    animationState.setPaused(isPaused);
+    animationState.setDuration(duration);
+    animationState.setPlaybackRate(playbackRate);
+    animationState.setCurrentTime(currentTime, clockTimestamp);
 }
 
 void ModelProcessModelPlayer::didFinishEnvironmentMapLoading(bool succeeded)
@@ -167,13 +199,16 @@ void ModelProcessModelPlayer::didFinishEnvironmentMapLoading(bool succeeded)
 
 // MARK: - WebCore::ModelPlayer
 
-std::optional<WebCore::ModelPlayerAnimationState> ModelProcessModelPlayer::currentAnimationState(WebCore::NodeIdentifier) const
+std::optional<WebCore::ModelPlayerAnimationState> ModelProcessModelPlayer::currentAnimationState(WebCore::NodeIdentifier nodeID) const
 {
     // Has no current state to return if the model load hasn't returned with its extents.
     if (!m_boundingBoxExtents)
         return std::nullopt;
 
-    return m_animationState;
+    if (auto* nodeAnimationState = animationStateIfExists(nodeID))
+        return nodeAnimationState->playbackState;
+
+    return std::nullopt;
 }
 
 std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> ModelProcessModelPlayer::currentTransformState(WebCore::NodeIdentifier) const
@@ -202,6 +237,7 @@ void ModelProcessModelPlayer::unload(WebCore::NodeIdentifier nodeID)
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer unload model nodeID=%" PRIu64 " id=%" PRIu64, this, nodeID.toUInt64(), m_id.toUInt64());
 
+    m_animationStates.remove(nodeID);
     send(Messages::ModelProcessModelPlayerProxy::UnloadModel(nodeID));
 }
 
@@ -232,7 +268,7 @@ void ModelProcessModelPlayer::reload(WebCore::NodeIdentifier nodeID, WebCore::Mo
     m_boundingBoxExtents = transformStateToRestore->boundingBoxExtents();
     setHasPortal(transformStateToRestore->hasPortal());
     setStageMode(transformStateToRestore->stageMode());
-    m_animationState = WebCore::ModelPlayerAnimationState(animationState);
+    ensureAnimationState(nodeID).playbackState = WebCore::ModelPlayerAnimationState(animationState);
     send(Messages::ModelProcessModelPlayerProxy::ReloadModel(nodeID, model, size, transformStateToRestore->entityTransform(), animationState));
 }
 
@@ -371,36 +407,44 @@ WebCore::ModelPlayerAccessibilityChildren ModelProcessModelPlayer::accessibility
 
 void ModelProcessModelPlayer::setAutoplay(WebCore::NodeIdentifier nodeID, bool autoplay)
 {
-    if (m_animationState.autoplay() == autoplay)
+    auto& animationState = ensureAnimationState(nodeID).playbackState;
+    if (animationState.autoplay() == autoplay)
         return;
 
-    m_animationState.setAutoplay(autoplay);
+    animationState.setAutoplay(autoplay);
     send(Messages::ModelProcessModelPlayerProxy::SetAutoplay(nodeID, autoplay));
 }
 
 void ModelProcessModelPlayer::setLoop(WebCore::NodeIdentifier nodeID, bool loop)
 {
-    if (m_animationState.loop() == loop)
+    auto& animationState = ensureAnimationState(nodeID).playbackState;
+    if (animationState.loop() == loop)
         return;
 
-    m_animationState.setLoop(loop);
+    animationState.setLoop(loop);
     send(Messages::ModelProcessModelPlayerProxy::SetLoop(nodeID, loop));
 }
 
 void ModelProcessModelPlayer::setPlaybackRate(WebCore::NodeIdentifier nodeID, double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
 {
-    m_requestedPlaybackRate = playbackRate;
-    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::SetPlaybackRate(nodeID, m_requestedPlaybackRate), WTF::move(completionHandler));
+    ensureAnimationState(nodeID).playbackState.setPlaybackRate(playbackRate);
+    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::SetPlaybackRate(nodeID, playbackRate), WTF::move(completionHandler));
 }
 
-double ModelProcessModelPlayer::duration(WebCore::NodeIdentifier) const
+double ModelProcessModelPlayer::duration(WebCore::NodeIdentifier nodeID) const
 {
-    return m_animationState.duration().seconds();
+    if (auto* animationState = animationStateIfExists(nodeID))
+        return animationState->playbackState.duration().seconds();
+
+    return 0;
 }
 
-bool ModelProcessModelPlayer::paused(WebCore::NodeIdentifier) const
+bool ModelProcessModelPlayer::paused(WebCore::NodeIdentifier nodeID) const
 {
-    return m_animationState.paused();
+    if (auto* animationState = animationStateIfExists(nodeID))
+        return animationState->playbackState.paused();
+
+    return true;
 }
 
 void ModelProcessModelPlayer::setPaused(WebCore::NodeIdentifier nodeID, bool paused, CompletionHandler<void(bool succeeded)>&& completionHandler)
@@ -408,33 +452,39 @@ void ModelProcessModelPlayer::setPaused(WebCore::NodeIdentifier nodeID, bool pau
     sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::SetPaused(nodeID, paused), WTF::move(completionHandler));
 }
 
-Seconds ModelProcessModelPlayer::currentTime(WebCore::NodeIdentifier) const
+Seconds ModelProcessModelPlayer::currentTime(WebCore::NodeIdentifier nodeID) const
 {
-    if (m_pendingCurrentTime)
-        return *m_pendingCurrentTime;
+    auto* animationState = animationStateIfExists(nodeID);
+    if (!animationState)
+        return 0_s;
 
-    return m_animationState.currentTime();
+    if (animationState->pendingCurrentTime)
+        return *animationState->pendingCurrentTime;
+
+    return animationState->playbackState.currentTime();
 }
 
 void ModelProcessModelPlayer::setCurrentTime(WebCore::NodeIdentifier nodeID, Seconds currentTime, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    double durationSeconds = duration(nodeID);
+    auto& animationState = ensureAnimationState(nodeID);
+    double durationSeconds = animationState.playbackState.duration().seconds();
     if (!durationSeconds) {
         completionHandler();
         return;
     }
 
-    m_pendingCurrentTime = Seconds(fmax(fmin(currentTime.seconds(), durationSeconds), 0));
+    animationState.pendingCurrentTime = Seconds(fmax(fmin(currentTime.seconds(), durationSeconds), 0));
     MonotonicTime timestamp = MonotonicTime::now();
-    m_clockTimestampOfLastCurrentTimeSet = timestamp;
+    animationState.clockTimestampOfLastCurrentTimeSet = timestamp;
 
-    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::SetCurrentTime(nodeID, *m_pendingCurrentTime), [weakThis = WeakPtr { *this }, timestamp, completionHandler = WTF::move(completionHandler)]() mutable {
+    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::SetCurrentTime(nodeID, *animationState.pendingCurrentTime), [weakThis = WeakPtr { *this }, nodeID, timestamp, completionHandler = WTF::move(completionHandler)]() mutable {
         ASSERT(RunLoop::isMain());
         if (RefPtr protectedThis = weakThis.get()) {
-            if (protectedThis->m_clockTimestampOfLastCurrentTimeSet && *(protectedThis->m_clockTimestampOfLastCurrentTimeSet) <= timestamp) {
-                protectedThis->m_pendingCurrentTime = std::nullopt;
-                protectedThis->m_clockTimestampOfLastCurrentTimeSet = std::nullopt;
+            auto it = protectedThis->m_animationStates.find(nodeID);
+            if (it != protectedThis->m_animationStates.end() && it->value.clockTimestampOfLastCurrentTimeSet && *it->value.clockTimestampOfLastCurrentTimeSet <= timestamp) {
+                it->value.pendingCurrentTime = std::nullopt;
+                it->value.clockTimestampOfLastCurrentTimeSet = std::nullopt;
             }
         }
         completionHandler();

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -38,6 +38,7 @@
 #import <WebCore/NodeIdentifier.h>
 #import <WebCore/StageModeOperations.h>
 #import <wtf/Compiler.h>
+#import <wtf/HashMap.h>
 
 namespace WebKit {
 
@@ -71,6 +72,15 @@ private:
     template<typename T, typename C> void sendWithAsyncReply(T&& message, C&& completionHandler);
 
     bool modelProcessEnabled() const;
+
+    struct NodeAnimationState {
+        WebCore::ModelPlayerAnimationState playbackState;
+        std::optional<Seconds> pendingCurrentTime;
+        std::optional<MonotonicTime> clockTimestampOfLastCurrentTimeSet;
+    };
+    NodeAnimationState& ensureAnimationState(WebCore::NodeIdentifier);
+    NodeAnimationState* animationStateIfExists(WebCore::NodeIdentifier);
+    const NodeAnimationState* animationStateIfExists(WebCore::NodeIdentifier) const;
 
     // Messages
     void didCreateLayer(WebCore::LayerHostingContextIdentifier);
@@ -152,10 +162,7 @@ private:
     WebCore::PortalTransformKind m_portalTransform { WebCore::PortalTransformKind::Auto };
 #endif
     WebCore::StageModeOperation m_stageModeOperation { WebCore::StageModeOperation::None };
-    double m_requestedPlaybackRate { 1.0 };
-    std::optional<Seconds> m_pendingCurrentTime;
-    std::optional<MonotonicTime> m_clockTimestampOfLastCurrentTimeSet;
-    WebCore::ModelPlayerAnimationState m_animationState;
+    HashMap<WebCore::NodeIdentifier, NodeAnimationState> m_animationStates;
     SharedPreferencesForWebProcess m_sharedPreferencesForWebProcess;
 };
 


### PR DESCRIPTION
#### 445ef5ac4f91f6af821e2211bb4f507d7c66a390
<pre>
Add animation forwarding to child models in spatial portals
<a href="https://bugs.webkit.org/show_bug.cgi?id=321050">https://bugs.webkit.org/show_bug.cgi?id=321050</a>
<a href="https://rdar.apple.com/182292543">rdar://182292543</a>

Reviewed by Mike Wyrzykowski and Etienne Segonzac.

A &lt;model&gt; child of a spatial portal has no ModelPlayer of its own, so
its animation attributes and playback accessors went nowhere. Route them
through the portal&apos;s player, which addresses each child by
NodeIdentifier, and track playback state per node in both the Web and
Model processes, so the first model loaded no longer reports playback
for the whole portal.

Tests: spatial-css/spatial-portal-animation-currenttime.html
       spatial-css/spatial-portal-animation-dynamic.html
       spatial-css/spatial-portal-animation-independent.html
       spatial-css/spatial-portal-model-animations.html

* LayoutTests/spatial-css/resources/spatial-portal-utils.js:
(async waitFor):
* LayoutTests/spatial-css/spatial-portal-animation-currenttime-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-animation-currenttime.html: Added.
* LayoutTests/spatial-css/spatial-portal-animation-dynamic-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-animation-dynamic.html: Added.
* LayoutTests/spatial-css/spatial-portal-animation-independent-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-animation-independent.html: Added.
* LayoutTests/spatial-css/spatial-portal-model-animations-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-model-animations.html: Added.
Cover autoplay and loop reaching a child, seeking a child,
siblings playing, pausing and looping independently of one another, and
a re-added child not reusing the playback state it had before.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::modelPlayerForAnimation const):
(WebCore::HTMLModelElement::applyInitialAnimationState):
(WebCore::HTMLModelElement::setPlaybackRate):
(WebCore::HTMLModelElement::duration const):
(WebCore::HTMLModelElement::paused const):
(WebCore::HTMLModelElement::setPaused):
(WebCore::HTMLModelElement::updateAutoplay):
(WebCore::HTMLModelElement::updateLoop):
(WebCore::HTMLModelElement::currentTime const):
(WebCore::HTMLModelElement::setCurrentTime):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
Reach the portal&apos;s player when the element has none of its own. The
attributes a standalone &lt;model&gt; pushes in createModelPlayer() move to
applyInitialAnimationState(), so the portal&apos;s load path can push the
same ones on the child&apos;s behalf.

* Source/WebCore/Modules/model-element/SpatialPortalController.cpp:
(WebCore::SpatialPortalController::ensureModelPlayer):
(WebCore::SpatialPortalController::loadChildModelIfReady):
(WebCore::SpatialPortalController::unregisterChildModel):
Reach the player of the portal this element is registered with when it
has none of its own. The attributes a standalone &lt;model&gt; pushes in
createModelPlayer() move to applyInitialAnimationState(), so the
portal&apos;s load path can push the same ones on the child&apos;s behalf.

* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::ensureAnimationState):
(WebKit::ModelProcessModelPlayer::animationStateIfExists):
(WebKit::ModelProcessModelPlayer::animationStateIfExists const):
(WebKit::ModelProcessModelPlayer::load):
(WebKit::ModelProcessModelPlayer::unload):
(WebKit::ModelProcessModelPlayer::reload):
(WebKit::ModelProcessModelPlayer::didFailLoading):
(WebKit::ModelProcessModelPlayer::didUpdateAnimationPlaybackState):
(WebKit::ModelProcessModelPlayer::currentAnimationState const):
(WebKit::ModelProcessModelPlayer::setAutoplay):
(WebKit::ModelProcessModelPlayer::setLoop):
(WebKit::ModelProcessModelPlayer::setPlaybackRate):
(WebKit::ModelProcessModelPlayer::duration const):
(WebKit::ModelProcessModelPlayer::paused const):
(WebKit::ModelProcessModelPlayer::currentTime const):
(WebKit::ModelProcessModelPlayer::setCurrentTime):
(WebKit::ModelProcessModelPlayer::didFailLoading):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
Key animation state by NodeIdentifier rather than holding one set of
values per player. A playback report for a node the player does not
track is dropped instead of inventing state that would then be
reported to script, and a failed load drops the node&apos;s state, since the
model process drops its own entry for it.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(-[WKModelProcessModelPlayerProxyObjCAdapter entityAnimationPlaybackStateDidUpdate:]):
(WebKit::ModelProcessModelPlayerProxy::entityForNode const):
(WebKit::ModelProcessModelPlayerProxy::loadModel):
(WebKit::ModelProcessModelPlayerProxy::reloadModel):
(WebKit::ModelProcessModelPlayerProxy::load):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::setUpLoadedEntity):
(WebKit::ModelProcessModelPlayerProxy::unloadModel):
(WebKit::ModelProcessModelPlayerProxy::animationPlaybackStateDidUpdate):
(WebKit::ModelProcessModelPlayerProxy::setAutoplay):
(WebKit::ModelProcessModelPlayerProxy::setLoop):
(WebKit::ModelProcessModelPlayerProxy::setPlaybackRate):
(WebKit::ModelProcessModelPlayerProxy::duration const):
(WebKit::ModelProcessModelPlayerProxy::paused const):
(WebKit::ModelProcessModelPlayerProxy::setPaused):
(WebKit::ModelProcessModelPlayerProxy::currentTime const):
(WebKit::ModelProcessModelPlayerProxy::setCurrentTime):
(WebKit::ModelProcessModelPlayerProxy::teardownEntity):
(WebKit::ModelProcessModelPlayerProxy::captureStateForReload):
(WebKit::ModelProcessModelPlayerProxy::computeTransform):
(WebKit::ModelProcessModelPlayerProxy::updateTransform):
(WebKit::ModelProcessModelPlayerProxy::updateOpacity):
(WebKit::ModelProcessModelPlayerProxy::didFailLoading):
(WebKit::ModelProcessModelPlayerProxy::reportingModelScale const):
(WebKit::ModelProcessModelPlayerProxy::findTrackedModelForLoader):
(WebKit::ModelProcessModelPlayerProxy::findTrackedModelForEntity):
(WebKit::ModelProcessModelPlayerProxy::ensureTrackedModel):
(WebKit::ModelProcessModelPlayerProxy::trackedModel):
(WebKit::ModelProcessModelPlayerProxy::trackedModel const):
(WebKit::ModelProcessModelPlayerProxy::cancelAllLoaders):
(WebKit::ModelProcessModelPlayerProxy::sizeDidChange):
(WebKit::ModelProcessModelPlayerProxy::ensureImmersivePresentation):
(WebKit::ModelProcessModelPlayerProxy::exitImmersivePresentation):
(WebKit::ModelProcessModelPlayerProxy::findHostedEntityForLoader): Deleted.
Hold autoplay, loop, playback rate and the state to restore on each
tracked model, and set the playback delegate on every entity so a
sibling reports its own state rather than the first model&apos;s. An
accessor for a node whose entity has not loaded now reports failure
rather than answering from a nil entity, so play() before load rejects.
teardownEntity() keeps its map entries, since captureStateForReload()
has just recorded playback state in them.

Canonical link: <a href="https://commits.webkit.org/318839@main">https://commits.webkit.org/318839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41bfb20dadb05cbafb375ff86b90e564fa21b540

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143765 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139941 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120393 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42220 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40548 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40194 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/742 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191508 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149202 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40018 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53746 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148947 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43612 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126018 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120913 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52263 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15183 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51648 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51889 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51709 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->