### PR TITLE
[JSC] Fix memory.init's overflow check

### DIFF
--- a/JSTests/wasm/stress/memory64-bulk-memory.js
+++ b/JSTests/wasm/stress/memory64-bulk-memory.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-import { instantiate } from "../wabt-wrapper.js";
+import { compile, instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 
 let wat = `
@@ -129,3 +129,43 @@ function testI32CopyOOB() {
 
 for (let i = 0; i < wasmTestLoopCount; i++)
     testI32CopyOOB();
+
+// memory.init is typed [at i32 i32]: only the destination takes the memory's address type. The
+// source offset and length index into a data segment, and a segment's size is capped at 32 bits by
+// the module encoding, so they stay i32 no matter how wide the memory is. Contrast memory.fill and
+// memory.copy above, whose lengths are memory lengths and so do widen to i64.
+async function testInitOperandTypes() {
+    const validationError = (detail) =>
+        `WebAssembly.Module doesn't validate: memory.init ${detail}, in function at index 0`;
+
+    await compile(`
+    (module (memory i64 1) (data "hello")
+        (func (memory.init 0 (i64.const 0) (i32.const 0) (i32.const 5))))
+    `, { memory64: true });
+
+    await assert.throwsAsync(compile(`
+    (module (memory i64 1) (data "hello")
+        (func (memory.init 0 (i64.const 0) (i64.const 0) (i32.const 5))))
+    `, { memory64: true }), WebAssembly.CompileError,
+        validationError("src address to type I64 expected I32"));
+
+    await assert.throwsAsync(compile(`
+    (module (memory i64 1) (data "hello")
+        (func (memory.init 0 (i64.const 0) (i32.const 0) (i64.const 5))))
+    `, { memory64: true }), WebAssembly.CompileError,
+        validationError("length to type I64 expected I32"));
+
+    await assert.throwsAsync(compile(`
+    (module (memory i64 1) (data "hello")
+        (func (memory.init 0 (i32.const 0) (i32.const 0) (i32.const 5))))
+    `, { memory64: true }), WebAssembly.CompileError,
+        validationError("dst address to type I32 expected I64"));
+
+    await assert.throwsAsync(compile(`
+    (module (memory 1) (data "hello")
+        (func (memory.init 0 (i64.const 0) (i32.const 0) (i32.const 5))))
+    `, { memory64: true }), WebAssembly.CompileError,
+        validationError("dst address to type I64 expected I32"));
+}
+
+await testInitOperandTypes();

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -385,51 +385,9 @@ Expected<PageCount, GrowFailReason> Memory::grow(VM& vm, PageCount delta)
     return oldPageCount;
 }
 
-bool Memory::fill(uint64_t offset, uint8_t targetValue, uint64_t count)
-{
-    bool offsetAndCountOverflows = addressType().is64Bit()
-        ? sumOverflows<uint64_t>(offset, count)
-        : sumOverflows<uint32_t>(offset, count);
-
-    if (offsetAndCountOverflows)
-        return false;
-
-    if (offset + count > m_handle->size())
-        return false;
-
-    memset(static_cast<uint8_t*>(basePointer()) + offset, targetValue, count);
-    return true;
-}
-
-bool Memory::copy(uint64_t dstAddress, uint64_t srcAddress, uint64_t count)
-{
-    bool dstAndCountOverflows = addressType().is64Bit()
-        ? sumOverflows<uint64_t>(dstAddress, count)
-        : sumOverflows<uint32_t>(dstAddress, count);
-    bool srcAndCountOverflows = addressType().is64Bit()
-        ? sumOverflows<uint64_t>(srcAddress, count)
-        : sumOverflows<uint32_t>(srcAddress, count);
-    if (dstAndCountOverflows || srcAndCountOverflows)
-        return false;
-
-    const uint64_t lastDstAddress = dstAddress + count;
-    const uint64_t lastSrcAddress = srcAddress + count;
-
-    if (lastDstAddress > size() || lastSrcAddress > size())
-        return false;
-
-    if (!count)
-        return true;
-
-    uint8_t* base = static_cast<uint8_t*>(basePointer());
-    // Source and destination areas might overlap, so using memmove.
-    memmove(base + dstAddress, base + srcAddress, count);
-    return true;
-}
-
 bool Memory::init(uint64_t offset, const uint8_t* data, uint32_t length)
 {
-    if (sumOverflows<uint32_t>(offset, length))
+    if (sumOverflows<uint64_t>(offset, length))
         return false;
 
     if (offset + length > m_handle->size())

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -88,8 +88,6 @@ public:
     MemoryMode mode() const { return m_handle->mode(); }
 
     Expected<PageCount, GrowFailReason> grow(VM&, PageCount);
-    bool fill(uint64_t, uint8_t, uint64_t);
-    bool copy(uint64_t, uint64_t, uint64_t);
     bool init(uint64_t, const uint8_t*, uint32_t);
 
     void registerInstance(JSWebAssemblyInstance&);


### PR DESCRIPTION
#### de45b9be42db063e9d045f47c8d2a7628e5429df
<pre>
[JSC] Fix memory.init&apos;s overflow check
<a href="https://bugs.webkit.org/show_bug.cgi?id=321056">https://bugs.webkit.org/show_bug.cgi?id=321056</a>
<a href="https://rdar.apple.com/184086611">rdar://184086611</a>

Reviewed by Dan Hecht.

Memory::init&apos;s overflow check is using uint32_t, but it is not correct
as memory64 is introduced. We use uint64_t instead. Also we drop dead
Memory::fill / Memory::copy implementations. Use Wasm::memoryCopy /
Wasm::memoryFill.

* JSTests/wasm/stress/memory64-bulk-memory.js:
(async testInitOperandTypes):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::init):
(JSC::Wasm::Memory::fill): Deleted.
(JSC::Wasm::Memory::copy): Deleted.
* Source/JavaScriptCore/wasm/WasmMemory.h:

Canonical link: <a href="https://commits.webkit.org/318617@main">https://commits.webkit.org/318617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/187609c612203be5a94d4ee6e82960fa3a1e5fcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188421 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7f6e3b48-ea82-4412-a210-d7a91e3e7d30) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139422 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/424ed4e0-1bee-410c-ad5b-4a34b669850b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119876 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/881be813-900e-44ed-9336-07da11b9cf5a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41656 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40002 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1846 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8640 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39652 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40078 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45344 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190849 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/178208 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52413 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148601 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53093 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148368 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27132 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43067 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125360 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120022 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51611 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14631 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50996 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51236 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51058 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->