### PR TITLE
[GFC] Distribute extra space into non-affected tracks.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -489,9 +489,7 @@ static void distributeExtraSpace(ExtraSpaceDistributionTarget spaceDistributionT
     ASSERT(accommodatedItemsIndexes.size() == sizeContributions.size());
 
     // 1. Maintain separately for each affected track a planned increase, initially set to 0. The
-    // vector is keyed by track index (sized to all tracks); non-affected slots stay unused.
-    // Note that tracks beyond affectedTrackIndexes may be resized in step 2.3,
-    // where space is distributed to non-affected tracks.
+    // vector is keyed by track index.
     Vector<LayoutUnit> plannedIncreases(unsizedTracks.size());
 
     // 2. For each accommodated item...
@@ -499,13 +497,15 @@ static void distributeExtraSpace(ExtraSpaceDistributionTarget spaceDistributionT
         // considering only tracks the item spans:
         auto itemSpan = gridItemSpanList[gridItemIndex];
 
-        ASSERT(itemSpan.distance() == 1);
-
-        // Gather the affected tracks the item spans; they receive space up to their limits.
+        // Partition the spanned tracks into the affected tracks, which receive space in 2.2, and
+        // the non-affected tracks, which never receive space but reduce spaceToDistribute in 2.3.
         Vector<size_t> spannedAffectedTracks;
+        Vector<size_t> spannedNonAffectedTracks;
         for (size_t trackIndex = itemSpan.begin(); trackIndex < itemSpan.end(); ++trackIndex) {
             if (affectedTracksIndexes.contains(trackIndex))
                 spannedAffectedTracks.append(trackIndex);
+            else
+                spannedNonAffectedTracks.append(trackIndex);
         }
 
         // https://drafts.csswg.org/css-grid-1/#extra-space
@@ -529,19 +529,26 @@ static void distributeExtraSpace(ExtraSpaceDistributionTarget spaceDistributionT
         Vector<LayoutUnit> itemIncurredIncreases(unsizedTracks.size());
         distributeSpaceEquallyAmongTracks(spaceToDistribute, spannedAffectedTracks, unsizedTracks, itemIncurredIncreases, spaceDistributionTarget, SpaceDistributionLimit::UpToGrowthLimit);
 
-        // 2.3. Distribute space to non-affected tracks: if extra space remains and the item spans
-        // both affected and non-affected tracks, distribute it into the non-affected tracks.
-        auto distributeSpaceToNonAffectedTracks = [] {
-            notImplemented();
-        };
-        UNUSED_VARIABLE(distributeSpaceToNonAffectedTracks);
+        // https://drafts.csswg.org/css-grid-1/#extra-space
+        // 2.3. "Distribute space to non-affected tracks: If extra space remains at this point, and
+        // the item spans both affected tracks and non-affected tracks, distribute space as for the
+        // previous step, but into the non-affected tracks instead."
+        if (spaceToDistribute > 0 && !spannedAffectedTracks.isEmpty() && !spannedNonAffectedTracks.isEmpty()) {
+            // These tracks are not affected, so we don't need to track their item-incurred increases for later.
+            // The purpose of this step is to reduce spaceToDistribute, so we can just use a throwaway vector.
+            Vector<LayoutUnit> unappliedIncreases(unsizedTracks.size());
+            // In step 2.1. we subtracted the size of non-affected tracks from the item's size contribution.
+            // In this step, we are subtracting extra space up to the growth limit of the non-affected tracks.
+            distributeSpaceEquallyAmongTracks(spaceToDistribute, spannedNonAffectedTracks, unsizedTracks, unappliedIncreases, spaceDistributionTarget, SpaceDistributionLimit::UpToGrowthLimit);
+        }
 
         // 2.4. Distribute space beyond limits: if extra space still remains, unfreeze and continue
         // distributing it to the item-incurred increases.
         auto distributeSpaceBeyondLimits = [] {
             notImplemented();
         };
-        UNUSED_VARIABLE(distributeSpaceBeyondLimits);
+        if (spaceToDistribute > 0)
+            distributeSpaceBeyondLimits();
 
         // 2.5. For each affected track, if its item-incurred increase is larger than its planned
         // increase, set the planned increase to that value.


### PR DESCRIPTION
#### 6562831a90c9390fdafa623c095d634c5a5885bb
<pre>
[GFC] Distribute extra space into non-affected tracks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=321053">https://bugs.webkit.org/show_bug.cgi?id=321053</a>
&lt;<a href="https://rdar.apple.com/184082252">rdar://184082252</a>&gt;

Reviewed by Alan Baradlay.

This PR distributes space to non-affected tracks per CSS Grid §11.5.1, step 2.3.

<a href="https://drafts.csswg.org/css-grid-1/#extra-space">https://drafts.csswg.org/css-grid-1/#extra-space</a>

Step 2.1 subtracts the affected size of spanned tracks from the item&apos;s contribution.
Step 2.2 distributes extra space into affected tracks up to their limits.
Step 2.3 subtracts the extra space non-affected tracks can contribute when sized to their limit.

The increases it computes are discarded, as the step&apos;s only purpose is to decrease
spaceToDistribute for step 2.4. This is because only affected tracks receive
a planned increase in step 2.5.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::distributeExtraSpace):

Canonical link: <a href="https://commits.webkit.org/318647@main">https://commits.webkit.org/318647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13bda2ac2fdf80152253bc5366f28b35a361efa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188424 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0d370ee-16d1-4cb7-9421-f7115965eede) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139421 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1251dc19-f6c4-41f9-9421-19c028ec6eb5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160149 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119875 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/625c8c54-624a-4c4c-b55f-59df9d4bb418) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41655 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40007 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39649 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190852 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52416 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148604 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53096 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148371 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27155 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43070 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125363 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120027 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51614 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14628 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50999 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51239 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51061 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->