### PR TITLE
Cherry-pick 318583@main (002fc6661049). https://bugs.webkit.org/show_bug.cgi?id=320985

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -646,6 +646,24 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
     const auto ctm = transform.asM33();
     bool enableAntialias = !ctm.preservesAxisAlignment() && !ctm.preservesRightAngles();
 
+    auto shouldBlend = [&]() -> bool {
+        if (m_contentsOpaque)
+            return false;
+
+        if (m_backingStore)
+            return true;
+
+        if (m_contentsBuffer)
+            return m_contentsBuffer->flags().contains(TextureMapperFlags::ShouldBlend);
+
+        if (m_imageBackingStore) {
+            if (const auto* buffer = m_imageBackingStore->buffer())
+                return buffer->flags().contains(TextureMapperFlags::ShouldBlend);
+        }
+
+        return true;
+    };
+
     // When the layer contents are fully opaque and composited at full opacity with the default
     // (source-over) blend mode, drawing the batched tiles/images with source-over needlessly keeps
     // GL_BLEND enabled for every draw. Compositing with source (kSrc) instead lets Skia's blend
@@ -656,7 +674,7 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
     // filter and still use kSrc when it provably keeps the contents opaque.
     bool forcedSrcBlendMode = false;
     auto batchBlendMode = context.blendMode;
-    if (!batchBlendMode && !context.colorFilter && m_contentsOpaque && context.opacity == 1) {
+    if (!batchBlendMode && !context.colorFilter && !shouldBlend() && context.opacity == 1) {
         batchBlendMode = SkBlendMode::kSrc;
         forcedSrcBlendMode = true;
     }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.cpp
@@ -34,12 +34,15 @@ namespace WebCore {
 
 std::unique_ptr<CoordinatedPlatformLayerBufferSkiaImage> CoordinatedPlatformLayerBufferSkiaImage::create(const sk_sp<SkImage>& image, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
 {
+    OptionSet<TextureMapperFlags> flags;
+    if (!image->isOpaque())
+        flags.add(TextureMapperFlags::ShouldBlend);
     sk_sp<SkImage> skiaImage = image->isTextureBacked() ? SkiaUtilities::createPromiseImageIfNeeded(image, threadSafeGrContext) : image;
-    return makeUnique<CoordinatedPlatformLayerBufferSkiaImage>(WTF::move(skiaImage));
+    return makeUnique<CoordinatedPlatformLayerBufferSkiaImage>(WTF::move(skiaImage), flags);
 }
 
-CoordinatedPlatformLayerBufferSkiaImage::CoordinatedPlatformLayerBufferSkiaImage(sk_sp<SkImage>&& image)
-    : CoordinatedPlatformLayerBuffer(Type::SkiaImage, { image->width(), image->height() }, { }, nullptr)
+CoordinatedPlatformLayerBufferSkiaImage::CoordinatedPlatformLayerBufferSkiaImage(sk_sp<SkImage>&& image, OptionSet<TextureMapperFlags> flags)
+    : CoordinatedPlatformLayerBuffer(Type::SkiaImage, { image->width(), image->height() }, flags, nullptr)
     , m_image(WTF::move(image))
 {
 }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.h
@@ -37,7 +37,7 @@ namespace WebCore {
 class CoordinatedPlatformLayerBufferSkiaImage final : public CoordinatedPlatformLayerBuffer {
 public:
     static std::unique_ptr<CoordinatedPlatformLayerBufferSkiaImage> create(const sk_sp<SkImage>&, const sk_sp<GrContextThreadSafeProxy>&);
-    explicit CoordinatedPlatformLayerBufferSkiaImage(sk_sp<SkImage>&&);
+    CoordinatedPlatformLayerBufferSkiaImage(sk_sp<SkImage>&&, OptionSet<TextureMapperFlags>);
     virtual ~CoordinatedPlatformLayerBufferSkiaImage() = default;
 
 private:

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -22,7 +22,6 @@ find_package(LibXml2 2.9.13 REQUIRED)
 find_package(PNG REQUIRED)
 find_package(SQLite3 REQUIRED)
 find_package(Threads REQUIRED)
-find_package(Unifdef REQUIRED)
 find_package(WebP REQUIRED COMPONENTS demux)
 find_package(ZLIB REQUIRED)
 


### PR DESCRIPTION
#### a9958a534041c3aa53c17bcb8f664ec3adfa7fee
<pre>
Cherry-pick 318583@main (002fc6661049). <a href="https://bugs.webkit.org/show_bug.cgi?id=320985">https://bugs.webkit.org/show_bug.cgi?id=320985</a>

    [CMake][WPE] Remove &quot;find_package(Unifdef REQUIRED)&quot; from OptionsWPE.cmake
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320985">https://bugs.webkit.org/show_bug.cgi?id=320985</a>

    Reviewed by Adrian Perez de Castro.

    Even with USE_SYSTEM_UNIFDEF=0, WPE builds failed due to the missing system
    `unifdef` command. 283695@main added the USE_SYSTEM_UNIFDEF option, and moved
    &quot;find_package(Unifdef REQUIRED)&quot; from OptionsGTK.cmake to
    Source/CMakeLists.txt. Removed it from OptionsWPE.cmake too.

    * Source/cmake/OptionsWPE.cmake:

    Canonical link: <a href="https://commits.webkit.org/318583@main">https://commits.webkit.org/318583@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.52@webkitglib/2.54">https://commits.webkit.org/317695.52@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### f181b4623ce230bc2cf1cbf25b81b1bc9c529492
<pre>
Cherry-pick 318453@main (b55ef6c140a6). <a href="https://bugs.webkit.org/show_bug.cgi?id=320895">https://bugs.webkit.org/show_bug.cgi?id=320895</a>

    [WPE][GTK] REGRESSION(318402@main): canvas and image layer contents composited without blending
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320895">https://bugs.webkit.org/show_bug.cgi?id=320895</a>

    Reviewed by Carlos Garcia Campos.

    Since 318402@main the Skia compositor decides whether a layer&apos;s contents
    buffer needs blending from the buffer&apos;s TextureMapperFlags::ShouldBlend
    flag. CoordinatedPlatformLayerBufferSkiaImage, the buffer type used for
    accelerated 2D canvas contents and image backing stores on the Skia
    compositor path, never set that flag. Set ShouldBlend from the SkImage
    opacity when creating the buffer.

    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.cpp:
    (WebCore::CoordinatedPlatformLayerBufferSkiaImage::create):
    (WebCore::CoordinatedPlatformLayerBufferSkiaImage::CoordinatedPlatformLayerBufferSkiaImage):
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.h:

    Canonical link: <a href="https://commits.webkit.org/318453@main">https://commits.webkit.org/318453@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.51@webkitglib/2.54">https://commits.webkit.org/317695.51@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 72ac1e19ed2bbfddb188070f769c5507b8a7f2c9
<pre>
Cherry-pick 318402@main (f878301fffa7). <a href="https://bugs.webkit.org/show_bug.cgi?id=320745">https://bugs.webkit.org/show_bug.cgi?id=320745</a>

    [WPE][GTK] Skia compositor blends opaque contents buffers, wasting memory bandwidth
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320745">https://bugs.webkit.org/show_bug.cgi?id=320745</a>

    Reviewed by Carlos Garcia Campos and Nikolas Zimmermann.

    m_contentsOpaque only describes what the layer paints into its own tiles, so a
    layer whose contents come from an opaque buffer like a WebGL canvas created with
    alpha:false, an opaque video frame or an opaque image, are composited with
    source-over and read the destination for every pixel adding read bandwidth usage.
    TextureMapper gets the same decision off the buffer flags.

    Consider those flags too, restricted to layers with no backing store of their
    own, since the flag says nothing about the opacity of the layer&apos;s own tiles.

    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
    (WebCore::SkiaCompositingLayer::paintContents):

    Canonical link: <a href="https://commits.webkit.org/318402@main">https://commits.webkit.org/318402@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.50@webkitglib/2.54">https://commits.webkit.org/317695.50@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/123d9ba01a814e168ae549cb0f366da83402e2b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178836 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/52774 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46569 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188452 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143145 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180699 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54068 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52485 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139443 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143145 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181793 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54068 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46569 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119897 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54068 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52485 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1867 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46569 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54068 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46569 "The change is no longer eligible for processing.") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/40109 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45375 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52485 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190880 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52444 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46569 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148640 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53124 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46569 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148399 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27134 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53124 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125391 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120068 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51642 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46569 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51027 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51267 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51089 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->