### PR TITLE
Nested multi-columns can cut off text

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4211,6 +4211,10 @@ webkit.org/b/202805 [ Debug ] fast/multicol/fragflow-gains-new-in-flow-descendan
 
 webkit.org/b/252597 fast/multicol/split-in-top-margin.html [ ImageOnlyFailure ]
 
+# A nested multicolumn flow sizes its columns to its own balanced height rather than the
+# height of the enclosing fragmentainer, so content is placed in column-major order.
+webkit.org/b/269202 fast/multicol/nested-columns-constrained-inner-height.html [ ImageOnlyFailure ]
+
 # This newly imported test crashes in debug and flakily times out.
 webkit.org/b/189917 imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/document-write/contentType.window.html [ Skip ]
 

--- a/LayoutTests/fast/multicol/nested-columns-constrained-inner-height-expected.html
+++ b/LayoutTests/fast/multicol/nested-columns-constrained-inner-height-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<p>The word 'PASSED' should be seen below.</p>
+<div style="position:relative; width:6em; height:2em; line-height:2em;">
+    <div style="position:absolute; top:0; left:0em; width:1em;">P</div>
+    <div style="position:absolute; top:0; left:1em; width:1em;">A</div>
+    <div style="position:absolute; top:0; left:2em; width:1em;">S</div>
+    <div style="position:absolute; top:0; left:3em; width:1em;">S</div>
+    <div style="position:absolute; top:0; left:4em; width:1em;">E</div>
+    <div style="position:absolute; top:0; left:5em; width:1em;">D</div>
+</div>

--- a/LayoutTests/fast/multicol/nested-columns-constrained-inner-height.html
+++ b/LayoutTests/fast/multicol/nested-columns-constrained-inner-height.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<p>The word 'PASSED' should be seen below.</p>
+<div style="width:6em; height:2em; columns:3; column-gap:0; column-fill:auto; line-height:2em;">
+    <div style="column-count:2; column-gap:0;">
+        P<br>A<br>S<br>S<br>E<br>D
+    </div>
+</div>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4678,6 +4678,12 @@ void RenderBlockFlow::checkForPaginationLogicalHeightChange(RelayoutChildren& re
             newColumnHeight = std::max<LayoutUnit>(computedValues.extent - borderAndPaddingLogicalHeight() - scrollbarLogicalHeight(), 0);
             if (fragmentedFlow->columnHeightAvailable() != newColumnHeight)
                 relayoutChildren = RelayoutChildren::Yes;
+        } else if (enclosingFragmentedFlow()) {
+            if (LayoutUnit outerColumnHeight = pageLogicalHeightForOffset(logicalTop())) {
+                newColumnHeight = std::max<LayoutUnit>(outerColumnHeight - borderAndPaddingLogicalHeight(), 0);
+                if (fragmentedFlow->columnHeightAvailable() != newColumnHeight)
+                    relayoutChildren = RelayoutChildren::Yes;
+            }
         }
         fragmentedFlow->setColumnHeightAvailable(newColumnHeight);
     } else if (CheckedPtr fragmentedFlow = dynamicDowncast<RenderFragmentedFlow>(*this)) {


### PR DESCRIPTION
#### 54a4b4553b4e795ea6c443b05a59e5ed11a9aab9
<pre>
Nested multi-columns can cut off text
<a href="https://bugs.webkit.org/show_bug.cgi?id=269202">https://bugs.webkit.org/show_bug.cgi?id=269202</a>
<a href="https://rdar.apple.com/122982032">rdar://122982032</a>

Reviewed by NOBODY (OOPS!).

A nested multicolumn flow gets columnHeightAvailable() == 0, since it is derived only from
the container&apos;s own definite height. calculateMaxColumnHeight() therefore falls back to
maxLogicalHeight(), the inner flow balances to its full content height, and the outer flow
slices that taller block, placing content in column-major order.

Deriving the inner flow&apos;s available height from the enclosing fragmentainer fixes the test
case, but is not sufficient: the inner flow then emits overflowing columns side by side
rather than continuing into the next fragmentainer, which regresses
fast/multicol/nested-columns-three-levels.html.

Test: fast/multicol/nested-columns-constrained-inner-height.html

* LayoutTests/TestExpectations:
* LayoutTests/fast/multicol/nested-columns-constrained-inner-height-expected.html: Added.
* LayoutTests/fast/multicol/nested-columns-constrained-inner-height.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::checkForPaginationLogicalHeightChange):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54a4b4553b4e795ea6c443b05a59e5ed11a9aab9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52723 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46518 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188401 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143094 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52434 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139399 "Found 14 new test failures: fast/multicol/nested-columns-three-levels.html imported/w3c/web-platform-tests/css/css-break/flexbox/multi-line-row-flex-fragmentation-012.html imported/w3c/web-platform-tests/css/css-break/flexbox/single-line-column-flex-fragmentation-012.html imported/w3c/web-platform-tests/css/css-break/flexbox/single-line-column-flex-fragmentation-044.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-017.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-018.html imported/w3c/web-platform-tests/css/css-multicol/getclientrects-003.html imported/w3c/web-platform-tests/css/css-multicol/getclientrects-004.html imported/w3c/web-platform-tests/css/css-multicol/multicol-fill-balance-022.html imported/w3c/web-platform-tests/css/css-multicol/multicol-nested-027.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96706 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181742 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42968 "Found 1 new test failure: fast/multicol/nested-columns-three-levels.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119853 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41632 "Found 13 new test failures: imported/w3c/web-platform-tests/css/css-break/flexbox/multi-line-row-flex-fragmentation-012.html imported/w3c/web-platform-tests/css/css-break/flexbox/single-line-column-flex-fragmentation-012.html imported/w3c/web-platform-tests/css/css-break/flexbox/single-line-column-flex-fragmentation-044.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-017.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-018.html imported/w3c/web-platform-tests/css/css-multicol/getclientrects-003.html imported/w3c/web-platform-tests/css/css-multicol/getclientrects-004.html imported/w3c/web-platform-tests/css/css-multicol/multicol-fill-balance-022.html imported/w3c/web-platform-tests/css/css-multicol/multicol-nested-027.html imported/w3c/web-platform-tests/css/css-multicol/spanner-fragmentation-001.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39983 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152032 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39636 "Found 14 new test failures: fast/multicol/nested-columns-three-levels.html imported/w3c/web-platform-tests/css/css-break/flexbox/multi-line-row-flex-fragmentation-012.html imported/w3c/web-platform-tests/css/css-break/flexbox/single-line-column-flex-fragmentation-012.html imported/w3c/web-platform-tests/css/css-break/flexbox/single-line-column-flex-fragmentation-044.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-017.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-018.html imported/w3c/web-platform-tests/css/css-multicol/getclientrects-003.html imported/w3c/web-platform-tests/css/css-multicol/getclientrects-004.html imported/w3c/web-platform-tests/css/css-multicol/multicol-fill-balance-022.html imported/w3c/web-platform-tests/css/css-multicol/multicol-nested-027.html ... (failure)") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45324 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44225 "Found 14 new test failures: fast/multicol/nested-columns-three-levels.html imported/w3c/web-platform-tests/css/css-break/flexbox/multi-line-row-flex-fragmentation-012.html imported/w3c/web-platform-tests/css/css-break/flexbox/single-line-column-flex-fragmentation-012.html imported/w3c/web-platform-tests/css/css-break/flexbox/single-line-column-flex-fragmentation-044.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-017.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-018.html imported/w3c/web-platform-tests/css/css-multicol/getclientrects-003.html imported/w3c/web-platform-tests/css/css-multicol/getclientrects-004.html imported/w3c/web-platform-tests/css/css-multicol/multicol-fill-balance-022.html imported/w3c/web-platform-tests/css/css-multicol/multicol-nested-027.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190829 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159659 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148584 "Found 10 new test failures: imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-017.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-018.html imported/w3c/web-platform-tests/css/css-multicol/getclientrects-003.html imported/w3c/web-platform-tests/css/css-multicol/getclientrects-004.html imported/w3c/web-platform-tests/css/css-multicol/multicol-fill-balance-022.html imported/w3c/web-platform-tests/css/css-multicol/multicol-nested-027.html imported/w3c/web-platform-tests/css/css-multicol/spanner-fragmentation-001.html imported/w3c/web-platform-tests/css/css-multicol/spanner-fragmentation-002.html imported/w3c/web-platform-tests/css/css-multicol/spanner-fragmentation-005.html imported/w3c/web-platform-tests/css/css-multicol/spanner-fragmentation-012.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53073 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36263 "Found 15 new test failures: fast/multicol/nested-columns-three-levels.html imported/w3c/web-platform-tests/css/css-break/flexbox/multi-line-row-flex-fragmentation-012.html imported/w3c/web-platform-tests/css/css-break/flexbox/single-line-column-flex-fragmentation-012.html imported/w3c/web-platform-tests/css/css-break/flexbox/single-line-column-flex-fragmentation-044.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-017.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-018.html imported/w3c/web-platform-tests/css/css-multicol/getclientrects-003.html imported/w3c/web-platform-tests/css/css-multicol/getclientrects-004.html imported/w3c/web-platform-tests/css/css-multicol/multicol-fill-balance-022.html imported/w3c/web-platform-tests/css/css-multicol/multicol-nested-027.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148351 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43046 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125340 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120001 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51591 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14615 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50976 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->