### PR TITLE
Global object attribute getters/setters throw when called as bare functions from global scope

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value-cross-realm-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value-cross-realm-expected.txt
@@ -2,7 +2,7 @@
 PASS Cross-realm global object's getter throws when called on incompatible object
 PASS Cross-realm global object's setter throws when called on incompatible object
 PASS Cross-realm global object's operation throws when called on incompatible object
-FAIL Cross-realm global object's getter called on null / undefined promise_test: Unhandled rejection with value: object "TypeError: The Window.name getter can only be used on instances of Window"
-FAIL Cross-realm global object's setter called on null / undefined promise_test: Unhandled rejection with value: object "TypeError: The Window.location setter can only be used on instances of Window"
+PASS Cross-realm global object's getter called on null / undefined
+PASS Cross-realm global object's setter called on null / undefined
 PASS Cross-realm global object's operation called on null / undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value.any-expected.txt
@@ -5,7 +5,7 @@ PASS Global object's operation throws when called on incompatible object
 PASS Global object's getter throws when called on incompatible object (document.all)
 PASS Global object's setter throws when called on incompatible object (document.all)
 PASS Global object's operation throws when called on incompatible object (document.all)
-FAIL Global object's getter works when called on null / undefined The Window.location getter can only be used on instances of Window
-FAIL Global object's setter works when called on null / undefined The Window.ononline setter can only be used on instances of Window
+PASS Global object's getter works when called on null / undefined
+PASS Global object's setter works when called on null / undefined
 PASS Global object's operation works when called on null / undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value.any.serviceworker-expected.txt
@@ -2,7 +2,7 @@
 PASS Global object's getter throws when called on incompatible object
 PASS Global object's setter throws when called on incompatible object
 PASS Global object's operation throws when called on incompatible object
-FAIL Global object's getter works when called on null / undefined The WorkerGlobalScope.location getter can only be used on instances of WorkerGlobalScope
-FAIL Global object's setter works when called on null / undefined The WorkerGlobalScope.ononline setter can only be used on instances of WorkerGlobalScope
+PASS Global object's getter works when called on null / undefined
+PASS Global object's setter works when called on null / undefined
 PASS Global object's operation works when called on null / undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value.any.sharedworker-expected.txt
@@ -2,7 +2,7 @@
 PASS Global object's getter throws when called on incompatible object
 PASS Global object's setter throws when called on incompatible object
 PASS Global object's operation throws when called on incompatible object
-FAIL Global object's getter works when called on null / undefined The WorkerGlobalScope.location getter can only be used on instances of WorkerGlobalScope
-FAIL Global object's setter works when called on null / undefined The WorkerGlobalScope.ononline setter can only be used on instances of WorkerGlobalScope
+PASS Global object's getter works when called on null / undefined
+PASS Global object's setter works when called on null / undefined
 PASS Global object's operation works when called on null / undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value.any.worker-expected.txt
@@ -2,7 +2,7 @@
 PASS Global object's getter throws when called on incompatible object
 PASS Global object's setter throws when called on incompatible object
 PASS Global object's operation throws when called on incompatible object
-FAIL Global object's getter works when called on null / undefined The WorkerGlobalScope.location getter can only be used on instances of WorkerGlobalScope
-FAIL Global object's setter works when called on null / undefined The WorkerGlobalScope.ononline setter can only be used on instances of WorkerGlobalScope
+PASS Global object's getter works when called on null / undefined
+PASS Global object's setter works when called on null / undefined
 PASS Global object's operation works when called on null / undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/embedded-opener-remove-frame-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/embedded-opener-remove-frame-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL opener of discarded nested browsing context The Window.opener getter can only be used on instances of Window
-FAIL opener of discarded auxiliary browsing context The Window.opener getter can only be used on instances of Window
+PASS opener of discarded nested browsing context
+PASS opener of discarded auxiliary browsing context
 

--- a/Source/WebCore/bindings/js/JSDOMCastThisValue.h
+++ b/Source/WebCore/bindings/js/JSDOMCastThisValue.h
@@ -45,9 +45,17 @@ template<class JSClass>
 JSClass* castThisValue(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue thisValue)
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
-    if constexpr (std::is_base_of_v<JSDOMGlobalObject, JSClass>)
+    if constexpr (std::is_base_of_v<JSDOMGlobalObject, JSClass>) {
+        // FIXME: Remove this normalization once FunctionCallResolveNode stops passing the resolved scope as the |this|
+        // value. https://bugs.webkit.org/show_bug.cgi?id=225397
+        // A function resolved from the global lexical environment and called as a bare call is handed the environment
+        // object itself as |this|; treat that as undefined so it substitutes to the global object below. We must not use
+        // JSValue::toThis() here because a global object (Window / RemoteDOMWindow) is itself a JSScope, and toThis()
+        // would map a legitimate cross-origin window |this| to undefined, defeating the security check below.
+        if (auto* object = thisValue.getObject(); object && object->inherits<JSC::JSScope>() && !object->inherits<JSC::JSGlobalObject>())
+            thisValue = JSC::jsUndefined();
         return toJSDOMGlobalObject<JSClass>(vm, thisValue.isUndefinedOrNull() ? JSC::JSValue(&lexicalGlobalObject) : thisValue);
-    else
+    } else
         return dynamicDowncast<JSClass>(thisValue);
 }
 


### PR DESCRIPTION
#### 2118488d189965301716accec578190bb80af2cd
<pre>
Global object attribute getters/setters throw when called as bare functions from global scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=321066">https://bugs.webkit.org/show_bug.cgi?id=321066</a>

Reviewed by Darin Adler.

When a global attribute&apos;s getter or setter is resolved from the global lexical
environment and invoked as a bare call (e.g. `const f = descriptor.get; f();`),
JSC hands the JSGlobalLexicalEnvironment object itself as the |this| value
rather than undefined (bug 225397, FunctionCallResolveNode passing the resolved
scope as |this|). For ordinary JS-function callees this is normalized away by
the op_to_this prologue, but host functions such as the custom getter/setter
functions have no such prologue, so the raw scope leaked into castThisValue().
There it is neither undefined/null nor a JSGlobalProxy/global object, so the
cast failed and we threw a TypeError (&quot;The Window.location getter can only be
used on instances of Window&quot;).

Normalize this in castThisValue() by treating a leaked scope as undefined, which
then substitutes to the global object below. This fixes the getter and setter
paths (which route through IDLAttribute) at a single shared point.

We must not use JSValue::toThis() to do this normalization: a global object
(Window / RemoteDOMWindow) is itself a JSScope, so toThis(strict) would map a
legitimate |this| window to undefined. For a cross-origin access such as
`crossOriginWindow.location`, JSGlobalProxy dispatches the getter/setter with
the target window as |this|; mapping that to undefined would substitute the
caller&apos;s global object, reading/writing the wrong window and defeating the
cross-origin security check. Instead we only normalize a scope that is not
itself a global object (i.e. the leaked JSGlobalLexicalEnvironment), leaving
real windows and global proxies untouched.

Covered by imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/
global-object-implicit-this-value.any.html (and its worker, sharedworker, and
serviceworker variants), which now pass the previously-failing &quot;getter/setter
works when called on null / undefined&quot; subtests. Those tests were already
passing in both Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value-cross-realm-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-object-implicit-this-value.any.worker-expected.txt:
* Source/WebCore/bindings/js/JSDOMCastThisValue.h:
(WebCore::castThisValue):

Canonical link: <a href="https://commits.webkit.org/318748@main">https://commits.webkit.org/318748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/851006b3573bec811ebf2813154b6eb458e3bc76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188494 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143186 "Build is in progress. Recent messages:") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f705285c-42a3-4651-88d6-2c932bd29805) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139488 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/143186 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69f1a8da-8f4f-4295-b476-ea6c1cb9b947) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119938 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d6ae7064-00da-41f6-961a-46152fbcf451) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41730 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40075 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39723 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/13 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190923 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52486 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148680 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39974 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53166 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148437 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43132 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125436 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120141 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51684 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14701 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51069 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51310 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51130 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->