### PR TITLE
[Test Coverage] Add tests for parsing the interactive-widget viewport meta argument

### DIFF
--- a/LayoutTests/fast/viewport/interactive-widget-conflicting-meta-tags-expected.txt
+++ b/LayoutTests/fast/viewport/interactive-widget-conflicting-meta-tags-expected.txt
@@ -1,0 +1,2 @@
+ALERT: viewport size 980x1078 scale 0.326531 with limits [0.326531, 5] and userScalable true
+

--- a/LayoutTests/fast/viewport/interactive-widget-conflicting-meta-tags.html
+++ b/LayoutTests/fast/viewport/interactive-widget-conflicting-meta-tags.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<head>
+    <title>With two viewport meta tags, the last one replaces the arguments of the first one entirely: its interactive-widget value wins, and width and initial-scale from the first tag are dropped (so the layout width falls back to 980).</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-visual">
+    <meta name="viewport" content="interactive-widget=overlays-content">
+    <script>
+        function test() {
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+                alert(internals.configurationForViewport(1, 320, 480, 320, 352));
+            }
+        }
+    </script>
+</head>
+<body onload="test();">

--- a/LayoutTests/fast/viewport/interactive-widget-disabled-expected.txt
+++ b/LayoutTests/fast/viewport/interactive-widget-disabled-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Viewport argument key "interactive-widget" not recognized and ignored.
+ALERT: viewport size 320x352 scale 1 with limits [1, 5] and userScalable true
+

--- a/LayoutTests/fast/viewport/interactive-widget-disabled.html
+++ b/LayoutTests/fast/viewport/interactive-widget-disabled.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MetaViewportInteractiveWidgetEnabled=false ] -->
+<head>
+    <title>The interactive-widget key is not recognized when the feature is disabled, even for otherwise valid values.</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content">
+    <script>
+        function test() {
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+                alert(internals.configurationForViewport(1, 320, 480, 320, 352));
+            }
+        }
+    </script>
+</head>
+<body onload="test();">

--- a/LayoutTests/fast/viewport/interactive-widget-duplicate-key-expected.txt
+++ b/LayoutTests/fast/viewport/interactive-widget-duplicate-key-expected.txt
@@ -1,0 +1,2 @@
+ALERT: viewport size 320x352 scale 1 with limits [1, 5] and userScalable true
+

--- a/LayoutTests/fast/viewport/interactive-widget-duplicate-key.html
+++ b/LayoutTests/fast/viewport/interactive-widget-duplicate-key.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<head>
+    <title>A duplicated interactive-widget key inside a single viewport meta content string is not a parse error: each occurrence is parsed in order, and the last one wins.</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-visual, interactive-widget=overlays-content">
+    <script>
+        function test() {
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+                alert(internals.configurationForViewport(1, 320, 480, 320, 352));
+            }
+        }
+    </script>
+</head>
+<body onload="test();">

--- a/LayoutTests/fast/viewport/interactive-widget-invalid-values-expected.txt
+++ b/LayoutTests/fast/viewport/interactive-widget-invalid-values-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Viewport argument value "" for key "interactive-widget" is invalid, and has been ignored.
+CONSOLE MESSAGE: Viewport argument value "" for key "interactive-widget" is invalid, and has been ignored.
+CONSOLE MESSAGE: Viewport argument value "foo" for key "interactive-widget" is invalid, and has been ignored.
+CONSOLE MESSAGE: Viewport argument value "resizes" for key "interactive-widget" is invalid, and has been ignored.
+CONSOLE MESSAGE: Viewport argument value "resizes-contentt" for key "interactive-widget" is invalid, and has been ignored.
+CONSOLE MESSAGE: Viewport argument value "overlays_content" for key "interactive-widget" is invalid, and has been ignored.
+CONSOLE MESSAGE: Viewport argument value "RESize-CONTENT" for key "interactive-widget" is invalid, and has been ignored.
+CONSOLE MESSAGE: Viewport argument value "RESİZES-VİSUAL" for key "interactive-widget" is invalid, and has been ignored.
+CONSOLE MESSAGE: Viewport argument value "resizes-visual;" for key "interactive-widget" is invalid, and has been ignored. Note that ';' is not a separator in viewport values. The list should be comma-separated.
+ALERT: viewport size 320x352 scale 1 with limits [1, 5] and userScalable true
+

--- a/LayoutTests/fast/viewport/interactive-widget-invalid-values.html
+++ b/LayoutTests/fast/viewport/interactive-widget-invalid-values.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<head>
+    <meta charset="utf-8">
+    <title>Invalid interactive-widget values are reported and ignored, and don't affect the other viewport arguments. "RESize-CONTENT" is invalid because it is missing the "s" in "resizes", and "RESİZES-VİSUAL" is invalid because keyword matching is ASCII case-insensitive only.</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget, interactive-widget=, interactive-widget=foo, interactive-widget=resizes, interactive-widget=resizes-contentt, interactive-widget=overlays_content, interactive-widget=RESize-CONTENT, interactive-widget=RESİZES-VİSUAL, interactive-widget=resizes-visual;">
+    <script>
+        function test() {
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+                alert(internals.configurationForViewport(1, 320, 480, 320, 352));
+            }
+        }
+    </script>
+</head>
+<body onload="test();">

--- a/LayoutTests/fast/viewport/interactive-widget-semicolon-separator-expected.txt
+++ b/LayoutTests/fast/viewport/interactive-widget-semicolon-separator-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Viewport argument value "device-width;" for key "width" is invalid, and has been ignored. Note that ';' is not a separator in viewport values. The list should be comma-separated.
+ALERT: viewport size 64x70.4 scale 5 with limits [5, 5] and userScalable true
+

--- a/LayoutTests/fast/viewport/interactive-widget-semicolon-separator.html
+++ b/LayoutTests/fast/viewport/interactive-widget-semicolon-separator.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<head>
+    <title>";" is not a viewport argument separator, so it is part of the preceding value ("device-width;" is rejected), while the interactive-widget argument after it is still parsed.</title>
+    <meta name="viewport" content="width=device-width; interactive-widget=resizes-content">
+    <script>
+        function test() {
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+                alert(internals.configurationForViewport(1, 320, 480, 320, 352));
+            }
+        }
+    </script>
+</head>
+<body onload="test();">

--- a/LayoutTests/fast/viewport/interactive-widget-valid-values-expected.txt
+++ b/LayoutTests/fast/viewport/interactive-widget-valid-values-expected.txt
@@ -1,0 +1,2 @@
+ALERT: viewport size 320x352 scale 1 with limits [1, 5] and userScalable true
+

--- a/LayoutTests/fast/viewport/interactive-widget-valid-values.html
+++ b/LayoutTests/fast/viewport/interactive-widget-valid-values.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<head>
+    <title>The interactive-widget key and its values are ASCII case-insensitive, and whitespace around the "=" separator is allowed, so no warnings are reported.</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=RESIZES-CONTENT, INTERACTIVE-WIDGET=Overlays-Content, interactive-widget = resizes-visual, interactive-widget=ReSiZeS-CoNtEnT">
+    <script>
+        function test() {
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+                alert(internals.configurationForViewport(1, 320, 480, 320, 352));
+            }
+        }
+    </script>
+</head>
+<body onload="test();">

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/invalid-value-falls-back-to-resizes-visual-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/invalid-value-falls-back-to-resizes-visual-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: Viewport argument value "resize-content" for key "interactive-widget" is invalid, and has been ignored.
+PASS internals.layoutViewportRect().height == window.initialLayoutViewportHeight is true
+PASS window.visualViewport.height < window.initialVisualViewportHeight is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/invalid-value-falls-back-to-resizes-visual.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/invalid-value-falls-back-to-resizes-visual.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=resize-content"/>
+    <style>
+        input {
+            width: 200px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../../resources/js-test.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            window.initialLayoutViewportHeight = internals.layoutViewportRect().height;
+            window.initialVisualViewportHeight = window.visualViewport.height;
+
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+            await UIHelper.ensureStablePresentationUpdate();
+
+            // "resize-content" is not a valid interactive-widget value (it is missing the "s" in
+            // "resizes"), so it must be ignored and the default resizes-visual behavior used: the
+            // keyboard shrinks the visual viewport but leaves the layout viewport unshrunk.
+            shouldBeTrue('internals.layoutViewportRect().height == window.initialLayoutViewportHeight');
+            shouldBeTrue('window.visualViewport.height < window.initialVisualViewportHeight');
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
#### 2fea5e9c6376a50df370cf88a65fa0983616282e
<pre>
[Test Coverage] Add tests for parsing the interactive-widget viewport meta argument
<a href="https://bugs.webkit.org/show_bug.cgi?id=321133">https://bugs.webkit.org/show_bug.cgi?id=321133</a>
<a href="https://rdar.apple.com/184165368">rdar://184165368</a>

Reviewed by Jessica Cheung.

We had no coverage for how the interactive-widget viewport meta argument is
parsed: the existing tests in fast/visual-viewport/ios/interactive-widget/ all
pass a valid value and exercise keyboard behavior. Nothing verified that a bad
value is rejected, or that rejecting it leaves the rest of the viewport
arguments alone.

There is no web-exposed way to read back the parsed value, so these tests
observe parsing through the warning reported by parseInteractiveWidgetValue()
and through internals.configurationForViewport(), which shows that the other
arguments still resolve as written.

Added to fast/viewport/:

- interactive-widget-invalid-values.html: an unknown value, an empty value, a
  bare key with no &quot;=&quot;, near misses (&quot;resizes&quot;, &quot;resizes-contentt&quot;,
  &quot;overlays_content&quot;, &quot;RESize-CONTENT&quot;), a value with a trailing &quot;;&quot;, and
  &quot;RESIZES-VISUAL&quot; spelled with U+0130 to pin that keyword matching folds ASCII
  only. Each is reported and ignored, and width/initial-scale still resolve to
  320x352 at scale 1.
- interactive-widget-valid-values.html: the key and its values are ASCII
  case-insensitive and whitespace around &quot;=&quot; is allowed, so no warnings.
- interactive-widget-semicolon-separator.html: &quot;;&quot; is not a viewport argument
  separator, so it becomes part of the preceding value while the
  interactive-widget argument after it is still parsed.
- interactive-widget-duplicate-key.html: a duplicated key within one content
  string is not a parse error; each occurrence is parsed in order.
- interactive-widget-conflicting-meta-tags.html: a second viewport meta tag
  replaces the first tag&apos;s arguments entirely.
- interactive-widget-disabled.html: with the feature disabled the key itself is
  unrecognized, even for a valid value.

Added to fast/visual-viewport/ios/interactive-widget/:

- invalid-value-falls-back-to-resizes-visual.html: an invalid value falls back
  to resizes-visual rather than to some other mode, checked end to end with the
  keyboard shown: the layout viewport is left unshrunk (unlike
  resizes-content) while the visual viewport does shrink (unlike
  overlays-content).

No change in behavior.

* LayoutTests/fast/viewport/interactive-widget-conflicting-meta-tags-expected.txt: Added.
* LayoutTests/fast/viewport/interactive-widget-conflicting-meta-tags.html: Added.
* LayoutTests/fast/viewport/interactive-widget-disabled-expected.txt: Added.
* LayoutTests/fast/viewport/interactive-widget-disabled.html: Added.
* LayoutTests/fast/viewport/interactive-widget-duplicate-key-expected.txt: Added.
* LayoutTests/fast/viewport/interactive-widget-duplicate-key.html: Added.
* LayoutTests/fast/viewport/interactive-widget-invalid-values-expected.txt: Added.
* LayoutTests/fast/viewport/interactive-widget-invalid-values.html: Added.
* LayoutTests/fast/viewport/interactive-widget-semicolon-separator-expected.txt: Added.
* LayoutTests/fast/viewport/interactive-widget-semicolon-separator.html: Added.
* LayoutTests/fast/viewport/interactive-widget-valid-values-expected.txt: Added.
* LayoutTests/fast/viewport/interactive-widget-valid-values.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget/invalid-value-falls-back-to-resizes-visual-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget/invalid-value-falls-back-to-resizes-visual.html: Added.

Canonical link: <a href="https://commits.webkit.org/318954@main">https://commits.webkit.org/318954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aeab1a76c39b07dab3505287614278c872285d2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144091 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f6fc799-fd01-4b2f-a585-ed93764657e3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140233 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f738d9db-d6a5-4b18-a58e-5c2b0f5b066f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120684 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/19bcde37-5cf5-4e2d-af25-64aa21e9f3a9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42514 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40829 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152915 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40489 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/abort.any.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1066 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191834 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149512 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40088 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54070 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149246 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43898 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121372 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52587 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15479 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51972 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52213 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52033 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->