### PR TITLE
Add an HTTP/3 server to API tests.

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.h
@@ -66,6 +66,7 @@ public:
         HttpsWithLegacyTLS,
         Http2Raw,
         Http2,
+        Http3,
         HttpsProxy,
         HttpsProxyWithAuthentication
     };

--- a/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.mm
@@ -121,14 +121,57 @@ static bool shouldDisableTLS(HTTPServer::Protocol protocol)
     case HTTPServer::Protocol::HttpsWithLegacyTLS:
     case HTTPServer::Protocol::Http2Raw:
     case HTTPServer::Protocol::Http2:
+    case HTTPServer::Protocol::Http3:
         return false;
     }
 }
+
+#if HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)
+
+static void attachHTTPMessagingListener(nw_parameters_t parameters)
+{
+    nw_parameters_set_server_mode(parameters, true);
+    nw_parameters_set_attach_protocol_listener(parameters, true);
+    RetainPtr stack = adoptNS(nw_parameters_copy_default_protocol_stack(parameters));
+    RetainPtr httpOptions = adoptNS(nw_http_messaging_create_options());
+    nw_protocol_stack_prepend_application_protocol(stack.get(), httpOptions.get());
+}
+
+static RetainPtr<nw_parameters_t> quicListenerParameters(HTTPServer::CertificateVerifier&& verifier, RetainPtr<SecIdentityRef>&& testIdentity, std::optional<uint16_t> port)
+{
+    RetainPtr identity = adoptNS(sec_identity_create(testIdentity.get()));
+    auto configureQuicConnection = [verifier = WTF::move(verifier), identity = WTF::move(identity)] (nw_protocol_options_t quicConnectionOptions) mutable {
+        RetainPtr options = adoptNS(nw_quic_connection_copy_sec_protocol_options(quicConnectionOptions));
+        sec_protocol_options_set_local_identity(options.get(), identity.get());
+        if (verifier) {
+            sec_protocol_options_set_peer_authentication_required(options.get(), true);
+            sec_protocol_options_set_verify_block(options.get(), makeBlockPtr([verifier = WTF::move(verifier)](sec_protocol_metadata_t metadata, sec_trust_t trust, sec_protocol_verify_complete_t completion) {
+                verifier(metadata, trust, completion);
+            }).get(), mainDispatchQueueSingleton());
+        }
+        sec_protocol_options_add_transport_specific_application_protocol(options.get(), "h3", sec_protocol_transport_quic);
+    };
+
+    RetainPtr parameters = adoptNS(nw_parameters_create_quic_stream(^(nw_protocol_options_t options) {
+        nw_quic_stream_set_is_unidirectional(options, true);
+    }, makeBlockPtr(WTF::move(configureQuicConnection)).get()));
+    if (port)
+        nw_parameters_set_local_endpoint(parameters.get(), nw_endpoint_create_host("::", makeString(*port).utf8().data()));
+    attachHTTPMessagingListener(parameters.get());
+    return parameters;
+}
+
+#endif // HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)
 
 RetainPtr<nw_parameters_t> HTTPServer::listenerParameters(Protocol protocol, CertificateVerifier&& verifier, RetainPtr<SecIdentityRef>&& customTestIdentity, std::optional<uint16_t> port)
 {
     if (protocol != Protocol::Http && !customTestIdentity)
         customTestIdentity = testIdentity();
+
+#if HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)
+    if (protocol == Protocol::Http3)
+        return quicListenerParameters(WTF::move(verifier), WTF::move(customTestIdentity), port);
+#endif
 
     auto configureTLS = [protocol, verifier = WTF::move(verifier), testIdentity = WTF::move(customTestIdentity)] (nw_protocol_options_t protocolOptions) mutable {
         RetainPtr options = adoptNS(nw_tls_copy_sec_protocol_options(protocolOptions));
@@ -166,13 +209,8 @@ RetainPtr<nw_parameters_t> HTTPServer::listenerParameters(Protocol protocol, Cer
     }
 
 #if HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)
-    if (protocol == Protocol::Http2) {
-        nw_parameters_set_server_mode(parameters.get(), true);
-        nw_parameters_set_attach_protocol_listener(parameters.get(), true);
-        RetainPtr stack = adoptNS(nw_parameters_copy_default_protocol_stack(parameters.get()));
-        RetainPtr httpOptions = adoptNS(nw_http_messaging_create_options());
-        nw_protocol_stack_prepend_application_protocol(stack.get(), httpOptions.get());
-    }
+    if (protocol == Protocol::Http2)
+        attachHTTPMessagingListener(parameters.get());
 #endif
 
     return parameters;
@@ -248,7 +286,7 @@ HTTPServer::HTTPServer(
         requestData->connections.append(Connection(connection));
         nw_connection_set_queue(connection, mainDispatchQueueSingleton());
         nw_connection_start(connection);
-        if (protocol == Protocol::Http2) {
+        if (protocol == Protocol::Http2 || protocol == Protocol::Http3) {
 #if HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)
             respondToHTTPMessagingRequests(Connection(connection), requestData);
 #else
@@ -567,6 +605,7 @@ const char* HTTPServer::scheme() const
     case Protocol::HttpsWithLegacyTLS:
     case Protocol::Http2Raw:
     case Protocol::Http2:
+    case Protocol::Http3:
         scheme = "https";
         break;
     case Protocol::HttpsProxy:

--- a/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.swift
@@ -117,6 +117,9 @@ public struct HTTPServer: ~Copyable {
         /// The HTTP2 protocol.
         case http2
 
+        /// The HTTP3 protocol.
+        case http3
+
         /// The HTTPS proxy protocol.
         case httpsProxy
 
@@ -224,6 +227,7 @@ extension TestWebKitAPI.__CxxHTTPServer.`Protocol` {
             case .httpsWithLegacyTLS: .HttpsWithLegacyTLS
             case .http2Raw: .Http2Raw
             case .http2: .Http2
+            case .http3: .Http3
             case .httpsProxy: .HttpsProxy
             case .httpsProxyWithAuthentication: .HttpsProxyWithAuthentication
             }

--- a/Tools/TestWebKitAPI/Helpers/cocoa/NetworkSPI.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/NetworkSPI.h
@@ -29,9 +29,10 @@ DECLARE_SYSTEM_HEADER
 
 #import <pal/spi/cocoa/NetworkSPI.h>
 
-// Real HTTP/2 server support (nw_http2_create_options / nw_http_messaging_create_options), see libnetcore
-// Source/libnetwork/http/{http_types,http_options,http_options_private}.h. Only TestWebKitAPI's HTTPServer/
-// Connection helpers use these, so they live here rather than in the shared PAL SPI header.
+#if USE(APPLE_INTERNAL_SDK) && HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)
+#import <Security/SecProtocolPriv.h>
+#endif
+
 #if HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING) && !USE(APPLE_INTERNAL_SDK)
 
 #if OS_OBJECT_USE_OBJC
@@ -50,6 +51,16 @@ typedef enum {
 typedef void (^nw_http_string_accessor_t)(const char *string);
 typedef bool (^nw_http_field_content_enumerator_t)(const char *name, size_t name_length, const char *value, size_t value_length);
 
+typedef enum {
+    sec_protocol_transport_any = 0,
+    sec_protocol_transport_tcp,
+    sec_protocol_transport_quic,
+} sec_protocol_transport_t;
+
+WTF_EXTERN_C_BEGIN
+void sec_protocol_options_add_transport_specific_application_protocol(sec_protocol_options_t, const char *application_protocol, sec_protocol_transport_t);
+WTF_EXTERN_C_END
+
 #ifndef NW_NOESCAPE
 #if __has_attribute(noescape)
 #define NW_NOESCAPE __attribute__((__noescape__))
@@ -65,6 +76,10 @@ void nw_parameters_set_attach_protocol_listener(nw_parameters_t, bool);
 OS_OBJECT_RETURNS_RETAINED nw_protocol_definition_t nw_protocol_copy_http_definition(void);
 OS_OBJECT_RETURNS_RETAINED nw_protocol_options_t nw_http_messaging_create_options(void);
 OS_OBJECT_RETURNS_RETAINED nw_protocol_options_t nw_http2_create_options(void);
+
+OS_OBJECT_RETURNS_RETAINED nw_parameters_t nw_parameters_create_quic_stream(nw_parameters_configure_protocol_block_t configure_quic_stream, nw_parameters_configure_protocol_block_t configure_quic_connection);
+OS_OBJECT_RETURNS_RETAINED sec_protocol_options_t nw_quic_connection_copy_sec_protocol_options(nw_protocol_options_t);
+void nw_quic_stream_set_is_unidirectional(nw_protocol_options_t stream_options, bool is_unidirectional);
 
 nw_http_metadata_type_t nw_http_metadata_get_type(nw_protocol_metadata_t);
 OS_OBJECT_RETURNS_RETAINED nw_http_request_t _Nullable nw_http_metadata_copy_request(nw_protocol_metadata_t);

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -164,6 +164,7 @@ Tests/WebKit/WKWebView/GetUserMedia.mm @nonARC @no-unify
 Tests/WebKit/WKWebView/HistoryDelegate.mm @nonARC
 Tests/WebKit/WKWebView/HSTS.mm @nonARC
 Tests/WebKit/WKWebView/HTTP2Server.mm @nonARC
+Tests/WebKit/WKWebView/HTTP3Server.mm @nonARC
 Tests/WebKit/WKWebView/IDBCheckpointWAL.mm @nonARC
 Tests/WebKit/WKWebView/IDBDeleteRecovery.mm @nonARC
 Tests/WebKit/WKWebView/IDBIndexUpgradeToV2.mm @nonARC

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP3Server.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP3Server.mm
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)
+
+#import "Helpers/Utilities.h"
+#import "Helpers/cocoa/HTTPServer.h"
+#import "Helpers/cocoa/TestUIDelegate.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+static RetainPtr<NSMutableURLRequest> http3Request(const HTTPServer& server, StringView path = "/"_s)
+{
+    RetainPtr request = adoptNS([server.request(path) mutableCopy]);
+    [request setAssumesHTTP3Capable:YES];
+    return request;
+}
+
+TEST(HTTP3Server, RequestMethodPathAndHeaders)
+{
+    RetainPtr<NSString> receivedMethod;
+    RetainPtr<NSString> receivedPath;
+    RetainPtr<NSString> receivedHeaderValue;
+
+    HTTPServer server([&](Connection connection) {
+        connection.receiveHTTPMessagingRequest([&, connection](HTTPRequestData&& request) {
+            receivedMethod = request.method.createNSString();
+            receivedPath = request.path.createNSString();
+            receivedHeaderValue = request.headerFields.get("x-test-header"_s).createNSString();
+            connection.sendHTTPMessagingResponse(HTTPResponse("hello"_s));
+        });
+    }, HTTPServer::Protocol::Http3);
+
+    RetainPtr request = http3Request(server, "/test"_s);
+    [request setValue:@"testvalue" forHTTPHeaderField:@"X-Test-Header"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadRequestIgnoringSSLErrors:request.get()];
+
+    EXPECT_WK_STREQ("GET", receivedMethod.get());
+    EXPECT_WK_STREQ("/test", receivedPath.get());
+    EXPECT_WK_STREQ("testvalue", receivedHeaderValue.get());
+    EXPECT_WK_STREQ("hello", [webView stringByEvaluatingJavaScript:@"document.body.textContent"]);
+    EXPECT_WK_STREQ("h3", [webView stringByEvaluatingJavaScript:@"performance.getEntriesByType('navigation')[0].nextHopProtocol"]);
+}
+
+TEST(HTTP3Server, POSTBody)
+{
+    RetainPtr<NSData> receivedBody;
+    RetainPtr<NSString> receivedMethod;
+
+    HTTPServer server([&](Connection connection) {
+        connection.receiveHTTPMessagingRequest([&, connection](HTTPRequestData&& request) {
+            if (request.path == "/"_s) {
+                connection.sendHTTPMessagingResponse(HTTPResponse("<script>fetch('/submit', { method: 'POST', body: 'hello world' }).then(() => alert('done'))</script>"_s));
+                return;
+            }
+            receivedMethod = request.method.createNSString();
+            receivedBody = adoptNS([[NSData alloc] initWithBytes:request.body.span().data() length:request.body.size()]);
+            connection.sendHTTPMessagingResponse(HTTPResponse("ok"_s));
+        });
+    }, HTTPServer::Protocol::Http3);
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadRequestIgnoringSSLErrors:http3Request(server).get()];
+    EXPECT_WK_STREQ("done", [webView _test_waitForAlert]);
+
+    RetainPtr<NSData> bodyData = [@"hello world" dataUsingEncoding:NSUTF8StringEncoding];
+    EXPECT_WK_STREQ("POST", receivedMethod.get());
+    EXPECT_TRUE([bodyData isEqualToData:receivedBody.get()]);
+    EXPECT_WK_STREQ("h3", [webView stringByEvaluatingJavaScript:@"performance.getEntriesByType('resource')[0].nextHopProtocol"]);
+}
+
+TEST(HTTP3Server, NonDefaultStatusCodeAndResponseHeader)
+{
+    HTTPServer server({
+        { "/"_s, HTTPResponse("<script>fetch('/missing').then(response => alert(`${response.status}:${response.headers.get('X-Custom-Response-Header')}`))</script>"_s) },
+        { "/missing"_s, HTTPResponse(404, { { "X-Custom-Response-Header"_s, "responsevalue"_s } }) }
+    }, HTTPServer::Protocol::Http3);
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadRequestIgnoringSSLErrors:http3Request(server).get()];
+    EXPECT_WK_STREQ("404:responsevalue", [webView _test_waitForAlert]);
+    EXPECT_WK_STREQ("h3", [webView stringByEvaluatingJavaScript:@"performance.getEntriesByType('resource')[0].nextHopProtocol"]);
+}
+
+TEST(HTTP3Server, MultipleRequestsOverOneConnection)
+{
+    HTTPServer server({
+        { "/"_s, HTTPResponse("<script>"
+            "Promise.all([fetch('/a').then(response => response.text()), fetch('/b').then(response => response.text())])"
+            ".then(([a, b]) => alert(`${a}:${b}`))"
+            "</script>"_s) },
+        { "/a"_s, HTTPResponse("a"_s) },
+        { "/b"_s, HTTPResponse("b"_s) },
+    }, HTTPServer::Protocol::Http3);
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadRequestIgnoringSSLErrors:http3Request(server).get()];
+    EXPECT_WK_STREQ("a:b", [webView _test_waitForAlert]);
+
+    EXPECT_EQ(server.totalRequests(), 3u);
+    EXPECT_WK_STREQ("true", [webView stringByEvaluatingJavaScript:@"performance.getEntriesByType('resource').every(entry => entry.nextHopProtocol === 'h3').toString()"]);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)


### PR DESCRIPTION
#### 136b4c7ce2ff25a0f80c20a85cc68163acd12b61
<pre>
Add an HTTP/3 server to API tests.
<a href="https://rdar.apple.com/181640656">rdar://181640656</a>

Reviewed by Alex Christensen.

This is implemented with the libnetcore library, similar to other existing API test helpers.
This reuses a lot of the work added by <a href="https://github.com/WebKit/WebKit/pull/70871">https://github.com/WebKit/WebKit/pull/70871</a> for the HTTP/2 server.

This commit was partially written by Claude, with human review.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP3Server.mm

* Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.h:
* Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.mm:
(TestWebKitAPI::shouldDisableTLS):
(TestWebKitAPI::attachHTTPMessagingListener):
(TestWebKitAPI::quicListenerParameters):
(TestWebKitAPI::HTTPServer::listenerParameters):
(TestWebKitAPI::HTTPServer::HTTPServer):
(TestWebKitAPI::HTTPServer::scheme const):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP3Server.mm: Added.
(-[HTTP3ServerSessionDelegate URLSession:task:didReceiveChallenge:completionHandler:]):
(TestWebKitAPI::http3Request):
(TestWebKitAPI::TEST(HTTP3Server, RoundTrip)):
(TestWebKitAPI::TEST(HTTP3Server, RequestMethodPathAndHeaders)):
(TestWebKitAPI::TEST(HTTP3Server, POSTBody)):
(TestWebKitAPI::TEST(HTTP3Server, NonDefaultStatusCodeAndResponseHeader)):
(TestWebKitAPI::TEST(HTTP3Server, MultipleRequestsOverOneConnection)):
(TestWebKitAPI::connectRawHTTP3Client):
(TestWebKitAPI::receiveRawHTTP3Response):
(TestWebKitAPI::performRawHTTP3Request):
* Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.swift:
* Tools/TestWebKitAPI/Helpers/cocoa/NetworkSPI.h:

Canonical link: <a href="https://commits.webkit.org/319204@main">https://commits.webkit.org/319204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89d7ff9a725faacf76ff5916efebcb69275ba091

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145095 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/431dc4d3-ec85-406a-bc2b-6c113b1bb349) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141012 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121464 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/53c43cd7-6126-4940-957b-25850b8f3371) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153753 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41292 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2146 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192920 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54383 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150394 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40256 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55071 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150111 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44705 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122623 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53588 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16285 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Uploaded test results") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52970 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53207 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->