### PR TITLE
SharedWorkerGlobalScope prototype is not an immutable prototype exotic object

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-immutable-prototype.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-immutable-prototype.any.sharedworker-expected.txt
@@ -1,6 +1,4 @@
 
-FAIL Setting to a different prototype assert_throws_js: function "() => {
-      Object.setPrototypeOf(object, {});
-    }" did not throw
+PASS Setting to a different prototype
 PASS Setting to the same prototype
 

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.idl
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.idl
@@ -27,6 +27,7 @@
     EnabledBySetting=SharedWorkerEnabled,
     Global=(Worker,SharedWorker),
     Exposed=SharedWorker,
+    IsImmutablePrototypeExoticObjectOnPrototype,
     JSGenerateToNativeObject,
 ]
 interface SharedWorkerGlobalScope : WorkerGlobalScope {


### PR DESCRIPTION
#### 73b4bbb977893a1d7c47cc14940a4cc47e487c43
<pre>
SharedWorkerGlobalScope prototype is not an immutable prototype exotic object
<a href="https://bugs.webkit.org/show_bug.cgi?id=321067">https://bugs.webkit.org/show_bug.cgi?id=321067</a>

Reviewed by Sam Weinig and Darin Adler.

Per Web IDL, the interface prototype object of a [Global] interface must be
an immutable prototype exotic object. WebKit implements this via the
IsImmutablePrototypeExoticObjectOnPrototype IDL extended attribute, which
DedicatedWorkerGlobalScope, ServiceWorkerGlobalScope, WorkerGlobalScope,
EventTarget and DOMWindow all declare. SharedWorkerGlobalScope was missing
it, so SharedWorkerGlobalScope.prototype was an ordinary extensible object
and Object.setPrototypeOf(SharedWorkerGlobalScope.prototype, {}) succeeded
instead of throwing a TypeError.

This matches the behavior of Chrome and Firefox and fixes the &quot;Setting to a
different prototype&quot; subtest of global-immutable-prototype.any.sharedworker.

No new tests, rebaselined existing WPT test.

* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-immutable-prototype.any.sharedworker-expected.txt:
* Source/WebCore/workers/shared/SharedWorkerGlobalScope.idl:

Canonical link: <a href="https://commits.webkit.org/318684@main">https://commits.webkit.org/318684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8839de75f6c461d4aeca987f58d1a57d4b1bed5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188454 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e27eeae-4731-425d-8acf-74feb14d78b7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139450 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cbd32d52-e6a8-4102-a239-46f57ef9df7a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119904 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7931d83-e96c-4443-93bd-75e8a57d7ec9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41686 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40034 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39682 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190882 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52446 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148636 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39934 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53126 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36314 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148401 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43099 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125393 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120070 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51644 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14663 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51029 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51269 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51091 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->