### PR TITLE
[macOS] ASSERTION FAILED: callback.version < m_cookiesVersion /Volumes/Data/worker/macOS-Tahoe-Debug-Build-EWS/build/Source/WebCore/platform/network/NetworkStorageSession.cpp

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2444,8 +2444,6 @@ webkit.org/b/320913 http/tests/security/contentSecurityPolicy/multipart-three-pa
 
 webkit.org/b/320326 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/320939 http/tests/websocket/tests/hybi/no-subprotocol.html [ Pass Crash Timeout ]
-
 webkit.org/b/321103 [ Debug ] imported/w3c/web-platform-tests/uievents/textInput/enter-textarea-contenteditable.html [ Pass Failure ]
 
 # webkit.org/b/321110 NEW TEST(317810@main): [iOS macOS]4 tests in imported/w3c/web-platform-tests/webtransport/idlharness are constant failure

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -658,7 +658,7 @@ void NetworkStorageSession::setCookiesVersion(uint64_t version)
 
 void NetworkStorageSession::addCookiesVersionChangeCallback(CookieVersionChangeCallback&& callback)
 {
-    ASSERT(callback.version < m_cookiesVersion);
+    ASSERT(callback.version > m_cookiesVersion);
     m_cookiesVersionChangeCallbacks.append(WTF::move(callback));
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -585,11 +585,18 @@ static void addPathsBlockedForSandboxExtensions(const WebsiteDataStoreParameters
 void NetworkProcess::addStorageSession(PAL::SessionID sessionID, const WebsiteDataStoreParameters& parameters)
 {
     auto addResult = m_networkStorageSessions.add(sessionID, nullptr);
-    if (!addResult.isNewEntry)
+    auto applyCookiesVersion = [&] {
+        CheckedPtr { addResult.iterator->value.get() }->setCookiesVersion(parameters.networkSessionParameters.cookiesVersion);
+    };
+
+    if (!addResult.isNewEntry) {
+        applyCookiesVersion();
         return;
+    }
 
     if (parameters.networkSessionParameters.shouldUseTestingNetworkSession) {
         addResult.iterator->value = newTestingSession(sessionID);
+        applyCookiesVersion();
         return;
     }
 
@@ -627,7 +634,7 @@ void NetworkProcess::addStorageSession(PAL::SessionID sessionID, const WebsiteDa
     addResult.iterator->value = makeUnique<NetworkStorageSession>(sessionID);
 #endif
 
-    CheckedPtr { addResult.iterator->value.get() }->setCookiesVersion(parameters.networkSessionParameters.cookiesVersion);
+    applyCookiesVersion();
 }
 
 void NetworkProcess::addWebsiteDataStore(WebsiteDataStoreParameters&& parameters)


### PR DESCRIPTION
#### 5dd200e810bf7fd95f072b6a29ab0de71293cacc
<pre>
[macOS] ASSERTION FAILED: callback.version &lt; m_cookiesVersion /Volumes/Data/worker/macOS-Tahoe-Debug-Build-EWS/build/Source/WebCore/platform/network/NetworkStorageSession.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=320939">https://bugs.webkit.org/show_bug.cgi?id=320939</a>
<a href="https://rdar.apple.com/183968921">rdar://183968921</a>

Reviewed by Chris Dumez.

The assertion in NetworkStorageSession::addCookiesVersionChangeCallback() has its comparison backwards. A callback is
added only while the session lags behind the version a request requires, and setCookiesVersion() runs it once the
session catches up, so the callback&apos;s version should always be ahead of m_cookiesVersion rather than behind it.

The more consequential problem is that NetworkProcess::addStorageSession() never applies the cookies version to a
testing session, since that branch returns before reaching the setCookiesVersion() call at the end of the function. The
session is left at version 0 even though the UI process has already advanced past it, and short of a client setting
another cookie there is nothing to advance it again, so every request requiring a higher version is suspended and never
resumed. The branch for a session that has already been added returns early for the same reason, so apply the version on
all three paths.

http/tests/websocket/tests/hybi/no-subprotocol.html was running into this whenever hybi/network-process-crash-error.html
had just relaunched the network process. Rebaseline its expectation after the issues are fixed.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::addCookiesVersionChangeCallback):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::addStorageSession):

Canonical link: <a href="https://commits.webkit.org/318686@main">https://commits.webkit.org/318686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4533cf7819b654591333325cac0b9cce64488c5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188806 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139557 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120003 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41823 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40168 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152222 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39816 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/113 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45522 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44414 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/core/float_exprs.wast.js.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191026 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148794 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39936 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53266 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148531 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43223 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125536 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120347 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51784 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14794 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51169 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51410 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->