### PR TITLE
[WGSL] Use std::forward() in allocateAbstractType() to avoid use-after-move of lvalue arguments

### DIFF
--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -148,15 +148,10 @@ struct SelectedOverload {
 std::optional<SelectedOverload> resolveOverloads(TypeStore&, const Vector<OverloadCandidate>&, const Vector<const Type*>& valueArguments, const Vector<const Type*>& typeArguments);
 
 template<typename T>
-static AbstractType allocateAbstractType(const T& type)
-{
-    return std::unique_ptr<AbstractTypeImpl>(new AbstractTypeImpl(type));
-}
-
-template<typename T>
 static AbstractType allocateAbstractType(T&& type)
 {
-    return std::unique_ptr<AbstractTypeImpl>(new AbstractTypeImpl(WTF::move(type)));
+    // Perfect forward so an lvalue argument is copied rather than moved.
+    return std::unique_ptr<AbstractTypeImpl>(new AbstractTypeImpl(std::forward<T>(type)));
 }
 
 } // namespace WGSL


### PR DESCRIPTION
#### 19c01c1ab93ebe875b1dde01db6eb3b87985a75f
<pre>
[WGSL] Use std::forward() in allocateAbstractType() to avoid use-after-move of lvalue arguments
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=321098">https://bugs.webkit.org/show_bug.cgi?id=321098</a>&gt;
&lt;<a href="https://rdar.apple.com/184137472">rdar://184137472</a>&gt;

Reviewed by Mike Wyrzykowski.

The `T&amp;&amp;` parameter of `allocateAbstractType()` is a forwarding
reference, so a non-const lvalue binds to it in preference to the
`const T&amp;` overload, and the unconditional move then moves the lvalue.
The generated overloads in `TypeOverloads.h` pass the same
`TypeVariable` lvalue to `allocateAbstractType()` more than once per
candidate (e.g. `(T, T) =&gt; T`), so the Clang static analyzer reports a
use-after-move.  This never crashed only because `TypeVariable` is
trivially copyable, so the move is really a copy; it would be a genuine
use-after-free if a non-trivial member were ever added.

Forward the argument instead so an lvalue is copied and only an rvalue
is moved.  Because the generated candidates always pass an lvalue, no
move happens, so the fix stays correct regardless of whether
`TypeVariable` remains trivially copyable.  A single forwarding overload
handles every value category, making the separate `const T&amp;` overload
redundant.

No new tests since no change in behavior.

* Source/WebGPU/WGSL/Overload.h:
(WGSL::allocateAbstractType):

Canonical link: <a href="https://commits.webkit.org/318662@main">https://commits.webkit.org/318662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62b756d28a01bfd22b2218c379c254064111a190

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188769 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d5f29f9f-70d9-4cc3-8ebc-5f03a56a0077) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52589 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139526 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3b597f3-3456-455c-98ca-dbde9ed3a124) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119972 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e86d73f-a721-4f4a-93d0-317ddd498c12) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41787 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40132 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39780 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/76 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45485 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190989 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52549 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148745 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53229 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148497 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27160 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43192 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125499 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120234 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51747 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14758 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51132 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51373 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51193 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->