### PR TITLE
MediaStreamAudioSourceNode captures the wrong track and keeps playing after the track ends

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -541,7 +541,6 @@ imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening
 imported/w3c/web-platform-tests/html/webappapis/scripting/event-loops/fully_active_document.window.html [ Skip ]
 
 # Skip WPT webaudio tests that are timing out.
-imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediastreamaudiosourcenode-interface/mediastreamaudiosourcenode-routing.html [ Skip ]
 webkit.org/b/280303  imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-sinkid-state-change.https.html [ Skip ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/setSinkId-with-MediaElementAudioSourceNode.https.html [ Skip ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-suspend-resume-close.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediastreamaudiosourcenode-interface/mediastreamaudiosourcenode-routing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediastreamaudiosourcenode-interface/mediastreamaudiosourcenode-routing-expected.txt
@@ -1,0 +1,3 @@
+
+PASS MediaStreamAudioSourceNode captures the right track.
+

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp
@@ -36,8 +36,10 @@
 #include "Logging.h"
 #include "MediaStreamAudioSourceOptions.h"
 #include "WebAudioSourceProvider.h"
+#include <algorithm>
 #include <wtf/Locker.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/StringView.h>
 
 namespace WebCore {
 
@@ -51,12 +53,13 @@ ExceptionOr<Ref<MediaStreamAudioSourceNode>> MediaStreamAudioSourceNode::create(
     if (audioTracks.isEmpty())
         return Exception { ExceptionCode::InvalidStateError, "Media stream has no audio tracks"_s };
 
-    RefPtr<WebAudioSourceProvider> provider;
-    for (auto& track : audioTracks) {
-        provider = track->createAudioSourceProvider();
-        if (provider)
-            break;
-    }
+    // https://webaudio.github.io/web-audio-api/#mediastreamaudiosourcenode: the input track is the
+    // first track in the media stream after sorting the audio tracks by their id using a code unit ordering.
+    Ref inputTrack = *std::min_element(audioTracks.begin(), audioTracks.end(), [](auto& a, auto& b) {
+        return codePointCompareLessThan(a->id(), b->id());
+    });
+
+    RefPtr provider = inputTrack->createAudioSourceProvider();
     if (!provider)
         return Exception { ExceptionCode::InvalidStateError, "Could not find an audio track with an audio source provider"_s };
 

--- a/Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.cpp
@@ -104,8 +104,19 @@ void MediaStreamTrackAudioSourceProviderCocoa::trackEnabledChanged(MediaStreamTr
     m_enabled = track.enabled();
 }
 
+void MediaStreamTrackAudioSourceProviderCocoa::trackEnded(MediaStreamTrackPrivate&)
+{
+    // Once the captured track has ended, the node must output silence.
+    m_ended = true;
+}
+
 void MediaStreamTrackAudioSourceProviderCocoa::provideInput(AudioBus& bus, size_t framesToProcess)
 {
+    if (m_ended) {
+        bus.zero();
+        return;
+    }
+
     if (!m_lock.tryLock()) {
         bus.zero();
         return;

--- a/Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.h
@@ -85,7 +85,7 @@ private:
 #endif
 
     // MediaStreamTrackPrivateObserver
-    void trackEnded(MediaStreamTrackPrivate&) final { }
+    void trackEnded(MediaStreamTrackPrivate&) final;
     void trackMutedChanged(MediaStreamTrackPrivate&) final { }
     void trackSettingsChanged(MediaStreamTrackPrivate&) final { }
     void trackEnabledChanged(MediaStreamTrackPrivate&) final;
@@ -107,6 +107,7 @@ private:
     WeakPtr<MediaStreamTrackPrivate> m_captureSource;
     const Ref<RealtimeMediaSource> m_source;
     bool m_enabled { true };
+    bool m_ended { false };
     bool m_connected { false };
 };
 


### PR DESCRIPTION
#### c8cef76f94bc80b9d5d50e17a2074e80fbb1366d
<pre>
MediaStreamAudioSourceNode captures the wrong track and keeps playing after the track ends
<a href="https://bugs.webkit.org/show_bug.cgi?id=321059">https://bugs.webkit.org/show_bug.cgi?id=321059</a>

Reviewed by Darin Adler.

The imported WPT test mediastreamaudiosourcenode-routing.html was timing
out. Two separate bugs were responsible:

  1. Track selection did not follow the spec. Per the MediaStreamAudioSourceNode
     constructor algorithm [1], the input track is the first audio track after
     sorting the tracks by their id using a code unit ordering. We instead picked
     the first track in getAudioTracks() insertion order, so with random track
     ids we captured the wrong track roughly half the time.

  2. Stopping the captured track did not silence the node. The Cocoa audio source
     provider&apos;s trackEnded() override was empty, so once the track ended the
     provider kept pulling samples from the still-running source instead of
     outputting silence.

No new tests, unskipped WPT test that is now passing (used to time out).

[1] <a href="https://webaudio.github.io/web-audio-api/#mediastreamaudiosourcenode">https://webaudio.github.io/web-audio-api/#mediastreamaudiosourcenode</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediastreamaudiosourcenode-interface/mediastreamaudiosourcenode-routing-expected.txt: Added.
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp:
(WebCore::MediaStreamAudioSourceNode::create):
* Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.cpp:
(WebCore::MediaStreamTrackAudioSourceProviderCocoa::trackEnded):
(WebCore::MediaStreamTrackAudioSourceProviderCocoa::provideInput):
* Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.h:

Canonical link: <a href="https://commits.webkit.org/318706@main">https://commits.webkit.org/318706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8139746abb85a244692ba9dc10a09fe2bcc3a1ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188908 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd0fe253-cb9e-4ada-98bd-570a69842163) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139651 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f872db60-2eee-4832-b298-c2e8b1044690) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120097 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/501e1b50-f180-4f97-8d12-9bdb9e05dda1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41917 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40261 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39908 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/215 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191128 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39946 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53368 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148629 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43320 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125639 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120453 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51886 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14887 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51271 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51512 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51332 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->