### PR TITLE
[LBSE] Do not seed the filter region with the object bounding box for pure <filter> references

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
@@ -18,7 +18,6 @@
 
 # Filter issues
 svg/W3C-SVG-1.1/filters-morph-01-f.svg                                                 [ ImageOnlyFailure ]
-svg/batik/filters/filterRegions.svg                                                    [ ImageOnlyFailure ]
 svg/batik/text/smallFonts.svg                                                          [ ImageOnlyFailure ]
 svg/batik/text/textFeatures.svg                                                        [ ImageOnlyFailure ]
 svg/crash-svg-filter-empty-viewport.svg                                                [ Failure ]

--- a/Source/WebCore/rendering/CSSFilterRenderer.cpp
+++ b/Source/WebCore/rendering/CSSFilterRenderer.cpp
@@ -213,13 +213,26 @@ OptionSet<FilterRenderingMode> CSSFilterRenderer::supportedFilterRenderingModes(
 
 void CSSFilterRenderer::expandFilterRegionForSVGReferences()
 {
-    auto expandedRegion = filterRegion();
+    // Each function contributes the area it paints into, and the filter region is their union.
+    // A referenced <filter> brings its own region, which alone decides where it paints. The CSS
+    // shorthand functions instead operate on the source graphic, so they contribute the region
+    // we already have, which is based on the object bounding box.
+    //
+    // Starting from that bounding box unconditionally would be wrong: an element with a very
+    // large bounding box and a small userSpaceOnUse filter region would end up with a region far
+    // bigger than the image buffer limits, and the resulting scale clamping would make the filter
+    // output vanish.
+    auto expandedRegion = FloatRect();
     auto minScale = filterScale();
 
     for (auto& function : m_functions) {
         RefPtr svgFilter = dynamicDowncast<SVGFilterRenderer>(function);
-        if (!svgFilter)
+        if (!svgFilter) {
+            // SourceGraphic is the input of the chain, not a function that paints on its own.
+            if (function->filterType() != FilterEffect::Type::SourceGraphic)
+                expandedRegion.unite(filterRegion());
             continue;
+        }
 
         expandedRegion.unite(svgFilter->filterRegion());
 


### PR DESCRIPTION
#### 57169084beb9ad1b37ed2ea3a1ee463f79cc46d7
<pre>
[LBSE] Do not seed the filter region with the object bounding box for pure &lt;filter&gt; references
<a href="https://bugs.webkit.org/show_bug.cgi?id=321129">https://bugs.webkit.org/show_bug.cgi?id=321129</a>

Reviewed by Rob Buis.

CSSFilterRenderer::expandFilterRegionForSVGReferences() started from the object
bounding box and united it with each referenced &lt;filter&gt; region. The bounding box
seed is only meaningful for the CSS shorthand functions, which operate on the
source graphic; a referenced &lt;filter&gt; brings its own region, and that region alone
decides where the filter paints.

For an element with a very large bounding box and a small userSpaceOnUse filter
region, the union grew far past the image buffer limits, so the region was clamped
and the resulting scale made the filter output vanish. This is what happened to
filterRegion_1 through filterRegion_6 in svg/batik/filters/filterRegions.svg, whose
rects are 20000000 units wide and sit at y=3000 while the filter region is
(20, 30, 50, 40). The legacy engine takes the region from the &lt;filter&gt; element
alone and does not have this problem.

When every function in the chain is a &lt;filter&gt; reference, drop the bounding box and
keep only the referenced regions. The reference box is unchanged, so objectBoundingBox
filter units still resolve as before. The code path is guarded by
FilterRenderingOption::ApplyToSVGRenderer, so HTML/CSS filters are
unaffected.

Fixes svg/batik/filters/filterRegions.svg.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations:
* Source/WebCore/rendering/CSSFilterRenderer.cpp:
(WebCore::CSSFilterRenderer::expandFilterRegionForSVGReferences):

Canonical link: <a href="https://commits.webkit.org/318751@main">https://commits.webkit.org/318751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60e138eaf03ee4100baba064a4abce0382ac379d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189098 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52915 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43386 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120245 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40049 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/405 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45811 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191315 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39976 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53555 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148783 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43458 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125827 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52073 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/15029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51458 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->