### PR TITLE
Introduce layout test for MediaRecorder dropping trailing video frames when a recording is stopped

### DIFF
--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-stop-trailing-video-frames-expected.txt
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-stop-trailing-video-frames-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Video frames drawn right before stop() are present in the recording
+

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-stop-trailing-video-frames.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-stop-trailing-video-frames.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html>
+<head>
+    <title>MediaRecorder trailing video frames</title>
+    <link rel="help" href="https://w3c.github.io/mediacapture-record/MediaRecorder.html#mediarecorder">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="divplayer"></div>
+<div id="canvasreference"></div>
+<div id="canvascopy"></div>
+<script>
+    function waitForEvent(object, eventName, testName) {
+        return new Promise((resolve, reject) => {
+            object.addEventListener(eventName, (e) => resolve(e), { once: true });
+            setTimeout(() => reject("waitForEvent " + (testName ? (testName + " ") : "") + "timed out for " + eventName), 2500);
+        });
+    }
+
+    async function runTest(mimeType) {
+        let context;
+        let drawStartTime;
+        // Needs to be a globabl variable to avoid being GCed (webkit.org/b/271227)
+        let oscillator;
+
+        const width = 200;
+        const height = 200;
+
+        function createVideoStream() {
+            const canvas = document.createElement("canvas");
+            canvas.width = width;
+            canvas.height = height;
+            canvasreference.appendChild(canvas);
+            context = canvas.getContext('2d');
+            return canvas.captureStream();
+        }
+        const ac = new AudioContext();
+        oscillator = ac.createOscillator();
+        const dest = ac.createMediaStreamDestination();
+        const audio = dest.stream;
+        oscillator.connect(dest);
+        oscillator.start();
+
+        const video = createVideoStream();
+        video.addTrack(audio.getAudioTracks()[0]);
+        assert_true(MediaRecorder.isTypeSupported(mimeType));
+        const recorder = new MediaRecorder(video, { mimeType });
+
+        function drawColor(fillStyle) {
+            context.fillStyle = fillStyle;
+            context.fillRect(0, 0, width, height);
+        }
+
+        function doRedImageDraw() {
+            drawColor("#ff0000");
+            if (Date.now() - drawStartTime < 300)
+                window.requestAnimationFrame(doRedImageDraw);
+            else {
+                drawStartTime = Date.now();
+                doGreenImageDraw();
+            }
+        }
+
+        function doGreenImageDraw() {
+            drawColor("#00ff00");
+            if (Date.now() - drawStartTime < 300)
+                window.requestAnimationFrame(doGreenImageDraw);
+            else {
+                drawStartTime = Date.now();
+                doBlueImageDraw();
+            }
+        }
+
+        let blueFrameCount = 0;
+        function doBlueImageDraw() {
+            drawColor("#0000ff");
+            blueFrameCount++;
+            if (blueFrameCount < 5 || Date.now() - drawStartTime < 300)
+                window.requestAnimationFrame(doBlueImageDraw);
+            else if (recorder.state == 'recording')
+                recorder.stop();
+        }
+
+        drawStartTime = Date.now();
+        doRedImageDraw();
+        recorder.start();
+        assert_equals(recorder.state, 'recording', 'MediaRecorder has been started successfully');
+
+        const blobEvent = await waitForEvent(recorder, 'dataavailable');
+        assert_true(blobEvent.data instanceof Blob, 'the type of data should be Blob');
+        assert_true(blobEvent.data.size > 0, 'the blob should contain some buffers');
+
+        const player = document.createElement("video");
+        divplayer.appendChild(player);
+        player.disableRemotePlayback = true;
+        player.src = URL.createObjectURL(blobEvent.data);
+        await waitForEvent(player, 'canplay');
+
+        const resFrame = document.createElement("canvas");
+        resFrame.width = width;
+        resFrame.height = height;
+        canvascopy.appendChild(resFrame);
+        const resContext = resFrame.getContext('2d');
+
+        assert_greater_than(player.duration, 0.3, 'the duration should be greater than .3s');
+
+        const seenColors = new Set();
+        let samplesAfterEnded = 10;
+        const samplingDone = new Promise(resolve => {
+            function sampleFrame() {
+                resContext.drawImage(player, 0, 0);
+                const [r, g, b] = resContext.getImageData(20, 20, 1, 1).data;
+                if (r > 200 && g < 80 && b < 80)
+                    seenColors.add('red');
+                else if (g > 200 && r < 80 && b < 80)
+                    seenColors.add('green');
+                else if (b > 200 && r < 80 && g < 80)
+                    seenColors.add('blue');
+                if (player.ended && --samplesAfterEnded < 0)
+                    return resolve();
+                requestAnimationFrame(sampleFrame);
+            }
+            requestAnimationFrame(sampleFrame);
+        });
+
+        await player.play();
+        await waitForEvent(player, 'ended');
+        await samplingDone;
+        assert_true(seenColors.has('red'), 'red frames should have been played');
+        assert_true(seenColors.has('blue'), 'the trailing blue frames should have been played');
+    }
+
+    promise_test(async (test) => {
+        const mimeType = MediaRecorder.isTypeSupported('video/mp4') ? 'video/mp4' : 'video/webm; codecs=vp8,opus';
+        return runTest(mimeType);
+    }, 'Video frames drawn right before stop() are present in the recording');
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1794,6 +1794,7 @@ webkit.org/b/307032 imported/w3c/web-platform-tests/mediacapture-streams/MediaSt
 # No support for Matroska container in GStreamer port.
 http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html
 
+webkit.org/b/293119 http/wpt/mediarecorder/MediaRecorder-stop-trailing-video-frames.html [ Failure ]
 webkit.org/b/293119 http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html [ Failure ]
 
 # The "Pausing and resuming the recording should impact the video duration" test fails.


### PR DESCRIPTION
#### 1db17e683a653fe7d80122a40738faf0b3912f76
<pre>
Introduce layout test for MediaRecorder dropping trailing video frames when a recording is stopped
<a href="https://bugs.webkit.org/show_bug.cgi?id=321052">https://bugs.webkit.org/show_bug.cgi?id=321052</a>
<a href="https://rdar.apple.com/184081925">rdar://184081925</a>

Reviewed by NOBODY (OOPS!).

This records red, green, then briefly blue frames, stops right
after the blue ones, and verifies by playing back the recording that the
trailing blue frames are played.

Test: http/wpt/mediarecorder/MediaRecorder-stop-trailing-video-frames.html
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-stop-trailing-video-frames-expected.txt: Added.
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-stop-trailing-video-frames.html: Added.
* LayoutTests/platform/glib/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1db17e683a653fe7d80122a40738faf0b3912f76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188819 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139571 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160324 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120017 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41836 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40181 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152235 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39827 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/126 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191039 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148793 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53279 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36453 "Found 1 new test failure: http/wpt/mediarecorder/MediaRecorder-stop-trailing-video-frames.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148543 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43235 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120364 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51797 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14806 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51182 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->