### PR TITLE
[Site Isolation] [iOS] Caret inside a cross-site iframe renders at a wrong location

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -448,6 +448,8 @@ void WebFrame::loadDidCommitInAnotherProcess(WebCore::ProcessIdentifier hostingP
     else {
         localFrame->loader().detachFromParent();
         corePage->setMainFrame(newFrame.copyRef());
+        if (RefPtr page = m_page.get())
+            page->updateRemoteMainFrameViewDelegatedScrolling();
     }
 
     if (ownerElement) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1054,6 +1054,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
             if (auto* remoteMainFrameClient = m_mainFrame->remoteFrameClient())
                 remoteMainFrameClient->applyWebsitePolicies(WTF::move(*remotePageParameters->websitePoliciesData));
         }
+
+        updateRemoteMainFrameViewDelegatedScrolling();
     }
     if (auto&& provisionalFrameCreationParameters = parameters.provisionalFrameCreationParameters) {
         ASSERT(page->settings().siteIsolationEnabled());
@@ -1973,6 +1975,20 @@ bool WebPage::shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const
 {
     RefPtr localTopDocument = protect(corePage())->localTopDocument();
     return localTopDocument && localTopDocument->quirks().shouldDispatchSyntheticMouseEventsWhenModifyingSelection();
+}
+
+void WebPage::updateRemoteMainFrameViewDelegatedScrolling()
+{
+    RefPtr drawingArea = m_drawingArea;
+    if (!drawingArea)
+        return;
+
+    RefPtr remoteMainFrame = dynamicDowncast<WebCore::RemoteFrame>(protect(corePage())->mainFrame());
+    if (!remoteMainFrame)
+        return;
+
+    if (RefPtr view = remoteMainFrame->view())
+        view->setDelegatedScrollingMode(drawingArea->delegatedScrollingMode());
 }
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -644,6 +644,11 @@ public:
 
     DrawingArea* drawingArea() const { return m_drawingArea.get(); }
 
+    // Mirror the drawing area's scrolling-delegation mode onto the main frame's RemoteFrameView so its
+    // coordinate conversions (e.g. selection rects) match the local main frame in the process that
+    // actually hosts it. Without this the proxy would double-subtract the main frame's scroll offset.
+    void updateRemoteMainFrameViewDelegatedScrolling();
+
 #if ENABLE(ASYNC_SCROLLING)
     WebCore::ScrollingCoordinator* scrollingCoordinator() const;
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -9836,6 +9836,96 @@ TEST(SiteIsolation, SelectionBoundingRectInMainFrameIsNotOffset)
     EXPECT_LT(CGRectGetMinY(rect), 50);
 }
 
+TEST(SiteIsolation, SelectionInCrossOriginIframeTracksMainFrameScroll)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0; height: 3000px'>"
+            "<iframe id='sameorigin' style='display: block; position: absolute; top: 100px; left: 100px; width: 400px; height: 200px; border: none;' src='https://example.com/iframe'></iframe>"
+            "<iframe id='crossorigin' style='display: block; position: absolute; top: 500px; left: 100px; width: 400px; height: 200px; border: none;' src='https://webkit.org/iframe'></iframe>"
+            "</body>"_s } },
+        { "/iframe"_s, { "<!DOCTYPE html><body style='margin: 0'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    enableSiteIsolation(configuration.get());
+    for (_WKFeature *feature in WKPreferences._features) {
+        if ([feature.key isEqualToString:@"SelectionHonorsOverflowScrolling"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // Locate the same-origin and cross-origin iframes in the frame tree.
+    auto childInfoForHost = [&](NSString *host) -> RetainPtr<WKFrameInfo> {
+        for (_WKFrameTreeNode *child in [webView mainFrame].childFrames) {
+            if ([child.info.securityOrigin.host isEqualToString:host])
+                return child.info;
+        }
+        return nil;
+    };
+    while (!childInfoForHost(@"example.com") || !childInfoForHost(@"webkit.org"))
+        Util::spinRunLoop();
+
+    auto readSelectionRect = [&]() -> CGRect {
+        __block CGRect rect = CGRectZero;
+        __block bool didReceiveRect = false;
+        [webView _selectionBoundingRectInMainFrameCoordinatesForTesting:^(CGRect receivedRect) {
+            rect = receivedRect;
+            didReceiveRect = true;
+        }];
+        Util::run(&didReceiveRect);
+        return rect;
+    };
+
+    // Focus the given iframe and select all of its text so the editor state is recomputed with the
+    // main frame at its current scroll offset, then report the selection rect. WKFrameInfo's focus
+    // state is a snapshot, so re-fetch it each spin. Clear the frame's selection first (so the
+    // subsequent SelectAll always recomputes) and key the waits off the specific frame.
+    auto selectTextAndReadRect = [&](NSString *elementID, NSString *host) -> CGRect {
+        [webView evaluateJavaScript:[NSString stringWithFormat:@"document.getElementById('%@').focus()", elementID] completionHandler:nil];
+        RetainPtr<WKFrameInfo> frame;
+        while (!(frame = childInfoForHost(host)) || ![frame _isFocused])
+            Util::spinRunLoop();
+        [webView evaluateJavaScript:@"getSelection().removeAllRanges()" inFrame:frame.get() completionHandler:nil];
+        while ([webView selectionRangeHasStartOffset:0 endOffset:4 inFrame:frame.get()])
+            Util::spinRunLoop();
+        [webView _synchronouslyExecuteEditCommand:@"SelectAll" argument:nil];
+        while (![webView selectionRangeHasStartOffset:0 endOffset:4 inFrame:frame.get()])
+            Util::spinRunLoop();
+        [webView waitForNextPresentationUpdate];
+        return readSelectionRect();
+    };
+
+    auto scrollDelta = [&](NSString *elementID, NSString *host) -> CGFloat {
+        [[webView scrollView] setContentOffset:CGPointZero animated:NO];
+        [webView waitForNextPresentationUpdate];
+        CGRect before = selectTextAndReadRect(elementID, host);
+
+        [[webView scrollView] setContentOffset:CGPointMake(0, 200) animated:NO];
+        [webView waitForNextPresentationUpdate];
+        CGRect after = selectTextAndReadRect(elementID, host);
+
+        return CGRectGetMinY(after) - CGRectGetMinY(before);
+    };
+
+    // A same-origin iframe shares the main frame's process, so its selection rect uses the ordinary
+    // (known-correct) conversion; a cross-origin iframe's rect goes through the site-isolation
+    // conversion. The two must respond to main-frame scrolling identically -- otherwise the selection
+    // (and caret) in the cross-origin iframe is drawn at the wrong location once the main frame is
+    // scrolled, because the main frame's RemoteFrameView proxy subtracts its scroll offset while the
+    // real main frame (which delegates scrolling to the UIScrollView) does not.
+    CGFloat sameOriginDelta = scrollDelta(@"sameorigin", @"example.com");
+    CGFloat crossOriginDelta = scrollDelta(@"crossorigin", @"webkit.org");
+    EXPECT_EQ(crossOriginDelta, sameOriginDelta);
+}
+
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
 TEST(SiteIsolation, SelectionInCrossOriginIframeIsContainedByContentView)
 {


### PR DESCRIPTION
#### d67629db80a219120c04862d20b6425bc267de60
<pre>
[Site Isolation] [iOS] Caret inside a cross-site iframe renders at a wrong location
<a href="https://bugs.webkit.org/show_bug.cgi?id=321068">https://bugs.webkit.org/show_bug.cgi?id=321068</a>

Reviewed by Simon Fraser.

When text is selected (or a caret is placed) inside a cross-origin, site-isolated
iframe, the selection and caret were drawn in the wrong place once the main frame
had been scrolled -- shifted by the main frame&apos;s scroll offset.

The selection rects are computed in the subframe&apos;s process and mapped to main-frame
coordinates by FrameView::convertToRootViewAcrossIsolatedFrames(), whose final step
calls contentsToView() on the main frame&apos;s view. On iOS the local main frame&apos;s
LocalFrameView is DelegatedToNativeScrollView (set from the drawing area in
WebLocalFrameLoaderClient), so contentsToView() is the identity and the rects stay
in main-frame content coordinates -- which is what UIKit expects, since the
WKContentView is document-sized. The main frame&apos;s RemoteFrameView proxy in the
subframe&apos;s process, however, defaulted to NotDelegated and its scrollPosition()
reflects the synced FrameScrollPosition, so contentsToView() subtracted the main
frame&apos;s scroll offset. The result was a cross-origin selection rect offset by
exactly the main-frame scroll, while a same-origin selection (which skips this
conversion) was correct.

Fix this by mirroring the drawing area&apos;s delegated-scrolling mode onto the main
frame&apos;s RemoteFrameView, so the proxy performs the same coordinate conversions as
the real main frame in the process that hosts it. This is correct cross-platform:
on iOS the mode is DelegatedToNativeScrollView (identity), and on macOS it is
DelegatedToWebKit, which still subtracts scroll -- matching the local main frame
there. The synced childFrameOwnerToRootContentTransform is already scroll-invariant;
only the final contentsToView() was wrong.

Test: TestWebKitAPI.SiteIsolation.SelectionInCrossOriginIframeTracksMainFrameScroll

* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::loadDidCommitInAnotherProcess): Call
updateRemoteMainFrameViewDelegatedScrolling when the main frame transitions from
local to remote.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::WebPage): Call updateRemoteMainFrameViewDelegatedScrolling when
the page is created with a remote main frame.
(WebKit::WebPage::updateRemoteMainFrameViewDelegatedScrolling): Added.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, SelectionInCrossOriginIframeTracksMainFrameScroll)):
Added SelectionInCrossOriginIframeTracksMainFrameScroll, comparing a same-origin
iframe (reference) against a cross-origin one under main-frame scroll.

Canonical link: <a href="https://commits.webkit.org/318716@main">https://commits.webkit.org/318716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/398fa4deb0e9ae8b17074987389d6cf654e073eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188857 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/366d2b85-b82a-4554-8f1e-5d6ba76baf78) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139604 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/95636dd4-b24f-42c0-b6b5-2b435397acd7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120050 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d8ea0d7-70f3-41b7-ab45-763fff74b0be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41871 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40215 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152270 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39861 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/164 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191077 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52637 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148832 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53317 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148580 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27185 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43272 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125588 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120402 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51835 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14840 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51220 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51461 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51281 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->