### PR TITLE
[Site Isolation] Remove dead process-qualified media identifier plumbing

### DIFF
--- a/Source/WebKit/Shared/PlaybackSessionContextIdentifier.h
+++ b/Source/WebKit/Shared/PlaybackSessionContextIdentifier.h
@@ -32,9 +32,4 @@ namespace WebKit {
 
 using PlaybackSessionContextIdentifier = WebCore::ProcessQualified<WebCore::HTMLMediaElementIdentifier>;
 
-inline PlaybackSessionContextIdentifier processQualify(WebCore::HTMLMediaElementIdentifier identifier)
-{
-    return WebCore::ProcessQualified(identifier, WebCore::Process::identifier());
-}
-
 }

--- a/Source/WebKit/Shared/ProcessQualified.serialization.in
+++ b/Source/WebKit/Shared/ProcessQualified.serialization.in
@@ -100,11 +100,6 @@ header: <WebCore/ProcessQualified.h>
     WebCore::ProcessIdentifier processIdentifier();
 };
 
-[Alias=class WebCore::ProcessQualified<ObjectIdentifier<WebCore::MediaPlayerClientIdentifierType>>, CustomHeader] alias WebKit::PlaybackSessionContextIdentifier {
-    WebCore::MediaPlayerClientIdentifier object();
-    WebCore::ProcessIdentifier processIdentifier();
-};
-
 header: <WebCore/WebKitJSHandle.h>
 [Alias=class ProcessQualified<ObjectIdentifier<WebCore::JSHandleIdentifierType>>, CustomHeader] alias WebCore::JSHandleIdentifier {
     WebCore::WebProcessJSHandleIdentifier object();


### PR DESCRIPTION
#### 7b1a9ea70e83ee49ddab02a1d2b1ad1ddbdd425f
<pre>
[Site Isolation] Remove dead process-qualified media identifier plumbing
<a href="https://bugs.webkit.org/show_bug.cgi?id=321126">https://bugs.webkit.org/show_bug.cgi?id=321126</a>
<a href="https://rdar.apple.com/184160039">rdar://184160039</a>

Reviewed by Charlie Wolfe.

The UI process now pairs a bare WebCore::MediaPlayerClientIdentifier from IPC with
the process identity of the sending IPC::Connection, so nothing constructs or sends a
process-qualified media identifier anymore. Delete the two pieces of machinery that
served only those senders:

- processQualify(), whose last callers were removed when the media manager messages
  and the layer-tree / text-recognition messages were converted.
- The WebKit::PlaybackSessionContextIdentifier serialization alias, whose generated
  coder is now unused and which needlessly advertised the type to
  IPC.serializedTypeInfo.

WebKit::PlaybackSessionContextIdentifier itself stays. It remains load-bearing as
UI-process-internal state — it is how the UI process distinguishes same-numbered
media elements in different processes. The end state is the point: the UI process
constructs this type and never receives it.

No change in behaviour; pure dead-code removal.

* Source/WebKit/Shared/PlaybackSessionContextIdentifier.h:
(WebKit::processQualify): Deleted.
* Source/WebKit/Shared/ProcessQualified.serialization.in:

Canonical link: <a href="https://commits.webkit.org/318820@main">https://commits.webkit.org/318820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c15ef5cca474efc20445b5b2cee23af521c321d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188818 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143298 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9cf2254d-c581-4221-b55d-b1001798b0b6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139570 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96735 "2 flakes 2 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46aabcf9-9ac3-4178-be4f-d1a5bc021fe0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120016 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e964b347-2474-4544-8463-b9a75bf79478) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41835 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40179 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39828 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/125 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191038 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52598 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148791 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40013 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53278 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36454 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148542 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43232 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125548 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120363 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51796 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14807 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51181 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51422 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51242 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->