### PR TITLE
Add unprefixed user-select (and feature flag)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -395,6 +395,7 @@ PASS transition-timing-function
 PASS translate
 PASS trigger-scope
 PASS unicode-bidi
+PASS user-select
 PASS vector-effect
 PASS vertical-align
 PASS view-timeline-axis

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Can set 'user-select' to CSS-wide keywords: initial Invalid property user-select
-FAIL Can set 'user-select' to CSS-wide keywords: inherit Invalid property user-select
-FAIL Can set 'user-select' to CSS-wide keywords: unset Invalid property user-select
-FAIL Can set 'user-select' to CSS-wide keywords: revert Invalid property user-select
-FAIL Can set 'user-select' to var() references:  var(--A) Invalid property user-select
-FAIL Can set 'user-select' to the 'auto' keyword: auto Invalid property user-select
-FAIL Can set 'user-select' to the 'text' keyword: text Invalid property user-select
-FAIL Can set 'user-select' to the 'none' keyword: none Invalid property user-select
-FAIL Can set 'user-select' to the 'contain' keyword: contain Invalid property user-select
-FAIL Can set 'user-select' to the 'all' keyword: all Invalid property user-select
+PASS Can set 'user-select' to CSS-wide keywords: initial
+PASS Can set 'user-select' to CSS-wide keywords: inherit
+PASS Can set 'user-select' to CSS-wide keywords: unset
+PASS Can set 'user-select' to CSS-wide keywords: revert
+PASS Can set 'user-select' to var() references:  var(--A)
+PASS Can set 'user-select' to the 'auto' keyword: auto
+PASS Can set 'user-select' to the 'text' keyword: text
+PASS Can set 'user-select' to the 'none' keyword: none
+FAIL Can set 'user-select' to the 'contain' keyword: contain Invalid values
+PASS Can set 'user-select' to the 'all' keyword: all
 PASS Setting 'user-select' to a length: 0px throws TypeError
 PASS Setting 'user-select' to a length: -3.14em throws TypeError
 PASS Setting 'user-select' to a length: 3.14cm throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/inheritance-expected.txt
@@ -25,6 +25,6 @@ PASS Property outline-width has initial value 3px
 PASS Property outline-width does not inherit
 PASS Property resize has initial value none
 PASS Property resize does not inherit
-FAIL Property user-select has initial value auto assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select does not inherit assert_true: expected true got false
+PASS Property user-select has initial value auto
+PASS Property user-select does not inherit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-computed-contain-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-computed-contain-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Property user-select value 'contain' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
+FAIL Property user-select value 'contain' assert_true: 'contain' is a supported value for user-select. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-computed-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Property user-select value 'auto' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select value 'text' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select value 'none' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select value 'all' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
+PASS Property user-select value 'auto'
+PASS Property user-select value 'text'
+PASS Property user-select value 'none'
+PASS Property user-select value 'all'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-valid-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL e.style['user-select'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['user-select'] = "text" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['user-select'] = "none" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['user-select'] = "all" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['user-select'] = "auto" should set the property value
+PASS e.style['user-select'] = "text" should set the property value
+PASS e.style['user-select'] = "none" should set the property value
+PASS e.style['user-select'] = "all" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-inheritance-expected.txt
@@ -2,9 +2,9 @@ abc
 xyz
 def
 
-FAIL user-select:all should not be inherited. assert_equals: user-select:all should be supported. expected (string) "all" but got (undefined) undefined
-FAIL user-select:auto should not be inherited. assert_equals: user-select:auto should be supported. expected (string) "auto" but got (undefined) undefined
-FAIL user-select:contain should not be inherited. assert_equals: user-select:contain should be supported. expected (string) "contain" but got (undefined) undefined
-FAIL user-select:none should not be inherited. assert_equals: user-select:none should be supported. expected (string) "none" but got (undefined) undefined
-FAIL user-select:text should not be inherited. assert_equals: user-select:text should be supported. expected (string) "text" but got (undefined) undefined
+PASS user-select:all should not be inherited.
+PASS user-select:auto should not be inherited.
+FAIL user-select:contain should not be inherited. assert_equals: user-select:contain should be supported. expected "contain" but got "auto"
+PASS user-select:none should not be inherited.
+PASS user-select:text should not be inherited.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
@@ -1,9 +1,9 @@
 
 
-FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 454
-FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 454
-FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 454
-FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 455
+FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 455
+FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 455
+FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 455
+FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 456
 PASS <select></select> has a shadow tree with slot
 PASS <select multiple=""></select> has a shadow tree with slot
 PASS <select size="4"></select> has a shadow tree with slot

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -395,6 +395,7 @@ PASS transition-timing-function
 PASS translate
 PASS trigger-scope
 PASS unicode-bidi
+PASS user-select
 PASS vector-effect
 PASS vertical-align
 PASS view-timeline-axis

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1843,6 +1843,20 @@ CSSUnprefixedBackdropFilterEnabled:
       "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
       default: false
 
+CSSUserSelectEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS Unprefixed User Select"
+  humanReadableDescription: "Enable the unprefixed user-select CSS property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSWhiteSpaceTrimEnabled:
   type: bool
   status: stable

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1829,6 +1829,21 @@ CSSUnprefixedBackdropFilterEnabled:
       "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
       default: false
 
+CSSUnprefixedUserSelectEnabled:
+  type: bool
+  status: internal
+  category: css
+  webcoreOnChange: setNeedsRecalcStyleInAllFrames
+  humanReadableName: "CSS Unprefixed User Select"
+  humanReadableDescription: "Enable the unprefixed user-select CSS property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSWhiteSpaceTrimEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12481,11 +12481,33 @@
             "status": "non-standard"
         },
         "-webkit-user-select": {
-            "animation-type": "not animatable (needs triage)",
-            "animation-type-comment": "Current spec for standard 'user-select' animation type is 'discrete'",
+            "animation-type": "not animatable (legacy)",
             "inherited": true,
             "initial": "text",
-            "initial-comment": "Current spec for standard 'user-select' initial is 'auto'",
+            "initial-comment": "Legacy behavior - 'auto' is folded into 'text'",
+            "values": [
+                "auto",
+                "text",
+                "none",
+                "all"
+            ],
+            "codegen-properties": {
+                "computed-style-has-explicitly-set-policy": "value-only",
+                "computed-style-has-explicitly-set-storage-path": ["m_inheritedRareData"],
+                "computed-style-name-for-methods": "WebkitUserSelect",
+                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-kind": "enum",
+                "computed-style-type": "UserSelect",
+                "parser-grammar": "<<values>>",
+                "comment": "Not an alias of 'user-select': this property is inherited, it overrides 'user-select' whenever it has been specified (hence the has-explicitly-set flag)."
+            },
+            "status": "non-standard"
+        },
+        "user-select": {
+            "animation-type": "not animatable (needs triage)",
+            "animation-type-comment": "Current spec animation type is 'discrete'",
+            "inherited": false,
+            "initial": "auto",
             "values": [
                 "auto",
                 "text",
@@ -12497,10 +12519,11 @@
                 "all"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_nonInheritedData", "miscData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "UserSelect",
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "settings-flag": "cssUnprefixedUserSelectEnabled"
             },
             "status": {
                 "status": "experimental"

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12530,11 +12530,33 @@
             "status": "non-standard"
         },
         "-webkit-user-select": {
-            "animation-type": "not animatable (needs triage)",
-            "animation-type-comment": "Current spec for standard 'user-select' animation type is 'discrete'",
+            "animation-type": "not animatable (legacy)",
             "inherited": true,
             "initial": "text",
-            "initial-comment": "Current spec for standard 'user-select' initial is 'auto'",
+            "initial-comment": "Legacy behavior - 'auto' is folded into 'text'",
+            "values": [
+                "auto",
+                "text",
+                "none",
+                "all"
+            ],
+            "codegen-properties": {
+                "computed-style-has-explicitly-set-policy": "value-only",
+                "computed-style-has-explicitly-set-storage-path": ["m_inheritedRareData"],
+                "computed-style-name-for-methods": "WebkitUserSelect",
+                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-kind": "enum",
+                "computed-style-type": "UserSelect",
+                "parser-grammar": "<<values>>",
+                "comment": "Not an alias of 'user-select': this property is inherited, it overrides 'user-select' whenever it has been specified (hence the has-explicitly-set flag)."
+            },
+            "status": "non-standard"
+        },
+        "user-select": {
+            "animation-type": "not animatable (needs triage)",
+            "animation-type-comment": "Current spec animation type is 'discrete'",
+            "inherited": false,
+            "initial": "auto",
             "values": [
                 "auto",
                 "text",
@@ -12546,10 +12568,11 @@
                 "all"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_nonInheritedData", "miscData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "UserSelect",
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "settings-flag": "cssUserSelectEnabled"
             },
             "status": {
                 "status": "experimental"

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1286,6 +1286,7 @@ TextStream& operator<<(TextStream& ts, UserModify userModify)
 TextStream& operator<<(TextStream& ts, UserSelect userSelect)
 {
     switch (userSelect) {
+    case UserSelect::Auto: ts << "auto"_s; break;
     case UserSelect::None: ts << "none"_s; break;
     case UserSelect::Text: ts << "text"_s; break;
     case UserSelect::All: ts << "all"_s; break;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1295,6 +1295,7 @@ TextStream& operator<<(TextStream& ts, UserModify userModify)
 TextStream& operator<<(TextStream& ts, UserSelect userSelect)
 {
     switch (userSelect) {
+    case UserSelect::Auto: ts << "auto"_s; break;
     case UserSelect::None: ts << "none"_s; break;
     case UserSelect::Text: ts << "text"_s; break;
     case UserSelect::All: ts << "all"_s; break;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -507,7 +507,8 @@ enum class UserDrag : uint8_t {
 enum class UserSelect : uint8_t {
     None,
     Text,
-    All
+    All,
+    Auto
 };
 
 // CSS3 Image Values

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -494,7 +494,8 @@ enum class UserDrag : uint8_t {
 enum class UserSelect : uint8_t {
     None,
     Text,
-    All
+    All,
+    Auto
 };
 
 // CSS3 Image Values

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -638,12 +638,13 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
 #if ENABLE(IMAGE_ANALYSIS)
         // Don't allow selecting individual glyphs on text recognized inside an image:
         if (m_element->isInUserAgentShadowTree() && m_element->userAgentPart() == UserAgentParts::internalImageOverlayText()) {
-            switch (style.userSelect()) {
+            switch (style.webkitUserSelect()) {
             case UserSelect::All:
             case UserSelect::None:
                 break;
+            case UserSelect::Auto:
             case UserSelect::Text:
-                style.setUserSelect(UserSelect::All);
+                style.setWebkitUserSelect(UserSelect::All);
                 break;
             }
         }
@@ -1089,7 +1090,7 @@ void Adjuster::adjustForSiteSpecificQuirks(Style::ComputedStyle& style) const
     if (documentQuirks.needsPrimeVideoUserSelectNoneQuirk()) {
         static MainThreadNeverDestroyed<const AtomString> className("webPlayerSDKUiContainer"_s);
         if (m_element->hasClassName(className))
-            style.setUserSelect(UserSelect::None);
+            style.setWebkitUserSelect(UserSelect::None);
     }
 
     if (auto tikTokOverflowingContentQuery = documentQuirks.needsTikTokOverflowingContentQuirk(protect(*m_element), m_parentStyle)) {

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -800,7 +800,7 @@ public:
     {
         return a.effectiveInert != b.effectiveInert
             || a.userModify != b.userModify
-            || a.userSelect != b.userSelect
+            || a.webkitUserSelect != b.webkitUserSelect
             || a.appleColorFilter != b.appleColorFilter
             || a.imageRendering != b.imageRendering
             || a.accentColor != b.accentColor

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -528,7 +528,7 @@ UserSelect ComputedStyle::usedUserSelect() const
     if (effectiveInert())
         return UserSelect::None;
 
-    auto value = userSelect();
+    auto value = webkitUserSelect();
     if (userModify() != UserModify::ReadOnly && userDrag() != UserDrag::Element)
         return value == UserSelect::None ? UserSelect::Text : value;
 

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
@@ -91,7 +91,7 @@ InheritedRareData::InheritedRareData()
     , overflowWrap(static_cast<unsigned>(ComputedStyle::initialOverflowWrap()))
     , nbspMode(static_cast<unsigned>(NBSPMode::Normal))
     , lineBreak(static_cast<unsigned>(LineBreak::Auto))
-    , userSelect(static_cast<unsigned>(ComputedStyle::initialUserSelect()))
+    , webkitUserSelect(static_cast<unsigned>(ComputedStyle::initialWebkitUserSelect()))
     , speakAs(ComputedStyle::initialSpeakAs().toRaw())
     , hyphens(static_cast<unsigned>(Hyphens::Manual))
     , textCombine(static_cast<unsigned>(ComputedStyle::initialTextCombine()))
@@ -123,6 +123,7 @@ InheritedRareData::InheritedRareData()
     , joinStyle(static_cast<unsigned>(ComputedStyle::initialJoinStyle()))
     , hasExplicitlySetStrokeWidth(false)
     , hasExplicitlySetStrokeColor(false)
+    , hasExplicitlySetWebkitUserSelect(false)
     , effectiveInert(false)
     , effectivelyTransparent(false)
     , effectiveWrapInsideAvoid(false)
@@ -197,7 +198,7 @@ inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     , overflowWrap(o.overflowWrap)
     , nbspMode(o.nbspMode)
     , lineBreak(o.lineBreak)
-    , userSelect(o.userSelect)
+    , webkitUserSelect(o.webkitUserSelect)
     , speakAs(o.speakAs)
     , hyphens(o.hyphens)
     , textCombine(o.textCombine)
@@ -229,6 +230,7 @@ inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     , joinStyle(o.joinStyle)
     , hasExplicitlySetStrokeWidth(o.hasExplicitlySetStrokeWidth)
     , hasExplicitlySetStrokeColor(o.hasExplicitlySetStrokeColor)
+    , hasExplicitlySetWebkitUserSelect(o.hasExplicitlySetWebkitUserSelect)
     , effectiveInert(o.effectiveInert)
     , effectivelyTransparent(o.effectivelyTransparent)
     , effectiveWrapInsideAvoid(o.effectiveWrapInsideAvoid)
@@ -293,7 +295,7 @@ bool InheritedRareData::operator==(const InheritedRareData& o) const
 #if ENABLE(TEXT_AUTOSIZING)
         && textSizeAdjust == o.textSizeAdjust
 #endif
-        && userSelect == o.userSelect
+        && webkitUserSelect == o.webkitUserSelect
         && speakAs == o.speakAs
         && hyphens == o.hyphens
         && hyphenateLimitBefore == o.hyphenateLimitBefore
@@ -331,6 +333,7 @@ bool InheritedRareData::operator==(const InheritedRareData& o) const
         && joinStyle == o.joinStyle
         && hasExplicitlySetStrokeWidth == o.hasExplicitlySetStrokeWidth
         && hasExplicitlySetStrokeColor == o.hasExplicitlySetStrokeColor
+        && hasExplicitlySetWebkitUserSelect == o.hasExplicitlySetWebkitUserSelect
         && mathShift == o.mathShift
         && mathStyle == o.mathStyle
         && isInSubtreeWithBlendMode == o.isInSubtreeWithBlendMode
@@ -409,7 +412,7 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
     LOG_IF_DIFFERENT_WITH_CAST(OverflowWrap, overflowWrap);
     LOG_IF_DIFFERENT_WITH_CAST(NBSPMode, nbspMode);
     LOG_IF_DIFFERENT_WITH_CAST(LineBreak, lineBreak);
-    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, userSelect);
+    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, webkitUserSelect);
 
     LOG_IF_DIFFERENT_WITH_FROM_RAW(SpeakAs, speakAs);
 
@@ -451,6 +454,7 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetStrokeWidth);
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetStrokeColor);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetWebkitUserSelect);
 
     LOG_IF_DIFFERENT_WITH_CAST(MathShift, mathShift);
     LOG_IF_DIFFERENT_WITH_CAST(MathStyle, mathStyle);

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.h
@@ -183,7 +183,7 @@ public:
     PREFERRED_TYPE(OverflowWrap) unsigned overflowWrap : 2;
     PREFERRED_TYPE(NBSPMode) unsigned nbspMode : 1;
     PREFERRED_TYPE(LineBreak) unsigned lineBreak : 3;
-    PREFERRED_TYPE(UserSelect) unsigned userSelect : 2;
+    PREFERRED_TYPE(UserSelect) unsigned webkitUserSelect : 2;
     PREFERRED_TYPE(SpeakAs) unsigned speakAs : 4;
     PREFERRED_TYPE(Hyphens) unsigned hyphens : 2;
     PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;
@@ -215,6 +215,7 @@ public:
     PREFERRED_TYPE(LineJoin) unsigned joinStyle : 2;
     PREFERRED_TYPE(bool) unsigned hasExplicitlySetStrokeWidth : 1;
     PREFERRED_TYPE(bool) unsigned hasExplicitlySetStrokeColor : 1;
+    PREFERRED_TYPE(bool) unsigned hasExplicitlySetWebkitUserSelect : 1;
     PREFERRED_TYPE(bool) unsigned effectiveInert : 1;
     PREFERRED_TYPE(bool) unsigned effectivelyTransparent : 1;
     PREFERRED_TYPE(bool) unsigned effectiveWrapInsideAvoid : 1; // This box or an ancestor has wrap-inside: avoid.

--- a/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.cpp
@@ -63,6 +63,7 @@ NonInheritedMiscData::NonInheritedMiscData()
     , tableLayout(static_cast<unsigned>(ComputedStyle::initialTableLayout()))
     , appearance(static_cast<unsigned>(ComputedStyle::initialAppearance()))
     , usedAppearance(static_cast<unsigned>(ComputedStyle::initialAppearance()))
+    , userSelect(static_cast<unsigned>(ComputedStyle::initialUserSelect()))
     , textOverflow(static_cast<unsigned>(ComputedStyle::initialTextOverflow()))
     , userDrag(static_cast<unsigned>(ComputedStyle::initialUserDrag()))
     , objectFit(static_cast<unsigned>(ComputedStyle::initialObjectFit()))
@@ -104,6 +105,7 @@ NonInheritedMiscData::NonInheritedMiscData(const NonInheritedMiscData& o)
     , tableLayout(o.tableLayout)
     , appearance(o.appearance)
     , usedAppearance(o.usedAppearance)
+    , userSelect(o.userSelect)
     , textOverflow(o.textOverflow)
     , userDrag(o.userDrag)
     , objectFit(o.objectFit)
@@ -152,6 +154,7 @@ bool NonInheritedMiscData::operator==(const NonInheritedMiscData& o) const
         && tableLayout == o.tableLayout
         && appearance == o.appearance
         && usedAppearance == o.usedAppearance
+        && userSelect == o.userSelect
         && textOverflow == o.textOverflow
         && userDrag == o.userDrag
         && objectFit == o.objectFit
@@ -209,6 +212,8 @@ void NonInheritedMiscData::dumpDifferences(TextStream& ts, const NonInheritedMis
     LOG_IF_DIFFERENT_WITH_CAST(TableLayoutType, tableLayout);
     LOG_IF_DIFFERENT_WITH_CAST(StyleAppearance, appearance);
     LOG_IF_DIFFERENT_WITH_CAST(StyleAppearance, usedAppearance);
+
+    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, userSelect);
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, textOverflow);
 

--- a/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.h
@@ -112,6 +112,7 @@ public:
     PREFERRED_TYPE(TableLayoutType) unsigned tableLayout : 1;
     PREFERRED_TYPE(StyleAppearance) unsigned appearance : appearanceBitWidth;
     PREFERRED_TYPE(StyleAppearance) unsigned usedAppearance : appearanceBitWidth;
+    PREFERRED_TYPE(UserSelect) unsigned userSelect : 2;
     PREFERRED_TYPE(bool) unsigned textOverflow : 1; // Whether or not lines that spill out should be truncated with "..."
     PREFERRED_TYPE(UserDrag) unsigned userDrag : 2;
     PREFERRED_TYPE(ObjectFit) unsigned objectFit : 3;

--- a/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
+++ b/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
@@ -1228,6 +1228,8 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 constexpr CSSValueID toCSSValueID(UserSelect e)
 {
     switch (e) {
+    case UserSelect::Auto:
+        return CSSValueAuto;
     case UserSelect::None:
         return CSSValueNone;
     case UserSelect::Text:
@@ -1243,7 +1245,7 @@ template<> constexpr UserSelect fromCSSValueID(CSSValueID valueID)
 {
     switch (valueID) {
     case CSSValueAuto:
-        return UserSelect::Text;
+        return UserSelect::Auto;
     case CSSValueNone:
         return UserSelect::None;
     case CSSValueText:

--- a/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
+++ b/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
@@ -1234,6 +1234,8 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 constexpr CSSValueID toCSSValueID(UserSelect e)
 {
     switch (e) {
+    case UserSelect::Auto:
+        return CSSValueAuto;
     case UserSelect::None:
         return CSSValueNone;
     case UserSelect::Text:
@@ -1249,7 +1251,7 @@ template<> constexpr UserSelect fromCSSValueID(CSSValueID valueID)
 {
     switch (valueID) {
     case CSSValueAuto:
-        return UserSelect::Text;
+        return UserSelect::Auto;
     case CSSValueNone:
         return UserSelect::None;
     case CSSValueText:


### PR DESCRIPTION
#### 21f1e674ff34d7628aa80ec7628084ececdd41af
<pre>
Add unprefixed user-select (and feature flag)
<a href="https://bugs.webkit.org/show_bug.cgi?id=321119">https://bugs.webkit.org/show_bug.cgi?id=321119</a>
<a href="https://rdar.apple.com/184152184">rdar://184152184</a>

Reviewed by Tim Nguyen.

Adds the (unprefixed) user-select property, gated by a new feature
flag (CSSUserSelectEnabled). The property is completely inert - this
commit only adds the plumbing required for making user-select actually
affect selectability in the future. The prefixed `-webkit-user-select`
still exists independently and is the only source of truth.

No changes in behavior expected. However, some tests now pass simply
because the user-select property exists (though only in testing -
feature flag set to &apos;testable&apos;).

Canonical link: <a href="https://commits.webkit.org/319023@main">https://commits.webkit.org/319023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32d69158b0fc6f3f322780c4ef7f2422218c95ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190321 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144428 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25857053-2e79-45f8-80b0-384cceadf137) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140477 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b1ba7f2-1cab-4043-929d-31f184b69bde) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120929 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db337fa8-5ab1-4681-b8bb-5d79274df113) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/179434 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42794 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41106 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2896 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9738 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40781 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1480 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41383 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46654 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45408 "Found 1 new test failure: imported/w3c/web-platform-tests/payment-request/show-consume-activation.https.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192255 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53721 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160777 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149815 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40140 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54409 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149542 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44182 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126672 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121787 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52926 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15768 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52308 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52545 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52373 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->