### PR TITLE
[EvaluationTimeZoom] Use the font's specifiedSize() getter consistently in length resolution

### DIFF
--- a/LayoutTests/fast/text/line-height-minimumFontSize-expected.txt
+++ b/LayoutTests/fast/text/line-height-minimumFontSize-expected.txt
@@ -1,8 +1,5 @@
 This test makes sure that minimumFontSize affects line-height.
-
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 PASS Math.round(parseFloat(window.getComputedStyle(document.getElementById('test1')).getPropertyValue('line-height'))) is comparisonLineHeight
 PASS Math.round(parseFloat(window.getComputedStyle(document.getElementById('test2')).getPropertyValue('line-height'))) is comparisonLineHeight
 PASS Math.round(parseFloat(window.getComputedStyle(document.getElementById('test3')).getPropertyValue('line-height'))) is 20 / 16 * 64

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL rem unit in SVGLength assert_equals: expected 100 but got 225
+PASS rem unit in SVGLength
 PASS Convert back to rem from new user unit value
 

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -320,16 +320,13 @@ inline void BuilderCustom::applyInitialLineHeight(BuilderState& builderState)
     builderState.style().setSpecifiedLineHeight(ComputedStyle::initialSpecifiedLineHeight());
 }
 
-static inline float computeBaseSpecifiedFontSize(const Document& document, const ComputedStyle& style, bool percentageAutosizingEnabled)
+static inline float computeBaseSpecifiedFontSize(const Document& document, const ComputedStyle& style)
 {
     float result = style.specifiedFontSize();
     auto* frame = document.frame();
     if (frame && style.textZoom() != TextZoom::Reset)
         result *= frame->textZoomFactor();
     result *= style.usedZoom();
-    if (percentageAutosizingEnabled
-        && (!document.settings().textAutosizingUsesIdempotentMode() || document.settings().idempotentModeAutosizingOnlyHonorsPercentages()))
-        result *= style.textSizeAdjust().multiplier();
     return result;
 }
 
@@ -340,7 +337,7 @@ static inline float computeLineHeightMultiplierDueToFontSize(const Document& doc
     if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value); primitiveValue && primitiveValue->isLength()) {
         auto minimumFontSize = document.settings().minimumFontSize();
         if (minimumFontSize > 0) {
-            auto specifiedFontSize = computeBaseSpecifiedFontSize(document, style, percentageAutosizingEnabled);
+            auto specifiedFontSize = computeBaseSpecifiedFontSize(document, style);
             // Small font sizes cause a preposterously large (near infinity) line-height. Add a fuzz-factor of 1px which opts out of
             // boosted line-height.
             if (specifiedFontSize < minimumFontSize && specifiedFontSize >= 1) {

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -216,6 +216,7 @@ void BuilderState::updateFontForTextSizeAdjust()
     float zoomFactor = m_style.usedZoom();
     if (auto* frame = document().frame(); frame && m_style.textZoom() != TextZoom::Reset)
         zoomFactor *= frame->textZoomFactor();
+    newFontDescription.setSpecifiedSize(baseSize);
     newFontDescription.setComputedSize(baseSize * zoomFactor, zoomFactor);
 
     m_style.setFontDescriptionWithoutUpdate(WTF::move(newFontDescription));

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -63,38 +63,29 @@ static double unzoomFontMetric(double metric, const FontDescription& fontDescrip
 // Resolve the "em", "rem" and "quirky-em" units.
 // https://drafts.csswg.org/css-values-4/#em
 // https://drafts.csswg.org/css-values-4/#rem
-static double resolveEm(CSSPropertyID propertyToCompute, const FontCascade& fontCascadeForUnit)
+static double resolveEm(const FontCascade& fontCascadeForUnit)
 {
     auto& fontDescription = fontCascadeForUnit.fontDescription();
-
-    // FIXME: Should probably use specifiedSize for every property.
-    if (propertyToCompute == CSSPropertyFontSize)
-        return fontDescription.specifiedSize();
-
-    return fontDescription.unzoomedComputedSize();
+    return fontDescription.specifiedSize();
 }
 
 // Resolve the "ex" and "rex" units.
 // https://drafts.csswg.org/css-values-4/#ex
 // https://drafts.csswg.org/css-values-4/#rex
-static double resolveEx(CSSPropertyID propertyToCompute, const FontCascade& fontCascadeForUnit)
+static double resolveEx(const FontCascade& fontCascadeForUnit)
 {
     auto& fontDescription = fontCascadeForUnit.fontDescription();
     auto& fontMetrics = fontCascadeForUnit.metricsOfPrimaryFont();
     if (fontMetrics.xHeight())
         return unzoomFontMetric(fontMetrics.xHeight().value(), fontDescription);
 
-    // FIXME: Should probably use specifiedSize for every property.
-    if (propertyToCompute == CSSPropertyFontSize)
-        return fontDescription.specifiedSize() / 2.0;
-
-    return fontDescription.unzoomedComputedSize() / 2.0;
+    return fontDescription.specifiedSize() / 2.0;
 }
 
 // Resolve the "cap" and "rcap" units.
 // https://drafts.csswg.org/css-values-4/#cap
 // https://drafts.csswg.org/css-values-4/#rcap
-static double resolveCap(CSSPropertyID, const FontCascade& fontCascadeForUnit)
+static double resolveCap(const FontCascade& fontCascadeForUnit)
 {
     auto& fontDescription = fontCascadeForUnit.fontDescription();
     auto& fontMetrics = fontCascadeForUnit.metricsOfPrimaryFont();
@@ -106,7 +97,7 @@ static double resolveCap(CSSPropertyID, const FontCascade& fontCascadeForUnit)
 // Resolve the "ch" and "rch" units.
 // https://drafts.csswg.org/css-values-4/#ch
 // https://drafts.csswg.org/css-values-4/#rch
-static double resolveCh(CSSPropertyID, const FontCascade& fontCascadeForUnit)
+static double resolveCh(const FontCascade& fontCascadeForUnit)
 {
     return unzoomFontMetric(fontCascadeForUnit.zeroWidth(), fontCascadeForUnit.fontDescription());
 }
@@ -114,7 +105,7 @@ static double resolveCh(CSSPropertyID, const FontCascade& fontCascadeForUnit)
 // Resolve the "ic" and "ric" units.
 // https://drafts.csswg.org/css-values-4/#ic
 // https://drafts.csswg.org/css-values-4/#ric
-static double resolveIc(CSSPropertyID, const FontCascade& fontCascadeForUnit)
+static double resolveIc(const FontCascade& fontCascadeForUnit)
 {
     auto& fontDescription = fontCascadeForUnit.fontDescription();
     auto ideogramWidth = fontCascadeForUnit.metricsOfPrimaryFont().ideogramWidth();
@@ -516,16 +507,16 @@ static double resolveLengthImpl(double value, CSS::LengthUnit lengthUnit, const 
 
     case Em:
     case QuirkyEm:
-        return value * adaptor.applyTextZoom(resolveEm(adaptor.property(), adaptor.fontCascadeForFontUnits()));
+        return value * adaptor.applyTextZoom(resolveEm(adaptor.fontCascadeForFontUnits()));
     case Ex:
-        return value * adaptor.applyTextZoom(resolveEx(adaptor.property(), adaptor.fontCascadeForFontUnits()));
+        return value * adaptor.applyTextZoom(resolveEx(adaptor.fontCascadeForFontUnits()));
     case Cap:
-        return value * adaptor.applyTextZoom(resolveCap(adaptor.property(), adaptor.fontCascadeForFontUnits()));
+        return value * adaptor.applyTextZoom(resolveCap(adaptor.fontCascadeForFontUnits()));
 
     case Ch:
-        return value * adaptor.applyTextZoom(resolveCh(adaptor.property(), adaptor.fontCascadeForFontUnits()));
+        return value * adaptor.applyTextZoom(resolveCh(adaptor.fontCascadeForFontUnits()));
     case Ic:
-        return value * adaptor.applyTextZoom(resolveIc(adaptor.property(), adaptor.fontCascadeForFontUnits()));
+        return value * adaptor.applyTextZoom(resolveIc(adaptor.fontCascadeForFontUnits()));
 
     case Lh:
         return value * applyTextZoomIfComputingLineHeight(resolveLh(adaptor.styleForLineHeightUnits(), adaptor.fontCascadeForFontUnits()));
@@ -533,15 +524,15 @@ static double resolveLengthImpl(double value, CSS::LengthUnit lengthUnit, const 
     // MARK: "root font dependent" resolution
 
     case Rem:
-        return value * adaptor.applyTextZoom(resolveEm(adaptor.property(), adaptor.fontCascadeForRootFontUnits()));
+        return value * adaptor.applyTextZoom(resolveEm(adaptor.fontCascadeForRootFontUnits()));
     case Rcap:
-        return value * adaptor.applyTextZoom(resolveCap(adaptor.property(), adaptor.fontCascadeForRootFontUnits()));
+        return value * adaptor.applyTextZoom(resolveCap(adaptor.fontCascadeForRootFontUnits()));
     case Rch:
-        return value * adaptor.applyTextZoom(resolveCh(adaptor.property(), adaptor.fontCascadeForRootFontUnits()));
+        return value * adaptor.applyTextZoom(resolveCh(adaptor.fontCascadeForRootFontUnits()));
     case Rex:
-        return value * adaptor.applyTextZoom(resolveEx(adaptor.property(), adaptor.fontCascadeForRootFontUnits()));
+        return value * adaptor.applyTextZoom(resolveEx(adaptor.fontCascadeForRootFontUnits()));
     case Ric:
-        return value * adaptor.applyTextZoom(resolveIc(adaptor.property(), adaptor.fontCascadeForRootFontUnits()));
+        return value * adaptor.applyTextZoom(resolveIc(adaptor.fontCascadeForRootFontUnits()));
 
     case Rlh:
         return value * applyTextZoomIfComputingLineHeight(resolveLh(adaptor.styleForRootLineHeightUnits(), adaptor.fontCascadeForRootFontUnits()));
@@ -773,7 +764,7 @@ double emToPxDouble(double value, const CSSToLengthConversionData& conversionDat
     CSSToLengthConversionDataAdaptor adaptor {
         .conversionData = conversionData,
     };
-    return value * adaptor.applyTextZoom(resolveEm(adaptor.property(), adaptor.fontCascadeForFontUnits()));
+    return value * adaptor.applyTextZoom(resolveEm(adaptor.fontCascadeForFontUnits()));
 }
 
 double emToPxDouble(double value, const ComputedStyle& style)


### PR DESCRIPTION
#### f082dfc9005c6a15d5bf43f6b21c5f4a3f234d53
<pre>
[EvaluationTimeZoom] Use the font&apos;s specifiedSize() getter consistently in length resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=321095">https://bugs.webkit.org/show_bug.cgi?id=321095</a>

Reviewed by Darin Adler.

Use the computed font size (confusingly named specifiedSize()) rather than the
minimum-font-size adjusted size (confusingly called unzoomedComputedSize()) always
when computing `em`, `rem`, `ex` and `rex` units.

This matches what CSS Values 4 says to do:

  &quot;Some user-agents allow users to apply additional restrictions to font sizes in a
   document, such as setting minimum font sizes to ensure readability. Such restrictions
   must be applied to the used value of the affected properties only; they must not
   affect the resolution of font-relative lengths used in properties&quot;
    - <a href="https://drafts.csswg.org/css-values-4/#font-relative-length">https://drafts.csswg.org/css-values-4/#font-relative-length</a>

The change whitespace change in line-height-minimumFontSize-expected.txt is due to the
margins around the description changing (due to 1em now being 16 and not 64px). The
dump-as-text code uses TextIterator, which has heuristic to add newlines that is based
on the used margins (see shouldEmitExtraNewlineForNode).

* LayoutTests/fast/text/line-height-minimumFontSize-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem-expected.txt:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:

Canonical link: <a href="https://commits.webkit.org/319340@main">https://commits.webkit.org/319340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2410ff852fa91cdf9856d0576511f2f318230c07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145512 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141392 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121843 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43737 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42014 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41670 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2565 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193338 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54800 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150784 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40386 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55488 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150500 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45088 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127756 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123314 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54005 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16666 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53624 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->