### PR TITLE
[JSC][Temporal] Resolve DST gaps through GetPossibleEpochNanoseconds so the epoch range check is not skipped

### DIFF
--- a/JSTests/stress/temporal-zdt-dst-gap-epoch-limits.js
+++ b/JSTests/stress/temporal-zdt-dst-gap-epoch-limits.js
@@ -1,0 +1,60 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldThrow(fn, type, msg) {
+    let err;
+    try { fn(); } catch (e) { err = e; }
+    if (!(err instanceof type))
+        throw new Error(`${msg}: expected ${type.name} but got ${err}`);
+}
+
+function shouldBe(actual, expected, msg) {
+    if (String(actual) !== String(expected))
+        throw new Error(`${msg}: expected ${JSON.stringify(String(expected))} but got ${JSON.stringify(String(actual))}`);
+}
+
+// Sydney springs forward 02:00 -> 03:00 on the first Sunday in October, so 02:30 does not exist.
+// +275760-10-05 is such a Sunday and is past the maximum representable epoch, so resolving the gap
+// must be rejected rather than silently produce an out-of-range instant.
+shouldThrow(() => Temporal.ZonedDateTime.from("+275760-10-05T02:30[Australia/Sydney]"),
+    RangeError, "gap shift past max epoch");
+
+// Every disambiguation that resolves a gap goes through the same re-entrant conversion.
+for (const disambiguation of ["compatible", "earlier", "later"]) {
+    shouldThrow(() => Temporal.ZonedDateTime.from("+275760-10-05T02:30[Australia/Sydney]", { disambiguation }),
+        RangeError, `gap shift past max epoch (${disambiguation})`);
+}
+
+// ~reject~ throws for being a gap at all, before any range question arises.
+shouldThrow(() => Temporal.ZonedDateTime.from("+275760-10-05T02:30[Australia/Sydney]", { disambiguation: "reject" }),
+    RangeError, "gap with disambiguation reject");
+
+// The same wall clock reached through the other entry point that funnels into
+// GetEpochNanosecondsFor must reject too.
+shouldThrow(() => Temporal.PlainDateTime.from("+275760-10-05T02:30").toZonedDateTime("Australia/Sydney"),
+    RangeError, "PlainDateTime.toZonedDateTime into an out-of-range gap");
+
+// A fold below the minimum epoch — Sydney falls back in April, so this covers
+// getPossibleEpochNanosecondsFor's candidate range check, not the gap branch. (Sydney's gap is in
+// October, which is inside the range at this year, so min-side gap coverage is not included here.)
+shouldThrow(() => Temporal.ZonedDateTime.from("-271821-04-11T02:30[Australia/Sydney]"),
+    RangeError, "fold below min epoch");
+
+// --- Regression guards: in-range gaps and folds must still resolve exactly as before. ---
+
+shouldBe(Temporal.ZonedDateTime.from("2023-10-01T02:30[Australia/Sydney]").toString(),
+    "2023-10-01T03:30:00+11:00[Australia/Sydney]", "in-range Sydney gap, compatible");
+shouldBe(Temporal.ZonedDateTime.from("2023-10-01T02:30[Australia/Sydney]", { disambiguation: "earlier" }).toString(),
+    "2023-10-01T01:30:00+10:00[Australia/Sydney]", "in-range Sydney gap, earlier");
+shouldBe(Temporal.ZonedDateTime.from("2023-10-01T02:30[Australia/Sydney]", { disambiguation: "later" }).toString(),
+    "2023-10-01T03:30:00+11:00[Australia/Sydney]", "in-range Sydney gap, later");
+shouldBe(Temporal.ZonedDateTime.from("2023-09-03T00:30[America/Santiago]").toString(),
+    "2023-09-03T01:30:00-03:00[America/Santiago]", "in-range Santiago gap");
+
+shouldBe(Temporal.ZonedDateTime.from("2023-04-02T02:30[Australia/Sydney]").toString(),
+    "2023-04-02T02:30:00+11:00[Australia/Sydney]", "in-range Sydney fold, compatible");
+shouldBe(Temporal.ZonedDateTime.from("2023-04-02T02:30[Australia/Sydney]", { disambiguation: "later" }).toString(),
+    "2023-04-02T02:30:00+10:00[Australia/Sydney]", "in-range Sydney fold, later");
+
+// The boundary stays reachable — the largest representable Sydney local time.
+shouldBe(Temporal.ZonedDateTime.from("+275760-09-13T03:30[Australia/Sydney]").toString(),
+    "+275760-09-13T03:30:00+10:00[Australia/Sydney]", "max in-range Sydney local time");

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -274,8 +274,8 @@ static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds
             return PossibleEpochNanoseconds { makeExactTime(localMs - static_cast<double>(*before)) };
 
         // Offset jumped up (spring-forward) → the local time is skipped (gap): no instant maps here.
-        // Hand the bracket offsets to the disambiguator, preserving the prior GapOffsets contract
-        // (disambiguate: earlier = naiveNs − afterNs; later/compatible = naiveNs − beforeNs).
+        // The probes above are also Disambiguate steps 6-13's offsetBefore/offsetAfter, which ICU
+        // gives directly; those steps cannot throw, so skipping them loses nothing observable.
         if (*after > *before)
             return PossibleEpochNanoseconds { GapOffsets { *before * nsPerMs, *after * nsPerMs } };
 
@@ -391,13 +391,10 @@ TemporalResult<std::optional<ISO8601::ExactTime>> getTimeZoneTransition(const Ti
 
 // disambiguatePossibleEpochNanoseconds — temporal_rs: TimeZone::disambiguate_possible_epoch_nanos (src/builtins/core/time_zone.rs)
 // https://tc39.es/proposal-temporal/#sec-temporal-disambiguatepossibleepochnanoseconds
-// NOTE: For the gap case (n=0), bracket offsets are precomputed in GapOffsets { beforeNs, afterNs } to avoid extra ICU calls.
-static TemporalResult<ISO8601::ExactTime> disambiguatePossibleEpochNanoseconds(const PossibleEpochNanoseconds& possible, const ISO8601::PlainDate& date, const ISO8601::PlainTime& time, TemporalDisambiguation disambiguation)
+// NOTE: steps 6-13 are done during gap detection in getNamedTimeZoneEpochNanoseconds and arrive as
+// GapOffsets, so the gap branch here starts at step 14.
+static TemporalResult<ISO8601::ExactTime> disambiguatePossibleEpochNanoseconds(const PossibleEpochNanoseconds& possible, const TimeZone& timeZone, const ISO8601::PlainDate& date, const ISO8601::PlainTime& time, TemporalDisambiguation disambiguation)
 {
-    double localMs = isoDateTimeToLocalMs(date, time);
-    Int128 subMs = static_cast<Int128>(time.microsecond()) * 1000 + static_cast<Int128>(time.nanosecond());
-    Int128 naiveNs = static_cast<Int128>(localMs) * ISO8601::ExactTime::nsPerMillisecond + subMs;
-
     return WTF::switchOn(possible,
         // 1. n = elements in possibleEpochNs (encoded in Variant type).
         // 2. If n = 1, return the sole element.
@@ -417,14 +414,36 @@ static TemporalResult<ISO8601::ExactTime> disambiguatePossibleEpochNanoseconds(c
             return fold[1];
         },
         // 4. Assert: n = 0 (DST gap — local time does not exist).
-        // 5. If disambiguation is ~reject~, throw a RangeError.
-        // 6-20. Bracket offsets from GapOffsets; step 16 (~earlier~): naiveNs - offsetAfter; step 17-20 (~later~/~compatible~): naiveNs - offsetBefore.
         [&](const GapOffsets& gap) -> TemporalResult<ISO8601::ExactTime> {
+            // 5. If disambiguation is ~reject~, throw a RangeError.
             if (disambiguation == TemporalDisambiguation::Reject)
                 return makeUnexpected(rangeError("nonexistent instant: local time does not exist in this time zone (DST gap)"_s));
-            if (disambiguation == TemporalDisambiguation::Earlier)
-                return ISO8601::ExactTime(naiveNs - Int128(gap.afterNs));
-            return ISO8601::ExactTime(naiveNs - Int128(gap.beforeNs));
+
+            // 14. nanoseconds = offsetAfter - offsetBefore.
+            int64_t nanoseconds = gap.afterNs - gap.beforeNs;
+            // 15. Assert: abs(nanoseconds) ≤ nsPerDay.
+            ASSERT(Int128(nanoseconds < 0 ? -nanoseconds : nanoseconds) <= ISO8601::ExactTime::nsPerDay);
+
+            bool isEarlier = disambiguation == TemporalDisambiguation::Earlier;
+            // 16.a-16.d / 18-21. Shift the local time by ∓nanoseconds: AddTime, AddDaysToISODate, CombineISODateAndTimeRecord.
+            auto [dayShift, shiftedTime] = balanceIsoTime(time.hour(), time.minute(), time.second(),
+                time.millisecond(), time.microsecond(),
+                static_cast<int64_t>(time.nanosecond()) + (isEarlier ? -nanoseconds : nanoseconds));
+            auto shiftedDate = balanceIsoDate(date.year(), date.month(), static_cast<int64_t>(date.day()) + dayShift);
+
+            // 16.e / 22. Re-entering, rather than computing naiveNs - offset, is what carries GetPossibleEpochNanoseconds step 5's IsValidEpochNanoseconds throw.
+            auto shiftedPossible = getPossibleEpochNanosecondsFor(timeZone, shiftedDate, shiftedTime);
+            if (!shiftedPossible)
+                return makeUnexpected(shiftedPossible.error());
+            auto candidates = epochCandidates(*shiftedPossible);
+
+            // 16.f / 23-24. Assert: n ≠ 0 — the shifted time is past the transition, so it exists.
+            ASSERT(!candidates.empty());
+            if (candidates.empty()) [[unlikely]]
+                return makeUnexpected(rangeError("nonexistent instant: local time does not exist in this time zone (DST gap)"_s));
+
+            // 16.g / 25. Return possibleEpochNs[0] / possibleEpochNs[n - 1].
+            return isEarlier ? candidates.front() : candidates.back();
         });
 }
 
@@ -436,8 +455,8 @@ TemporalResult<ISO8601::ExactTime> getEpochNanosecondsFor(const TimeZone& timeZo
     auto possible = getPossibleEpochNanosecondsFor(timeZone, date, time);
     if (!possible)
         return makeUnexpected(possible.error());
-    // 2. Return ? DisambiguatePossibleInstants(possibleEpochNs, timeZone, date, time, disambiguation).
-    return disambiguatePossibleEpochNanoseconds(*possible, date, time, disambiguation);
+    // 2. Return ? DisambiguatePossibleEpochNanoseconds(possibleEpochNs, timeZone, isoDateTime, disambiguation).
+    return disambiguatePossibleEpochNanoseconds(*possible, timeZone, date, time, disambiguation);
 }
 
 // addZonedDateTime — temporal_rs: ZonedDateTime::add_zoned_date_time (src/builtins/core/zoned_date_time.rs)


### PR DESCRIPTION
#### 6fd438a4aef274513546006638ff58275695eaa4
<pre>
[JSC][Temporal] Resolve DST gaps through GetPossibleEpochNanoseconds so the epoch range check is not skipped
<a href="https://bugs.webkit.org/show_bug.cgi?id=321102">https://bugs.webkit.org/show_bug.cgi?id=321102</a>
<a href="https://rdar.apple.com/184140083">rdar://184140083</a>

Reviewed by Yusuke Suzuki.

Temporal.ZonedDateTime.from(&quot;+275760-10-05T02:30[Australia/Sydney]&quot;) produced a live
ZonedDateTime whose [[EpochNanoseconds]] was outside the ±8.64e21 limit: Sydney springs
forward on the first Sunday in October, and that gap is past the maximum epoch.

DisambiguatePossibleEpochNanoseconds resolves a gap by shifting the local time and
re-entering GetPossibleEpochNanoseconds (steps 16.e and 22), which range-checks it in its
own step 5. We computed the shifted instant as naiveNs - offsetBefore instead —
value-equivalent but not throw-equivalent, and the only guard on this path, since a gap
leaves step 4&apos;s per-candidate loop nothing to check. Latent until 318635@main replaced
TemporalZonedDateTime::tryCreate&apos;s release-mode isValid() throw with
CreateTemporalZonedDateTime step 1&apos;s ASSERT.

Steps 14-25 are now literal, which also fixes the candidate selection (16.g returns
possibleEpochNs[0], 25 returns possibleEpochNs[n - 1]). Steps 6-13 stay folded into the
FORMER/LATTER probe in getNamedTimeZoneEpochNanoseconds, as temporal_rs does; those steps
cannot throw, so skipping them loses nothing observable.

Test: JSTests/stress/temporal-zdt-dst-gap-epoch-limits.js
Canonical link: <a href="https://commits.webkit.org/318663@main">https://commits.webkit.org/318663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46f9e2d92116fed76fa0aab3013322d69a0ef02f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188768 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1bb11996-f182-4ad7-afd3-8a0182e897e9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52588 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139527 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49dd111b-0a9e-4851-ad47-a79bdf47bd24) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119973 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51cedc8f-0c27-4abc-aca3-0a8fc02c1379) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41785 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40131 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1949 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8760 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39778 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/75 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40213 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190988 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52548 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148744 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53228 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148496 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27161 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43187 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125498 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120233 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51746 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14756 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51131 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51372 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51192 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->