### PR TITLE
[WPT] Fix css/selectors/media/sound-state.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/media/sound-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/media/sound-state-expected.txt
@@ -2,5 +2,7 @@
 
 PASS Test :pseudo-class syntax is supported without throwing a SyntaxError
 PASS Test :muted pseudo-class
-FAIL Test :muted matches .muted for content attribute default assert_true: expected true got false
+PASS Test :muted matches .muted for content attribute default
+PASS Test :muted matches .muted for content attribute set
+PASS Test :muted matches .muted for content attribute set, and overridden
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/media/sound-state.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/media/sound-state.html
@@ -53,20 +53,34 @@
 
       assert_false(video.muted);
       assert_false(video.matches(":muted"));
+    }, "Test :muted matches .muted for content attribute default");
 
+    test((t) => {
+      assert_implements(CSS.supports("selector(:muted)"), ":muted is not supported");
+
+      const video = document.createElement("video");
       video.setAttribute("muted", "");
+      document.body.appendChild(video);
+      t.add_cleanup(() => video.remove());
+
+      assert_true(video.muted);
+      assert_true(video.matches(":muted"));
+    }, "Test :muted matches .muted for content attribute set");
+
+    test((t) => {
+      assert_implements(CSS.supports("selector(:muted)"), ":muted is not supported");
+
+      const video = document.createElement("video");
+      video.setAttribute("muted", "");
+      document.body.appendChild(video);
+      t.add_cleanup(() => video.remove());
+
       assert_true(video.muted);
       assert_true(video.matches(":muted"));
 
-      video.removeAttribute("muted");
-      assert_false(video.muted);
-      assert_false(video.matches(":muted"));
-
-      video.setAttribute("muted", "");
-      assert_true(video.muted);
       video.muted = false;
       assert_false(video.muted);
       assert_false(video.matches(":muted"));
-    }, "Test :muted matches .muted for content attribute default");
+    }, "Test :muted matches .muted for content attribute set, and overridden");
   </script>
 </body>


### PR DESCRIPTION
#### 8d269928e2774681dd44c8738b1018ae6f67145f
<pre>
[WPT] Fix css/selectors/media/sound-state.html
<a href="https://rdar.apple.com/184148295">rdar://184148295</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321113">https://bugs.webkit.org/show_bug.cgi?id=321113</a>

Reviewed by Jean-Yves Avenard.

The &quot;Test :muted matches .muted for content attribute&quot; sub-test tries to validate that setting
the &quot;muted&quot; content attribute correctly reflects to the .muted DOM property as well as the :muted
pseudo selector. However, the behavior of the &quot;muted&quot; content attribute is such that it does not
universally reflect to the DOM and CSS; specifically, all three UAs will collapse the &quot;default&quot;
mute state to an explicit value at different points. There is a proposal in whatwg/html/pull/12473
to make this collapse point explicit: either during the load algorithm or during the post connection
steps.

Modify the sound-state.html test to validate that the :muted CSS pseudo selector matches the .muted
IDL attribute by splitting the existing content attribute test into three separate tests. This-
ensures that the desired functionality (that the IDL and CSS match) is equally well tested both before
the proposed post-connection change is merged and after.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/media/sound-state-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/media/sound-state.html:

Canonical link: <a href="https://commits.webkit.org/319299@main">https://commits.webkit.org/319299@main</a>
</pre>
