### PR TITLE
AudioWorkletNode processorerror event lacks filename, lineno and colno

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-onerror.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-onerror.https.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 let context = null;
+const ERROR_PROCESSOR_FILENAME = 'processors/error-processor.js';
 
 promise_setup(async () => {
   const sampleRate = 48000;
@@ -11,13 +12,13 @@ promise_setup(async () => {
   context = new OfflineAudioContext(1, renderLength, sampleRate);
 
   // Loads all processor definitions that are necessary for tests in this file.
-  await context.audioWorklet.addModule('./processors/error-processor.js');
+  await context.audioWorklet.addModule('./' + ERROR_PROCESSOR_FILENAME);
 });
 
 promise_test(async () => {
   const constructorErrorWorkletNode =
       new AudioWorkletNode(context, 'constructor-error');
-  let error = await new Promise(resolve => {
+  const error = await new Promise((resolve) => {
     constructorErrorWorkletNode.onprocessorerror = (e) => resolve(e);
   });
   assert_true(error instanceof ErrorEvent,
@@ -29,12 +30,12 @@ promise_test(async () => {
 promise_test(async () => {
   // An arbitrary Blob for testing. This is not deserializable on
   // AudioWorkletGlobalScope.
-  const blob = new Blob([JSON.stringify({ hello: "world"}, null, 2)], {
-    type: "application/json",
+  const blob = new Blob([JSON.stringify({hello: 'world'}, null, 2)], {
+    type: 'application/json',
   });
   const emptyErrorWorkletNode =
       new AudioWorkletNode(context, 'empty-error', {processorOptions: {blob}});
-  let error = await new Promise(resolve => {
+  const error = await new Promise((resolve) => {
     emptyErrorWorkletNode.onprocessorerror = (e) => resolve(e);
   });
   assert_true(error instanceof ErrorEvent,
@@ -46,7 +47,7 @@ promise_test(async () => {
 promise_test(async () => {
   const processErrorWorkletNode =
       new AudioWorkletNode(context, 'process-error');
-  let error = await new Promise(resolve => {
+  const error = await new Promise((resolve) => {
     processErrorWorkletNode.onprocessorerror = (e) => resolve(e);
     // Need to start render to cause an exception in process().
     context.startRendering();
@@ -54,5 +55,9 @@ promise_test(async () => {
   assert_true(error instanceof ErrorEvent,
       'onprocessorerror argument should be an ErrorEvent when the ' +
       'process method of the AudioWorkletProcessor has an error.');
+  assert_greater_than(error.lineno, 0, 'Error line number should be set');
+  assert_greater_than(error.colno, 0, 'Error column number should be set');
+  assert_true(error.filename.endsWith(ERROR_PROCESSOR_FILENAME),
+      'Error filename should end with ' + ERROR_PROCESSOR_FILENAME);
 }, 'Test if |onprocessorerror| is called upon failure of process() method.');
 </script>

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -48,6 +48,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "ErrorEvent.h"
 #include "EventNames.h"
+#include "ExceptionDetails.h"
 #include "JSAudioWorkletNodeOptions.h"
 #include "JSDOMGlobalObject.h"
 #include "MessageChannel.h"
@@ -239,7 +240,7 @@ void AudioWorkletNode::process(size_t framesToProcess)
     // Once process() has returned false and the node no longer has any active inputs, the processor
     // is done and we stop calling process().
     if (!m_isActiveSource && !hasActiveInputs) {
-        didFinishProcessingOnRenderingThread(false);
+        didFinishProcessingOnRenderingThread(std::nullopt);
         zeroOutput();
         return;
     }
@@ -268,16 +269,16 @@ void AudioWorkletNode::process(size_t framesToProcess)
             std::ranges::fill(paramValues->span().first(framesToProcess), audioParam->finalValue());
     }
 
-    bool threwException = false;
-    m_isActiveSource = m_processor->process(m_inputs, m_outputs, m_paramValuesMap, threwException);
-    if ((!m_isActiveSource && !hasActiveInputs) || threwException)
-        didFinishProcessingOnRenderingThread(threwException);
+    std::optional<ExceptionDetails> exceptionDetails;
+    m_isActiveSource = m_processor->process(m_inputs, m_outputs, m_paramValuesMap, exceptionDetails);
+    if ((!m_isActiveSource && !hasActiveInputs) || exceptionDetails)
+        didFinishProcessingOnRenderingThread(WTF::move(exceptionDetails));
 }
 
-void AudioWorkletNode::didFinishProcessingOnRenderingThread(bool threwException)
+void AudioWorkletNode::didFinishProcessingOnRenderingThread(std::optional<ExceptionDetails>&& exceptionDetails)
 {
-    if (threwException)
-        fireProcessorErrorOnMainThread(ProcessorError::ProcessError);
+    if (exceptionDetails)
+        fireProcessorErrorOnMainThread(ProcessorError::ProcessError, WTF::move(exceptionDetails));
 
     m_processor = nullptr;
     m_tailTime = 0;
@@ -326,14 +327,17 @@ void AudioWorkletNode::checkNumberOfChannelsForInput(AudioNodeInput* input)
     updatePullStatus();
 }
 
-void AudioWorkletNode::fireProcessorErrorOnMainThread(ProcessorError error)
+void AudioWorkletNode::fireProcessorErrorOnMainThread(ProcessorError error, std::optional<ExceptionDetails>&& exceptionDetails)
 {
     ASSERT(!isMainThread());
 
     // Heap allocations are forbidden on the audio thread for performance reasons so we need to
     // explicitly allow the following allocation(s).
     DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
-    callOnMainThread([this, protectedThis = Ref { *this }, error]() mutable {
+    String sourceURL = exceptionDetails ? exceptionDetails->sourceURL.isolatedCopy() : String { };
+    unsigned lineNumber = exceptionDetails ? exceptionDetails->lineNumber : 0;
+    unsigned columnNumber = exceptionDetails ? exceptionDetails->columnNumber : 0;
+    callOnMainThread([this, protectedThis = Ref { *this }, error, sourceURL = WTF::move(sourceURL), lineNumber, columnNumber]() mutable {
         String errorMessage;
         switch (error) {
         case ProcessorError::ConstructorError:
@@ -343,7 +347,7 @@ void AudioWorkletNode::fireProcessorErrorOnMainThread(ProcessorError error)
             errorMessage = "An error was thrown from AudioWorkletProcessor::process() method"_s;
             break;
         }
-        queueTaskToDispatchEvent(*this, TaskSource::MediaElement, ErrorEvent::create(eventNames().processorerrorEvent, errorMessage, { }, 0, 0));
+        queueTaskToDispatchEvent(*this, TaskSource::MediaElement, ErrorEvent::create(eventNames().processorerrorEvent, errorMessage, sourceURL, lineNumber, columnNumber));
     });
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
@@ -32,6 +32,8 @@
 
 #include "ActiveDOMObject.h"
 #include "AudioNode.h"
+#include "ExceptionDetails.h"
+#include <optional>
 #include <wtf/Lock.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/ThreadAssertions.h>
@@ -77,8 +79,8 @@ private:
     AudioWorkletNode(BaseAudioContext&, const String& name, AudioWorkletNodeOptions&&, Ref<MessagePort>&&);
 
     enum class ProcessorError { ConstructorError, ProcessError };
-    void fireProcessorErrorOnMainThread(ProcessorError);
-    void didFinishProcessingOnRenderingThread(bool threwException);
+    void fireProcessorErrorOnMainThread(ProcessorError, std::optional<ExceptionDetails>&& = std::nullopt);
+    void didFinishProcessingOnRenderingThread(std::optional<ExceptionDetails>&&);
 
     // AudioNode.
     void process(size_t framesToProcess) final;

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -35,6 +35,7 @@
 #include "AudioChannel.h"
 #include "AudioWorkletGlobalScope.h"
 #include "AudioWorkletProcessorConstructionData.h"
+#include "ExceptionDetails.h"
 #include "JSCallbackData.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSValueInWrappedObjectInlines.h"
@@ -298,7 +299,7 @@ void AudioWorkletProcessor::buildJSArguments(VM& vm, JSGlobalObject& globalObjec
     args.append(m_jsParamValues.getValue());
 }
 
-bool AudioWorkletProcessor::process(const Vector<RefPtr<AudioBus>>& inputs, Vector<Ref<AudioBus>>& outputs, const MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap, bool& threwException)
+bool AudioWorkletProcessor::process(const Vector<RefPtr<AudioBus>>& inputs, Vector<Ref<AudioBus>>& outputs, const MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap, std::optional<ExceptionDetails>& exceptionDetails)
 {
     // Heap allocations are forbidden on the audio thread for performance reasons so we need to
     // explicitly allow the following allocation(s).
@@ -320,16 +321,16 @@ bool AudioWorkletProcessor::process(const Vector<RefPtr<AudioBus>>& inputs, Vect
     buildJSArguments(vm, *globalObject, args, inputs, outputs, paramValuesMap);
     ASSERT(!args.hasOverflowed());
     if (scope.exception()) [[unlikely]] {
-        reportException(globalObject, scope.exception());
-        threwException = true;
+        exceptionDetails.emplace();
+        reportException(globalObject, scope.exception(), nullptr, false, &*exceptionDetails);
         return false;
     }
 
     NakedPtr<JSC::Exception> returnedException;
     auto result = JSCallbackData::invokeCallback(*globalObject, wrapper(), jsUndefined(), args, JSCallbackData::CallbackType::Object, Identifier::fromString(vm, "process"_s), returnedException);
     if (returnedException) {
-        reportException(globalObject, returnedException);
-        threwException = true;
+        exceptionDetails.emplace();
+        reportException(globalObject, returnedException, nullptr, false, &*exceptionDetails);
         return false;
     }
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.h
@@ -32,6 +32,7 @@
 #include "AudioArray.h"
 #include "JSValueInWrappedObject.h"
 #include "ScriptWrappable.h"
+#include <optional>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RobinHoodHashMap.h>
@@ -55,6 +56,8 @@ class ScriptExecutionContext;
 class WebCoreOpaqueRoot;
 template<typename> class ExceptionOr;
 
+struct ExceptionDetails;
+
 class AudioWorkletProcessor : public ScriptWrappable, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AudioWorkletProcessor> {
     WTF_MAKE_TZONE_ALLOCATED(AudioWorkletProcessor);
 public:
@@ -64,7 +67,7 @@ public:
     const String& name() const LIFETIME_BOUND { return m_name; }
     MessagePort& port() LIFETIME_BOUND { return m_port.get(); }
 
-    bool process(const Vector<RefPtr<AudioBus>>& inputs, Vector<Ref<AudioBus>>& outputs, const MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap, bool& threwException);
+    bool process(const Vector<RefPtr<AudioBus>>& inputs, Vector<Ref<AudioBus>>& outputs, const MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap, std::optional<ExceptionDetails>&);
 
     JSValueInWrappedObject& jsInputsWrapper() LIFETIME_BOUND { return m_jsInputs; }
     JSValueInWrappedObject& jsOutputsWrapper() LIFETIME_BOUND { return m_jsOutputs; }


### PR DESCRIPTION
#### 8577db2c85c6968809fd0e7375ec26ba32cf6279
<pre>
AudioWorkletNode processorerror event lacks filename, lineno and colno
<a href="https://bugs.webkit.org/show_bug.cgi?id=321057">https://bugs.webkit.org/show_bug.cgi?id=321057</a>

Reviewed by Darin Adler.

When an exception was thrown from an AudioWorkletProcessor&apos;s process()
method, the ErrorEvent dispatched to onprocessorerror was always created
with an empty filename and 0 for lineno / colno, even though the actual
exception location was readily available. Chrome and Firefox populate
these fields from the thrown exception.

Capture the exception&apos;s location via the ExceptionDetails out-param that
reportException() already fills in, and thread it from the rendering
thread through to the dispatched ErrorEvent so that filename, lineno and
colno reflect the real error site.

No new tests, rebaselined WPT test to gain test coverage.

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-onerror.https.html:
Rebaseline WPT test to gain test coverage. Without this fix, the last
subtest was failing in WebKit (but passing in Chrome / Firefox).

* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::process):
(WebCore::AudioWorkletNode::didFinishProcessingOnRenderingThread):
(WebCore::AudioWorkletNode::fireProcessorErrorOnMainThread):
* Source/WebCore/Modules/webaudio/AudioWorkletNode.h:
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp:
(WebCore::AudioWorkletProcessor::process):
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.h:

Canonical link: <a href="https://commits.webkit.org/318705@main">https://commits.webkit.org/318705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6261368f64a900af9df7144696f3efc7c8c0822c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188940 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139675 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e564bce-e5ee-4215-851f-f13553ca5ef4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120122 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86416f4f-7d3f-4814-b104-17e84885a3c5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39934 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/248 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45656 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191160 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148906 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39945 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53400 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148652 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43340 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125671 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120485 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51918 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14912 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51303 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51544 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51364 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->