### PR TITLE
[css-values-5 inherit()] Implement inherit() substitution function

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-inherit-substitution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-inherit-substitution-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL inherit() refers to parent stack frame (element) assert_equals: expected "PASS" but got "inherit(--x)"
-FAIL inherit() refers to parent stack frame (other function call) assert_equals: expected "PASS" but got "inherit(--x)"
-FAIL inherit() referring to guaranteed-invalid in parent frame assert_equals: expected "PASS" but got "inherit(--x, PASS)"
-FAIL inherit() referring to cycle in parent frame assert_equals: expected "PASS" but got "inherit(--x, PASS)"
-FAIL inherit() referring to typed value in parent frame assert_equals: expected "42px" but got "inherit(--x)"
+PASS inherit() refers to parent stack frame (element)
+PASS inherit() refers to parent stack frame (other function call)
+PASS inherit() referring to guaranteed-invalid in parent frame
+PASS inherit() referring to cycle in parent frame
+PASS inherit() referring to typed value in parent frame
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/custom-property-explicit-inherit-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/custom-property-explicit-inherit-invalidation-expected.txt
@@ -1,0 +1,4 @@
+
+PASS inherit keyword on a non-inherited custom property tracks the parent
+PASS inherit() on a non-inherited custom property tracks the parent
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/custom-property-explicit-inherit-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/custom-property-explicit-inherit-invalidation.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<title>Explicit inheritance of a non-inherited custom property is re-applied when the parent changes</title>
+<link rel="help" href="https://drafts.csswg.org/css-cascade-5/#inherit">
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#inherit-notation">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+@property --non-inherited-length { syntax: "<length>"; inherits: false; initial-value: 0px; }
+@property --non-inherited-color  { syntax: "<color>";  inherits: false; initial-value: black; }
+#outer { --non-inherited-length: 5px; --non-inherited-color: rgb(0, 0, 255); }
+#keyword { --non-inherited-length: inherit; }
+#fn { --non-inherited-color: inherit(--non-inherited-color); }
+</style>
+
+<div id="outer"><div id="keyword"></div><div id="fn"></div></div>
+
+<script>
+// A style resolution has to complete before the mutation, otherwise the stale value cannot be
+// observed: it only survives when a previously computed style is reused.
+test(() => {
+  const outer = document.getElementById("outer");
+  const style = getComputedStyle(document.getElementById("keyword"));
+  assert_equals(style.getPropertyValue("--non-inherited-length"), "5px", "before");
+  outer.style.setProperty("--non-inherited-length", "40px");
+  assert_equals(style.getPropertyValue("--non-inherited-length"), "40px", "after");
+}, "inherit keyword on a non-inherited custom property tracks the parent");
+
+test(() => {
+  const outer = document.getElementById("outer");
+  const style = getComputedStyle(document.getElementById("fn"));
+  assert_equals(style.getPropertyValue("--non-inherited-color"), "rgb(0, 0, 255)", "before");
+  outer.style.setProperty("--non-inherited-color", "rgb(0, 128, 0)");
+  assert_equals(style.getPropertyValue("--non-inherited-color"), "rgb(0, 128, 0)", "after");
+}, "inherit() on a non-inherited custom property tracks the parent");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/inherit-function-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/inherit-function-basic-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL inherit() on value set on parent assert_equals: expected "2" but got "auto"
-FAIL inherit() on value set on ancestor assert_equals: expected "2" but got "auto"
-FAIL inherit(), no value set on parent assert_equals: expected "4" but got "auto"
-FAIL inherit(), accumulating values assert_equals: expected "e3 e2 e1" but got "e3 inherit(--v)"
-FAIL inherit(), accumulating font-size assert_equals: expected "15px" but got "0px"
-FAIL inherit() can be used within if() assert_equals: expected "4" but got "7"
+PASS inherit() on value set on parent
+PASS inherit() on value set on ancestor
+PASS inherit(), no value set on parent
+PASS inherit(), accumulating values
+PASS inherit(), accumulating font-size
+PASS inherit() can be used within if()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/inherit-function-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/inherit-function-invalidation-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL inherit() invalidates when values changes on parent element, inherited assert_equals: expected "2" but got "auto"
-FAIL inherit() invalidates when values changes on parent element, inherited, deeper assert_equals: expected "2" but got "auto"
-FAIL inherit() invalidates when values changes on parent element, non-inherited assert_equals: expected "2" but got "auto"
+PASS inherit() invalidates when values changes on parent element, inherited
+PASS inherit() invalidates when values changes on parent element, inherited, deeper
+PASS inherit() invalidates when values changes on parent element, non-inherited
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/inherit-function-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/inherit-function-parsing-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL e.style['left'] = "inherit(--x)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['left'] = "calc(inherit(--x) + 1px)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['left'] = "inherit(--x,)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['left'] = "inherit(--x, )" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['left'] = "inherit(--x , )" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['left'] = "inherit(--x, foo)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['left'] = "inherit(--x)" should set the property value
+PASS e.style['left'] = "calc(inherit(--x) + 1px)" should set the property value
+PASS e.style['left'] = "inherit(--x,)" should set the property value
+PASS e.style['left'] = "inherit(--x, )" should set the property value
+PASS e.style['left'] = "inherit(--x , )" should set the property value
+PASS e.style['left'] = "inherit(--x, foo)" should set the property value
 PASS e.style['left'] = "inherit(!!, foo)" should not set the property value
 PASS e.style['left'] = "inherit(, foo)" should not set the property value
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1343,6 +1343,20 @@ CSSIfFunctionEnabled:
     WebCore:
       default: true
 
+CSSInheritFunctionEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS inherit() function"
+  humanReadableDescription: "Enable the CSS Values 5 inherit() function"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSInputSecurityEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/css/CSSSubstitutionValue.cpp
+++ b/Source/WebCore/css/CSSSubstitutionValue.cpp
@@ -35,10 +35,24 @@
 
 namespace WebCore {
 
+// The tokens are flat, including nested ones, and functionId() is CSSValueInvalid for anything that
+// is not a function token, so a linear scan finds inherit() at any depth.
+static bool containsInheritFunctionToken(const CSSVariableData& data)
+{
+    if (!data.context().cssInheritFunctionEnabled)
+        return false;
+    for (auto& token : data.tokens()) {
+        if (token.functionId() == CSSValueInherit)
+            return true;
+    }
+    return false;
+}
+
 CSSSubstitutionValue::CSSSubstitutionValue(Ref<CSSVariableData>&& data, const CSSNamespacePrefixMap& namespacePrefixMap)
     : CSSValue(ClassType::Substitution)
     , m_data(WTF::move(data))
     , m_namespacePrefixMap(namespacePrefixMap)
+    , m_containsInheritFunction(containsInheritFunctionToken(m_data))
 {
     cacheSimpleReference();
 }

--- a/Source/WebCore/css/CSSSubstitutionValue.h
+++ b/Source/WebCore/css/CSSSubstitutionValue.h
@@ -61,6 +61,11 @@ public:
 
     const CSSVariableData& data() const { return m_data.get(); }
 
+    // https://drafts.csswg.org/css-values-5/#funcdef-inherit
+    // inherit() reads a value from the parent that may be a property which does not itself inherit,
+    // so the cascade has to know a declaration contains one before deciding whether to re-apply it.
+    bool containsInheritFunction() const { return m_containsInheritFunction; }
+
 private:
     friend class Style::SubstitutionResolver;
 
@@ -78,6 +83,8 @@ private:
         CSSValueID functionId;
     };
     std::optional<SimpleReference> m_simpleReference;
+
+    bool m_containsInheritFunction { false };
 
     struct Cache {
         // For var() case: cache key is the substituted data pointer.

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -132,6 +132,7 @@ CSSParserContext::CSSParserContext(const Settings& settings)
     , cssCalcMixEnabled { settings.cssCalcMixEnabled() }
     , cssIdentFunctionEnabled { settings.cssIdentFunctionEnabled() }
     , cssIfFunctionEnabled { settings.cssIfFunctionEnabled() }
+    , cssInheritFunctionEnabled { settings.cssInheritFunctionEnabled() }
     , propertySettings { CSSPropertySettings { settings } }
 {
 }
@@ -183,6 +184,7 @@ void add(Hasher& hasher, const CSSParserContext& context)
         context.cssCalcMixEnabled,
         context.cssIdentFunctionEnabled,
         context.cssIfFunctionEnabled,
+        context.cssInheritFunctionEnabled,
         context.legacyFontFaceAttributeMode
     );
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, context.enclosingRuleType, bits);

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -95,6 +95,7 @@ struct CSSParserContext {
     bool cssCalcMixEnabled : 1 { false };
     bool cssIdentFunctionEnabled : 1 { false };
     bool cssIfFunctionEnabled : 1 { false };
+    bool cssInheritFunctionEnabled : 1 { false };
 
     // Enabled only for the legacy <font face> attribute: allows a numeric token within a family
     // name (e.g. "Bodoni 72"). Regular CSS font-family parsing stays strict.

--- a/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
+++ b/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
@@ -136,6 +136,13 @@ static std::optional<ClassifyBlockResult> classifyBlock(CSSParserTokenRange rang
                 result.hasSubstitutionFunctions = true;
                 continue;
             }
+            if (token.functionId() == CSSValueInherit && parserContext.cssInheritFunctionEnabled) {
+                // <inherit-args> is the same argument grammar as var()'s.
+                if (!isValidVariableReference(block, parserContext))
+                    return { };
+                result.hasSubstitutionFunctions = true;
+                continue;
+            }
             if (token.functionId() == CSSValueAttr && parserContext.cssAttrSubstitutionFunctionEnabled) {
                 if (!isValidAttrReference(block, parserContext))
                     return { };

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -29,6 +29,8 @@
 #include "CSSCustomPropertyValue.h"
 #include "CSSKeywordValueInlines.h"
 #include "CSSPaintImageValue.h"
+#include "CSSShorthandSubstitutionValue.h"
+#include "CSSSubstitutionValue.h"
 #include "CSSValuePool.h"
 #include "ComputedStyleDependencies.h"
 #include "PaintWorkletGlobalScope.h"
@@ -263,6 +265,28 @@ const PropertyCascade::Property* PropertyCascade::lastPropertyResolvingLogicalPr
     return nullptr;
 }
 
+// inherit() reads a value from the parent that may be a custom property which does not itself
+// inherit, so like the inherit keyword it has to be re-applied when the parent's non-inherited
+// style changes. https://drafts.csswg.org/css-values-5/#funcdef-inherit
+static bool explicitlyInheritsFromParent(const CSSValue& value)
+{
+    if (isValueID(value, CSSValueInherit))
+        return true;
+    if (RefPtr shorthandValue = dynamicDowncast<CSSShorthandSubstitutionValue>(value))
+        return shorthandValue->shorthandValue().containsInheritFunction();
+    if (RefPtr substitutionValue = dynamicDowncast<CSSSubstitutionValue>(value))
+        return substitutionValue->containsInheritFunction();
+    if (RefPtr customPropertyValue = dynamicDowncast<CSSCustomPropertyValue>(value)) {
+        return WTF::switchOn(customPropertyValue->value(),
+            [](const Ref<CSSSubstitutionValue>& substitution) { return substitution->containsInheritFunction(); },
+            [](const Ref<CSSVariableData>&) { return false; },
+            [](CSSWideKeyword keyword) {
+                return keyword == CSSWideKeyword::Inherit;
+            });
+    }
+    return false;
+}
+
 bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Origin origin, IsImportant important)
 {
     auto includePropertiesForRollback = [&] {
@@ -329,8 +353,11 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Origi
             bool currentIsInherited = CSSProperty::isInheritedProperty(current.id());
             if (m_includedProperties.types.contains(PropertyType::Inherited) && currentIsInherited)
                 return true;
-            if (m_includedProperties.types.contains(PropertyType::ExplicitlyInherited) && isValueID(*current.value(), CSSValueInherit))
-                return true;
+            if (m_includedProperties.types.contains(PropertyType::ExplicitlyInherited)) {
+                RefPtr value = current.value();
+                if (explicitlyInheritsFromParent(*value))
+                    return true;
+            }
             if (m_includedProperties.types.contains(PropertyType::NonInherited) && !currentIsInherited)
                 return true;
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -303,6 +303,61 @@ bool SubstitutionResolver::substituteFirstValid(CSSParserTokenRange range, Vecto
     return false;
 }
 
+// https://drafts.csswg.org/css-values-5/#funcdef-inherit
+// inherit() = inherit( <custom-property-name> , <declaration-value>? )
+// https://drafts.csswg.org/css-values-5/#replace-an-inherit-function
+bool SubstitutionResolver::substituteInheritFunction(CSSParserTokenRange range, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
+{
+    // <inherit-args> is the same argument grammar as var()'s, including leaving an unparseable name
+    // unset so that the fallback still gets used.
+    auto arguments = substituteVarArgumentGrammar(range, context);
+
+    auto inheritedValue = [&]() -> RefPtr<const CustomProperty> {
+        if (!arguments.name)
+            return nullptr;
+
+        // Inside a custom function the parent is the calling context's element, whose custom
+        // properties are resolved lazily, so force this one before reading it. Otherwise the result
+        // would depend on the order the calling element's declarations happen to be applied in.
+        // https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+        if (auto* callingContextBuilder = m_styleBuilder.state().callingContextBuilder())
+            callingContextBuilder->applyCustomProperty(*arguments.name);
+
+        // The property read may be one that does not itself inherit, so a change to the parent's
+        // non-inherited properties has to re-resolve this element. Set this even when the fallback
+        // ends up being used, since the parent gaining the property later flips that choice.
+        protect(m_styleBuilder.state().style())->setHasExplicitlyInheritedProperties();
+
+        return protect(m_styleBuilder.state().parentStyle())->customPropertyValue(*arguments.name);
+    }();
+
+    auto startIndex = tokens.size();
+
+    if (inheritedValue && !inheritedValue->isGuaranteedInvalid()) {
+        if (inheritedValue->tokens().size() > maxSubstitutionTokens)
+            return false;
+
+        // https://drafts.csswg.org/css-values-5/#attr-security
+        // Propagate attr()-taint through inherit() references.
+        propagateAttrTaint(inheritedValue->isAttrTainted(), inheritedValue->tokens());
+
+        tokens.appendVector(inheritedValue->tokens());
+    } else if (arguments.fallbackRange) {
+        auto fallbackTokens = substituteTokenRange(*arguments.fallbackRange, context);
+        if (!fallbackTokens || fallbackTokens->size() > maxSubstitutionTokens)
+            return false;
+
+        tokens.appendVector(*fallbackTokens);
+    } else
+        return false;
+
+    // https://drafts.csswg.org/css-values-5/#attr-security
+    // A name argument resolved from attr()-tainted values taints the whole substitution value.
+    propagateAttrTaint(arguments.isNameAttrTainted, std::span(tokens).subspan(startIndex));
+
+    return true;
+}
+
 // https://drafts.csswg.org/css-mixins/#evaluate-a-custom-function
 // Registers each parameter with its type, resolves argument styles, then updates registrations
 // to universal syntax with resolved values as initial values.
@@ -1154,6 +1209,11 @@ std::optional<Vector<CSSParserToken>> SubstitutionResolver::substituteTokenRange
             }
             if (functionId == CSSValueEnv) {
                 if (!substituteEnvFunction(range.consumeBlock(), tokens, context))
+                    success = false;
+                continue;
+            }
+            if (functionId == CSSValueInherit && context.cssInheritFunctionEnabled) {
+                if (!substituteInheritFunction(range.consumeBlock(), tokens, context))
                     success = false;
                 continue;
             }

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -68,6 +68,7 @@ private:
     bool substituteEnvFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteNamedValueOrFallback(const std::optional<AtomString>& name, const std::optional<CSSParserTokenRange>& fallbackRange, CSSValueID, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteFirstValid(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
+    bool substituteInheritFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteDashedFunction(StringView functionName, CSSParserTokenRange, Vector<CSSParserToken>&);
     RefPtr<MutableStyleProperties> resolveAndRegisterDashedFunctionArguments(const Vector<StyleRuleFunction::Parameter>&, const Vector<Vector<CSSParserToken>>&, LocalPropertyRegistry&, ScopeOrdinal definitionScope);
     bool substituteAttrFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);


### PR DESCRIPTION
#### ae3c47183d329b9d9d4c04a594cef7359dc00700
<pre>
[css-values-5 inherit()] Implement inherit() substitution function
<a href="https://bugs.webkit.org/show_bug.cgi?id=320984">https://bugs.webkit.org/show_bug.cgi?id=320984</a>
<a href="https://rdar.apple.com/184017733">rdar://184017733</a>

Reviewed by Antti Koivisto.

Implement the inherit() arbitrary substitution function, which resolves to the
inherited value of a custom property, meaning the parent&apos;s computed value, with
an optional second argument as a fallback when the first resolves to the
guaranteed-invalid value.

&lt;inherit()&gt; = inherit( &lt;custom-property-name&gt;, &lt;declaration-value&gt;? )

The argument grammar is the same as attr()&apos;s, so parsing and argument
substitution are shared with it. The first argument is substituted before being
parsed as a custom property name, and failing that parse falls through to the
fallback rather than being an error.

Inside a custom function the parent is the calling context&apos;s element, whose
custom properties resolve lazily, so the read forces that property first.
Otherwise the result would depend on the calling element&apos;s declaration order.

The cascade now re-applies a declaration containing inherit() when the parent&apos;s
non-inherited style changes, where it previously recognised only a literally
written inherit keyword. This covers custom property declarations too, which
also fixes the pre-existing case of `--y: inherit` on a non-inherited
registered property. A declaration that only reads such a property, as in
`border-color: var(--y)`, is still not re-applied; that is the more general
problem tracked in bug 321094.

Behind the CSSInheritFunctionEnabled setting, off by default.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-inherit-substitution-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/custom-property-explicit-inherit-invalidation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/custom-property-explicit-inherit-invalidation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/inherit-function-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/inherit-function-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/inherit-function-parsing-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSSubstitutionValue.cpp:
(WebCore::containsInheritFunctionToken):
(WebCore::CSSSubstitutionValue::CSSSubstitutionValue):
* Source/WebCore/css/CSSSubstitutionValue.h:
(WebCore::CSSSubstitutionValue::containsInheritFunction const):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSubstitutionParser.cpp:
(WebCore::classifyBlock):
(WebCore::isValidDeclarationValueAndFallback):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::explicitlyInheritsFromParent):
(WebCore::Style::PropertyCascade::addMatch):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteInheritFunction):
(WebCore::Style::SubstitutionResolver::substituteDeclarationValueAndFallback):
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):
(WebCore::Style::SubstitutionResolver::substituteTokenRange):
* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/318999@main">https://commits.webkit.org/318999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a07be69e98032c415c44b199806f01db8b19aa4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144364 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2d16817-8626-4507-93e5-cb6da0193d19) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140434 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d51a861e-bcb4-4b16-83e0-878e31489702) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120885 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf7f3c9e-2e78-4ad9-b282-124e9ca6a0a5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41056 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2853 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9684 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40726 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1414 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41319 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192189 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149755 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40120 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54344 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149486 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44127 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126657 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121714 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52861 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15714 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52244 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52481 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52307 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->