### PR TITLE
[Custom Highlight] Support the shadowRoots option in HighlightRegistry.highlightsFromPoint().

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/HighlightRegistry-highlightsFromPoint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/HighlightRegistry-highlightsFromPoint-expected.txt
@@ -1,7 +1,7 @@
 0123456789
 
 PASS CSS.highlights.highlightsFromPoint() should throw when called with nodes that are not ShadowRoot objects in options.
-FAIL CSS.highlights.highlightsFromPoint() returns Highlights present at a given point inside a shadow tree in the right order. assert_equals: CSS.highlights.highlightsFromPoint() returns no Highlights when the coordinates provided point at one Highlight in the shadow DOM but shadowRoots provided is empty expected 0 but got 1
-FAIL CSS.highlights.highlightsFromPoint() doesn't return Highlights that are not painted at the given coordinates even when they fall inside the Highlights' ranges assert_equals: CSS.highlights.highlightsFromPoint() returns no Highlights when the given coordinates point at text under the shadow root provided even when there is a Highlight set with a Range that starts and ends in the regular DOM surrounding it, even when shadowRoots are provided expected 0 but got 1
+PASS CSS.highlights.highlightsFromPoint() returns Highlights present at a given point inside a shadow tree in the right order.
+PASS CSS.highlights.highlightsFromPoint() doesn't return Highlights that are not painted at the given coordinates even when they fall inside the Highlights' ranges
 PASS CSS.highlights.highlightsFromPoint() handles slotted light DOM content correctly.
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3949,17 +3949,17 @@ HiddenUntilFoundEnabled:
 
 HighlightsFromPointEnabled:
    type: bool
-   status: testable
+   status: stable
    category: css
    humanReadableName: "CSS Custom Highlight API: highlightsFromPoint()"
    humanReadableDescription: "Enable the CSS Custom Highlight API highlightsFromPoint() method"
    defaultValue:
      WebKitLegacy:
-       default: false
+       default: true
      WebKit:
-       default: false
+       default: true
      WebCore:
-       default: false
+       default: true
 
 HorizontalBannerViewOverlaysEnabled:
   type: bool

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
@@ -35,6 +35,7 @@
 #include "JSHighlight.h"
 #include "NodeDocument.h"
 #include "RenderObject.h"
+#include "ShadowRoot.h"
 #include "SimpleRange.h"
 #include "StaticRange.h"
 #include <algorithm>
@@ -47,11 +48,21 @@ void HighlightRegistry::initializeMapLike(DOMMapAdapter& map)
         map.set<IDLDOMString, IDLInterface<Highlight>>(keyValue.key, keyValue.value);
 }
 
-Vector<HighlightHitResult> HighlightRegistry::highlightsFromPoint(Document& document, float x, float y, HighlightsFromPointOptions&&)
+Vector<HighlightHitResult> HighlightRegistry::highlightsFromPoint(Document& document, float x, float y, HighlightsFromPointOptions&& options)
 {
     document.updateLayout();
 
     FloatPoint point { x, y };
+
+    auto reachableGivenShadowRoots = [&](const Ref<Node>& node) {
+        for (RefPtr shadowRoot = node->containingShadowRoot(); shadowRoot;) {
+            if (!options.shadowRoots.containsIf([&](auto& allowed) { return allowed.ptr() == shadowRoot.get(); }))
+                return false;
+            RefPtr host = shadowRoot->host();
+            shadowRoot = host ? host->containingShadowRoot() : nullptr;
+        }
+        return true;
+    };
 
     struct HitCandidate {
         int priority { 0 };
@@ -73,13 +84,17 @@ Vector<HighlightHitResult> HighlightRegistry::highlightsFromPoint(Document& docu
             if (abstractRange->collapsed())
                 continue;
 
-            if (&abstractRange->startContainer().document() != &document)
+            Ref startContainer = abstractRange->startContainer();
+            if (&startContainer->document() != &document)
+                continue;
+
+            if (!reachableGivenShadowRoots(startContainer))
                 continue;
 
             if (RefPtr staticRange = dynamicDowncast<StaticRange>(abstractRange.get()); staticRange && !staticRange->computeValidity())
                 continue;
 
-            for (auto& rect : RenderObject::clientBorderAndTextRects(makeSimpleRange(abstractRange))) {
+            for (auto& rect : RenderObject::clientTextRects(makeSimpleRange(abstractRange))) {
                 if (rect.contains(point)) {
                     matchingRanges.append(WTF::move(abstractRange));
                     break;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2283,7 +2283,9 @@ static RefPtr<Node> nodeAfter(const BoundaryPoint& point)
 
 enum class CoordinateSpace { Client, Absolute };
 
-static Vector<FloatRect> borderAndTextRects(const SimpleRange& range, CoordinateSpace space, OptionSet<RenderObject::BoundingRectBehavior> behavior)
+enum class TextOnly : bool { No, Yes };
+
+static Vector<FloatRect> borderAndTextRects(const SimpleRange& range, CoordinateSpace space, OptionSet<RenderObject::BoundingRectBehavior> behavior, TextOnly textOnly = TextOnly::No)
 {
     Vector<FloatRect> rects;
 
@@ -2306,7 +2308,7 @@ static Vector<FloatRect> borderAndTextRects(const SimpleRange& range, Coordinate
 
     for (Ref node : intersectingNodesWithDeprecatedZeroOffsetStartQuirk(range)) {
         auto* element = dynamicDowncast<Element>(node.get());
-        if (element && selectedElementsSet.contains(element) && (useVisibleBounds || !node->parentElement() || !selectedElementsSet.contains(node->parentElement()))) {
+        if (textOnly == TextOnly::No && element && selectedElementsSet.contains(element) && (useVisibleBounds || !node->parentElement() || !selectedElementsSet.contains(node->parentElement()))) {
             if (CheckedPtr renderer = element->renderBoxModelObject()) {
                 if (useVisibleBounds) {
                     auto localBounds = renderer->borderBoundingBox();
@@ -2365,6 +2367,11 @@ Vector<FloatRect> RenderObject::absoluteBorderAndTextRects(const SimpleRange& ra
 Vector<FloatRect> RenderObject::clientBorderAndTextRects(const SimpleRange& range)
 {
     return borderAndTextRects(range, CoordinateSpace::Client, { });
+}
+
+Vector<FloatRect> RenderObject::clientTextRects(const SimpleRange& range)
+{
+    return borderAndTextRects(range, CoordinateSpace::Client, { }, TextOnly::Yes);
 }
 
 ScrollAnchoringController* RenderObject::searchParentChainForScrollAnchoringController(const RenderObject& renderer)

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -863,6 +863,7 @@ public:
     WEBCORE_EXPORT static Vector<IntRect> absoluteTextRects(const SimpleRange&, OptionSet<BoundingRectBehavior> = { });
     WEBCORE_EXPORT static Vector<FloatRect> absoluteBorderAndTextRects(const SimpleRange&, OptionSet<BoundingRectBehavior> = { });
     static Vector<FloatRect> clientBorderAndTextRects(const SimpleRange&);
+    static Vector<FloatRect> clientTextRects(const SimpleRange&);
 
     // the rect that will be painted if this object is passed as the subtree paint root
     enum class RespectTransforms : bool { No, Yes };


### PR DESCRIPTION
#### 99ba7bed33ec0c233af78158e583d78545d9a3e7
<pre>
[Custom Highlight] Support the shadowRoots option in HighlightRegistry.highlightsFromPoint().
<a href="https://bugs.webkit.org/show_bug.cgi?id=321116">https://bugs.webkit.org/show_bug.cgi?id=321116</a>
<a href="https://rdar.apple.com/184150480">rdar://184150480</a>

Reviewed by Ryosuke Niwa, Wenson Hsieh, and Abrar Rahman Protyasha.

Completes highlightsFromPoint() with shadow-tree support. A highlight range whose content
lives inside a shadow tree is now only returned when every shadow root between that content
and the document is listed in the options.shadowRoots argument; ranges reached through an
unlisted shadow root are skipped. Reachability is determined by walking the range&apos;s start
container up through containingShadowRoot()/host() to the document.

Hit-testing also switches from RenderObject::clientBorderAndTextRects() to a new text-only
RenderObject::clientTextRects(). Custom highlights paint over text, not element boxes,
but clientBorderAndTextRects() includes the border box of any fully-selected element.
That caused a highlight whose range spans a block-level element (such as a shadow host)
to report a spurious hit over that element&apos;s box on a line where no text of the highlight
is actually painted. clientTextRects() returns only the text runs, matching what is painted.
The new helper is an additive, guarded variant of the existing borderAndTextRects() path, so
clientBorderAndTextRects()/absoluteBorderAndTextRects() callers are unaffected.

imported/w3c/web-platform-tests/shadow-dom/HighlightRegistry-highlightsFromPoint.html

* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/HighlightRegistry-highlightsFromPoint-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/highlight/HighlightRegistry.cpp:
(WebCore::HighlightRegistry::highlightsFromPoint):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::borderAndTextRects):
(WebCore::RenderObject::clientTextRects):
* Source/WebCore/rendering/RenderObject.h:

Canonical link: <a href="https://commits.webkit.org/318758@main">https://commits.webkit.org/318758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d03f2720f0b3011922cedbe3c1dd2a9593ad6fab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188988 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3404fecf-55fb-4b08-8be1-fb23ca36d42b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139713 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f96b0fb7-9565-413f-b7b7-1a683ba122ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120161 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/013326c1-59b5-49f5-8797-d8176535a6f2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41974 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40319 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2135 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8950 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152374 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39969 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Skipped layout-tests; 343 new passes 3 flakes 2 failures; Uploaded test results; 343 new passes 2 flakes 1 failures; layout-tests; Passed layout tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/294 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40431 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191206 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52766 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148949 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39978 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53446 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148695 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43375 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125717 "Build is in progress. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Found 27228 issues") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120560 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51964 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14948 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51349 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51590 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51410 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->