### PR TITLE
[Custom Highlight] ::highlight() pseudo-elements should inherit from the parent element's highlight.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3882,8 +3882,6 @@ imported/w3c/web-platform-tests/css/css-pseudo/first-line-line-height-002.html [
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-currentcolor-painting-properties-001.html [ ImageOnlyFailure Timeout Pass ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-currentcolor-painting-properties-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-currentcolor-painting-text-shadow-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-currentcolor-root-explicit-default-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-currentcolor-root-implicit-default-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-currentcolor-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-currentcolor-002a.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-currentcolor-002b.html [ ImageOnlyFailure ]
@@ -3916,7 +3914,6 @@ imported/w3c/web-platform-tests/css/css-pseudo/slider/slider-track-003.html [ Im
 imported/w3c/web-platform-tests/css/css-pseudo/svg-text-selection-002.html [ ImageOnlyFailure ]
 # Implement highlight pseudo-element cascade / painting behaviors (webkit.org/b/278216)
 imported/w3c/web-platform-tests/css/css-pseudo/target-text-004.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-pseudo/target-text-009.html [ ImageOnlyFailure ]
 # Incorrect test, needs WPT resync (webkit.org/b/277692)
 imported/w3c/web-platform-tests/css/css-pseudo/selection-background-painting-order.html [ ImageOnlyFailure ]
 
@@ -5750,11 +5747,6 @@ webkit.org/b/217931 imported/w3c/web-platform-tests/html/semantics/scripting-1/t
 webkit.org/b/217931 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/move-back-iframe-success-external-module.html [ Pass Failure ]
 webkit.org/b/217931 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/move-back-iframe-success-inline-classic.html [ Pass Failure ]
 
-webkit.org/b/220325 imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-cascade.html [ ImageOnlyFailure ]
-
-# Tests need updating relating to Highlight Spec
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-inheritance-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-inheritance-002.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-highlight-api/highlight-image-currentcolor.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/highlight-image-stacked.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-007-expected.txt
@@ -5,11 +5,11 @@ U
 PASS M::selection’s font-size is the same as in M
 PASS M span::selection’s font-size is the same as in M span
 PASS M::selection’s own text-shadow respects M’s font-size
-FAIL M span::selection’s inherited text-shadow respects M’s font-size assert_equals: expected "rgb(0, 128, 0) 12px 0px 0px" but got "none"
+PASS M span::selection’s inherited text-shadow respects M’s font-size
 PASS W::selection’s line-height is the same as in W
 PASS W span::selection’s line-height is the same as in W span
 PASS W::selection’s own text-shadow respects W’s line-height
-FAIL W span::selection’s inherited text-shadow respects W’s line-height assert_equals: expected "rgb(0, 128, 0) 0px 13px 0px" but got "none"
+PASS W span::selection’s inherited text-shadow respects W’s line-height
 PASS U::selection’s font-size is the same as in U
 PASS U span::selection’s font-size is the same as in U span
 PASS U::selection’s own text-decoration-thickness respects U’s font-size

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-parent-style-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-parent-style-change-expected.txt
@@ -1,0 +1,4 @@
+text
+
+PASS A highlight pseudo-element inherits from the parent's new style, not its previous one
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-parent-style-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-parent-style-change.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: highlight cascade: inheritance after a parent style change</title>
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-cascade">
+<meta name="assert" content="This test verifies that a highlight pseudo-element inherits from the current style of the corresponding highlight pseudo-element of its parent element, not from a previously resolved one.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #parent { font-size: 10px; }
+  #parent::selection { text-shadow: green 1em 0; }
+</style>
+<div id="parent"><span id="child">text</span></div>
+<script>
+test(() => {
+    const parent = document.getElementById("parent");
+    const child = document.getElementById("child");
+    const shadow = element => getComputedStyle(element, "::selection").textShadow;
+
+    // Resolves and caches the highlight styles of both, the child inheriting from the parent.
+    assert_equals(shadow(parent), "rgb(0, 128, 0) 10px 0px 0px", "parent");
+    assert_equals(shadow(child), "rgb(0, 128, 0) 10px 0px 0px", "child");
+
+    // The parent's own highlight text-shadow is in em, so this changes it, and the child inherits
+    // that computed value through the highlight chain.
+    parent.style.fontSize = "40px";
+
+    assert_equals(shadow(parent), "rgb(0, 128, 0) 40px 0px 0px", "parent after the change");
+    assert_equals(shadow(child), "rgb(0, 128, 0) 40px 0px 0px", "child after the change");
+}, "A highlight pseudo-element inherits from the parent's new style, not its previous one");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-shadow-boundary-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-shadow-boundary-expected.txt
@@ -1,0 +1,5 @@
+text
+
+PASS A highlight pseudo-element in a shadow tree inherits from the shadow host's
+PASS A highlight pseudo-element of slotted content inherits through the slot
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-shadow-boundary.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-shadow-boundary.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: highlight cascade: inheritance across a shadow boundary</title>
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-cascade">
+<meta name="assert" content="This test verifies that highlight inheritance follows the flat tree, so that a highlight pseudo-element in a shadow tree inherits from the corresponding highlight pseudo-element of the shadow host, and slotted content inherits through the slot.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #host::selection { background-color: rgb(1, 2, 3); }
+  #slotHost::selection { background-color: rgb(4, 5, 6); }
+</style>
+<div id="host"></div>
+<div id="slotHost"><span id="slotted">text</span></div>
+<script>
+const host = document.getElementById("host");
+const slotHost = document.getElementById("slotHost");
+host.attachShadow({ mode: "open" }).innerHTML = "<span id='inner'>text</span>";
+slotHost.attachShadow({ mode: "open" }).innerHTML = "<slot></slot>";
+
+const background = element => getComputedStyle(element, "::selection").backgroundColor;
+
+test(() => {
+    assert_equals(background(host.shadowRoot.getElementById("inner")), "rgb(1, 2, 3)");
+}, "A highlight pseudo-element in a shadow tree inherits from the shadow host's");
+
+test(() => {
+    assert_equals(background(document.getElementById("slotted")), "rgb(4, 5, 6)");
+}, "A highlight pseudo-element of slotted content inherits through the slot");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-currentcolor-computed-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-currentcolor-computed-inheritance-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL getComputedStyle() for ::selection assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::target-text assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
+PASS getComputedStyle() for ::selection
+PASS getComputedStyle() for ::target-text
 FAIL getComputedStyle() for ::search-text assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got ""
-FAIL getComputedStyle() for ::spelling-error assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::grammar-error assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::highlight(foo) assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
+PASS getComputedStyle() for ::spelling-error
+PASS getComputedStyle() for ::grammar-error
+PASS getComputedStyle() for ::highlight(foo)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-pseudos-inheritance-computed-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-pseudos-inheritance-computed-001-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL getComputedStyle() for ::selection at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::selection at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::target-text at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::target-text at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
+PASS getComputedStyle() for ::selection at #child1
+PASS getComputedStyle() for ::selection at #child2
+PASS getComputedStyle() for ::target-text at #child1
+PASS getComputedStyle() for ::target-text at #child2
 FAIL getComputedStyle() for ::search-text at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got ""
 FAIL getComputedStyle() for ::search-text at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got ""
-FAIL getComputedStyle() for ::spelling-error at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::spelling-error at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::grammar-error at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::grammar-error at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::highlight(foo) at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::highlight(foo) at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
+PASS getComputedStyle() for ::spelling-error at #child1
+PASS getComputedStyle() for ::spelling-error at #child2
+PASS getComputedStyle() for ::grammar-error at #child1
+PASS getComputedStyle() for ::grammar-error at #child2
+PASS getComputedStyle() for ::highlight(foo) at #child1
+PASS getComputedStyle() for ::highlight(foo) at #child2
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -49,13 +49,13 @@
         "\"overflowWrap() / setOverflowWrap() / initialOverflowWrap()\".",
         "",
         "* style-builder-custom:",
-        "A string that is \"All\", \"Initial\", \"Inherit\", or \"Value\" or some combination",
-        "of the latter three separated by '|' (e.g. \"Inherit|Value\"). These options",
-        "are described as follows:",
+        "A string that is \"All\", \"Initial\", \"Inherit\", \"Value\", \"HighlightInitial\",",
+        "\"HighlightInherit\", or \"HighlightValue\", or some combination of all but the first,",
+        "separated by '|' (e.g. \"Inherit|Value\"). These options are described as follows:",
         "",
         "All - the CSS property requires special handling to set its initial value,",
         "inherit value, and its value. Prefer this option over listing the individual",
-        "options.",
+        "options. Does not include HighlightInherit.",
         "",
         "Initial - the CSS property requires special handling to set its initial value.",
         "",
@@ -63,6 +63,11 @@
         "",
         "Value - the CSS property requires special handling to set its value, and a",
         "regular converter helper cannot be used.",
+        "",
+        "HighlightInitial, HighlightInherit and HighlightValue - as above, but for the property in a",
+        "highlight pseudo-element, where it behaves differently. Only for properties that apply to",
+        "them, and HighlightInherit is required for a property that needs a custom Inherit and",
+        "inherits in highlight pseudo-elements.",
         "",
         "The custom code for the property should be located in css/StyleBuilderCustom.h",
         "and named applyValue[CSSPropertyName]().",
@@ -77,6 +82,13 @@
         "* color-property:",
         "Indicates that this CSS property is color-related (populates",
         "CSSProperty::isColorProperty().",
+        "",
+        "* applies-to-highlight-pseudo-elements:",
+        "A string that is \"no\" (the default), \"yes\", or \"yes-without-inheritance\". Anything but",
+        "\"no\" allows the property in the highlight pseudo-element cascade. \"yes\" also inherits it",
+        "from the corresponding highlight pseudo-element of the parent element, rather than from the",
+        "originating element.",
+        "https://drafts.csswg.org/css-pseudo-4/#highlight-cascade",
         "",
         "* fast-path-inherited:",
         "Indicates that this CSS property can use the fast-path inheritance mechanism.",
@@ -395,7 +407,7 @@
                 "color-property": true,
                 "color-property-traits-color-custom": true,
                 "color-property-traits-visited-link-color-custom": true,
-                "style-builder-custom": "Initial|Value",
+                "style-builder-custom": "Initial|Value|HighlightInitial|HighlightInherit|HighlightValue",
                 "style-extractor-custom": true,
                 "fast-path-inherited": true,
                 "skip-computed-style-initial": true,
@@ -410,7 +422,8 @@
                 "computed-style-type": "WebCore::Color",
                 "computed-style-visited-link-storage-path": ["m_inheritedData"],
                 "computed-style-visited-dependent-exported": true,
-                "parser-grammar": "<color>"
+                "parser-grammar": "<color>",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-color",
@@ -2303,7 +2316,8 @@
                 "computed-style-type": "Style::Color",
                 "computed-style-visited-link-storage-path": ["m_nonInheritedData", "miscData", "visitedLinkColor"],
                 "computed-style-visited-dependent-applying-color-filter-exported": true,
-                "parser-grammar": "<color>"
+                "parser-grammar": "<color>",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -4914,7 +4928,8 @@
                 "visited-link-color-support": true,
                 "parser-grammar": "none | <color> | [ <url> [ none | <color> ]? ]",
                 "parser-grammar-comment": "Current spec grammar is 'none | <color> | [ <url> [ none | <color> ]? ] | context-fill | context-stroke'",
-                "comment": "Also specified (with different grammar) in CSS Fill and Stroke Module Level 3"
+                "comment": "Also specified (with different grammar) in CSS Fill and Stroke Module Level 3",
+                "applies-to-highlight-pseudo-elements": "yes-without-inheritance"
             },
             "specification": {
                 "category": "svg",
@@ -8218,7 +8233,8 @@
                 "visited-link-color-support": true,
                 "parser-grammar": "none | <color> | [ <url> [ none | <color> ]? ]",
                 "parser-grammar-comment": "Current spec grammar is 'none | <color> | [ <url> [ none | <color> ]? ] | context-fill | context-stroke'",
-                "comment": "Also specified (with different grammar) in CSS Fill and Stroke Module Level 3"
+                "comment": "Also specified (with different grammar) in CSS Fill and Stroke Module Level 3",
+                "applies-to-highlight-pseudo-elements": "yes-without-inheritance"
             },
             "specification": {
                 "category": "svg",
@@ -8367,7 +8383,8 @@
                 "computed-style-visited-link-storage-path": ["m_inheritedRareData"],
                 "visited-link-color-support": true,
                 "color-property": true,
-                "parser-grammar": "<color>"
+                "parser-grammar": "<color>",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "status": "supported",
             "specification": {
@@ -8385,7 +8402,8 @@
                 "computed-style-storage-path": ["m_inheritedRareData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::StrokeWidth",
-                "parser-grammar": "<length-percentage [0,inf]> | <number [0,inf]>"
+                "parser-grammar": "<length-percentage [0,inf]> | <number [0,inf]>",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "status": "supported",
             "specification": {
@@ -8681,7 +8699,8 @@
                 "parser-function": "consumeTextShadow",
                 "parser-grammar-unused": "none | [ <color>? && <length>{2,3} ]#",
                 "parser-grammar-unused-reason": "Needs support for the strong value representation.",
-                "parser-grammar-comment": "FIXME: Current implementation is a bit closer to box-shadow, where the third (and optional) length representing blur radius is non-negative."
+                "parser-grammar-comment": "FIXME: Current implementation is a bit closer to box-shadow, where the third (and optional) length representing blur radius is non-negative.",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -11839,7 +11858,8 @@
                 "shorthand-pattern": "StandardSpaceSeparated",
                 "style-extractor-custom": true,
                 "parser-grammar-unused": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'>",
-                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars.",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -11870,7 +11890,8 @@
                 "computed-style-storage-kind": "raw",
                 "computed-style-type": "Style::TextDecorationLine",
                 "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt) | spelling-error@(settings-flag=cssTextDecorationLineErrorValues) | grammar-error@(settings-flag=cssTextDecorationLineErrorValues)",
-                "parser-exported": true
+                "parser-exported": true,
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -11894,7 +11915,8 @@
                 "computed-style-storage-path": ["m_nonInheritedData", "rareData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "TextDecorationStyle",
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -11915,7 +11937,8 @@
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::Color",
                 "computed-style-visited-link-storage-path": ["m_nonInheritedData", "miscData", "visitedLinkColor"],
-                "parser-grammar": "<color>"
+                "parser-grammar": "<color>",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -11933,7 +11956,8 @@
                 ],
                 "parser-function": "consumeTextDecorationSkipShorthand",
                 "parser-grammar-unused": "none | auto | ink@(aliased-to=auto)",
-                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars.",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -11953,7 +11977,8 @@
                 "computed-style-storage-path": ["m_inheritedRareData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "TextDecorationSkipInk",
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -11978,7 +12003,8 @@
                 "computed-style-storage-path": ["m_inheritedRareData"],
                 "computed-style-storage-kind": "raw",
                 "computed-style-type": "Style::TextUnderlinePosition",
-                "parser-grammar": "auto | [ [ under | from-font ] || [ left | right ] ]@(no-single-item-opt)"
+                "parser-grammar": "auto | [ [ under | from-font ] || [ left | right ] ]@(no-single-item-opt)",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -11993,7 +12019,8 @@
                 "computed-style-storage-path": ["m_inheritedRareData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::TextUnderlineOffset",
-                "parser-grammar": "auto | <length-percentage>"
+                "parser-grammar": "auto | <length-percentage>",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -12011,7 +12038,8 @@
                 "computed-style-storage-path": ["m_nonInheritedData", "rareData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::TextDecorationThickness",
-                "parser-grammar": "auto | from-font | <length-percentage>"
+                "parser-grammar": "auto | from-font | <length-percentage>",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -12029,7 +12057,8 @@
                 "computed-style-storage-path": ["m_nonInheritedData", "rareData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::TextDecorationInset",
-                "parser-grammar": "auto | <length>{1,2}@(type=CSSValuePair default=previous)"
+                "parser-grammar": "auto | <length>{1,2}@(type=CSSValuePair default=previous)",
+                "applies-to-highlight-pseudo-elements": "yes"
             },
             "specification": {
                 "category": "css-text-decor",

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -139,6 +139,10 @@ public:
 
     static bool disablesNativeAppearance(CSSPropertyID);
 
+    // Properties that apply to the highlight pseudo-elements.
+    // https://drafts.csswg.org/css-pseudo-4/#highlight-styling
+    static bool NODELETE appliesToHighlightPseudoElements(CSSPropertyID);
+
     // Returns the valid keyword values for a property from CSSProperties.json.
     // This is used by the Inspector to provide completions for properties
     // that aren't keyword-fast-path eligible but still have enumerated values.

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -291,10 +291,10 @@ struct StyleFeatureSchema : public FeatureSchema {
 
             // Resolve the queried custom property value for var() references, css-wide keywords and registered properties.
             auto builderContext = Style::BuilderContext {
-                context.document.get(),
-                context.conversionData.parentStyle(),
-                context.conversionData.rootStyle(),
-                context.conversionData.elementForContainerUnitResolution()
+                .document = context.document.get(),
+                .parentStyle = context.conversionData.parentStyle(),
+                .rootElementStyle = context.conversionData.rootStyle(),
+                .element = context.conversionData.elementForContainerUnitResolution()
             };
 
             auto dummyStyle = Style::ComputedStyle::clone(*style);
@@ -326,10 +326,10 @@ struct StyleFeatureSchema : public FeatureSchema {
         auto ensureBuilder = [&]() -> Style::Builder& {
             if (!styleBuilder) {
                 auto builderContext = Style::BuilderContext {
-                    context.document.get(),
-                    context.conversionData.parentStyle(),
-                    context.conversionData.rootStyle(),
-                    context.conversionData.elementForContainerUnitResolution()
+                    .document = context.document.get(),
+                    .parentStyle = context.conversionData.parentStyle(),
+                    .rootElementStyle = context.conversionData.rootStyle(),
+                    .element = context.conversionData.elementForContainerUnitResolution()
                 };
                 dummyStyle = Style::ComputedStyle::clonePtr(style);
                 dummyMatchResult = Style::MatchResult::create();

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -586,6 +586,7 @@ class StylePropertyCodeGenProperties:
         Schema.Entry("animation-wrapper-requires-override-parameters", allowed_types=[list]),
         Schema.Entry("animation-wrapper-requires-setter", allowed_types=[str]),
         Schema.Entry("animation-wrapper", allowed_types=[str]),
+        Schema.Entry("applies-to-highlight-pseudo-elements", allowed_types=[str], default_value="no"),
         Schema.Entry("cascade-alias", allowed_types=[str]),
         Schema.Entry("color-property-traits-color-custom", allowed_types=[bool], default_value=False),
         Schema.Entry("color-property-traits-requires-excludes-visited-link-color", allowed_types=[bool], default_value=False),
@@ -804,6 +805,12 @@ class StylePropertyCodeGenProperties:
         if "skip-computed-style-setter" in json_value:
             if "skip-render-style-setter" not in json_value:
                 json_value["skip-render-style-setter"] = json_value["skip-computed-style-setter"]
+
+        if 'applies-to-highlight-pseudo-elements' in json_value:
+            if json_value['applies-to-highlight-pseudo-elements'] not in ['no', 'yes', 'yes-without-inheritance']:
+                raise Exception(f"{key_path} has unsupported 'applies-to-highlight-pseudo-elements' value '{json_value['applies-to-highlight-pseudo-elements']}'.")
+        elif any(function in json_value.get('style-builder-custom', '') for function in ['HighlightInitial', 'HighlightInherit', 'HighlightValue']):
+            raise Exception(f"{key_path} has a custom highlight function but does not apply to highlight pseudo-elements.")
 
         if "style-builder-custom" not in json_value:
             json_value["style-builder-custom"] = ""
@@ -3482,6 +3489,14 @@ class GenerateCSSPropertyInitialValues:
                 )
 
 
+def applies_to_highlight_pseudo_elements(property):
+    return property.codegen_properties.applies_to_highlight_pseudo_elements != "no"
+
+
+def inherits_in_highlight_pseudo_elements(property):
+    return property.codegen_properties.applies_to_highlight_pseudo_elements == "yes"
+
+
 # Generates `CSSPropertyNames.h` and `CSSPropertyNames.cpp`.
 class GenerateCSSPropertyNames:
     def __init__(self, generation_context):
@@ -4195,6 +4210,12 @@ class GenerateCSSPropertyNames:
                 iterable=(p for p in self.properties_and_descriptors.style_properties.all if p.codegen_properties.disables_native_appearance)
             )
 
+            self.generation_context.generate_property_id_switch_function_bool(
+                to=writer,
+                signature="bool CSSProperty::appliesToHighlightPseudoElements(CSSPropertyID id)",
+                iterable=(p for p in self.properties_and_descriptors.style_properties.all if applies_to_highlight_pseudo_elements(p))
+            )
+
             for group_name, property_group in sorted(self.generation_context.properties_and_descriptors.style_properties.logical_property_groups.items(), key=lambda x: x[0]):
                 properties = set()
                 for kind in ["logical", "physical"]:
@@ -4731,11 +4752,11 @@ class GenerateStyleBuilderGenerated:
         to.write(f"if (builderState.applyPropertyToVisitedLinkStyle())")
         to.write(f"    builderState.style().setVisitedLink{property.codegen_properties.computed_style_name_for_methods}({initial_function}());")
 
-    def _generate_visited_link_color_supporting_property_inherit_value_setter(self, to, property):
+    def _generate_visited_link_color_supporting_property_inherit_value_setter(self, to, property, source_style):
         to.write(f"if (builderState.applyPropertyToRegularStyle())")
-        to.write(f"    builderState.style().{property.codegen_properties.computed_style_setter}(forwardInheritedValue(builderState.parentStyle().{property.codegen_properties.computed_style_getter}()));")
+        to.write(f"    builderState.style().{property.codegen_properties.computed_style_setter}(forwardInheritedValue({source_style}{property.codegen_properties.computed_style_getter}()));")
         to.write(f"if (builderState.applyPropertyToVisitedLinkStyle())")
-        to.write(f"    builderState.style().setVisitedLink{property.codegen_properties.computed_style_name_for_methods}(forwardInheritedValue(builderState.parentStyle().{property.codegen_properties.computed_style_getter}()));")
+        to.write(f"    builderState.style().setVisitedLink{property.codegen_properties.computed_style_name_for_methods}(forwardInheritedValue({source_style}{property.codegen_properties.computed_style_getter}()));")
 
     def _generate_visited_link_color_supporting_property_value_setter(self, to, property):
         to.write(f"if (builderState.applyPropertyToRegularStyle())")
@@ -4771,8 +4792,8 @@ class GenerateStyleBuilderGenerated:
     def _generate_property_initial_value_setter(self, to, property):
         to.write(f"builderState.style().{property.codegen_properties.computed_style_setter}(Style::ComputedStyle::{property.codegen_properties.computed_style_initial}());")
 
-    def _generate_property_inherit_value_setter(self, to, property):
-        to.write(f"builderState.style().{property.codegen_properties.computed_style_setter}(forwardInheritedValue(builderState.parentStyle().{property.codegen_properties.computed_style_getter}()));")
+    def _generate_property_inherit_value_setter(self, to, property, source_style):
+        to.write(f"builderState.style().{property.codegen_properties.computed_style_setter}(forwardInheritedValue({source_style}{property.codegen_properties.computed_style_getter}()));")
 
     def _generate_property_value_setter(self, to, property, value):
         to.write(f"builderState.style().{property.codegen_properties.computed_style_setter}({value});")
@@ -4804,25 +4825,46 @@ class GenerateStyleBuilderGenerated:
 
         to.write(f"}}")
 
-    def _generate_style_builder_generated_cpp_inherit_value_setter(self, to, property):
-        to.write(f"static void applyInherit{property.id_without_prefix}(BuilderState& builderState)")
+    # Highlight pseudo-elements inherit the properties that apply to them from the corresponding
+    # highlight pseudo-element of the parent element. https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+    def _generate_style_builder_generated_cpp_inherit_value_setter(self, to, property, highlight=False):
+        source_style = "builderState.parentHighlightStyle()->" if highlight else "builderState.parentStyle()."
+        function_prefix = "applyHighlightInherit" if highlight else "applyInherit"
+
+        to.write(f"static void {function_prefix}{property.id_without_prefix}(BuilderState& builderState)")
         to.write(f"{{")
 
         with to.indent():
+            if highlight:
+                # At the start of the chain there is no highlight to inherit from, and the inherited
+                # value is the initial value. https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+                to.write(f"if (!builderState.parentHighlightStyle()) {{")
+                with to.indent():
+                    to.write(f"applyInitial{property.id_without_prefix}(builderState);")
+                    to.write(f"return;")
+                to.write(f"}}")
+                to.newline()
+
             if property.codegen_properties.visited_link_color_support:
-                self._generate_visited_link_color_supporting_property_inherit_value_setter(to, property)
+                self._generate_visited_link_color_supporting_property_inherit_value_setter(to, property, source_style)
             elif property.codegen_properties.coordinated_value_list_property:
+                assert not highlight, f"{property.name}: coordinated value list properties do not support highlight inheritance"
                 self._generate_coordinated_value_list_property_inherit_value_setter(to, property)
             elif property.codegen_properties.font_property:
+                assert not highlight, f"{property.name}: font properties do not support highlight inheritance"
                 self._generate_font_property_inherit_value_setter(to, property)
             else:
-                self._generate_property_inherit_value_setter(to, property)
+                self._generate_property_inherit_value_setter(to, property, source_style)
 
             if property.codegen_properties.computed_style_has_explicitly_set_policy:
                 if property.codegen_properties.computed_style_has_explicitly_set_policy == "all-author-origin":
-                    to.write(f"builderState.style().setHasExplicitlySet{property.codegen_properties.computed_style_name_for_methods}(builderState.isAuthorOrigin());")
+                    # There is no declaration to take the origin from when inheriting from the parent highlight.
+                    if highlight:
+                        to.write(f"builderState.style().setHasExplicitlySet{property.codegen_properties.computed_style_name_for_methods}({source_style}hasExplicitlySet{property.codegen_properties.computed_style_name_for_methods}());")
+                    else:
+                        to.write(f"builderState.style().setHasExplicitlySet{property.codegen_properties.computed_style_name_for_methods}(builderState.isAuthorOrigin());")
                 elif property.codegen_properties.computed_style_has_explicitly_set_policy == "all-border-radius":
-                    to.write(f"builderState.style().setHasExplicitlySet{property.codegen_properties.computed_style_name_for_methods}(builderState.parentStyle().hasExplicitlySet{property.codegen_properties.computed_style_name_for_methods}());")
+                    to.write(f"builderState.style().setHasExplicitlySet{property.codegen_properties.computed_style_name_for_methods}({source_style}hasExplicitlySet{property.codegen_properties.computed_style_name_for_methods}());")
 
             if property.codegen_properties.fast_path_inherited:
                 to.write(f"builderState.style().setDisallowsFastPathInheritance();")
@@ -4881,6 +4923,11 @@ class GenerateStyleBuilderGenerated:
                     self._generate_style_builder_generated_cpp_initial_value_setter(to, property)
                 if "Inherit" not in property.codegen_properties.style_builder_custom:
                     self._generate_style_builder_generated_cpp_inherit_value_setter(to, property)
+                custom_functions = property.codegen_properties.style_builder_custom
+                if inherits_in_highlight_pseudo_elements(property) and "HighlightInherit" not in custom_functions:
+                    if "Inherit" in custom_functions:
+                        raise Exception(f"Property '{property.name}' has a custom Inherit function and needs a custom HighlightInherit function too.")
+                    self._generate_style_builder_generated_cpp_inherit_value_setter(to, property, highlight=True)
                 if "Value" not in property.codegen_properties.style_builder_custom:
                     self._generate_style_builder_generated_cpp_value_setter(to, property)
 
@@ -4942,6 +4989,92 @@ class GenerateStyleBuilderGenerated:
         to.write(f"}}")
         to.newline()
 
+    def _generate_style_builder_generated_cpp_builder_generated_apply_highlight_property(self, *, to):
+        def highlight_function(property, function):
+            if f"Highlight{function}" in property.codegen_properties.style_builder_custom:
+                return f"BuilderCustom::applyHighlight{function}{property.id_without_prefix}"
+            if function == "Inherit" and inherits_in_highlight_pseudo_elements(property):
+                return f"BuilderFunctions::applyHighlightInherit{property.id_without_prefix}"
+            return None
+
+        to.write(f"void BuilderGenerated::applyHighlightProperty(CSSPropertyID id, BuilderState& builderState, CSSValue& value, ApplyValueType valueType)")
+        to.write(f"{{")
+
+        with to.indent():
+            to.write(f"ASSERT(builderState.isBuildingHighlightStyle());")
+            to.write(f"ASSERT(CSSProperty::appliesToHighlightPseudoElements(id));")
+            to.newline()
+            to.write(f"switch (id) {{")
+
+            for property in self.properties_and_descriptors.all_unique:
+                if not isinstance(property, StyleProperty):
+                    continue
+                if not applies_to_highlight_pseudo_elements(property):
+                    continue
+                if property.codegen_properties.longhands or property.codegen_properties.skip_style_builder:
+                    continue
+
+                functions = [(function, highlight_function(property, function)) for function in ["Initial", "Inherit", "Value"]]
+                functions = [(function, name) for function, name in functions if name]
+                if not functions:
+                    continue
+
+                to.write(f"case {property.id}:")
+                with to.indent():
+                    if len(functions) == 1:
+                        function, name = functions[0]
+                        to.write(f"if (valueType == ApplyValueType::{function}) {{")
+                        with to.indent():
+                            to.write(f"{name}(builderState{', value' if function == 'Value' else ''});")
+                            to.write(f"return;")
+                        to.write(f"}}")
+                    else:
+                        to.write(f"switch (valueType) {{")
+                        for function, name in functions:
+                            to.write(f"case ApplyValueType::{function}:")
+                            with to.indent():
+                                to.write(f"{name}(builderState{', value' if function == 'Value' else ''});")
+                                to.write(f"return;")
+                        if len(functions) < 3:
+                            to.write(f"default:")
+                            with to.indent():
+                                to.write(f"break;")
+                        to.write(f"}}")
+                    to.write(f"break;")
+
+            to.write(f"default:")
+            with to.indent():
+                to.write(f"break;")
+            to.write(f"}}")
+            to.newline()
+            to.write(f"// Everything else is not specific to highlight pseudo-elements.")
+            to.write(f"applyProperty(id, builderState, value, valueType);")
+
+        to.write(f"}}")
+        to.newline()
+
+    def _generate_style_builder_generated_cpp_builder_generated_apply_highlight(self, *, to):
+        to.write(f"void BuilderGenerated::applyHighlightInheritAllProperties(BuilderState& builderState)")
+        to.write(f"{{")
+
+        with to.indent():
+            to.write(f"ASSERT(builderState.isBuildingHighlightStyle());")
+            to.newline()
+
+            for property in self.properties_and_descriptors.all_unique:
+                if not isinstance(property, StyleProperty):
+                    continue
+                if not inherits_in_highlight_pseudo_elements(property):
+                    continue
+                if property.codegen_properties.longhands or property.codegen_properties.skip_style_builder:
+                    continue
+
+                scope = "BuilderCustom" if "HighlightInherit" in property.codegen_properties.style_builder_custom else "BuilderFunctions"
+                to.write(f"{scope}::applyHighlightInherit{property.id_without_prefix}(builderState);")
+
+        to.write(f"}}")
+        to.newline()
+
     def generate_style_builder_generated_cpp(self):
         with open('StyleBuilderGenerated.cpp', 'w') as output_file:
             writer = Writer(output_file)
@@ -4975,6 +5108,14 @@ class GenerateStyleBuilderGenerated:
                 )
 
                 self._generate_style_builder_generated_cpp_builder_generated_apply(
+                    to=writer
+                )
+
+                self._generate_style_builder_generated_cpp_builder_generated_apply_highlight(
+                    to=writer
+                )
+
+                self._generate_style_builder_generated_cpp_builder_generated_apply_highlight_property(
                     to=writer
                 )
 

--- a/Source/WebCore/css/scripts/test/TestCSSProperties.json
+++ b/Source/WebCore/css/scripts/test/TestCSSProperties.json
@@ -1026,7 +1026,8 @@
                 "computed-style-storage-path": ["level1"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::Color",
-                "parser-grammar": "<color>"
+                "parser-grammar": "<color>",
+                "applies-to-highlight-pseudo-elements": "yes-without-inheritance"
             }
         },
         "test-color-allows-types-absolute": {
@@ -1050,7 +1051,8 @@
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::Color",
                 "computed-style-visited-link-storage-path": ["level1", "level2"],
-                "parser-grammar": "<color>"
+                "parser-grammar": "<color>",
+                "applies-to-highlight-pseudo-elements": "yes"
             }
         },
         "test-image": {
@@ -1216,7 +1218,8 @@
                 "computed-style-has-explicitly-set-storage-path": ["level1", "level2"],
                 "computed-style-storage-path": ["level1", "level2"],
                 "computed-style-storage-kind": "value",
-                "computed-style-type": "Style::Number<>"
+                "computed-style-type": "Style::Number<>",
+                "applies-to-highlight-pseudo-elements": "yes"
             }
         },
         "test-render-style-has-explicitly-set-policy-all-border-radius": {

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf
@@ -680,6 +680,18 @@ bool CSSProperty::disablesNativeAppearance(CSSPropertyID id)
     }
 }
 
+bool CSSProperty::appliesToHighlightPseudoElements(CSSPropertyID id)
+{
+    switch (id) {
+    case CSSPropertyID::CSSPropertyTestColor:
+    case CSSPropertyID::CSSPropertyTestColorPropertyWithVisitedLinkSupport:
+    case CSSPropertyID::CSSPropertyTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool CSSProperty::isTestGroupProperty(CSSPropertyID id)
 {
     switch (id) {

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp
@@ -115,6 +115,18 @@ public:
         if (builderState.applyPropertyToVisitedLinkStyle())
             builderState.style().setVisitedLinkTestColorPropertyWithVisitedLinkSupport(forwardInheritedValue(builderState.parentStyle().testColorPropertyWithVisitedLinkSupport()));
     }
+    static void applyHighlightInheritTestColorPropertyWithVisitedLinkSupport(BuilderState& builderState)
+    {
+        if (!builderState.parentHighlightStyle()) {
+            applyInitialTestColorPropertyWithVisitedLinkSupport(builderState);
+            return;
+        }
+
+        if (builderState.applyPropertyToRegularStyle())
+            builderState.style().setTestColorPropertyWithVisitedLinkSupport(forwardInheritedValue(builderState.parentHighlightStyle()->testColorPropertyWithVisitedLinkSupport()));
+        if (builderState.applyPropertyToVisitedLinkStyle())
+            builderState.style().setVisitedLinkTestColorPropertyWithVisitedLinkSupport(forwardInheritedValue(builderState.parentHighlightStyle()->testColorPropertyWithVisitedLinkSupport()));
+    }
     static void applyValueTestColorPropertyWithVisitedLinkSupport(BuilderState& builderState, CSSValue& value)
     {
         if (builderState.applyPropertyToRegularStyle())
@@ -131,6 +143,16 @@ public:
     {
         builderState.style().setTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin(forwardInheritedValue(builderState.parentStyle().testRenderStyleHasExplicitlySetPolicyAllAuthorOrigin()));
         builderState.style().setHasExplicitlySetTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin(builderState.isAuthorOrigin());
+    }
+    static void applyHighlightInheritTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin(BuilderState& builderState)
+    {
+        if (!builderState.parentHighlightStyle()) {
+            applyInitialTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin(builderState);
+            return;
+        }
+
+        builderState.style().setTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin(forwardInheritedValue(builderState.parentHighlightStyle()->testRenderStyleHasExplicitlySetPolicyAllAuthorOrigin()));
+        builderState.style().setHasExplicitlySetTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin(builderState.parentHighlightStyle()->hasExplicitlySetTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin());
     }
     static void applyValueTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin(BuilderState& builderState, CSSValue& value)
     {
@@ -771,6 +793,40 @@ void BuilderGenerated::applyProperty(CSSPropertyID id, BuilderState& builderStat
         ASSERT_NOT_REACHED();
         break;
     }
+}
+
+void BuilderGenerated::applyHighlightInheritAllProperties(BuilderState& builderState)
+{
+    ASSERT(builderState.isBuildingHighlightStyle());
+
+    BuilderFunctions::applyHighlightInheritTestColorPropertyWithVisitedLinkSupport(builderState);
+    BuilderFunctions::applyHighlightInheritTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin(builderState);
+}
+
+void BuilderGenerated::applyHighlightProperty(CSSPropertyID id, BuilderState& builderState, CSSValue& value, ApplyValueType valueType)
+{
+    ASSERT(builderState.isBuildingHighlightStyle());
+    ASSERT(CSSProperty::appliesToHighlightPseudoElements(id));
+
+    switch (id) {
+    case CSSPropertyID::CSSPropertyTestColorPropertyWithVisitedLinkSupport:
+        if (valueType == ApplyValueType::Inherit) {
+            BuilderFunctions::applyHighlightInheritTestColorPropertyWithVisitedLinkSupport(builderState);
+            return;
+        }
+        break;
+    case CSSPropertyID::CSSPropertyTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin:
+        if (valueType == ApplyValueType::Inherit) {
+            BuilderFunctions::applyHighlightInheritTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin(builderState);
+            return;
+        }
+        break;
+    default:
+        break;
+    }
+
+    // Everything else is not specific to highlight pseudo-elements.
+    applyProperty(id, builderState, value, valueType);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -111,6 +111,14 @@ constexpr auto allPublicPseudoElementTypes = EnumSet {
     PseudoElementType::ViewTransitionNew
 };
 
+constexpr auto allHighlightPseudoElementTypes = EnumSet {
+    PseudoElementType::GrammarError,
+    PseudoElementType::Highlight,
+    PseudoElementType::Selection,
+    PseudoElementType::SpellingError,
+    PseudoElementType::TargetText
+};
+
 constexpr auto allInternalPseudoElementTypes = EnumSet {
     PseudoElementType::WebKitScrollbarThumb,
     PseudoElementType::WebKitScrollbarButton,

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -34,6 +34,7 @@
 #include "DocumentInlines.h"
 #include "FontCascade.h"
 #include "NodeDocument.h"
+#include "PseudoElementIdentifier.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleComputedStyle+InitialInlines.h"
 #include "StyleLengthResolution.h"
@@ -76,8 +77,13 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const Style::
     // PseudoElementIdentifier-aware might be a possible solution.
     if (!style.pseudoElementNameArgument().isNull())
         return false;
+    auto pseudoElementType = style.pseudoElementType();
+    // Highlight pseudo-element styles inherit from the parent element's highlight pseudo-element
+    // style, which is not part of the cache key.
+    if (pseudoElementType && isHighlightPseudoElement(*pseudoElementType))
+        return false;
     // content:attr() value depends on the element it is being applied to.
-    if (style.hasAttrContent() || (style.pseudoElementType() && parentStyle.hasAttrContent()))
+    if (style.hasAttrContent() || (pseudoElementType && parentStyle.hasAttrContent()))
         return false;
     if (style.zoom() != Style::ComputedStyle::initialZoom())
         return false;

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "PropertyAllowlist.h"
 
+#include "CSSProperty.h"
+
 namespace WebCore {
 namespace Style {
 
@@ -48,30 +50,11 @@ PropertyAllowlist propertyAllowlistForPseudoElement(PseudoElementType type)
 // https://drafts.csswg.org/css-pseudo-4/#highlight-styling
 bool isValidHighlightStyleProperty(CSSPropertyID id)
 {
-    switch (id) {
-    case CSSPropertyBackgroundColor:
-    case CSSPropertyColor:
-    case CSSPropertyCustom:
-    case CSSPropertyFill:
-    case CSSPropertyStroke:
-    case CSSPropertyStrokeColor:
-    case CSSPropertyStrokeWidth:
-    case CSSPropertyTextDecoration:
-    case CSSPropertyTextDecorationColor:
-    case CSSPropertyTextDecorationInset:
-    case CSSPropertyTextDecorationLine:
-    case CSSPropertyTextDecorationSkip:
-    case CSSPropertyTextDecorationSkipInk:
-    case CSSPropertyTextDecorationStyle:
-    case CSSPropertyTextDecorationThickness:
-    case CSSPropertyTextShadow:
-    case CSSPropertyTextUnderlineOffset:
-    case CSSPropertyTextUnderlinePosition:
+    // Custom properties are not part of the applicable property list but are allowed, since they
+    // can be substituted into the properties that are. https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+    if (id == CSSPropertyCustom)
         return true;
-    default:
-        break;
-    }
-    return false;
+    return CSSProperty::appliesToHighlightPseudoElements(id);
 }
 
 // https://drafts.csswg.org/css-lists-3/#marker-properties (Editor's Draft, 14 July 2021)

--- a/Source/WebCore/style/PseudoElementIdentifier.h
+++ b/Source/WebCore/style/PseudoElementIdentifier.h
@@ -73,16 +73,7 @@ inline bool isNamedViewTransitionPseudoElement(const std::optional<Style::Pseudo
 
 inline bool isHighlightPseudoElement(PseudoElementType type)
 {
-    switch (type) {
-    case PseudoElementType::GrammarError:
-    case PseudoElementType::Highlight:
-    case PseudoElementType::Selection:
-    case PseudoElementType::SpellingError:
-    case PseudoElementType::TargetText:
-        return true;
-    default:
-        return false;
-    }
+    return allHighlightPseudoElementTypes.contains(type);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -48,6 +48,7 @@
 #include "Settings.h"
 #include "StyleAdjuster.h"
 #include "StyleBuilderGenerated.h"
+#include "StyleBuilderStateInlines.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleComputedStyle+InitialInlines.h"
 #include "StyleComputedStyle+SettersInlines.h"
@@ -123,6 +124,15 @@ void Builder::applyAllProperties()
     applyNonHighPriorityProperties();
 
     adjustAfterApplying();
+}
+
+// The values are computed values from the parent highlight style, so this doesn't depend on the
+// high priority properties having been applied.
+void Builder::applyHighlightInheritance()
+{
+    ASSERT(m_state->isBuildingHighlightStyle());
+
+    BuilderGenerated::applyHighlightInheritAllProperties(m_state);
 }
 
 // Top priority properties affect resolution of high priority properties.
@@ -422,7 +432,14 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
         return CSSProperty::isInheritedProperty(id);
     };
 
+    // https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+    // In a highlight pseudo-element the properties that inherit from the corresponding highlight
+    // pseudo-element of the originating element's parent do so whether or not they are inherited
+    // properties. The ones that apply without inheriting through the chain, fill and stroke, are
+    // inherited properties, so unset means inherit for them too.
     auto unsetValueType = [&] {
+        if (m_state->isBuildingHighlightStyle())
+            return ApplyValueType::Inherit;
         // https://drafts.csswg.org/css-cascade-4/#inherit-initial
         // The unset CSS-wide keyword acts as either inherit or initial, depending on whether the property is inherited or not.
         return isInheritedProperty() ? ApplyValueType::Inherit : ApplyValueType::Initial;
@@ -455,7 +472,15 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
         return;
     }
 
-    BuilderGenerated::applyProperty(id, m_state, valueToApply.get(), valueType);
+    auto apply = [&](ApplyValueType valueType) {
+        if (m_state->isBuildingHighlightStyle()) {
+            BuilderGenerated::applyHighlightProperty(id, m_state, valueToApply.get(), valueType);
+            return;
+        }
+        BuilderGenerated::applyProperty(id, m_state, valueToApply.get(), valueType);
+    };
+
+    apply(valueType);
 
     if (!isAnyRevert)
         m_state->disableNativeAppearanceIfNeeded(id, cascadeOrigin);
@@ -466,7 +491,7 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
         // When this happens, the computed value is one of the following...
         // Otherwise: Either the property’s inherited value or its initial value depending on whether the property
         // is inherited or not, respectively, as if the property’s value had been specified as the unset keyword
-        BuilderGenerated::applyProperty(id, m_state, valueToApply.get(), unsetValueType());
+        apply(unsetValueType());
     }
 }
 

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -51,6 +51,11 @@ public:
     void applyNonHighPriorityProperties();
     void adjustAfterApplying();
 
+    // Inherits the properties that inherit in highlight pseudo-elements from the corresponding
+    // highlight pseudo-element of the originating element's parent, before applying the cascade on top.
+    // https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+    void applyHighlightInheritance();
+
     void applyProperty(CSSPropertyID propertyID) { applyProperties(propertyID, propertyID); }
     void applyCustomProperty(const AtomString& name);
 

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -107,6 +107,9 @@ public:
 
     static void applyInitialColor(BuilderState&);
     static void applyValueColor(BuilderState&, CSSValue&);
+    static void applyHighlightInitialColor(BuilderState&);
+    static void applyHighlightInheritColor(BuilderState&);
+    static void applyHighlightValueColor(BuilderState&, CSSValue&);
 
     // Custom handling of value setting only.
     static void applyValueWebkitLocale(BuilderState&, CSSValue&);
@@ -703,6 +706,46 @@ inline void BuilderCustom::applyValueColor(BuilderState& builderState, CSSValue&
 
     builderState.style().setDisallowsFastPathInheritance();
     builderState.style().setHasExplicitlySetColor(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyHighlightInitialColor(BuilderState& builderState)
+{
+    applyInitialColor(builderState);
+    builderState.style().setColorIsCurrentColorForHighlight(false);
+}
+
+// currentcolor in a highlight pseudo-element is the originating element's color, so the chain
+// inherits the keyword rather than the color it resolved to. At the start of the chain the inherited
+// value is currentColor. https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+// FIXME: A value that only references currentcolor, like color-mix(in oklab, teal, currentcolor),
+// still propagates as the color it resolved to. Resolving those per element needs the unresolved
+// Style::Color, which the color property doesn't store, and no engine does it today.
+inline void BuilderCustom::applyHighlightInheritColor(BuilderState& builderState)
+{
+    CheckedPtr parentHighlightStyle = builderState.parentHighlightStyle();
+    auto isCurrentColor = !parentHighlightStyle || parentHighlightStyle->colorIsCurrentColorForHighlight();
+    auto& sourceStyle = isCurrentColor ? builderState.parentStyle() : *parentHighlightStyle;
+
+    if (builderState.applyPropertyToRegularStyle()) {
+        builderState.style().setColor(forwardInheritedValue(sourceStyle.color()));
+        // FIXME: visitedLinkColor needs its own bit for this.
+        builderState.style().setColorIsCurrentColorForHighlight(isCurrentColor);
+    }
+    if (builderState.applyPropertyToVisitedLinkStyle())
+        builderState.style().setVisitedLinkColor(forwardInheritedValue(sourceStyle.color()));
+
+    builderState.style().setDisallowsFastPathInheritance();
+    // The seeding pass has no declaration to take the origin from, so it comes from the source.
+    // FIXME: When the source is the originating element, its own color counts as one the highlight set.
+    builderState.style().setHasExplicitlySetColor(builderState.isAuthorOrigin() || sourceStyle.hasExplicitlySetColor());
+}
+
+inline void BuilderCustom::applyHighlightValueColor(BuilderState& builderState, CSSValue& value)
+{
+    applyValueColor(builderState, value);
+
+    if (builderState.applyPropertyToRegularStyle())
+        builderState.style().setColorIsCurrentColorForHighlight(valueID(value) == CSSValueCurrentcolor);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleBuilderGenerated.h
+++ b/Source/WebCore/style/StyleBuilderGenerated.h
@@ -38,6 +38,14 @@ enum class ApplyValueType : uint8_t;
 class BuilderGenerated {
 public:
     static void applyProperty(CSSPropertyID, BuilderState&, CSSValue&, ApplyValueType);
+
+    // Same as applyProperty(), for the properties that behave differently in a highlight
+    // pseudo-element. https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+    static void applyHighlightProperty(CSSPropertyID, BuilderState&, CSSValue&, ApplyValueType);
+
+    // Inherits every property that inherits in highlight pseudo-elements from the corresponding
+    // highlight pseudo-element of the originating element's parent.
+    static void applyHighlightInheritAllProperties(BuilderState&);
 };
 
 } // namespace Style

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -95,6 +95,9 @@ struct RegisteredSubstitutionAttribute {
 struct BuilderContext {
     const Ref<const Document> document;
     const Style::ComputedStyle* parentStyle { };
+    // For highlight pseudo-elements: the corresponding highlight pseudo-element style of the
+    // originating element's parent, if any. https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+    const Style::ComputedStyle* parentHighlightStyle { };
     const Style::ComputedStyle* rootElementStyle { };
     RefPtr<const Element> element { };
     CheckedPtr<TreeResolutionState> treeResolutionState { };
@@ -121,6 +124,14 @@ public:
     const ComputedStyle& style() const LIFETIME_BOUND { return m_style; }
 
     const ComputedStyle& parentStyle() const LIFETIME_BOUND { return *m_context.parentStyle; }
+
+    // The highlight pseudo-element style this one inherits from. Null for the highlight
+    // pseudo-element of the root element, and for anything that isn't a highlight pseudo-element.
+    // https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+    const ComputedStyle* parentHighlightStyle() const LIFETIME_BOUND { return m_context.parentHighlightStyle; }
+
+    // True for any highlight pseudo-element style, including one with nothing to inherit from.
+    inline bool isBuildingHighlightStyle() const;
 
     Builder* callingContextBuilder() const { return m_context.callingContextBuilder; }
 

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -26,13 +26,21 @@
 
 #pragma once
 
+#include "PseudoElementIdentifier.h"
 #include "StyleBuilderState.h"
+#include "StyleComputedStyle+GettersInlines.h"
 #include "StyleComputedStyle+SettersInlines.h"
 #include "StyleFontSizeFunctions.h"
 #include "StyleZoom.h"
 
 namespace WebCore {
 namespace Style {
+
+inline bool BuilderState::isBuildingHighlightStyle() const
+{
+    auto pseudoElementType = m_style.pseudoElementType();
+    return pseudoElementType && isHighlightPseudoElement(*pseudoElementType);
+}
 
 inline void BuilderState::setTextOrientation(TextOrientation orientation) { m_fontDirty |= m_style.setTextOrientation(orientation); }
 inline void BuilderState::setWritingMode(StyleWritingMode mode) { m_fontDirty |= m_style.setWritingMode(mode); }

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -59,6 +59,7 @@
 #include "NodeInlinesLight.h"
 #include "NodeRenderStyle.h"
 #include "PageRuleCollector.h"
+#include "PseudoElementIdentifier.h"
 #include "RenderScrollbar.h"
 #include "RenderStyleConstants.h"
 #include "RenderView.h"
@@ -75,6 +76,7 @@
 #include "SharedStringHash.h"
 #include "StyleAdjuster.h"
 #include "StyleBuilder.h"
+#include "StyleBuilderStateInlines.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleComputedStyle+SettersInlines.h"
 #include "StyleEasingFunction.h"
@@ -114,9 +116,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(Resolver);
 class Resolver::State {
 public:
     State() = default;
-    State(const Element& element, const Style::ComputedStyle* parentStyle, const Style::ComputedStyle* documentElementStyle, TreeResolutionState* treeResolutionState)
+    State(const Element& element, const Style::ComputedStyle* parentStyle, const Style::ComputedStyle* documentElementStyle, TreeResolutionState* treeResolutionState, const Style::ComputedStyle* parentHighlightStyle = nullptr)
         : m_element(&element)
         , m_parentStyle(parentStyle)
+        , m_parentHighlightStyle(parentHighlightStyle)
         , m_treeResolutionState(treeResolutionState)
     {
         ASSERT(element.isConnected());
@@ -145,6 +148,7 @@ public:
         m_parentStyle = m_ownedParentStyle.get();
     }
     const Style::ComputedStyle* NODELETE parentStyle() const { return m_parentStyle; }
+    const Style::ComputedStyle* NODELETE parentHighlightStyle() const { return m_parentHighlightStyle; }
     const Style::ComputedStyle* NODELETE rootElementStyle() const { return m_rootElementStyle; }
 
     CheckedPtr<TreeResolutionState> NODELETE treeResolutionState() { return m_treeResolutionState; }
@@ -153,6 +157,7 @@ private:
     const Element* m_element { };
     std::unique_ptr<Style::ComputedStyle> m_style;
     const Style::ComputedStyle* m_parentStyle { };
+    const Style::ComputedStyle* m_parentHighlightStyle { };
     std::unique_ptr<const Style::ComputedStyle> m_ownedParentStyle;
     const Style::ComputedStyle* m_rootElementStyle { };
 
@@ -285,11 +290,12 @@ auto Resolver::initializeStateAndStyle(const Element& element, const ResolutionC
 BuilderContext Resolver::builderContext(State& state) const
 {
     return {
-        document(),
-        state.parentStyle(),
-        state.rootElementStyle(),
-        state.element(),
-        state.treeResolutionState()
+        .document = document(),
+        .parentStyle = state.parentStyle(),
+        .parentHighlightStyle = state.parentHighlightStyle(),
+        .rootElementStyle = state.rootElementStyle(),
+        .element = state.element(),
+        .treeResolutionState = state.treeResolutionState()
     };
 }
 
@@ -304,8 +310,14 @@ UnadjustedStyle Resolver::unadjustedStyleForElement(Element& element, const Reso
     collector.setMedium(m_mediaQueryEvaluator);
     collector.matchAllRules(m_matchAuthorAndUserStyles, matchingBehavior != RuleMatchingBehavior::MatchAllRulesExcludingSMIL);
 
-    if (collector.matchedPseudoElements())
-        style.setHasPseudoStyles(collector.matchedPseudoElements());
+    auto matchedPseudoElements = collector.matchedPseudoElements();
+    // https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+    // A highlight pseudo-element exists whenever it exists for the parent element, since it inherits
+    // from it even with no rules of its own.
+    if (state.parentStyle())
+        matchedPseudoElements.add(state.parentStyle()->highlightPseudoElementTypes());
+    if (matchedPseudoElements)
+        style.setHasPseudoStyles(matchedPseudoElements);
 
     auto elementStyleRelations = commitRelationsToRenderStyle(style, element, collector.styleRelations());
 
@@ -560,9 +572,38 @@ bool Resolver::keyframeStylesForAnimation(Element& element, const Style::Compute
     return true;
 }
 
+// Resolves the chain lazily, one level per style, each cached in the ancestor's style. Meant for
+// callers outside style resolution, where the ancestor styles are current. During resolution the
+// parent highlight style comes in with the ResolutionContext.
+// FIXME: It is still reached during tree resolution when the parent has no highlight style cached
+// for this identifier, and then reads and caches into the style being replaced.
+static const Style::ComputedStyle* parentHighlightStyleIgnoringPendingUpdate(const Element& element, const PseudoElementIdentifier& pseudoElementIdentifier)
+{
+    RefPtr parentElement = element.parentElementInComposedTree();
+    if (!parentElement)
+        return nullptr;
+
+    CheckedPtr parentStyle = parentElement->existingComputedStyle();
+    if (!parentStyle)
+        return nullptr;
+
+    if (auto* highlightStyle = parentStyle->pseudoElementStyle(pseudoElementIdentifier))
+        return highlightStyle;
+
+    auto resolvedStyle = protect(parentElement->styleResolver())->styleForPseudoElement(*parentElement, pseudoElementIdentifier, { .parentStyle = parentStyle.get() });
+    if (!resolvedStyle)
+        return nullptr;
+
+    return const_cast<Style::ComputedStyle&>(*parentStyle).addPseudoElementStyle(WTF::move(resolvedStyle->style));
+}
+
 std::optional<ResolvedStyle> Resolver::styleForPseudoElement(Element& element, const PseudoElementRequest& pseudoElementRequest, const ResolutionContext& context)
 {
-    auto state = State(element, context.parentStyle, context.documentElementStyle, context.treeResolutionState.get());
+    auto parentHighlightStyle = context.parentHighlightStyle;
+    if (!parentHighlightStyle && isHighlightPseudoElement(pseudoElementRequest.type()))
+        parentHighlightStyle = parentHighlightStyleIgnoringPendingUpdate(element, pseudoElementRequest.identifier());
+
+    auto state = State(element, context.parentStyle, context.documentElementStyle, context.treeResolutionState.get(), parentHighlightStyle);
 
     if (state.parentStyle()) {
         state.setStyle(Style::ComputedStyle::createPtrWithRegisteredInitialValues(document().customPropertyRegistry()));
@@ -584,7 +625,9 @@ std::optional<ResolvedStyle> Resolver::styleForPseudoElement(Element& element, c
 
     ASSERT(!collector.matchedPseudoElements());
 
-    if (collector.matchResult().isEmpty())
+    // A highlight pseudo-element with no rules of its own still needs a style to pass the inherited
+    // values down to the highlight pseudo-elements of its descendants.
+    if (collector.matchResult().isEmpty() && !state.parentHighlightStyle())
         return { };
 
     state.style()->setPseudoElementIdentifier(pseudoElementRequest.identifier());
@@ -730,6 +773,9 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
     }
 
     Builder builder(style, builderContext(state), matchResult, WTF::move(includedProperties));
+
+    if (builder.state().isBuildingHighlightStyle())
+        builder.applyHighlightInheritance();
 
     // Top priority properties may affect resolution of high priority ones.
     builder.applyTopPriorityProperties();

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -77,6 +77,9 @@ struct UnadjustedStyle;
 
 struct ResolutionContext {
     const Style::ComputedStyle* parentStyle;
+    // For highlight pseudo-elements: the corresponding highlight pseudo-element style of the
+    // originating element's parent. https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+    const Style::ComputedStyle* parentHighlightStyle { nullptr };
     const Style::ComputedStyle* parentBoxStyle { nullptr };
     // This needs to be provided during style resolution when up-to-date document element style is not available via DOM.
     const Style::ComputedStyle* documentElementStyle { nullptr };

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -712,11 +712,11 @@ std::optional<ResolvedStyle> TreeResolver::resolveAncestorFirstLetterPseudoEleme
 ResolutionContext TreeResolver::makeResolutionContext()
 {
     return {
-        &parent().style,
-        parentBoxStyle(),
-        documentElementStyle(),
-        &scope().selectorMatchingState,
-        &m_treeResolutionState
+        .parentStyle = &parent().style,
+        .parentBoxStyle = parentBoxStyle(),
+        .documentElementStyle = documentElementStyle(),
+        .selectorMatchingState = &scope().selectorMatchingState,
+        .treeResolutionState = &m_treeResolutionState
     };
 }
 
@@ -730,12 +730,20 @@ ResolutionContext TreeResolver::makeResolutionContextForPseudoElement(const Elem
         return elementUpdate.style.get();
     };
 
+    // The parent's style is the one being resolved in this pass, not the one still on the element.
+    auto parentHighlightStyle = [&]() -> const Style::ComputedStyle* {
+        if (!isHighlightPseudoElement(pseudoElementIdentifier.type))
+            return nullptr;
+        return parent().style.pseudoElementStyle(pseudoElementIdentifier);
+    };
+
     return {
-        parentStyle(),
-        parentBoxStyleForPseudoElement(elementUpdate),
-        documentElementStyle(),
-        &scope().selectorMatchingState,
-        &m_treeResolutionState
+        .parentStyle = parentStyle(),
+        .parentHighlightStyle = parentHighlightStyle(),
+        .parentBoxStyle = parentBoxStyleForPseudoElement(elementUpdate),
+        .documentElementStyle = documentElementStyle(),
+        .selectorMatchingState = &scope().selectorMatchingState,
+        .treeResolutionState = &m_treeResolutionState
     };
 }
 
@@ -747,11 +755,11 @@ std::optional<ResolutionContext> TreeResolver::makeResolutionContextForInherited
 
     // First line style for inlines is made by inheriting from parent first line style.
     return ResolutionContext {
-        parentFirstLineStyle,
-        parentBoxStyleForPseudoElement(elementUpdate),
-        documentElementStyle(),
-        &scope().selectorMatchingState,
-        &m_treeResolutionState
+        .parentStyle = parentFirstLineStyle,
+        .parentBoxStyle = parentBoxStyleForPseudoElement(elementUpdate),
+        .documentElementStyle = documentElementStyle(),
+        .selectorMatchingState = &scope().selectorMatchingState,
+        .treeResolutionState = &m_treeResolutionState
     };
 }
 
@@ -1038,12 +1046,13 @@ std::unique_ptr<Style::ComputedStyle> TreeResolver::resolveAgainInDifferentConte
     newStyle->copyPseudoElementBitsFrom(*resolvedStyle.style);
 
     auto builderContext = BuilderContext {
-        m_document.get(),
-        &parentStyle,
-        resolutionContext.documentElementStyle,
-        &styleable.element,
-        &m_treeResolutionState,
-        WTF::move(positionTryFallback)
+        .document = m_document.get(),
+        .parentStyle = &parentStyle,
+        .parentHighlightStyle = resolutionContext.parentHighlightStyle,
+        .rootElementStyle = resolutionContext.documentElementStyle,
+        .element = &styleable.element,
+        .treeResolutionState = &m_treeResolutionState,
+        .positionTryFallback = WTF::move(positionTryFallback)
     };
 
     auto styleBuilder = Builder {
@@ -1076,11 +1085,12 @@ const Style::ComputedStyle& TreeResolver::parentAfterChangeStyle(const Styleable
 HashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimation(Style::ComputedStyle& animatedStyle, const HashMap<AnimatableCSSProperty, EnumSet<PropertyCascade::AnimationSource>>& animatedProperties, const MatchResult& matchResult, const Element& element, const ResolutionContext& resolutionContext)
 {
     auto builderContext = BuilderContext {
-        m_document.get(),
-        resolutionContext.parentStyle,
-        resolutionContext.documentElementStyle,
-        &element,
-        &m_treeResolutionState
+        .document = m_document.get(),
+        .parentStyle = resolutionContext.parentStyle,
+        .parentHighlightStyle = resolutionContext.parentHighlightStyle,
+        .rootElementStyle = resolutionContext.documentElementStyle,
+        .element = &element,
+        .treeResolutionState = &m_treeResolutionState
     };
 
     auto styleBuilder = Builder {

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -114,6 +114,11 @@ inline bool ComputedStyleBase::useTreeCountingFunctions() const
     return m_nonInheritedFlags.useTreeCountingFunctions;
 }
 
+inline bool ComputedStyleBase::colorIsCurrentColorForHighlight() const
+{
+    return m_inheritedData->colorIsCurrentColorForHighlight;
+}
+
 inline InsideLink ComputedStyleBase::insideLink() const
 {
     return static_cast<InsideLink>(m_inheritedFlags.insideLink);
@@ -276,6 +281,11 @@ inline std::optional<PseudoElementType> pseudoElementType(const ComputedStyleBas
 inline const AtomString& ComputedStyleBase::pseudoElementNameArgument() const
 {
     return m_nonInheritedData->rareData->pseudoElementNameArgument;
+}
+
+inline EnumSet<PseudoElementType> ComputedStyleBase::highlightPseudoElementTypes() const
+{
+    return EnumSet<PseudoElementType>::fromRaw(m_nonInheritedFlags.pseudoBits) & allHighlightPseudoElementTypes;
 }
 
 inline bool ComputedStyleBase::hasPseudoStyle(PseudoElementType pseudo) const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -73,6 +73,12 @@ inline void ComputedStyleBase::setUsesTreeCountingFunctions()
     m_nonInheritedFlags.useTreeCountingFunctions = true;
 }
 
+inline void ComputedStyleBase::setColorIsCurrentColorForHighlight(bool colorIsCurrentColorForHighlight)
+{
+    if (m_inheritedData->colorIsCurrentColorForHighlight != colorIsCurrentColorForHighlight)
+        m_inheritedData.access().colorIsCurrentColorForHighlight = colorIsCurrentColorForHighlight;
+}
+
 inline void ComputedStyleBase::setInsideLink(InsideLink insideLink)
 {
     m_inheritedFlags.insideLink = static_cast<unsigned>(insideLink);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -480,6 +480,9 @@ public:
     inline InsideLink insideLink() const;
     inline void setInsideLink(InsideLink);
 
+    inline bool colorIsCurrentColorForHighlight() const;
+    inline void setColorIsCurrentColorForHighlight(bool);
+
     inline bool isLink() const;
     inline void setIsLink(bool);
 
@@ -591,6 +594,7 @@ public:
 
     inline bool hasAnyPublicPseudoStyles() const;
     inline bool hasPseudoStyle(PseudoElementType) const;
+    inline EnumSet<PseudoElementType> highlightPseudoElementTypes() const;
     inline void setHasPseudoStyles(EnumSet<PseudoElementType>);
 
     Style::ComputedStyle* NODELETE pseudoElementStyle(const PseudoElementIdentifier&) const;

--- a/Source/WebCore/style/computed/data/StyleInheritedData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedData.cpp
@@ -43,6 +43,7 @@ InheritedData::InheritedData()
     , fontData(FontData::create())
     , color(WebCore::Color::black)
     , visitedLinkColor(WebCore::Color::black)
+    , colorIsCurrentColorForHighlight(false)
 {
 }
 
@@ -57,6 +58,7 @@ inline InheritedData::InheritedData(const InheritedData& o)
     , fontData(o.fontData)
     , color(o.color)
     , visitedLinkColor(o.visitedLinkColor)
+    , colorIsCurrentColorForHighlight(o.colorIsCurrentColorForHighlight)
 {
     ASSERT(o == *this, "InheritedData should be properly copied.");
 }
@@ -78,7 +80,8 @@ bool InheritedData::fastPathInheritedEqual(const InheritedData& other) const
     // These properties also need to have "fast-path-inherited" codegen property set.
     // Cases where other properties depend on these values need to disallow the fast path (via Style::ComputedStyle::setDisallowsFastPathInheritance).
     return color == other.color
-        && visitedLinkColor == other.visitedLinkColor;
+        && visitedLinkColor == other.visitedLinkColor
+        && colorIsCurrentColorForHighlight == other.colorIsCurrentColorForHighlight;
 }
 
 bool InheritedData::nonFastPathInheritedEqual(const InheritedData& other) const
@@ -96,6 +99,7 @@ void InheritedData::fastPathInheritFrom(const InheritedData& inheritParent)
 {
     color = inheritParent.color;
     visitedLinkColor = inheritParent.visitedLinkColor;
+    colorIsCurrentColorForHighlight = inheritParent.colorIsCurrentColorForHighlight;
 }
 
 #if !LOG_DISABLED
@@ -112,6 +116,7 @@ void InheritedData::dumpDifferences(TextStream& ts, const InheritedData& other) 
 #endif
 
     LOG_IF_DIFFERENT(color);
+    LOG_IF_DIFFERENT(colorIsCurrentColorForHighlight);
     LOG_IF_DIFFERENT(visitedLinkColor);
 }
 #endif

--- a/Source/WebCore/style/computed/data/StyleInheritedData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedData.h
@@ -67,6 +67,14 @@ public:
     WebCore::Color color;
     WebCore::Color visitedLinkColor;
 
+    // Whether color came from the currentcolor keyword. A highlight pseudo-element resolves
+    // currentcolor against its originating element, so the chain inherits the keyword rather than
+    // the color it resolved to. Highlight styles always set this, so it doesn't depend on being
+    // inherited with the color. https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+    // FIXME: A value that merely references currentcolor, like color-mix(in oklab, teal,
+    // currentcolor), is not covered. See BuilderCustom::applyHighlightInheritColor().
+    bool colorIsCurrentColorForHighlight;
+
 private:
     InheritedData();
     InheritedData(const InheritedData&);

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -387,6 +387,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'animation-wrapper-requires-override-parameters': self.validate_array,
             'animation-wrapper-requires-setter': self.validate_string,
             'animation-wrapper': self.validate_string,
+            'applies-to-highlight-pseudo-elements': self.validate_string,
             'cascade-alias': self.validate_string,
             'color-property-traits-color-custom': self.validate_boolean,
             'color-property-traits-requires-excludes-visited-link-color': self.validate_boolean,


### PR DESCRIPTION
#### 9334b44ff7ef9b546018ba0417e9f0f0cfaddc22
<pre>
[Custom Highlight] ::highlight() pseudo-elements should inherit from the parent element&apos;s highlight.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320716">https://bugs.webkit.org/show_bug.cgi?id=320716</a>
<a href="https://rdar.apple.com/183702060">rdar://183702060</a>

Reviewed by Alan Baradlay.

Implement per-property highlight cascade per

<a href="https://drafts.csswg.org/css-pseudo-4/#highlight-cascade">https://drafts.csswg.org/css-pseudo-4/#highlight-cascade</a>

&quot;When any supported property is not given a value by the cascade, or given a value of inherit or unset,
its specified value is determined by inheritance from the corresponding highlight pseudo-element of its
originating element’s parent element. This occurs regardless of whether that property is an inherited property.&quot;

This requires adding highlight specific inheritance paths to style builder.

Test: imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-parent-style-change.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-parent-style-change-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-parent-style-change.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-shadow-boundary-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-shadow-boundary.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-currentcolor-computed-inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-pseudos-inheritance-computed-001-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
(WebCore::CQ::Features::StyleFeatureSchema::evaluateRange const):

Designated initializers for BuilderContext, so that adding a member doesn&apos;t silently shift
the arguments. Same for ResolutionContext in StyleTreeResolver.cpp below.

* Source/WebCore/css/scripts/process-css-properties.py:
(StylePropertyCodeGenProperties):
(StylePropertyCodeGenProperties.from_json):
(applies_to_highlight_pseudo_elements):
(inherits_in_highlight_pseudo_elements):
(GenerateCSSPropertyNames):
* Source/WebCore/css/scripts/test/TestCSSProperties.json:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp:
(WebCore::Style::BuilderFunctions::applyHighlightInheritTestColorPropertyWithVisitedLinkSupport):
(WebCore::Style::BuilderFunctions::applyHighlightInheritTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin):
(WebCore::Style::BuilderGenerated::applyHighlightInheritAllProperties):
(WebCore::Style::BuilderGenerated::applyHighlightProperty):

New applies-to-highlight-pseudo-elements codegen property. It generates the allowlist
predicate and an applyHighlightInherit&lt;Property&gt;() reading the parent highlight style
instead of the parent style. Its &quot;yes-without-inheritance&quot; value is for fill and stroke,
which stay allowed but keep inheriting from the originating element: the applicable
property list has &apos;fill-color&apos; and &apos;stroke-color&apos;, which we don&apos;t support, rather than
the SVG paint properties.

style-builder-custom takes HighlightInitial, HighlightInherit and HighlightValue for the
properties that need more than reading a value out of the parent highlight style.

* Source/WebCore/rendering/style/RenderStyleConstants.h:

A highlight pseudo-element exists whenever it exists for the parent element, since it
inherits from it even with no rules of its own. The bits get propagated to the children
so that the early return in RenderElement::resolvePseudoElementStyle() keeps working
without gating out descendants that match nothing themselves.

* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::isCacheable):

The parent highlight style is not part of the cache key, and copyNonInheritedFrom() on a
hit would drop the inherited background-color and text-decoration values.

* Source/WebCore/style/PropertyAllowlist.cpp:
(WebCore::Style::isValidHighlightStyleProperty):

The allowlist is generated now. Custom properties are not in the applicable property list
but are allowed, since they can be substituted into the properties that are.

* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyHighlightInheritance):
(WebCore::Style::Builder::applyProperty):
* Source/WebCore/style/StyleBuilder.h:

A highlight style applies every property through applyHighlightProperty(), which uses the
highlight version of a function where there is one and otherwise falls back to
applyProperty(), so the normal path has no highlight code in it.

unset inherits instead of resolving to the initial value, which is what makes the
non-inherited properties like background-color participate.

* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyHighlightInitialColor):
(WebCore::Style::BuilderCustom::applyHighlightValueColor):
(WebCore::Style::BuilderCustom::applyHighlightInheritColor):

currentcolor in a highlight pseudo-element is the originating element&apos;s color, so the
chain inherits the keyword rather than the color it resolved to. These are the only
functions that write the bit for it.

* Source/WebCore/style/StyleBuilderGenerated.h:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleBuilderStateInlines.h:
(WebCore::Style::BuilderState::isBuildingHighlightStyle const):

parentHighlightStyle() returns a pointer, since it is null at the start of the chain,
where the inherited value is the initial value except for color.

* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::State::State):
(WebCore::Style::Resolver::State::parentHighlightStyle const):
(WebCore::Style::Resolver::builderContext const):
(WebCore::Style::Resolver::unadjustedStyleForElement):
(WebCore::Style::parentHighlightStyleIgnoringPendingUpdate):
(WebCore::Style::Resolver::styleForPseudoElement):
(WebCore::Style::Resolver::applyMatchedProperties):
* Source/WebCore/style/StyleResolver.h:

The chain is resolved one level per style, each cached in the ancestor&apos;s style, and
follows the flat tree like the rest of inheritance, so it continues past a shadow
boundary to the host. A highlight pseudo-element with no rules of its own now gets a
style too, so that it can pass the inherited values on to its descendants.

The parent highlight style comes in with the ResolutionContext, because highlight styles
are also re-resolved during tree resolution, where the parent&apos;s existing computed style
is the one being replaced. The lazy paths still walk up to find it, which is correct
there since nothing is being resolved.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::makeResolutionContext):
(WebCore::Style::TreeResolver::makeResolutionContextForPseudoElement):
(WebCore::Style::TreeResolver::makeResolutionContextForInheritedFirstLine):
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext):
(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
(WebCore::Style::ComputedStyleBase::colorIsCurrentColorForHighlight const):
(WebCore::Style::ComputedStyleBase::highlightPseudoElementTypes const):
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
(WebCore::Style::ComputedStyleBase::setColorIsCurrentColorForHighlight):
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/data/StyleInheritedData.cpp:
(WebCore::Style::InheritedData::InheritedData):
(WebCore::Style::InheritedData::fastPathInheritedEqual const):
(WebCore::Style::InheritedData::fastPathInheritFrom):
(WebCore::Style::InheritedData::dumpDifferences const):
* Source/WebCore/style/computed/data/StyleInheritedData.h:

The bit lives with the color it describes, so it travels with inheritFrom() and the fast
path without any handling of its own.

* Tools/Scripts/webkitpy/style/checkers/jsonchecker.py:
(JSONCSSPropertiesChecker.check_codegen_properties):

Canonical link: <a href="https://commits.webkit.org/318779@main">https://commits.webkit.org/318779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d1a4e21e505b8f9a19d867b00333dfa05b0a728

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143234 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02d258c4-ac93-418c-aa66-a940f37d529e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139530 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96721 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/931b5bb6-a4c9-4dd4-b236-ea3aa85467d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160272 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119976 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e98ea6d-6497-49d4-a61a-bc7a119e5133) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178250 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41784 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40122 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152183 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39775 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/61 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190974 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148736 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39996 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53214 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36400 "Found 2 new test failures: http/tests/media/now-playing-info-default-artwork-favicon.html http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148488 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43185 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125484 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120219 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51732 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14753 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51117 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51358 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51178 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->