### PR TITLE
[Site Isolation] Some website policies applied to main frame navigations don't apply to cross site iframes

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1943,6 +1943,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/TextResourceDecoder.h
     loader/ThreadableLoader.h
     loader/ThreadableLoaderClient.h
+    loader/WebsitePolicies.h
     loader/archive/Archive.h
     loader/archive/ArchiveError.h
     loader/archive/ArchiveResource.h

--- a/Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb
@@ -190,6 +190,39 @@ void Settings::disableFeaturesForLockdownMode()
 <%- end -%>
 }
 
+void Settings::applyMainFrameWebsitePolicies(const WebsitePolicySettings& policies)
+{
+#if ENABLE(MEDIA_SOURCE)
+    setMediaSourceEnabled(policies.mediaSourcePolicy == MediaSourcePolicy::Default ? platformDefaultMediaSourceEnabled() : policies.mediaSourcePolicy == MediaSourcePolicy::Enable);
+#endif
+#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
+    if (policies.legacyOverflowScrollingTouchPolicy == LegacyOverflowScrollingTouchPolicy::Disable)
+        setLegacyOverflowScrollingTouchEnabled(false);
+#endif
+#if ENABLE(TEXT_AUTOSIZING)
+    setIdempotentModeAutosizingOnlyHonorsPercentages(policies.idempotentModeAutosizingOnlyHonorsPercentages);
+#endif
+
+    if (policies.pushAndNotificationsEnabledPolicy != PushAndNotificationsEnabledPolicy::UseGlobalPolicy) {
+        bool enabled = policies.pushAndNotificationsEnabledPolicy == PushAndNotificationsEnabledPolicy::Yes;
+        setPushAPIEnabled(enabled);
+#if ENABLE(NOTIFICATIONS)
+        setNotificationsEnabled(enabled);
+#endif
+#if ENABLE(NOTIFICATION_EVENT)
+        setNotificationEventEnabled(enabled);
+#endif
+#if PLATFORM(IOS)
+        setAppBadgeEnabled(enabled);
+#endif
+    }
+
+    if (policies.inlineMediaPlaybackPolicy != InlineMediaPlaybackPolicy::Default)
+        setInlineMediaPlaybackRequiresPlaysInlineAttribute(policies.inlineMediaPlaybackPolicy == InlineMediaPlaybackPolicy::RequiresPlaysInlineAttribute);
+
+    setGlobalPrivacyControlEnabled(policies.globalPrivacyControlEnabled);
+}
+
 <%- for @condition in @allSettingsSet.conditions do -%>
 <%- if @condition.settingsWithComplexSettersNeedingImplementation.length != 0 -%>
 <%- if @condition.condition -%>

--- a/Source/WebCore/Scripts/SettingsTemplates/Settings.h.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/Settings.h.erb
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <WebCore/SettingsBase.h>
+#include <WebCore/WebsitePolicies.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
@@ -84,6 +85,7 @@ public:
     WEBCORE_EXPORT void disableUnstableFeaturesForModernWebKit();
     WEBCORE_EXPORT static void disableGlobalUnstableFeaturesForModernWebKit();
     WEBCORE_EXPORT void disableFeaturesForLockdownMode();
+    WEBCORE_EXPORT void applyMainFrameWebsitePolicies(const WebsitePolicySettings&);
 
 <%- for @condition in @allSettingsSet.conditions do -%>
 <%- if @condition.condition -%>

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -367,6 +367,7 @@
 		0B90561A0F2578BF0095FF6A /* DocumentThreadableLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9056160F2578BE0095FF6A /* DocumentThreadableLoader.h */; settings = {ATTRIBUTES = (); }; };
 		0B90561B0F2578BF0095FF6A /* ThreadableLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9056170F2578BE0095FF6A /* ThreadableLoader.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0B90561C0F2578BF0095FF6A /* ThreadableLoaderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9056180F2578BE0095FF6A /* ThreadableLoaderClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7B2E4C1D9A3F60518D4E27AC /* WebsitePolicies.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B2E4C1D9A3F60518D4E27AB /* WebsitePolicies.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0B9056F90F2685F30095FF6A /* WorkerThreadableLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9056F70F2685F30095FF6A /* WorkerThreadableLoader.h */; settings = {ATTRIBUTES = (); }; };
 		0BCF83F71059C1EB00D999DD /* MathMLFractionElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BCF83F01059C1EB00D999DD /* MathMLFractionElement.h */; };
 		0BE030A20F3112FB003C1A46 /* RenderLineBoxList.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BE030A10F3112FB003C1A46 /* RenderLineBoxList.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -8253,6 +8254,7 @@
 		0B9056160F2578BE0095FF6A /* DocumentThreadableLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocumentThreadableLoader.h; sourceTree = "<group>"; };
 		0B9056170F2578BE0095FF6A /* ThreadableLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadableLoader.h; sourceTree = "<group>"; };
 		0B9056180F2578BE0095FF6A /* ThreadableLoaderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadableLoaderClient.h; sourceTree = "<group>"; };
+		7B2E4C1D9A3F60518D4E27AB /* WebsitePolicies.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebsitePolicies.h; sourceTree = "<group>"; };
 		0B90561D0F257E930095FF6A /* ThreadableLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadableLoader.cpp; sourceTree = "<group>"; };
 		0B9056F60F2685F30095FF6A /* WorkerThreadableLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WorkerThreadableLoader.cpp; sourceTree = "<group>"; };
 		0B9056F70F2685F30095FF6A /* WorkerThreadableLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorkerThreadableLoader.h; sourceTree = "<group>"; };
@@ -39009,6 +39011,7 @@
 				0B9056170F2578BE0095FF6A /* ThreadableLoader.h */,
 				0B9056180F2578BE0095FF6A /* ThreadableLoaderClient.h */,
 				1A7E3C281710997300367935 /* ThreadableLoaderClientWrapper.h */,
+				7B2E4C1D9A3F60518D4E27AB /* WebsitePolicies.h */,
 				0B9056F60F2685F30095FF6A /* WorkerThreadableLoader.cpp */,
 				0B9056F70F2685F30095FF6A /* WorkerThreadableLoader.h */,
 			);
@@ -50267,6 +50270,7 @@
 				1CAF34810A6C405200ABE06E /* WebScriptObject.h in Headers */,
 				1CAF34830A6C405200ABE06E /* WebScriptObjectPrivate.h in Headers */,
 				1A569D1B0D7E2B82007C3983 /* WebScriptObjectProtocol.h in Headers */,
+				7B2E4C1D9A3F60518D4E27AC /* WebsitePolicies.h in Headers */,
 				97AABD1B14FA09D5007457AE /* WebSocket.h in Headers */,
 				97AABD1F14FA09D5007457AE /* WebSocketChannelClient.h in Headers */,
 				41100C8023F74583001BC33B /* WebSocketChannelInspector.h in Headers */,

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -12095,12 +12095,8 @@ OptionSet<NoiseInjectionPolicy> Document::noiseInjectionPolicies() const
 
 OptionSet<AdvancedPrivacyProtections> Document::advancedPrivacyProtections() const
 {
-    RefPtr mainFrameDocument = this->mainFrameDocument();
-    if (!mainFrameDocument)
-        return { };
-
-    if (auto* loader = mainFrameDocument->loader())
-        return loader->advancedPrivacyProtections();
+    if (RefPtr page = this->page())
+        return page->advancedPrivacyProtections();
 
     return { };
 }

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1506,35 +1506,14 @@ void DocumentLoader::applyPoliciesToSettings()
     if (!m_frame->isMainFrame())
         return;
 
-#if ENABLE(MEDIA_SOURCE)
-    m_frame->settings().setMediaSourceEnabled(m_mediaSourcePolicy == MediaSourcePolicy::Default ? Settings::platformDefaultMediaSourceEnabled() : m_mediaSourcePolicy == MediaSourcePolicy::Enable);
-#endif
-#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-    if (m_legacyOverflowScrollingTouchPolicy == LegacyOverflowScrollingTouchPolicy::Disable)
-        m_frame->settings().setLegacyOverflowScrollingTouchEnabled(false);
-#endif
-#if ENABLE(TEXT_AUTOSIZING)
-    m_frame->settings().setIdempotentModeAutosizingOnlyHonorsPercentages(m_idempotentModeAutosizingOnlyHonorsPercentages);
-#endif
-
-    if (m_pushAndNotificationsEnabledPolicy != PushAndNotificationsEnabledPolicy::UseGlobalPolicy) {
-        bool enabled = m_pushAndNotificationsEnabledPolicy == PushAndNotificationsEnabledPolicy::Yes;
-        m_frame->settings().setPushAPIEnabled(enabled);
-#if ENABLE(NOTIFICATIONS)
-        m_frame->settings().setNotificationsEnabled(enabled);
-#endif
-#if ENABLE(NOTIFICATION_EVENT)
-        m_frame->settings().setNotificationEventEnabled(enabled);
-#endif
-#if PLATFORM(IOS)
-        m_frame->settings().setAppBadgeEnabled(enabled);
-#endif
-    }
-
-    if (m_inlineMediaPlaybackPolicy != InlineMediaPlaybackPolicy::Default)
-        m_frame->settings().setInlineMediaPlaybackRequiresPlaysInlineAttribute(m_inlineMediaPlaybackPolicy == InlineMediaPlaybackPolicy::RequiresPlaysInlineAttribute);
-
-    m_frame->settings().setGlobalPrivacyControlEnabled(m_globalPrivacyControlEnabled);
+    m_frame->settings().applyMainFrameWebsitePolicies({
+        m_mediaSourcePolicy,
+        m_legacyOverflowScrollingTouchPolicy,
+        m_pushAndNotificationsEnabledPolicy,
+        m_inlineMediaPlaybackPolicy,
+        m_globalPrivacyControlEnabled,
+        m_idempotentModeAutosizingOnlyHonorsPercentages
+    });
 }
 
 ColorSchemePreference NODELETE DocumentLoader::colorSchemePreference() const

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -61,6 +61,7 @@
 #include <WebCore/StyleSheetContents.h>
 #include <WebCore/SubstituteData.h>
 #include <WebCore/Timer.h>
+#include <WebCore/WebsitePolicies.h>
 #include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Platform.h>
@@ -126,22 +127,10 @@ enum class MetaViewportPolicy : uint8_t {
     Ignore,
 };
 
-enum class MediaSourcePolicy : uint8_t {
-    Default,
-    Disable,
-    Enable
-};
-
 enum class SimulatedMouseEventsDispatchPolicy : uint8_t {
     Default,
     Allow,
     Deny,
-};
-
-enum class LegacyOverflowScrollingTouchPolicy : uint8_t {
-    Default,
-    Disable,
-    Enable,
 };
 
 enum class MouseEventPolicy : uint8_t {
@@ -152,24 +141,6 @@ enum class MouseEventPolicy : uint8_t {
 };
 
 enum class ModalContainerObservationPolicy : bool { Disabled, Prompt };
-
-enum class ColorSchemePreference : uint8_t {
-    NoPreference,
-    Light,
-    Dark
-};
-
-enum class PushAndNotificationsEnabledPolicy: uint8_t {
-    UseGlobalPolicy,
-    No,
-    Yes,
-};
-
-enum class InlineMediaPlaybackPolicy : uint8_t {
-    Default,
-    RequiresPlaysInlineAttribute,
-    DoesNotRequirePlaysInlineAttribute
-};
 
 enum class ContentExtensionDefaultEnablement : bool { Disabled, Enabled };
 using ContentExtensionEnablement = std::pair<ContentExtensionDefaultEnablement, HashSet<String>>;

--- a/Source/WebCore/loader/WebsitePolicies.h
+++ b/Source/WebCore/loader/WebsitePolicies.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <optional>
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+enum class MediaSourcePolicy : uint8_t {
+    Default,
+    Disable,
+    Enable
+};
+
+enum class LegacyOverflowScrollingTouchPolicy : uint8_t {
+    Default,
+    Disable,
+    Enable,
+};
+
+enum class ColorSchemePreference : uint8_t {
+    NoPreference,
+    Light,
+    Dark
+};
+
+enum class PushAndNotificationsEnabledPolicy: uint8_t {
+    UseGlobalPolicy,
+    No,
+    Yes,
+};
+
+enum class InlineMediaPlaybackPolicy : uint8_t {
+    Default,
+    RequiresPlaysInlineAttribute,
+    DoesNotRequirePlaysInlineAttribute
+};
+
+// Page-wide Settings derived from the main frame's per-navigation website policies.
+// Subframe policies should never take precedence over these.
+struct WebsitePolicySettings {
+    MediaSourcePolicy mediaSourcePolicy { MediaSourcePolicy::Default };
+    LegacyOverflowScrollingTouchPolicy legacyOverflowScrollingTouchPolicy { LegacyOverflowScrollingTouchPolicy::Default };
+    PushAndNotificationsEnabledPolicy pushAndNotificationsEnabledPolicy { PushAndNotificationsEnabledPolicy::UseGlobalPolicy };
+    InlineMediaPlaybackPolicy inlineMediaPlaybackPolicy { InlineMediaPlaybackPolicy::Default };
+    std::optional<bool> globalPrivacyControlEnabled;
+    bool idempotentModeAutosizingOnlyHonorsPercentages { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -61,6 +61,7 @@ struct OwnerPermissionsPolicyData;
 
 enum class AdvancedPrivacyProtections : uint16_t;
 enum class AutoplayPolicy : uint8_t;
+enum class ColorSchemePreference : uint8_t;
 enum class ReferrerPolicy : uint8_t;
 enum class SandboxFlag : uint16_t;
 enum class ScrollbarMode : uint8_t;
@@ -129,6 +130,7 @@ public:
     virtual OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const = 0;
     virtual bool allowPrivacyProxy() const = 0;
     virtual AutoplayPolicy autoplayPolicy() const = 0;
+    virtual ColorSchemePreference colorSchemePreference() const = 0;
 
     virtual void updateSandboxFlags(SandboxFlags, NotifyUIProcess);
     virtual void updateReferrerPolicy(ReferrerPolicy) { }

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1416,6 +1416,13 @@ AutoplayPolicy LocalFrame::autoplayPolicy() const
     return AutoplayPolicy::Default;
 }
 
+ColorSchemePreference LocalFrame::colorSchemePreference() const
+{
+    if (auto* documentLoader = loader().documentLoader())
+        return documentLoader->colorSchemePreference();
+    return ColorSchemePreference::NoPreference;
+}
+
 SandboxFlags LocalFrame::effectiveSandboxFlags() const
 {
     auto effectiveSandboxFlags = m_sandboxFlags;

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -340,6 +340,7 @@ public:
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const final;
     bool allowPrivacyProxy() const final;
     AutoplayPolicy autoplayPolicy() const final;
+    ColorSchemePreference colorSchemePreference() const final;
 
     WEBCORE_EXPORT SandboxFlags NODELETE effectiveSandboxFlags() const;
     SandboxFlags sandboxFlagsFromSandboxAttributeNotCSP() { return m_sandboxFlags; }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4406,13 +4406,11 @@ bool Page::useDarkAppearance() const
         RefPtr view = localMainFrame->view();
         if (!view || view->mediaType() != screenAtom())
             return false;
-
-        if (auto* documentLoader = localMainFrame->loader().documentLoader()) {
-            auto colorSchemePreference = documentLoader->colorSchemePreference();
-            if (colorSchemePreference != ColorSchemePreference::NoPreference)
-                return colorSchemePreference == ColorSchemePreference::Dark;
-        }
     }
+
+    auto colorSchemePreference = protect(mainFrame())->colorSchemePreference();
+    if (colorSchemePreference != ColorSchemePreference::NoPreference)
+        return colorSchemePreference == ColorSchemePreference::Dark;
 
     return m_useDarkAppearance;
 #else

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -39,6 +39,7 @@
 #include "RemoteFrameView.h"
 #include "ResourceTiming.h"
 #include "SecurityOrigin.h"
+#include "WebsitePolicies.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/HexNumber.h>
 #include <wtf/text/StringBuilder.h>
@@ -61,6 +62,7 @@ RemoteFrame::RemoteFrame(Page& page, ClientCreator&& clientCreator, FrameIdentif
     , m_client(clientCreator(*this))
     , m_layerHostingContextIdentifier(layerHostingContextIdentifier)
     , m_autoplayPolicy(AutoplayPolicy::Default)
+    , m_colorSchemePreference(ColorSchemePreference::NoPreference)
 {
     setView(RemoteFrameView::create(*this));
 }
@@ -239,6 +241,11 @@ const SecurityOrigin& RemoteFrame::frameDocumentSecurityOriginOrOpaque() const
 AutoplayPolicy RemoteFrame::autoplayPolicy() const
 {
     return m_autoplayPolicy;
+}
+
+ColorSchemePreference RemoteFrame::colorSchemePreference() const
+{
+    return m_colorSchemePreference;
 }
 
 float RemoteFrame::usedZoomForChild(const Frame& child) const

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -102,6 +102,9 @@ public:
     void setAutoplayPolicy(AutoplayPolicy autoplayPolicy) { m_autoplayPolicy = autoplayPolicy; }
     AutoplayPolicy NODELETE autoplayPolicy() const final;
 
+    void setColorSchemePreference(ColorSchemePreference colorSchemePreference) { m_colorSchemePreference = colorSchemePreference; }
+    ColorSchemePreference NODELETE colorSchemePreference() const final;
+
     void updateScrollingMode() final;
     void reportMixedContentViolation(bool blocked, const URL& target) const final;
     void addResourceTimingFromChild(ResourceTiming&&);
@@ -142,6 +145,7 @@ private:
     OptionSet<AdvancedPrivacyProtections> m_advancedPrivacyProtections;
     bool m_allowPrivacyProxy { true };
     AutoplayPolicy m_autoplayPolicy;
+    ColorSchemePreference m_colorSchemePreference;
     bool m_preventsParentFromBeingComplete { true };
 };
 

--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -39,6 +39,79 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebsitePoliciesData);
 
+static WebCore::MediaSourcePolicy core(WebsiteMediaSourcePolicy policy)
+{
+    switch (policy) {
+    case WebsiteMediaSourcePolicy::Default:
+        return WebCore::MediaSourcePolicy::Default;
+    case WebsiteMediaSourcePolicy::Disable:
+        return WebCore::MediaSourcePolicy::Disable;
+    case WebsiteMediaSourcePolicy::Enable:
+        return WebCore::MediaSourcePolicy::Enable;
+    }
+    ASSERT_NOT_REACHED();
+    return WebCore::MediaSourcePolicy::Default;
+}
+
+static WebCore::LegacyOverflowScrollingTouchPolicy core(WebsiteLegacyOverflowScrollingTouchPolicy policy)
+{
+    switch (policy) {
+    case WebsiteLegacyOverflowScrollingTouchPolicy::Default:
+        return WebCore::LegacyOverflowScrollingTouchPolicy::Default;
+    case WebsiteLegacyOverflowScrollingTouchPolicy::Disable:
+        return WebCore::LegacyOverflowScrollingTouchPolicy::Disable;
+    case WebsiteLegacyOverflowScrollingTouchPolicy::Enable:
+        return WebCore::LegacyOverflowScrollingTouchPolicy::Enable;
+    }
+    ASSERT_NOT_REACHED();
+    return WebCore::LegacyOverflowScrollingTouchPolicy::Default;
+}
+
+static WebCore::PushAndNotificationsEnabledPolicy core(WebsitePushAndNotificationsEnabledPolicy policy)
+{
+    switch (policy) {
+    case WebsitePushAndNotificationsEnabledPolicy::UseGlobalPolicy:
+        return WebCore::PushAndNotificationsEnabledPolicy::UseGlobalPolicy;
+    case WebsitePushAndNotificationsEnabledPolicy::No:
+        return WebCore::PushAndNotificationsEnabledPolicy::No;
+    case WebsitePushAndNotificationsEnabledPolicy::Yes:
+        return WebCore::PushAndNotificationsEnabledPolicy::Yes;
+    }
+    ASSERT_NOT_REACHED();
+    return WebCore::PushAndNotificationsEnabledPolicy::UseGlobalPolicy;
+}
+
+static WebCore::InlineMediaPlaybackPolicy core(WebsiteInlineMediaPlaybackPolicy policy)
+{
+    switch (policy) {
+    case WebsiteInlineMediaPlaybackPolicy::Default:
+        return WebCore::InlineMediaPlaybackPolicy::Default;
+    case WebsiteInlineMediaPlaybackPolicy::RequiresPlaysInlineAttribute:
+        return WebCore::InlineMediaPlaybackPolicy::RequiresPlaysInlineAttribute;
+    case WebsiteInlineMediaPlaybackPolicy::DoesNotRequirePlaysInlineAttribute:
+        return WebCore::InlineMediaPlaybackPolicy::DoesNotRequirePlaysInlineAttribute;
+    }
+    ASSERT_NOT_REACHED();
+    return WebCore::InlineMediaPlaybackPolicy::Default;
+}
+
+void WebsitePoliciesData::applyToSettings(const WebsitePoliciesData& websitePolicies, WebCore::Settings& settings)
+{
+    settings.applyMainFrameWebsitePolicies({
+        core(websitePolicies.mediaSourcePolicy),
+        core(websitePolicies.legacyOverflowScrollingTouchPolicy),
+        core(websitePolicies.pushAndNotificationsEnabledPolicy),
+        core(websitePolicies.inlineMediaPlaybackPolicy),
+        websitePolicies.globalPrivacyControlEnabled,
+        websitePolicies.idempotentModeAutosizingOnlyHonorsPercentages
+    });
+
+#if ENABLE(TOUCH_EVENTS)
+    if (auto overrideValue = websitePolicies.overrideTouchEventDOMAttributesEnabled)
+        settings.setTouchEventDOMAttributesEnabled(*overrideValue);
+#endif
+}
+
 void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePolicies, WebCore::DocumentLoader& documentLoader)
 {
     documentLoader.setCustomHeaderFields(WTF::move(websitePolicies.customHeaderFields));
@@ -103,17 +176,7 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
         break;
     }
 
-    switch (websitePolicies.mediaSourcePolicy) {
-    case WebsiteMediaSourcePolicy::Default:
-        documentLoader.setMediaSourcePolicy(WebCore::MediaSourcePolicy::Default);
-        break;
-    case WebsiteMediaSourcePolicy::Disable:
-        documentLoader.setMediaSourcePolicy(WebCore::MediaSourcePolicy::Disable);
-        break;
-    case WebsiteMediaSourcePolicy::Enable:
-        documentLoader.setMediaSourcePolicy(WebCore::MediaSourcePolicy::Enable);
-        break;
-    }
+    documentLoader.setMediaSourcePolicy(core(websitePolicies.mediaSourcePolicy));
 
     switch (websitePolicies.simulatedMouseEventsDispatchPolicy) {
     case WebsiteSimulatedMouseEventsDispatchPolicy::Default:
@@ -127,17 +190,7 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
         break;
     }
 
-    switch (websitePolicies.legacyOverflowScrollingTouchPolicy) {
-    case WebsiteLegacyOverflowScrollingTouchPolicy::Default:
-        documentLoader.setLegacyOverflowScrollingTouchPolicy(WebCore::LegacyOverflowScrollingTouchPolicy::Default);
-        break;
-    case WebsiteLegacyOverflowScrollingTouchPolicy::Disable:
-        documentLoader.setLegacyOverflowScrollingTouchPolicy(WebCore::LegacyOverflowScrollingTouchPolicy::Disable);
-        break;
-    case WebsiteLegacyOverflowScrollingTouchPolicy::Enable:
-        documentLoader.setLegacyOverflowScrollingTouchPolicy(WebCore::LegacyOverflowScrollingTouchPolicy::Enable);
-        break;
-    }
+    documentLoader.setLegacyOverflowScrollingTouchPolicy(core(websitePolicies.legacyOverflowScrollingTouchPolicy));
 
     switch (websitePolicies.mouseEventPolicy) {
     case WebCore::MouseEventPolicy::Default:
@@ -159,29 +212,9 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
     documentLoader.setIdempotentModeAutosizingOnlyHonorsPercentages(websitePolicies.idempotentModeAutosizingOnlyHonorsPercentages);
     documentLoader.setHTTPSByDefaultMode(websitePolicies.httpsByDefaultMode);
 
-    switch (websitePolicies.pushAndNotificationsEnabledPolicy) {
-    case WebsitePushAndNotificationsEnabledPolicy::UseGlobalPolicy:
-        documentLoader.setPushAndNotificationsEnabledPolicy(WebCore::PushAndNotificationsEnabledPolicy::UseGlobalPolicy);
-        break;
-    case WebsitePushAndNotificationsEnabledPolicy::No:
-        documentLoader.setPushAndNotificationsEnabledPolicy(WebCore::PushAndNotificationsEnabledPolicy::No);
-        break;
-    case WebsitePushAndNotificationsEnabledPolicy::Yes:
-        documentLoader.setPushAndNotificationsEnabledPolicy(WebCore::PushAndNotificationsEnabledPolicy::Yes);
-        break;
-    }
+    documentLoader.setPushAndNotificationsEnabledPolicy(core(websitePolicies.pushAndNotificationsEnabledPolicy));
 
-    switch (websitePolicies.inlineMediaPlaybackPolicy) {
-    case WebsiteInlineMediaPlaybackPolicy::Default:
-        documentLoader.setInlineMediaPlaybackPolicy(WebCore::InlineMediaPlaybackPolicy::Default);
-        break;
-    case WebsiteInlineMediaPlaybackPolicy::RequiresPlaysInlineAttribute:
-        documentLoader.setInlineMediaPlaybackPolicy(WebCore::InlineMediaPlaybackPolicy::RequiresPlaysInlineAttribute);
-        break;
-    case WebsiteInlineMediaPlaybackPolicy::DoesNotRequirePlaysInlineAttribute:
-        documentLoader.setInlineMediaPlaybackPolicy(WebCore::InlineMediaPlaybackPolicy::DoesNotRequirePlaysInlineAttribute);
-        break;
-    }
+    documentLoader.setInlineMediaPlaybackPolicy(core(websitePolicies.inlineMediaPlaybackPolicy));
 
     if (!websitePolicies.alternateRequest.isNull())
         documentLoader.willContinueMainResourceLoadAfterRedirect(websitePolicies.alternateRequest);

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -48,6 +48,7 @@
 
 namespace WebCore {
 class DocumentLoader;
+class Settings;
 }
 
 namespace WebKit {
@@ -56,6 +57,7 @@ struct WebsitePoliciesData {
     WTF_MAKE_TZONE_ALLOCATED(WebsitePoliciesData);
 public:
     static void applyToDocumentLoader(WebsitePoliciesData&&, WebCore::DocumentLoader&);
+    static void applyToSettings(const WebsitePoliciesData&, WebCore::Settings&);
 
     HashMap<String, Vector<String>> activeContentRuleListActionPatterns;
     Vector<WebCore::CustomHeaderFields> customHeaderFields;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5808,8 +5808,17 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
             sourceURL = provisionalPage->provisionalURL();
     }
 
-    m_isLockdownModeExplicitlySet = (websitePolicies && websitePolicies->isLockdownModeExplicitlySet()) || m_configuration->isLockdownModeExplicitlySet();
-    auto lockdownMode = (websitePolicies ? websitePolicies->lockdownModeEnabled() : shouldEnableLockdownMode()) ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled;
+    // WKWebpagePreferences security restrictions are page-wide: a cross-site subframe must be placed
+    // in a process with the same restrictions as the main frame rather than have them recomputed from
+    // its own website policies.
+    RefPtr<WebFrameProxy> securityRestrictionsSourceFrame;
+    if (frame.isMainFrame())
+        m_isLockdownModeExplicitlySet = (websitePolicies && websitePolicies->isLockdownModeExplicitlySet()) || m_configuration->isLockdownModeExplicitlySet();
+    else
+        securityRestrictionsSourceFrame = m_mainFrame;
+
+    auto lockdownMode = securityRestrictionsSourceFrame ? securityRestrictionsSourceFrame->process().lockdownMode()
+        : ((websitePolicies ? websitePolicies->lockdownModeEnabled() : shouldEnableLockdownMode()) ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled);
 
     // Apply CSP upgrade-insecure-requests before computing Site. Only needed for remote-frame
     // navigations. Same-process navigations are already upgraded in the WebProcess.
@@ -5832,7 +5841,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
     if (frame.isMainFrame() && shouldUseEnhancedSecurityHeuristics(preferences))
         internals().enhancedSecurityTracker.trackNavigation(navigation, hasOpenedPage(), internals().pageLoadState.httpFallbackInProgress());
 
-    auto enhancedSecurity = currentEnhancedSecurityState(websitePolicies.get());
+    auto enhancedSecurity = securityRestrictionsSourceFrame ? securityRestrictionsSourceFrame->process().enhancedSecurity() : currentEnhancedSecurityState(websitePolicies.get());
 
     if (RefPtr process = browsingContextGroup->processForSite(Site { navigation.currentRequest().url() }))
         enhancedSecurity = process->process().enhancedSecurity();

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -391,7 +391,7 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
     Ref mainFrame = frame->mainFrame();
     RefPtr policySourceDocumentLoader = policySourceDocumentLoaderForFrame(*frame, isMainFrameNavigation);
 
-    parameters.allowPrivacyProxy = !policySourceDocumentLoader || policySourceDocumentLoader->allowPrivacyProxy();
+    parameters.allowPrivacyProxy = policySourceDocumentLoader ? policySourceDocumentLoader->allowPrivacyProxy() : mainFrame->allowPrivacyProxy();
 
     if (RefPtr framePolicySourceDocumentLoader = frame->loader().loaderForWebsitePolicies(isMainFrameNavigation ? FrameLoader::CanIncludeCurrentDocumentLoader::No : FrameLoader::CanIncludeCurrentDocumentLoader::Yes)) {
         if (String referrer = framePolicySourceDocumentLoader->preferences().overrideReferrerForAllRequests; !referrer.isNull())
@@ -433,7 +433,7 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
         }
     }
 
-    auto advancedPrivacyProtections = policySourceDocumentLoader ? policySourceDocumentLoader->advancedPrivacyProtections() : OptionSet<AdvancedPrivacyProtections> { };
+    auto advancedPrivacyProtections = policySourceDocumentLoader ? policySourceDocumentLoader->advancedPrivacyProtections() : mainFrame->advancedPrivacyProtections();
     parameters.advancedPrivacyProtections = advancedPrivacyProtections;
 
     if (isMainFrameNavigation)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -45,6 +45,7 @@
 #include <WebCore/PolicyChecker.h>
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/RemoteFrame.h>
+#include <WebCore/Settings.h>
 #include <WebCore/UserGestureIndicator.h>
 
 namespace WebKit {
@@ -257,12 +258,16 @@ void WebRemoteFrameClient::applyWebsitePolicies(WebsitePoliciesData&& websitePol
         return;
     }
 
+    if (coreFrame->isMainFrame())
+        WebsitePoliciesData::applyToSettings(websitePolicies, coreFrame->settings());
+
     coreFrame->setCustomUserAgent(WTF::move(websitePolicies.customUserAgent));
     coreFrame->setCustomUserAgentAsSiteSpecificQuirks(WTF::move(websitePolicies.customUserAgentAsSiteSpecificQuirks));
     coreFrame->setAdvancedPrivacyProtections(websitePolicies.advancedPrivacyProtections);
     coreFrame->setAllowPrivacyProxy(websitePolicies.allowPrivacyProxy);
     coreFrame->setCustomNavigatorPlatform(WTF::move(websitePolicies.customNavigatorPlatform));
     coreFrame->setAutoplayPolicy(core(websitePolicies.autoplayPolicy));
+    coreFrame->setColorSchemePreference(websitePolicies.colorSchemePreference);
 }
 
 void WebRemoteFrameClient::updateScrollingMode(ScrollbarMode scrollingMode)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -72,6 +72,7 @@
 #import <WebKit/_WKUserInitiatedAction.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/text/MakeString.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -12384,6 +12385,212 @@ TEST(SiteIsolation, WebsitePoliciesAppliedToCrossOriginSubframeDocumentLoader)
 
     // The subframe's process must also have the policy applied to its document loader.
     EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:check inFrame:[webView firstChildFrame]], "available");
+}
+
+static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> mainFrameOnlyPolicyViewAndDelegate(const HTTPServer& server, void (^applyToMainFramePolicy)(WKWebpagePreferences *), WKWebViewConfiguration *configuration = nil)
+{
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration ?: server.httpsProxyConfiguration(), CGRectMake(0, 0, 800, 600), true);
+    navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        if (action.targetFrame.mainFrame)
+            applyToMainFramePolicy(preferences);
+        completionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
+}
+
+static RetainPtr<WKFrameInfo> loadAndWaitForCrossSiteChildFrame(TestWKWebView *webView, TestNavigationDelegate *navigationDelegate, NSString *mainFrameURL, NSString *childFrameHost)
+{
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:mainFrameURL]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    while (![[webView firstChildFrame].securityOrigin.host isEqualToString:childFrameHost])
+        Util::spinRunLoop();
+    return [webView firstChildFrame];
+}
+
+static HTTPServer::ResponseMap mainAndSubframeResponses()
+{
+    HTTPServer::ResponseMap responses;
+    responses.add("/mainframe"_s, HTTPResponse("<!DOCTYPE html><iframe src='https://b.com/subframe'></iframe>"_s));
+    responses.add("/subframe"_s, HTTPResponse("<!DOCTYPE html>subframe"_s));
+    return responses;
+}
+
+#if !PLATFORM(IOS_FAMILY)
+// The process variant SPI reads process paths and entitlements TestWebKitAPI cannot see on iOS.
+
+TEST(SiteIsolation, LockdownModeInheritedByCrossSiteIframeProcess)
+{
+    HTTPServer server(mainAndSubframeResponses(), HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = mainFrameOnlyPolicyViewAndDelegate(server, ^(WKWebpagePreferences *preferences) {
+        preferences.lockdownModeEnabled = YES;
+    });
+
+    RetainPtr childFrame = loadAndWaitForCrossSiteChildFrame(webView.get(), navigationDelegate.get(), @"https://a.com/mainframe", @"b.com");
+
+    EXPECT_WK_STREQ([webView _webContentProcessVariantForFrame:nil], @"lockdown");
+    EXPECT_WK_STREQ([webView _webContentProcessVariantForFrame:childFrame.get()._handle], @"lockdown");
+}
+
+TEST(SiteIsolation, EnhancedSecurityInheritedByCrossSiteIframeProcess)
+{
+    HTTPServer server(mainAndSubframeResponses(), HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = mainFrameOnlyPolicyViewAndDelegate(server, ^(WKWebpagePreferences *preferences) {
+        preferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
+    });
+
+    RetainPtr childFrame = loadAndWaitForCrossSiteChildFrame(webView.get(), navigationDelegate.get(), @"https://a.com/mainframe", @"b.com");
+
+    EXPECT_WK_STREQ([webView _webContentProcessVariantForFrame:nil], @"security");
+    EXPECT_WK_STREQ([webView _webContentProcessVariantForFrame:childFrame.get()._handle], @"security");
+}
+
+#endif // !PLATFORM(IOS_FAMILY)
+
+TEST(SiteIsolation, LockdownModeSettingsInheritedByCrossSiteIframe)
+{
+    HTTPServer server(mainAndSubframeResponses(), HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = mainFrameOnlyPolicyViewAndDelegate(server, ^(WKWebpagePreferences *preferences) {
+        preferences.lockdownModeEnabled = YES;
+    });
+
+    RetainPtr childFrame = loadAndWaitForCrossSiteChildFrame(webView.get(), navigationDelegate.get(), @"https://a.com/mainframe", @"b.com");
+
+    NSString *check = @"(!!window.WebGL2RenderingContext) + ',' + (!!window.Gamepad)";
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:check], "false,false");
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:check inFrame:childFrame.get()], "false,false");
+}
+
+TEST(SiteIsolation, GlobalPrivacyControlInheritedByCrossSiteIframe)
+{
+    constexpr auto mainframeHTML = "<!DOCTYPE html><iframe src='https://b.com/subframe'></iframe><script>fetch('/mainframe-subresource')</script>"_s;
+    constexpr auto subframeHTML = "<!DOCTYPE html><script>fetch('/subframe-subresource')</script>"_s;
+
+    bool receivedMainFrameSubresource { false };
+    bool receivedSubframeSubresource { false };
+    bool mainFrameSubresourceHadGPCHeader { false };
+    bool subframeSubresourceHadGPCHeader { false };
+
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (1) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+            bool hasGPCHeader = contains(request.span(), "Sec-GPC"_span);
+            if (path == "/mainframe"_s) {
+                co_await connection.awaitableSend(HTTPResponse(mainframeHTML).serialize());
+                continue;
+            }
+            if (path == "/subframe"_s) {
+                co_await connection.awaitableSend(HTTPResponse(subframeHTML).serialize());
+                continue;
+            }
+            if (path == "/mainframe-subresource"_s) {
+                mainFrameSubresourceHadGPCHeader = hasGPCHeader;
+                receivedMainFrameSubresource = true;
+            } else if (path == "/subframe-subresource"_s) {
+                subframeSubresourceHadGPCHeader = hasGPCHeader;
+                receivedSubframeSubresource = true;
+            }
+            co_await connection.awaitableSend(HTTPResponse(""_s).serialize());
+        }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = mainFrameOnlyPolicyViewAndDelegate(server, ^(WKWebpagePreferences *preferences) {
+        preferences.globalPrivacyControlEnabled = YES;
+    });
+
+    RetainPtr childFrame = loadAndWaitForCrossSiteChildFrame(webView.get(), navigationDelegate.get(), @"https://a.com/mainframe", @"b.com");
+
+    NSString *check = @"String(navigator.globalPrivacyControl)";
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:check], "true");
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:check inFrame:childFrame.get()], "true");
+
+    Util::run(&receivedMainFrameSubresource);
+    Util::run(&receivedSubframeSubresource);
+    EXPECT_TRUE(mainFrameSubresourceHadGPCHeader);
+    EXPECT_TRUE(subframeSubresourceHadGPCHeader);
+}
+
+// With noise injection active, two identical OfflineAudioContext renders produce different results.
+TEST(SiteIsolation, AdvancedPrivacyProtectionsInheritedByCrossSiteIframeDocument)
+{
+    constexpr auto renderScript =
+        "<script>"
+        "async function renderOscillatorThroughCompressor() {"
+        "    const context = new OfflineAudioContext(1, 5000, 44100);"
+        "    const oscillator = context.createOscillator();"
+        "    oscillator.type = 'triangle';"
+        "    oscillator.frequency.value = 1000;"
+        "    const compressor = context.createDynamicsCompressor();"
+        "    compressor.threshold.value = -50;"
+        "    compressor.knee.value = 40;"
+        "    compressor.ratio.value = 12;"
+        "    compressor.attack.value = 0;"
+        "    compressor.release.value = 0.2;"
+        "    oscillator.connect(compressor);"
+        "    compressor.connect(context.destination);"
+        "    oscillator.start();"
+        "    const rendered = await context.startRendering();"
+        "    let sum = 0;"
+        "    for (const value of rendered.getChannelData(0)) {"
+        "        if (isFinite(value))"
+        "            sum += value;"
+        "    }"
+        "    return sum;"
+        "}"
+        "</script>"_s;
+
+    HTTPServer::ResponseMap responses;
+    responses.add("/mainframe"_s, HTTPResponse(makeString("<!DOCTYPE html>"_s, renderScript, "<iframe src='https://b.com/subframe'></iframe>"_s)));
+    responses.add("/subframe"_s, HTTPResponse(makeString("<!DOCTYPE html>"_s, renderScript)));
+    HTTPServer server(WTF::move(responses), HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = mainFrameOnlyPolicyViewAndDelegate(server, ^(WKWebpagePreferences *preferences) {
+        preferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyEnabled | _WKWebsiteNetworkConnectionIntegrityPolicyEnhancedTelemetry;
+    });
+
+    RetainPtr childFrame = loadAndWaitForCrossSiteChildFrame(webView.get(), navigationDelegate.get(), @"https://a.com/mainframe", @"b.com");
+
+    auto renderedSum = [&](WKFrameInfo *frame) {
+        return [[webView objectByCallingAsyncFunction:@"return await renderOscillatorThroughCompressor()" withArguments:@{ } inFrame:frame inContentWorld:WKContentWorld.pageWorld] doubleValue];
+    };
+
+    EXPECT_NE(renderedSum(nil), renderedSum(nil));
+    EXPECT_NE(renderedSum(childFrame.get()), renderedSum(childFrame.get()));
+}
+
+TEST(SiteIsolation, PushAndNotificationAPIPolicyInheritedByCrossSiteIframe)
+{
+    HTTPServer server(mainAndSubframeResponses(), HTTPServer::Protocol::HttpsProxy);
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [[configuration preferences] _setPushAPIEnabled:YES];
+    [[configuration preferences] _setNotificationsEnabled:YES];
+
+    auto [webView, navigationDelegate] = mainFrameOnlyPolicyViewAndDelegate(server, ^(WKWebpagePreferences *preferences) {
+        preferences._pushAndNotificationAPIEnabled = NO;
+    }, configuration.get());
+
+    RetainPtr childFrame = loadAndWaitForCrossSiteChildFrame(webView.get(), navigationDelegate.get(), @"https://a.com/mainframe", @"b.com");
+
+    NSString *check = @"String('PushManager' in window || 'Notification' in window)";
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:check], "false");
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:check inFrame:childFrame.get()], "false");
+}
+
+TEST(SiteIsolation, ColorSchemePreferenceInheritedByCrossSiteIframe)
+{
+    HTTPServer server(mainAndSubframeResponses(), HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = mainFrameOnlyPolicyViewAndDelegate(server, ^(WKWebpagePreferences *preferences) {
+        preferences._colorSchemePreference = _WKWebsiteColorSchemePreferenceDark;
+    });
+    // Without this the subframe falls back to the system appearance, which reports dark for the
+    // wrong reason on a machine running in Dark Mode.
+    [webView forceLightMode];
+
+    RetainPtr childFrame = loadAndWaitForCrossSiteChildFrame(webView.get(), navigationDelegate.get(), @"https://a.com/mainframe", @"b.com");
+
+    NSString *check = @"String(matchMedia('(prefers-color-scheme: dark)').matches)";
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:check], "true");
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:check inFrame:childFrame.get()], "true");
 }
 
 }


### PR DESCRIPTION
#### 11a216a7fd0399dd9d93fca02a356f354ccabc2e
<pre>
[Site Isolation] Some website policies applied to main frame navigations don&apos;t apply to cross site iframes
<a href="https://rdar.apple.com/184091553">rdar://184091553</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321060">https://bugs.webkit.org/show_bug.cgi?id=321060</a>

Reviewed by Matthew Finkel.

WebKit API clients can apply various website policies on a per navigation basis.
These policies are meant to apply to all documents hosted by the navigated-to page,
including cross-origin iframes.

Under site isolation, some of these policies were not migrated to the new process
hosting the cross-origin iframe, therefore breaking the intended contract.

This patch makes sure all of these policies apply to the cross-origin iframe even
in its new process and also tests that they are applied correctly.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebCore/Headers.cmake:
* Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb:
* Source/WebCore/Scripts/SettingsTemplates/Settings.h.erb:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::advancedPrivacyProtections const):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::applyPoliciesToSettings):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/WebsitePolicies.h: Added.
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::colorSchemePreference const):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::useDarkAppearance const):
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::m_colorSchemePreference):
(WebCore::RemoteFrame::colorSchemePreference const):
(WebCore::m_autoplayPolicy): Deleted.
* Source/WebCore/page/RemoteFrame.h:
* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::core):
(WebKit::WebsitePoliciesData::applyToSettings):
(WebKit::WebsitePoliciesData::applyToDocumentLoader):
* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::applyWebsitePolicies):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, LockdownModeInheritedByCrossSiteIframeProcess)):
(TestWebKitAPI::(SiteIsolation, EnhancedSecurityInheritedByCrossSiteIframeProcess)):
(TestWebKitAPI::(SiteIsolation, LockdownModeSettingsInheritedByCrossSiteIframe)):
(TestWebKitAPI::(SiteIsolation, GlobalPrivacyControlInheritedByCrossSiteIframe)):
(TestWebKitAPI::(SiteIsolation, AdvancedPrivacyProtectionsInheritedByCrossSiteIframeDocument)):
(TestWebKitAPI::(SiteIsolation, PushAndNotificationAPIPolicyInheritedByCrossSiteIframe)):
(TestWebKitAPI::(SiteIsolation, ColorSchemePreferenceInheritedByCrossSiteIframe)):

Canonical link: <a href="https://commits.webkit.org/318742@main">https://commits.webkit.org/318742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14f6cacc1b310dd38738ed6939636cafddfc24d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179020 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188849 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c225a56-4fca-48f3-a341-c40aed01e2bc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139608 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a55f4d2-2657-433e-94a8-1394150d4bde) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120054 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df708c6b-a557-4077-8f11-a4eb106ebd27) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41865 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40209 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152264 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39868 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/156 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191069 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52629 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148836 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39968 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53309 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148583 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43269 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125580 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120394 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51827 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14847 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51212 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51453 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51273 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->