### PR TITLE
[Text Extraction] Add a way to map node identifier strings to `WKFrameInfo`

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -3151,6 +3151,19 @@ InteractionDescription interactionDescription(const Interaction& interaction, Lo
     return { description.toString(), WTF::move(stringsToValidate), didFindTargetNode };
 }
 
+std::optional<FrameIdentifier> contentFrameIdentifierForNode(NodeIdentifier identifier)
+{
+    RefPtr frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(Node::fromIdentifier(identifier));
+    if (!frameOwner)
+        return { };
+
+    RefPtr contentFrame = frameOwner->contentFrame();
+    if (!contentFrame)
+        return { };
+
+    return contentFrame->frameID();
+}
+
 RefPtr<Element> elementForExtractedText(const LocalFrame& frame, ExtractedText&& extractedText)
 {
     auto nodeIdentifier = extractedText.nodeIdentifier;

--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -54,6 +54,7 @@ WEBCORE_EXPORT std::optional<SimpleRange> rangeForExtractedText(const LocalFrame
 WEBCORE_EXPORT RefPtr<Element> elementForExtractedText(const LocalFrame&, ExtractedText&&);
 WEBCORE_EXPORT RefPtr<Element> containerElementForExtractedText(const LocalFrame&, ExtractedText&&);
 WEBCORE_EXPORT RefPtr<Element> containerElementForSearchTexts(const LocalFrame&, Vector<String>&&, std::optional<NodeIdentifier>&&);
+WEBCORE_EXPORT std::optional<FrameIdentifier> contentFrameIdentifierForNode(NodeIdentifier);
 
 WEBCORE_EXPORT Vector<FilterRule> extractRules(Vector<FilterRuleData>&&);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm
@@ -1200,4 +1200,28 @@ static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTe
     });
 }
 
+- (void)_requestFrameInfoForNodeIdentifier:(NSString *)nodeIdentifierString completionHandler:(void (^)(WKFrameInfo *))completion
+{
+    auto identifiers = WebKit::parseExtractedNodeInfo(String { nodeIdentifierString });
+    if (!identifiers)
+        return completion(nil);
+
+    RefPtr enclosingFrame = _page->mainFrame();
+    if (identifiers->frameIdentifier)
+        enclosingFrame = WebKit::WebFrameProxy::webFrame(identifiers->frameIdentifier);
+
+    if (!enclosingFrame)
+        return completion(nil);
+
+    enclosingFrame->requestContentFrameIdentifierForNode(identifiers->nodeIdentifier, [completion = makeBlockPtr(completion), enclosingFrame](auto&& contentFrameIdentifier) mutable {
+        RefPtr targetFrame = WebKit::WebFrameProxy::webFrame(contentFrameIdentifier);
+        if (!targetFrame)
+            targetFrame = WTF::move(enclosingFrame);
+
+        targetFrame->getFrameInfo([completion = WTF::move(completion)](auto&& info) {
+            completion(info ? wrapper(API::FrameInfo::create(WTF::move(*info))) : nil);
+        });
+    });
+}
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -788,6 +788,7 @@ struct LiveResizeSnapshotState {
 - (void)_requestJSHandleForNodeIdentifier:(NSString *)nodeIdentifier searchText:(NSString *)searchText completionHandler:(void (^)(_WKJSHandle * _Nullable))completionHandler;
 - (void)_requestContainerJSHandleForNodeIdentifier:(NSString *)nodeIdentifier searchText:(NSString *)searchText completionHandler:(void (^)(_WKJSHandle * _Nullable))completionHandler;
 - (void)_requestContainerJSHandleForSearchTexts:(NSArray<NSString *> *)searchTexts nodeIdentifier:(NSString *)nodeIdentifier completionHandler:(void (^)(_WKJSHandle * _Nullable))completionHandler;
+- (void)_requestFrameInfoForNodeIdentifier:(NSString *)nodeIdentifier completionHandler:(void (^)(WKFrameInfo * _Nullable))completionHandler;
 
 #if !__has_feature(modules) || WK_SUPPORTS_SWIFT_OBJCXX_INTEROP
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -307,6 +307,14 @@ WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 - (void)requestContainerJSHandleForSearchTexts:(NSArray<NSString *> *)searchTexts nodeIdentifier:(nullable NSString *)nodeIdentifier completionHandler:(void (^)(_WKJSHandle * _Nullable))completionHandler;
 - (void)requestContainerHandleForSearchTexts:(NSArray<NSString *> *)searchTexts nodeIdentifier:(nullable NSString *)nodeIdentifier completionHandler:(void (^)(WKJSHandle * _Nullable))completionHandler WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
+/*!
+ Asynchronously map a node identifier string to the frame whose content the node belongs to.
+ @param nodeIdentifier  The unique ID of an `iframe` (or other frame owner element), in which case
+                        the frame hosted by that element is returned; otherwise, the frame
+                        containing the node corresponding to this ID is returned.
+ */
+- (void)requestFrameInfoForNodeIdentifier:(NSString *)nodeIdentifier completionHandler:(void (^)(WKFrameInfo * _Nullable))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @end
 
 typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -280,6 +280,15 @@
     }];
 }
 
+- (void)requestFrameInfoForNodeIdentifier:(NSString *)nodeIdentifier completionHandler:(void (^)(WKFrameInfo *))completionHandler
+{
+    RetainPtr webView = _webView;
+    if (!webView)
+        return completionHandler(nil);
+
+    [webView _requestFrameInfoForNodeIdentifier:nodeIdentifier completionHandler:completionHandler];
+}
+
 @end
 
 @implementation _WKTextExtractionInteraction {

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -1182,6 +1182,14 @@ void WebFrameProxy::requestContainerJSHandleForSearchTexts(Vector<String>&& sear
     sendWithAsyncReply(Messages::WebFrame::RequestContainerJSHandleForSearchTexts(WTF::move(searchTexts), WTF::move(targetNodeIdentifier)), WTF::move(completion));
 }
 
+void WebFrameProxy::requestContentFrameIdentifierForNode(NodeIdentifier nodeIdentifier, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>&&)>&& completion)
+{
+    if (RefPtr page = m_page.get(); !page || !page->hasRunningProcess())
+        return completion({ });
+
+    sendWithAsyncReply(Messages::WebFrame::RequestContentFrameIdentifierForNode(nodeIdentifier), WTF::move(completion));
+}
+
 void WebFrameProxy::getSelectorPathsForNode(JSHandleInfo&& handle, CompletionHandler<void(Vector<HashSet<String>>&&)>&& completion)
 {
     if (RefPtr page = m_page.get(); !page || !page->hasRunningProcess())

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -329,6 +329,7 @@ public:
     void requestJSHandleForExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
     void requestContainerJSHandleForExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
     void requestContainerJSHandleForSearchTexts(Vector<String>&&, std::optional<WebCore::NodeIdentifier>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
+    void requestContentFrameIdentifierForNode(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>&&)>&&);
 
     void getSelectorPathsForNode(JSHandleInfo&&, CompletionHandler<void(Vector<HashSet<String>>&&)>&&);
     void getNodeForSelectorPaths(Vector<HashSet<String>>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1995,6 +1995,11 @@ void WebFrame::requestContainerJSHandleForSearchTexts(Vector<String>&& searchTex
     completion({ WTF::move(handleAndInfo->second) });
 }
 
+void WebFrame::requestContentFrameIdentifierForNode(NodeIdentifier nodeIdentifier, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>&&)>&& completion)
+{
+    completion(TextExtraction::contentFrameIdentifierForNode(nodeIdentifier));
+}
+
 void WebFrame::getSelectorPathsForNode(JSHandleInfo&& handle, CompletionHandler<void(Vector<HashSet<String>>&&)>&& completion)
 {
     RefPtr node = nodeFromJSHandleIdentifier(handle.identifier);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -300,6 +300,7 @@ public:
     void requestJSHandleForExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
     void requestContainerJSHandleForExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
     void requestContainerJSHandleForSearchTexts(Vector<String>&&, std::optional<WebCore::NodeIdentifier>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
+    void requestContentFrameIdentifierForNode(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>&&)>&&);
 
     void getSelectorPathsForNode(JSHandleInfo&&, CompletionHandler<void(Vector<HashSet<String>>&&)>&&);
     void getNodeForSelectorPaths(Vector<HashSet<String>>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
@@ -45,6 +45,7 @@ messages -> WebFrame {
     RequestJSHandleForExtractedText(struct WebCore::TextExtraction::ExtractedText text) -> (struct std::optional<WebKit::JSHandleInfo> handle)
     RequestContainerJSHandleForExtractedText(struct WebCore::TextExtraction::ExtractedText text) -> (struct std::optional<WebKit::JSHandleInfo> handle)
     RequestContainerJSHandleForSearchTexts(Vector<String> texts, std::optional<WebCore::NodeIdentifier> fallbackNodeIdentifier) -> (struct std::optional<WebKit::JSHandleInfo> handle)
+    RequestContentFrameIdentifierForNode(WebCore::NodeIdentifier nodeIdentifier) -> (std::optional<WebCore::FrameIdentifier> frameIdentifier)
 
     # Element targeting support
     GetSelectorPathsForNode(struct WebKit::JSHandleInfo handle) -> (Vector<HashSet<String>> selectors)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -91,6 +91,7 @@ SOFT_LINK_CLASS(SafariSafeBrowsing, SSBLookupContext);
 - (_WKJSHandle *)jsHandleForNodeIdentifier:(NSString *)nodeIdentifier searchText:(NSString *)searchText;
 - (_WKJSHandle *)containerJSHandleForNodeIdentifier:(NSString *)nodeIdentifier searchText:(NSString *)searchText;
 - (_WKJSHandle *)containerJSHandleForSearchTexts:(NSArray<NSString *> *)searchTexts nodeIdentifier:(NSString *)nodeIdentifier;
+- (WKFrameInfo *)frameInfoForNodeIdentifier:(NSString *)nodeIdentifier;
 @end
 
 @implementation WKWebView (TextExtractionTests)
@@ -206,6 +207,18 @@ SOFT_LINK_CLASS(SafariSafeBrowsing, SSBLookupContext);
     __block RetainPtr<_WKJSHandle> result;
     [self requestContainerJSHandleForSearchTexts:searchTexts nodeIdentifier:nodeIdentifier completionHandler:^(_WKJSHandle *handle) {
         result = handle;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    return result.autorelease();
+}
+
+- (WKFrameInfo *)frameInfoForNodeIdentifier:(NSString *)nodeIdentifier
+{
+    __block bool done = false;
+    __block RetainPtr<WKFrameInfo> result;
+    [self requestFrameInfoForNodeIdentifier:nodeIdentifier completionHandler:^(WKFrameInfo *frameInfo) {
+        result = frameInfo;
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
@@ -1944,6 +1957,67 @@ TEST(TextExtractionTests, SubframeOriginInDebugText)
     EXPECT_TRUE([debugText containsString:crossOriginExpected.createNSString()]);
     EXPECT_FALSE([debugText containsString:@"origin=http://localhost"]);
     EXPECT_FALSE([debugText containsString:@"origin=127.0.0.1"]);
+}
+
+TEST(TextExtractionTests, RequestFrameInfoForNodeIdentifier)
+{
+    HTTPServer server { {
+        { "/subframe-cross.html"_s, { subFrameMarkup("Cross origin: click here"_s) } },
+        { "/subframe-same.html"_s, { subFrameMarkup("Same origin: click here"_s) } },
+    }, HTTPServer::Protocol::Http };
+
+    server.addResponse("/"_s, { mainFrameMarkup(server.port()) });
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    __block RetainPtr subframes = adoptNS([NSMutableArray new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate setDidCommitLoadWithRequestInFrame:^(WKWebView *, NSURLRequest *, WKFrameInfo *frame) {
+        if (!frame.mainFrame && ![frame.request.URL.scheme isEqualToString:@"about"])
+            [subframes addObject:frame];
+    }];
+    [webView setNavigationDelegate:navigationDelegate];
+    [webView loadRequest:server.request()];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    Util::waitForConditionWithLogging([webView] {
+        return [[webView objectByEvaluatingJavaScript:@"subframeLoadedCount"] intValue] == 2;
+    }, 2, @"Expected subframes to finish loading.");
+
+    RetainPtr result = [webView synchronouslyExtractDebugTextResult:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setIncludeRects:NO];
+        [configuration setAdditionalFrames:subframes];
+        return configuration.autorelease();
+    }()];
+
+    RetainPtr debugText = [result textContent];
+    auto crossOriginToken = makeString("origin=localhost:"_s, server.port());
+
+    RetainPtr crossOriginFrameInfo = [result frameInfoForNodeIdentifier:extractNodeIdentifier(debugText, crossOriginToken.createNSString())];
+    EXPECT_NOT_NULL(crossOriginFrameInfo);
+    EXPECT_FALSE([crossOriginFrameInfo isMainFrame]);
+    EXPECT_WK_STREQ("/subframe-cross.html", [[crossOriginFrameInfo request].URL path]);
+
+    RetainPtr crossOriginButtonFrameInfo = [result frameInfoForNodeIdentifier:extractNodeIdentifier(debugText, @"Cross origin: click here")];
+    EXPECT_NOT_NULL(crossOriginButtonFrameInfo);
+    EXPECT_FALSE([crossOriginButtonFrameInfo isMainFrame]);
+    EXPECT_WK_STREQ("/subframe-cross.html", [[crossOriginButtonFrameInfo request].URL path]);
+
+    RetainPtr sameOriginButtonFrameInfo = [result frameInfoForNodeIdentifier:extractNodeIdentifier(debugText, @"Same origin: click here")];
+    EXPECT_NOT_NULL(sameOriginButtonFrameInfo);
+    EXPECT_FALSE([sameOriginButtonFrameInfo isMainFrame]);
+    EXPECT_WK_STREQ("/subframe-same.html", [[sameOriginButtonFrameInfo request].URL path]);
+
+    RetainPtr mainFrameInfo = [result frameInfoForNodeIdentifier:extractNodeIdentifier(debugText, @"Link to WebKit home page")];
+    EXPECT_NOT_NULL(mainFrameInfo);
+    EXPECT_TRUE([mainFrameInfo isMainFrame]);
+
+    EXPECT_NULL([result frameInfoForNodeIdentifier:@"not-a-node-identifier"]);
 }
 
 TEST(TextExtractionTests, ClickInteractionWithTextOnly)


### PR DESCRIPTION
#### bd875a909950772189f7265bcb1e909bf3c3d29c
<pre>
[Text Extraction] Add a way to map node identifier strings to `WKFrameInfo`
<a href="https://bugs.webkit.org/show_bug.cgi?id=321096">https://bugs.webkit.org/show_bug.cgi?id=321096</a>
<a href="https://rdar.apple.com/184135720">rdar://184135720</a>

Reviewed by Richard Robinson.

Add a way for text extractions to grab a `WKFrameInfo`, corresponding to a node `uid` string. If the
`uid` corresponds to an `iframe`, this finds the frame info corresponding to the content frame of
the `iframe` element; otherwise, it falls back to returning the content frame containing the given
target node.

This allows agents to (for instance) evaluate script in the context of the content frame underneath
an `iframe`, without requiring the agent to first extract content within the target subframe.

Test: TextExtractionTests.RequestFrameInfoForNodeIdentifier

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::contentFrameIdentifierForNode):
* Source/WebCore/page/text-extraction/TextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm:
(-[WKWebView _requestFrameInfoForNodeIdentifier:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionResult requestFrameInfoForNodeIdentifier:completionHandler:]):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::requestContentFrameIdentifierForNode):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::requestContentFrameIdentifierForNode):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.messages.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(-[_WKTextExtractionResult frameInfoForNodeIdentifier:]):
(TestWebKitAPI::(TextExtractionTests, RequestFrameInfoForNodeIdentifier)):

Add an API test to exercise this new method.

Canonical link: <a href="https://commits.webkit.org/318652@main">https://commits.webkit.org/318652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34ce3a613c4d3314c41477f468946f19f3340c3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188752 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13cd3d3a-cb2c-4b74-9bc1-5d4ddf6c6917) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52572 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c47f5c1-93c5-40ce-8ecc-f89faf063fa1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160268 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/119964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e463d136-cde2-4007-a7af-bd5c8807de1d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41774 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40119 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152173 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39771 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/59 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190972 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52532 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148730 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39913 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53212 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148482 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; run-api-tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43176 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125482 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120217 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51730 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14749 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51115 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51356 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51176 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->