### PR TITLE
Site-isolated iframe processes keep a page load assertion after a cross-site navigation

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -175,6 +175,8 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 
 @property (nonatomic, readonly) BOOL _hasAccessibilityActivityForTesting;
 
++ (NSUInteger)_suspendedRemotePageNetworkActivityCountForTesting;
+
 - (void)_setMediaVolumeForTesting:(float)volume;
 
 - (void)_textFragmentRangesWithCompletionHandlerForTesting:(void(^)(NSArray<NSValue *> *fragmentRanges))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -37,6 +37,7 @@
 #import "PrintInfo.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteScrollingCoordinatorProxy.h"
+#import "SuspendedPageProxy.h"
 #import "UserMediaProcessManager.h"
 #import "ViewGestureController.h"
 #import "ViewSnapshotStore.h"
@@ -1033,6 +1034,11 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 #else
     completionHandler(nil);
 #endif
+}
+
++ (NSUInteger)_suspendedRemotePageNetworkActivityCountForTesting
+{
+    return WebKit::SuspendedPageProxy::remotePagesWithNetworkActivityCountForTesting();
 }
 
 - (BOOL)_hasAccessibilityActivityForTesting

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -223,6 +223,9 @@ void RemotePageProxy::injectPageIntoNewProcess()
 
 void RemotePageProxy::processDidTerminate(WebProcessProxy& process, ProcessTerminationReason reason)
 {
+    m_processActivityState->reset();
+    m_processActivityState->dropNetworkActivity();
+
     RefPtr page = m_page.get();
     if (!page)
         return;

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -43,6 +43,7 @@
 #include "WebPageMessages.h"
 #include "WebPageProxy.h"
 #include "WebPageProxyMessages.h"
+#include "WebProcessActivityState.h"
 #include "WebProcessMessages.h"
 #include "WebProcessPool.h"
 #include <wtf/CallbackAggregator.h>
@@ -64,6 +65,21 @@ static WeakHashSet<SuspendedPageProxy>& NODELETE allSuspendedPages()
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SuspendedPageProxy);
+
+unsigned SuspendedPageProxy::remotePagesWithNetworkActivityCountForTesting()
+{
+    unsigned count = 0;
+    for (Ref suspendedPage : allSuspendedPages()) {
+        RefPtr page = suspendedPage->page();
+        if (!page)
+            continue;
+        suspendedPage->m_browsingContextGroup->forEachRemotePage(*page, [&count](auto& remotePage) {
+            if (remotePage.processActivityState().hasValidNetworkActivity())
+                ++count;
+        });
+    }
+    return count;
+}
 
 RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(WebProcessPool& processPool, const RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
 {
@@ -168,6 +184,10 @@ void SuspendedPageProxy::startSuspension(std::optional<BackForwardFrameItemIdent
         suspendSubframeProcesses(*mainFrameItemID);
     } else
         m_allSubframesSuspended = true;
+
+    // FIXME: unify page load activity management between main frame and remote frame processes so
+    // this isn't necessary.
+    dropNetworkActivityOnRemotePages();
 
     m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, *this);
     m_suspensionTimeoutTimer.startOneShot(suspensionTimeout);
@@ -371,6 +391,16 @@ void SuspendedPageProxy::suspensionTimedOut()
 
     RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::suspensionTimedOut() destroying the suspended page because it failed to suspend in time", this);
     protect(backForwardCache())->removeEntry(*this); // Will destroy |this|.
+}
+
+void SuspendedPageProxy::dropNetworkActivityOnRemotePages()
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    m_browsingContextGroup->forEachRemotePage(*page, [](auto& remotePage) {
+        remotePage.processActivityState().dropNetworkActivity();
+    });
 }
 
 void SuspendedPageProxy::suspendSubframeProcesses(BackForwardFrameItemIdentifier mainFrameItemID)

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -89,6 +89,8 @@ public:
 
     bool hasSubframeInProcess(WebCore::ProcessIdentifier) const;
 
+    static unsigned remotePagesWithNetworkActivityCountForTesting();
+
     std::optional<WebCore::BackForwardFrameItemIdentifier> suspendedFrameItemID() const { return m_suspendedFrameItemID; }
     HashSet<Ref<WebProcessProxy>> iframeProcesses() const;
 
@@ -114,6 +116,7 @@ private:
     void didProcessRequestToSuspend(SuspensionState);
     void suspensionTimedOut();
     void suspendSubframeProcesses(WebCore::BackForwardFrameItemIdentifier);
+    void dropNetworkActivityOnRemotePages();
     void maybeCompleteSuspension();
 
     void close();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8075,6 +8075,44 @@ TEST(SiteIsolation, SharedProcessInProcessCacheAfterNavigation)
     }
 }
 
+#if USE(RUNNINGBOARD)
+TEST(SiteIsolation, SharedProcessDropsPageLoadActivityAfterCrossSiteNavigation)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/webkit'>"_s } },
+        { "/webkit"_s, { "webkit"_s } },
+        { "/safari"_s, { "<body>safari</body>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewWithSharedProcess(server, EnableProcessCache::No, nil, nil, nil, EnableBackForwardCache::Yes);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        {
+            "https://example.com"_s,
+            { { RemoteFrame } }
+        },
+        {
+            RemoteFrame,
+            { { "https://webkit.org"_s } }
+        },
+    });
+    auto sharedProcess = [webView mainFrame].childFrames[0].info._processIdentifier;
+    EXPECT_NE(sharedProcess, [webView mainFrame].info._processIdentifier);
+
+    // Cross-site navigation. The example.com page enters the back/forward cache, which keeps the
+    // old BrowsingContextGroup and webkit.org remote page alive.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://apple.com/safari"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // The shared process is still alive so the cached example.com page can be restored, but it
+    // shouldn't be holding on to any page load activity.
+    EXPECT_TRUE(processStillRunning(sharedProcess));
+    EXPECT_EQ([WKWebView _suspendedRemotePageNetworkActivityCountForTesting], 0u);
+}
+#endif // USE(RUNNINGBOARD)
+
 TEST(SiteIsolation, WebProcessCacheCrashWithZeroSharedProcess)
 {
     HTTPServer server({


### PR DESCRIPTION
#### f5b7a0e8ef5d9a43f004d4c9db666408be234302
<pre>
Site-isolated iframe processes keep a page load assertion after a cross-site navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=320790">https://bugs.webkit.org/show_bug.cgi?id=320790</a>
<a href="https://rdar.apple.com/183676310">rdar://183676310</a>

Reviewed by Per Arne Vollan.

We are seeing that remote frame processes are running too long after a main frame navigation due to
the remote frame processes holding a page load activity through a navigation (m_networkActivity in
WebProcessActivityState).

The reason for this is that when a PSON occurs, we try to move the page load activities from the old
WebProcesses pre-swap to the new WebProcesses post-swap via NavigationState::didSwapWebProcesses()
=&gt; WebPageProxy::takeNetworkActivity().

This works for the main frame because WebPageProxy&apos;s m_mainFrameProcessActivityState stays the same
through the navigation.

It doesn&apos;t work for remote frames because a PSON will generally cause a BrowsingContextGroup
switch. So by the time WebPageProxy::takeNetworkActivity() runs, its BCG points to a new set of
RemotePageProxy objects. WebPageProxy has no way of reaching back to the old BCG pre-swap, so it
also can&apos;t reach the pre-swap RemotePageProxy objects. So the page load activities associated with
those old RemotePageProxy objects keep running until the RemotePageProxy dies.

This becomes a problem when multi-process back/forward cache is enabled, because that can keep a
RemotePageProxy object alive for a long time (as long as it&apos;s in cache). Previously, this wasn&apos;t
really an issue because RemotePageProxy objects would die soon after the PSON.

My first attempt at fixing this (318458@main) was extremely simple: I just reset m_networkActivity
inside WebProcessActivityState::reset. However, while this works to fix this bug, it caused a large
PLT regression through another convoluted chain of events:

1. The network activity might be the last activity for the process, causing it to suspend.
2. WebProcess::prepareToSuspend runs and thinks the process isn&apos;t in the process cache, so it dumps
all caches (see 289156@main).
3. We then shortly thereafter put this process in the process cache with cold caches, which leads to
a PLT regression.

So this is my second attempt at fixing the issue. Instead of preemptively dropping the network
activity in WebProcessActivityState::reset, we now drop the network activity when the
RemotePageProxy enters the b/f cache (in SuspendedPageProxy::startSuspension).

This really should be cleaned up at some point, but I can&apos;t see a cleaner way of doing this without
a major refactor.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(+[WKWebView _suspendedRemotePageNetworkActivityCountForTesting]):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::processDidTerminate):
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::remotePagesWithNetworkActivityCountForTesting):
(WebKit::SuspendedPageProxy::startSuspension):
(WebKit::SuspendedPageProxy::dropNetworkActivityOnRemotePages):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, SharedProcessDropsPageLoadActivityAfterCrossSiteNavigation)):

Canonical link: <a href="https://commits.webkit.org/318796@main">https://commits.webkit.org/318796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16cc71caf49da8206acc2f3d5ae34dcefbe6781b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179353 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189185 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/821aeb37-6ce6-4c8f-8ab8-bc1528515025) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139862 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27236c9a-3fea-40e7-993b-f1f0eed8bcfd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160610 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120314 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0775672b-7fe6-41e8-ac2f-988c193245f1) 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42141 "An unexpected error occured. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Running run-layout-tests-in-stress-mode; 1 new passes 2 flakes; Uploaded test results; 1 new passes 3 flakes") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40471 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2284 "Build is in progress. Recent messages:") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152541 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40115 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/636 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191403 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52962 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149117 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40000 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53643 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148860 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43533 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125915 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120781 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52160 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15101 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51545 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51786 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51606 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->