### PR TITLE
[JSC] Terminate Atomics.wait / Wasm atomic.wait on worker.terminate()

### DIFF
--- a/LayoutTests/fast/workers/resources/worker-atomics-wait-forever.js
+++ b/LayoutTests/fast/workers/resources/worker-atomics-wait-forever.js
@@ -1,0 +1,4 @@
+const sab = new SharedArrayBuffer(4);
+const view = new Int32Array(sab);
+self.postMessage("ready");
+Atomics.wait(view, 0, 0);

--- a/LayoutTests/fast/workers/resources/worker-wasm-atomic-wait-forever.js
+++ b/LayoutTests/fast/workers/resources/worker-wasm-atomic-wait-forever.js
@@ -1,0 +1,8 @@
+const wasmBytes = new Uint8Array([
+    0,97,115,109,1,0,0,0,1,4,1,96,0,0,2,16,1,3,101,110,118,6,109,101,109,111,114,121,2,3,1,1,3,2,1,0,7,7,1,3,114,117,110,0,0,10,27,1,25,0,3,64,65,0,65,0,54,2,0,65,0,65,0,66,127,254,1,2,0,26,12,0,11,11
+]);
+const memory = new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true });
+WebAssembly.instantiate(wasmBytes, { env: { memory } }).then(({ instance }) => {
+    self.postMessage("ready");
+    instance.exports.run();
+});

--- a/LayoutTests/fast/workers/worker-terminate-atomics-wait-expected.txt
+++ b/LayoutTests/fast/workers/worker-terminate-atomics-wait-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Worker was started
+CONSOLE MESSAGE: Worker was terminated
+Test worker.terminate() while blocked in Atomics.wait.

--- a/LayoutTests/fast/workers/worker-terminate-atomics-wait.html
+++ b/LayoutTests/fast/workers/worker-terminate-atomics-wait.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
+<body>
+<p>Test worker.terminate() while blocked in Atomics.wait.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+var worker = new Worker("resources/worker-atomics-wait-forever.js");
+var sawStart = false;
+
+worker.onmessage = function() {
+    sawStart = true;
+    console.log("Worker was started");
+    worker.terminate();
+    setTimeout(waitForWorkerToStop, 0);
+};
+
+function waitForWorkerToStop() {
+    var startTime = Date.now();
+    function checkIfWorkerStopped() {
+        if (typeof GCController !== "undefined")
+            GCController.collect();
+        if (internals.workerThreadCount == 0) {
+            console.log("Worker was terminated");
+            testRunner.notifyDone();
+        } else if (Date.now() - startTime < 5000) {
+            setTimeout(checkIfWorkerStopped, 10);
+        } else {
+            console.log("Did not see worker terminate");
+            testRunner.notifyDone();
+        }
+    }
+    setTimeout(checkIfWorkerStopped, 0);
+}
+
+setTimeout(function() {
+    if (!sawStart) {
+        console.log("Worker did not show up");
+        worker.terminate();
+        testRunner.notifyDone();
+    }
+}, 5000);
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/workers/worker-terminate-wasm-atomic-wait-expected.txt
+++ b/LayoutTests/fast/workers/worker-terminate-wasm-atomic-wait-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Worker was started
+CONSOLE MESSAGE: Worker was terminated
+Test worker.terminate() while blocked in Wasm memory.atomic.wait32.

--- a/LayoutTests/fast/workers/worker-terminate-wasm-atomic-wait.html
+++ b/LayoutTests/fast/workers/worker-terminate-wasm-atomic-wait.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
+<body>
+<p>Test worker.terminate() while blocked in Wasm memory.atomic.wait32.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+var worker = new Worker("resources/worker-wasm-atomic-wait-forever.js");
+var sawStart = false;
+
+worker.onmessage = function() {
+    sawStart = true;
+    console.log("Worker was started");
+    setTimeout(function() {
+        worker.terminate();
+        setTimeout(waitForWorkerToStop, 0);
+    }, 50);
+};
+
+function waitForWorkerToStop() {
+    var startTime = Date.now();
+    function checkIfWorkerStopped() {
+        if (typeof GCController !== "undefined")
+            GCController.collect();
+        if (internals.workerThreadCount == 0) {
+            console.log("Worker was terminated");
+            testRunner.notifyDone();
+        } else if (Date.now() - startTime < 5000) {
+            setTimeout(checkIfWorkerStopped, 10);
+        } else {
+            console.log("Did not see worker terminate");
+            testRunner.notifyDone();
+        }
+    }
+    setTimeout(checkIfWorkerStopped, 0);
+}
+
+setTimeout(function() {
+    if (!sawStart) {
+        console.log("Worker did not show up");
+        worker.terminate();
+        testRunner.notifyDone();
+    }
+}, 5000);
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -470,7 +470,7 @@ JSValue atomicsWaitImpl(JSGlobalObject* globalObject, JSArrayType* typedArray, u
     case WaiterListManager::WaitSyncResult::TimedOut:
         return vm.smallStrings.timedOutString();
     case WaiterListManager::WaitSyncResult::Terminated:
-        vm.throwTerminationException();
+        vm.throwTerminationExceptionIfNeeded();
         return { };
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1103,6 +1103,21 @@ void VM::throwTerminationException()
         setExecutionForbidden();
 }
 
+void VM::throwTerminationExceptionIfNeeded()
+{
+    if (hasPendingTerminationException())
+        return;
+
+    if (traps().needHandling(VMTraps::NeedTermination))
+        traps().handleTraps(VMTraps::NeedTermination);
+
+    if (hasPendingTerminationException())
+        return;
+
+    if (hasTerminationRequest() && !traps().isDeferringTermination())
+        throwTerminationException();
+}
+
 Exception* VM::throwException(JSGlobalObject* globalObject, Exception* exceptionToThrow)
 {
     // The TerminationException should never be overridden.

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -334,6 +334,7 @@ public:
     }
 
     void throwTerminationException();
+    void throwTerminationExceptionIfNeeded();
 
     enum class EntryScopeService : uint8_t {
         // Sticky services i.e. if set, these will never be cleared.

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -32,6 +32,7 @@
 #include "JSObjectInlines.h"
 #include "ObjectConstructor.h"
 #include "VMManager.h"
+#include "VMTrapsInlines.h"
 #include <wtf/DataLog.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RawPointer.h>
@@ -82,6 +83,10 @@ WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueT
     Ref<WaiterList> list = findOrCreateList(ptr);
     MonotonicTime time = MonotonicTime::timePointFromNow(timeout);
 
+    auto isTerminating = [&] {
+        return vm.hasTerminationRequest() || vm.traps().needHandling(VMTraps::NeedTermination);
+    };
+
     {
         VMBlockingScope waitScope(vm, StopTheWorldEvent::AtomicsWaitBlocked);
 
@@ -92,8 +97,16 @@ WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueT
         list->addLast(listLocker, syncWaiter);
         dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::currentSingleton(), "> added a new SyncWaiter=", syncWaiter.get(), " to a waiterList for ptr ", RawPointer(ptr));
 
-        while (syncWaiter->isOnList() && time.now() < time && !vm.hasTerminationRequest())
+        while (syncWaiter->isOnList() && time.now() < time && !isTerminating())
             syncWaiter->condition().waitUntil(list->lock, time.approximate<WallTime>());
+
+        if (isTerminating()) {
+            if (syncWaiter->isOnList()) {
+                bool removed = list->findAndRemove(listLocker, syncWaiter);
+                ASSERT_UNUSED(removed, removed);
+            }
+            return WaitSyncResult::Terminated;
+        }
 
         // At this point, syncWaiter should be either notified (dequeued) or timeout (not dequeued).
         bool didGetDequeued = !syncWaiter->isOnList();
@@ -102,7 +115,7 @@ WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueT
 
         didGetDequeued = list->findAndRemove(listLocker, syncWaiter);
         ASSERT(didGetDequeued);
-        return vm.hasTerminationRequest() ? WaitSyncResult::Terminated : WaitSyncResult::TimedOut;
+        return WaitSyncResult::TimedOut;
     }
 }
 

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -747,7 +747,7 @@ static inline int32_t waitImpl(VM& vm, ValueType* pointer, ValueType expectedVal
     case WaiterListManager::WaitSyncResult::TimedOut:
         return static_cast<int32_t>(result);
     case WaiterListManager::WaitSyncResult::Terminated:
-        vm.throwTerminationException();
+        vm.throwTerminationExceptionIfNeeded();
         return -1;
     }
     RELEASE_ASSERT_NOT_REACHED();
@@ -833,12 +833,15 @@ inline void* throwWasmToJSException(CallFrame* callFrame, Wasm::ExceptionType ty
     do {
         auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-        JSObject* error;
+        if (vm.hasPendingTerminationException())
+            break;
+
         if (type == ExceptionType::Termination) {
-            // Nothing to do because the exception should have already been thrown.
-            RELEASE_ASSERT(vm.hasPendingTerminationException());
+            RELEASE_ASSERT_NOT_REACHED();
             break;
         }
+
+        JSObject* error;
         if (type == ExceptionType::StackOverflow)
             error = createStackOverflowError(globalObject);
         else if (isTypeErrorExceptionType(type))


### PR DESCRIPTION
#### 03e836de2f7bd5627a95f60357633d59fb6bb18d
<pre>
[JSC] Terminate Atomics.wait / Wasm atomic.wait on worker.terminate()
<a href="https://bugs.webkit.org/show_bug.cgi?id=289686">https://bugs.webkit.org/show_bug.cgi?id=289686</a>

Reviewed by Yusuke Suzuki.

After <a href="https://bugs.webkit.org/show_bug.cgi?id=305440">https://bugs.webkit.org/show_bug.cgi?id=305440</a>, notifyNeedTermination()
only fires the NeedTermination trap bit and no longer sets
hasTerminationRequest() immediately. waitSync still only checked
hasTerminationRequest(), so a worker blocked in Atomics.wait or Wasm
memory.atomic.wait was woken by the stop-request condition notify but
never returned Terminated.

Teach waitSync to observe the pending NeedTermination trap, prefer
Terminated when shutdown races with notify or timeout, and materialize the
TerminationException via throwTerminationExceptionIfNeeded(). When Wasm
tiers take the OutOfBounds path for wait&apos;s -1 return with termination
already pending, throwWasmToJSException keeps the TerminationException.

Tests handshake that the worker is inside the wait, then terminate and GC
until workerThreadCount hits zero.

* Source/JavaScriptCore/runtime/AtomicsObject.cpp:
(JSC::atomicsWaitImpl):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::throwTerminationExceptionIfNeeded):
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/runtime/WaiterListManager.cpp:
(JSC::WaiterListManager::waitSyncImpl):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::waitImpl):
(JSC::Wasm::throwWasmToJSException):
* LayoutTests/fast/workers/worker-terminate-atomics-wait.html: Added.
* LayoutTests/fast/workers/worker-terminate-atomics-wait-expected.txt: Added.
* LayoutTests/fast/workers/worker-terminate-wasm-atomic-wait.html: Added.
* LayoutTests/fast/workers/worker-terminate-wasm-atomic-wait-expected.txt: Added.
* LayoutTests/fast/workers/resources/worker-atomics-wait-forever.js: Added.
* LayoutTests/fast/workers/resources/worker-wasm-atomic-wait-forever.js: Added.

Canonical link: <a href="https://commits.webkit.org/319508@main">https://commits.webkit.org/319508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff5ea536046959569cdd2091290ee4d0058c4dc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144323 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140379 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97197 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120830 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42706 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41019 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2798 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9644 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40686 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1373 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41278 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192148 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149717 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54303 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149448 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27594 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44091 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126566 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121651 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52820 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15674 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52202 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52440 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->