### PR TITLE
ImageOverlay text style should be set by the style adjuster and never be editable

### DIFF
--- a/LayoutTests/fast/images/text-recognition/image-overlay-text-is-not-editable-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-text-is-not-editable-expected.txt
@@ -1,0 +1,12 @@
+Recognized text inside an image overlay should not be editable, even when the image is inside a contenteditable.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS editor.isContentEditable is true
+PASS overlayText(image).isContentEditable is false
+PASS getComputedStyle(overlayText(image)).webkitUserModify is "read-only"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/images/text-recognition/image-overlay-text-is-not-editable.html
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-text-is-not-editable.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<script src="../../../resources/js-test.js"></script>
+<body>
+<div id="editor" contenteditable>
+    <img id="image" src="../resources/green-400x400.png">
+</div>
+<script>
+description('Recognized text inside an image overlay should not be editable, even when the image is inside a contenteditable.');
+
+jsTestIsAsync = true;
+
+function overlayText(image) {
+    return internals.shadowRoot(image).querySelector(".image-overlay-text");
+}
+
+addEventListener("load", () => {
+    internals.installImageOverlay(image, [
+        {
+            topLeft : new DOMPointReadOnly(0, 0),
+            topRight : new DOMPointReadOnly(1, 0),
+            bottomRight : new DOMPointReadOnly(1, 1),
+            bottomLeft : new DOMPointReadOnly(0, 1),
+            children: [
+                {
+                    text : "Hello",
+                    topLeft : new DOMPointReadOnly(0, 0),
+                    topRight : new DOMPointReadOnly(1, 0),
+                    bottomRight : new DOMPointReadOnly(1, 1),
+                    bottomLeft : new DOMPointReadOnly(0, 1),
+                }
+            ],
+        }
+    ]);
+
+    shouldBeTrue("editor.isContentEditable");
+    shouldBeFalse("overlayText(image).isContentEditable");
+    shouldBeEqualToString("getComputedStyle(overlayText(image)).webkitUserModify", "read-only");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/images/text-recognition/image-overlay-user-select-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-user-select-expected.txt
@@ -1,0 +1,16 @@
+The user-select value of recognized text inside an image overlay should be all or none.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getComputedStyle(overlayText(plain)).webkitUserSelect is "all"
+PASS getComputedStyle(overlayText(unselectable)).webkitUserSelect is "none"
+PASS getComputedStyle(overlayText(inInert)).webkitUserSelect is "all"
+PASS getSelection().toString() is ""
+PASS getComputedStyle(overlayText(plain)).webkitUserSelect is "none"
+PASS getComputedStyle(overlayText(plain)).webkitUserSelect is "all"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/images/text-recognition/image-overlay-user-select.html
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-user-select.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<script src="../../../resources/js-test.js"></script>
+<body>
+<img id="plain" src="../resources/green-400x400.png">
+<img id="unselectable" style="-webkit-user-select: none" src="../resources/green-400x400.png">
+<div inert>
+    <img id="inInert" src="../resources/green-400x400.png">
+</div>
+<script>
+description('The user-select value of recognized text inside an image overlay should be all or none.');
+
+jsTestIsAsync = true;
+
+function overlayText(image) {
+    return internals.shadowRoot(image).querySelector(".image-overlay-text");
+}
+
+addEventListener("load", () => {
+    for (const image of document.querySelectorAll("img")) {
+        internals.installImageOverlay(image, [
+            {
+                topLeft : new DOMPointReadOnly(0, 0),
+                topRight : new DOMPointReadOnly(1, 0),
+                bottomRight : new DOMPointReadOnly(1, 1),
+                bottomLeft : new DOMPointReadOnly(0, 1),
+                children: [
+                    {
+                        text : "Hello",
+                        topLeft : new DOMPointReadOnly(0, 0),
+                        topRight : new DOMPointReadOnly(1, 0),
+                        bottomRight : new DOMPointReadOnly(1, 1),
+                        bottomLeft : new DOMPointReadOnly(0, 1),
+                    }
+                ],
+            }
+        ]);
+    }
+
+    shouldBeEqualToString("getComputedStyle(overlayText(plain)).webkitUserSelect", "all");
+    shouldBeEqualToString("getComputedStyle(overlayText(unselectable)).webkitUserSelect", "none");
+
+    shouldBeEqualToString("getComputedStyle(overlayText(inInert)).webkitUserSelect", "all");
+    getSelection().selectAllChildren(overlayText(inInert));
+    shouldBeEqualToString("getSelection().toString()", "");
+
+    plain.style.webkitUserSelect = "none";
+    shouldBeEqualToString("getComputedStyle(overlayText(plain)).webkitUserSelect", "none");
+    plain.style.webkitUserSelect = "text";
+    shouldBeEqualToString("getComputedStyle(overlayText(plain)).webkitUserSelect", "all");
+
+    getSelection().removeAllRanges();
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -553,6 +553,11 @@
             "status": "non-standard",
             "user-agent-part": true
         },
+        "-internal-image-overlay-text": {
+            "conditional": "ENABLE(IMAGE_ANALYSIS)",
+            "status": "non-standard",
+            "user-agent-part": true
+        },
         "file-selector-button": {
             "aliases": [
                 "-webkit-file-upload-button"

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -62,6 +62,7 @@
 #include "TextIterator.h"
 #include "TextRecognitionResult.h"
 #include "TreeScopeInlines.h"
+#include "UserAgentParts.h"
 #include "UserAgentStyleSheets.h"
 #include "VisibleSelection.h"
 #include <numeric>
@@ -404,6 +405,7 @@ static Elements updateSubtree(HTMLElement& element, const TextRecognitionResult&
                 auto& child = line.children[childIndex];
                 Ref textContainer = HTMLDivElement::create(document.get());
                 protect(textContainer)->classList().add(imageOverlayTextClass());
+                protect(textContainer)->setUserAgentPart(UserAgentParts::internalImageOverlayText());
                 lineContainer->appendChild(textContainer);
                 textContainer->appendChild(Text::create(document.get(), child.hasLeadingWhitespace ? makeString('\n', child.text) : String { child.text }));
                 lineElements.children.append(WTF::move(textContainer));
@@ -507,11 +509,6 @@ void updateWithTextRecognitionResult(HTMLElement& element, const TextRecognition
         renderer->setHasImageOverlay();
     }
 
-    bool applyUserSelectAll = [&] {
-        auto* renderer = dynamicDowncast<RenderImage>(element.renderer());
-        return document->isImageDocument() || (renderer && renderer->style().userSelect() != UserSelect::None);
-    }();
-
     for (size_t lineIndex = 0; lineIndex < result.lines.size(); ++lineIndex) {
         auto& lineElements = elements.lines[lineIndex];
         auto& lineContainer = lineElements.line;
@@ -584,8 +581,6 @@ void updateWithTextRecognitionResult(HTMLElement& element, const TextRecognition
                 (targetSize.height() - sizeBeforeTransform.height()) / 2, "px) "_s,
                 "scale("_s, targetSize.width() / sizeBeforeTransform.width(), ", "_s, targetSize.height() / sizeBeforeTransform.height(), ") "_s
             ));
-
-            textContainer->setInlineStyleProperty(CSSPropertyWebkitUserSelect, applyUserSelectAll ? CSSValueAll : CSSValueNone);
 
             if (line.isVertical)
                 textContainer->setInlineStyleProperty(CSSPropertyWritingMode, CSSValueVerticalRl);

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -635,6 +635,20 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
         if (m_document->settings().detailsAutoExpandEnabled() && m_element->isInUserAgentShadowTree() && m_element->userAgentPart() == UserAgentParts::detailsContent())
             style.setAutoRevealsWhenFound();
 
+#if ENABLE(IMAGE_ANALYSIS)
+        // Don't allow selecting individual glyphs on text recognized inside an image:
+        if (m_element->isInUserAgentShadowTree() && m_element->userAgentPart() == UserAgentParts::internalImageOverlayText()) {
+            switch (style.userSelect()) {
+            case UserSelect::All:
+            case UserSelect::None:
+                break;
+            case UserSelect::Text:
+                style.setUserSelect(UserSelect::All);
+                break;
+            }
+        }
+#endif
+
         if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(element); htmlElement && htmlElement->isHiddenUntilFound())
             style.setAutoRevealsWhenFound();
     }


### PR DESCRIPTION
#### 2de88792d97aa8e4f13a2e76e9613142875035dc
<pre>
ImageOverlay text style should be set by the style adjuster and never be editable
<a href="https://bugs.webkit.org/show_bug.cgi?id=321055">https://bugs.webkit.org/show_bug.cgi?id=321055</a>
<a href="https://rdar.apple.com/184083714">rdar://184083714</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

We now apply the user-select override logic for recognized text overlay
in Adjuster::adjust() instead of baking it in
ImageOverlay::updateWithTextRecognitionResult(). This ensures it gets
recalculated if the shadow host&apos;s value is modified after the overlay is
built.

To recognize the appropriate elements to adjust, these were tagged with
a new user-agent-part, `-internal-image-overlay-text`. This also had
the (desirable) side-effect of ensuring that the overlaid text isn&apos;t
made editable due to a contenteditable shadow host (see the preexisting
!element-&gt;userAgentPart().isNull() check in the adjuster).

New tests:
 * fast/images/text-recognition/image-overlay-text-is-not-editable.html
 * fast/images/text-recognition/image-overlay-user-select.html

* LayoutTests/fast/images/text-recognition/image-overlay-text-is-not-editable-expected.txt: Added.
* LayoutTests/fast/images/text-recognition/image-overlay-text-is-not-editable.html: Added.
* LayoutTests/fast/images/text-recognition/image-overlay-user-select-expected.txt: Added.
* LayoutTests/fast/images/text-recognition/image-overlay-user-select.html: Added.
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateSubtree):
(WebCore::ImageOverlay::updateWithTextRecognitionResult):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):

Canonical link: <a href="https://commits.webkit.org/318677@main">https://commits.webkit.org/318677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9e1feb9ce3045823b1604205d9fe5612aa1986c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188759 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/601c194a-22b0-4a7a-a410-716e92f53717) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139519 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a1fc082-1368-4195-9ccc-a91b34fddb3b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119965 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a79006f0-1cdd-4428-86af-2dae12876b48) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41778 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40126 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39773 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/66 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190979 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148733 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39929 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53219 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148485 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43181 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125489 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120224 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51737 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14751 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51122 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51363 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51183 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->