### PR TITLE
Cherry-pick 318589@main (f959dc4080ec). https://bugs.webkit.org/show_bug.cgi?id=320990

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -189,6 +189,11 @@ void SkiaCompositingLayer::setContentsBuffer(std::unique_ptr<CoordinatedPlatform
     m_contentsBuffer = WTF::move(contentsBuffer);
 }
 
+std::unique_ptr<CoordinatedPlatformLayerBuffer> SkiaCompositingLayer::takeContentsBuffer()
+{
+    return WTF::move(m_contentsBuffer);
+}
+
 void SkiaCompositingLayer::setContentsSolidColor(const Color& color)
 {
     if (m_contentsSolidColor == color)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -108,6 +108,7 @@ public:
     void processPendingTileUpdates();
     void setImageBackingStore(CoordinatedImageBackingStore*);
     void setContentsBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&);
+    std::unique_ptr<CoordinatedPlatformLayerBuffer> takeContentsBuffer();
     CoordinatedPlatformLayerBuffer* contentsBuffer() const { return m_contentsBuffer.get(); }
     void setContentsSolidColor(const Color&);
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.cpp
@@ -37,14 +37,9 @@
 
 namespace WebCore {
 
-Ref<CoordinatedAnimatedBackingStoreClient> CoordinatedAnimatedBackingStoreClient::create(GraphicsLayer& layer)
+Ref<CoordinatedAnimatedBackingStoreClient> CoordinatedAnimatedBackingStoreClient::create()
 {
-    return adoptRef(*new CoordinatedAnimatedBackingStoreClient(layer));
-}
-
-CoordinatedAnimatedBackingStoreClient::CoordinatedAnimatedBackingStoreClient(GraphicsLayer& layer)
-    : m_layer(&layer)
-{
+    return adoptRef(*new CoordinatedAnimatedBackingStoreClient());
 }
 
 void CoordinatedAnimatedBackingStoreClient::invalidate()
@@ -53,9 +48,11 @@ void CoordinatedAnimatedBackingStoreClient::invalidate()
     m_layer = nullptr;
 }
 
-void CoordinatedAnimatedBackingStoreClient::update(const FloatRect& visibleRect, const FloatRect& coverRect, const FloatSize& size, float contentsScale)
+void CoordinatedAnimatedBackingStoreClient::update(GraphicsLayer* layer, const FloatRect& visibleRect, const FloatRect& coverRect, const FloatSize& size, float contentsScale)
 {
     ASSERT(isMainThread());
+    ASSERT(layer);
+    m_layer = layer;
     m_visibleRect = visibleRect;
     m_coverRect = coverRect;
     m_size = size;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.cpp
@@ -44,25 +44,31 @@ Ref<CoordinatedAnimatedBackingStoreClient> CoordinatedAnimatedBackingStoreClient
 
 void CoordinatedAnimatedBackingStoreClient::invalidate()
 {
-    ASSERT(isMainThread());
+    assertIsMainThread();
     m_layer = nullptr;
 }
 
 void CoordinatedAnimatedBackingStoreClient::update(GraphicsLayer* layer, const FloatRect& visibleRect, const FloatRect& coverRect, const FloatSize& size, float contentsScale)
 {
-    ASSERT(isMainThread());
+    assertIsMainThread();
     ASSERT(layer);
     m_layer = layer;
-    m_visibleRect = visibleRect;
-    m_coverRect = coverRect;
-    m_size = size;
-    m_contentsScale = contentsScale;
+
+    {
+        Locker locker { m_lock };
+        m_visibleRect = visibleRect;
+        m_coverRect = coverRect;
+        m_size = size;
+        m_contentsScale = contentsScale;
+    }
 }
 
-void CoordinatedAnimatedBackingStoreClient::requestBackingStoreUpdateIfNeeded(const TransformationMatrix& transform)
+void CoordinatedAnimatedBackingStoreClient::requestBackingStoreUpdateIfNeeded(const TransformationMatrix& transform) const
 {
     // This is called from the compositor thread.
     ASSERT(!isMainThread());
+
+    Locker locker { m_lock };
 
     // Calculate the contents rectangle of the layer in backingStore coordinates.
     FloatRect contentsRect = { { }, m_size };
@@ -74,33 +80,33 @@ void CoordinatedAnimatedBackingStoreClient::requestBackingStoreUpdateIfNeeded(co
         return;
 
     // Non-invertible layers are not visible.
-    if (!transform.isInvertible())
-        return;
+    if (auto unscaledTransform = transform.inverse()) {
+        // Calculate the inverse of the layer transformation. The inverse transform will have the inverse of the
+        // scaleFactor applied, so we need to scale it back.
+        TransformationMatrix inverse = unscaledTransform->scale(m_contentsScale);
 
-    // Calculate the inverse of the layer transformation. The inverse transform will have the inverse of the
-    // scaleFactor applied, so we need to scale it back.
-    TransformationMatrix inverse = transform.inverse().value_or(TransformationMatrix()).scale(m_contentsScale);
+        // Apply the inverse transform to the visible rectangle, so we have the visible rectangle in layer coordinates.
+        FloatRect rect = inverse.clampedBoundsOfProjectedQuad(FloatQuad(m_visibleRect));
+        GraphicsLayerCoordinated::clampToSizeIfRectIsInfinite(rect, m_size);
+        FloatRect transformedVisibleRect = enclosingIntRect(rect);
 
-    // Apply the inverse transform to the visible rectangle, so we have the visible rectangle in layer coordinates.
-    FloatRect rect = inverse.clampedBoundsOfProjectedQuad(FloatQuad(m_visibleRect));
-    GraphicsLayerCoordinated::clampToSizeIfRectIsInfinite(rect, m_size);
-    FloatRect transformedVisibleRect = enclosingIntRect(rect);
+        // Convert the calculated visible rectangle to backingStore coordinates.
+        transformedVisibleRect.scale(m_contentsScale);
 
-    // Convert the calculated visible rectangle to backingStore coordinates.
-    transformedVisibleRect.scale(m_contentsScale);
+        // Restrict the calculated visible rect to the contents rectangle of the layer.
+        transformedVisibleRect.intersect(contentsRect);
 
-    // Restrict the calculated visible rect to the contents rectangle of the layer.
-    transformedVisibleRect.intersect(contentsRect);
+        if (m_coverRect.contains(transformedVisibleRect))
+            return;
 
-    if (m_coverRect.contains(transformedVisibleRect))
-        return;
-
-    // The coverRect doesn't contain the calculated visible rectangle we need to request a backingStore
-    // update to render more tiles.
-    callOnMainThread([this, protectedThis = Ref { *this }]() {
-        if (m_layer)
-            m_layer->client().notifyFlushRequired(m_layer);
-    });
+        // The coverRect doesn't contain the calculated visible rectangle we need to request a backingStore
+        // update to render more tiles.
+        callOnMainThread([this, protectedThis = Ref { *this }]() {
+            assertIsMainThread();
+            if (m_layer)
+                m_layer->client().notifyFlushRequired(m_layer);
+        });
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h
@@ -30,6 +30,8 @@
 
 #if USE(COORDINATED_GRAPHICS)
 #include "FloatRect.h"
+#include <wtf/Lock.h>
+#include <wtf/MainThread.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
@@ -43,16 +45,17 @@ public:
 
     void invalidate();
     void update(GraphicsLayer*, const FloatRect& visibleRect, const FloatRect& coverRect, const FloatSize&, float contentsScale);
-    void requestBackingStoreUpdateIfNeeded(const TransformationMatrix&);
+    void requestBackingStoreUpdateIfNeeded(const TransformationMatrix&) const;
 
 private:
     CoordinatedAnimatedBackingStoreClient() = default;
 
-    GraphicsLayer* m_layer { nullptr };
-    FloatRect m_visibleRect;
-    FloatRect m_coverRect;
-    FloatSize m_size;
-    float m_contentsScale { 1 };
+    GraphicsLayer* m_layer WTF_GUARDED_BY_CAPABILITY(mainThread) { nullptr };
+    mutable Lock m_lock;
+    FloatRect m_visibleRect WTF_GUARDED_BY_LOCK(m_lock);
+    FloatRect m_coverRect WTF_GUARDED_BY_LOCK(m_lock);
+    FloatSize m_size WTF_GUARDED_BY_LOCK(m_lock);
+    float m_contentsScale WTF_GUARDED_BY_LOCK(m_lock) { 1 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h
@@ -38,15 +38,15 @@ class TransformationMatrix;
 
 class CoordinatedAnimatedBackingStoreClient final : public ThreadSafeRefCounted<CoordinatedAnimatedBackingStoreClient> {
 public:
-    static Ref<CoordinatedAnimatedBackingStoreClient> create(GraphicsLayer&);
+    static Ref<CoordinatedAnimatedBackingStoreClient> create();
     ~CoordinatedAnimatedBackingStoreClient() = default;
 
     void invalidate();
-    void update(const FloatRect& visibleRect, const FloatRect& coverRect, const FloatSize&, float contentsScale);
+    void update(GraphicsLayer*, const FloatRect& visibleRect, const FloatRect& coverRect, const FloatSize&, float contentsScale);
     void requestBackingStoreUpdateIfNeeded(const TransformationMatrix&);
 
 private:
-    explicit CoordinatedAnimatedBackingStoreClient(GraphicsLayer&);
+    CoordinatedAnimatedBackingStoreClient() = default;
 
     GraphicsLayer* m_layer { nullptr };
     FloatRect m_visibleRect;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
@@ -21,8 +21,10 @@
 #include "CoordinatedBackingStoreProxy.h"
 
 #if USE(COORDINATED_GRAPHICS)
+#include "CoordinatedAnimatedBackingStoreClient.h"
 #include "CoordinatedPlatformLayer.h"
 #include "CoordinatedTileBuffer.h"
+#include "GraphicsLayerCoordinated.h"
 #include "PlatformDisplay.h"
 #include "ProcessCapabilities.h"
 #include <wtf/CheckedArithmetic.h>
@@ -97,13 +99,36 @@ Ref<CoordinatedBackingStoreProxy> CoordinatedBackingStoreProxy::create()
     return adoptRef(*new CoordinatedBackingStoreProxy());
 }
 
-OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStoreProxy::updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, const IntSize& unscaledViewportSize, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>& dirtyRegion, Damage& damage, CoordinatedPlatformLayer& layer)
+CoordinatedBackingStoreProxy::~CoordinatedBackingStoreProxy()
+{
+    ASSERT(!m_animatedBackingStoreClient);
+}
+
+void CoordinatedBackingStoreProxy::invalidate()
+{
+    setAffectedByTransformAnimation(false);
+}
+
+void CoordinatedBackingStoreProxy::setAffectedByTransformAnimation(bool affectedByTransformAnimation)
+{
+    if (affectedByTransformAnimation && !m_animatedBackingStoreClient)
+        m_animatedBackingStoreClient = CoordinatedAnimatedBackingStoreClient::create();
+    else if (!affectedByTransformAnimation && m_animatedBackingStoreClient) {
+        m_animatedBackingStoreClient->invalidate();
+        m_animatedBackingStoreClient = nullptr;
+    }
+}
+
+OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStoreProxy::updateIfNeeded(const IntRect& unscaledVisibleRect, const FloatSize& unscaledSize, const FloatRect& unscaledViewportRect, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>& dirtyRegion, Damage& damage, CoordinatedPlatformLayer& layer)
 {
     assertIsHeld(layer.lock());
     Vector<uint32_t> tilesToCreate;
     Vector<uint32_t> tilesToRemove;
     if (shouldCreateAndDestroyTiles)
-        createOrDestroyTiles(unscaledVisibleRect, unscaledContentsRect, unscaledViewportSize, contentsScale, layer.maxTextureSize(), damage, tilesToCreate, tilesToRemove);
+        createOrDestroyTiles(unscaledVisibleRect, IntRect { { }, IntSize(unscaledSize) }, enclosingIntRect(unscaledViewportRect).size(), contentsScale, layer.maxTextureSize(), damage, tilesToCreate, tilesToRemove);
+
+    if (m_animatedBackingStoreClient)
+        m_animatedBackingStoreClient->update(layer.owner(), unscaledViewportRect, m_coverRect, unscaledSize, contentsScale);
 
     if (!m_tiles.isEmpty())
         invalidateRegion(dirtyRegion);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
@@ -97,13 +97,13 @@ Ref<CoordinatedBackingStoreProxy> CoordinatedBackingStoreProxy::create()
     return adoptRef(*new CoordinatedBackingStoreProxy());
 }
 
-OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStoreProxy::updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>& dirtyRegion, Damage& damage, CoordinatedPlatformLayer& layer)
+OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStoreProxy::updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, const IntSize& unscaledViewportSize, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>& dirtyRegion, Damage& damage, CoordinatedPlatformLayer& layer)
 {
     assertIsHeld(layer.lock());
     Vector<uint32_t> tilesToCreate;
     Vector<uint32_t> tilesToRemove;
     if (shouldCreateAndDestroyTiles)
-        createOrDestroyTiles(unscaledVisibleRect, unscaledContentsRect, enclosingIntRect(layer.visibleRect()).size(), contentsScale, layer.maxTextureSize(), damage, tilesToCreate, tilesToRemove);
+        createOrDestroyTiles(unscaledVisibleRect, unscaledContentsRect, unscaledViewportSize, contentsScale, layer.maxTextureSize(), damage, tilesToCreate, tilesToRemove);
 
     if (!m_tiles.isEmpty())
         invalidateRegion(dirtyRegion);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
@@ -39,6 +39,11 @@
 #include "SkiaRecordingResult.h"
 #endif
 
+#if USE(CAIRO)
+#include "CairoPaintingContext.h"
+#include "CairoPaintingEngine.h"
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CoordinatedBackingStoreProxy);
@@ -119,9 +124,10 @@ void CoordinatedBackingStoreProxy::setAffectedByTransformAnimation(bool affected
     }
 }
 
-OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStoreProxy::updateIfNeeded(const IntRect& unscaledVisibleRect, const FloatSize& unscaledSize, const FloatRect& unscaledViewportRect, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>& dirtyRegion, Damage& damage, CoordinatedPlatformLayer& layer)
+OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStoreProxy::updateIfNeeded(const IntRect& unscaledVisibleRect, const FloatSize& unscaledSize, const FloatRect& unscaledViewportRect, float contentsScale, bool contentsOpaque, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>& dirtyRegion, Damage& damage, CoordinatedPlatformLayer& layer)
 {
-    assertIsHeld(layer.lock());
+    assertIsMainThread();
+    ASSERT(layer.owner());
     Vector<uint32_t> tilesToCreate;
     Vector<uint32_t> tilesToRemove;
     if (shouldCreateAndDestroyTiles)
@@ -152,9 +158,11 @@ OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStorePro
     if (dirtyTilesCount) {
         WTFBeginSignpost(this, UpdateTiles, "dirty tiles: %u", dirtyTilesCount);
 
+        auto& paintingEngine = layer.client().paintingEngine();
+
 #if USE(SKIA)
         // Record only once the whole layer.
-        auto recording = layer.record(tileDirtyRectUnion, dirtyTilesCount);
+        auto recording = paintingEngine.record(*layer.owner(), tileDirtyRectUnion, contentsOpaque, contentsScale, dirtyTilesCount);
 #endif
 
         unsigned dirtyTileIndex = 0;
@@ -166,9 +174,13 @@ OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStorePro
                 tile.rect.x(), tile.rect.y(), tile.rect.width(), tile.rect.height(), tile.dirtyRect.x(), tile.dirtyRect.y(), tile.dirtyRect.width(), tile.dirtyRect.height());
 
 #if USE(SKIA)
-            auto buffer = layer.replay(recording.copyRef(), tile.rect, tile.dirtyRect);
+            auto buffer = paintingEngine.replay(*layer.owner(), recording.copyRef(), tile.rect, tile.dirtyRect);
 #else
-            auto buffer = layer.paint(tile.dirtyRect);
+            FloatRect scaledDirtyRect(tile.dirtyRect);
+            scaledDirtyRect.scale(1 / contentsScale);
+
+            auto buffer = CoordinatedUnacceleratedTileBuffer::create(tile.dirtyRect.size(), contentsOpaque ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha);
+            paintingEngine.paint(*layer.owner(), buffer.get(), tile.dirtyRect, enclosingIntRect(scaledDirtyRect), IntRect { { }, tile.dirtyRect.size() }, contentsScale);
 #endif
 
             IntRect updateRect(tile.dirtyRect);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -31,6 +31,7 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
+class CoordinatedAnimatedBackingStoreClient;
 class CoordinatedPlatformLayer;
 class CoordinatedTileBuffer;
 class Damage;
@@ -40,11 +41,14 @@ class CoordinatedBackingStoreProxy final : public ThreadSafeRefCounted<Coordinat
     WTF_MAKE_TZONE_ALLOCATED(CoordinatedBackingStoreProxy);
 public:
     static Ref<CoordinatedBackingStoreProxy> create();
-    ~CoordinatedBackingStoreProxy() = default;
+    ~CoordinatedBackingStoreProxy();
 
     static constexpr int s_defaultCPUTileSize = 256;
 
-    const IntRect& coverRect() const LIFETIME_BOUND { return m_coverRect; }
+    void setAffectedByTransformAnimation(bool);
+    CoordinatedAnimatedBackingStoreClient* animatedBackingStoreClient() const { return m_animatedBackingStoreClient.get(); }
+
+    void invalidate();
 
     class Update {
         WTF_MAKE_NONCOPYABLE(Update);
@@ -81,7 +85,7 @@ public:
         TilesPending = 1 << 1,
         TilesChanged = 1 << 2
     };
-    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, const IntSize& unscaledViewportSize, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>&, Damage&, CoordinatedPlatformLayer&);
+    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const FloatSize& unscaledSize, const FloatRect& unscaledViewportRect, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>&, Damage&, CoordinatedPlatformLayer&);
     Update takePendingUpdate();
 
     void waitUntilPaintingComplete();
@@ -151,6 +155,7 @@ private:
     IntRect m_coverRect;
     IntRect m_keepRect;
     HashMap<IntPoint, Tile> m_tiles;
+    RefPtr<CoordinatedAnimatedBackingStoreClient> m_animatedBackingStoreClient;
     struct {
         Lock lock;
         Update pending WTF_GUARDED_BY_LOCK(lock);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -85,7 +85,7 @@ public:
         TilesPending = 1 << 1,
         TilesChanged = 1 << 2
     };
-    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const FloatSize& unscaledSize, const FloatRect& unscaledViewportRect, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>&, Damage&, CoordinatedPlatformLayer&);
+    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const FloatSize& unscaledSize, const FloatRect& unscaledViewportRect, float contentsScale, bool contentsOpaque, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>&, Damage&, CoordinatedPlatformLayer&);
     Update takePendingUpdate();
 
     void waitUntilPaintingComplete();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -81,7 +81,7 @@ public:
         TilesPending = 1 << 1,
         TilesChanged = 1 << 2
     };
-    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>&, Damage&, CoordinatedPlatformLayer&);
+    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, const IntSize& unscaledViewportSize, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>&, Damage&, CoordinatedPlatformLayer&);
     Update takePendingUpdate();
 
     void waitUntilPaintingComplete();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -147,6 +147,7 @@ void CoordinatedPlatformLayer::invalidateTarget()
         m_imageBackingStore.committed = nullptr;
         if (shouldReleaseBuffer(m_contentsBuffer.committed.get()))
             m_contentsBuffer.committed = nullptr;
+        m_contentsBuffer.hasCommitted = false;
     }
     m_target = nullptr;
 #if USE(SKIA)
@@ -488,21 +489,10 @@ float CoordinatedPlatformLayer::contentsScale() const
     return m_contentsScale;
 }
 
-bool CoordinatedPlatformLayer::hasCommittedContentsBuffer() const
-{
-    assertIsHeld(m_lock);
-#if USE(SKIA)
-    if (m_skiaTarget)
-        return !!m_skiaTarget->contentsBuffer();
-#endif
-
-    return !!m_contentsBuffer.committed;
-}
-
 void CoordinatedPlatformLayer::setContentsBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&& buffer, std::optional<Damage>&& dirtyRegion, RequireComposition requireComposition)
 {
     assertIsHeld(m_lock);
-    if (!buffer && !m_contentsBuffer.pending && !hasCommittedContentsBuffer())
+    if (!buffer && !m_contentsBuffer.pending && !m_contentsBuffer.hasCommitted)
         return;
 
     m_contentsBuffer.pending = WTF::move(buffer);
@@ -523,7 +513,7 @@ void CoordinatedPlatformLayer::setContentsBuffer(std::unique_ptr<CoordinatedPlat
 void CoordinatedPlatformLayer::replaceCurrentContentsBufferWithCopy()
 {
     Locker locker { m_lock };
-    if (!hasCommittedContentsBuffer())
+    if (!m_contentsBuffer.hasCommitted)
         return;
 
     m_contentsBuffer.pending = nullptr;
@@ -533,6 +523,7 @@ void CoordinatedPlatformLayer::replaceCurrentContentsBufferWithCopy()
         if (auto* buffer = m_skiaTarget->contentsBuffer()) {
             if (is<CoordinatedPlatformLayerBufferVideo>(*buffer))
                 m_contentsBuffer.pending = downcast<CoordinatedPlatformLayerBufferVideo>(*buffer).copyBuffer();
+            m_contentsBuffer.hasCommitted = !!m_contentsBuffer.pending;
             m_skiaTarget->setContentsBuffer(WTF::move(m_contentsBuffer.pending));
         }
         return;
@@ -541,6 +532,7 @@ void CoordinatedPlatformLayer::replaceCurrentContentsBufferWithCopy()
     if (is<CoordinatedPlatformLayerBufferVideo>(*m_contentsBuffer.committed))
         m_contentsBuffer.pending = downcast<CoordinatedPlatformLayerBufferVideo>(*m_contentsBuffer.committed).copyBuffer();
     m_contentsBuffer.committed = WTF::move(m_contentsBuffer.pending);
+    m_contentsBuffer.hasCommitted = !!m_contentsBuffer.committed;
     ensureTarget().setContentsLayer(m_contentsBuffer.committed.get());
 }
 #endif
@@ -1238,6 +1230,7 @@ void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<Com
     if (reasons.containsAny({ CompositionReason::RenderingUpdate, CompositionReason::VideoFrame, CompositionReason::AsyncScrolling })) {
         if (m_pendingChanges.contains(Change::ContentsBuffer)) {
             m_contentsBuffer.committed = WTF::move(m_contentsBuffer.pending);
+            m_contentsBuffer.hasCommitted = !!m_contentsBuffer.committed;
             m_pendingChanges.remove(Change::ContentsBuffer);
         }
 
@@ -1433,6 +1426,7 @@ void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet
         }
 #endif
         if (m_pendingChanges.contains(Change::ContentsBuffer)) {
+            m_contentsBuffer.hasCommitted = !!m_contentsBuffer.pending;
             layer.setContentsBuffer(WTF::move(m_contentsBuffer.pending));
             m_pendingChanges.remove(Change::ContentsBuffer);
         }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -809,15 +809,12 @@ void CoordinatedPlatformLayer::updateBackingStore()
         return;
 
     Damage damage(m_size, Damage::Mode::Rectangles);
-    IntRect contentsRect(IntPoint::zero(), IntSize(m_size));
-    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRect, contentsRect, enclosingIntRect(m_visibleRect).size(), m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
+    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRect, m_size, m_visibleRect, m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
     m_needsTilesUpdate = false;
 #if ENABLE(DAMAGE_TRACKING)
     addDamage(WTF::move(damage));
 #endif
     m_dirtyRegion.clear();
-    if (m_animatedBackingStoreClient)
-        m_animatedBackingStoreClient->update(m_visibleRect, m_backingStoreProxy->coverRect(), m_size, m_contentsScale);
 
     if (updateResult.contains(CoordinatedBackingStoreProxy::UpdateResult::TilesChanged)) {
         if (m_repaintCount != -1 && updateResult.contains(CoordinatedBackingStoreProxy::UpdateResult::BuffersChanged)) {
@@ -838,28 +835,20 @@ void CoordinatedPlatformLayer::updateContents(bool affectedByTransformAnimation)
     if (needsBackingStore()) {
         if (!m_backingStoreProxy) {
             m_backingStoreProxy = CoordinatedBackingStoreProxy::create();
+            m_backingStoreProxy->setAffectedByTransformAnimation(affectedByTransformAnimation);
             m_needsTilesUpdate = true;
             m_pendingChanges.add(Change::BackingStore);
-        }
-
-        if (affectedByTransformAnimation) {
-            if (!m_animatedBackingStoreClient) {
-                m_animatedBackingStoreClient = CoordinatedAnimatedBackingStoreClient::create(*m_owner);
+        } else {
+            bool wasAffectedByTransformAnimation = !!m_backingStoreProxy->animatedBackingStoreClient();
+            if (wasAffectedByTransformAnimation != affectedByTransformAnimation) {
+                m_backingStoreProxy->setAffectedByTransformAnimation(affectedByTransformAnimation);
                 m_pendingChanges.add(Change::BackingStore);
             }
-        } else if (m_animatedBackingStoreClient) {
-            m_animatedBackingStoreClient->invalidate();
-            m_animatedBackingStoreClient = nullptr;
-            m_pendingChanges.add(Change::BackingStore);
         }
     } else {
         if (m_backingStoreProxy) {
+            m_backingStoreProxy->invalidate();
             m_backingStoreProxy = nullptr;
-            m_pendingChanges.add(Change::BackingStore);
-        }
-        if (m_animatedBackingStoreClient) {
-            m_animatedBackingStoreClient->invalidate();
-            m_animatedBackingStoreClient = nullptr;
             m_pendingChanges.add(Change::BackingStore);
         }
     }
@@ -873,10 +862,9 @@ void CoordinatedPlatformLayer::updateContents(bool affectedByTransformAnimation)
 void CoordinatedPlatformLayer::purgeBackingStores()
 {
     Locker locker { m_lock };
-    m_backingStoreProxy = nullptr;
-    if (m_animatedBackingStoreClient) {
-        m_animatedBackingStoreClient->invalidate();
-        m_animatedBackingStoreClient = nullptr;
+    if (m_backingStoreProxy) {
+        m_backingStoreProxy->invalidate();
+        m_backingStoreProxy = nullptr;
     }
     m_imageBackingStore.current = nullptr;
     if (shouldReleaseBuffer(m_contentsBuffer.pending.get()))
@@ -1125,8 +1113,8 @@ void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<Com
                     m_backingStore = CoordinatedBackingStore::create();
                 layer.setBackingStore(m_backingStore.get());
 
-                if (m_animatedBackingStoreClient)
-                    layer.setAnimatedBackingStoreClient(m_animatedBackingStoreClient.get());
+                if (auto* animatedBackingStoreClient = m_backingStoreProxy->animatedBackingStoreClient())
+                    layer.setAnimatedBackingStoreClient(animatedBackingStoreClient);
             } else {
                 layer.setBackingStore(nullptr);
                 layer.setAnimatedBackingStoreClient(nullptr);
@@ -1319,7 +1307,7 @@ void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet
         }
 
         if (m_pendingChanges.contains(Change::BackingStore)) {
-            layer.setUseBackingStore(!!m_backingStoreProxy, m_backingStoreProxy && m_animatedBackingStoreClient ? m_animatedBackingStoreClient.get() : nullptr);
+            layer.setUseBackingStore(!!m_backingStoreProxy, m_backingStoreProxy ? m_backingStoreProxy->animatedBackingStoreClient() : nullptr);
             m_pendingChanges.remove(Change::BackingStore);
         }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -41,15 +41,9 @@
 #include "TextureMapperLayer.h"
 #include <wtf/MainThread.h>
 
-#if USE(CAIRO)
-#include "CairoPaintingContext.h"
-#include "CairoPaintingEngine.h"
-#endif
-
 #if USE(SKIA)
 #include "SkiaCompositingLayer.h"
 #include "SkiaPaintingEngine.h"
-#include "SkiaRecordingResult.h"
 #endif
 
 namespace WebCore {
@@ -801,30 +795,48 @@ bool CoordinatedPlatformLayer::needsBackingStore() const
 void CoordinatedPlatformLayer::updateBackingStore()
 {
     assertIsMainThread();
-    Locker locker { m_lock };
-    if (!m_backingStoreProxy)
-        return;
 
     if (m_dirtyRegion.isEmpty() && !m_pendingTilesCreation && !m_needsTilesUpdate)
         return;
 
-    Damage damage(m_size, Damage::Mode::Rectangles);
-    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRect, m_size, m_visibleRect, m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
-    m_needsTilesUpdate = false;
-#if ENABLE(DAMAGE_TRACKING)
-    addDamage(WTF::move(damage));
-#endif
-    m_dirtyRegion.clear();
+    FloatSize size;
+    float contentsScale;
+    bool contentsOpaque;
+    RefPtr<CoordinatedBackingStoreProxy> backingStoreProxy;
+    {
+        Locker locker { m_lock };
+        if (!m_backingStoreProxy)
+            return;
 
-    if (updateResult.contains(CoordinatedBackingStoreProxy::UpdateResult::TilesChanged)) {
-        if (m_repaintCount != -1 && updateResult.contains(CoordinatedBackingStoreProxy::UpdateResult::BuffersChanged)) {
-            m_repaintCount = m_owner->incrementRepaintCount();
-            m_pendingChanges.add(Change::DebugIndicators);
-        }
-        notifyCompositionRequired();
+        size = m_size;
+        contentsScale = m_contentsScale;
+        contentsOpaque = m_contentsOpaque;
+        backingStoreProxy = m_backingStoreProxy;
     }
 
+    Damage damage(size, Damage::Mode::Rectangles);
+    auto updateResult = backingStoreProxy->updateIfNeeded(m_transformedVisibleRect, size, m_visibleRect, contentsScale, contentsOpaque, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
+    m_dirtyRegion.clear();
+    m_needsTilesUpdate = false;
     m_pendingTilesCreation = updateResult.contains(CoordinatedBackingStoreProxy::UpdateResult::TilesPending);
+
+    bool tilesChanged = updateResult.contains(CoordinatedBackingStoreProxy::UpdateResult::TilesChanged);
+    {
+        Locker locker { m_lock };
+#if ENABLE(DAMAGE_TRACKING)
+        addDamage(WTF::move(damage));
+#endif
+
+        if (tilesChanged) {
+            if (m_repaintCount != -1 && updateResult.contains(CoordinatedBackingStoreProxy::UpdateResult::BuffersChanged)) {
+                m_repaintCount = m_owner->incrementRepaintCount();
+                m_pendingChanges.add(Change::DebugIndicators);
+            }
+        }
+    }
+
+    if (tilesChanged)
+        notifyCompositionRequired();
 }
 
 void CoordinatedPlatformLayer::updateContents(bool affectedByTransformAnimation)
@@ -906,25 +918,6 @@ void CoordinatedPlatformLayer::didPaintTile()
         m_client->didPaintTile();
 }
 
-Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::paint(const IntRect& dirtyRect)
-{
-    assertIsMainThread();
-    assertIsHeld(m_lock);
-    ASSERT(m_client);
-    ASSERT(m_owner);
-#if USE(CAIRO)
-    FloatRect scaledDirtyRect(dirtyRect);
-    scaledDirtyRect.scale(1 / m_contentsScale);
-
-    auto buffer = CoordinatedUnacceleratedTileBuffer::create(dirtyRect.size(), m_contentsOpaque ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha);
-    m_client->paintingEngine().paint(*m_owner, buffer.get(), dirtyRect, enclosingIntRect(scaledDirtyRect), IntRect { { }, dirtyRect.size() }, m_contentsScale);
-    return buffer;
-#elif USE(SKIA)
-    UNUSED_PARAM(dirtyRect);
-    RELEASE_ASSERT_NOT_REACHED();
-#endif
-}
-
 #if USE(SKIA)
 sk_sp<GrContextThreadSafeProxy> CoordinatedPlatformLayer::threadSafeGrContext() const
 {
@@ -932,24 +925,6 @@ sk_sp<GrContextThreadSafeProxy> CoordinatedPlatformLayer::threadSafeGrContext() 
         return nullptr;
 
     return m_client->paintingEngine().threadSafeGrContext();
-}
-
-Ref<SkiaRecordingResult> CoordinatedPlatformLayer::record(const IntRect& recordRect, unsigned dirtyTilesCount)
-{
-    assertIsMainThread();
-    assertIsHeld(m_lock);
-    ASSERT(m_client);
-    ASSERT(m_owner);
-    return m_client->paintingEngine().record(*m_owner, recordRect, m_contentsOpaque, m_contentsScale, dirtyTilesCount);
-}
-
-Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::replay(Ref<SkiaRecordingResult>&& recording, const IntRect& tileRect, const IntRect& dirtyRect)
-{
-    assertIsMainThread();
-    assertIsHeld(m_lock);
-    ASSERT(m_client);
-    ASSERT(m_owner);
-    return m_client->paintingEngine().replay(*m_owner, WTF::move(recording), tileRect, dirtyRect);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -126,13 +126,12 @@ SkiaCompositingLayer& CoordinatedPlatformLayer::ensureSkiaTarget()
 
 static bool shouldReleaseBuffer(CoordinatedPlatformLayerBuffer* buffer)
 {
-    if (!buffer)
-        return false;
-
 #if ENABLE(VIDEO)
     // Do not release hole punch buffers early. See https://bugs.webkit.org/show_bug.cgi?id=267322.
-    if (is<CoordinatedPlatformLayerBufferHolePunch>(*buffer))
+    if (is<CoordinatedPlatformLayerBufferHolePunch>(buffer))
         return false;
+#else
+    UNUSED_PARAM(buffer);
 #endif
 
     return true;
@@ -145,8 +144,12 @@ void CoordinatedPlatformLayer::invalidateTarget()
         Locker locker { m_lock };
         m_backingStore = nullptr;
         m_imageBackingStore.committed = nullptr;
-        if (shouldReleaseBuffer(m_contentsBuffer.committed.get()))
+        if (m_target && shouldReleaseBuffer(m_contentsBuffer.committed.get()))
             m_contentsBuffer.committed = nullptr;
+#if USE(SKIA)
+        if (m_skiaTarget && !shouldReleaseBuffer(m_skiaTarget->contentsBuffer()))
+            m_contentsBuffer.committed = m_skiaTarget->takeContentsBuffer();
+#endif
         m_contentsBuffer.hasCommitted = false;
     }
     m_target = nullptr;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -75,7 +75,7 @@ CoordinatedPlatformLayer::~CoordinatedPlatformLayer() = default;
 
 void CoordinatedPlatformLayer::setOwner(GraphicsLayerCoordinated* owner)
 {
-    ASSERT(isMainThread());
+    assertIsMainThread();
     if (m_owner == owner)
         return;
 
@@ -93,7 +93,7 @@ void CoordinatedPlatformLayer::setOwner(GraphicsLayerCoordinated* owner)
 
 GraphicsLayerCoordinated* CoordinatedPlatformLayer::owner() const
 {
-    ASSERT(isMainThread());
+    assertIsMainThread();
     return m_owner;
 }
 
@@ -303,27 +303,22 @@ const TransformationMatrix& CoordinatedPlatformLayer::childrenTransform() const
 
 void CoordinatedPlatformLayer::didUpdateLayerTransform()
 {
+    assertIsMainThread();
     m_needsTilesUpdate = true;
 }
 
 void CoordinatedPlatformLayer::setVisibleRect(const FloatRect& visibleRect)
 {
-    assertIsHeld(m_lock);
+    assertIsMainThread();
     if (m_visibleRect == visibleRect)
         return;
 
     m_visibleRect = visibleRect;
 }
 
-const FloatRect& CoordinatedPlatformLayer::visibleRect() const
-{
-    assertIsHeld(m_lock);
-    return m_visibleRect;
-}
-
 void CoordinatedPlatformLayer::setTransformedVisibleRect(IntRect&& transformedVisibleRect)
 {
-    assertIsHeld(m_lock);
+    assertIsMainThread();
     if (m_transformedVisibleRect == transformedVisibleRect)
         return;
 
@@ -347,7 +342,7 @@ const Markable<ScrollingNodeID>& CoordinatedPlatformLayer::scrollingNodeID() con
 
 void CoordinatedPlatformLayer::setDrawsContent(bool drawsContent)
 {
-    assertIsHeld(m_lock);
+    assertIsMainThread();
     m_drawsContent = drawsContent;
 }
 
@@ -477,6 +472,7 @@ void CoordinatedPlatformLayer::setContentsClippingRect(const FloatRoundedRect& c
 
 void CoordinatedPlatformLayer::setContentsScale(float contentsScale)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     if (m_contentsScale == contentsScale)
         return;
@@ -596,6 +592,7 @@ void CoordinatedPlatformLayer::setContentsTilePhase(const FloatSize& contentsTil
 
 void CoordinatedPlatformLayer::setDirtyRegion(Damage&& damage)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     auto dirtyRegion = damage.rects();
     if (m_dirtyRegion != dirtyRegion) {
@@ -769,6 +766,7 @@ void CoordinatedPlatformLayer::setDebugBorder(Color&& borderColor, float borderW
 
 void CoordinatedPlatformLayer::setShowRepaintCounter(bool showRepaintCounter)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     if ((m_repaintCount != -1 && showRepaintCounter) || (m_repaintCount == -1 && !showRepaintCounter))
         return;
@@ -780,6 +778,7 @@ void CoordinatedPlatformLayer::setShowRepaintCounter(bool showRepaintCounter)
 
 bool CoordinatedPlatformLayer::needsBackingStore() const
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     if (!m_owner)
         return false;
@@ -801,6 +800,7 @@ bool CoordinatedPlatformLayer::needsBackingStore() const
 
 void CoordinatedPlatformLayer::updateBackingStore()
 {
+    assertIsMainThread();
     Locker locker { m_lock };
     if (!m_backingStoreProxy)
         return;
@@ -810,7 +810,7 @@ void CoordinatedPlatformLayer::updateBackingStore()
 
     Damage damage(m_size, Damage::Mode::Rectangles);
     IntRect contentsRect(IntPoint::zero(), IntSize(m_size));
-    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRect, contentsRect, m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
+    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRect, contentsRect, enclosingIntRect(m_visibleRect).size(), m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
     m_needsTilesUpdate = false;
 #if ENABLE(DAMAGE_TRACKING)
     addDamage(WTF::move(damage));
@@ -832,6 +832,7 @@ void CoordinatedPlatformLayer::updateBackingStore()
 
 void CoordinatedPlatformLayer::updateContents(bool affectedByTransformAnimation)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
 
     if (needsBackingStore()) {
@@ -919,6 +920,7 @@ void CoordinatedPlatformLayer::didPaintTile()
 
 Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::paint(const IntRect& dirtyRect)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     ASSERT(m_client);
     ASSERT(m_owner);
@@ -946,6 +948,7 @@ sk_sp<GrContextThreadSafeProxy> CoordinatedPlatformLayer::threadSafeGrContext() 
 
 Ref<SkiaRecordingResult> CoordinatedPlatformLayer::record(const IntRect& recordRect, unsigned dirtyTilesCount)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     ASSERT(m_client);
     ASSERT(m_owner);
@@ -954,6 +957,7 @@ Ref<SkiaRecordingResult> CoordinatedPlatformLayer::record(const IntRect& recordR
 
 Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::replay(Ref<SkiaRecordingResult>&& recording, const IntRect& tileRect, const IntRect& dirtyRect)
 {
+    assertIsMainThread();
     assertIsHeld(m_lock);
     ASSERT(m_client);
     ASSERT(m_owner);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -317,14 +317,13 @@ const FloatRect& CoordinatedPlatformLayer::visibleRect() const
     return m_visibleRect;
 }
 
-void CoordinatedPlatformLayer::setTransformedVisibleRect(IntRect&& transformedVisibleRect, IntRect&& transformedVisibleRectIncludingFuture)
+void CoordinatedPlatformLayer::setTransformedVisibleRect(IntRect&& transformedVisibleRect)
 {
     assertIsHeld(m_lock);
-    if (m_transformedVisibleRect == transformedVisibleRect && m_transformedVisibleRectIncludingFuture == transformedVisibleRectIncludingFuture)
+    if (m_transformedVisibleRect == transformedVisibleRect)
         return;
 
     m_transformedVisibleRect = WTF::move(transformedVisibleRect);
-    m_transformedVisibleRectIncludingFuture = WTF::move(transformedVisibleRectIncludingFuture);
     m_needsTilesUpdate = true;
 }
 
@@ -816,7 +815,7 @@ void CoordinatedPlatformLayer::updateBackingStore()
 
     Damage damage(m_size, Damage::Mode::Rectangles);
     IntRect contentsRect(IntPoint::zero(), IntSize(m_size));
-    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRectIncludingFuture, contentsRect, m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
+    auto updateResult = m_backingStoreProxy->updateIfNeeded(m_transformedVisibleRect, contentsRect, m_contentsScale, m_pendingTilesCreation || m_needsTilesUpdate, m_dirtyRegion, damage, *this);
     m_needsTilesUpdate = false;
 #if ENABLE(DAMAGE_TRACKING)
     addDamage(WTF::move(damage));

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -36,6 +36,7 @@
 #include "TransformationMatrix.h"
 #include <wtf/EnumSet.h>
 #include <wtf/Lock.h>
+#include <wtf/MainThread.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 #if USE(SKIA)
@@ -135,16 +136,15 @@ public:
     const TransformationMatrix& childrenTransform() const WTF_REQUIRES_LOCK(m_lock);
     void didUpdateLayerTransform();
 
-    void setVisibleRect(const FloatRect&) WTF_REQUIRES_LOCK(m_lock);
-    const FloatRect& visibleRect() const WTF_REQUIRES_LOCK(m_lock);
-    void setTransformedVisibleRect(IntRect&&) WTF_REQUIRES_LOCK(m_lock);
+    void setVisibleRect(const FloatRect&);
+    void setTransformedVisibleRect(IntRect&&);
 
 #if ENABLE(SCROLLING_THREAD)
     void setScrollingNodeID(std::optional<ScrollingNodeID>) WTF_REQUIRES_LOCK(m_lock);
     const Markable<ScrollingNodeID>& scrollingNodeID() const WTF_REQUIRES_LOCK(m_lock);
 #endif
 
-    void setDrawsContent(bool) WTF_REQUIRES_LOCK(m_lock);
+    void setDrawsContent(bool);
     void setMasksToBounds(bool) WTF_REQUIRES_LOCK(m_lock);
     void setPreserves3D(bool) WTF_REQUIRES_LOCK(m_lock);
     void setBackfaceVisibility(bool) WTF_REQUIRES_LOCK(m_lock);
@@ -198,7 +198,7 @@ public:
     void flushPositionChanges(const OptionSet<CompositionReason>&, bool = false);
     void flushCompositingState(const OptionSet<CompositionReason>&, bool = false);
 
-    bool hasPendingTilesCreation() const { return m_pendingTilesCreation; }
+    bool hasPendingTilesCreation() const { assertIsMainThread(); return m_pendingTilesCreation; }
     bool hasPendingBackingStoreTileUpdates() const;
     void processPendingBackingStoreTileUpdates();
     bool isCompositionRequiredOrOngoing() const;
@@ -275,13 +275,19 @@ private:
 
     const PlatformLayerIdentifier m_id;
 
-    GraphicsLayerCoordinated* m_owner { nullptr };
+    GraphicsLayerCoordinated* m_owner WTF_GUARDED_BY_CAPABILITY(mainThread) { nullptr };
     std::unique_ptr<TextureMapperLayer> m_target;
 #if USE(SKIA)
     RefPtr<SkiaCompositingLayer> m_skiaTarget;
 #endif
-    bool m_pendingTilesCreation { false };
-    bool m_needsTilesUpdate { false };
+
+    // Accessed only from the main thread.
+    bool m_drawsContent WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    bool m_pendingTilesCreation WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    bool m_needsTilesUpdate WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    FloatRect m_visibleRect WTF_GUARDED_BY_CAPABILITY(mainThread);
+    IntRect m_transformedVisibleRect WTF_GUARDED_BY_CAPABILITY(mainThread);
+    Vector<IntRect, 1> m_dirtyRegion WTF_GUARDED_BY_CAPABILITY(mainThread);
 
 #if ENABLE(DAMAGE_TRACKING)
     bool m_damagePropagationEnabled { false };
@@ -296,9 +302,6 @@ private:
     FloatPoint m_boundsOrigin WTF_GUARDED_BY_LOCK(m_lock);
     TransformationMatrix m_transform WTF_GUARDED_BY_LOCK(m_lock);
     TransformationMatrix m_childrenTransform WTF_GUARDED_BY_LOCK(m_lock);
-    FloatRect m_visibleRect WTF_GUARDED_BY_LOCK(m_lock);
-    IntRect m_transformedVisibleRect WTF_GUARDED_BY_LOCK(m_lock);
-    bool m_drawsContent WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_masksToBounds WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_preserves3D WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_backfaceVisibility WTF_GUARDED_BY_LOCK(m_lock) { true };
@@ -329,7 +332,6 @@ private:
         Path path;
         WindRule windRule;
     } m_clipPath WTF_GUARDED_BY_LOCK(m_lock);
-    Vector<IntRect, 1> m_dirtyRegion WTF_GUARDED_BY_LOCK(m_lock);
     FilterOperations m_filters WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedPlatformLayer> m_mask WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedPlatformLayer> m_replica WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -46,7 +46,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 namespace WebCore {
-class CoordinatedAnimatedBackingStoreClient;
 class CoordinatedBackingStore;
 class CoordinatedBackingStoreProxy;
 class CoordinatedImageBackingStore;
@@ -318,7 +317,6 @@ private:
     float m_contentsScale WTF_GUARDED_BY_LOCK(m_lock) { 1. };
     RefPtr<CoordinatedBackingStoreProxy> m_backingStoreProxy WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedBackingStore> m_backingStore WTF_GUARDED_BY_LOCK(m_lock);
-    RefPtr<CoordinatedAnimatedBackingStoreClient> m_animatedBackingStoreClient WTF_GUARDED_BY_LOCK(m_lock);
     struct {
         RefPtr<CoordinatedImageBackingStore> current;
         RefPtr<CoordinatedImageBackingStore> committed;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -223,8 +223,6 @@ private:
     bool needsBackingStore() const;
     void purgeBackingStores();
 
-    bool hasCommittedContentsBuffer() const WTF_REQUIRES_LOCK(m_lock);
-
 #if ENABLE(DAMAGE_TRACKING)
     void addDamage(Damage&&) WTF_REQUIRES_LOCK(m_lock);
 #endif
@@ -325,6 +323,7 @@ private:
     struct {
         std::unique_ptr<CoordinatedPlatformLayerBuffer> pending;
         std::unique_ptr<CoordinatedPlatformLayerBuffer> committed;
+        bool hasCommitted { false };
     } m_contentsBuffer WTF_GUARDED_BY_LOCK(m_lock);
     struct {
         Path path;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -59,7 +59,6 @@ class TextureMapperLayer;
 #if USE(SKIA)
 class SkiaCompositingLayer;
 class SkiaPaintingEngine;
-class SkiaRecordingResult;
 #endif
 #if USE(CAIRO)
 namespace Cairo {
@@ -205,11 +204,6 @@ public:
     RunLoop* compositingRunLoop() const;
     int maxTextureSize() const;
 
-    Ref<CoordinatedTileBuffer> paint(const IntRect&) WTF_REQUIRES_LOCK(m_lock);
-#if USE(SKIA)
-    Ref<SkiaRecordingResult> record(const IntRect&, unsigned dirtyTilesCount) WTF_REQUIRES_LOCK(m_lock);
-    Ref<CoordinatedTileBuffer> replay(Ref<SkiaRecordingResult>&&, const IntRect&, const IntRect&) WTF_REQUIRES_LOCK(m_lock);
-#endif
     void willPaintTile();
     void didPaintTile();
     void waitUntilPaintingComplete();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -137,7 +137,7 @@ public:
 
     void setVisibleRect(const FloatRect&) WTF_REQUIRES_LOCK(m_lock);
     const FloatRect& visibleRect() const WTF_REQUIRES_LOCK(m_lock);
-    void setTransformedVisibleRect(IntRect&& visibleRect, IntRect&& visibleRectIncludingFuture) WTF_REQUIRES_LOCK(m_lock);
+    void setTransformedVisibleRect(IntRect&&) WTF_REQUIRES_LOCK(m_lock);
 
 #if ENABLE(SCROLLING_THREAD)
     void setScrollingNodeID(std::optional<ScrollingNodeID>) WTF_REQUIRES_LOCK(m_lock);
@@ -300,7 +300,6 @@ private:
     TransformationMatrix m_childrenTransform WTF_GUARDED_BY_LOCK(m_lock);
     FloatRect m_visibleRect WTF_GUARDED_BY_LOCK(m_lock);
     IntRect m_transformedVisibleRect WTF_GUARDED_BY_LOCK(m_lock);
-    IntRect m_transformedVisibleRectIncludingFuture WTF_GUARDED_BY_LOCK(m_lock);
     bool m_drawsContent WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_masksToBounds WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_preserves3D WTF_GUARDED_BY_LOCK(m_lock) { false };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -921,17 +921,16 @@ void GraphicsLayerCoordinated::computeLayerTransformIfNeeded(bool affectedByTran
     m_layerTransform.current.setChildrenTransform(childrenTransform());
     m_layerTransform.current.combineTransforms(parent() ? downcast<GraphicsLayerCoordinated>(*parent()).m_layerTransform.current.combinedForChildren() : TransformationMatrix());
 
-    m_layerTransform.cachedCombined = m_layerTransform.current.combined();
-    m_layerTransform.cachedInverse = m_layerTransform.cachedCombined.inverse().value_or(TransformationMatrix());
-
     m_layerTransform.future = m_layerTransform.current;
+
+    m_layerTransform.cachedInverse = m_layerTransform.current.combined().inverse();
     m_layerTransform.cachedFutureInverse = m_layerTransform.cachedInverse;
 
     auto* parentLayer = downcast<GraphicsLayerCoordinated>(parent());
     if (currentTransform != futureTransform || (parentLayer && parentLayer->m_layerTransform.current.combinedForChildren() != parentLayer->m_layerTransform.future.combinedForChildren())) {
         m_layerTransform.future.setLocalTransform(futureTransform);
         m_layerTransform.future.combineTransforms(parentLayer ? parentLayer->m_layerTransform.future.combinedForChildren() : TransformationMatrix());
-        m_layerTransform.cachedFutureInverse = m_layerTransform.future.combined().inverse().value_or(TransformationMatrix());
+        m_layerTransform.cachedFutureInverse = m_layerTransform.future.combined().inverse();
     }
 
     m_platformLayer->didUpdateLayerTransform();
@@ -955,28 +954,25 @@ void GraphicsLayerCoordinated::updateVisibleRect(const FloatRect& rect)
     assertIsHeld(m_platformLayer->lock());
     m_platformLayer->setVisibleRect(rect);
 
-    IntRect visibleRect;
-    IntRect visibleRectFuture;
     // Non-invertible layers are not visible.
-    if (!m_layerTransform.current.combined().isInvertible()) {
-        m_platformLayer->setTransformedVisibleRect(WTF::move(visibleRect), WTF::move(visibleRect));
+    if (!m_layerTransform.cachedInverse) {
+        m_platformLayer->setTransformedVisibleRect({ });
         return;
     }
 
     // Return a projection of the rect (surface coordinates) onto the layer's plane (layer coordinates).
     // The resulting quad might be squewed and the result is the bounding box of this quad,
     // so it might spread further than the real visible area (and then even more amplified by the cover rect multiplier).
-    ASSERT(m_layerTransform.cachedInverse == m_layerTransform.current.combined().inverse().value_or(TransformationMatrix()));
+    ASSERT(m_layerTransform.cachedInverse == m_layerTransform.current.combined().inverse());
     auto transformedRect = [&](const TransformationMatrix& matrix) -> IntRect {
         FloatRect result = matrix.clampedBoundsOfProjectedQuad(FloatQuad(rect));
         clampToSizeIfRectIsInfinite(result, m_size);
         return enclosingIntRect(result);
     };
-    visibleRect = transformedRect(m_layerTransform.cachedInverse);
-    visibleRectFuture = visibleRect;
-    if (m_layerTransform.cachedInverse != m_layerTransform.cachedFutureInverse)
-        visibleRectFuture.unite(transformedRect(m_layerTransform.cachedFutureInverse));
-    m_platformLayer->setTransformedVisibleRect(WTF::move(visibleRect), WTF::move(visibleRectFuture));
+    auto visibleRect = transformedRect(*m_layerTransform.cachedInverse);
+    if (m_layerTransform.cachedFutureInverse && m_layerTransform.cachedInverse != m_layerTransform.cachedFutureInverse)
+        visibleRect.unite(transformedRect(*m_layerTransform.cachedFutureInverse));
+    m_platformLayer->setTransformedVisibleRect(WTF::move(visibleRect));
 }
 
 void GraphicsLayerCoordinated::updateBackdropFilters()

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -215,9 +215,8 @@ private:
     struct {
         GraphicsLayerTransform current;
         GraphicsLayerTransform future;
-        TransformationMatrix cachedInverse;
-        TransformationMatrix cachedFutureInverse;
-        TransformationMatrix cachedCombined;
+        std::optional<TransformationMatrix> cachedInverse;
+        std::optional<TransformationMatrix> cachedFutureInverse;
     } m_layerTransform;
     bool m_needsUpdateLayerTransform { false };
     bool m_shouldUpdateRootRelativeScaleFactor : 1 { false };


### PR DESCRIPTION
#### 580595538d7f06a8c2a189d82bfb59f9c6ad374d
<pre>
Cherry-pick 318589@main (f959dc4080ec). <a href="https://bugs.webkit.org/show_bug.cgi?id=320990">https://bugs.webkit.org/show_bug.cgi?id=320990</a>

Unreviewed cherry-pick.

    [CoordinatedGraphics] CoordinatedAnimatedBackingStoreClient is not thread safe
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320990">https://bugs.webkit.org/show_bug.cgi?id=320990</a>

    Reviewed by Nikolas Zimmermann.

    Its members are written from the main thread in update() and read from
    the compositing thread in requestBackingStoreUpdateIfNeeded() without
    locking.

    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.cpp:
    (WebCore::CoordinatedAnimatedBackingStoreClient::invalidate):
    (WebCore::CoordinatedAnimatedBackingStoreClient::update):
    (WebCore::CoordinatedAnimatedBackingStoreClient::requestBackingStoreUpdateIfNeeded const):
    (WebCore::CoordinatedAnimatedBackingStoreClient::requestBackingStoreUpdateIfNeeded): Deleted.
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h:

    Canonical link: <a href="https://commits.webkit.org/318589@main">https://commits.webkit.org/318589@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.62@webkitglib/2.54">https://commits.webkit.org/317695.62@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 5bb8bea61297a3f8863989b5305584a991e023a9
<pre>
Cherry-pick 318554@main (0fd8ffebbc04). <a href="https://bugs.webkit.org/show_bug.cgi?id=320978">https://bugs.webkit.org/show_bug.cgi?id=320978</a>

    [CoordinatedGraphics] Release the CoordinatedPlatformLayer lock while recording and replaying tiles
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320978">https://bugs.webkit.org/show_bug.cgi?id=320978</a>

    Reviewed by Nikolas Zimmermann.

    Recording can take a while, if the scrolling thread needs to access the
    layer while being recorded it has to wait for something that doesn&apos;t
    change the layer state. We can copy the values we need to pass to
    CoordinatedBackingStoreProxy::updateIfNeeded() and release the log
    before calling it. This patch also moves the painting code back to
    CoordinatedBackingStoreProxy since nowadays the implementation of record
    and replay is just a single line on code and we avoid passing values
    from layer to proxy and then back from proxy to layer.

    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
    (WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h:
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
    (WebCore::CoordinatedPlatformLayer::updateBackingStore):
    (WebCore::CoordinatedPlatformLayer::threadSafeGrContext const):
    (WebCore::CoordinatedPlatformLayer::paint): Deleted.
    (WebCore::CoordinatedPlatformLayer::record): Deleted.
    (WebCore::CoordinatedPlatformLayer::replay): Deleted.
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:

    Canonical link: <a href="https://commits.webkit.org/318554@main">https://commits.webkit.org/318554@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.61@webkitglib/2.54">https://commits.webkit.org/317695.61@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### bd4f9a352ba2bfcf7a9d399e00304ff549199710
<pre>
Cherry-pick 318535@main (0f25453ee003). <a href="https://bugs.webkit.org/show_bug.cgi?id=320970">https://bugs.webkit.org/show_bug.cgi?id=320970</a>

    [CoordinatedGraphics] Move CoordinatedAnimatedBackingStoreClient ownership to CoordinatedBackingStoreProxy
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320970">https://bugs.webkit.org/show_bug.cgi?id=320970</a>

    Reviewed by Nikolas Zimmermann.

    A CoordinatedAnimatedBackingStoreClient can only exist when the layer
    has a CoordinatedBackingStoreProxy, and the client is updated with the
    cover rect computed by CoordinatedBackingStoreProxy so it&apos;s simpler to
    make CoordinatedBackingStoreProxy own the CoordinatedAnimatedBackingStoreClient.

    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.cpp:
    (WebCore::CoordinatedAnimatedBackingStoreClient::create):
    (WebCore::CoordinatedAnimatedBackingStoreClient::update):
    (WebCore::CoordinatedAnimatedBackingStoreClient::CoordinatedAnimatedBackingStoreClient): Deleted.
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h:
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
    (WebCore::CoordinatedBackingStoreProxy::~CoordinatedBackingStoreProxy):
    (WebCore::CoordinatedBackingStoreProxy::invalidate):
    (WebCore::CoordinatedBackingStoreProxy::setAffectedByTransformAnimation):
    (WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h:
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
    (WebCore::CoordinatedPlatformLayer::updateBackingStore):
    (WebCore::CoordinatedPlatformLayer::updateContents):
    (WebCore::CoordinatedPlatformLayer::purgeBackingStores):
    (WebCore::CoordinatedPlatformLayer::flushCompositingStateOnTarget):
    (WebCore::CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget):
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:

    Canonical link: <a href="https://commits.webkit.org/318535@main">https://commits.webkit.org/318535@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.60@webkitglib/2.54">https://commits.webkit.org/317695.60@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 21049455a19f1434599996a30c37e528eb4d1f73
<pre>
Cherry-pick 318455@main (4b1174b93a43). <a href="https://bugs.webkit.org/show_bug.cgi?id=320902">https://bugs.webkit.org/show_bug.cgi?id=320902</a>

    [CoordinatedGraphics] Remove the lock requirement for CoordinatedPlatformLayer members that are only accessed from the main thread
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320902">https://bugs.webkit.org/show_bug.cgi?id=320902</a>

    Reviewed by Nikolas Zimmermann.

    Replace the lock requirement by main thread requirement. Also remove the
    visibleRect() getter, since it&apos;s only ued by CoordinatedBackingStoreProxy::updateIfNeeded()
    and we can just pass the unscaled viewport size instead.

    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
    (WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h:
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
    (WebCore::CoordinatedPlatformLayer::setOwner):
    (WebCore::CoordinatedPlatformLayer::owner const):
    (WebCore::CoordinatedPlatformLayer::didUpdateLayerTransform):
    (WebCore::CoordinatedPlatformLayer::setVisibleRect):
    (WebCore::CoordinatedPlatformLayer::setTransformedVisibleRect):
    (WebCore::CoordinatedPlatformLayer::setContentsScale):
    (WebCore::CoordinatedPlatformLayer::setDirtyRegion):
    (WebCore::CoordinatedPlatformLayer::setShowRepaintCounter):
    (WebCore::CoordinatedPlatformLayer::updateBackingStore):
    (WebCore::CoordinatedPlatformLayer::updateContents):
    (WebCore::CoordinatedPlatformLayer::paint):
    (WebCore::CoordinatedPlatformLayer::record):
    (WebCore::CoordinatedPlatformLayer::replay):
    (WebCore::CoordinatedPlatformLayer::visibleRect const): Deleted.
    (WebCore::CoordinatedPlatformLayer::setDrawsContent):
    (WebCore::CoordinatedPlatformLayer::needsBackingStore const):
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
    (WebCore::CoordinatedPlatformLayer::WTF_GUARDED_BY_CAPABILITY):
    (WebCore::CoordinatedPlatformLayer::hasPendingTilesCreation const):

    Canonical link: <a href="https://commits.webkit.org/318455@main">https://commits.webkit.org/318455@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.59@webkitglib/2.54">https://commits.webkit.org/317695.59@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 2be3288c8fb977ce910a6ebfd0d00e1afe34679f
<pre>
Cherry-pick 318449@main (fbc68d0f05e7). <a href="https://bugs.webkit.org/show_bug.cgi?id=320888">https://bugs.webkit.org/show_bug.cgi?id=320888</a>

    [GTK][WPE] Skia compositor: do not early release hole punch buffers on layer invalidation
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320888">https://bugs.webkit.org/show_bug.cgi?id=320888</a>

    Reviewed by Nikolas Zimmermann.

    We only do it for texture mapper. With skia compositor the committed
    buffer is owned by SkiaCompositingLayer that is also going to be
    destroyed on invalidate, so we need to transfer the ownership of the
    hole punch buffer to CoordinatedPlatformLayer.

    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
    (WebCore::CoordinatedPlatformLayer::invalidateTarget):
    (WebCore::shouldReleaseBuffer):
    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
    (WebCore::SkiaCompositingLayer::takeContentsBuffer):

    Canonical link: <a href="https://commits.webkit.org/318449@main">https://commits.webkit.org/318449@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.58@webkitglib/2.54">https://commits.webkit.org/317695.58@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 19d7d8d68f6896e449ccba943a58045d89a061bb
<pre>
Cherry-pick 318445@main (68b163ff10b4). <a href="https://bugs.webkit.org/show_bug.cgi?id=320890">https://bugs.webkit.org/show_bug.cgi?id=320890</a>

    [GTK][WPE] Skia compositor: CoordinatedPlatformLayer::hasCommittedContentsBuffer() uses m_skiaTarget and can be called from different threads
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320890">https://bugs.webkit.org/show_bug.cgi?id=320890</a>

    Reviewed by Nikolas Zimmermann.

    In CoordinatedPlatformLayer m_skiaTarget is not pretected by any lock
    because it&apos;s only expected to be used from the compositing thread, but
    it&apos;s used from hasCommittedContentsBuffer() that can be called from gst
    threads. Add a bool flag protected by m_lock to note when the layer has
    a committed contents buffer and use it instead of hasCommittedContentsBuffer().

    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
    (WebCore::CoordinatedPlatformLayer::invalidateTarget):
    (WebCore::CoordinatedPlatformLayer::setContentsBuffer):
    (WebCore::CoordinatedPlatformLayer::replaceCurrentContentsBufferWithCopy):
    (WebCore::CoordinatedPlatformLayer::flushCompositingStateOnTarget):
    (WebCore::CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget):
    (WebCore::CoordinatedPlatformLayer::hasCommittedContentsBuffer const): Deleted.
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:

    Canonical link: <a href="https://commits.webkit.org/318445@main">https://commits.webkit.org/318445@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.57@webkitglib/2.54">https://commits.webkit.org/317695.57@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 6b7bdba8dcad4a433821c72854115293640ef833
<pre>
Cherry-pick 318313@main (715e92812255). <a href="https://bugs.webkit.org/show_bug.cgi?id=320738">https://bugs.webkit.org/show_bug.cgi?id=320738</a>

    [CoordinatedGraphics] Remove unused m_transformedVisibleRect from CoordinatedPlatformLayer
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320738">https://bugs.webkit.org/show_bug.cgi?id=320738</a>

    Reviewed by Fujii Hironori.

    Only the one including future is used, so we can keep that one as just
    m_transformedVisibleRect. We can also simplify GraphicsLayerCoordinated,
    m_layerTransform.cachedCombined is only used inside computeLayerTransformIfNeeded()
    so it can be a local variable.

    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
    (WebCore::CoordinatedPlatformLayer::setTransformedVisibleRect):
    (WebCore::CoordinatedPlatformLayer::updateBackingStore):
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
    * Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
    (WebCore::GraphicsLayerCoordinated::computeLayerTransformIfNeeded):
    (WebCore::GraphicsLayerCoordinated::updateVisibleRect):
    * Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:

    Canonical link: <a href="https://commits.webkit.org/318313@main">https://commits.webkit.org/318313@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.56@webkitglib/2.54">https://commits.webkit.org/317695.56@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7751e78084d7a22dd17d2d5e85b1db5fed532f42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179141 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53080 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46875 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188972 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143450 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181004 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54373 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52790 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139696 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143450 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182098 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54373 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46875 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120143 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54373 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52790 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46875 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54373 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46875 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/278 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45686 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52790 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191190 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52750 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46875 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148934 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53430 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46875 "The change is no longer eligible for processing.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148680 "Found 1 new API test failure: WebKitGTK/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27179 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53430 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125701 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120535 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51948 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46875 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51333 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51574 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51394 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->