### PR TITLE
Convert CSSValue ValueSeparator to an enum class

### DIFF
--- a/Source/WebCore/css/CSSFunctionValue.cpp
+++ b/Source/WebCore/css/CSSFunctionValue.cpp
@@ -34,37 +34,37 @@
 namespace WebCore {
     
 CSSFunctionValue::CSSFunctionValue(CSSValueID name, CSSValueListBuilder arguments)
-    : CSSValueContainingVector(ClassType::Function, CommaSeparator, WTF::move(arguments))
+    : CSSValueContainingVector(ClassType::Function, ValueSeparator::Comma, WTF::move(arguments))
     , m_name(name)
 {
 }
 
 CSSFunctionValue::CSSFunctionValue(CSSValueID name)
-    : CSSValueContainingVector(ClassType::Function, CommaSeparator)
+    : CSSValueContainingVector(ClassType::Function, ValueSeparator::Comma)
     , m_name(name)
 {
 }
 
 CSSFunctionValue::CSSFunctionValue(CSSValueID name, Ref<CSSValue>&& argument)
-    : CSSValueContainingVector(ClassType::Function, CommaSeparator, WTF::move(argument))
+    : CSSValueContainingVector(ClassType::Function, ValueSeparator::Comma, WTF::move(argument))
     , m_name(name)
 {
 }
 
 CSSFunctionValue::CSSFunctionValue(CSSValueID name, Ref<CSSValue>&& argument1, Ref<CSSValue>&& argument2)
-    : CSSValueContainingVector(ClassType::Function, CommaSeparator, WTF::move(argument1), WTF::move(argument2))
+    : CSSValueContainingVector(ClassType::Function, ValueSeparator::Comma, WTF::move(argument1), WTF::move(argument2))
     , m_name(name)
 {
 }
 
 CSSFunctionValue::CSSFunctionValue(CSSValueID name, Ref<CSSValue>&& argument1, Ref<CSSValue>&& argument2, Ref<CSSValue>&& argument3)
-    : CSSValueContainingVector(ClassType::Function, CommaSeparator, WTF::move(argument1), WTF::move(argument2), WTF::move(argument3))
+    : CSSValueContainingVector(ClassType::Function, ValueSeparator::Comma, WTF::move(argument1), WTF::move(argument2), WTF::move(argument3))
     , m_name(name)
 {
 }
 
 CSSFunctionValue::CSSFunctionValue(CSSValueID name, Ref<CSSValue>&& argument1, Ref<CSSValue>&& argument2, Ref<CSSValue>&& argument3, Ref<CSSValue>&& argument4)
-    : CSSValueContainingVector(ClassType::Function, CommaSeparator, WTF::move(argument1), WTF::move(argument2), WTF::move(argument3), WTF::move(argument4))
+    : CSSValueContainingVector(ClassType::Function, ValueSeparator::Comma, WTF::move(argument1), WTF::move(argument2), WTF::move(argument3), WTF::move(argument4))
     , m_name(name)
 {
 }

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -45,7 +45,7 @@ Ref<CSSImageSetValue> CSSImageSetValue::create(CSSValueListBuilder builder)
 }
 
 CSSImageSetValue::CSSImageSetValue(CSSValueListBuilder builder)
-    : CSSValueContainingVector(ClassType::ImageSet, CommaSeparator, WTF::move(builder))
+    : CSSValueContainingVector(ClassType::ImageSet, ValueSeparator::Comma, WTF::move(builder))
 {
 }
 

--- a/Source/WebCore/css/CSSTransformListValue.cpp
+++ b/Source/WebCore/css/CSSTransformListValue.cpp
@@ -36,12 +36,12 @@
 namespace WebCore {
 
 CSSTransformListValue::CSSTransformListValue(CSSValueListBuilder builder)
-    : CSSValueContainingVector(ClassType::TransformList, SpaceSeparator, WTF::move(builder))
+    : CSSValueContainingVector(ClassType::TransformList, ValueSeparator::Space, WTF::move(builder))
 {
 }
 
 CSSTransformListValue::CSSTransformListValue(Ref<CSSValue> value)
-    : CSSValueContainingVector(ClassType::TransformList, SpaceSeparator, WTF::move(value))
+    : CSSValueContainingVector(ClassType::TransformList, ValueSeparator::Space, WTF::move(value))
 {
 }
 

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -384,11 +384,11 @@ String CSSValue::cssText(const CSS::SerializationContext& context) const
 ASCIILiteral CSSValue::separatorCSSText(ValueSeparator separator)
 {
     switch (separator) {
-    case SpaceSeparator:
+        case ValueSeparator::Space:
         return " "_s;
-    case CommaSeparator:
+        case ValueSeparator::Comma:
         return ", "_s;
-    case SlashSeparator:
+        case ValueSeparator::Slash:
         return " / "_s;
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -181,7 +181,7 @@ public:
     enum StaticCSSValueTag { StaticCSSValue };
 
     static constexpr size_t ValueSeparatorBits = 2;
-    enum ValueSeparator : uint8_t { SpaceSeparator, CommaSeparator, SlashSeparator };
+    enum class ValueSeparator : uint8_t { Space, Comma, Slash };
 
     inline const CSSValue& first() const; // CSSValuePair
     inline const CSSValue& second() const; // CSSValuePair
@@ -294,7 +294,7 @@ protected:
 
     WEBCORE_EXPORT void operator delete(CSSValue*, std::destroying_delete_t);
 
-    ValueSeparator separator() const { return static_cast<ValueSeparator>(m_valueSeparator); }
+    ValueSeparator separator() const { return m_valueSeparator; }
     ASCIILiteral separatorCSSText() const { return separatorCSSText(separator()); };
 
 private:
@@ -315,7 +315,7 @@ protected:
     uint8_t m_isImplicitInitialValue : 1 { false };
 
     // CSSValueList and CSSValuePair:
-    uint8_t m_valueSeparator : ValueSeparatorBits { 0 };
+    ValueSeparator m_valueSeparator : ValueSeparatorBits { ValueSeparator::Space };
 
 private:
     ClassType m_classType : ClassTypeBits;

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -124,57 +124,57 @@ CSSValueList::CSSValueList(ValueSeparator separator, Ref<CSSValue> value1, Ref<C
 
 Ref<CSSValueList> CSSValueList::createCommaSeparated(CSSValueListBuilder values)
 {
-    return adoptRef(*new CSSValueList(CommaSeparator, WTF::move(values)));
+    return adoptRef(*new CSSValueList(ValueSeparator::Comma, WTF::move(values)));
 }
 
 Ref<CSSValueList> CSSValueList::createCommaSeparated(Ref<CSSValue> value)
 {
-    return adoptRef(*new CSSValueList(CommaSeparator, WTF::move(value)));
+    return adoptRef(*new CSSValueList(ValueSeparator::Comma, WTF::move(value)));
 }
 
 Ref<CSSValueList> CSSValueList::createSlashSeparated(CSSValueListBuilder values)
 {
-    return adoptRef(*new CSSValueList(SlashSeparator, WTF::move(values)));
+    return adoptRef(*new CSSValueList(ValueSeparator::Slash, WTF::move(values)));
 }
 
 Ref<CSSValueList> CSSValueList::createSlashSeparated(Ref<CSSValue> value)
 {
-    return adoptRef(*new CSSValueList(SlashSeparator, WTF::move(value)));
+    return adoptRef(*new CSSValueList(ValueSeparator::Slash, WTF::move(value)));
 }
 
 Ref<CSSValueList> CSSValueList::createSlashSeparated(Ref<CSSValue> value1, Ref<CSSValue> value2)
 {
-    return adoptRef(*new CSSValueList(SlashSeparator, WTF::move(value1), WTF::move(value2)));
+    return adoptRef(*new CSSValueList(ValueSeparator::Slash, WTF::move(value1), WTF::move(value2)));
 }
 
 Ref<CSSValueList> CSSValueList::createSpaceSeparated()
 {
-    return adoptRef(*new CSSValueList(SpaceSeparator));
+    return adoptRef(*new CSSValueList(ValueSeparator::Space));
 }
 
 Ref<CSSValueList> CSSValueList::createSpaceSeparated(CSSValueListBuilder values)
 {
-    return adoptRef(*new CSSValueList(SpaceSeparator, WTF::move(values)));
+    return adoptRef(*new CSSValueList(ValueSeparator::Space, WTF::move(values)));
 }
 
 Ref<CSSValueList> CSSValueList::createSpaceSeparated(Ref<CSSValue> value)
 {
-    return adoptRef(*new CSSValueList(SpaceSeparator, WTF::move(value)));
+    return adoptRef(*new CSSValueList(ValueSeparator::Space, WTF::move(value)));
 }
 
 Ref<CSSValueList> CSSValueList::createSpaceSeparated(Ref<CSSValue> value1, Ref<CSSValue> value2)
 {
-    return adoptRef(*new CSSValueList(SpaceSeparator, WTF::move(value1), WTF::move(value2)));
+    return adoptRef(*new CSSValueList(ValueSeparator::Space, WTF::move(value1), WTF::move(value2)));
 }
 
 Ref<CSSValueList> CSSValueList::createSpaceSeparated(Ref<CSSValue> value1, Ref<CSSValue> value2, Ref<CSSValue> value3)
 {
-    return adoptRef(*new CSSValueList(SpaceSeparator, WTF::move(value1), WTF::move(value2), WTF::move(value3)));
+    return adoptRef(*new CSSValueList(ValueSeparator::Space, WTF::move(value1), WTF::move(value2), WTF::move(value3)));
 }
 
 Ref<CSSValueList> CSSValueList::createSpaceSeparated(Ref<CSSValue> value1, Ref<CSSValue> value2, Ref<CSSValue> value3, Ref<CSSValue> value4)
 {
-    return adoptRef(*new CSSValueList(SpaceSeparator, WTF::move(value1), WTF::move(value2), WTF::move(value3), WTF::move(value4)));
+    return adoptRef(*new CSSValueList(ValueSeparator::Space, WTF::move(value1), WTF::move(value2), WTF::move(value3), WTF::move(value4)));
 }
 
 Ref<CSSValueList> CSSValueList::create(char16_t separator, CSSValueListBuilder builder)

--- a/Source/WebCore/css/CSSValuePair.cpp
+++ b/Source/WebCore/css/CSSValuePair.cpp
@@ -43,17 +43,17 @@ CSSValuePair::CSSValuePair(ValueSeparator separator, Ref<CSSValue> first, Ref<CS
 
 Ref<CSSValuePair> CSSValuePair::create(Ref<CSSValue> first, Ref<CSSValue> second)
 {
-    return adoptRef(*new CSSValuePair(SpaceSeparator, WTF::move(first), WTF::move(second), IdenticalValueSerialization::Coalesce));
+    return adoptRef(*new CSSValuePair(ValueSeparator::Space, WTF::move(first), WTF::move(second), IdenticalValueSerialization::Coalesce));
 }
 
 Ref<CSSValuePair> CSSValuePair::createSlashSeparated(Ref<CSSValue> first, Ref<CSSValue> second)
 {
-    return adoptRef(*new CSSValuePair(SlashSeparator, WTF::move(first), WTF::move(second), IdenticalValueSerialization::DoNotCoalesce));
+    return adoptRef(*new CSSValuePair(ValueSeparator::Slash, WTF::move(first), WTF::move(second), IdenticalValueSerialization::DoNotCoalesce));
 }
 
 Ref<CSSValuePair> CSSValuePair::createNoncoalescing(Ref<CSSValue> first, Ref<CSSValue> second)
 {
-    return adoptRef(*new CSSValuePair(SpaceSeparator, WTF::move(first), WTF::move(second), IdenticalValueSerialization::DoNotCoalesce));
+    return adoptRef(*new CSSValuePair(ValueSeparator::Space, WTF::move(first), WTF::move(second), IdenticalValueSerialization::DoNotCoalesce));
 }
 
 bool CSSValuePair::canBeCoalesced() const

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -68,7 +68,7 @@ String serializeLonghandValue(const CSS::SerializationContext& context, CSSPrope
     // We need to serialize those lists with the actual values, not as "initial".
     // Doing this for all CSSValueList with comma separators is better than checking the property is one of those longhands.
     // Serializing this way is harmless for other properties; those won't have any implicit initial values.
-    if (auto* list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::CommaSeparator) {
+    if (auto* list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::ValueSeparator::Comma) {
         StringBuilder result;
         auto separator = ""_s;
         for (Ref individualValue : *list)

--- a/Source/WebCore/css/values/CSSValueTypes+DeprecatedCSSOMValueCreation.cpp
+++ b/Source/WebCore/css/values/CSSValueTypes+DeprecatedCSSOMValueCreation.cpp
@@ -51,17 +51,17 @@ Ref<DeprecatedCSSOMValue> makePrimitiveDeprecatedCSSOMValue(CSSValueID value, CS
 
 template<> Ref<DeprecatedCSSOMValue> makeListDeprecatedCSSOMValue<SerializationSeparatorType::Space>(DeprecatedCSSOMValueListBuilder&& builder, CSSStyleDeclaration& owner)
 {
-    return DeprecatedCSSOMValueList::create(WTF::move(builder), CSSValue::ValueSeparator::SpaceSeparator, owner);
+    return DeprecatedCSSOMValueList::create(WTF::move(builder), CSSValue::ValueSeparator::Space, owner);
 }
 
 template<> Ref<DeprecatedCSSOMValue> makeListDeprecatedCSSOMValue<SerializationSeparatorType::Comma>(DeprecatedCSSOMValueListBuilder&& builder, CSSStyleDeclaration& owner)
 {
-    return DeprecatedCSSOMValueList::create(WTF::move(builder), CSSValue::ValueSeparator::CommaSeparator, owner);
+    return DeprecatedCSSOMValueList::create(WTF::move(builder), CSSValue::ValueSeparator::Comma, owner);
 }
 
 template<> Ref<DeprecatedCSSOMValue> makeListDeprecatedCSSOMValue<SerializationSeparatorType::Slash>(DeprecatedCSSOMValueListBuilder&& builder, CSSStyleDeclaration& owner)
 {
-    return DeprecatedCSSOMValueList::create(WTF::move(builder), CSSValue::ValueSeparator::SlashSeparator, owner);
+    return DeprecatedCSSOMValueList::create(WTF::move(builder), CSSValue::ValueSeparator::Slash, owner);
 }
 
 } // namespace CSS

--- a/Source/WebCore/style/StyleCustomProperty.cpp
+++ b/Source/WebCore/style/StyleCustomProperty.cpp
@@ -97,11 +97,11 @@ Ref<CSSValue> CustomProperty::propertyValue(CSSValuePool& pool, const Style::Com
             for (auto& value : valueList.values)
                 builder.append(convertValue(value));
             switch (valueList.separator) {
-            case CSSValue::SpaceSeparator:
+            case CSSValue::ValueSeparator::Space:
                 return CSSValueList::createSpaceSeparated(WTF::move(builder));
-            case CSSValue::CommaSeparator:
+                case CSSValue::ValueSeparator::Comma:
                 return CSSValueList::createCommaSeparated(WTF::move(builder));
-            case CSSValue::SlashSeparator:
+                case CSSValue::ValueSeparator::Slash:
                 return CSSValueList::createSlashSeparated(WTF::move(builder));
             }
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h
@@ -46,7 +46,7 @@ struct CSSValueConversion<StyleType> {
 template<typename T> struct CSSValueConversion<SpaceSeparatedEnumSet<T>> {
     template<typename... Rest> SpaceSeparatedEnumSet<T> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
-        if (auto list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::SpaceSeparator) {
+        if (auto list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::ValueSeparator::Space) {
             return SpaceSeparatedEnumSet<T>::map(*list, [&](const CSSValue& element) {
                 return toStyleFromCSSValue<T>(state, element, rest...);
             });
@@ -59,7 +59,7 @@ template<typename T> struct CSSValueConversion<SpaceSeparatedEnumSet<T>> {
 template<typename T> struct CSSValueConversion<CommaSeparatedEnumSet<T>> {
     template<typename... Rest> CommaSeparatedEnumSet<T> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
-        if (auto list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::CommaSeparator) {
+        if (auto list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::ValueSeparator::Comma) {
             return CommaSeparatedEnumSet<T>::map(*list, [&](const CSSValue& element) {
                 return toStyleFromCSSValue<T>(state, element, rest...);
             });
@@ -98,7 +98,7 @@ template<typename T> struct CSSValueConversion<CommaSeparatedOrderedHashSet<T>> 
 template<typename StyleType> struct CSSValueConversion<SpaceSeparatedFixedVector<StyleType>> {
     template<typename... Rest> SpaceSeparatedFixedVector<StyleType> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
-        if (auto list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::SpaceSeparator) {
+        if (auto list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::ValueSeparator::Space) {
             return SpaceSeparatedFixedVector<StyleType>::map(*list, [&](const CSSValue& element) {
                 return toStyleFromCSSValue<StyleType>(state, element, rest...);
             });
@@ -111,7 +111,7 @@ template<typename StyleType> struct CSSValueConversion<SpaceSeparatedFixedVector
 template<typename StyleType> struct CSSValueConversion<CommaSeparatedFixedVector<StyleType>> {
     template<typename... Rest> CommaSeparatedFixedVector<StyleType> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
-        if (auto list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::CommaSeparator) {
+        if (auto list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::ValueSeparator::Comma) {
             return CommaSeparatedFixedVector<StyleType>::map(*list, [&](const CSSValue& element) {
                 return toStyleFromCSSValue<StyleType>(state, element, rest...);
             });

--- a/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
+++ b/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
@@ -80,7 +80,7 @@ bool PositionTryFallback::operator==(const PositionTryFallback& other) const
 auto CSSValueConversion<PositionTryFallback>::operator()(BuilderState& state, const CSSValue& value) -> PositionTryFallback
 {
     if (RefPtr valueList = dynamicDowncast<CSSValueList>(value)) {
-        if (valueList->separator() != CSSValueList::SpaceSeparator) {
+        if (valueList->separator() != CSSValueList::ValueSeparator::Space) {
             state.setCurrentPropertyInvalidAtComputedValueTime();
             return { };
         }


### PR DESCRIPTION
#### 0a711e1ee27f582c594afc0cf44edcaeb0215689
<pre>
Convert CSSValue ValueSeparator to an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=321100">https://bugs.webkit.org/show_bug.cgi?id=321100</a>
<a href="https://rdar.apple.com/184139255">rdar://184139255</a>

Reviewed by Tim Nguyen and David Kilzer.

Make the ValueSeparator enum in CSSValue.h an enum class

* Source/WebCore/css/CSSFunctionValue.cpp:
(WebCore::CSSFunctionValue::CSSFunctionValue):
* Source/WebCore/css/CSSImageSetValue.cpp:
(WebCore::CSSImageSetValue::CSSImageSetValue):
* Source/WebCore/css/CSSTransformListValue.cpp:
(WebCore::CSSTransformListValue::CSSTransformListValue):
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::separatorCSSText):
* Source/WebCore/css/CSSValue.h:
(WebCore::CSSValue::separator const):
* Source/WebCore/css/CSSValueList.cpp:
(WebCore::CSSValueList::createCommaSeparated):
(WebCore::CSSValueList::createSlashSeparated):
(WebCore::CSSValueList::createSpaceSeparated):
* Source/WebCore/css/CSSValuePair.cpp:
(WebCore::CSSValuePair::create):
(WebCore::CSSValuePair::createSlashSeparated):
(WebCore::CSSValuePair::createNoncoalescing):
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::serializeLonghandValue):
* Source/WebCore/css/values/CSSValueTypes+DeprecatedCSSOMValueCreation.cpp:
(WebCore::CSS::makeListDeprecatedCSSOMValue&lt;SerializationSeparatorType::Space&gt;):
(WebCore::CSS::makeListDeprecatedCSSOMValue&lt;SerializationSeparatorType::Comma&gt;):
(WebCore::CSS::makeListDeprecatedCSSOMValue&lt;SerializationSeparatorType::Slash&gt;):
* Source/WebCore/style/StyleCustomProperty.cpp:
(WebCore::Style::CustomProperty::propertyValue const):
* Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h:
(WebCore::Style::CSSValueConversion&lt;SpaceSeparatedEnumSet&lt;T&gt;&gt;::operator()):
(WebCore::Style::CSSValueConversion&lt;CommaSeparatedEnumSet&lt;T&gt;&gt;::operator()):
(WebCore::Style::CSSValueConversion&lt;SpaceSeparatedFixedVector&lt;StyleType&gt;&gt;::operator()):
(WebCore::Style::CSSValueConversion&lt;CommaSeparatedFixedVector&lt;StyleType&gt;&gt;::operator()):
* Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp:
(WebCore::Style::CSSValueConversion&lt;PositionTryFallback&gt;::operator):

Canonical link: <a href="https://commits.webkit.org/318666@main">https://commits.webkit.org/318666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05d74c7d147b1bfb1c85ed585a0e8010124bc06f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188766 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38af75a3-582c-4cd0-ac9c-63fd1488a59e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180800 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52586 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f74120ab-3e21-44f7-b4bf-1fb76b0b5192) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119988 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7995ea2c-23e4-4ef7-a049-0f2ade06bb1d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41792 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40135 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152191 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39787 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/73 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45482 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44381 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190986 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52546 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148743 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39920 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53226 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148495 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43191 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125496 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120231 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51744 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14765 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51129 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51190 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->