### PR TITLE
[GFC] Enable negative grid line numbers for column and row placement

### DIFF
--- a/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-expected.txt
@@ -1,0 +1,4 @@
+This test checks that grid items placed with negative grid line numbers, which count backwards from the end of the explicit grid, are positioned in the correct grid area. It also covers placements which name one edge with a positive line and the other with a negative line.
+
+PASS
+PASS

--- a/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-leading-implicit-tracks-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-leading-implicit-tracks-expected.txt
@@ -1,0 +1,5 @@
+This test checks that a negative grid line which counts past the start edge of the explicit grid generates leading implicit tracks, sized by grid-auto-columns and grid-auto-rows, and that every other item shifts forward by those tracks. The first grid needs one leading track per axis, the second needs two, and the third also has gutters, which apply between a leading implicit track and the explicit grid just as they do between explicit tracks.
+
+PASS
+PASS
+PASS

--- a/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-leading-implicit-tracks.html
+++ b/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-leading-implicit-tracks.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+    display: grid;
+    position: relative;
+}
+
+.oneLeadingTrack {
+    grid-template-columns: 50px 50px;
+    grid-template-rows: 40px;
+    grid-auto-columns: 30px;
+    grid-auto-rows: 20px;
+}
+
+.twoLeadingTracks {
+    grid-template-columns: 50px;
+    grid-template-rows: 40px;
+    grid-auto-columns: 20px;
+    grid-auto-rows: 10px;
+}
+
+.leadingTracksWithGaps {
+    grid-template-columns: 50px 50px;
+    grid-template-rows: 40px;
+    grid-auto-columns: 30px;
+    grid-auto-rows: 20px;
+    column-gap: 10px;
+    row-gap: 5px;
+}
+
+.item {
+    background-color: green;
+}
+</style>
+<script src="../../resources/check-layout.js"></script>
+<body onload="checkLayout('.grid');">
+
+<p>This test checks that a negative grid line which counts past the start edge of the explicit grid generates leading implicit tracks, sized by grid-auto-columns and grid-auto-rows, and that every other item shifts forward by those tracks. The first grid needs one leading track per axis, the second needs two, and the third also has gutters, which apply between a leading implicit track and the explicit grid just as they do between explicit tracks.</p>
+
+<div class="grid oneLeadingTrack">
+    <div class="item" style="grid-column: -4 / -3; grid-row: -3 / -2;" data-offset-x="0" data-offset-y="0" data-expected-width="30" data-expected-height="20"></div>
+    <div class="item" style="grid-column: -3 / -2; grid-row: -2 / -1;" data-offset-x="30" data-offset-y="20" data-expected-width="50" data-expected-height="40"></div>
+    <div class="item" style="grid-column: 2 / 3; grid-row: 1 / 2;" data-offset-x="80" data-offset-y="20" data-expected-width="50" data-expected-height="40"></div>
+</div>
+
+<div class="grid twoLeadingTracks">
+    <div class="item" style="grid-column: -4 / -3; grid-row: -4 / -3;" data-offset-x="0" data-offset-y="0" data-expected-width="20" data-expected-height="10"></div>
+    <div class="item" style="grid-column: -3 / -2; grid-row: -3 / -2;" data-offset-x="20" data-offset-y="10" data-expected-width="20" data-expected-height="10"></div>
+    <div class="item" style="grid-column: -2 / -1; grid-row: -2 / -1;" data-offset-x="40" data-offset-y="20" data-expected-width="50" data-expected-height="40"></div>
+</div>
+
+<div class="grid leadingTracksWithGaps">
+    <div class="item" style="grid-column: -4 / -3; grid-row: -3 / -2;" data-offset-x="0" data-offset-y="0" data-expected-width="30" data-expected-height="20"></div>
+    <div class="item" style="grid-column: -3 / -2; grid-row: -2 / -1;" data-offset-x="40" data-offset-y="25" data-expected-width="50" data-expected-height="40"></div>
+    <div class="item" style="grid-column: 2 / 3; grid-row: 1 / 2;" data-offset-x="100" data-offset-y="25" data-expected-width="50" data-expected-height="40"></div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-many-leading-implicit-tracks-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-many-leading-implicit-tracks-expected.txt
@@ -1,0 +1,4 @@
+This test checks placements which need many leading implicit columns. GFC only takes on a bounded number of them, because its implicit grid is a dense matrix, so the second grid here falls back to the legacy path. Both paths have to agree: with three explicit columns, a column start of -14 resolves ten lines before the explicit grid and a start of -15 resolves eleven, so the explicit grid begins at 200px and 220px respectively.
+
+PASS
+PASS

--- a/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-many-leading-implicit-tracks.html
+++ b/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-many-leading-implicit-tracks.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+    display: grid;
+    position: relative;
+    grid-template-columns: 50px 50px 50px;
+    grid-template-rows: 40px;
+    grid-auto-columns: 20px;
+}
+
+.item {
+    background-color: green;
+}
+</style>
+<script src="../../resources/check-layout.js"></script>
+<body onload="checkLayout('.grid');">
+
+<p>This test checks placements which need many leading implicit columns. GFC only takes on a bounded number of them, because its implicit grid is a dense matrix, so the second grid here falls back to the legacy path. Both paths have to agree: with three explicit columns, a column start of -14 resolves ten lines before the explicit grid and a start of -15 resolves eleven, so the explicit grid begins at 200px and 220px respectively.</p>
+
+<div class="grid">
+    <div class="item" style="grid-column: -14 / -13; grid-row: 1 / 2;" data-offset-x="0" data-offset-y="0" data-expected-width="20" data-expected-height="40"></div>
+    <div class="item" style="grid-column: -4 / -3; grid-row: 1 / 2;" data-offset-x="200" data-offset-y="0" data-expected-width="50" data-expected-height="40"></div>
+</div>
+
+<div class="grid">
+    <div class="item" style="grid-column: -15 / -14; grid-row: 1 / 2;" data-offset-x="0" data-offset-y="0" data-expected-width="20" data-expected-height="40"></div>
+    <div class="item" style="grid-column: -4 / -3; grid-row: 1 / 2;" data-offset-x="220" data-offset-y="0" data-expected-width="50" data-expected-height="40"></div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-with-gaps-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-with-gaps-expected.txt
@@ -1,0 +1,3 @@
+This test checks that negative grid line numbers resolve against the explicit grid independently of the gutters, so an item placed with negative lines lands in the same grid area as the equivalent positive-line placement and is offset by the preceding gaps.
+
+PASS

--- a/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-with-gaps.html
+++ b/LayoutTests/fast/css-grid-layout/grid-negative-line-placement-with-gaps.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+    display: grid;
+    position: relative;
+    grid-template-columns: 50px 50px 50px;
+    grid-template-rows: 30px 30px;
+    row-gap: 10px;
+    column-gap: 20px;
+}
+
+.item {
+    background-color: green;
+}
+</style>
+<script src="../../resources/check-layout.js"></script>
+<body onload="checkLayout('.grid');">
+
+<p>This test checks that negative grid line numbers resolve against the explicit grid independently of the gutters, so an item placed with negative lines lands in the same grid area as the equivalent positive-line placement and is offset by the preceding gaps.</p>
+
+<div class="grid">
+    <div class="item" style="grid-column: -4 / -3; grid-row: -3 / -2;" data-offset-x="0" data-offset-y="0" data-expected-width="50" data-expected-height="30"></div>
+    <div class="item" style="grid-column: -2 / -1; grid-row: -2 / -1;" data-offset-x="140" data-offset-y="40" data-expected-width="50" data-expected-height="30"></div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-negative-line-placement.html
+++ b/LayoutTests/fast/css-grid-layout/grid-negative-line-placement.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+    display: grid;
+    position: relative;
+}
+
+.threeColumnsTwoRows {
+    grid-template-columns: 50px 100px 50px;
+    grid-template-rows: 40px 60px;
+}
+
+.mixedSignGrid {
+    grid-template-columns: 60px 40px 80px;
+    grid-template-rows: 30px 50px;
+}
+
+.item {
+    background-color: green;
+}
+</style>
+<script src="../../resources/check-layout.js"></script>
+<body onload="checkLayout('.grid');">
+
+<p>This test checks that grid items placed with negative grid line numbers, which count backwards from the end of the explicit grid, are positioned in the correct grid area. It also covers placements which name one edge with a positive line and the other with a negative line.</p>
+
+<div class="grid threeColumnsTwoRows">
+    <div class="item" style="grid-column: -4 / -3; grid-row: -3 / -2;" data-offset-x="0" data-offset-y="0" data-expected-width="50" data-expected-height="40"></div>
+    <div class="item" style="grid-column: -3 / -2; grid-row: -3 / -2;" data-offset-x="50" data-offset-y="0" data-expected-width="100" data-expected-height="40"></div>
+    <div class="item" style="grid-column: -2 / -1; grid-row: -3 / -2;" data-offset-x="150" data-offset-y="0" data-expected-width="50" data-expected-height="40"></div>
+    <div class="item" style="grid-column: -4 / -3; grid-row: -2 / -1;" data-offset-x="0" data-offset-y="40" data-expected-width="50" data-expected-height="60"></div>
+    <div class="item" style="grid-column: -3 / -2; grid-row: -2 / -1;" data-offset-x="50" data-offset-y="40" data-expected-width="100" data-expected-height="60"></div>
+    <div class="item" style="grid-column: -2 / -1; grid-row: -2 / -1;" data-offset-x="150" data-offset-y="40" data-expected-width="50" data-expected-height="60"></div>
+</div>
+
+<div class="grid mixedSignGrid">
+    <div class="item" style="grid-column: 1 / -3; grid-row: 1 / -2;" data-offset-x="0" data-offset-y="0" data-expected-width="60" data-expected-height="30"></div>
+    <div class="item" style="grid-column: -3 / 3; grid-row: -3 / 2;" data-offset-x="60" data-offset-y="0" data-expected-width="40" data-expected-height="30"></div>
+    <div class="item" style="grid-column: -2 / 4; grid-row: 2 / -1;" data-offset-x="100" data-offset-y="30" data-expected-width="80" data-expected-height="50"></div>
+</div>
+
+</body>
+</html>

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
+#include "LayoutElementBox.h"
 #include "StyleGridPosition.h"
 
 namespace WebCore {
 namespace Layout {
 
-class ElementBox;
 class GridLayout;
 
 class UnplacedGridItem {

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -34,6 +34,7 @@
 #include "RenderText.h"
 #include "RenderView.h"
 #include "Settings.h"
+#include "UnplacedGridItem.h"
 #include <pal/Logging.h>
 #include <wtf/text/TextStream.h>
 
@@ -85,16 +86,18 @@ enum class GridAvoidanceReason : uint8_t {
     RelativeGridItemHasPercentageInset,
 
     GridItemColumnStartHasLineName,
-    GridItemColumnStartHasNegativeLineNumber,
     GridItemColumnStartHasSpan,
     GridItemHasColumnStartOutsideExplicitGrid,
+    GridItemNeedsLeadingImplicitColumnsWithMultipleAutoColumns,
+    GridItemNeedsTooManyLeadingImplicitColumns,
     GridItemHasUnsupportedColumnEnd,
 
     GridNeedsImplicitColumnsForItemsLockedToRow,
     GridItemRowStartHasLineName,
-    GridItemRowStartHasNegativeLineNumber,
     GridItemRowStartHasSpan,
     GridItemHasRowStartOutsideExplicitGrid,
+    GridItemNeedsLeadingImplicitRowsWithMultipleAutoRows,
+    GridItemNeedsTooManyLeadingImplicitRows,
     GridItemHasUnsupportedRowEnd,
 
     GridItemHasUnsupportedWidthValue,
@@ -112,9 +115,10 @@ static bool avoidanceReasonIsColumnPlacementRelated(GridAvoidanceReason gridAvoi
 {
     switch (gridAvoidanceReason) {
     case GridAvoidanceReason::GridItemColumnStartHasLineName:
-    case GridAvoidanceReason::GridItemColumnStartHasNegativeLineNumber:
     case GridAvoidanceReason::GridItemColumnStartHasSpan:
     case GridAvoidanceReason::GridItemHasColumnStartOutsideExplicitGrid:
+    case GridAvoidanceReason::GridItemNeedsLeadingImplicitColumnsWithMultipleAutoColumns:
+    case GridAvoidanceReason::GridItemNeedsTooManyLeadingImplicitColumns:
     case GridAvoidanceReason::GridItemHasUnsupportedColumnEnd:
         return true;
     default:
@@ -126,9 +130,10 @@ static bool avoidanceReasonIsRowPlacementRelated(GridAvoidanceReason gridAvoidan
 {
     switch (gridAvoidanceReason) {
     case GridAvoidanceReason::GridItemRowStartHasLineName:
-    case GridAvoidanceReason::GridItemRowStartHasNegativeLineNumber:
     case GridAvoidanceReason::GridItemRowStartHasSpan:
     case GridAvoidanceReason::GridItemHasRowStartOutsideExplicitGrid:
+    case GridAvoidanceReason::GridItemNeedsLeadingImplicitRowsWithMultipleAutoRows:
+    case GridAvoidanceReason::GridItemNeedsTooManyLeadingImplicitRows:
     case GridAvoidanceReason::GridItemHasUnsupportedRowEnd:
         return true;
     default:
@@ -153,26 +158,55 @@ static bool avoidanceReasonIsRowPlacementRelated(GridAvoidanceReason gridAvoidan
     }
 #endif
 
-static bool hasValidColumnEnd(const Style::GridPositionExplicit& explicitColumnStart, const Style::GridPosition columnEnd, size_t linesFromGridTemplateColumnsCount)
+// GFC's implicit grid is a dense matrix: ImplicitGrid's constructor allocates every cell of a
+// rows x columns matrix up front. The legacy Grid instead grows a row's storage only once that row
+// is used (see Grid::ensureStorageForRow), so it tolerates a sparse grid with a huge track count
+// that GFC cannot. A negative line may resolve as far as Style::GridPosition::min() lines before
+// the explicit grid, so leaving the leading implicit track count unbounded would let content force
+// a quadratic allocation. Cap what GFC takes on and leave the rest to the legacy path.
+static constexpr int maximumLeadingImplicitTracksCount = 10;
+
+// Resolves the 0-based line range for an axis whose start references an explicit line, using the
+// same mapping GFC applies in UnplacedGridItem::resolveDefinitePosition(). A negative CSS line
+// counts backward from the end of the explicit grid, so the resolved start line may be negative
+// when the placement counts past the start edge; those lines generate leading implicit tracks.
+static std::pair<int, int> resolveExplicitStartLineRange(const Style::GridPosition& explicitStart, const Style::GridPosition& end, size_t explicitTrackCount)
+{
+    ASSERT(explicitStart.isExplicit());
+    auto range = Layout::UnplacedGridItem::resolveDefinitePosition(explicitStart, end, explicitTrackCount);
+    ASSERT(range);
+    return *range;
+}
+
+// Resolves a start line that references an explicit line to its 0-based index. Whenever the start
+// is explicit its resolved line does not depend on the end at all, so pairing it with an auto end
+// makes this safe to call before the end kind has been validated.
+static int resolveExplicitStartLine(const Style::GridPosition& explicitStart, size_t explicitTrackCount)
+{
+    return resolveExplicitStartLineRange(explicitStart, CSS::Keyword::Auto { }, explicitTrackCount).first;
+}
+
+static bool hasValidColumnEnd(const Style::GridPosition& explicitColumnStart, const Style::GridPosition columnEnd, size_t explicitColumnCount)
 {
     return WTF::switchOn(columnEnd,
         [](const CSS::Keyword::Auto&) {
             return false;
         },
         [&](const Style::GridPositionExplicit&) {
-            if (!columnEnd.namedGridLine().value.isEmpty() || columnEnd.explicitPosition() < 0 || columnEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateColumnsCount))
+            if (!columnEnd.namedGridLine().value.isEmpty())
+                return false;
+
+            auto [startLine, endLine] = resolveExplicitStartLineRange(explicitColumnStart, columnEnd, explicitColumnCount);
+
+            // A negative end line may resolve before the start of the explicit grid, which generates
+            // leading implicit columns and is supported. Lines past the end edge are not.
+            if (endLine > static_cast<int>(explicitColumnCount))
                 return false;
 
             // FIXME: Multi-span items are not yet supported in intrinsic sizing
             // (see TrackSizingAlgorithm::sizeTracksForIntrinsicSizing).
             // Only accept items that span a single column.
-            auto startPosition = explicitColumnStart.position.value;
-            auto endPosition = columnEnd.explicitPosition();
-            auto gridLineDistance = endPosition - startPosition;
-            if (gridLineDistance != 1)
-                return false;
-
-            return true;
+            return endLine - startLine == 1;
         },
         [&](const Style::GridPositionSpan&) {
             return false;
@@ -223,26 +257,27 @@ static bool hasValidRowEnd(const CSS::Keyword::Auto& autoRowStart, const Style::
     );
 }
 
-static bool hasValidRowEnd(const Style::GridPositionExplicit& explicitRowStart, const Style::GridPosition rowEnd, size_t linesFromGridTemplateRowsCount)
+static bool hasValidRowEnd(const Style::GridPosition& explicitRowStart, const Style::GridPosition rowEnd, size_t explicitRowCount)
 {
     return WTF::switchOn(rowEnd,
         [&](const CSS::Keyword::Auto&) {
             return true;
         },
         [&](const Style::GridPositionExplicit&) {
-            if (!rowEnd.namedGridLine().value.isEmpty() || rowEnd.explicitPosition() < 0 || rowEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateRowsCount))
+            if (!rowEnd.namedGridLine().value.isEmpty())
+                return false;
+
+            auto [startLine, endLine] = resolveExplicitStartLineRange(explicitRowStart, rowEnd, explicitRowCount);
+
+            // A negative end line may resolve before the start of the explicit grid, which generates
+            // leading implicit rows and is supported. Lines past the end edge are not.
+            if (endLine > static_cast<int>(explicitRowCount))
                 return false;
 
             // FIXME: Multi-span items are not yet supported in intrinsic sizing
             // (see TrackSizingAlgorithm::sizeTracksForIntrinsicSizing).
             // Only accept items that span a single row.
-            auto startPosition = explicitRowStart.position.value;
-            auto endPosition = rowEnd.explicitPosition();
-            auto gridLineDistance = endPosition - startPosition;
-            if (gridLineDistance != 1)
-                return false;
-
-            return true;
+            return endLine - startLine == 1;
         },
         [&](const Style::GridPositionSpan&) {
             return false;
@@ -461,7 +496,9 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
 
     ASSERT(renderGridStyle->gridAutoFlow().isRow(),
         "If we end up supporting column auto flow before broader implicit grid support then the logic using explicitlyPlacedItemsInRowCount will need to be reworked to be based upon the auto flow direction");
-    Vector<size_t> explicitlyPlacedItemsInRowCount;
+    // Keyed by the resolved 0-based row line, which is negative for placements that count past the
+    // start edge of the explicit grid, so zero is a valid key.
+    HashMap<int, size_t, DefaultHash<int>, WTF::SignedWithZeroKeyHashTraits<int>> explicitlyPlacedItemsInRowCount;
 
     for (CheckedRef gridItem : childrenOfType<RenderBox>(renderGrid)) {
         // We do not yet support grid item sizing spec for replaced elements.
@@ -534,8 +571,8 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
         if (gridItemStyle->boxSizing() == BoxSizing::BorderBox)
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasBorderBoxSizing, reasons, reasonCollectionMode);
 
-        auto linesFromGridTemplateColumnsCount = gridTemplateColumns.sizes.size() + 1;
-        auto linesFromGridTemplateRowsCount = gridTemplateRows.sizes.size() + 1;
+        auto explicitColumnCount = gridTemplateColumns.sizes.size();
+        auto explicitRowCount = gridTemplateRows.sizes.size();
         auto& columnStart = gridItemStyle->gridItemColumnStart();
         auto columnPositioningAvoidanceReason = WTF::switchOn(columnStart,
             [&](const CSS::Keyword::Auto& autoPosition) -> std::optional<GridAvoidanceReason> {
@@ -544,16 +581,30 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
                     return GridAvoidanceReason::GridItemHasUnsupportedColumnEnd;
                 return { };
             },
-            [&](const Style::GridPositionExplicit& explicitPosition) -> std::optional<GridAvoidanceReason> {
-                auto columnStartLineNumber = explicitPosition.position.value;
+            [&](const Style::GridPositionExplicit&) -> std::optional<GridAvoidanceReason> {
                 if (!columnStart.namedGridLine().value.isEmpty())
                     return GridAvoidanceReason::GridItemColumnStartHasLineName;
-                if (columnStartLineNumber < 0)
-                    return GridAvoidanceReason::GridItemColumnStartHasNegativeLineNumber;
-                if (columnStartLineNumber > static_cast<int>(linesFromGridTemplateColumnsCount))
+
+                auto columnStartLine = resolveExplicitStartLine(columnStart, explicitColumnCount);
+                if (columnStartLine > static_cast<int>(explicitColumnCount))
                     return GridAvoidanceReason::GridItemHasColumnStartOutsideExplicitGrid;
-                if (!hasValidColumnEnd(explicitPosition, gridItemStyle->gridItemColumnEnd(), linesFromGridTemplateColumnsCount))
+
+                auto& columnEnd = gridItemStyle->gridItemColumnEnd();
+                if (!hasValidColumnEnd(columnStart, columnEnd, explicitColumnCount))
                     return GridAvoidanceReason::GridItemHasUnsupportedColumnEnd;
+
+                // A start line resolving before the explicit grid generates leading implicit columns.
+                // The item's own line is the most negative of its two, so capping per item also caps
+                // the count GridFormattingContext::computeLeadingImplicitTracks() arrives at.
+                if (columnStartLine < -maximumLeadingImplicitTracksCount)
+                    return GridAvoidanceReason::GridItemNeedsTooManyLeadingImplicitColumns;
+
+                // Per spec leading implicit tracks cycle grid-auto-columns backwards from the
+                // explicit grid, but GridLayout::generateImplicitTrackSizingFunctions() always
+                // cycles forwards, so it only produces the right sizes when there is a single track
+                // size to cycle through.
+                if (columnStartLine < 0 && renderGridStyle->gridAutoColumns().size() > 1)
+                    return GridAvoidanceReason::GridItemNeedsLeadingImplicitColumnsWithMultipleAutoColumns;
                 return { };
             },
             [&](const Style::GridPositionSpan&) -> std::optional<GridAvoidanceReason> {
@@ -576,25 +627,30 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
                     return GridAvoidanceReason::GridItemHasUnsupportedRowEnd;
                 return { };
             },
-            [&](const Style::GridPositionExplicit& explicitPosition) -> std::optional<GridAvoidanceReason> {
-                auto rowStartLineNumber = explicitPosition.position.value;
+            [&](const Style::GridPositionExplicit&) -> std::optional<GridAvoidanceReason> {
                 if (!rowStart.namedGridLine().value.isEmpty())
                     return GridAvoidanceReason::GridItemRowStartHasLineName;
-                if (rowStartLineNumber < 0)
-                    return GridAvoidanceReason::GridItemRowStartHasNegativeLineNumber;
-                if (rowStartLineNumber > static_cast<int>(linesFromGridTemplateRowsCount))
+
+                auto rowStartLine = resolveExplicitStartLine(rowStart, explicitRowCount);
+                if (rowStartLine > static_cast<int>(explicitRowCount))
                     return GridAvoidanceReason::GridItemHasRowStartOutsideExplicitGrid;
 
-                auto rowEnd = gridItemStyle->gridItemRowEnd();
-                if (!hasValidRowEnd(explicitPosition, rowEnd, linesFromGridTemplateRowsCount))
+                auto& rowEnd = gridItemStyle->gridItemRowEnd();
+                if (!hasValidRowEnd(rowStart, rowEnd, explicitRowCount))
                     return GridAvoidanceReason::GridItemHasUnsupportedRowEnd;
 
-                ASSERT(rowEnd.isExplicit());
-                size_t rowIndex = rowStartLineNumber + 1;
-                auto rowsCount = explicitlyPlacedItemsInRowCount.size();
-                if (rowIndex > rowsCount)
-                    explicitlyPlacedItemsInRowCount.insertFill(rowsCount, 0, rowIndex - rowsCount);
-                ++explicitlyPlacedItemsInRowCount[rowStartLineNumber];
+                // See the grid-auto-columns comments above for why leading implicit rows are capped
+                // and why they need a single grid-auto-rows track size.
+                if (rowStartLine < -maximumLeadingImplicitTracksCount)
+                    return GridAvoidanceReason::GridItemNeedsTooManyLeadingImplicitRows;
+
+                if (rowStartLine < 0 && renderGridStyle->gridAutoRows().size() > 1)
+                    return GridAvoidanceReason::GridItemNeedsLeadingImplicitRowsWithMultipleAutoRows;
+
+                // Key by the resolved line rather than the specified one so that two placements
+                // naming the same row through different line numbers (e.g. 1 and -4 on a grid with
+                // three explicit rows) share a bucket.
+                ++explicitlyPlacedItemsInRowCount.add(rowStartLine, 0).iterator->value;
                 return { };
             },
             [&](const Style::GridPositionSpan&) -> std::optional<GridAvoidanceReason> {
@@ -614,10 +670,14 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
         // explicit grid, then we may need to add additional columns to the implicit grid to place
         // them properly. We can be more fine grained than what we are doing now, but this is
         // a good start as we allow more complex placements.
-        auto ineligibleRowIndex = explicitlyPlacedItemsInRowCount.findIf([&](size_t itemsInRowCount) {
-            return itemsInRowCount >= linesFromGridTemplateColumnsCount;
-        });
-        if (ineligibleRowIndex != notFound)
+        auto hasRowWithTooManyExplicitlyPlacedItems = [&] {
+            for (auto itemsInRowCount : explicitlyPlacedItemsInRowCount.values()) {
+                if (itemsInRowCount >= explicitColumnCount + 1)
+                    return true;
+            }
+            return false;
+        };
+        if (hasRowWithTooManyExplicitlyPlacedItems())
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridNeedsImplicitColumnsForItemsLockedToRow, reasons, reasonCollectionMode);
 
         if (gridItemStyle->writingMode().isVertical() || gridItemStyle->writingMode().isBlockFlipped())
@@ -823,14 +883,17 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
     case GridAvoidanceReason::GridItemColumnStartHasLineName:
         stream << "grid item column start has line name";
         break;
-    case GridAvoidanceReason::GridItemColumnStartHasNegativeLineNumber:
-        stream << "grid item column start has negative line number";
-        break;
     case GridAvoidanceReason::GridItemColumnStartHasSpan:
         stream << "grid item column start has span";
         break;
     case GridAvoidanceReason::GridItemHasColumnStartOutsideExplicitGrid:
         stream << "grid item has column start outside explicit grid";
+        break;
+    case GridAvoidanceReason::GridItemNeedsLeadingImplicitColumnsWithMultipleAutoColumns:
+        stream << "grid item needs leading implicit columns with multiple grid-auto-columns track sizes";
+        break;
+    case GridAvoidanceReason::GridItemNeedsTooManyLeadingImplicitColumns:
+        stream << "grid item needs too many leading implicit columns";
         break;
     case GridAvoidanceReason::GridItemHasUnsupportedColumnEnd:
         stream << "grid item has unsupported column end";
@@ -841,14 +904,17 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
     case GridAvoidanceReason::GridItemRowStartHasLineName:
         stream << "grid item row start has line name";
         break;
-    case GridAvoidanceReason::GridItemRowStartHasNegativeLineNumber:
-        stream << "grid item row start has negative line number";
-        break;
     case GridAvoidanceReason::GridItemRowStartHasSpan:
         stream << "grid item row start has span";
         break;
     case GridAvoidanceReason::GridItemHasRowStartOutsideExplicitGrid:
         stream << "grid item has row start outside explicit grid";
+        break;
+    case GridAvoidanceReason::GridItemNeedsLeadingImplicitRowsWithMultipleAutoRows:
+        stream << "grid item needs leading implicit rows with multiple grid-auto-rows track sizes";
+        break;
+    case GridAvoidanceReason::GridItemNeedsTooManyLeadingImplicitRows:
+        stream << "grid item needs too many leading implicit rows";
         break;
     case GridAvoidanceReason::GridItemHasUnsupportedRowEnd:
         stream << "grid item has unsupported row end";


### PR DESCRIPTION
#### fb26aaf85687a871433470f2d9b59dd3634b345d
<pre>
[GFC] Enable negative grid line numbers for column and row placement
<a href="https://bugs.webkit.org/show_bug.cgi?id=NNNNNN">https://bugs.webkit.org/show_bug.cgi?id=NNNNNN</a>
<a href="https://rdar.apple.com/NNNNNNNNN">rdar://NNNNNNNNN</a>

Reviewed by NOBODY (OOPS!).

GFC already had everything needed to place items with negative grid lines:
UnplacedGridItem::resolveDefinitePosition() maps a negative line backwards from
the end of the explicit grid, GridFormattingContext::computeLeadingImplicitTracks()
computes the shift for lines that resolve past the start edge, and
GridLayout::trackSizingFunctions() generates sizing functions for the resulting
leading implicit tracks. Only the coverage gate kept these placements on the
legacy RenderGrid path, so this change relaxes the gate for both axes.

The gate used to validate the raw CSS line values, which cannot work once the two
edges of a placement may have different signs. On a three column grid,
grid-column: 3 / -1 is a legal single-track placement, but its raw distance is
-1 - 3 = -4, so the single-span check would have rejected it. Coverage now
resolves both edges through UnplacedGridItem::resolveDefinitePosition(), the same
function GFC uses, and applies the existing bounds to the resolved indices. The
upper bound is unchanged in effect; the lower bound is replaced by a cap on how
many leading implicit tracks GFC will take on, described below.

Reusing GFC&apos;s resolution requires including UnplacedGridItem.h, which
GridFormattingContext.h does not pull in. That is preferable to duplicating the
negative line formula in coverage, where it could silently drift from the
resolution GFC actually performs.

explicitlyPlacedItemsInRowCount was a Vector indexed by the raw CSS row line. It
is now keyed by the resolved row line, which is needed for two reasons: a negative
raw line would index the Vector out of bounds, and two placements naming the same
row through different line numbers (1 and -4 on a grid with three explicit rows)
would otherwise land in separate buckets and defeat the
GridNeedsImplicitColumnsForItemsLockedToRow guard. The key can be zero or
negative, hence SignedWithZeroKeyHashTraits.

A negative line can resolve as far as Style::GridPosition::min() lines before the
explicit grid, and GFC cannot absorb that. ImplicitGrid&apos;s constructor allocates
every cell of a rows x columns matrix up front, whereas the legacy Grid grows a
given row&apos;s storage only once that row is used, in Grid::ensureStorageForRow. So
where legacy handles a sparse grid with a large track count in memory linear in
the track counts, GFC needs the full product: grid-column and grid-row both
starting at -3000 on a 1x1 explicit grid is roughly 3000 x 3000 x 72 bytes, and
at the clamp of 1000000 it is a guaranteed allocation failure. GFC therefore takes
on at most maximumLeadingImplicitTracksCount leading tracks per axis;
GridItemNeedsTooManyLeadingImplicitColumns and
GridItemNeedsTooManyLeadingImplicitRows keep the rest on the legacy path. Capping
per item is sufficient because an item&apos;s start line is the more negative of its
two lines, so it also caps what computeLeadingImplicitTracks() arrives at.

Leading implicit tracks are held back in one further case.
GridLayout::generateImplicitTrackSizingFunctions() cycles multi-value
grid-auto-{columns,rows} forwards for leading implicit tracks, whereas the spec
cycles them backwards from the explicit grid, as its FIXME notes. Nothing gated
grid-auto-{columns,rows} before, so enabling leading implicit tracks would newly
expose that as wrong track sizes. GridItemNeedsLeadingImplicitColumnsWithMultipleAutoColumns
and GridItemNeedsLeadingImplicitRowsWithMultipleAutoRows keep those grids on the
legacy path until the cycling is fixed.

The new tests exercise the newly enabled GFC path, covering negative lines within
the explicit grid, mixed sign placements, one and two leading implicit tracks per
axis, leading implicit tracks combined with gutters, and the cap boundary where
one grid runs on GFC and the next falls back to legacy. They also pass on the
legacy path, which is the required invariant, since there is no test visible signal
for which path ran; their value is catching a GFC regression in negative line
resolution or in leading implicit track sizing.

* LayoutTests/fast/css-grid-layout/grid-negative-line-placement-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/grid-negative-line-placement-leading-implicit-tracks-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/grid-negative-line-placement-leading-implicit-tracks.html: Added.
* LayoutTests/fast/css-grid-layout/grid-negative-line-placement-many-leading-implicit-tracks-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/grid-negative-line-placement-many-leading-implicit-tracks.html: Added.
* LayoutTests/fast/css-grid-layout/grid-negative-line-placement-with-gaps-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/grid-negative-line-placement-with-gaps.html: Added.
* LayoutTests/fast/css-grid-layout/grid-negative-line-placement.html: Added.
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::resolveExplicitStartLineRange): Added.
(WebCore::LayoutIntegration::resolveExplicitStartLine): Added.
(WebCore::LayoutIntegration::hasValidColumnEnd): Validate the resolved line range
rather than the raw CSS line values.
(WebCore::LayoutIntegration::hasValidRowEnd): Ditto. Also drops an
ASSERT(rowEnd.isExplicit()) from the caller, which was reachable and wrong because
an auto row end is accepted here.
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9557e5ddb1afb3ec613177c8f61c779102aa171b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188839 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143319 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52659 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139587 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96739 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5574d3c-986c-43cc-b62a-8310d1f349b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120033 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41848 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40196 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39843 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/146 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191059 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52619 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148813 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53299 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148561 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43252 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125569 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120384 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51817 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14822 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51202 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51443 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51263 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->