### PR TITLE
[wip]Add miscellaneous tests for lazy-loading cross-site frames

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-2-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-2-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS When a loading=lazy iframe is loaded, it loads relative to the document's base URL computed at parse-time.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-2-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-2-site-isolated.sub.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<head>
+  <title>Deferred loading=lazy iframes load relative to the document's base URL
+         at parse-time</title>
+  <link rel="author" title="Dom Farolino" href="mailto:dom@chromium.org">
+  <link rel="author" title="Raj T" href="mailto:rajendrant@chromium.org">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<script>
+  let has_window_loaded = false;
+  const expected_url = 'http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html';
+
+  async_test(t => {
+    // Change the document's base URL to a bogus one, and scroll the
+    // below-viewport iframe into view. When it loads, it should load relative
+    // to the old base URL computed at parse-time.
+    window.addEventListener("load", t.step_func(() => {
+      window.history.pushState(2, document.title,
+                               '/invalid-url-where-no-subresources-exist/');
+      has_window_loaded = true;
+      document.getElementById('below-viewport').scrollIntoView();
+    }));
+
+    window.addEventListener("message", t.step_func_done(event => {
+      assert_true(has_window_loaded,
+            "Below-viewport loading=lazy iframes do not block the " +
+            "window load event");
+      assert_equals(event.data, expected_url, "The loading=lazy iframe loaded with the parse-time base URL");
+    }));
+
+  }, "When a loading=lazy iframe is loaded, it loads relative to the document's base URL computed at parse-time.");
+</script>
+
+<body>
+  <div style="height:1000vh;"></div>
+  <script>
+    // Change the document's base URL so that the iframe request parses relative
+    // to it when it sets up the request at parse-time.
+    window.history.pushState(1, document.title, 'resources/');
+  </script>
+  <iframe id="below-viewport" src='http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html' loading="lazy" width="200px" height="100px"></iframe>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-3-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-3-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS When a loading=lazy iframe is changed to eager later before loading, it loads relative to the document's base URL computed at parse-time.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-3-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-3-site-isolated.sub.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<head>
+  <title>Deferred iframes with loading='lazy' changed to eager later
+         use the document's base URL computed at parse-time</title>
+  <link rel="author" title="Oliver Medhurst" href="mailto:omedhurst@mozilla.com">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <base href='http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/'>
+</head>
+
+<script>
+  let has_window_loaded = false;
+  const expected_url = 'http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html';
+
+  async_test(t => {
+    // Change the base URL and scroll down to load the deferred iframe.
+    window.addEventListener("load", t.step_func(() => {
+      const base = document.querySelector('base');
+      base.href = '/invalid-url-where-no-subresources-exist/';
+      has_window_loaded = true;
+      document.getElementById('below-viewport').loading = 'eager';
+    }));
+
+    window.addEventListener("message", t.step_func_done(event => {
+      assert_true(has_window_loaded, "Below-viewport loading=lazy iframes do not block the window load event");
+      assert_equals(event.data, expected_url, "The loading=lazy iframe loaded with the parse-time base URL");
+    }));
+
+  }, "When a loading=lazy iframe is changed to eager later before loading, it loads relative to the " +
+     "document's base URL computed at parse-time.");
+</script>
+
+<body>
+  <div style="height:1000vh"></div>
+  <iframe id="below-viewport" src="subframe-post-msg.html" loading="lazy"
+          width="200px" height="100px">
+  </iframe>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS When a loading=lazy iframe is loaded, it loads relative to the document's base URL computed at parse-time.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-site-isolated.sub.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<head>
+  <title>Deferred iframes with loading='lazy' use the original
+         base URL specified at parse-time</title>
+  <link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <base href='http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/'>
+</head>
+
+<script>
+  let has_window_loaded = false;
+  const expected_url = 'http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html';
+
+  async_test(t => {
+    // Change the base URL and scroll down to load the deferred iframe.
+    window.addEventListener("load", t.step_func(() => {
+      const base = document.querySelector('base');
+      base.href = '/invalid-url-where-no-subresources-exist/';
+      has_window_loaded = true;
+      document.getElementById('below-viewport').scrollIntoView();
+    }));
+
+    window.addEventListener("message", t.step_func_done(event => {
+      assert_true(has_window_loaded, "Below-viewport loading=lazy iframes do not block the window load event");
+      assert_equals(event.data, expected_url, "The loading=lazy iframe loaded with the parse-time base URL");
+    }));
+
+  }, "When a loading=lazy iframe is loaded, it loads relative to the document's base URL computed at parse-time.");
+</script>
+
+<body>
+  <div style="height:1000vh"></div>
+  <iframe id="below-viewport" src="subframe-post-msg.html" loading="lazy"
+          width="200px" height="100px">
+  </iframe>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-history-pushState-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-history-pushState-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS History state change for iframe loading='lazy' before it is loaded: history.pushState
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-history-pushState-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-history-pushState-site-isolated.sub.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>History state change for iframe loading='lazy' before it is loaded: history.pushState</title>
+<iframe data-src="about:blank#push" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src" loading="lazy" hidden></iframe>
+<script>
+const iframe = document.querySelector('iframe');
+const expectedURL = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src";
+const iframeLoaded = new Promise(resolve => {
+  window.addEventListener("message", event => resolve(event.data));
+});
+let pushStateSuccess = true;
+try {
+  // Should have no effect on lazy-loading.
+  // Per https://html.spec.whatwg.org/C#can-have-its-url-rewritten
+  // only the fragment can be changed for about: URLs.
+  iframe.contentWindow.history.pushState(null, "", iframe.dataset.src);
+} catch(ex) {
+  pushStateSuccess = false;
+}
+const locationAfterPushState = iframe.contentWindow.location.href;
+iframe.hidden = false;
+</script>
+<!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({single_test: true});
+assert_true(pushStateSuccess);
+assert_equals(locationAfterPushState, new URL("about:blank#push", location.href).href);
+iframeLoaded.then(url => {
+  // No timeout needed in this test because history.pushState() doesn't navigate.
+  assert_equals(url, expectedURL);
+  done();
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-history-replaceState-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-history-replaceState-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS History state change for iframe loading='lazy' before it is loaded: history.replaceState
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-history-replaceState-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-history-replaceState-site-isolated.sub.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>History state change for iframe loading='lazy' before it is loaded: history.replaceState</title>
+<iframe data-src="about:blank#replace" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src" loading="lazy" hidden></iframe>
+<script>
+const iframe = document.querySelector('iframe');
+const expectedURL = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src";
+const iframeLoaded = new Promise(resolve => {
+  window.addEventListener("message", event => resolve(event.data));
+});
+let replaceStateSuccess = true;
+try {
+  // Should have no effect on lazy-loading.
+  // Per https://html.spec.whatwg.org/C#can-have-its-url-rewritten
+  // only the fragment can be changed for about: URLs.
+  iframe.contentWindow.history.replaceState(null, "", iframe.dataset.src);
+} catch(ex) {
+  replaceStateSuccess = false;
+}
+const locationAfterReplaceState = iframe.contentWindow.location.href;
+iframe.hidden = false;
+</script>
+<!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({single_test: true});
+assert_true(replaceStateSuccess);
+assert_equals(locationAfterReplaceState, new URL("about:blank#replace", location.href).href);
+iframeLoaded.then(url => {
+  // No timeout needed in this test because history.replaceState() doesn't navigate.
+  assert_equals(url, expectedURL);
+  done();
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-script-disabled-iframe-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-script-disabled-iframe-site-isolated.sub-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Iframes with loading='lazy' in script disabled iframe are not handled
+       as 'lazy'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-script-disabled-iframe-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-script-disabled-iframe-site-isolated.sub.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<head>
+<title>Iframes with loading='lazy' in script disabled iframe are not handled
+       as 'lazy'</title>
+<link rel="help" href="https://github.com/scott-little/lazyload">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+
+<div style="height:1000vh;"></div>
+<iframe src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/iframe-loading-lazy-in-script-disabled-iframe-wrapper.html">
+</iframe>
+<script>
+  async_test(t => {
+    window.addEventListener("message", t.step_func_done(event => {
+      assert_equals(event.data, "Subframe",
+          "lazy-load iframe shouldn't be honored in script disabled iframe");
+    }));
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-far-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-far-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Test that lazy-loaded iframes do not load when far from viewport.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-far-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-far-site-isolated.sub.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/#lazy-load-root-margin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #scroller {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    background-color: gray;
+  }
+
+  #spacer {
+    width: 130px;
+    height: 10000vh;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<div id="scroller">
+  <div id="spacer"></div>
+  <iframe
+    id="target"
+    src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html"
+    loading="lazy"
+    onload="iframe_onload();"
+  ></iframe>
+</div>
+
+<script>
+  const t = async_test(
+    "Test that lazy-loaded iframes do not load when far from viewport."
+  );
+
+  function iframe_onload() {
+    t.unreached_func(
+      "Lazy-loading iframe far from viewport should not load."
+    )();
+  }
+
+  t.step_timeout(() => {
+    t.done();
+  }, 2000);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-horizontal-far-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-horizontal-far-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Test that lazy-loaded iframes do not load when far from viewport.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-horizontal-far-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-horizontal-far-site-isolated.sub.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/#lazy-load-root-margin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #scroller {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    background-color: gray;
+    display: flex;
+  }
+
+  #spacer {
+    width: 10000vw;
+    height: 130px;
+    flex-shrink: 0;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+    flex-shrink: 0;
+  }
+</style>
+
+<div id="scroller">
+  <div id="spacer"></div>
+  <iframe
+    id="target"
+    src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html"
+    loading="lazy"
+    onload="iframe_onload();"
+  ></iframe>
+</div>
+
+<script>
+  const t = async_test(
+    "Test that lazy-loaded iframes do not load when far from viewport."
+  );
+
+  function img_onload() {
+    t.unreached_func(
+      "Lazy-loading iframe far from viewport should not load."
+    )();
+  }
+
+  t.step_timeout(() => {
+    t.done();
+  }, 2000);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-horizontal-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-horizontal-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Test that lazy-loaded iframes load when near viewport. assert_unreached: Timed out while waiting for iframe to load. Reached unreachable code
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-horizontal-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-horizontal-site-isolated.sub.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/#lazy-load-root-margin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #scroller {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    background-color: gray;
+    display: flex;
+  }
+
+  #spacer {
+    width: 130px;
+    height: 130px;
+    flex-shrink: 0;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+    flex-shrink: 0;
+  }
+</style>
+
+<div id="scroller">
+  <div id="spacer"></div>
+  <iframe
+    id="target"
+    src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html"
+    loading="lazy"
+    onload="iframe_onload();"
+  ></iframe>
+</div>
+
+<script>
+  const t = async_test(
+    "Test that lazy-loaded iframes load when near viewport."
+  );
+
+  function iframe_onload() {
+    t.done();
+  }
+
+  t.step_timeout(() => {
+    t.unreached_func(
+      "Timed out while waiting for iframe to load."
+    )();
+  }, 2000);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-2-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-2-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Test that lazy-loaded iframes load when near viewport. assert_unreached: Timed out while waiting for iframe to load. Reached unreachable code
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-2-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-2-site-isolated.sub.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/#lazy-load-root-margin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #scroller {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    background-color: gray;
+  }
+
+  #scroller2 {
+    width: 110px;
+    height: 110px;
+    overflow: scroll;
+  }
+
+  #spacer {
+    width: 130px;
+    height: 130px;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<div id=scroller2>
+  <div id="spacer"></div>
+  <div id="scroller">
+    <iframe
+      id="target"
+      src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html"
+      loading="lazy"
+      onload="iframe_onload();"
+    ></iframe>
+  </div>
+</div>
+
+<script>
+  const t = async_test(
+    "Test that lazy-loaded iframes load when near viewport."
+  );
+
+  function iframe_onload() {
+    t.done();
+  }
+
+  t.step_timeout(() => {
+    t.unreached_func(
+      "Timed out while waiting for iframe to load."
+    )();
+  }, 2000);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-3-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-3-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Test that lazy-loaded iframes load when near viewport. assert_unreached: Timed out while waiting for iframe to load. Reached unreachable code
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-3-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-3-site-isolated.sub.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/#lazy-load-root-margin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #scroller {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    background-color: gray;
+  }
+
+  #scroller2 {
+    width: 110px;
+    height: 110px;
+    overflow: scroll;
+  }
+
+  #scroller3 {
+    width: 120px;
+    height: 120px;
+    overflow: scroll;
+  }
+
+  #spacer {
+    width: 130px;
+    height: 130px;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<div id=scroller3>
+  <div id=scroller2>
+    <div id="scroller">
+      <div id="spacer"></div>
+      <iframe
+        id="target"
+        src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html"
+        loading="lazy"
+        onload="iframe_onload();"
+      ></iframe>
+    </div>
+  </div>
+</div>
+
+<script>
+  const t = async_test(
+    "Test that lazy-loaded iframes load when near viewport."
+  );
+
+  function iframe_onload() {
+    t.done();
+  }
+
+  t.step_timeout(() => {
+    t.unreached_func(
+      "Timed out while waiting for iframe to load."
+    )();
+  }, 2000);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-4-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-4-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Test that lazy-loaded iframes load when near viewport. assert_unreached: Timed out while waiting for iframe to load. Reached unreachable code
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-4-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-4-site-isolated.sub.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/#lazy-load-root-margin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #scroller {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    background-color: gray;
+  }
+
+  #scroller2 {
+    width: 110px;
+    height: 110px;
+    overflow: scroll;
+  }
+
+  .spacer {
+    width: 130px;
+    height: 130px;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<div id=scroller2>
+  <div class="spacer"></div>
+  <div id="scroller">
+    <div class="spacer"></div>
+    <iframe
+      id="target"
+      src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html"
+      loading="lazy"
+      onload="iframe_onload();"
+    ></iframe>
+  </div>
+</div>
+
+<script>
+  const t = async_test(
+    "Test that lazy-loaded iframes load when near viewport."
+  );
+
+  function iframe_onload() {
+    t.done();
+  }
+
+  t.step_timeout(() => {
+    t.unreached_func(
+      "Timed out while waiting for iframe to load."
+    )();
+  }, 2000);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-5-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-5-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Test that lazy-loaded images load when near viewport. assert_unreached: Timed out while waiting for iframe to load. Reached unreachable code
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-5-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-5-site-isolated.sub.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/#lazy-load-root-margin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #scroller {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    background-color: gray;
+    display: flex;
+  }
+
+  #scroller2 {
+    width: 110px;
+    height: 110px;
+    overflow: scroll;
+  }
+
+  .spacer {
+    width: 130px;
+    height: 130px;
+    flex-shrink: 0;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+    flex-shrink: 0;
+  }
+</style>
+
+<div id=scroller2>
+  <div class="spacer"></div>
+  <div id="scroller">
+    <div class="spacer"></div>
+    <iframe
+      id="target"
+      src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html"
+      loading="lazy"
+      onload="iframe_onload();"
+    ></iframe>
+  </div>
+</div>
+
+<script>
+  const t = async_test(
+    "Test that lazy-loaded images load when near viewport."
+  );
+
+  function iframe_onload() {
+    t.done();
+  }
+
+  t.step_timeout(() => {
+    t.unreached_func(
+      "Timed out while waiting for iframe to load."
+    )();
+  }, 2000);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Test that lazy-loaded iframes load when near viewport. assert_unreached: Timed out while waiting for iframe to load. Reached unreachable code
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-site-isolated.sub.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/#lazy-load-root-margin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #scroller {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    background-color: gray;
+  }
+
+  #scroller2 {
+    width: 110px;
+    height: 110px;
+    overflow: scroll;
+  }
+
+  #spacer {
+    width: 130px;
+    height: 130px;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<div id=scroller2>
+  <div id="scroller">
+    <div id="spacer"></div>
+    <iframe
+      id="target"
+      src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html"
+      loading="lazy"
+      onload="iframe_onload();"
+    ></iframe>
+  </div>
+</div>
+
+<script>
+  const t = async_test(
+    "Test that lazy-loaded iframes load when near viewport."
+  );
+
+  function iframe_onload() {
+    t.done();
+  }
+
+  t.step_timeout(() => {
+    t.unreached_func(
+      "Timed out while waiting for iframe to load."
+    )();
+  }, 2000);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Test that lazy-loaded iframes load when near viewport.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-site-isolated.sub.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/#lazy-load-root-margin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #scroller {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    background-color: gray;
+  }
+
+  #spacer {
+    width: 100px;
+    height: 100px;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<div id="scroller">
+  <div id="spacer"></div>
+  <iframe
+    id="target"
+    src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html"
+    loading="lazy"
+    onload="iframe_onload();"
+  ></iframe>
+</div>
+
+<script>
+  const t = async_test(
+    "Test that lazy-loaded iframes load when near viewport."
+  );
+
+  function iframe_onload() {
+    t.done();
+  }
+
+  t.step_timeout(() => {
+    t.unreached_func(
+      "Timed out while waiting for iframe to load."
+    )();
+  }, 2000);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-multiple-queued-navigations-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-multiple-queued-navigations-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Multiple queued lazy load navigations do not crash the page
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-multiple-queued-navigations-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-multiple-queued-navigations-site-isolated.sub.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<head>
+  <title>Multiple queued lazy load navigations do not crash the page</title>
+  <link rel="author" title="Dom Farolino" href="mailto:dom@chromium.org">
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<script>
+  const t = async_test('Multiple queued lazy load navigations do not crash ' +
+                       'the page');
+
+  let has_below_viewport_loaded = false;
+
+  window.addEventListener("load", t.step_func(() => {
+    assert_false(has_below_viewport_loaded,
+                "The below_viewport element should not have loaded before " +
+                "window.load().");
+
+    // Queue another lazy load navigation on the iframe. This should not result
+    // in multiple internal intersection observers being created for the iframe
+    // element, but instead should result in only one intersection observer
+    // associated with the iframe element, and the resulting navigation should
+    // be for the latest `src` attribute mutation.
+    const target = document.querySelector('#below_viewport');
+    target.src = 'http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?new-src';
+    target.scrollIntoView();
+  }));
+
+  window.addEventListener("message", t.step_func_done(event => {
+    const target = document.querySelector('#below_viewport');
+    assert_true(
+      target.src.includes('new-src'),
+      "The iframe's src should be updated to reflect the latest `src` " +
+      "mutation");
+
+    assert_true(event.data.includes('new-src'),
+      'The iframe should be navigated to the resource provided by the latest ' +
+      '`src` mutation');
+  }));
+
+
+</script>
+
+<body>
+  <div style="height:3000vh;"></div>
+  <iframe id="below_viewport" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?old-src"
+          loading="lazy" width="200px" height="100px"></iframe>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-multiple-times-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-multiple-times-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Iframes with loading='lazy' can be lazy loaded multiple times
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-multiple-times-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-multiple-times-site-isolated.sub.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<head>
+  <title>Iframes with loading='lazy' can be lazy loaded multiple times</title>
+  <link rel="author" title="Dom Farolino" href="mailto:dom@chromium.org">
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+  <!-- This is used to represent the top of the viewport, so we can scroll the
+       below-viewport iframe out-of-view later in the test -->
+  <div id="top_div"></div>
+  <div style="height:1000vh;"></div>
+  <iframe id="below_viewport" loading="lazy" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/unload-reporter.html?first"></iframe>
+
+<script>
+  const t = async_test();
+  const iframe = document.querySelector('#below_viewport');
+  const top_div = document.querySelector('#top_div');
+
+  let has_window_load_fired = false;
+  let iframe_being_unloaded = false;
+
+  // This should be triggered first.
+  window.addEventListener('load', t.step_func(() => {
+    has_window_load_fired = true;
+    // Scroll the loading=lazy below-viewport iframe into view, so that it loads.
+    iframe.scrollIntoView();
+  }));
+
+  window.addEventListener('message', t.step_func(msg => {
+    if (msg.data === 'unloading')
+      iframe_being_unloaded = true;
+  }));
+
+  iframe.onload = t.step_func(() => {
+    assert_true(has_window_load_fired,
+                "The loading=lazy below-viewport iframe should not block the " +
+                "window load event");
+    changeIframeSourceAndScrollToTop();
+  });
+
+  function changeIframeSourceAndScrollToTop() {
+    top_div.scrollIntoView();
+
+    // Lazily load a "different" iframe.
+    iframe.src = 'http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/unload-reporter.html?second';
+    iframe.onload =
+      t.unreached_func("The loading=lazy below-viewport iframe should lazily " +
+                       "load its second resource, and not load it eagerly " +
+                       "when the `src` attribute is changed");
+
+    // In 1s, scroll the iframe *back* into view, and record that it loads
+    // successfully.
+    t.step_timeout(() => {
+      assert_false(iframe_being_unloaded,
+                   "The iframe's old resource is not eagerly unloaded");
+
+      iframe.onload = t.step_func_done(() => {
+        assert_true(iframe_being_unloaded,
+                    "The iframe's old resources was unloaded correctly");
+      });
+
+      iframe.scrollIntoView();
+    }, 1000);
+  }
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-form-submit-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-form-submit-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Navigating iframe loading='lazy' before it is loaded: form submit Error: assert_equals: expected "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?" but got "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-form-submit-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-form-submit-site-isolated.sub.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>Navigating iframe loading='lazy' before it is loaded: form submit</title>
+<iframe name="iframe" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src" loading="lazy" hidden></iframe>
+<form action="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html" target="iframe"></form>
+<script>
+const iframe = document.querySelector('iframe');
+const iframeLoaded = new Promise(resolve => {
+  iframe.onload = resolve;
+});
+const loadedURLs = [];
+window.addEventListener("message", event => loadedURLs.push(event.data));
+const form = document.querySelector('form');
+form.submit();
+iframe.hidden = false;
+</script>
+<!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({single_test: true});
+iframeLoaded.then(() => {
+  // Need a timeout to detect failure when there are two navigations.
+  step_timeout(() => {
+    // The "?" in the URL is there because the default method is "GET"
+    // and the form data (empty here) is populated into the query.
+    assert_equals(loadedURLs[loadedURLs.length - 1],
+        "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?");
+    done();
+  }, 1000);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-link-click-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-link-click-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Navigating iframe loading='lazy' before it is loaded: link click Error: assert_equals: expected "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav" but got "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-link-click-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-link-click-site-isolated.sub.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>Navigating iframe loading='lazy' before it is loaded: link click</title>
+<iframe name="iframe" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src" loading="lazy" hidden></iframe>
+<a href="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav" target="iframe"></a>
+<script>
+const iframe = document.querySelector('iframe');
+const iframeLoaded = new Promise(resolve => {
+  iframe.onload = resolve;
+});
+const loadedURLs = [];
+window.addEventListener("message", event => loadedURLs.push(event.data));
+const a = document.querySelector('a');
+a.click();
+iframe.hidden = false;
+</script>
+<!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({single_test: true});
+iframeLoaded.then(() => {
+  // Need a timeout to detect failure when there are two navigations.
+  step_timeout(() => {
+    assert_equals(loadedURLs[loadedURLs.length - 1],
+        "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav");
+    done();
+  }, 1000);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-assign-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-assign-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Navigating iframe loading='lazy' before it is loaded: location.assign Error: assert_equals: expected "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav" but got "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-assign-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-assign-site-isolated.sub.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>Navigating iframe loading='lazy' before it is loaded: location.assign</title>
+<iframe data-src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src" loading="lazy" hidden></iframe>
+<script>
+const iframe = document.querySelector('iframe');
+const iframeLoaded = new Promise(resolve => {
+  iframe.onload = resolve;
+});
+const loadedURLs = [];
+window.addEventListener("message", event => loadedURLs.push(event.data));
+iframe.contentWindow.location.assign(iframe.dataset.src);
+iframe.hidden = false;
+</script>
+<!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({single_test: true});
+iframeLoaded.then(() => {
+  // Need a timeout to detect failure when there are two navigations.
+  step_timeout(() => {
+    assert_equals(loadedURLs[loadedURLs.length - 1],
+        "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav");
+    done();
+  }, 1000);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-cross-origin-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-cross-origin-site-isolated.sub-expected.txt
@@ -1,0 +1,6 @@
+
+
+FAIL Navigating to a cross-origin for iframe loading='lazy' before it is loaded: location.replace Error: assert_throws_dom: The iframe should load the cross-site url via locaiton.replace function "() => {
+        iframe.contentWindow.location.href
+      }" did not throw
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-cross-origin-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-cross-origin-site-isolated.sub.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>Navigating to a cross-origin for iframe loading='lazy' before it is loaded: location.replace</title>
+<iframe src="../resources/subframe.html?src" loading="lazy" hidden></iframe>
+<script>
+const iframe = document.querySelector('iframe');
+iframe.setAttribute(
+  "data-src",
+  "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?nav"
+);
+
+const iframeLoaded = new Promise(resolve => {
+  iframe.onload = resolve;
+});
+iframe.contentWindow.location.replace(iframe.dataset.src);
+iframe.hidden = false;
+</script>
+<!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({single_test: true});
+iframeLoaded.then(() => {
+  // Need a timeout to detect failure when there are two navigations.
+  step_timeout(() => {
+    assert_throws_dom(
+      "SecurityError", // Use the SecurityError to assert this is a cross-origin iframe
+      () => {
+        iframe.contentWindow.location.href
+      },
+      "The iframe should load the cross-site url via locaiton.replace");
+    done();
+  }, 1000);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-set-src-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-set-src-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Navigating iframe loading='lazy' and then setting src: location.replace
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-set-src-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-set-src-site-isolated.sub.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>Navigating iframe loading='lazy' and then setting src: location.replace</title>
+<iframe data-src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav" loading="lazy" hidden></iframe>
+<script>
+const iframe = document.querySelector('iframe');
+const iframeLoaded = new Promise(resolve => {
+  iframe.onload = resolve;
+});
+const loadedURLs = [];
+window.addEventListener("message", event => loadedURLs.push(event.data));
+iframe.contentWindow.location.replace(iframe.dataset.src);
+// Setting src invokes https://html.spec.whatwg.org/C#process-the-iframe-attributes
+iframe.src = 'http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src';
+iframe.hidden = false;
+</script>
+<!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({single_test: true});
+iframeLoaded.then(() => {
+  // Need a timeout to detect failure when there are two navigations.
+  step_timeout(() => {
+    assert_array_equals(loadedURLs, [iframe.src]);
+    done();
+  }, 1000);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Navigating iframe loading='lazy' before it is loaded: location.replace Error: assert_equals: expected "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav" but got "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-site-isolated.sub.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>Navigating iframe loading='lazy' before it is loaded: location.replace</title>
+<iframe data-src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src" loading="lazy" hidden></iframe>
+<script>
+const iframe = document.querySelector('iframe');
+const iframeLoaded = new Promise(resolve => {
+  iframe.onload = resolve;
+});
+const loadedURLs = [];
+window.addEventListener("message", event => loadedURLs.push(event.data));
+iframe.contentWindow.location.replace(iframe.dataset.src);
+iframe.hidden = false;
+</script>
+<!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({single_test: true});
+iframeLoaded.then(() => {
+  // Need a timeout to detect failure when there are two navigations.
+  step_timeout(() => {
+    assert_equals(loadedURLs[loadedURLs.length - 1],
+        "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav");
+    done();
+  }, 1000);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-meta-refresh-site-isolated.optional.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-meta-refresh-site-isolated.optional.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Navigating iframe loading='lazy' before it is loaded: meta refresh Error: assert_equals: expected "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav" but got "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-meta-refresh-site-isolated.optional.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-meta-refresh-site-isolated.optional.sub.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>Navigating iframe loading='lazy' before it is loaded: meta refresh</title>
+<!-- This test is optional because the spec allows delaying or doing nothing for meta refresh. -->
+<iframe src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src" loading="lazy" hidden></iframe>
+<script>
+const iframe = document.querySelector('iframe');
+const iframeLoaded = new Promise(resolve => {
+  iframe.onload = resolve;
+});
+const loadedURLs = [];
+window.addEventListener("message", event => loadedURLs.push(event.data));
+const meta = iframe.contentDocument.createElement('meta');
+meta.httpEquiv = 'Refresh';
+meta.content = '0; url=http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav';
+iframe.contentDocument.head.append(meta);
+iframe.hidden = false;
+</script>
+<!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({single_test: true});
+iframeLoaded.then(() => {
+  // Need a timeout to detect failure when there are two navigations.
+  step_timeout(() => {
+    assert_equals(loadedURLs[loadedURLs.length - 1],
+        "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav");
+    done();
+  }, 1000);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-navigation-navigate-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-navigation-navigate-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Navigating iframe loading='lazy' before it is loaded: navigation.navigate Error: assert_equals: expected "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav" but got "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-navigation-navigate-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-navigation-navigate-site-isolated.sub.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>Navigating iframe loading='lazy' before it is loaded: navigation.navigate</title>
+<iframe data-src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src" loading="lazy" hidden></iframe>
+<script>
+const iframe = document.querySelector('iframe');
+const iframeLoaded = new Promise(resolve => {
+  iframe.onload = resolve;
+});
+const loadedURLs = [];
+window.addEventListener("message", event => loadedURLs.push(event.data));
+iframe.contentWindow.navigation.navigate(iframe.dataset.src);
+iframe.hidden = false;
+</script>
+<!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({single_test: true});
+assert_true("navigation" in window, "Navigation API is supported");
+iframeLoaded.then(() => {
+  // Need a timeout to detect failure when there are two navigations.
+  step_timeout(() => {
+    assert_equals(loadedURLs[loadedURLs.length - 1],
+        "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav");
+    done();
+  }, 1000);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-window-open-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-window-open-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Navigating iframe loading='lazy' before it is loaded: location.replace Error: assert_equals: expected "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav" but got "http://not-web-platform.test:8800/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-window-open-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-window-open-site-isolated.sub.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>Navigating iframe loading='lazy' before it is loaded: location.replace</title>
+<iframe name="iframe" data-src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?src" loading="lazy" hidden></iframe>
+<script>
+const iframe = document.querySelector('iframe');
+const iframeLoaded = new Promise(resolve => {
+  iframe.onload = resolve;
+});
+const loadedURLs = [];
+window.addEventListener("message", event => loadedURLs.push(event.data));
+window.open(iframe.dataset.src, 'iframe');
+iframe.hidden = false;
+</script>
+<!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({single_test: true});
+iframeLoaded.then(() => {
+  // Need a timeout to detect failure when there are two navigations.
+  step_timeout(() => {
+    assert_equals(loadedURLs[loadedURLs.length - 1],
+        "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html?nav");
+    done();
+  }, 1000);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-site-isolated.sub-expected.txt
@@ -1,0 +1,6 @@
+
+
+
+PASS In-viewport iframes load eagerly
+PASS Below-viewport iframes load lazily
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-site-isolated.sub.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<head>
+  <title>Iframes with loading='lazy' load when in the viewport</title>
+  <link rel="author" title="Scott Little" href="mailto:sclittle@chromium.org">
+  <link rel="author" title="Dom Farolino" href="mailto:dom@chromium.org">
+  <link rel="help" href="https://github.com/whatwg/html/pull/5579">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<script>
+  const t_in_viewport =
+    async_test('In-viewport iframes load eagerly');
+  const t_below_viewport =
+    async_test('Below-viewport iframes load lazily');
+
+  let has_window_loaded = false;
+
+  const in_viewport_iframe_onload = t_in_viewport.step_func_done(() => {
+    assert_false(has_window_loaded,
+      "The in_viewport iframe should not block the load event");
+  });
+
+  window.addEventListener("load", () => {
+    has_window_loaded = true;
+    document.getElementById("below_viewport").scrollIntoView();
+  });
+
+  const below_viewport_iframe_onload = t_below_viewport.step_func_done(() => {
+    assert_true(has_window_loaded,
+                "The window load event should have fired before " +
+                "the below-viewport iframe loads");
+  });
+
+</script>
+
+<body>
+  <iframe id="in_viewport" src="../resources/subframe.html?in-viewport"
+          loading="lazy" width="200px" height="100px"
+          onload="in_viewport_iframe_onload();"></iframe>
+
+
+ <div style="height:2000vh;"></div>
+  <iframe id="below_viewport" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?below-viewport"
+          loading="lazy" width="200px" height="100px"
+          onload="below_viewport_iframe_onload();"></iframe>
+
+
+  <!-- This async script loads very slowly in order to ensure that, if the
+       below_viewport* elements have started loading, it has a chance to finish
+       loading before window load event fires, so that the test will dependably
+       fail in that case instead of potentially passing depending on how long
+       different resource fetches take. -->
+  <script async src="/common/slow.py"></script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-to-eager-site-isolated.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-to-eager-site-isolated.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Below-viewport iframes with loading='lazy' load when set to loading='eager' or the `loading` attribute is removed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-to-eager-site-isolated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-to-eager-site-isolated.sub.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<head>
+  <title>Below-viewport iframes with loading='lazy' load when set to
+         loading='eager' or the `loading` attribute is removed</title>
+  <link rel="author" title="Dom Farolino" href="mailto:domfarolino@gmail.com">
+  <link rel="help" href="https://github.com/whatwg/html/pull/5579">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<script>
+  const t = async_test("Below-viewport iframes with loading='lazy' load when " +
+                       "set to loading='eager' or the `loading` attribute is " +
+                       "removed");
+
+  const iframe_1_onload = t.unreached_func("#iframe_1 should not load before " +
+                                           "the window load event");
+  const iframe_2_onload = t.unreached_func("#iframe_2 should not load before " +
+                                           "the window load event");
+
+  window.addEventListener("load", t.step_func(() => {
+    const iframe_1 = document.querySelector('#iframe_1');
+    const iframe_2 = document.querySelector('#iframe_2');
+
+    const iframe_1_promise = new Promise((resolve, reject) => {
+      iframe_1.onerror = reject;
+      iframe_1.onload = resolve;
+    });
+
+    const iframe_2_promise = new Promise((resolve, reject) => {
+      iframe_2.onerror = reject;
+      iframe_2.onload = resolve;
+    });
+
+    Promise.all([iframe_1_promise, iframe_2_promise])
+      .then(t.step_func_done())
+      .catch(t.unreached_func("The iframes should load successfully"));
+
+    // Kick off the requests.
+    iframe_1.loading = 'eager';
+    iframe_2.removeAttribute('loading'); // unset the attribute, putting it in
+                                         // the default (eager) state.
+  }));
+
+</script>
+
+<body>
+  <div style="height:1000vh;"></div>
+  <iframe id="iframe_1"
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?1"
+          loading="lazy" onload="iframe_1_onload();"></iframe>
+  <iframe id="iframe_2"
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?2"
+          loading="lazy" onload="iframe_2_onload();"></iframe>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/iframe-loading-lazy-in-script-disabled-iframe-wrapper.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/iframe-loading-lazy-in-script-disabled-iframe-wrapper.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<iframe id="iframe" sandbox="allow-same-origin"
+        src="/html/semantics/embedded-content/the-iframe-element/resources/iframe-loading-lazy-in-viewport.html">
+</iframe>
+
+<script>
+    iframe.addEventListener("load", () => {
+        const inner_iframe = iframe.contentDocument.querySelector("iframe");
+        parent.postMessage(inner_iframe.contentDocument.body.textContent.trim(), "*");
+    });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<body>
+  <p>Subframe</p>
+</body>
+<script>
+parent.postMessage(location.href, '*');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/unload-reporter.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/unload-reporter.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<h1>I'll report to my parent when I'm unloaded</h1>
+
+<script>
+  window.onbeforeunload = e => {
+    parent.postMessage('unloading', '*');
+  };
+</script>


### PR DESCRIPTION
#### 1cad7d3fe525a5d1a5845bc55b360f9fb5adb819
<pre>
Add miscellaneous tests for lazy-loading cross-site frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=321075">https://bugs.webkit.org/show_bug.cgi?id=321075</a>
<a href="https://rdar.apple.com/184112467">rdar://184112467</a>

Reviewed by NOBODY (OOPS!).

See if automation catches any failures.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-2-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-2-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-3-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-3-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-base-url-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-history-pushState-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-history-pushState-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-history-replaceState-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-history-replaceState-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-script-disabled-iframe-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-script-disabled-iframe-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-far-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-far-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-horizontal-far-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-horizontal-far-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-horizontal-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-horizontal-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-2-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-2-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-3-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-3-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-4-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-4-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-5-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-5-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-nested-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-in-scroller-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-multiple-queued-navigations-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-multiple-queued-navigations-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-multiple-times-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-multiple-times-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-form-submit-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-form-submit-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-link-click-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-link-click-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-assign-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-assign-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-cross-origin-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-cross-origin-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-set-src-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-set-src-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-meta-refresh-site-isolated.optional.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-meta-refresh-site-isolated.optional.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-navigation-navigate-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-navigation-navigate-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-window-open-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-window-open-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-to-eager-site-isolated.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-to-eager-site-isolated.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/iframe-loading-lazy-in-script-disabled-iframe-wrapper.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/subframe-post-msg.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/resources/unload-reporter.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cad7d3fe525a5d1a5845bc55b360f9fb5adb819

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143589 "Built successfully") | ⏳ 🛠 ios-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181143 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139802 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96777 "1 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e26c939-3197-440f-9391-06b7f54f098e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182237 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43396 "Exiting early after 10 failures. 425 tests run. 1 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120254 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e06f5e18-22c7-4fce-a01b-87e132928f6e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42066 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40412 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152466 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40064 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/site-isolated/iframe-loading-lazy-nav-location-replace-set-src-site-isolated.sub.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/419 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191329 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52889 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160076 "1 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149051 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53569 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36691 "Too many flaky failures: http/tests/media/media-element-frame-destroyed-crash.html, http/tests/misc/repeat-open-cancel.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/downgraded-referrer-for-navigation-with-link-query-from-prevalent-resource.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https.html, http/tests/site-isolation/focus-click-navigation-activeElement.html, http/tests/site-isolation/inspector/network/resource-timing-cross-origin-page-navigation.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html, http/tests/webshare/webshare-allow-attribute-share.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148796 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43469 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120700 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52087 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15048 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51472 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51713 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51533 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->