### PR TITLE
[Web Audio] Reduce padding in ParamEvent, AutomationState, AudioNode and RealtimeAnalyser

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -112,12 +112,12 @@ auto AudioNode::toWeakOrStrongContext(BaseAudioContext& context, NodeType nodeTy
 }
 
 AudioNode::AudioNode(BaseAudioContext& context, NodeType type)
-    : m_nodeType(type)
-    , m_context(toWeakOrStrongContext(context, type))
+    : m_context(toWeakOrStrongContext(context, type))
 #if !RELEASE_LOG_DISABLED
     , m_logger(context.logger())
     , m_logIdentifier(context.nextAudioNodeLogIdentifier())
 #endif
+    , m_nodeType(type)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -252,9 +252,6 @@ private:
     enum EventTargetInterfaceType eventTargetInterface() const override;
     ScriptExecutionContext* scriptExecutionContext() const final;
 
-    volatile bool m_isInitialized { false };
-    NodeType m_nodeType;
-
     WeakOrStrongContext m_context;
 
     Vector<Ref<AudioNodeInput>> m_inputs;
@@ -262,16 +259,6 @@ private:
 
     double m_lastProcessingTime { -1 };
     double m_lastNonSilentTime { -1 };
-
-    // Ref-counting
-    // start out with normal refCount == 1 (like WTF::RefCounted class).
-    mutable std::atomic<int> m_normalRefCount { 1 };
-    std::atomic<int> m_connectionRefCount { 0 };
-    
-    bool m_isMarkedForDeletion { false };
-    bool m_isDisabled { false };
-    bool m_isFinishedSourceNode { false };
-    bool m_isTailProcessing { false };
 
 #if DEBUG_AUDIONODE_REFERENCES
     static bool s_isNodeCountInitialized;
@@ -286,9 +273,21 @@ private:
     const uint64_t m_logIdentifier;
 #endif
 
+    // Ref-counting
+    // start out with normal refCount == 1 (like WTF::RefCounted class).
+    mutable std::atomic<int> m_normalRefCount { 1 };
+    std::atomic<int> m_connectionRefCount { 0 };
+
     unsigned m_channelCount { 2 };
     ChannelCountMode m_channelCountMode { ChannelCountMode::Max };
     ChannelInterpretation m_channelInterpretation { ChannelInterpretation::Speakers };
+    NodeType m_nodeType;
+
+    volatile bool m_isInitialized { false };
+    bool m_isMarkedForDeletion { false };
+    bool m_isDisabled { false };
+    bool m_isFinishedSourceNode { false };
+    bool m_isTailProcessing { false };
 };
 
 template<typename T> struct AudioNodeConnectionRefDerefTraits {

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
@@ -417,10 +417,10 @@ float AudioParamTimeline::valuesForFrameRangeImpl(size_t startFrame, size_t endF
     // stopping when we've rendered all the requested values.
     // FIXME: could try to optimize by avoiding having to iterate starting from the very first event
     // and keeping track of a "current" event index.
-    int n = m_events.size();
-    for (int i = 0; i < n && writeIndex < values.size(); ++i) {
+    size_t n = m_events.size();
+    for (size_t i = 0; i < n && writeIndex < values.size(); ++i) {
         auto* event = &m_events[i];
-        auto* nextEvent = i < n - 1 ? &m_events[i + 1] : nullptr;
+        auto* nextEvent = i + 1 < n ? &m_events[i + 1] : nullptr;
 
         // Wait until we get a more recent event.
         if (!isEventCurrent(*event, nextEvent, currentFrame, sampleRate)) {
@@ -458,12 +458,12 @@ float AudioParamTimeline::valuesForFrameRangeImpl(size_t startFrame, size_t endF
             samplingPeriod,
             fillToFrame,
             fillToEndFrame,
-            value1,
             time1,
-            value2,
             time2,
             event,
             i,
+            value1,
+            value2,
         };
 
         // First handle linear and exponential ramps which require looking ahead to the next event.
@@ -793,7 +793,7 @@ void AudioParamTimeline::processSetValueCurve(const AutomationState& currentStat
     currentFrame += nextEventFillToFrame;
 }
 
-void AudioParamTimeline::processSetTargetFollowedByRamp(int eventIndex, ParamEvent*& event, ParamEvent::Type nextEventType, size_t currentFrame, double sampleRate, double controlRate, float& value)
+void AudioParamTimeline::processSetTargetFollowedByRamp(size_t eventIndex, ParamEvent*& event, ParamEvent::Type nextEventType, size_t currentFrame, double sampleRate, double controlRate, float& value)
 {
     // If the current event is SetTarget and the next event is a LinearRampToValue or ExponentialRampToValue,
     // special handling is needed. In this case, the linear and exponential ramp should start at wherever

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.h
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.h
@@ -70,7 +70,7 @@ private:
     class ParamEvent {
         WTF_MAKE_TZONE_ALLOCATED(ParamEvent);
     public:
-        enum Type {
+        enum Type : uint8_t {
             SetValue,
             LinearRampToValue,
             ExponentialRampToValue,
@@ -94,15 +94,15 @@ private:
         static ParamEvent createCancelValuesEvent(Seconds cancelTime, std::optional<SavedEvent>&&);
 
         ParamEvent(Type type, float value, Seconds time, float timeConstant, Seconds duration, Vector<float>&& curve, double curvePointsPerSecond, float curveEndValue, std::optional<SavedEvent>&& savedEvent)
-            : m_type(type)
-            , m_value(value)
-            , m_time(time)
-            , m_timeConstant(timeConstant)
+            : m_time(time)
             , m_duration(duration)
             , m_curve(WTF::move(curve))
             , m_curvePointsPerSecond(curvePointsPerSecond)
-            , m_curveEndValue(curveEndValue)
             , m_savedEvent(WTF::move(savedEvent))
+            , m_value(value)
+            , m_timeConstant(timeConstant)
+            , m_curveEndValue(curveEndValue)
+            , m_type(type)
         {
         }
 
@@ -130,12 +130,7 @@ private:
         float curveEndValue() const { return m_curveEndValue; }
 
     private:
-        Type m_type;
-        float m_value { 0 };
         Seconds m_time;
-
-        // Only used for SetTarget events.
-        float m_timeConstant { 0 };
 
         // The duration of the curve.
         Seconds m_duration;
@@ -147,19 +142,26 @@ private:
         // the curve index step when running the automation.
         double m_curvePointsPerSecond { 0 };
 
-        // The default value to use at the end of the curve. Normally
-        // it's the last entry in m_curve, but cancelling a SetValueCurve
-        // will set this to a new value.
-        float m_curveEndValue { 0 };
-
-        // True if a default value has been assigned to the CancelValues event.
-        bool m_hasDefaultCancelledValue { false };
-
         // For CancelValues. If CancelValues is in the middle of an event, this
         // holds the event that is being cancelled, so that processing can
         // continue as if the event still existed up until we reach the actual
         // scheduled cancel time.
         std::optional<SavedEvent> m_savedEvent;
+
+        float m_value { 0 };
+
+        // Only used for SetTarget events.
+        float m_timeConstant { 0 };
+
+        // The default value to use at the end of the curve. Normally
+        // it's the last entry in m_curve, but cancelling a SetValueCurve
+        // will set this to a new value.
+        float m_curveEndValue { 0 };
+
+        Type m_type;
+
+        // True if a default value has been assigned to the CancelValues event.
+        bool m_hasDefaultCancelledValue { false };
     };
 
     // State of the timeline for the current event.
@@ -180,17 +182,17 @@ private:
         const size_t fillToFrame;
         const size_t fillToEndFrame;
 
-        // Value and time for the current event
-        const float value1;
+        // Time for the current event, and for the next event, if any.
         const Seconds time1;
-
-        // Value and time for the next event, if any.
-        const float value2;
         const Seconds time2;
 
         // The current event, and it's index in the event vector.
         const ParamEvent* event;
-        const int eventIndex;
+        const size_t eventIndex;
+
+        // Value for the current event, and for the next event, if any.
+        const float value1;
+        const float value2;
     };
 
     void removeCancelledEvents(size_t firstEventToRemove) WTF_REQUIRES_LOCK(m_eventsLock);
@@ -207,7 +209,7 @@ private:
     void processCancelValues(const AutomationState&, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex) WTF_REQUIRES_LOCK(m_eventsLock);
     void processSetTarget(const AutomationState&, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex);
     void processSetValueCurve(const AutomationState&, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex);
-    void processSetTargetFollowedByRamp(int eventIndex, ParamEvent*&, ParamEvent::Type nextEventType, size_t currentFrame, double samplingPeriod, double controlRate, float& value) WTF_REQUIRES_LOCK(m_eventsLock);
+    void processSetTargetFollowedByRamp(size_t eventIndex, ParamEvent*&, ParamEvent::Type nextEventType, size_t currentFrame, double samplingPeriod, double controlRate, float& value) WTF_REQUIRES_LOCK(m_eventsLock);
 
     Vector<ParamEvent> m_events WTF_GUARDED_BY_LOCK(m_eventsLock);
 

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.h
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.h
@@ -79,15 +79,14 @@ public:
 private:
     // The audio thread writes the input audio here.
     AudioFloatArray m_inputBuffer;
-    unsigned m_writeIndex { 0 };
 
     // AudioBus used for downmixing input audio before copying it to m_inputBuffer.
     const Ref<AudioBus> m_downmixBus;
-    
+
     size_t m_fftSize { DefaultFFTSize };
     std::unique_ptr<FFTFrame> m_analysisFrame;
     void doFFTAnalysisIfNecessary();
-    
+
     // doFFTAnalysisIfNecessary() unrolls the input buffer here before windowing and doing the FFT.
     AudioFloatArray m_temporaryBuffer { DefaultFFTSize };
 
@@ -98,9 +97,12 @@ private:
     // A value between 0 and 1 which averages the previous version of m_magnitudeBuffer with the current analysis magnitude data.
     double m_smoothingTimeConstant { DefaultSmoothingTimeConstant };
 
-    // The range used when converting when using getByteFrequencyData(). 
+    // The range used when converting when using getByteFrequencyData().
     double m_minDecibels { DefaultMinDecibels };
     double m_maxDecibels { DefaultMaxDecibels };
+
+    // The position in m_inputBuffer the audio thread writes to next.
+    unsigned m_writeIndex { 0 };
 
     // We should only do the FFT analysis once per render quantum.
     bool m_shouldDoFFTAnalysis { true };


### PR DESCRIPTION
#### 2c0cc9251bcd4e0e897f8d4c24fe9582a8410544
<pre>
[Web Audio] Reduce padding in ParamEvent, AutomationState, AudioNode and RealtimeAnalyser
<a href="https://bugs.webkit.org/show_bug.cgi?id=321106">https://bugs.webkit.org/show_bug.cgi?id=321106</a>
<a href="https://rdar.apple.com/184144764">rdar://184144764</a>

Reviewed by Chris Dumez.

Several Web Audio classes interleave 8-byte and 4-byte members, leaving interior
and trailing holes. Group members by alignment to close them. Sizes measured with
-fdump-record-layouts using WebCore&apos;s Release compile flags (arm64e):

AudioParamTimeline::ParamEvent88 -&gt; 80
AudioParamTimeline::AutomationState112 -&gt; 104
AudioNode160 -&gt; 152
RealtimeAnalyser 120 -&gt; 112

* Source/WebCore/Modules/webaudio/AudioParamTimeline.h:
(WebCore::AudioParamTimeline::ParamEvent::ParamEvent):
Move the Seconds/Vector/double/optional members ahead of the floats. Reordering
alone saves nothing here (the payload lands at 81 bytes and still rounds to 88),
so ParamEvent::Type is now explicitly uint8_t, which packs it alongside
m_hasDefaultCancelledValue for 78 -&gt; 80. The constructor&apos;s initializer list is
reordered to match the new declaration order.

In AutomationState, pair up time1/time2 and value1/value2 rather than
interleaving them, and make eventIndex a size_t instead of an int -- it indexes
m_events, so it was the wrong type as well as the cause of the trailing hole.

* Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp:
(WebCore::AudioParamTimeline::valuesForFrameRangeImpl):
Update the aggregate initializer for the new member order, and drive the event
loop with a size_t index so no conversion is needed at the AutomationState and
processSetTargetFollowedByRamp() call sites. The bounds check becomes
(WebCore::AudioParamTimeline::valuesForFrameRangeImpl):
Update the aggregate initializer for the new member order, and drive the event
loop with a size_t index so no conversion is needed at the AutomationState and
processSetTargetFollowedByRamp() call sites. The bounds check becomes
(WebCore::AudioParamTimeline::valuesForFrameRangeImpl):
Update the aggregate initializer for the new member order, and drive the event
loop with a size_t index so no conversion is needed at the AutomationState and
processSetTargetFollowedByRamp() call sites. The bounds check becomes
(WebCore::AudioParamTimeline::valuesForFrameRangeImpl):
Update the aggregate initializer for the new member order, and drive the event
loop with a size_t index so no conversion is needed at the AutomationState and
processSetTargetFollowedByRamp() call sites. The bounds check becomes
i + 1 &lt; n rather than i &lt; n - 1 to avoid underflow on an empty vector.
(WebCore::AudioParamTimeline::processSetTargetFollowedByRamp):
Take the event index as size_t.

* Source/WebCore/Modules/webaudio/AudioNode.h:
Order the 8-byte members first, then the 4-byte group (the two atomic ref counts,
m_channelCount, the two channel enums and m_nodeType), then m_isInitialized with
the other four bools. This closes the 3-byte hole after m_isInitialized, the
4-byte hole before m_logger and the 4-byte trailing hole.

* Source/WebCore/Modules/webaudio/AudioNode.cpp:
(WebCore::AudioNode::AudioNode):
Reorder the initializer list to match, keeping -Wreorder quiet. m_context is
initialized from the constructor parameter, not from m_nodeType, so moving
m_nodeType last is safe.

* Source/WebCore/Modules/webaudio/RealtimeAnalyser.h:
Move m_writeIndex down next to m_shouldDoFFTAnalysis and
m_noiseInjectionPolicies, closing the 4-byte hole it left between
m_inputBuffer and m_downmixBus.

AudioBuffer is left alone: RefCountedBase is exactly 4 bytes with no tail
padding, so m_sampleRate already occupies offset 12 for free and 48 is the
alignment floor. Moving m_sampleRate down beside m_noiseInjectionMultiplier
pushes m_originalLength to offset 16 and grows the class to 56.

These are layout-only changes with no behavior change. The same before/after
layouts were checked against x86_64-pc-windows-msvc and x86_64-unknown-linux-gnu,
which save the same 8 bytes per class; 32-bit x86 is size-neutral for AudioNode
and RealtimeAnalyser and still saves 8 for the other two. No bitfields,
no [[no_unique_address]] and no reliance on base-class tail-padding reuse are
involved, and std::optional&lt;SavedEvent&gt; is value-then-flag in both libc++ and
the MS STL.

* Source/WebCore/Modules/webaudio/AudioNode.cpp:
* Source/WebCore/Modules/webaudio/AudioNode.h:
* Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp:
* Source/WebCore/Modules/webaudio/AudioParamTimeline.h:
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.h:

Canonical link: <a href="https://commits.webkit.org/318685@main">https://commits.webkit.org/318685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cbefee39ee6117d5194155c5accf200c1d9e085

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188783 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f19a0d3-231e-4744-ba40-8d1007710b8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139540 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119986 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44d47db8-91e9-421d-ad0b-a0e37d416668) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41800 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40146 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152199 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39794 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/90 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191003 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52563 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148757 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39935 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53243 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148509 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43202 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125570 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120258 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51761 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14772 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51146 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51387 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51207 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->