### PR TITLE
[Site Isolation] [iOS] Tapping on a text field does not move the caret from a cross-site iframe

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/text-input.html
+++ b/LayoutTests/http/tests/site-isolation/resources/text-input.html
@@ -3,6 +3,9 @@
 <body>
 <input id="target" type="text" autocapitalize="none" style="width: 200px; font-size: 16px;">
 <script>
+window.addEventListener("blur", () => {
+    window.parent.postMessage({ type: "windowBlurred" }, "*");
+});
 window.addEventListener("message", (event) => {
     if (event.data.type === "getInputRect") {
         const rect = document.getElementById("target").getBoundingClientRect();
@@ -16,6 +19,14 @@ window.addEventListener("message", (event) => {
             type: "inputValue",
             value: document.getElementById("target").value
         }, "*");
+    } else if (event.data.type === "focusInput") {
+        const target = document.getElementById("target");
+        // Focus with a user gesture so a cross-origin iframe is allowed to take focus from the main frame.
+        if (window.internals)
+            internals.withUserGesture(() => target.focus());
+        else
+            target.focus();
+        window.parent.postMessage({ type: "inputFocused", focused: document.activeElement === target }, "*");
     }
 });
 </script>

--- a/LayoutTests/http/tests/site-isolation/tap-main-frame-clears-caret-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/tap-main-frame-clears-caret-in-cross-origin-iframe-expected.txt
@@ -1,0 +1,13 @@
+Tapping the main frame moves focus out of a focused text field in a cross-origin iframe (dispatching a blur and clearing its caret) when site isolation is enabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS mainInputWasFocused is true
+PASS mainFrameBlurred is true
+PASS iframeBlurred is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/http/tests/site-isolation/tap-main-frame-clears-caret-in-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/tap-main-frame-clears-caret-in-cross-origin-iframe.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+</head>
+<body style="margin: 0">
+<input id="maininput" style="width: 100px;">
+<iframe id="frame" width="300" height="100" src="http://localhost:8000/site-isolation/resources/text-input.html" onload="runTest()"></iframe>
+<div id="mainarea" style="width: 300px; height: 300px;"></div>
+<script>
+description("Tapping the main frame moves focus out of a focused text field in a cross-origin iframe (dispatching a blur and clearing its caret) when site isolation is enabled.");
+jsTestIsAsync = true;
+
+window.mainFrameBlurred = false;
+window.iframeBlurred = false;
+
+// The main frame dispatches blur once focus moves into the cross-origin iframe.
+window.addEventListener("blur", () => { window.mainFrameBlurred = true; });
+// The iframe posts this when its window is blurred, i.e. when focus leaves it.
+window.addEventListener("message", (event) => {
+    if (event.data.type === "windowBlurred")
+        window.iframeBlurred = true;
+});
+
+async function runTest()
+{
+    // Focus an element in the main frame so it is the focused frame to begin with.
+    const mainInput = document.getElementById("maininput");
+    mainInput.focus();
+    window.mainInputWasFocused = document.activeElement === mainInput;
+    shouldBeTrue("mainInputWasFocused");
+
+    // Focus the text field in the cross-origin iframe, then wait for the main frame to lose focus. This
+    // confirms the focus change reached the main frame's process before we tap.
+    document.getElementById("frame").contentWindow.postMessage({ type: "focusInput" }, "*");
+    for (let i = 0; i < 50 && !window.mainFrameBlurred; i++)
+        await UIHelper.ensurePresentationUpdate();
+    shouldBeTrue("mainFrameBlurred");
+
+    // Tapping an empty area of the main frame must move focus out of the cross-origin iframe, which
+    // dispatches a blur event there and clears the caret in its text field.
+    const mainRect = document.getElementById("mainarea").getBoundingClientRect();
+    await UIHelper.activateAt(mainRect.left + mainRect.width / 2, mainRect.top + mainRect.height / 2);
+    for (let i = 0; i < 50 && !window.iframeBlurred; i++)
+        await UIHelper.ensurePresentationUpdate();
+    shouldBeTrue("iframeBlurred");
+
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -30,6 +30,7 @@
 #include "APIObject.h"
 #include "MessageReceiver.h"
 #include "TextExtractionAssertionScope.h"
+#include <WebCore/ProcessIdentifier.h>
 #include <WebCore/UserGestureTokenIdentifier.h>
 #include <WebCore/SpeechRecognitionConnectionClientIdentifier.h>
 #include <wtf/ApproximateTime.h>
@@ -3436,7 +3437,7 @@ private:
     void restorePageCenterAndScale(IPC::Connection&, std::optional<WebCore::FloatPoint>, double scale);
 
     void elementDidFocus(IPC::Connection&, const FocusedElementInformation&, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, const UserData&);
-    void elementDidBlur();
+    void elementDidBlur(IPC::Connection&);
     void convertFocusedElementInformationRectsToMainFrameCoordinates(FocusedElementInformation, CompletionHandler<void(FocusedElementInformation)>&&);
     void updateInputContextAfterBlurringAndRefocusingElement();
     void didProgrammaticallyClearFocusedElement(WebCore::ElementContext&&);
@@ -3823,6 +3824,8 @@ private:
     RefPtr<WebFrameProxy> m_mainFrame;
     RefPtr<WebCore::DocumentSyncData> m_topDocumentSyncData;
     RefPtr<WebFrameProxy> m_focusedFrame;
+
+    std::optional<WebCore::ProcessIdentifier> m_focusedElementProcessID;
 
     String m_userAgent;
     String m_applicationNameForUserAgent;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -913,6 +913,7 @@ void WebPageProxy::didProgrammaticallyClearFocusedElement(WebCore::ElementContex
 void WebPageProxy::elementDidFocus(IPC::Connection& connection, const FocusedElementInformation& information, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, const UserData& userData)
 {
     m_pendingInputModeChange = std::nullopt;
+    m_focusedElementProcessID = WebProcessProxy::fromConnection(connection)->coreProcessIdentifier();
 
     RefPtr pageClient = this->pageClient();
     if (!pageClient)
@@ -935,8 +936,12 @@ void WebPageProxy::elementDidFocus(IPC::Connection& connection, const FocusedEle
         });
 }
 
-void WebPageProxy::elementDidBlur()
+void WebPageProxy::elementDidBlur(IPC::Connection& connection)
 {
+    if (m_focusedElementProcessID && *m_focusedElementProcessID != WebProcessProxy::fromConnection(connection)->coreProcessIdentifier())
+        return;
+
+    m_focusedElementProcessID = std::nullopt;
     m_pendingInputModeChange = std::nullopt;
     if (RefPtr pageClient = this->pageClient())
         pageClient->elementDidBlur();

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -3251,6 +3251,13 @@ Awaitable<std::optional<WebCore::FrameIdentifier>> WebPage::commitPotentialTap(s
     RefPtr localRootFrame = this->localRootFrame(frameID);
 
     auto reportFailedTap = [&] {
+        if (localRootFrame) {
+            if (RefPtr focusedFrame = m_page->focusController().focusedFrame(); focusedFrame && focusedFrame->frameType() == WebCore::Frame::FrameType::Remote) {
+                m_page->focusController().setFocusedFrame(localRootFrame.get());
+                if (m_isClosed)
+                    return;
+            }
+        }
 #if ENABLE(FOCUS_ADJUSTMENT_IN_SYNTHETIC_CLICK)
         if (localRootFrame) {
             m_page->focusController().setFocusedElement(nullptr, localRootFrame.get(), { .trigger = FocusTrigger::Click });

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -9972,6 +9972,85 @@ TEST(SiteIsolation, SelectionInCrossOriginIframeIsContainedByContentView)
 }
 #endif // HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
 
+} // namespace TestWebKitAPI
+
+@interface SiteIsolationInputSessionWebView : TestWKWebView
+@property (nonatomic, readonly) BOOL hasActiveInputSession;
+@end
+
+@implementation SiteIsolationInputSessionWebView {
+    BOOL _hasActiveInputSession;
+}
+
+- (BOOL)hasActiveInputSession
+{
+    return _hasActiveInputSession;
+}
+
+- (void)didStartFormControlInteraction
+{
+    _hasActiveInputSession = YES;
+    [super didStartFormControlInteraction];
+}
+
+- (void)didEndFormControlInteraction
+{
+    _hasActiveInputSession = NO;
+    [super didEndFormControlInteraction];
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+TEST(SiteIsolation, FocusingMainFrameFieldKeepsFocusAfterCrossOriginIframeField)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><input id='mainInput'><iframe id='iframe' style='display: block; width: 300px; height: 200px; border: none;' src='https://webkit.org/iframe'></iframe></body>"_s } },
+        { "/iframe"_s, { "<!DOCTYPE html><body style='margin: 0'><input id='iframeInput'></body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    enableSiteIsolation(configuration.get());
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    RetainPtr webView = adoptNS([[SiteIsolationInputSessionWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    [inputDelegate setFocusStartsInputSessionPolicyHandler:[](WKWebView *, id<_WKFocusedElementInfo>) {
+        return _WKFocusStartsInputSessionPolicyAllow;
+    }];
+    [webView _setInputDelegate:inputDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+    [webView focusInWindow];
+
+    RetainPtr childFrame = [webView firstChildFrame];
+
+    // Focus the text field in the cross-origin iframe and wait (via the didStartFormControlInteraction
+    // hook) for its input session to begin. A cross-origin frame needs a user gesture to take focus, so
+    // this can't use -evaluateJavaScriptAndWaitForInputSessionToChange, which evaluates without one.
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"document.getElementById('iframeInput').focus()" inFrame:childFrame.get()];
+    while (![webView hasActiveInputSession])
+        Util::spinRunLoop();
+
+    // Focus the text field in the main frame.
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"document.getElementById('mainInput').focus()"];
+
+    // Once the main frame takes focus, the subframe process blurs its now-defocused field and sends an
+    // ElementDidBlur that can arrive afterwards. Round-trip through the subframe process so that blur has
+    // been delivered to and processed by the UI process (messages from a process are ordered) before we
+    // assert. The main frame's input session must remain active -- previously the stale blur cleared it.
+    [webView objectByEvaluatingJavaScript:@"0" inFrame:childFrame.get()];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_TRUE([webView hasActiveInputSession]);
+}
+
 #endif // PLATFORM(IOS_FAMILY)
 
 #if ENABLE(IMAGE_ANALYSIS)


### PR DESCRIPTION
#### 9fd70490c75d5f5af1675ef73bfb7988687d2bc3
<pre>
[Site Isolation] [iOS] Tapping on a text field does not move the caret from a cross-site iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=321125">https://bugs.webkit.org/show_bug.cgi?id=321125</a>

Reviewed by Wenson Hsieh and Megan Gardner.

When a text field inside a cross-origin (site-isolated) iframe has a caret, two related
iOS behaviors were broken:

1. Tapping empty (non-click-target) content in the main frame did not clear the caret in
   the cross-origin subframe&apos;s field. commitPotentialTap()&apos;s reportFailedTap() clears focus
   via setFocusedElement(nullptr) only under ENABLE(FOCUS_ADJUSTMENT_IN_SYNTHETIC_CLICK),
   which is disabled on iOS; and even when enabled, localFocusedFrame() is null while a
   remote frame holds focus, so nothing defocused the subframe. As a result the subframe
   stayed focused and its caret persisted.

2. Focusing a text field in the main frame (after a cross-origin subframe&apos;s field was
   focused) left the main-frame field with no caret. Focus moves in the main frame&apos;s
   process first (ElementDidFocus), then the subframe process blurs its now-defocused
   field and sends ElementDidBlur. That blur arrives after the main-frame field was
   focused, and the UI process blurred it unconditionally -- wiping the new caret.

Fix (1) by having reportFailedTap() move focus to the local root frame when a remote frame
currently holds focus, which broadcasts the focus change and defocuses the subframe
(scoped to the remote case so local behavior, intentionally untouched when synthetic-click
focus adjustment is off, is unchanged).

Fix (2) by tracking, in the UI process, which web process reported the currently-focused
element (from ElementDidFocus, which already carries the connection) and ignoring an
ElementDidBlur from a different process. This is a no-op for the single-process case and
for focus moving to nothing (no newer ElementDidFocus, so the process still matches).

Add a regression test for (2). It focuses a cross-origin iframe field, then focuses a
main-frame field, and verifies (via a new _hasFocusedElementForTesting hook) that the
main-frame field remains focused after the subframe&apos;s stale blur has been delivered.
(1) is verified manually; TestWebKitAPI has no way to synthesize a real tap on iOS.

Test: http/tests/site-isolation/tap-main-frame-clears-caret-in-cross-origin-iframe.html
      TestWebKitAPI.SiteIsolation.FocusingMainFrameFieldKeepsFocusAfterCrossOriginIframeField

* LayoutTests/http/tests/site-isolation/resources/text-input.html:
* LayoutTests/http/tests/site-isolation/tap-main-frame-clears-caret-in-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/tap-main-frame-clears-caret-in-cross-origin-iframe.html: Added.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::elementDidFocus): Record the reporting process.
(WebKit::WebPageProxy::elementDidBlur): Ignore a stale blur from another process.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::commitPotentialTap): In reportFailedTap(), defocus a cross-origin subframe
that holds focus by moving focus to the local root frame.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(-[SiteIsolationInputSessionWebView hasActiveInputSession]):
(-[SiteIsolationInputSessionWebView didStartFormControlInteraction]):
(-[SiteIsolationInputSessionWebView didEndFormControlInteraction]):
(TestWebKitAPI::(SiteIsolation, FocusingMainFrameFieldKeepsFocusAfterCrossOriginIframeField)):

Canonical link: <a href="https://commits.webkit.org/318717@main">https://commits.webkit.org/318717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a78e03361d940959991119a28d0de669a1e331d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188882 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5dd8aaa-7b66-43d1-8d9d-394438db38c6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139628 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b8e102f-a97a-41f2-9b37-f36727200cae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120074 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c4668f8-8d7d-4ba6-8c36-752c9c2d288d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41895 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40237 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; 6 api tests failed or timed out") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2050 "Build is in progress. Recent messages:") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39887 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/189 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45598 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44482 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/core/float_exprs.wast.js.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191102 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148859 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53342 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36513 "343 new passes 13 flakes 3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148604 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27187 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43290 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125613 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120427 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51860 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14866 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51245 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51486 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51306 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->