### PR TITLE
Updated popover WPT suite to match current content

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/WEB_FEATURES.yml
@@ -1,28 +1,9 @@
-features:
-- name: popover
-  files:
-  - "*"
-  # keep exclusions synced with mappings below
-  - "!popover-close-request.html"
-  - "!popovertarget-disabled-fieldset.html"
-  - "!popover-hint-crash.html"
-  - "!popover-light-dismiss-hint.html"
-  - "!popover-top-layer-nesting-hints.html"
-  - "!popover-types-with-hints.html"
-  - "!popover-toggle-source.html"
-# keep subsequent mappings synced with exclusions above
-- name: closewatcher
-  files:
-  - "popover-close-request.html"
-- name: invoker-commands
-  files:
-  - popovertarget-disabled-fieldset.html
-- name: popover-hint
-  files:
-  - popover-hint-crash.html
-  - popover-light-dismiss-hint.html
-  - popover-top-layer-nesting-hints.html
-  - popover-types-with-hints.html
-- name: toggleevent-source
-  files:
-  - popover-toggle-source.html
+rules:
+- popover-close-request.html: [closewatcher]
+- popovertarget-disabled-fieldset.html: [invoker-commands]
+- popover-hint-crash.html: [popover-hint]
+- popover-light-dismiss-hint.html: [popover-hint]
+- popover-top-layer-nesting-hints.html: [popover-hint]
+- popover-types-with-hints.html: [popover-hint]
+- popover-toggle-source.html: [toggleevent-source]
+- "*": [popover]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-hint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-hint-expected.txt
@@ -5,6 +5,7 @@ PASS Mixed auto/hint light dismiss behavior, click on innerhint1
 PASS Mixed auto/hint light dismiss behavior, click on innerhint2
 PASS Mixed auto/hint light dismiss behavior, click on hint1
 PASS Mixed auto/hint light dismiss behavior, click on hint2
+PASS Clicking an auto nested inside a hint keeps the whole chain open
 PASS Clicking outside closes all setA
 PASS Clicking outside closes all setB
 PASS Auto can be nested inside hint (nothing should throw, auto demoted to hint)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-hint.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-hint.html
@@ -37,7 +37,7 @@
   #improperlynestedauto1 {left:100px; top:500px;}
   #hint1        {left:200px; top:100px;}
   #hint2        {left:200px; top:200px;}
-  #improperlynestedauto1 {left:200px; top:400px;}
+  #improperlynestedauto2 {left:200px; top:300px;}
   #manual1      {left:300px; top:100px;}
   #outside {width:25px;height:25px}
 </style>
@@ -93,6 +93,13 @@
       assertState(setB, expectedState);
     }, 'Mixed auto/hint light dismiss behavior, click on ' + setB[i].id);
   }
+
+  promise_test(async (t) => {
+    const popovers = [hint1, hint2, improperlynestedauto2, manual1];
+    openall(popovers, t);
+    await clickOn(improperlynestedauto2);
+    assertState(popovers, [true, true, true, true]);
+  }, 'Clicking an auto nested inside a hint keeps the whole chain open');
 
   promise_test(async (t) => {
     openall(setA, t);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/w3c-import.log
@@ -82,6 +82,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hidden-display-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hidden-display.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-dialog-dismisses-unrelated-auto.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-hierarchy.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-reentrant-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-iframe-backdrop-expected.html
@@ -108,6 +109,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-touch-scroll.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-manual-hide-does-not-close-auto.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-manual-reentrant-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-minimum-role.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-move-documents.html


### PR DESCRIPTION
#### afa93d4b08cc1ae7f72c0211f0ec9b138fc2031f
<pre>
Updated popover WPT suite to match current content
<a href="https://bugs.webkit.org/show_bug.cgi?id=321099">https://bugs.webkit.org/show_bug.cgi?id=321099</a>
<a href="https://rdar.apple.com/184139028">rdar://184139028</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/7b860c524151c4a5ad6b925ba48719a6e70b2464">https://github.com/web-platform-tests/wpt/commit/7b860c524151c4a5ad6b925ba48719a6e70b2464</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-hint-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-hint.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/318694@main">https://commits.webkit.org/318694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e15635763db18ec9dac44e83e832fa7ae29a24cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188860 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a78650d3-b563-4c31-a193-fbe72f46f677) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139607 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae015d22-0f71-49b2-b1c0-60ab4f651731) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120053 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/697196a6-3d20-49f6-94d8-829cf5578260) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41872 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40220 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39863 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/167 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191080 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148835 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53320 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36489 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148582 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27171 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43273 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120405 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51838 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14842 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51223 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51464 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51284 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->