### PR TITLE
[JSC] Remove enableInt52

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -754,21 +754,12 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case UInt32ToNumber: {
         JSValue child = forNode(node->child1()).value();
         if (doesOverflow(node->arithMode())) {
-            if (enableInt52()) {
-                if (child && child.isAnyInt()) {
-                    int64_t machineInt = child.asAnyInt();
-                    setConstant(node, jsNumber(static_cast<uint32_t>(machineInt)));
-                    break;
-                }
-                setNonCellTypeForNode(node, SpecInt52Any);
+            if (child && child.isAnyInt()) {
+                int64_t machineInt = child.asAnyInt();
+                setConstant(node, jsNumber(static_cast<uint32_t>(machineInt)));
                 break;
             }
-            if (child && child.isInt32()) {
-                uint32_t value = child.asInt32();
-                setConstant(node, jsNumber(value));
-                break;
-            }
-            setNonCellTypeForNode(node, SpecAnyIntAsDouble);
+            setNonCellTypeForNode(node, SpecInt52Any);
             break;
         }
         if (child && child.isInt32()) {

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -4212,10 +4212,7 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
                 return CallOptimizationResult::DidNothing;
             insertChecks();
             VirtualRegister operand = virtualRegisterForArgumentIncludingThis(1, registerOffset);
-            if (enableInt52())
-                setResult(addToGraph(FiatInt52, get(operand)));
-            else
-                setResult(get(operand));
+            setResult(addToGraph(FiatInt52, get(operand)));
             return CallOptimizationResult::Inlined;
         }
 
@@ -5671,10 +5668,6 @@ bool ByteCodeParser::handleDOMJITCall(Node* callTarget, Operand result, const DO
 template<typename ChecksFunctor>
 bool ByteCodeParser::handleIntrinsicGetter(Operand result, SpeculatedType prediction, const GetByVariant& variant, Node* thisNode, Node* unwrapped, const ChecksFunctor& insertChecks)
 {
-#if USE(LARGE_TYPED_ARRAYS)
-    static_assert(enableInt52());
-#endif
-
     if (thisNode != unwrapped)
         return false;
 

--- a/Source/JavaScriptCore/dfg/DFGCommon.h
+++ b/Source/JavaScriptCore/dfg/DFGCommon.h
@@ -94,11 +94,6 @@ inline bool validationEnabled()
 #endif
 }
 
-inline bool constexpr enableInt52()
-{
-    return true;
-}
-
 // The prediction propagator effectively does four passes, with the last pass
 // being done by the separate FixuPhase.
 enum PredictionPass {

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -489,7 +489,7 @@ private:
                 node->setArithMode(Arith::CheckOverflow);
             else {
                 node->setArithMode(Arith::DoOverflow);
-                node->setResult(enableInt52() ? NodeResultInt52 : NodeResultDouble);
+                node->setResult(NodeResultInt52);
             }
             break;
         }
@@ -2817,7 +2817,6 @@ private:
         }
 
         case FiatInt52: {
-            RELEASE_ASSERT(enableInt52());
             node->convertToIdentity();
             fixEdge<Int52RepUse>(node->child1());
             node->setResult(NodeResultInt52);
@@ -3114,13 +3113,9 @@ private:
                     break;
                 }
 
-                if (enableInt52()) {
-                    fixEdge<AnyIntUse>(node->child1());
-                    node->remove(m_graph);
-                    break;
-                }
-
-                // Must not perform fixEdge<NumberUse> here since the type set only includes TypeAnyInt. Double values should be logged.
+                fixEdge<AnyIntUse>(node->child1());
+                node->remove(m_graph);
+                break;
             }
 
             if (typeSet->doesTypeConformTo(TypeNumber | TypeAnyInt)) {

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -380,9 +380,6 @@ public:
     
     bool addShouldSpeculateInt52(Node* add)
     {
-        if (!enableInt52())
-            return false;
-        
         Node* left = add->child1().node();
         Node* right = add->child2().node();
 
@@ -426,9 +423,6 @@ public:
     {
         // This is much more relaxed compared to addShouldSpeculateInt52.
         // The reason is double mod is so costly, so it is worth trying with much more aggressively compared to addShouldSpeculateInt52.
-        if (!enableInt52())
-            return false;
-
         Node* left = node->child1().node();
         Node* right = node->child2().node();
 
@@ -463,9 +457,6 @@ public:
     
     bool binaryArithShouldSpeculateInt52(Node* node, PredictionPass pass)
     {
-        if (!enableInt52())
-            return false;
-        
         Node* left = node->child1().node();
         Node* right = node->child2().node();
 
@@ -482,8 +473,6 @@ public:
     
     bool unaryArithShouldSpeculateInt52(Node* node, PredictionPass pass)
     {
-        if (!enableInt52())
-            return false;
         return node->child1()->shouldSpeculateInt52()
             && node->canSpeculateInt52(pass)
             && !hasExitSite(node, Int52Overflow);

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -3223,12 +3223,12 @@ public:
         // However, we only emit such an add if both inputs can be Int52, and Int32
         // can trivially become Int52.
         //
-        return enableInt52() && isInt32OrInt52Speculation(prediction());
+        return isInt32OrInt52Speculation(prediction());
     }
 
     bool shouldSpeculateInt52OrOther()
     {
-        return enableInt52() && isInt32OrInt52OrOtherSpeculation(prediction());
+        return isInt32OrInt52OrOtherSpeculation(prediction());
     }
 
     bool shouldSpeculateDouble()
@@ -3532,7 +3532,7 @@ public:
     
     static bool shouldSpeculateInt52(Node* op1, Node* op2)
     {
-        return enableInt52() && op1->shouldSpeculateInt52() && op2->shouldSpeculateInt52();
+        return op1->shouldSpeculateInt52() && op2->shouldSpeculateInt52();
     }
     
     static bool shouldSpeculateNumber(Node* op1, Node* op2)

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -202,10 +202,8 @@ private:
         case UInt32ToNumber: {
             if (node->canSpeculateInt32(m_pass))
                 changed |= mergePrediction(SpecInt32Only);
-            else if (enableInt52())
-                changed |= mergePrediction(SpecInt52Any);
             else
-                changed |= mergePrediction(SpecBytecodeNumber);
+                changed |= mergePrediction(SpecInt52Any);
             break;
         }
 
@@ -619,18 +617,14 @@ private:
                 break;
             case Array::Uint32Array: {
                 if (isInt32SpeculationForArithmetic(node->getHeapPrediction()) && node->op() == GetByVal) {
-                    if (node->op() == GetByVal && arrayMode.isOutOfBounds())
+                    if (arrayMode.isOutOfBounds())
                         changed |= mergePrediction(SpecInt32Only | SpecOther);
                     else
                         changed |= mergePrediction(SpecInt32Only);
-                } else if (!(node->op() == GetByVal && arrayMode.isOutOfBounds()) && enableInt52())
+                } else if (!(node->op() == GetByVal && arrayMode.isOutOfBounds()))
                     changed |= mergePrediction(SpecInt52Any);
-                else {
-                    if (node->op() == GetByVal && arrayMode.isOutOfBounds())
-                        changed |= mergePrediction(SpecInt32Only | SpecAnyIntAsDouble | SpecOther);
-                    else
-                        changed |= mergePrediction(SpecInt32Only | SpecAnyIntAsDouble);
-                }
+                else
+                    changed |= mergePrediction(SpecInt32Only | SpecAnyIntAsDouble | SpecOther);
                 break;
             }
             case Array::Int8Array:
@@ -1006,7 +1000,7 @@ private:
         switch (m_currentNode->op()) {
         case JSConstant: {
             SpeculatedType type = speculationFromValue(m_currentNode->asJSValue());
-            if (type == SpecAnyIntAsDouble && enableInt52()) 
+            if (type == SpecAnyIntAsDouble)
                 type = int52AwareSpeculationFromValue(m_currentNode->asJSValue());
             setPrediction(type);
             break;
@@ -1546,7 +1540,6 @@ private:
         }
 
         case FiatInt52: {
-            RELEASE_ASSERT(enableInt52());
             setPrediction(SpecInt52Any);
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2895,19 +2895,10 @@ void SpeculativeJIT::compileValueToInt32(Node* node)
 void SpeculativeJIT::compileUInt32ToNumber(Node* node)
 {
     if (doesOverflow(node->arithMode())) {
-        if (enableInt52()) {
-            SpeculateInt32Operand op1(this, node->child1());
-            GPRTemporary result(this, Reuse, op1);
-            zeroExtend32ToWord(op1.gpr(), result.gpr());
-            strictInt52Result(result.gpr(), node);
-            return;
-        }
         SpeculateInt32Operand op1(this, node->child1());
-        FPRTemporary result(this);
-        GPRReg inputGPR = op1.gpr();
-        FPRReg outputFPR = result.fpr();
-        convertUInt32ToDouble(inputGPR, outputFPR);
-        doubleResult(outputFPR, node);
+        GPRTemporary result(this, Reuse, op1);
+        zeroExtend32ToWord(op1.gpr(), result.gpr());
+        strictInt52Result(result.gpr(), node);
         return;
     }
     
@@ -3267,7 +3258,6 @@ void SpeculativeJIT::setIntTypedArrayLoadResult(Node* node, JSValueRegs resultRe
     }
     
     if (node->shouldSpeculateInt52()) {
-        ASSERT(enableInt52());
         zeroExtend32ToWord(resultReg, resultReg);
         strictInt52Result(resultReg, node);
         return;

--- a/Source/JavaScriptCore/dfg/DFGVariableAccessData.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVariableAccessData.cpp
@@ -170,10 +170,6 @@ bool VariableAccessData::couldRepresentInt52()
 
 bool VariableAccessData::couldRepresentInt52Impl()
 {
-    // The hardware has to support it.
-    if (!enableInt52())
-        return false;
-    
     // We punt for machine arguments.
     if (operand().isArgument())
         return false;


### PR DESCRIPTION
#### 9226ba78d93d9c8d5b99accb87b4528e5a9a3dde
<pre>
[JSC] Remove enableInt52
<a href="https://bugs.webkit.org/show_bug.cgi?id=321072">https://bugs.webkit.org/show_bug.cgi?id=321072</a>
<a href="https://rdar.apple.com/184103404">rdar://184103404</a>

Reviewed by Yijia Huang.

As ARMv7 JIT is removed, now this is unconditionally enabled. Remove enableInt52.

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
(JSC::DFG::ByteCodeParser::handleIntrinsicGetter):
* Source/JavaScriptCore/dfg/DFGCommon.h:
(JSC::DFG::enableInt52): Deleted.
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::shouldSpeculateInt52):
(JSC::DFG::Node::shouldSpeculateInt52OrOther):
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileUInt32ToNumber):
(JSC::DFG::SpeculativeJIT::setIntTypedArrayLoadResult):
* Source/JavaScriptCore/dfg/DFGVariableAccessData.cpp:
(JSC::DFG::VariableAccessData::couldRepresentInt52Impl):

Canonical link: <a href="https://commits.webkit.org/318640@main">https://commits.webkit.org/318640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ba3c44bc3799dda9325e92d2cdd4dccc97b7911

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188468 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b70903d-1870-4308-a06b-c251118eef74) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139463 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cbcc7ae5-35f4-4e6f-b079-092c8c464f74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119917 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ed465d6-3234-409b-80e8-82fcde237ee6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41699 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40055 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1887 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8694 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152111 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39696 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40125 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190897 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52460 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148661 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53140 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148416 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27152 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43113 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125408 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120087 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51658 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14678 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51043 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->