### PR TITLE
REGRESSION(313859@main): SVGForeignObjectElement dynamic x/y take no effect

### DIFF
--- a/LayoutTests/svg/foreignObject/foreignobject-svgdom-x-property-update-expected.html
+++ b/LayoutTests/svg/foreignObject/foreignobject-svgdom-x-property-update-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>foreignObject: SVG DOM 'x' property update repositions the element</title>
+<style>* { margin: 0; padding: 0; }</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <foreignObject x="100" y="50" width="150" height="100">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="background-color: green; width: 150px; height: 100px;"></div>
+  </foreignObject>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/foreignObject/foreignobject-svgdom-x-property-update.html
+++ b/LayoutTests/svg/foreignObject/foreignobject-svgdom-x-property-update.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>foreignObject: SVG DOM 'x' property update repositions the element</title>
+<link rel="match" href="foreignobject-svgdom-x-property-update-expected.html">
+<!-- Setting SVGForeignObjectElement.x.baseVal.value must reposition the foreignObject.
+     layout() derives the viewport from the resolved style, so the x/y presentation
+     hint style has to be invalidated when the SVG DOM property changes. This green
+     block must end up at x=100, exactly overlapping the reference. -->
+<style>* { margin: 0; padding: 0; }</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <foreignObject id="fo" x="-100" y="50" width="150" height="100">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="background-color: green; width: 150px; height: 100px;"></div>
+  </foreignObject>
+</svg>
+<script>
+  var fo = document.getElementById("fo");
+  // Force an initial layout at the wrong position, then move via the SVG DOM property.
+  document.body.offsetTop;
+  fo.x.baseVal.value = 100;
+</script>
+</body>
+</html>

--- a/LayoutTests/svg/foreignObject/foreignobject-svgdom-y-property-update-expected.html
+++ b/LayoutTests/svg/foreignObject/foreignobject-svgdom-y-property-update-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>foreignObject: SVG DOM 'y' property update repositions the element</title>
+<style>* { margin: 0; padding: 0; }</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <foreignObject x="50" y="100" width="150" height="100">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="background-color: green; width: 150px; height: 100px;"></div>
+  </foreignObject>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/foreignObject/foreignobject-svgdom-y-property-update.html
+++ b/LayoutTests/svg/foreignObject/foreignobject-svgdom-y-property-update.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>foreignObject: SVG DOM 'y' property update repositions the element</title>
+<link rel="match" href="foreignobject-svgdom-y-property-update-expected.html">
+<!-- Setting SVGForeignObjectElement.y.baseVal.value must reposition the foreignObject.
+     layout() derives the viewport from the resolved style, so the x/y presentation
+     hint style has to be invalidated when the SVG DOM property changes. This green
+     block must end up at y=100, exactly overlapping the reference. -->
+<style>* { margin: 0; padding: 0; }</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <foreignObject id="fo" x="50" y="-100" width="150" height="100">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="background-color: green; width: 150px; height: 100px;"></div>
+  </foreignObject>
+</svg>
+<script>
+  var fo = document.getElementById("fo");
+  // Force an initial layout at the wrong position, then move via the SVG DOM property.
+  document.body.offsetTop;
+  fo.y.baseVal.value = 100;
+</script>
+</body>
+</html>

--- a/Source/WebCore/svg/SVGForeignObjectElement.cpp
+++ b/Source/WebCore/svg/SVGForeignObjectElement.cpp
@@ -89,13 +89,9 @@ void SVGForeignObjectElement::svgAttributeChanged(const QualifiedName& attrName)
 {
     if (PropertyRegistry::isKnownAttribute(attrName)) {
         InstanceInvalidationGuard guard(*this);
-        if (attrName == SVGNames::widthAttr || attrName == SVGNames::heightAttr)
-            setPresentationalHintStyleIsDirty();
-        else {
-            ASSERT(attrName == SVGNames::xAttr || attrName == SVGNames::yAttr);
+        setPresentationalHintStyleIsDirty();
+        if (attrName == SVGNames::xAttr || attrName == SVGNames::yAttr)
             updateRelativeLengthsInformation();
-            updateSVGRendererForElementChange();
-        }
         return;
     }
 


### PR DESCRIPTION
#### 27a59f0ec20efd6724c6b8d6ba49d5d47baf52b8
<pre>
REGRESSION(313859@main): SVGForeignObjectElement dynamic x/y take no effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=321122">https://bugs.webkit.org/show_bug.cgi?id=321122</a>

Reviewed by Sam Weinig.

Since 313859@main, LegacyRenderSVGForeignObject::layout() (and the LBSE
RenderSVGForeignObject::layout()) derive the viewport geometry from the
resolved style instead of the SVG animated properties. The x/y/width/height
attributes are presentation attributes mapped to the CSS x/y/width/height
properties, so the resolved style must be invalidated when they change.

SVGForeignObjectElement::svgAttributeChanged() only marked the presentational
hint style dirty for width/height. For x/y it invalidated the renderer without
refreshing the presentation style, so a style recalc never happened and layout
kept reading the stale x/y. Updating x/y via the SVG DOM property
(x.baseVal.value = ...) therefore left the foreignObject at its old position.

Mark the presentational hint style dirty for all four geometry attributes,
matching how SVGRectElement handles its geometry attributes, and keep updating
the relative-lengths information for x/y.

Added new reftests to verify this functionality instead of relying on
svg/dynamic-updates/SVGForeignObjectElement-svgdom-x-prop.html which only
verify the logic through pixel testing, which isn&apos;t executed by default.

* LayoutTests/svg/foreignObject/foreignobject-svgdom-x-property-update-expected.html: Added.
* LayoutTests/svg/foreignObject/foreignobject-svgdom-x-property-update.html: Added.
* LayoutTests/svg/foreignObject/foreignobject-svgdom-y-property-update-expected.html: Added.
* LayoutTests/svg/foreignObject/foreignobject-svgdom-y-property-update.html: Added.
* Source/WebCore/svg/SVGForeignObjectElement.cpp:
(WebCore::SVGForeignObjectElement::svgAttributeChanged):

Canonical link: <a href="https://commits.webkit.org/318669@main">https://commits.webkit.org/318669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c2b0308136b55ee612cccf5d49fa55617240942

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188821 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52641 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120020 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41838 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152237 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39830 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/128 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45537 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191041 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159844 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/148798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39923 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53281 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148546 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43239 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125551 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51799 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14809 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51184 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->