### PR TITLE
[Fullscreen] Unwind fullscreen state when entering fullscreen fails

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -172,25 +172,32 @@ void WebFullScreenManagerProxy::setFullscreenAutoHideDuration(Seconds duration)
     sendToWebProcess(Messages::WebFullScreenManager::SetFullscreenAutoHideDuration(duration));
 }
 
+void WebFullScreenManagerProxy::closeFullScreen(IPC::Connection& connection)
+{
+    MESSAGE_CHECK_BASE(isFullScreenInSendingProcess(connection), connection);
+    close();
+}
+
 void WebFullScreenManagerProxy::close()
 {
     if (CheckedPtr client = m_client)
         client->closeFullScreenManager();
+
+    if (m_fullscreenState == FullscreenState::NotInFullscreen)
+        return;
+
+    m_fullscreenState = FullscreenState::NotInFullscreen;
+
+    if (auto frameID = std::exchange(m_fullScreenFrameID, { }))
+        exitFullScreenInOtherProcesses(*frameID, [] { });
+
+    if (RefPtr page = m_page.get())
+        page->fullscreenClient().didExitFullscreen(page.get());
 }
 
 void WebFullScreenManagerProxy::detachFromClient()
 {
     close();
-
-    // If we were in fullscreen, notify the client that fullscreen has exited,
-    // since the normal IPC round-trip through the web process won't complete
-    // after the page is closed.
-    if (m_fullscreenState != FullscreenState::NotInFullscreen) {
-        m_fullscreenState = FullscreenState::NotInFullscreen;
-        if (RefPtr page = m_page.get())
-            page->fullscreenClient().didExitFullscreen(page.get());
-    }
-
     m_client = nullptr;
 }
 
@@ -219,6 +226,16 @@ bool WebFullScreenManagerProxy::isFrameInSendingProcess(FrameIdentifier frameID,
     if (!page || !frame)
         return true;
     return frame->page() == page.get() && &frame->process() == WebProcessProxy::fromConnection(connection).ptr();
+}
+
+bool WebFullScreenManagerProxy::isFullScreenInSendingProcess(IPC::Connection& connection) const
+{
+    if (m_fullScreenFrameID)
+        return isFrameInSendingProcess(*m_fullScreenFrameID, connection);
+    RefPtr fullScreenProcess = m_fullScreenProcess.get();
+    if (!fullScreenProcess)
+        return true;
+    return fullScreenProcess.get() == WebProcessProxy::fromConnection(connection).ptr();
 }
 
 Awaitable<bool> WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& connection, FrameIdentifier frameID, bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails mediaDetails)

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -139,10 +139,12 @@ private:
     Awaitable<void> exitFullScreen();
     Awaitable<bool> beganEnterFullScreen(IPC::Connection&, WebCore::FrameIdentifier, WebCore::IntRect initialFrameInRootViewCoordinates, WebCore::IntRect finalFrameInRootViewCoordinates);
     Awaitable<void> beganExitFullScreen(WebCore::IntRect initialFrameInRootViewCoordinates, WebCore::IntRect finalFrameInRootViewCoordinates);
+    void closeFullScreen(IPC::Connection&);
     void callCloseCompletionHandlers();
     template<typename M> void sendToWebProcess(M&&);
 
     bool isFrameInSendingProcess(WebCore::FrameIdentifier, IPC::Connection&) const;
+    bool isFullScreenInSendingProcess(IPC::Connection&) const;
 
     std::optional<std::pair<WebCore::IntRect, WebCore::IntRect>> convertFromRootViewToScreenCoordinates(std::pair<WebCore::IntRect, WebCore::IntRect> rectsInRootViewCoordinates);
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
@@ -35,6 +35,6 @@ messages -> WebFullScreenManagerProxy {
     ExitFullScreen() -> ()
     BeganEnterFullScreen(WebCore::FrameIdentifier frameID, WebCore::IntRect initialRect, WebCore::IntRect finalRect) -> (bool success)
     BeganExitFullScreen(WebCore::IntRect initialRect, WebCore::IntRect finalRect) -> ()
-    Close()
+    CloseFullScreen()
 }
 #endif

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -494,6 +494,8 @@ void WebFullScreenManager::performEnterFullScreen()
                 willEnterFullScreen(element, WTF::move(willEnterFullScreenCallback), WTF::move(didEnterFullScreenCallback));
                 return;
             }
+            m_page->prepareToExitElementFullScreen();
+            invalidate();
             willEnterFullScreenCallback(Exception { ExceptionCode::InvalidStateError });
             didEnterFullScreenCallback(false);
         });
@@ -565,8 +567,12 @@ void WebFullScreenManager::willEnterFullScreen(Element& element, CompletionHandl
     m_page->isInFullscreenChanged(WebPage::IsInFullscreenMode::Yes);
 
     auto result = protect(protect(element.document())->fullscreen())->willEnterFullscreen(element, mode);
-    if (result.hasException())
+    if (result.hasException()) {
         close();
+        willEnterFullscreenCallback(result);
+        didEnterFullscreenCallback(false);
+        return;
+    }
     willEnterFullscreenCallback(result);
 
 #if !PLATFORM(IOS_FAMILY)
@@ -577,6 +583,7 @@ void WebFullScreenManager::willEnterFullScreen(Element& element, CompletionHandl
 
     RefPtr frame = element.document().frame();
     if (!frame) {
+        close();
         didEnterFullscreenCallback(false);
         return;
     }
@@ -801,6 +808,7 @@ void WebFullScreenManager::close()
         return;
     m_closing = true;
     ALWAYS_LOG(LOGIDENTIFIER);
+    m_page->isInFullscreenChanged(WebPage::IsInFullscreenMode::No);
     m_page->closeFullScreen();
     invalidate();
     m_closing = false;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5869,7 +5869,7 @@ void WebPage::closeFullScreen()
 {
     removeReasonsToDisallowLayoutViewportHeightExpansion(DisallowLayoutViewportHeightExpansionReason::ElementFullScreen);
 
-    send(Messages::WebFullScreenManagerProxy::Close());
+    send(Messages::WebFullScreenManagerProxy::CloseFullScreen());
 }
 
 void WebPage::prepareToEnterElementFullScreen()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenRemoveNodeBeforeEnter.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenRemoveNodeBeforeEnter.mm
@@ -76,6 +76,51 @@ TEST(Fullscreen, RemoveNodeBeforeEnter)
     } while (++tries <= 100);
 
     ASSERT_FALSE([webView _isInFullscreen]);
+    EXPECT_EQ([webView fullscreenState], WKFullscreenStateNotInFullscreen);
+}
+
+TEST(Fullscreen, RemoveFrameBeforeEnter)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration preferences].elementFullscreenEnabled = YES;
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+
+    [webView synchronouslyLoadHTMLString:
+        @"<html><head><script>"
+        @"function enterFullscreenThenRemoveFrame() { "
+        @"    let frame = document.querySelector('iframe');"
+        @"    frame.contentDocument.querySelector('div').webkitRequestFullscreen();"
+        @"    setTimeout(() => { "
+        @"        frame.parentNode.removeChild(frame);"
+        @"        window.webkit.messageHandlers.testHandler.postMessage(\"frameremoved\");"
+        @"    });"
+        @"}"
+        @"</script></head><body>"
+        @"<iframe allowfullscreen srcdoc=\"<div>some text</div>\"></iframe>"
+        @"</body></html>"];
+
+    ASSERT_FALSE([webView _isInFullscreen]);
+
+    __block bool frameRemoved = false;
+    [webView performAfterReceivingMessage:@"frameremoved" action:^{ frameRemoved = true; }];
+
+    [webView evaluateJavaScript:@"enterFullscreenThenRemoveFrame()" completionHandler:nil];
+
+    TestWebKitAPI::Util::run(&frameRemoved);
+
+    // Allow the potential negative result time to occur.
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    // Fullscreen mode should eventually close.
+    int tries = 0;
+    do {
+        if (![webView _isInFullscreen] && [webView fullscreenState] == WKFullscreenStateNotInFullscreen)
+            break;
+        TestWebKitAPI::Util::runFor(0.1_s);
+    } while (++tries <= 100);
+
+    ASSERT_FALSE([webView _isInFullscreen]);
+    EXPECT_EQ([webView fullscreenState], WKFullscreenStateNotInFullscreen);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### ebc2413b86622c54219f311b81a98ccdd4b7063d
<pre>
[Fullscreen] Unwind fullscreen state when entering fullscreen fails
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=321123">https://bugs.webkit.org/show_bug.cgi?id=321123</a>&gt;
&lt;<a href="https://rdar.apple.com/problem/184157871">rdar://problem/184157871</a>&gt;

Reviewed by Charlie Wolfe.

The UI process sets m_fullscreenState and fullscreens the owner elements in the
processes hosting ancestor frames before the web process confirms entering. Only
beganExitFullScreen undoes that, and the failure paths send CloseFullScreen()
instead of reaching it, so the page and its ancestor frames stay fullscreened for
the lifetime of the page.

Unwind in close(), since CloseFullScreen() means fullscreen failed or is over:
reset m_fullscreenState, exit fullscreen in the ancestor processes, and notify the
fullscreen client. Every process hosting a frame of the page can send that
message, so the handler now message checks the sender against the process that
owns fullscreen. Rename Close() to CloseFullScreen() to keep that checked handler
distinct from close(), which detachFromClient and closeWithCallback call with no
sender to validate.

The web process keeps the same state stuck: only didExitFullScreen resets
WebPage::m_isInFullscreenMode, which selects native viewport parameters on iOS.
Reset it in WebFullScreenManager::close() too, and return early when
willEnterFullscreen() throws, since that path closed and then sent
BeganEnterFullScreen anyway.

performEnterFullScreen cleans up locally when the UI process declines: nothing was
entered there, and m_fullScreenFrameID can belong to another process.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::closeFullScreen):
(WebKit::WebFullScreenManagerProxy::close):
(WebKit::WebFullScreenManagerProxy::detachFromClient):
(WebKit::WebFullScreenManagerProxy::isFullScreenInSendingProcess const):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::performEnterFullScreen):
(WebKit::WebFullScreenManager::willEnterFullScreen):
(WebKit::WebFullScreenManager::close):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::closeFullScreen):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenRemoveNodeBeforeEnter.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/319243@main">https://commits.webkit.org/319243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c28bafb10a1eb767c159a9e79fd8769f47cf2272

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144979 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140906 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97624 "2 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3439d094-f4ca-49f2-9806-9da0ef3ac9a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121358 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c000a89-c341-40d6-8d7f-0b9866f9294c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43256 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41539 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41210 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2029 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192805 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54268 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150287 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40277 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54956 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150004 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44622 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127221 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122437 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53473 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16203 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52855 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53092 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52920 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->