### PR TITLE
Web Extensions sidebar is rendered per-tab instead of per-window, even in the absence of tab-specific sidebars

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -883,9 +883,15 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> NODELETE toI
 - (_WKWebExtensionSidebar *)sidebarForTab:(id<WKWebExtensionTab>)tab
 {
     Ref extensionContext { *_webExtensionContext };
-    if (RefPtr maybeSidebar = extensionContext->getOrCreateSidebar(toImplNullable(tab, extensionContext.get())))
-        return maybeSidebar->wrapper();
-    return nil;
+    RefPtr implTab = toImplNullable(tab, extensionContext.get());
+    if (!implTab)
+        return nil;
+
+    auto sidebar = extensionContext->sidebarForTab(*implTab);
+    if (!sidebar || !sidebar.value()->opensSidebar())
+        return nil;
+
+    return sidebar.value()->wrapper();
 }
 #else
 - (_WKWebExtensionSidebar *)sidebarForTab:(id<WKWebExtensionTab>)tab

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h
@@ -66,12 +66,15 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 - (void)_resetCommands;
 
 /*!
- @abstract Retrieves the extension sidebar for a given tab, or the default sidebar if `nil` is passed.
- @param tab The tab for which to retrieve the extension sidebar, or `nil` to get the default sidebar.
- @discussion The returned object represents the sidebar specific to the tab when provided; otherwise, it returns the default sidebar.
- The default sidebar should not be directly displayed. When possible, specify the tab to get the most context-relevant sidebar.
+ @abstract Retrieves the extension sidebar which applies to a given tab.
+ @param tab The tab for which to retrieve the extension sidebar.
+ @result The sidebar for that tab, or `nil` if the extension has no sidebar to show there.
+ @discussion The same object is returned for every tab in a window which the extension has not set tab-specific
+ overrides for.  Successive results can be compared by identity when the user switches tabs to determine if the
+ sidebar must also be switched. The returned sidebar's `WKWebView` may likewise be shared with the sidebars of
+ other tabs in the window, even if the sidebar object itself may have tab-specific overrides.
  */
-- (nullable _WKWebExtensionSidebar *)sidebarForTab:(nullable id <WKWebExtensionTab>)tab NS_SWIFT_NAME(sidebar(for:));
+- (nullable _WKWebExtensionSidebar *)sidebarForTab:(id <WKWebExtensionTab>)tab NS_SWIFT_NAME(sidebar(for:));
 
 /*! @abstract Whether the extension context has access to file:// URLs.
  @discussion When YES, the extension can inject content into and interact with file:// pages. Defaults to NO. */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
@@ -109,7 +109,9 @@ WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
  @param context The context within which the web extension is running.
  @param completionHandler A block to be called once the sidebar has been opened.
  @discussion This method is called in response to the extension's scripts programmatically requesting the sidebar to open. Implementing this method
- is needed if the app intends to support programmatically showing the sidebar from the extension.
+ is needed if the app intends to support programmatically showing the sidebar from the extension. The sidebar pane is shown or hidden per window, so
+ it should stay open as the user switches tabs; the app is responsible for displaying whichever sidebar applies to the tab which becomes active, which it
+ can obtain with ``-[WKWebExtensionContext sidebarForTab:]``.
  */
 - (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller presentSidebar:(_WKWebExtensionSidebar * _Nonnull)sidebar forExtensionContext:(WKWebExtensionContext * _Nonnull)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
@@ -119,17 +121,34 @@ WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
  @param sidebar The sidebar which should be closed.
  @param context The context within which the web extension is running.
  @param completionHandler A block to be called once the sidebar has been closed.
- @discussion This method is called in response to the extension's scripts programmatically requesting the sidebar to close. Implementing this method is needed if the app intends to support programmatically closing the sidebar from the extension.
+ @discussion This method is called in response to the extension's scripts programmatically requesting the sidebar to close. Implementing this method is
+ needed if the app intends to support programmatically closing the sidebar from the extension. This should close the sidebar's pane in the sidebar's
+ browser window, if the given sidebar object is currently being displayed.
  */
 - (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller closeSidebar:(_WKWebExtensionSidebar * _Nonnull)sidebar forExtensionContext:(WKWebExtensionContext * _Nonnull)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
- @abstract Called when a sidebar's properties must be re-queried by the browser.
+ @abstract Called when a sidebar's properties have changed and it should be re-read.
  @param controller The web extension controller initiating the request.
- @param sidebar The sidebar whose properties must be re-queried.
+ @param sidebar The sidebar whose properties changed.
  @param context The context within which the web extension is running.
+ @discussion Use ``associatedTab`` and ``associatedWindow`` to tell which tabs are affected: a sidebar specific to a tab
+ affects only that tab, while one which is not affects every tab in ``associatedWindow`` which the extension has not
+ singled out. This method is not called when a tab ceases to have a tab-specific override; instead, see:
+ ``-_webExtensionController:didInvalidateSidebar:forExtensionContext:``.
  */
 - (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller didUpdateSidebar:(_WKWebExtensionSidebar * _Nonnull)sidebar forExtensionContext:(WKWebExtensionContext * _Nonnull)context;
+
+/*!
+ @abstract Called when a sidebar is no longer valid and should stop being displayed.
+ @param controller The web extension controller initiating the request.
+ @param sidebar The sidebar which is no longer valid.
+ @param context The context within which the web extension is running.
+ @discussion This is sent when a tab stops having a sidebar of its own. The given ``sidebar`` is the one
+ being discarded; stop displaying it, and obtain the sidebar which now applies to its ``associatedTab``
+ with ``-[WKWebExtensionContext sidebarForTab:]``.
+ */
+- (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller didInvalidateSidebar:(_WKWebExtensionSidebar * _Nonnull)sidebar forExtensionContext:(WKWebExtensionContext * _Nonnull)context;
 
 /*!
  @abstract Called when the root-level bookmarks are needed to begin building the bookmark tree.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.h
@@ -29,6 +29,7 @@
 @class WKWebExtensionContext;
 @class WKWebView;
 @protocol WKWebExtensionTab;
+@protocol WKWebExtensionWindow;
 
 #if TARGET_OS_IPHONE
 @class UIImage;
@@ -41,8 +42,13 @@
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*!
- @abstract A `_WKWebExtensionSidebar` object encapsulates the properties for a specific web extension sidebar.
- @discussion When this property is `nil`, it indicates that the action is the default action and not associated with a specific tab.
+ @abstract A `_WKWebExtensionSidebar` object encapsulates the properties of a web extension sidebar.
+ @discussion An extension may specify a sidebar for a particular tab or for a whole window. Use
+ ``-[WKWebExtensionContext sidebarForTab:]`` to obtain the sidebar which applies to a tab. Every tab in a
+ window which the extension has not set unique properties for is given the same sidebar object, so comparing successive
+ results by identity tells the app whether anything needs to change when the user switches tabs. The sidebar pane
+ itself is shown or hidden per window; when a tab has a sidebar of its own, the app swaps between sidebars by
+ closing the one being replaced and opening the one taking its place.
  */
 WK_CLASS_AVAILABLE(macos(15.2), ios(18.2), visionos(2.2))
 @interface _WKWebExtensionSidebar : NSObject
@@ -53,7 +59,16 @@ WK_CLASS_AVAILABLE(macos(15.2), ios(18.2), visionos(2.2))
 /*! @abstract The extension context to which this sidebar is related. */
 @property (nonatomic, nullable, readonly, weak) WKWebExtensionContext *webExtensionContext;
 
-/*! @abstract The tab that this sidebar is associated with, or `nil` if it is the default sidebar */
+/*!
+ @abstract The window this sidebar belongs to.
+ */
+@property (nonatomic, readonly, weak) id <WKWebExtensionWindow> associatedWindow;
+
+/*!
+ @abstract The tab this sidebar is specific to, or `nil` if it applies to its whole window.
+ @discussion When this property is nil, this sidebar should be the global default for ``associatedWindow``. Otherwise,
+ it should only be showed alongside ``associatedTab``.
+ */
 @property (nonatomic, nullable, readonly, weak) id <WKWebExtensionTab> associatedTab;
 
 /*! @abstract The title of this sidebar. */
@@ -73,39 +88,50 @@ WK_CLASS_AVAILABLE(macos(15.2), ios(18.2), visionos(2.2))
 /*! @abstract Whether this sidebar is enabled or not. */
 @property (nonatomic, readonly, getter=isEnabled) BOOL enabled;
 
-/*! @abstract The web view which should be displayed when this sidebar is opened, or `nil` if this sidebar is not a tab-specific sidebar. */
-@property (nonatomic, nullable, readonly) WKWebView *webView;
+/*!
+ @abstract The web view which renders this sidebar's content.
+ @discussion Sidebars which show the same document share a web view, so this may return the same web view for
+ several sidebars. Other properties, such as title and icon, may still differ in cases where different sidebars share the
+ same WKWebView.
+ */
+@property (nonatomic, readonly) WKWebView *webView;
 
 #if TARGET_OS_IPHONE
 /*!
- @abstract A view controller that presents a web view which will load the sidebar page for this sidebar, or `nil` if this sidebar
- is not a tab-specific sidebar.
+ @abstract A view controller which presents this sidebar's web view.
+ @discussion As with ``webView``, this may return the same view controller for several sidebars.
  */
-@property (nonatomic, nullable, readonly) UIViewController *viewController;
+@property (nonatomic, readonly) UIViewController *viewController;
 #endif
 
 #if TARGET_OS_OSX
 /*!
- @abstract The view controller that presents a web view which will load the sidebar page for this sidebar, or `nil` if this sidebar
- is not a tab-specific sidebar.
+ @abstract A view controller which presents this sidebar's web view.
+ @discussion As with ``webView``, this may return the same view controller for several sidebars.
  */
-@property (nonatomic, nullable, readonly) NSViewController *viewController;
+@property (nonatomic, readonly) NSViewController *viewController;
 #endif
 
 /*!
- @abstract Indicate that the sidebar will be opened
- @discussion This method should be invoked by the browser when this sidebar will be opened due to some action by the user. If
- this method is not called before the sidebar is opened, then the ``WKWebView`` associated with this sidebar may not have a
- document loaded, and the extension may not receive the `activeTab` permission from this user interaction.
+ @abstract Indicate that the sidebar will be opened.
+ @param fromUserInteraction Whether the sidebar is opening due to the user.
+ @discussion This method should be invoked by the browser before this sidebar is displayed. If it is not called, then the
+ ``WKWebView`` associated with this sidebar may not have a document loaded. It also marks this particular sidebar as the one
+ on screen, so when the app replaces one sidebar with another -- because the user moved to a tab which has a sidebar of its
+ own, for instance -- it should call ``willCloseSidebar`` on the one being replaced and this on the one taking its place.
+ Pass `YES` for `fromUserInteraction` only when the sidebar is opening due to direct user action, since that will grant
+ the extension the `activeTab` permission for the tab this sidebar applies to. Pass `NO` when the sidebar is opening as a side
+ effect of some other action (e.g. switching tabs), or generally not due to direct user intent.
  */
-- (void)willOpenSidebar;
+- (void)willOpenSidebarFromUserInteraction:(BOOL)fromUserInteraction;
 
 /*!
  @abstract Indicate that the sidebar will be closed
  @discussion This method should be invoked by the browser when the sidebar will be closed -- i.e., its associated ``WKWebView`` will cease
  to be displayed. If this method is not called when the sidebar is closed, then the sidebar's associated ``WKWebView`` may remain active longer than
  necessary. Note that calling this method does not guarantee that the ``WKWebView`` associated with a particular sidebar will be deallocated, as the
- web view may be shared between mutliple sidebars.
+ web view may be shared between mutliple sidebars. This should also be called on a sidebar which is being replaced by another (e.g. due to the user
+ switching tabs).
  */
 - (void)willCloseSidebar;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm
@@ -52,7 +52,9 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionSidebar, WebExtensionSideba
 
 - (NSString *)title
 {
-    return _webExtensionSidebar->title().createNSString().get();
+    auto *title = _webExtensionSidebar->title().createNSString().get();
+    ASSERT(title);
+    return title;
 }
 
 - (CocoaImage *)iconForSize:(CGSize)size
@@ -64,7 +66,9 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionSidebar, WebExtensionSideba
 
 - (SidebarViewControllerType *)viewController
 {
-    return _webExtensionSidebar->viewController().get();
+    auto *viewController = _webExtensionSidebar->viewController().get();
+    ASSERT(viewController);
+    return viewController;
 }
 
 - (BOOL)isEnabled
@@ -74,12 +78,14 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionSidebar, WebExtensionSideba
 
 - (WKWebView *)webView
 {
-    return _webExtensionSidebar->webView();
+    auto *webView = _webExtensionSidebar->webView();
+    ASSERT(webView);
+    return webView;
 }
 
-- (void)willOpenSidebar
+- (void)willOpenSidebarFromUserInteraction:(BOOL)fromUserInteraction
 {
-    _webExtensionSidebar->willOpenSidebar();
+    _webExtensionSidebar->willOpenSidebar(fromUserInteraction ? WebKit::WebExtensionSidebar::FromUserInteraction::Yes : WebKit::WebExtensionSidebar::FromUserInteraction::No);
 }
 
 - (void)willCloseSidebar
@@ -91,6 +97,20 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionSidebar, WebExtensionSideba
 {
     if (auto tab = _webExtensionSidebar->tab())
         return tab.value()->delegate();
+    return nil;
+}
+
+- (id<WKWebExtensionWindow>)associatedWindow
+{
+    if (auto window = _webExtensionSidebar->window())
+        return window.value()->delegate();
+
+    if (auto tab = _webExtensionSidebar->tab()) {
+        if (RefPtr window = tab.value()->window())
+            return window->delegate();
+    }
+
+    ASSERT_NOT_REACHED();
     return nil;
 }
 
@@ -145,7 +165,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionSidebar, WebExtensionSideba
     return nil;
 }
 
-- (void)willOpenSidebar
+- (void)willOpenSidebarFromUserInteraction:(BOOL)fromUserInteraction
 {
 }
 
@@ -154,6 +174,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionSidebar, WebExtensionSideba
 }
 
 - (id<WKWebExtensionTab>)associatedTab
+{
+    return nil;
+}
+
+- (id<WKWebExtensionWindow>)associatedWindow
 {
     return nil;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
@@ -149,6 +149,44 @@ void WebExtensionContext::closeSidebar(WebExtensionSidebar& sidebar)
     [controllerDelegate _webExtensionController:controllerWrapper closeSidebar:sidebarWrapper forExtensionContext:contextWrapper completionHandler:^(NSError *error) { }];
 }
 
+void WebExtensionContext::notifyDelegateOfSidebarUpdate(WebExtensionSidebar& sidebar)
+{
+    RefPtr controller = extensionController();
+    if (!controller)
+        return;
+
+    auto *controllerDelegate = controller->delegate();
+    if (![controllerDelegate respondsToSelector:@selector(_webExtensionController:didUpdateSidebar:forExtensionContext:)])
+        return;
+
+    auto *controllerWrapper = controller->wrapper();
+    auto *sidebarWrapper = sidebar.wrapper();
+    auto *contextWrapper = wrapper();
+    if (!(controllerWrapper && sidebarWrapper && contextWrapper))
+        return;
+
+    [controllerDelegate _webExtensionController:controllerWrapper didUpdateSidebar:sidebarWrapper forExtensionContext:contextWrapper];
+}
+
+void WebExtensionContext::notifyDelegateOfSidebarInvalidation(WebExtensionSidebar& sidebar)
+{
+    RefPtr controller = extensionController();
+    if (!controller)
+        return;
+
+    auto *controllerDelegate = controller->delegate();
+    if (![controllerDelegate respondsToSelector:@selector(_webExtensionController:didInvalidateSidebar:forExtensionContext:)])
+        return;
+
+    auto *controllerWrapper = controller->wrapper();
+    auto *sidebarWrapper = sidebar.wrapper();
+    auto *contextWrapper = wrapper();
+    if (!(controllerWrapper && sidebarWrapper && contextWrapper))
+        return;
+
+    [controllerDelegate _webExtensionController:controllerWrapper didInvalidateSidebar:sidebarWrapper forExtensionContext:contextWrapper];
+}
+
 bool WebExtensionContext::canProgrammaticallyOpenSidebar()
 {
     if (!extension().hasAnySidebar())
@@ -200,28 +238,20 @@ void WebExtensionContext::sidebarOpen(const std::optional<WebExtensionWindowIden
             completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), @"no windows are open"));
             return;
         }
+    } else if (tabIdentifier) {
+        tab = getTab(*tabIdentifier);
+        if (!tab) {
+            completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), @"the tab was not found"));
+            return;
+        }
     } else {
-        // sidePanel allows both windowIdentifier and tabIdentifier to be specified for sidePanel.open(), so we will discard windowIdentifier if they are both set
-        // since sidebarAction.open() takes no arguments, this does not break behavior for that API
-        auto correctedWindowIdentifier = tabIdentifier ? std::nullopt : windowIdentifier;
-
-        auto maybeSidebar = getOrCreateSidebarWithIdentifiers(correctedWindowIdentifier, tabIdentifier, *this);
-        if (!maybeSidebar) {
-            completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), @"options", maybeSidebar.error()));
+        RefPtr window = getWindow(*windowIdentifier);
+        if (!window) {
+            completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), @"the window was not found"));
             return;
         }
-        Ref<WebExtensionSidebar> sidebar = WTF::move(maybeSidebar.value());
 
-        if (auto window = sidebar->window())
-            tab = window->get().activeTab();
-        else if (auto maybeTab = sidebar->tab())
-            tab = RefPtr { maybeTab.value().ptr() };
-        else if (auto window = frontmostWindow())
-            tab = window->activeTab();
-        else {
-            completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), unknownErrorString));
-            return;
-        }
+        tab = window->activeTab();
     }
 
     if (!tab) {
@@ -229,7 +259,7 @@ void WebExtensionContext::sidebarOpen(const std::optional<WebExtensionWindowIden
         return;
     }
 
-    std::optional<Ref<WebExtensionSidebar>> sidebar = getOrCreateSidebar(*tab);
+    std::optional<Ref<WebExtensionSidebar>> sidebar = sidebarForTab(*tab);
     if (!sidebar) {
         completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), unknownErrorString));
         return;
@@ -237,6 +267,12 @@ void WebExtensionContext::sidebarOpen(const std::optional<WebExtensionWindowIden
 
     if (!sidebar.value()->isEnabled()) {
         completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), @"the sidebar is not enabled"));
+        return;
+    }
+
+    // A sidebar with no panel has nothing to display, so there is no sidebar object to hand the browser.
+    if (!sidebar.value()->opensSidebar()) {
+        completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), @"no sidebar panel is set"));
         return;
     }
 
@@ -267,7 +303,7 @@ void WebExtensionContext::sidebarClose(CompletionHandler<void(Expected<void, Web
         return;
     }
 
-    auto maybeSidebar = getOrCreateSidebar(*tab);
+    auto maybeSidebar = sidebarForTab(*tab);
     if (!maybeSidebar) {
         completionHandler(toWebExtensionError(apiName, nullString(), unknownErrorString));
         return;
@@ -295,8 +331,8 @@ void WebExtensionContext::sidebarIsOpen(const std::optional<WebExtensionWindowId
 
     bool isOpen = false;
     if (auto currentTab = window->activeTab()) {
-        if (auto currentTabSidebar = getSidebar(*currentTab))
-            isOpen |= currentTabSidebar.value()->isOpen();
+        if (auto currentTabSidebar = sidebarForTab(*currentTab))
+            isOpen = currentTabSidebar.value()->isOpen();
     }
 
     completionHandler(isOpen);
@@ -325,13 +361,19 @@ void WebExtensionContext::sidebarToggle(CompletionHandler<void(Expected<void, We
         return;
     }
 
-    auto maybeSidebar = getOrCreateSidebar(*tab);
+    auto maybeSidebar = sidebarForTab(*tab);
     if (!maybeSidebar) {
         completionHandler(toWebExtensionError(apiName, nullString(), unknownErrorString));
         return;
     }
 
     Ref sidebar = WTF::move(maybeSidebar.value());
+
+    if (!sidebar->opensSidebar()) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"no sidebar panel is set"));
+        return;
+    }
+
     if (sidebar->isOpen())
         closeSidebar(sidebar.get());
     else
@@ -364,6 +406,14 @@ void WebExtensionContext::sidebarSetTitle(const std::optional<WebExtensionWindow
     // this method services a sidebarAction-only API method
     static NSString * const apiName = @"sidebarAction.setTitle()";
 
+    // A clear on a tab which has no sidebar of its own has nothing to change.
+    if (tabIdentifier && !title) {
+        if (RefPtr tab = getTab(*tabIdentifier); tab && !getSidebar(*tab)) {
+            completionHandler({ });
+            return;
+        }
+    }
+
     auto sidebar = getOrCreateSidebarWithIdentifiers(windowIdentifier, tabIdentifier, *this);
     if (!sidebar) {
         completionHandler(toWebExtensionError(apiName, @"details", sidebar.error()));
@@ -386,7 +436,7 @@ void WebExtensionContext::sidebarGetOptions(const std::optional<WebExtensionWind
         objectName = @"details";
     }
 
-    auto maybeSidebar = getOrCreateSidebarWithIdentifiers(windowIdentifier, tabIdentifier, *this);
+    auto maybeSidebar = getSidebarWithIdentifiers(windowIdentifier, tabIdentifier, *this);
     if (!maybeSidebar) {
         completionHandler(toWebExtensionError(apiName, objectName, maybeSidebar.error()));
         return;
@@ -412,6 +462,14 @@ void WebExtensionContext::sidebarSetOptions(const std::optional<WebExtensionWind
         objectName = @"details";
     }
 
+    // A clear-only call (empty path and no enabled) on a tab which has no sidebar of its own has nothing to change.
+    if (tabIdentifier && !panelSourcePath && !enabled) {
+        if (RefPtr tab = getTab(*tabIdentifier); tab && !getSidebar(*tab)) {
+            completionHandler({ });
+            return;
+        }
+    }
+
     auto maybeSidebar = getOrCreateSidebarWithIdentifiers(windowIdentifier, tabIdentifier, *this);
     if (!maybeSidebar) {
         completionHandler(toWebExtensionError(apiName, objectName, maybeSidebar.error()));
@@ -419,11 +477,7 @@ void WebExtensionContext::sidebarSetOptions(const std::optional<WebExtensionWind
     }
 
     auto& sidebar = maybeSidebar.value().get();
-    sidebar.setSidebarPath(panelSourcePath);
-    // according to the sidePanel docs, `enabled` is optional with default value `true`
-    // we only need to be concerned with chrome's semantics here since sidebarAction does not have any concept of enablement
-    // see: https://developer.chrome.com/docs/extensions/reference/api/sidePanel#type-PanelOptions
-    sidebar.setEnabled(enabled.value_or(true));
+    sidebar.setOptions(panelSourcePath, enabled);
     completionHandler({ });
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -379,6 +379,9 @@ Expected<bool, RefPtr<API::Error>> WebExtensionContext::unload()
     m_actionTabMap.clear();
     m_defaultAction = nullptr;
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    m_sidebarWindowMap.clear();
+    m_sidebarTabMap.clear();
+    m_sidebarPageMap.clear();
     m_defaultSidebar = nullptr;
 #endif
     m_popupPageActionMap.clear();
@@ -1055,6 +1058,38 @@ RefPtr<WebExtensionTab> WebExtensionContext::getCurrentTab(WebPageProxyIdentifie
         goto finish;
     }
 
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    // Search sidebars for the page. A sidebar's web view may be shared by several tabs in a window, so the
+    // page maps to the sidebar's own tab when it has one, and otherwise to the active tab of its window.
+    for (auto entry : m_sidebarPageMap) {
+        if (entry.key.identifier() != webPageProxyIdentifier)
+            continue;
+
+        RefPtr sidebar = entry.value.get();
+        if (!sidebar)
+            continue;
+
+        if (includeExtensionViews == IncludeExtensionViews::No)
+            return nullptr;
+
+        RefPtr tab = sidebar->tab()
+            .transform([](auto const& tab) { return RefPtr { tab.ptr() }; })
+            .value_or(nullptr);
+
+        if (tab) {
+            result = tab;
+            goto finish;
+        }
+
+        RefPtr currentActiveTab = sidebar->window()
+            .transform([](auto const& window) { return window->activeTab(); })
+            .value_or(nullptr);
+
+        result = currentActiveTab;
+        goto finish;
+    }
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
     // Search open tabs for the page.
     for (Ref tab : openTabs()) {
         if (WKWebView *webView = tab->webView()) {
@@ -1441,6 +1476,28 @@ void WebExtensionContext::didMoveTab(WebExtensionTab& tab, size_t oldIndex, cons
     else if (newWindow)
         RELEASE_LOG_DEBUG(Extensions, "Added tab %{public}llu to window %{public}llu at index %{public}zu", tab.identifier().toUInt64(), newWindow->identifier().toUInt64(), newIndex);
 
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    // A tab sidebar inherits from the sidebar of the window its tab is in, so it has to be re-linked when the
+    // tab changes windows. Without this it would keep inheriting from, and being updated by, the old window.
+    if (oldWindow != newWindow) {
+        if (RefPtr tabSidebar = m_sidebarTabMap.get(tab)) {
+            if (oldWindow) {
+                if (auto oldWindowSidebar = getSidebar(*oldWindow))
+                    oldWindowSidebar.value()->removeChild(*tabSidebar);
+            }
+
+            if (newWindow) {
+                if (auto newWindowSidebar = getOrCreateSidebar(*newWindow))
+                    newWindowSidebar.value()->addChild(*tabSidebar);
+            }
+
+            // The tab now inherits from a different window, so its title/panel/icon and the web view it
+            // shares may have changed; tell the browser to re-read it.
+            tabSidebar->propertiesDidChange();
+        }
+    }
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
     if (!oldWindow)
         didOpenTab(tab);
 
@@ -1820,7 +1877,7 @@ void WebExtensionContext::performAction(WebExtensionTab* tab, UserTriggered user
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
     std::optional<Ref<WebExtensionSidebar>> sidebar;
-    if (m_actionClickBehavior == WebExtensionActionClickBehavior::OpenSidebar && (sidebar = getOrCreateSidebar(*tab)) && canProgrammaticallyOpenSidebar() && canProgrammaticallyCloseSidebar() && sidebar.value()->opensSidebar()) {
+    if (m_actionClickBehavior == WebExtensionActionClickBehavior::OpenSidebar && (sidebar = sidebarForTab(*tab)) && canProgrammaticallyOpenSidebar() && canProgrammaticallyCloseSidebar() && sidebar.value()->opensSidebar()) {
         if (!sidebar.value()->isOpen())
             openSidebar(sidebar.value());
         else
@@ -1883,16 +1940,40 @@ std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getOrCreateSidebar(
     }).iterator->value;
 }
 
-RefPtr<WebExtensionSidebar> WebExtensionContext::getOrCreateSidebar(RefPtr<WebExtensionTab> tab)
+std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::sidebarForTab(WebExtensionTab& tab)
 {
     if (!protect(extension())->hasAnySidebar())
-        return nil;
-    if (!tab)
-        return &defaultSidebar();
+        return std::nullopt;
 
-    return getOrCreateSidebar(*tab.get())
-        .and_then([](auto const& sidebar) { return std::optional(RefPtr<WebExtensionSidebar>(&sidebar.get())); })
-        .value_or(nil);
+    if (auto tabSidebar = getSidebar(tab))
+        return tabSidebar;
+
+    if (RefPtr window = tab.window())
+        return getOrCreateSidebar(*window);
+
+    return std::nullopt;
+}
+
+void WebExtensionContext::addSidebarPage(WebPageProxy& page, WebExtensionSidebar& sidebar)
+{
+    m_sidebarPageMap.set(page, sidebar);
+}
+
+bool WebExtensionContext::discardSidebarIfUnmodified(WebExtensionSidebar& sidebar)
+{
+    auto sidebarTab = sidebar.tab();
+    if (!sidebarTab || sidebar.hasOverriddenProperties())
+        return false;
+
+    Ref tab = sidebarTab.value();
+
+    if (auto parentSidebar = sidebar.parent())
+        parentSidebar.value()->removeChild(sidebar);
+
+    m_sidebarTabMap.remove(tab.get());
+
+    notifyDelegateOfSidebarInvalidation(sidebar);
+    return true;
 }
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm
@@ -85,6 +85,10 @@
         else if (!currentWindow && !currentTab)
             currentWindow = toOptional(context->frontmostWindow());
 
+        // A window sidebar has no tab of its own, so open next to the active tab
+        if (!currentTab && currentWindow)
+            currentTab = toOptional(currentWindow.value()->activeTab());
+
         WebKit::WebExtensionTabParameters tabParameters;
         tabParameters.url = targetURL;
         tabParameters.windowIdentifier = currentWindow
@@ -272,6 +276,11 @@ const std::optional<Ref<WebExtensionWindow>> WebExtensionSidebar::window() const
     });
 }
 
+bool WebExtensionSidebar::hasOverriddenProperties() const
+{
+    return m_iconsOverride || m_titleOverride || m_sidebarPathOverride || m_isEnabled;
+}
+
 std::optional<Ref<WebExtensionSidebar>> WebExtensionSidebar::parent() const
 {
     RefPtr context = extensionContext();
@@ -280,7 +289,7 @@ std::optional<Ref<WebExtensionSidebar>> WebExtensionSidebar::parent() const
 
     return tab().and_then([&](Ref<WebExtensionTab> const& tab) -> std::optional<Ref<WebExtensionSidebar>> {
         RefPtr window = tab->window();
-        return window ? context->getSidebar(*window) : std::nullopt;
+        return window ? context->getOrCreateSidebar(*window) : std::nullopt;
     }).or_else([&] -> std::optional<Ref<WebExtensionSidebar>> {
         return Ref { context->defaultSidebar() };
     });
@@ -289,9 +298,13 @@ std::optional<Ref<WebExtensionSidebar>> WebExtensionSidebar::parent() const
 void WebExtensionSidebar::propertiesDidChange()
 {
     if (isParentSidebar())
-        notifyChildrenOfPropertyUpdate(ShouldReloadWebView::No);
-    else
-        notifyDelegateOfPropertyUpdate();
+        notifyChildrenOfPropertyUpdate();
+
+    // Discard this sidebar object if it no longer overrides any properties
+    if (RefPtr context = extensionContext(); context && context->discardSidebarIfUnmodified(*this))
+        return;
+
+    notifyDelegateOfPropertyUpdate();
 }
 
 std::optional<Ref<WebCore::Icon>> WebExtensionSidebar::icon(WebCore::FloatSize size)
@@ -319,15 +332,14 @@ std::optional<Ref<WebCore::Icon>> WebExtensionSidebar::icon(WebCore::FloatSize s
 
 void WebExtensionSidebar::setIconsDictionary(std::optional<Ref<JSON::Object>> icons)
 {
-    if (!icons || !icons.value()->size()) {
+    if (m_iconsOverride == icons)
+        return;
+
+    if (icons && icons.value()->size())
+        m_iconsOverride = WTF::move(icons);
+    else
         m_iconsOverride = std::nullopt;
-        return;
-    }
 
-    if (m_iconsOverride && m_iconsOverride.value() == icons.value())
-        return;
-
-    m_iconsOverride = WTF::move(icons);
     propertiesDidChange();
 }
 
@@ -365,12 +377,6 @@ bool WebExtensionSidebar::isEnabled() const
         .value_or(false);
 }
 
-void WebExtensionSidebar::setEnabled(bool enabled)
-{
-    m_isEnabled = enabled;
-    propertiesDidChange();
-}
-
 std::optional<String> WebExtensionSidebar::resolvedSidebarPath() const
 {
     return m_sidebarPathOverride.or_else([this] {
@@ -385,41 +391,59 @@ String WebExtensionSidebar::sidebarPath() const
     return resolvedSidebarPath().value_or(fallbackPath);
 }
 
-void WebExtensionSidebar::setSidebarPath(std::optional<String> sidebarPath)
+void WebExtensionSidebar::setOptions(std::optional<String> panelPath, std::optional<bool> enabled)
 {
     RefPtr context = extensionContext();
-    if (!sidebarPath && isDefaultSidebar() && context)
+
+    bool wasSharingWindowWebView = tab() && !m_sidebarPathOverride;
+    auto oldPathOverride = m_sidebarPathOverride;
+
+    if (!panelPath && isDefaultSidebar() && context)
         m_sidebarPathOverride = context->extension().sidebarDocumentPath();
     else
-        m_sidebarPathOverride = sidebarPath;
+        m_sidebarPathOverride = panelPath;
 
-    if (isParentSidebar())
-        notifyChildrenOfPropertyUpdate(ShouldReloadWebView::Yes);
-    else
+    if (enabled)
+        m_isEnabled = enabled;
+
+    bool isSharingWindowWebView = tab() && !m_sidebarPathOverride;
+    bool webViewDidChange = wasSharingWindowWebView != isSharingWindowWebView;
+
+    if (webViewDidChange && isSharingWindowWebView) {
+        [m_webView _close];
+        m_webView = nil;
+        m_viewController = nil;
+        m_webViewDelegate = nil;
+    }
+
+    if (m_sidebarPathOverride != oldPathOverride) {
         reloadWebView();
+        reloadDescendantWebViews();
+    }
+
+    if (enabled || webViewDidChange)
+        propertiesDidChange();
 }
 
-void WebExtensionSidebar::willOpenSidebar()
+void WebExtensionSidebar::willOpenSidebar(FromUserInteraction fromUserInteraction)
 {
     ASSERT(isEnabled());
     ASSERT(!isDefaultSidebar());
-    ASSERT(!static_cast<bool>(m_window));
 
     RELEASE_LOG_ERROR_IF(!isEnabled(), Extensions, "willOpenSidebar was called on a sidebar object which is currently disabled");
     RELEASE_LOG_ERROR_IF(isDefaultSidebar(), Extensions, "willOpenSidebar was called on the default sidebar object");
-    RELEASE_LOG_ERROR_IF(static_cast<bool>(m_window), Extensions, "willOpenSidebar was called on a window-global sidebar object");
 
     m_isOpen = true;
-    didReceiveUserInteraction();
+
+    if (fromUserInteraction == FromUserInteraction::Yes)
+        didReceiveUserInteraction();
 }
 
 void WebExtensionSidebar::willCloseSidebar()
 {
     ASSERT(!isDefaultSidebar());
-    ASSERT(!static_cast<bool>(m_window));
 
     RELEASE_LOG_ERROR_IF(isDefaultSidebar(), Extensions, "willCloseSidebar was called on the default sidebar object");
-    RELEASE_LOG_ERROR_IF(static_cast<bool>(m_window), Extensions, "willCloseSidebar was called on a window-global sidebar object");
 
     m_isOpen = false;
 }
@@ -447,22 +471,39 @@ void WebExtensionSidebar::removeChild(WebExtensionSidebar const& child)
 
 void WebExtensionSidebar::didReceiveUserInteraction()
 {
-    auto currentTab = tab();
     RefPtr currentContext = extensionContext();
 
-    ASSERT(isOpen());
-    ASSERT(currentTab);
+    // A window sidebar owns the web view shared by its tabs, so an interaction can arrive here with no tab of
+    // our own. It belongs to whichever tab is active in that window now, resolved at the time of the
+    // interaction rather than remembered, since the web view stays on screen across tab switches.
+    RefPtr<WebExtensionTab> currentTab = tab()
+        .transform([](auto const& ownTab) { return RefPtr { ownTab.ptr() }; })
+        .or_else([&] { return window().transform([](auto const& ownWindow) { return ownWindow->activeTab(); }); })
+        .value_or(nullptr);
 
-    if (!(isOpen() && currentTab && currentContext))
+    if (!(isOpen() && currentTab && currentContext)) {
+        ASSERT_NOT_REACHED();
         return;
+    }
 
-    currentContext->userGesturePerformed(currentTab.value());
+    currentContext->userGesturePerformed(*currentTab);
 }
 
 RetainPtr<SidebarViewControllerType> WebExtensionSidebar::viewController()
 {
-    // Only tab-specific sidebars should be rendered
-    if (!m_tab)
+    if (isDefaultSidebar())
+        return nil;
+
+    // If this is a tab sidebar without a path override, use the parent sidebar's view controller
+    if (tab() && !m_sidebarPathOverride) {
+        auto windowSidebar = parent();
+        ASSERT(windowSidebar && windowSidebar.value()->window());
+        if (windowSidebar && windowSidebar.value()->window())
+            return windowSidebar.value()->viewController();
+    }
+
+    // Must agree with webView(): a view controller with no web view to host would be useless.
+    if (!opensSidebar())
         return nil;
 
     if (!m_viewController)
@@ -473,9 +514,16 @@ RetainPtr<SidebarViewControllerType> WebExtensionSidebar::viewController()
 
 WKWebView *WebExtensionSidebar::webView()
 {
-    // Only tab-specific sidebars should be rendered
-    if (!m_tab)
+    if (isDefaultSidebar())
         return nil;
+
+    // If this is a tab sidebar without a path override, use the parent sidebar's web view
+    if (tab() && !m_sidebarPathOverride) {
+        auto windowSidebar = parent();
+        ASSERT(windowSidebar && windowSidebar.value()->window());
+        if (windowSidebar && windowSidebar.value()->window())
+            return windowSidebar.value()->webView();
+    }
 
     RefPtr context = extensionContext();
     if (!opensSidebar() || !context)
@@ -491,56 +539,42 @@ WKWebView *WebExtensionSidebar::webView()
     m_webViewDelegate = [[_WKWebExtensionSidebarWebViewDelegate alloc] initWithWebExtensionSidebar:*this];
     m_webView.get().navigationDelegate = m_webViewDelegate.get();
 
+    if (auto *page = m_webView.get()._page.get())
+        context->addSidebarPage(*page, *this);
+
     reloadWebView();
 
     return m_webView.get();
 }
 
-void WebExtensionSidebar::parentPropertiesWereUpdated(ShouldReloadWebView shouldReload)
+void WebExtensionSidebar::parentPropertiesWereUpdated()
 {
     ASSERT(!isDefaultSidebar());
 
-    // If we have local overrides on all properties, then a parent property update does not effect this sidebar
+    // If we have local overrides on all properties, then a parent property update does not affect this sidebar
     if (m_iconsOverride.has_value() && m_titleOverride.has_value() && m_sidebarPathOverride.has_value() && m_isEnabled.has_value())
         return;
 
-    // Delegate property update notifications should only come from non-parent (i.e. tab-specific) sidebars
     if (isParentSidebar())
-        notifyChildrenOfPropertyUpdate(shouldReload);
-    else if (shouldReload == ShouldReloadWebView::Yes)
-        reloadWebView();
-    else
-        notifyDelegateOfPropertyUpdate();
+        notifyChildrenOfPropertyUpdate();
+
+    notifyDelegateOfPropertyUpdate();
 }
 
-void WebExtensionSidebar::notifyChildrenOfPropertyUpdate(ShouldReloadWebView shouldReload)
+void WebExtensionSidebar::notifyChildrenOfPropertyUpdate()
 {
     for (auto& childSidebar : m_children)
-        childSidebar.parentPropertiesWereUpdated(shouldReload);
+        childSidebar.parentPropertiesWereUpdated();
 }
 
 void WebExtensionSidebar::notifyDelegateOfPropertyUpdate()
 {
-    RefPtr context = extensionContext();
-    if (!context)
+    // The global/default sidebar is never displayed, so there is nothing for the browser to re-read.
+    if (isDefaultSidebar())
         return;
 
-    RefPtr extensionController = context->extensionController();
-    if (!extensionController)
-        return;
-
-    auto *delegate = extensionController->delegate();
-    if (![delegate respondsToSelector:@selector(_webExtensionController:didUpdateSidebar:forExtensionContext:)])
-        return;
-
-    auto *extensionControllerWrapper = extensionController->wrapper();
-    auto *sidebarWrapper = wrapper();
-    auto *contextWrapper = context->wrapper();
-
-    if (!(extensionControllerWrapper && sidebarWrapper && contextWrapper))
-        return;
-
-    [delegate _webExtensionController:extensionControllerWrapper didUpdateSidebar:sidebarWrapper forExtensionContext:contextWrapper];
+    if (RefPtr context = extensionContext())
+        context->notifyDelegateOfSidebarUpdate(*this);
 }
 
 void WebExtensionSidebar::reloadWebView()
@@ -554,6 +588,18 @@ void WebExtensionSidebar::reloadWebView()
 
     auto url = URL { context->baseURL(), sidebarPath() };
     [m_webView loadRequest:[NSURLRequest requestWithURL:url.createNSURL().get()]];
+}
+
+void WebExtensionSidebar::reloadDescendantWebViews()
+{
+    // Reload the web view of every descendant which inherits this sidebar's panel path.
+    for (auto& childSidebar : m_children) {
+        if (childSidebar.m_sidebarPathOverride)
+            continue;
+
+        childSidebar.reloadWebView();
+        childSidebar.reloadDescendantWebViews();
+    }
 }
 
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -532,9 +532,16 @@ public:
     std::optional<Ref<WebExtensionSidebar>> getSidebar(WebExtensionTab const&);
     std::optional<Ref<WebExtensionSidebar>> getOrCreateSidebar(WebExtensionWindow&);
     std::optional<Ref<WebExtensionSidebar>> getOrCreateSidebar(WebExtensionTab&);
-    RefPtr<WebExtensionSidebar> getOrCreateSidebar(RefPtr<WebExtensionTab>);
+
+    // The sidebar object which should be given to the browser for the specified tab. If the extension
+    // has specified tab-specific overrides for this tab, then the tab's sidebar; otherwise, the window's.
+    std::optional<Ref<WebExtensionSidebar>> sidebarForTab(WebExtensionTab&);
+    bool discardSidebarIfUnmodified(WebExtensionSidebar&);
+    void addSidebarPage(WebPageProxy&, WebExtensionSidebar&);
     void openSidebar(WebExtensionSidebar&);
     void closeSidebar(WebExtensionSidebar&);
+    void notifyDelegateOfSidebarUpdate(WebExtensionSidebar&);
+    void notifyDelegateOfSidebarInvalidation(WebExtensionSidebar&);
     bool canProgrammaticallyOpenSidebar();
     bool canProgrammaticallyCloseSidebar();
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
@@ -1124,6 +1131,7 @@ private:
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
     WeakHashMap<WebExtensionWindow, Ref<WebExtensionSidebar>> m_sidebarWindowMap;
     WeakHashMap<WebExtensionTab, Ref<WebExtensionSidebar>> m_sidebarTabMap;
+    WeakHashMap<WebPageProxy, WeakPtr<WebExtensionSidebar>> m_sidebarPageMap;
     RefPtr<WebExtensionSidebar> m_defaultSidebar;
     WebExtensionActionClickBehavior m_actionClickBehavior { WebExtensionActionClickBehavior::OpenPopup };
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
@@ -60,7 +60,7 @@ class WebExtensionSidebar : public API::ObjectImpl<API::Object::Type::WebExtensi
 
 public:
     enum class IsDefault { No, Yes };
-    enum class ShouldReloadWebView { No, Yes };
+    enum class FromUserInteraction { No, Yes };
 
     template<typename... Args>
     static Ref<WebExtensionSidebar> create(Args&&... args)
@@ -79,7 +79,12 @@ public:
     const std::optional<Ref<WebExtensionWindow>> window() const;
     std::optional<Ref<WebExtensionSidebar>> parent() const;
 
+    /// Whether anything is set on this sidebar itself, as opposed to inherited from its parent.
+    bool hasOverriddenProperties() const;
     void propertiesDidChange();
+
+    /// Reports to the delegate that this sidebar's properties changed and it should be re-read.
+    void notifyDelegateOfPropertyUpdate();
 
     /// `icon()` will return the overridden icon of this sidebar, or the icon of the first parent sidebar in which the icon is set
     std::optional<Ref<WebCore::Icon>> icon(WebCore::FloatSize);
@@ -90,7 +95,6 @@ public:
     void setTitle(std::optional<String>);
 
     bool isEnabled() const;
-    void setEnabled(bool);
 
     bool isOpen() const { return m_isOpen; }
     bool opensSidebar()
@@ -101,10 +105,9 @@ public:
 
     /// `sidebarPath()` will return the overriden path of this sidebar, or the path of the first parent sidebar in which the path is set
     String sidebarPath() const;
-    void setSidebarPath(std::optional<String>);
+    void setOptions(std::optional<String> panelPath, std::optional<bool> enabled);
 
-    /// Should be called when a user action will open the sidebar
-    void willOpenSidebar();
+    void willOpenSidebar(FromUserInteraction);
     void willCloseSidebar();
 
     /// Should be called when the sidebar will be displayed, regardless of whether this stems from a user action.
@@ -129,11 +132,11 @@ private:
     bool isDefaultSidebar() const { return m_isDefault == IsDefault::Yes; };
     bool isParentSidebar() const { return isDefaultSidebar() || m_window.has_value(); };
 
-    void parentPropertiesWereUpdated(ShouldReloadWebView);
-    void notifyChildrenOfPropertyUpdate(ShouldReloadWebView);
-    void notifyDelegateOfPropertyUpdate();
+    void parentPropertiesWereUpdated();
+    void notifyChildrenOfPropertyUpdate();
 
     void reloadWebView();
+    void reloadDescendantWebViews();
 
     /// The configured panel path from this sidebar's override/parent chain
     std::optional<String> resolvedSidebarPath() const;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm
@@ -107,24 +107,6 @@ static NSDictionary<NSString *, id> *serializeSidebarParameters(WebExtensionSide
     return serializedParameters;
 }
 
-static Expected<WebExtensionSidebarParameters, WebExtensionError> deserializeSidebarParameters(NSDictionary<NSString *, id> *serializedParameters)
-{
-    WebExtensionSidebarParameters parameters;
-
-    if (auto enabled = objectForKey<NSNumber>(serializedParameters, @"enabled"))
-        parameters.enabled = [enabled boolValue];
-
-    if (auto path = objectForKey<NSString>(serializedParameters, @"path"))
-        parameters.panelPath = path;
-
-    auto tabIdentifierResult = parseTabIdentifier(serializedParameters);
-    if (NSString *error = indicatesError(tabIdentifierResult).get())
-        return toWebExtensionError(nullString(), @"details", error);
-    parameters.tabIdentifier = WTF::move(tabIdentifierResult.value());
-
-    return parameters;
-}
-
 void WebExtensionAPISidePanel::getOptions(NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     auto result = parseTabIdentifier(options);
@@ -146,15 +128,28 @@ void WebExtensionAPISidePanel::getOptions(NSDictionary *options, Ref<WebExtensio
 
 void WebExtensionAPISidePanel::setOptions(NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    auto result = deserializeSidebarParameters(options);
-    if (!result) {
-        *outExceptionString = result.error().createNSString().get();
+    auto tabIdentifierResult = parseTabIdentifier(options);
+    if ((*outExceptionString = indicatesError(tabIdentifierResult).get()))
+        return;
+
+    RetainPtr path = objectForKey<NSString>(options, @"path", false);
+    RetainPtr enabled = objectForKey<NSNumber>(options, @"enabled");
+
+    if (!path && !enabled) {
+        *outExceptionString = toErrorString(nullString(), @"options", @"it must specify at least one of 'path' or 'enabled'").createNSString().get();
         return;
     }
 
-    std::optional<String> panelPath = result->panelPath != ""_s ? std::optional(result->panelPath) : std::nullopt;
+    // An empty path (`path: ""`) clears the panel, so it is sent as nullopt.
+    std::optional<String> panelPath;
+    if (path.get().length)
+        panelPath = String { path.get() };
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetOptions(std::nullopt, result->tabIdentifier, panelPath, result->enabled), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
+    std::optional<bool> enabledValue;
+    if (enabled)
+        enabledValue = enabled.get().boolValue;
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetOptions(std::nullopt, tabIdentifierResult.value(), panelPath, enabledValue), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error().createNSString().get());
             return;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.h
@@ -71,6 +71,8 @@
 
 @property (nonatomic, copy) void (^didUpdateSidebar)(_WKWebExtensionSidebar *);
 
+@property (nonatomic, copy) void (^didInvalidateSidebar)(_WKWebExtensionSidebar *);
+
 @property (nonatomic, copy) void (^createBookmarkWithParentIdentifier)(NSString *parentId, NSNumber *index, NSString *url, NSString *title, void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *));
 @property (nonatomic, copy) void (^bookmarksForExtensionContext)(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *));
 @property (nonatomic, copy) void (^removeBookmarkWithIdentifier)(NSString *bookmarkId, BOOL removeFolderWithChildren, void (^completionHandler)(NSError *));

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.mm
@@ -198,6 +198,12 @@
         _didUpdateSidebar(sidebar);
 }
 
+- (void)_webExtensionController:(WKWebExtensionController *)controller didInvalidateSidebar:(_WKWebExtensionSidebar *)sidebar forExtensionContext:(WKWebExtensionContext *)context
+{
+    if (_didInvalidateSidebar)
+        _didInvalidateSidebar(sidebar);
+}
+
 
 - (void)_webExtensionController:(WKWebExtensionController *)controller createBookmarkWithParentIdentifier:(NSString *)parentId index:(NSNumber *)index url:(NSString *)url title:(NSString *)title forExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *))completionHandler
 {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPISidebar.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPISidebar.mm
@@ -863,7 +863,8 @@ TEST_F(WKWebExtensionAPISidebar, SidebarActionOpenSucceedsWithUserGesture)
     auto manager = getManagerFor(resources, sidebarActionManifest);
     manager.get().internalDelegate.presentSidebar = ^(_WKWebExtensionSidebar *sidebar) {
         (*presentSidebarCallCountPtr)++;
-        EXPECT_NOT_NULL(sidebar.associatedTab);
+        EXPECT_NULL(sidebar.associatedTab);
+        EXPECT_NOT_NULL(sidebar.associatedWindow);
         EXPECT_NOT_NULL(sidebar.webExtensionContext);
         EXPECT_NOT_NULL(sidebar.title);
         EXPECT_NOT_NULL(sidebar.webView);
@@ -902,7 +903,8 @@ TEST_F(WKWebExtensionAPISidebar, SidebarActionCloseSucceedsWithUserGesture)
         (*closeSidebarCallCountPtr)++;
 
         // Make sure all the properties are still there when delegate closeSidebar is called, since the sidebar is still displayed at the moment of the call
-        EXPECT_NOT_NULL(sidebar.associatedTab);
+        EXPECT_NULL(sidebar.associatedTab);
+        EXPECT_NOT_NULL(sidebar.associatedWindow);
         EXPECT_NOT_NULL(sidebar.webExtensionContext);
         EXPECT_NOT_NULL(sidebar.title);
         EXPECT_NOT_NULL(sidebar.webView);
@@ -1262,7 +1264,8 @@ TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForTabSucceedsWithUserGesture)
     auto manager = getManagerFor(resources, sidePanelManifest);
     manager.get().internalDelegate.presentSidebar = ^(_WKWebExtensionSidebar *sidebar) {
         (*presentSidebarCallCountPtr)++;
-        EXPECT_NOT_NULL(sidebar.associatedTab);
+        EXPECT_NULL(sidebar.associatedTab);
+        EXPECT_NOT_NULL(sidebar.associatedWindow);
         EXPECT_NOT_NULL(sidebar.webExtensionContext);
         EXPECT_NOT_NULL(sidebar.title);
         EXPECT_NOT_NULL(sidebar.webView);
@@ -1305,7 +1308,8 @@ TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForWindowSucceedsWithUserGesture)
 
     manager.get().internalDelegate.presentSidebar = ^(_WKWebExtensionSidebar *sidebar) {
         (*presentSidebarCallCountPtr)++;
-        EXPECT_NOT_NULL(sidebar.associatedTab);
+        EXPECT_NULL(sidebar.associatedTab);
+        EXPECT_NOT_NULL(sidebar.associatedWindow);
         EXPECT_NOT_NULL(sidebar.webExtensionContext);
         EXPECT_NOT_NULL(sidebar.title);
         EXPECT_NOT_NULL(sidebar.webView);
@@ -1315,8 +1319,8 @@ TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForWindowSucceedsWithUserGesture)
         EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
         EXPECT_NS_EQUAL(webViewURL.path, @"/sidebar.html");
 
-        EXPECT_FALSE([newWindow.tabs containsObject:sidebar.associatedTab]);
-        EXPECT_TRUE([defaultWindow.tabs containsObject:sidebar.associatedTab]);
+        EXPECT_EQ(sidebar.associatedWindow, defaultWindow);
+        EXPECT_NE(sidebar.associatedWindow, newWindow);
     };
 
     [manager loadAndRun];
@@ -1432,6 +1436,438 @@ TEST_F(WKWebExtensionAPISidebar, SidePanelActionClickDoesNotOpenPathlessSidebar)
 
     EXPECT_EQ(presentSidebarCallCount, 0);
     EXPECT_EQ(presentActionPopupCallCount, 1);
+}
+
+#pragma mark - Per-Window Rendering Tests
+
+TEST_F(WKWebExtensionAPISidebar, TabsWithoutOverridesShareTheirWindowSidebar)
+{
+    auto *script = @[
+        @"browser.test.sendMessage('Loaded')",
+    ];
+
+    auto *resources = @{
+        @"background.js": Util::constructScript(script),
+        @"sidebar.html": @"<h1>Sidebar</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    auto *defaultWindow = [manager defaultWindow];
+    auto *firstTab = manager.get().defaultTab;
+    auto *secondTab = [defaultWindow openNewTab];
+
+    [manager load];
+    [manager runUntilTestMessage:@"Loaded"];
+
+    auto *context = manager.get().context;
+    auto *firstSidebar = [context sidebarForTab:firstTab];
+    auto *secondSidebar = [context sidebarForTab:secondTab];
+
+    // Neither tab is singled out by the extension, so both are shown their window's sidebar: the same object,
+    // in the same web view, so moving between them leaves the sidebar pane alone.
+    EXPECT_NOT_NULL(firstSidebar);
+    EXPECT_EQ(firstSidebar, secondSidebar);
+    EXPECT_NULL(firstSidebar.associatedTab);
+    EXPECT_EQ(firstSidebar.associatedWindow, defaultWindow);
+    EXPECT_EQ(firstSidebar.webView, secondSidebar.webView);
+}
+
+TEST_F(WKWebExtensionAPISidebar, DidInvalidateSidebarFiresWhenLastOverrideCleared)
+{
+    auto *script = @[
+        @"let tabs = await browser.tabs.query({})",
+        @"let [tab] = tabs",
+
+        @"browser.test.onMessage.addListener(async (message) => {",
+        @"  if (message === 'Override')",
+        @"    await browser.sidebarAction.setTitle({ tabId: tab.id, title: 'tab title' })",
+        @"  else if (message === 'Clear')",
+        @"    await browser.sidebarAction.setTitle({ tabId: tab.id, title: null })",
+        @"  browser.test.sendMessage('Done')",
+        @"})",
+
+        @"browser.test.sendMessage('Loaded')",
+    ];
+
+    auto *resources = @{
+        @"background.js": Util::constructScript(script),
+        @"sidebar.html": @"<h1>Sidebar</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+
+    __block RetainPtr<_WKWebExtensionSidebar> lastUpdated;
+    __block RetainPtr<_WKWebExtensionSidebar> lastInvalidated;
+    manager.get().internalDelegate.didUpdateSidebar = ^(_WKWebExtensionSidebar *sidebar) {
+        lastUpdated = sidebar;
+    };
+    manager.get().internalDelegate.didInvalidateSidebar = ^(_WKWebExtensionSidebar *sidebar) {
+        lastInvalidated = sidebar;
+    };
+
+    [manager load];
+    [manager runUntilTestMessage:@"Loaded"];
+
+    auto *context = manager.get().context;
+    auto *tab = manager.get().defaultTab;
+
+    // With nothing set for the tab, it is shown its window's sidebar.
+    auto *windowSidebar = [context sidebarForTab:tab];
+    EXPECT_NOT_NULL(windowSidebar);
+    EXPECT_NULL(windowSidebar.associatedTab);
+
+    // Setting a tab override gives the tab a sidebar of its own and reports it as an update, not an invalidation.
+    [manager sendTestMessage:@"Override"];
+    [manager runUntilTestMessage:@"Done"];
+    EXPECT_NE([context sidebarForTab:tab], windowSidebar);
+    EXPECT_NOT_NULL(lastUpdated.get());
+    EXPECT_EQ(lastUpdated.get().associatedTab, tab);
+    EXPECT_NULL(lastInvalidated.get());
+
+    lastUpdated = nil;
+
+    // Clearing the last override discards the tab's own sidebar: it is shown its window's sidebar again, and the
+    // discard is reported as an invalidation carrying that sidebar (so the browser can drop it and re-query),
+    // never as an update for the sidebar being gotten rid of.
+    [manager sendTestMessage:@"Clear"];
+    [manager runUntilTestMessage:@"Done"];
+    EXPECT_EQ([context sidebarForTab:tab], windowSidebar);
+    EXPECT_NOT_NULL(lastInvalidated.get());
+    EXPECT_EQ(lastInvalidated.get().associatedTab, tab);
+    EXPECT_NULL(lastUpdated.get());
+}
+
+TEST_F(WKWebExtensionAPISidebar, WillOpenSidebarWithoutUserInteractionDoesNotStartUserGesture)
+{
+    auto *script = @[
+        @"browser.test.sendMessage('Loaded')",
+    ];
+
+    auto *resources = @{
+        @"background.js": Util::constructScript(script),
+        @"sidebar.html": @"<h1>Sidebar</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+
+    [manager load];
+    [manager runUntilTestMessage:@"Loaded"];
+
+    auto *context = manager.get().context;
+    auto *tab = manager.get().defaultTab;
+    auto *sidebar = [context sidebarForTab:tab];
+
+    EXPECT_NOT_NULL(sidebar);
+    EXPECT_FALSE([context hasActiveUserGestureInTab:tab]);
+
+    // Replacing which sidebar is on screen is not an interaction with the extension, and the extension can
+    // bring one about itself by setting a property for a single tab, so it must not start a user gesture.
+    [sidebar willOpenSidebarFromUserInteraction:NO];
+    EXPECT_FALSE([context hasActiveUserGestureInTab:tab]);
+
+    [sidebar willCloseSidebar];
+    [sidebar willOpenSidebarFromUserInteraction:YES];
+    EXPECT_TRUE([context hasActiveUserGestureInTab:tab]);
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidePanelSetOptionsRequiresPathOrEnabled)
+{
+    auto *script = @[
+        @"let tabs = await browser.tabs.query({})",
+        @"let [tab] = tabs",
+
+        // `tabId` only says which sidebar to change, so these calls have nothing to do.
+        @"browser.test.assertThrows(() => browser.sidePanel.setOptions({ tabId: tab.id }))",
+        @"browser.test.assertThrows(() => browser.sidePanel.setOptions({ }))",
+
+        // Clearing the path, or setting enablement, is a change.
+        @"await browser.test.assertSafeResolve(() => browser.sidePanel.setOptions({ tabId: tab.id, path: '' }))",
+        @"await browser.test.assertSafeResolve(() => browser.sidePanel.setOptions({ tabId: tab.id, enabled: false }))",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(sidePanelManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
+}
+
+TEST_F(WKWebExtensionAPISidebar, TabPanelOverrideSwapsWebViewAndRestoresIt)
+{
+    auto *script = @[
+        @"let [tab1, tab2] = await browser.tabs.query({})",
+
+        @"browser.test.onMessage.addListener(async (message) => {",
+        @"  if (message === 'Override')",
+        @"    await browser.sidebarAction.setPanel({ tabId: tab1.id, panel: '/tab.html' })",
+        @"  else if (message === 'Clear')",
+        @"    await browser.sidebarAction.setPanel({ tabId: tab1.id, panel: null })",
+        @"  browser.test.sendMessage('Done')",
+        @"})",
+
+        @"browser.test.sendMessage('Loaded')",
+    ];
+
+    auto *resources = @{
+        @"background.js": Util::constructScript(script),
+        @"sidebar.html": @"<h1>Window Sidebar</h1>",
+        @"tab.html": @"<h1>Tab Sidebar</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    auto *defaultWindow = [manager defaultWindow];
+    auto *firstTab = manager.get().defaultTab;
+    auto *secondTab = [defaultWindow openNewTab];
+
+    [manager load];
+    [manager runUntilTestMessage:@"Loaded"];
+
+    auto *context = manager.get().context;
+
+    // Neither tab is singled out, so both are shown their window's sidebar and share its single web view.
+    auto *windowSidebar = [context sidebarForTab:firstTab];
+    EXPECT_EQ(windowSidebar, [context sidebarForTab:secondTab]);
+    RetainPtr<WKWebView> sharedWebView = windowSidebar.webView;
+    EXPECT_NOT_NULL(sharedWebView.get());
+
+    // Giving one tab its own panel promotes it to a distinct sidebar with a web view of its own; the other tab
+    // keeps sharing the window's.
+    [manager sendTestMessage:@"Override"];
+    [manager runUntilTestMessage:@"Done"];
+
+    auto *tabSidebar = [context sidebarForTab:firstTab];
+    EXPECT_NE(tabSidebar, windowSidebar);
+    EXPECT_EQ(tabSidebar.associatedTab, firstTab);
+    EXPECT_NE(tabSidebar.webView, sharedWebView.get());
+    EXPECT_EQ([context sidebarForTab:secondTab], windowSidebar);
+    EXPECT_EQ([context sidebarForTab:secondTab].webView, sharedWebView.get());
+
+    // Clearing that panel demotes the tab back to sharing its window's sidebar and its original web view.
+    [manager sendTestMessage:@"Clear"];
+    [manager runUntilTestMessage:@"Done"];
+
+    EXPECT_EQ([context sidebarForTab:firstTab], windowSidebar);
+    EXPECT_EQ([context sidebarForTab:firstTab].webView, sharedWebView.get());
+}
+
+TEST_F(WKWebExtensionAPISidebar, WindowPanelChangeReloadsSharedWebViewInPlace)
+{
+    auto *script = @[
+        @"let window = await browser.windows.getCurrent()",
+
+        @"browser.test.onMessage.addListener(async (message) => {",
+        @"  if (message === 'ChangeWindowPanel')",
+        @"    await browser.sidebarAction.setPanel({ windowId: window.id, panel: '/window-2.html' })",
+        @"  browser.test.sendMessage('Done')",
+        @"})",
+
+        @"browser.test.sendMessage('Loaded')",
+    ];
+
+    auto *resources = @{
+        @"background.js": Util::constructScript(script),
+        @"sidebar.html": @"<h1>Window Sidebar</h1>",
+        @"window-2.html": @"<h1>Window Sidebar 2</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    auto *defaultWindow = [manager defaultWindow];
+    auto *firstTab = manager.get().defaultTab;
+    auto *secondTab = [defaultWindow openNewTab];
+
+    [manager load];
+    [manager runUntilTestMessage:@"Loaded"];
+
+    auto *context = manager.get().context;
+    auto *windowSidebar = [context sidebarForTab:firstTab];
+    RetainPtr<WKWebView> sharedWebView = windowSidebar.webView;
+    EXPECT_NOT_NULL(sharedWebView.get());
+
+    // Changing the window's panel reloads the shared web view in place rather than rebuilding it, so the object
+    // both tabs are looking at stays the same and sharing is preserved.
+    [manager sendTestMessage:@"ChangeWindowPanel"];
+    [manager runUntilTestMessage:@"Done"];
+
+    EXPECT_EQ([context sidebarForTab:firstTab], windowSidebar);
+    EXPECT_EQ(windowSidebar.webView, sharedWebView.get());
+    EXPECT_EQ([context sidebarForTab:secondTab], windowSidebar);
+    EXPECT_EQ([context sidebarForTab:secondTab].webView, sharedWebView.get());
+}
+
+TEST_F(WKWebExtensionAPISidebar, ParentTitleChangeNotifiesInheritingTabSidebar)
+{
+    auto *script = @[
+        @"let window = await browser.windows.getCurrent()",
+        @"let [tab] = await browser.tabs.query({})",
+
+        @"browser.test.onMessage.addListener(async (message) => {",
+        @"  if (message === 'OverrideTabPanel')",
+        @"    await browser.sidebarAction.setPanel({ tabId: tab.id, panel: '/tab.html' })",
+        @"  else if (message === 'ChangeWindowTitle')",
+        @"    await browser.sidebarAction.setTitle({ windowId: window.id, title: 'Window Title' })",
+        @"  browser.test.sendMessage('Done')",
+        @"})",
+
+        @"browser.test.sendMessage('Loaded')",
+    ];
+
+    auto *resources = @{
+        @"background.js": Util::constructScript(script),
+        @"sidebar.html": @"<h1>Window Sidebar</h1>",
+        @"tab.html": @"<h1>Tab Sidebar</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+
+    __block RetainPtr<NSMutableArray> updatedSidebars = [NSMutableArray array];
+    manager.get().internalDelegate.didUpdateSidebar = ^(_WKWebExtensionSidebar *sidebar) {
+        [updatedSidebars addObject:sidebar];
+    };
+
+    [manager load];
+    [manager runUntilTestMessage:@"Loaded"];
+
+    auto *context = manager.get().context;
+    auto *tab = manager.get().defaultTab;
+
+    // The tab overrides only its panel, so it keeps a sidebar of its own that still inherits its title from the
+    // window.
+    [manager sendTestMessage:@"OverrideTabPanel"];
+    [manager runUntilTestMessage:@"Done"];
+    EXPECT_EQ([context sidebarForTab:tab].associatedTab, tab);
+
+    [updatedSidebars removeAllObjects];
+
+    // Changing the window's title has to reach the inheriting tab sidebar, not only the window's own, since the
+    // tab sidebar is what the browser displays for that tab.
+    [manager sendTestMessage:@"ChangeWindowTitle"];
+    [manager runUntilTestMessage:@"Done"];
+
+    bool notifiedTabSidebar = false;
+    for (_WKWebExtensionSidebar *sidebar in updatedSidebars.get()) {
+        if (sidebar.associatedTab == tab)
+            notifiedTabSidebar = true;
+    }
+    EXPECT_TRUE(notifiedTabSidebar);
+    EXPECT_NS_EQUAL([context sidebarForTab:tab].title, @"Window Title");
+}
+
+TEST_F(WKWebExtensionAPISidebar, SetOptionsNotifiesDelegateAtMostOnce)
+{
+    auto *script = @[
+        @"let [tab] = await browser.tabs.query({})",
+
+        @"browser.test.onMessage.addListener(async (message) => {",
+        @"  if (message === 'SetPathAndEnabled')",
+        @"    await browser.sidePanel.setOptions({ tabId: tab.id, path: '/tab.html', enabled: false })",
+        @"  browser.test.sendMessage('Done')",
+        @"})",
+
+        @"browser.test.sendMessage('Loaded')",
+    ];
+
+    auto *resources = @{
+        @"background.js": Util::constructScript(script),
+        @"sidebar.html": @"<h1>Window Sidebar</h1>",
+        @"tab.html": @"<h1>Tab Sidebar</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidePanelManifest);
+
+    __block int updateCount = 0;
+    manager.get().internalDelegate.didUpdateSidebar = ^(_WKWebExtensionSidebar *) {
+        ++updateCount;
+    };
+
+    [manager load];
+    [manager runUntilTestMessage:@"Loaded"];
+
+    updateCount = 0;
+
+    // Setting the path (which promotes the tab to its own web view) and enablement in one call must report a
+    // single update, not one per mutated property.
+    [manager sendTestMessage:@"SetPathAndEnabled"];
+    [manager runUntilTestMessage:@"Done"];
+
+    EXPECT_EQ(updateCount, 1);
+}
+
+TEST_F(WKWebExtensionAPISidebar, TabSidebarRelinksToNewWindowOnMove)
+{
+    auto *script = @[
+        @"let [windowA, windowB] = await browser.windows.getAll()",
+        @"let [tab] = await browser.tabs.query({ windowId: windowA.id })",
+
+        @"browser.test.onMessage.addListener(async (message) => {",
+        @"  if (message === 'Setup') {",
+        @"    await browser.sidebarAction.setTitle({ windowId: windowA.id, title: 'A title' })",
+        @"    await browser.sidebarAction.setTitle({ windowId: windowB.id, title: 'B title' })",
+        @"    await browser.sidebarAction.setPanel({ tabId: tab.id, panel: '/tab.html' })",
+        @"  } else if (message === 'ChangeWindowBTitle')",
+        @"    await browser.sidebarAction.setTitle({ windowId: windowB.id, title: 'B title 2' })",
+        @"  else if (message === 'ChangeWindowATitle')",
+        @"    await browser.sidebarAction.setTitle({ windowId: windowA.id, title: 'A title 2' })",
+        @"  browser.test.sendMessage('Done')",
+        @"})",
+
+        @"browser.test.sendMessage('Loaded')",
+    ];
+
+    auto *resources = @{
+        @"background.js": Util::constructScript(script),
+        @"sidebar.html": @"<h1>Window Sidebar</h1>",
+        @"tab.html": @"<h1>Tab Sidebar</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    auto *windowB = [manager openNewWindow];
+
+    __block RetainPtr<NSMutableArray> updatedSidebars = [NSMutableArray array];
+    manager.get().internalDelegate.didUpdateSidebar = ^(_WKWebExtensionSidebar *sidebar) {
+        [updatedSidebars addObject:sidebar];
+    };
+
+    [manager load];
+    [manager runUntilTestMessage:@"Loaded"];
+
+    [manager sendTestMessage:@"Setup"];
+    [manager runUntilTestMessage:@"Done"];
+
+    auto *context = manager.get().context;
+    auto *tab = manager.get().defaultTab;
+
+    // The tab overrides only its panel, so it inherits its title from whichever window holds it -- window A for now.
+    auto *tabSidebar = [context sidebarForTab:tab];
+    EXPECT_EQ(tabSidebar.associatedTab, tab);
+    EXPECT_NS_EQUAL(tabSidebar.title, @"A title");
+
+    // Moving the tab into window B has to re-point its inheritance at B.
+    [windowB moveTab:tab toIndex:0];
+    EXPECT_NS_EQUAL([context sidebarForTab:tab].title, @"B title");
+
+    // A change to window B's title now reaches the tab, proving it was linked as a child of B's sidebar.
+    [updatedSidebars removeAllObjects];
+    [manager sendTestMessage:@"ChangeWindowBTitle"];
+    [manager runUntilTestMessage:@"Done"];
+
+    bool notifiedByWindowB = false;
+    for (_WKWebExtensionSidebar *sidebar in updatedSidebars.get()) {
+        if (sidebar.associatedTab == tab)
+            notifiedByWindowB = true;
+    }
+    EXPECT_TRUE(notifiedByWindowB);
+    EXPECT_NS_EQUAL([context sidebarForTab:tab].title, @"B title 2");
+
+    // A change to window A's title, on the other hand, must no longer reach the tab -- it was unlinked from A.
+    [updatedSidebars removeAllObjects];
+    [manager sendTestMessage:@"ChangeWindowATitle"];
+    [manager runUntilTestMessage:@"Done"];
+
+    bool notifiedByWindowA = false;
+    for (_WKWebExtensionSidebar *sidebar in updatedSidebars.get()) {
+        if (sidebar.associatedTab == tab)
+            notifiedByWindowA = true;
+    }
+    EXPECT_FALSE(notifiedByWindowA);
+    EXPECT_NS_EQUAL([context sidebarForTab:tab].title, @"B title 2");
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 6815dd9b127c2197d355f3bd4427b37ed9be2cde
<pre>
Web Extensions sidebar is rendered per-tab instead of per-window, even in the absence of tab-specific sidebars
<a href="https://rdar.apple.com/182752551">rdar://182752551</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321128">https://bugs.webkit.org/show_bug.cgi?id=321128</a>

Reviewed by Timothy Hatcher.

The sidebar pane was rendered per tab rather than per window: every tab was given its own
sidebar object and its own WKWebView, even when the extension had set nothing specific to that
tab. Switching between such tabs tore down one sidebar and built an identical one instead of
leaving the window&apos;s sidebar in place, and changes made at the window (or global) tier were not
reflected on the tabs that inherited them.

Make each window own a single sidebar whose WKWebView is shared by every tab that sets no panel
of its own; a tab gets its own sidebar and web view only while it overrides its own panel path.
sidebarForTab: hands back that shared object for every non-overriding tab, so the browser can
compare successive results by identity to decide whether the displayed sidebar must change on a
tab switch. A tab sidebar is discarded once it stops overriding anything, and the browser is told
to drop it through the new didInvalidateSidebar: delegate method.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPISidebar.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext sidebarForTab:]):
    Resolve through the shared per-window sidebar rather than creating a tab-specific one.
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm:
(-[_WKWebExtensionSidebar title]):
(-[_WKWebExtensionSidebar viewController]):
(-[_WKWebExtensionSidebar webView]):
(-[_WKWebExtensionSidebar willOpenSidebarFromUserInteraction:]):
(-[_WKWebExtensionSidebar associatedWindow]):
    The sidebar&apos;s window, or its tab&apos;s window for a tab-specific sidebar.
(-[_WKWebExtensionSidebar willOpenSidebar]): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm:
(WebKit::WebExtensionContext::notifyDelegateOfSidebarUpdate):
(WebKit::WebExtensionContext::notifyDelegateOfSidebarInvalidation):
(WebKit::WebExtensionContext::sidebarOpen):
    Resolve the tab directly; creating a sidebar here would defeat per-window sharing.
(WebKit::WebExtensionContext::sidebarClose):
(WebKit::WebExtensionContext::sidebarIsOpen):
(WebKit::WebExtensionContext::sidebarToggle):
    Reject when no panel is set.
(WebKit::WebExtensionContext::sidebarSetTitle):
(WebKit::WebExtensionContext::sidebarGetOptions):
    Use the non-creating resolver so a query never materializes a tab sidebar.
(WebKit::WebExtensionContext::sidebarSetOptions):
    Apply path and enablement together so one call notifies the browser at most once.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::unload):
    Clear the sidebar maps, which were never cleared, leaking sidebars and web views across reloads.
(WebKit::WebExtensionContext::getCurrentTab const):
(WebKit::WebExtensionContext::didMoveTab):
(WebKit::WebExtensionContext::performAction):
(WebKit::WebExtensionContext::sidebarForTab):
(WebKit::WebExtensionContext::addSidebarPage):
(WebKit::WebExtensionContext::discardSidebarIfUnmodified):
    Drop a tab sidebar which overrides nothing, unlink it, and notify the delegate it is invalidated.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm:
(-[_WKWebExtensionSidebarWebViewDelegate webView:decidePolicyForNavigationAction:decisionHandler:]):
(WebKit::WebExtensionSidebar::hasOverriddenProperties const):
(WebKit::WebExtensionSidebar::parent const):
    Create the window sidebar when resolving a tab&apos;s parent, so it inherits from its window rather
    than falling through to the global sidebar.
(WebKit::WebExtensionSidebar::propertiesDidChange):
    Report this sidebar to the delegate as well as its children, so a parent-tier change reaches
    the tabs that inherit it.
(WebKit::WebExtensionSidebar::setIconsDictionary):
    Notify when an icon override is cleared, not only when one is set.
(WebKit::WebExtensionSidebar::setOptions):
    Replaces setSidebarPath/setEnabled: mutate both, tear down a demoted tab&apos;s web view, reload the
    shared web views, and notify at most once.
(WebKit::WebExtensionSidebar::willOpenSidebar):
    Grant activeTab only for a user-initiated open, so an extension cannot grant itself the
    permission by changing a tab&apos;s sidebar.
(WebKit::WebExtensionSidebar::willCloseSidebar):
(WebKit::WebExtensionSidebar::didReceiveUserInteraction):
(WebKit::WebExtensionSidebar::viewController):
(WebKit::WebExtensionSidebar::webView):
(WebKit::WebExtensionSidebar::parentPropertiesWereUpdated):
(WebKit::WebExtensionSidebar::notifyChildrenOfPropertyUpdate):
(WebKit::WebExtensionSidebar::notifyDelegateOfPropertyUpdate):
(WebKit::WebExtensionSidebar::reloadDescendantWebViews):
(WebKit::WebExtensionSidebar::setEnabled): Deleted.
(WebKit::WebExtensionSidebar::setSidebarPath): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm:
(WebKit::WebExtensionAPISidePanel::setOptions):
    Reject a call that sets neither path nor enabled, and forward each only when the caller supplied it.
(WebKit::deserializeSidebarParameters): Deleted.
* Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate _webExtensionController:didInvalidateSidebar:forExtensionContext:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPISidebar.mm:
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarActionOpenSucceedsWithUserGesture)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarActionCloseSucceedsWithUserGesture)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForTabSucceedsWithUserGesture)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForWindowSucceedsWithUserGesture)):
    These four now assert associatedWindow rather than associatedTab, since a tab that overrides
    nothing is shown its window&apos;s sidebar.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, TabsWithoutOverridesShareTheirWindowSidebar)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, DidInvalidateSidebarFiresWhenLastOverrideCleared)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, WillOpenSidebarWithoutUserInteractionDoesNotStartUserGesture)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelSetOptionsRequiresPathOrEnabled)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, TabPanelOverrideSwapsWebViewAndRestoresIt)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, WindowPanelChangeReloadsSharedWebViewInPlace)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, ParentTitleChangeNotifiesInheritingTabSidebar)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SetOptionsNotifiesDelegateAtMostOnce)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, TabSidebarRelinksToNewWindowOnMove)):

Canonical link: <a href="https://commits.webkit.org/318790@main">https://commits.webkit.org/318790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34070afa20c2371cc25f8ffb5850a9559e5464f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47011 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189109 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139801 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160556 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120253 "1 api test failed or timed out") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42075 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40411 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40061 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/416 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191326 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52886 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149049 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53566 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148794 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27228 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43473 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125838 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120697 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52084 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15045 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51469 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51710 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51530 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->