### PR TITLE
[Site isolation] Stale ScrollingTree active nodes crash the UI process in establishLayerTreeScrollingRelations()

### DIFF
--- a/LayoutTests/http/tests/site-isolation/scrolling/remove-iframe-with-active-scroll-proxy-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/scrolling/remove-iframe-with-active-scroll-proxy-expected.txt
@@ -1,0 +1,12 @@
+Verifies that removing a cross-origin iframe also removes the scroll proxy nodes its process contributed to the scrolling tree's active node sets.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframe content scrolled
+PASS active scroll proxy nodes exist while the iframe is present
+PASS active scroll proxy nodes were removed with the iframe
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/scrolling/remove-iframe-with-active-scroll-proxy.html
+++ b/LayoutTests/http/tests/site-isolation/scrolling/remove-iframe-with-active-scroll-proxy.html
@@ -1,0 +1,63 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true AsyncOverflowScrollingEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<body>
+<script>
+description("Verifies that removing a cross-origin iframe also removes the scroll proxy nodes its process contributed to the scrolling tree's active node sets.");
+jsTestIsAsync = true;
+
+// internals.scrollingTreeAsText() is empty under site isolation and omits node IDs,
+// so read the UI process tree directly rather than via UIHelper.getScrollingTree().
+function scrollingTree()
+{
+    return new Promise((resolve) => {
+        testRunner.runUIScript("(function() { return uiController.scrollingTreeIncludingNodeIDsAsText; })();", resolve);
+    });
+}
+
+// The active set prints as its own "(overflow scroll proxy nodes" section; the
+// per-node dump is singular, so the plural is unambiguous.
+function hasActiveScrollProxyNodes(tree)
+{
+    return tree.includes("(overflow scroll proxy nodes");
+}
+
+// Registered at parse time: the subframe's load fires before ours, so a listener
+// installed from our own load handler can miss the message.
+window.addEventListener("message", async (event) => {
+    if (!event.data || event.data.type != "scrolled")
+        return;
+
+    if (event.data.scrollTop > 0)
+        testPassed("iframe content scrolled");
+    else
+        testFailed("iframe content did not scroll, so no scroll proxy nodes can become active");
+
+    // The iframe commits in its own transaction, so poll rather than assume it landed.
+    await UIHelper.waitForConditionAsync(async () => hasActiveScrollProxyNodes(await scrollingTree()), 120);
+
+    if (hasActiveScrollProxyNodes(await scrollingTree()))
+        testPassed("active scroll proxy nodes exist while the iframe is present");
+    else
+        testFailed("expected active scroll proxy nodes while the iframe is present");
+
+    document.getElementById("frameToRemove").remove();
+
+    // establishLayerTreeScrollingRelations() runs before presentation update callbacks
+    // are answered, so once these resolve the walk over the active sets has happened.
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.ensurePresentationUpdate();
+
+    if (hasActiveScrollProxyNodes(await scrollingTree()))
+        testFailed("active scroll proxy nodes outlived the iframe that contributed them");
+    else
+        testPassed("active scroll proxy nodes were removed with the iframe");
+
+    finishJSTest();
+}, false);
+
+if (!window.testRunner || !testRunner.runUIScript)
+    finishJSTest();
+</script>
+<iframe id="frameToRemove" width="300" height="200" src="http://localhost:8000/site-isolation/scrolling/resources/scroll-proxy-iframe.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/scrolling/resources/scroll-proxy-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/scrolling/resources/scroll-proxy-iframe.html
@@ -1,0 +1,41 @@
+<style>
+/* Overflow on html and body keeps body a composited scroller. */
+html { margin: 0; height: 100%; overflow: hidden auto; }
+body { margin: 0; height: 100%; overflow: hidden auto; position: relative; }
+
+#content { height: 3000px; }
+
+.clipper {
+    position: relative;
+    overflow: hidden;
+    width: 200px;
+    height: 100px;
+    border-radius: 8px;
+}
+
+/* Composited, clipped by .clipper, and moved by the body scroller: that
+   combination is what gives it an overflow scroll proxy node. */
+.banner {
+    position: absolute;
+    top: 10px;
+    width: 150px;
+    height: 50px;
+    background-color: green;
+    will-change: transform;
+}
+</style>
+<body>
+    <div id="content">
+        <div class="clipper"><div class="banner"></div></div>
+        <div class="clipper"><div class="banner"></div></div>
+    </div>
+</body>
+<script>
+// Proxy nodes only join the active sets once the scroller has scrolled.
+window.addEventListener("load", () => {
+    document.body.scrollTop = 400;
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+        parent.postMessage({ type: "scrolled", scrollTop: document.body.scrollTop }, "*");
+    }));
+}, false);
+</script>

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -332,10 +332,36 @@ void ScrollingTree::removeNode(ScrollingNodeID nodeID, ScrollingTreeFrameHosting
             if (nodeList != m_nodeMapPerFrame.end())
                 nodeList->value.remove(nodeID);
         }
+        removeFromActiveNodes(*node);
         if (hostingNode)
             hostingNode->removeHostedChild(*node);
         node->willBeDestroyed();
     }
+}
+
+void ScrollingTree::removeFromActiveNodes(ScrollingTreeNode& node)
+{
+    // The active node sets hold refs, so a node removed from m_nodeMap would otherwise stay in
+    // them and remain unresolvable via nodeForID() for the rest of the tree's lifetime.
+    if (auto* positionedNode = dynamicDowncast<ScrollingTreePositionedNode>(node))
+        m_activePositionedNodes.remove(*positionedNode);
+    else if (auto* scrollProxyNode = dynamicDowncast<ScrollingTreeOverflowScrollProxyNode>(node))
+        m_activeOverflowScrollProxyNodes.remove(*scrollProxyNode);
+
+    // Active nodes can also reference the node going away, and those references resolve
+    // by ID, so drop the referrers rather than leave them pointing at nothing.
+    if (!node.isOverflowScrollingNode())
+        return;
+
+    auto removedNodeID = node.scrollingNodeID();
+
+    m_activeOverflowScrollProxyNodes.removeIf([removedNodeID](auto& scrollProxyNode) {
+        return scrollProxyNode->overflowScrollingNodeID() == removedNodeID;
+    });
+
+    m_activePositionedNodes.removeIf([removedNodeID](auto& positionedNode) {
+        return positionedNode->relatedOverflowScrollingNodes().contains(removedNodeID);
+    });
 }
 
 void ScrollingTree::removeFrameHostingNode(LayerHostingContextIdentifier hostingIdentifier)
@@ -575,6 +601,11 @@ bool ScrollingTree::updateTreeFromStateNodeRecursive(const ScrollingStateNode* s
 void ScrollingTree::removeAllNodes()
 {
     auto nodes = std::exchange(m_nodeMap, { });
+
+    // Every node is going away, so no entry in the active sets can still be resolved via nodeForID().
+    m_activePositionedNodes.clear();
+    m_activeOverflowScrollProxyNodes.clear();
+
     for (auto iter : nodes)
         Ref { iter.value }->willBeDestroyed();
 
@@ -1150,7 +1181,6 @@ String ScrollingTree::scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBeha
                 }
             }
 
-#if ENABLE(SCROLLING_THREAD)
             if (!m_activeOverflowScrollProxyNodes.isEmpty()) {
                 TextStream::GroupScope scope(ts);
                 ts << "overflow scroll proxy nodes"_s;
@@ -1170,7 +1200,6 @@ String ScrollingTree::scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBeha
                         ts << '\n' << indent << node->scrollingNodeID();
                 }
             }
-#endif // ENABLE(SCROLLING_THREAD)
         }
     }
     return ts.release();

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -320,7 +320,8 @@ protected:
 
     WEBCORE_EXPORT virtual void applyLayerPositionsInternal() WTF_REQUIRES_LOCK(m_treeLock);
     WEBCORE_EXPORT void removeAllNodes() WTF_REQUIRES_LOCK(m_treeLock);
-    
+    void removeFromActiveNodes(ScrollingTreeNode&);
+
     virtual void hasNodeWithAnimatedScrollChanged(bool /* hasNodeWithAnimatedScroll */) { }
 
     bool hasProcessedWheelEventsRecently();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -116,6 +116,7 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 
 @property (nonatomic, setter=_setScrollingUpdatesDisabledForTesting:) BOOL _scrollingUpdatesDisabledForTesting;
 @property (nonatomic, readonly) NSString *_scrollingTreeAsText;
+@property (nonatomic, readonly) NSString *_scrollingTreeIncludingNodeIDsAsText;
 @property (nonatomic, readonly) double _rubberbandHyperbolicCoefficientForTesting;
 
 @property (nonatomic, readonly) pid_t _networkProcessIdentifier;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -360,6 +360,15 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     return coordinator->scrollingTreeAsText().createNSString().autorelease();
 }
 
+- (NSString *)_scrollingTreeIncludingNodeIDsAsText
+{
+    CheckedPtr coordinator = _page->scrollingCoordinatorProxy();
+    if (!coordinator)
+        return @"";
+
+    return coordinator->scrollingTreeIncludingNodeIDsAsText().createNSString().autorelease();
+}
+
 - (double)_rubberbandHyperbolicCoefficientForTesting
 {
     if (CheckedPtr coordinator = _page->scrollingCoordinatorProxy())

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -372,6 +372,11 @@ String RemoteScrollingCoordinatorProxy::scrollingTreeAsText() const
     return m_scrollingTree->scrollingTreeAsText();
 }
 
+String RemoteScrollingCoordinatorProxy::scrollingTreeIncludingNodeIDsAsText() const
+{
+    return m_scrollingTree->scrollingTreeAsText(ScrollingStateTreeAsTextBehavior::IncludeNodeIDs);
+}
+
 float RemoteScrollingCoordinatorProxy::rubberbandHyperbolicCoefficientForTesting() const
 {
     return m_scrollingTree->rubberbandHyperbolicCoefficientForTesting();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -167,6 +167,7 @@ public:
 #endif
 
     String scrollingTreeAsText() const;
+    String scrollingTreeIncludingNodeIDsAsText() const;
     float rubberbandHyperbolicCoefficientForTesting() const;
 
     void resetStateAfterProcessExited();

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -392,6 +392,7 @@ interface UIScriptController {
     undefined replaceTextAtRange(DOMString text, long location, long length);
 
     readonly attribute DOMString scrollingTreeAsText;
+    readonly attribute DOMString scrollingTreeIncludingNodeIDsAsText;
     readonly attribute DOMString uiViewTreeAsText;
     readonly attribute DOMString caLayerTreeAsText;
     DOMString caLayerTreeAsTextForLayerWithID(unsigned long long layerID);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -205,6 +205,7 @@ public:
     virtual JSObjectRef adjustedContentInset() const { notImplemented(); return nullptr; }
 
     virtual JSRetainPtr<JSStringRef> scrollingTreeAsText() const { notImplemented(); return nullptr; }
+    virtual JSRetainPtr<JSStringRef> scrollingTreeIncludingNodeIDsAsText() const { notImplemented(); return nullptr; }
     virtual JSRetainPtr<JSStringRef> uiViewTreeAsText() const { notImplemented(); return nullptr; }
     virtual JSRetainPtr<JSStringRef> caLayerTreeAsText() const { notImplemented(); return nullptr; }
     virtual JSRetainPtr<JSStringRef> caLayerTreeAsTextForLayerWithID(unsigned long long) const { notImplemented(); return nullptr; }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -11367,6 +11367,50 @@ TEST(SiteIsolation, CrossOriginIframeWithoutHorizontalOverflowCanShortCircuitHor
         return !WKPageWillHandleHorizontalScrollEvents([webView _pageForTesting]);
     }));
 }
+
+// Hosted subtree nodes are removed without the frame-scoped pruning in commitTreeStateInternal(),
+// stranding active entries that then fail a MESSAGE_CHECK. See rdar://175191840.
+TEST(SiteIsolation, RemoveIframeWithActiveScrollProxyNodes)
+{
+    auto mainHTML = "<body style='margin:0'><iframe id='frame' src='https://webkit.org/iframe' style='width:300px;height:200px;border:none'></iframe></body>"_s;
+
+    // Overflow on html and body keeps body a composited scroller; the clipped
+    // composited banners are what give it overflow scroll proxy nodes.
+    auto iframeHTML = "<style>"
+        "  html { margin: 0; height: 100%; overflow: hidden auto; }"
+        "  body { margin: 0; height: 100%; overflow: hidden auto; position: relative; }"
+        "  #content { height: 3000px; }"
+        "  .clipper { position: relative; overflow: hidden; width: 200px; height: 100px; border-radius: 8px; }"
+        "  .banner { position: absolute; top: 10px; width: 150px; height: 50px;"
+        "            background-color: green; will-change: transform; }"
+        "</style>"
+        "<div id='content'>"
+        "  <div class='clipper'><div class='banner'></div></div>"
+        "  <div class='clipper'><div class='banner'></div></div>"
+        "</div>"
+        "<script>onload=()=>{ document.body.scrollTop = 400; alert('loaded') }</script>"_s;
+
+    HTTPServer server({
+        { "/main"_s, { mainHTML } },
+        { "/iframe"_s, { iframeHTML } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "loaded");
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_TRUE([[webView _scrollingTreeIncludingNodeIDsAsText] containsString:@"(overflow scroll proxy nodes"]);
+
+    [webView objectByEvaluatingJavaScript:@"document.getElementById('frame').remove();1"];
+    [webView waitForNextPresentationUpdate];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_FALSE([[webView _scrollingTreeIncludingNodeIDsAsText] containsString:@"(overflow scroll proxy nodes"]);
+
+    // The UI process surviving to round-trip this is the real assertion.
+    EXPECT_WK_STREQ([webView objectByEvaluatingJavaScript:@"'alive'"], "alive");
+}
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -58,6 +58,7 @@ private:
     JSObjectRef propertiesOfLayerWithID(uint64_t layerID) const final;
 
     JSRetainPtr<JSStringRef> scrollingTreeAsText() const override;
+    JSRetainPtr<JSStringRef> scrollingTreeIncludingNodeIDsAsText() const override;
 
     void setDidShowContextMenuCallback(JSValueRef) override;
     void setDidDismissContextMenuCallback(JSValueRef) override;

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -117,6 +117,11 @@ JSRetainPtr<JSStringRef> UIScriptControllerCocoa::scrollingTreeAsText() const
     return adopt(JSStringCreateWithCFString((CFStringRef)[webView() _scrollingTreeAsText]));
 }
 
+JSRetainPtr<JSStringRef> UIScriptControllerCocoa::scrollingTreeIncludingNodeIDsAsText() const
+{
+    return adopt(JSStringCreateWithCFString((CFStringRef)[webView() _scrollingTreeIncludingNodeIDsAsText]));
+}
+
 void UIScriptControllerCocoa::removeViewFromWindow(JSValueRef callback)
 {
     // FIXME: On iOS, we never invoke the completion callback that's passed in. Fixing this causes the layout


### PR DESCRIPTION
#### 4a0a8eee54a492f3059110adfb08ed46ba356f5e
<pre>
[Site isolation] Stale ScrollingTree active nodes crash the UI process in establishLayerTreeScrollingRelations()
<a href="https://bugs.webkit.org/show_bug.cgi?id=321051">https://bugs.webkit.org/show_bug.cgi?id=321051</a>
<a href="https://rdar.apple.com/175191840">rdar://175191840</a>

Reviewed by Matt Woodrow.

ScrollingTree keeps two active node sets, m_activePositionedNodes and
m_activeOverflowScrollProxyNodes, which hold Ref&lt;&gt;. Their only cleanup was a
frame-scoped removeIf in commitTreeStateInternal() that drops entries whose
frameIdentifier() matches the committing frame.

A node removed without its owning frame committing therefore leaked into those
sets permanently: the Ref keeps it alive while nodeForID() can no longer
resolve it. establishLayerTreeScrollingRelations() then walked the stale entry
and failed MESSAGE_CHECK_BASE. Under site isolation WebPageProxy sets
setShouldCrashOnMessageCheckFailure(true), so this terminated the UI process
rather than the web process.

The dominant path is hosted subtree teardown: every node in a hosted subtree is
registered as a hosted child, and ScrollingTreeFrameHostingNode::
removeHostedChildren() calls removeNode() for each one without the committing
frame ever being the iframe&apos;s own frame. Removing a cross-origin iframe,
navigating it cross-origin, or committing it empty all reach this.

Add ScrollingTree::removeFromActiveNodes(), called from removeNode(). It drops
the removed node itself, and also any active node that *references* a removed
overflow scrolling node -- the latter is what the failing check actually reads,
since it resolves the proxy&apos;s overflowScrollingNodeID() rather than the proxy
itself. removeAllNodes() clears both sets outright.

Two supporting changes were needed to make this testable at all:

- The active sets are only dumped under ScrollingStateTreeAsTextBehavior::
  IncludeNodeIDs, which no test-reachable API passed. Add
  scrollingTreeIncludingNodeIDsAsText() -&gt;
  -[WKWebView _scrollingTreeIncludingNodeIDsAsText] -&gt;
  uiController.scrollingTreeIncludingNodeIDsAsText.

- That dump sat inside #if ENABLE(SCROLLING_THREAD), which is mac-only, while
  both sets are declared and populated unconditionally. Remove the guard so the
  state is observable everywhere; without this the new layout test is a
  permanent no-op off mac. The unrelated SCROLLING_THREAD guard around
  synchronousScrollingNodes is left alone.

Note a single-process layout test cannot cover this: removing content from the
frame that owns the nodes makes that frame commit, so the frame-scoped removeIf
cleans up correctly. The test uses a cross-origin iframe so the removal happens
with no commit from the iframe&apos;s process.

Both tests were verified in both directions -- they pass with the fix and crash
without it. (On Release a MESSAGE_CHECK_BASE failure calls CRASH(), since
CRASH_IF_TESTING is only compiled out under ENABLE(IPC_TESTING_API).) Also
verified against the live repro: saratogasun.com -&gt; Obituaries in a private
window with site isolation on crashed twice before the fix and survived eight
navigation cycles after.

* LayoutTests/http/tests/site-isolation/scrolling/remove-iframe-with-active-scroll-proxy-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/scrolling/remove-iframe-with-active-scroll-proxy.html: Added.
* LayoutTests/http/tests/site-isolation/scrolling/resources/scroll-proxy-iframe.html: Added.
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::removeNode):
(WebCore::ScrollingTree::removeFromActiveNodes):
(WebCore::ScrollingTree::removeAllNodes):
(WebCore::ScrollingTree::scrollingTreeAsText):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _scrollingTreeIncludingNodeIDsAsText]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeIncludingNodeIDsAsText const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::scrollingTreeIncludingNodeIDsAsText const):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, RemoveIframeWithActiveScrollProxyNodes)):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::scrollingTreeIncludingNodeIDsAsText const):

Canonical link: <a href="https://commits.webkit.org/319425@main">https://commits.webkit.org/319425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89508eab2caf7a3e389f92e911ba4a1681a3fe8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139400 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96707 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119854 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41634 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39985 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152034 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39637 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190830 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159660 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148585 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40446 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53074 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148352 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43048 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125341 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120002 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51592 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14616 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50977 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51217 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51039 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->