### PR TITLE
[JSC][Temporal] Align time zone identifier parsing with the spec's parse records

### DIFF
--- a/JSTests/stress/temporal-plaindate.js
+++ b/JSTests/stress/temporal-plaindate.js
@@ -139,15 +139,10 @@ let failures = [
     "2007-01-09T03:24:30+01:00[Hey/Hello",
     "2007-01-09T03:24:30+01:00[]",
     "2007-01-09T03:24:30+01:00[Hey/]",
-    "2007-01-09T03:24:30+01:00[..]",
-    "2007-01-09T03:24:30+01:00[.]",
-    "2007-01-09T03:24:30+01:00[./.]",
-    "2007-01-09T03:24:30+01:00[../..]",
     "2007-01-09T03:24:30+01:00[-Hey/Hello]",
     "2007-01-09T03:24:30+01:00[-]",
     "2007-01-09T03:24:30+01:00[-/_]",
     "2007-01-09T03:24:30+01:00[_/-]",
-    "2007-01-09T03:24:30+01:00[CocoaCappuccinoMatcha]",
     "2007-01-09T03:24:30+10:20:30.0123456789",
     "2007-01-09 03:24:30+01:00[Etc/GMT\u221201]",
     "2007-01-09 03:24:30+01:00[+02:00:00.0123456789]",
@@ -436,4 +431,17 @@ shouldBe(Temporal.PlainDate.prototype.toPlainYearMonth.length, 0);
 
     shouldBe(date.toPlainMonthDay().toString(), '02-28');
     shouldBe(date.toPlainYearMonth().toString(), '2020-02');
+}
+
+// proposal-temporal a8f6b0d3 ("Editorial: Align time zone name syntax with IXDTF") dropped
+// TimeZoneIANANameComponent's 14-character limit and its exclusion of "." and "..", so these
+// annotations are valid now. Do not move them back to `failures`.
+for (let text of [
+    "2007-01-09T03:24:30+01:00[..]",
+    "2007-01-09T03:24:30+01:00[.]",
+    "2007-01-09T03:24:30+01:00[./.]",
+    "2007-01-09T03:24:30+01:00[../..]",
+    "2007-01-09T03:24:30+01:00[CocoaCappuccinoMatcha]",
+]) {
+    Temporal.PlainDate.from(text);
 }

--- a/JSTests/stress/temporal-plaindatetime.js
+++ b/JSTests/stress/temporal-plaindatetime.js
@@ -163,15 +163,10 @@ const badStrings = [
     "2007-01-09T03:24:30+01:00[Hey/Hello",
     "2007-01-09T03:24:30+01:00[]",
     "2007-01-09T03:24:30+01:00[Hey/]",
-    "2007-01-09T03:24:30+01:00[..]",
-    "2007-01-09T03:24:30+01:00[.]",
-    "2007-01-09T03:24:30+01:00[./.]",
-    "2007-01-09T03:24:30+01:00[../..]",
     "2007-01-09T03:24:30+01:00[-Hey/Hello]",
     "2007-01-09T03:24:30+01:00[-]",
     "2007-01-09T03:24:30+01:00[-/_]",
     "2007-01-09T03:24:30+01:00[_/-]",
-    "2007-01-09T03:24:30+01:00[CocoaCappuccinoMatcha]",
     "2007-01-09T03:24:30+10:20:30.0123456789",
     "2007-01-09 03:24:30+01:00[Etc/GMT\u221201]",
     "2007-01-09 03:24:30+01:00[+02:00:00.0123456789]",
@@ -302,3 +297,16 @@ shouldThrow(() => { pdt.round({}); }, RangeError);
 shouldThrow(() => { pdt.round({ smallestUnit: 'bogus' }); }, RangeError);
 shouldThrow(() => { pdt.round({ smallestUnit: 'minute', roundingIncrement: 24 }); }, RangeError);
 shouldThrow(() => { pdt.round({ smallestUnit: 'minute', roundingMode: 'bogus' }); }, RangeError);
+
+// proposal-temporal a8f6b0d3 ("Editorial: Align time zone name syntax with IXDTF") dropped
+// TimeZoneIANANameComponent's 14-character limit and its exclusion of "." and "..", so these
+// annotations are valid now. Do not move them back to `failures`.
+for (let text of [
+    "2007-01-09T03:24:30+01:00[..]",
+    "2007-01-09T03:24:30+01:00[.]",
+    "2007-01-09T03:24:30+01:00[./.]",
+    "2007-01-09T03:24:30+01:00[../..]",
+    "2007-01-09T03:24:30+01:00[CocoaCappuccinoMatcha]",
+]) {
+    Temporal.PlainDateTime.from(text);
+}

--- a/JSTests/stress/temporal-plaintime.js
+++ b/JSTests/stress/temporal-plaintime.js
@@ -233,15 +233,10 @@ let failures = [
     "1995-12-07T03:24:30+01:00[Hey/Hello",
     "1995-12-07T03:24:30+01:00[]",
     "1995-12-07T03:24:30+01:00[Hey/]",
-    "1995-12-07T03:24:30+01:00[..]",
-    "1995-12-07T03:24:30+01:00[.]",
-    "1995-12-07T03:24:30+01:00[./.]",
-    "1995-12-07T03:24:30+01:00[../..]",
     "1995-12-07T03:24:30+01:00[-Hey/Hello]",
     "1995-12-07T03:24:30+01:00[-]",
     "1995-12-07T03:24:30+01:00[-/_]",
     "1995-12-07T03:24:30+01:00[_/-]",
-    "1995-12-07T03:24:30+01:00[CocoaCappuccinoMatcha]",
     "1995-12-07T03:24:30+10:20:30.0123456789",
     "1995-12-07 03:24:30+01:00[Etc/GMT\u221201]",
     "1995-12-07 03:24:30+01:00[+02:00:00.0123456789]",
@@ -369,4 +364,17 @@ shouldThrow(() => {
     let time = Temporal.PlainTime.from('20:13:20.971398099');
     shouldBe(String(time.since(Temporal.PlainTime.from('19:39:09.068346205'))), `PT34M11.903051894S`);
     shouldBe(String(time.since(Temporal.PlainTime.from('22:39:09.068346205'))), `-PT2H25M48.096948106S`);
+}
+
+// proposal-temporal a8f6b0d3 ("Editorial: Align time zone name syntax with IXDTF") dropped
+// TimeZoneIANANameComponent's 14-character limit and its exclusion of "." and "..", so these
+// annotations are valid now. Do not move them back to `failures`.
+for (let text of [
+    "1995-12-07T03:24:30+01:00[..]",
+    "1995-12-07T03:24:30+01:00[.]",
+    "1995-12-07T03:24:30+01:00[./.]",
+    "1995-12-07T03:24:30+01:00[../..]",
+    "1995-12-07T03:24:30+01:00[CocoaCappuccinoMatcha]",
+]) {
+    Temporal.PlainTime.from(text);
 }

--- a/JSTests/stress/temporal-timezone.js
+++ b/JSTests/stress/temporal-timezone.js
@@ -48,3 +48,104 @@ shouldThrow(() => { Temporal.TimeZone.from("UTC"); }, TypeError);
     shouldBe(typeof tzId, "string");
     shouldBe(tzId.length > 0, true);
 }
+
+// ParseTemporalTimeZoneString Step 3 allows the annotation on any of 6 productions, not just the
+// two datetime ones. https://tc39.es/proposal-temporal/#sec-temporal-parsetemporaltimezonestring
+{
+    let cases = [
+        ["2024-12[Europe/Berlin]", "Europe/Berlin"],   // TemporalYearMonthString + bracket
+        ["--12-25[Europe/Berlin]", "Europe/Berlin"],   // TemporalMonthDayString + bracket
+        ["12:00[Europe/Berlin]", "Europe/Berlin"],     // TemporalTimeString + bracket
+    ];
+    for (let [tzLike, expected] of cases) {
+        shouldBe(Temporal.Now.zonedDateTimeISO(tzLike).timeZoneId, expected);
+        shouldBe(Temporal.ZonedDateTime.from("2024-06-15T12:00[UTC]").withTimeZone(tzLike).timeZoneId, expected);
+        shouldBe(Temporal.Instant.fromEpochNanoseconds(0n).toZonedDateTimeISO(tzLike).timeZoneId, expected);
+    }
+
+    // The annotation is what makes those acceptable, not the production.
+    shouldThrow(() => Temporal.Now.zonedDateTimeISO("2024-12"), RangeError);
+    shouldThrow(() => Temporal.Now.zonedDateTimeISO("--12-25"), RangeError);
+    shouldThrow(() => Temporal.Now.zonedDateTimeISO("12:00"), RangeError);
+}
+
+// Step 7 delegates to ParseTimeZoneIdentifier, which only accepts UTCOffset[~SubMinutePrecision].
+{
+    shouldThrow(() => Temporal.Now.zonedDateTimeISO("+01:00:30"), RangeError);
+    shouldThrow(() => Temporal.Now.zonedDateTimeISO("2024-01-01T00:00[+01:00:30]"), RangeError);
+}
+
+// The 4th caller of ToTemporalTimeZoneIdentifier; the other three are covered above.
+{
+    let instant = Temporal.Instant.fromEpochNanoseconds(0n);
+    for (let tzLike of ["2024-12[Europe/Berlin]", "--12-25[Europe/Berlin]", "12:00[Europe/Berlin]"])
+        shouldBe(instant.toString({ timeZone: tzLike }), "1970-01-01T01:00:00+01:00");
+
+    // toLocaleString goes through Intl.DateTimeFormat instead, which rejects annotated strings.
+    shouldThrow(() => instant.toLocaleString("en", { timeZone: "12:00[Europe/Berlin]" }), RangeError);
+}
+
+// An offset with no annotation matches TemporalDateTimeString[~Zoned]; [+Zoned] requires one.
+{
+    shouldBe(Temporal.Now.zonedDateTimeISO("2024-01-01T00:00+01:00").timeZoneId, "+01:00");
+    shouldBe(Temporal.Now.zonedDateTimeISO("2024-01-01T00:00Z").timeZoneId, "UTC");
+}
+
+// Every Temporal.Now entry point resolves its timeZone argument through the same AO.
+{
+    shouldBe(Temporal.Now.plainDateISO("2024-12[Europe/Berlin]") instanceof Temporal.PlainDate, true);
+    shouldBe(Temporal.Now.plainDateTimeISO("12:00[Europe/Berlin]") instanceof Temporal.PlainDateTime, true);
+    shouldBe(Temporal.Now.plainTimeISO("--12-25[Europe/Berlin]") instanceof Temporal.PlainTime, true);
+}
+
+// Step 2 commits to the ParseTimeZoneIdentifier reading. "T12+01" is both a TimeZoneIANAName and a
+// TemporalTimeString with an offset, so falling through to Step 3 would give "+01:00" rather than rejecting an unavailable named zone.
+{
+    let instant = Temporal.Instant.fromEpochNanoseconds(0n);
+    shouldThrow(() => instant.toString({ timeZone: "T12+01" }), RangeError);
+    shouldThrow(() => Temporal.Now.zonedDateTimeISO("T12+01"), RangeError);
+    shouldThrow(() => new Temporal.ZonedDateTime(0n, "T12+01"), RangeError);
+
+    // "Z" is an unavailable TimeZoneIANAName; only Step 6 gives it its UTC meaning.
+    shouldThrow(() => new Temporal.ZonedDateTime(0n, "Z"), RangeError);
+    shouldThrow(() => instant.toString({ timeZone: "Z" }), RangeError);
+    shouldBe(Temporal.Now.zonedDateTimeISO("2024-01-01T00:00Z").timeZoneId, "UTC");
+}
+
+// ParseTimeZoneIdentifier Steps 5-8: offset identifiers are minute-granular and sign-normalized.
+{
+    let cases = [
+        ["+01:00", "+01:00"],
+        ["+0530", "+05:30"],   // UTCOffset accepts the colon-less form
+        ["-05:00", "-05:00"],
+        ["-00:00", "+00:00"],  // negative zero formats as "+00:00"
+        ["+23:59", "+23:59"],
+        ["-12:00", "-12:00"],
+    ];
+    for (let [tz, expected] of cases) {
+        let zdt = new Temporal.ZonedDateTime(0n, tz);
+        shouldBe(zdt.timeZoneId, expected);
+        shouldBe(zdt.offset, expected);
+    }
+    shouldThrow(() => new Temporal.ZonedDateTime(0n, "+24:00"), RangeError);
+
+    // The constructor takes ParseTimeZoneIdentifier, so datetime strings are not identifiers here.
+    shouldThrow(() => new Temporal.ZonedDateTime(0n, "2024-01-01T00:00+01:00"), RangeError);
+    shouldThrow(() => new Temporal.ZonedDateTime(0n, "2024-01-01T00:00[Europe/Berlin]"), RangeError);
+    shouldBe(Temporal.Now.zonedDateTimeISO("2024-01-01T00:00[Europe/Berlin]").timeZoneId, "Europe/Berlin");
+}
+
+// Step 3 accepts a syntactically valid name without checking availability; the constructor's
+// Step 6.b rejects it. "." and "./." are grammatical, "Hey/" and "_/-" are not.
+{
+    for (let tz of ["Foo/Bar", ".", "./.", "Hey/", "/Hey", "_/-", ""])
+        shouldThrow(() => new Temporal.ZonedDateTime(0n, tz), RangeError);
+
+    // Every TimeZoneIANANameComponent must be non-empty and start with a TZLeadingChar, not just the first.
+    for (let tz of ["a/", "a/-", "a/-b", "a//b"])
+        shouldThrow(() => Temporal.PlainDate.from(`2007-01-09T03:24:30+01:00[${tz}]`), RangeError);
+
+    // Case-normalization happens in Step 6.c, via GetAvailableNamedTimeZoneIdentifier.
+    shouldBe(new Temporal.ZonedDateTime(0n, "europe/berlin").timeZoneId, "Europe/Berlin");
+    shouldBe(new Temporal.ZonedDateTime(0n, "UTC").timeZoneId, "UTC");
+}

--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -2945,10 +2945,24 @@ static void testExactTimeToLocalDateAndTime()
     TCHECK_EQ(time3.hour(), 19u, "localDT: UTC-5 epoch hour");
 }
 
+// Resolves an identifier to a TimeZone the way ToTemporalTimeZoneIdentifier steps 3-9 do:
+// parseTemporalTimeZoneString returns the Time Zone Identifier Parse Record, not a resolved zone.
+static std::optional<TimeZone> timeZoneFromIdentifier(StringView identifier)
+{
+    auto parse = ISO8601::parseTemporalTimeZoneString(identifier);
+    if (!parse)
+        return std::nullopt;
+    if (parse->offsetMinutes)
+        return TimeZone::fromUTCOffset(*parse->offsetMinutes * static_cast<int64_t>(ISO8601::ExactTime::nsPerMinute));
+    if (auto tzId = ISO8601::parseTimeZoneName(parse->name.span()))
+        return TimeZone::fromID(*tzId);
+    return std::nullopt;
+}
+
 static void testInterpretISODateTimeOffset()
 {
     // temporal_rs: interpret_isodatetime_offset tested via zdt_from_partial, zdt_offset_match_minutes
-    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    auto utcOpt = timeZoneFromIdentifier("UTC"_s);
     if (!utcOpt) {
         fprintf(stderr, "SKIP [interpretISODateTimeOffset]: UTC not available\n");
         return;
@@ -2959,16 +2973,16 @@ static void testInterpretISODateTimeOffset()
 
     // Step 1: start-of-day -> getStartOfDay
     {
-        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { }, true, OffsetBehaviour::Wall,
-            TemporalOffsetDisambiguation::Ignore, 0, false, utc, TemporalDisambiguation::Compatible);
+        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { }, UseStartOfDay::Yes, OffsetBehaviour::Wall,
+            TemporalOffsetDisambiguation::Ignore, 0, MatchBehaviour::MatchMinutes, utc, TemporalDisambiguation::Compatible);
         TCHECK_TRUE(r.has_value(), "interpretISO: start-of-day ok");
         TCHECK_EQ(r->epochNanoseconds(), Int128(1577836800000000000LL), "interpretISO: start-of-day = midnight UTC");
     }
 
     // Step 3: Wall -> GetEpochNanosecondsFor (ignore offset entirely)
     {
-        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { 12, 0, 0, 0, 0, 0 }, false,
-            OffsetBehaviour::Wall, TemporalOffsetDisambiguation::Ignore, 3600000000000LL, false,
+        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { 12, 0, 0, 0, 0, 0 }, UseStartOfDay::No,
+            OffsetBehaviour::Wall, TemporalOffsetDisambiguation::Ignore, 3600000000000LL, MatchBehaviour::MatchMinutes,
             utc, TemporalDisambiguation::Compatible);
         TCHECK_TRUE(r.has_value(), "interpretISO: Wall ok");
         TCHECK_EQ(r->epochNanoseconds(), epoch2020Jan1Noon, "interpretISO: Wall = noon UTC (offset ignored)");
@@ -2978,8 +2992,8 @@ static void testInterpretISODateTimeOffset()
     // 2020-01-01T12:00:00+01:00 -> epoch = noon_UTC - 1h = 11:00 UTC
     {
         constexpr Int128 epoch2020Jan1_11UTC { 1577876400000000000LL };
-        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { 12, 0, 0, 0, 0, 0 }, false,
-            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Use, 3600000000000LL, false,
+        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { 12, 0, 0, 0, 0, 0 }, UseStartOfDay::No,
+            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Use, 3600000000000LL, MatchBehaviour::MatchMinutes,
             utc, TemporalDisambiguation::Compatible);
         TCHECK_TRUE(r.has_value(), "interpretISO: Use ok");
         TCHECK_EQ(r->epochNanoseconds(), epoch2020Jan1_11UTC, "interpretISO: Use = noon - 1h offset");
@@ -2987,8 +3001,8 @@ static void testInterpretISODateTimeOffset()
 
     // Step 10b: Prefer — offset matches UTC (0), returns the UTC candidate
     {
-        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { 12, 0, 0, 0, 0, 0 }, false,
-            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Prefer, 0, false,
+        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { 12, 0, 0, 0, 0, 0 }, UseStartOfDay::No,
+            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Prefer, 0, MatchBehaviour::MatchMinutes,
             utc, TemporalDisambiguation::Compatible);
         TCHECK_TRUE(r.has_value(), "interpretISO: Prefer UTC=0 ok");
         TCHECK_EQ(r->epochNanoseconds(), epoch2020Jan1Noon, "interpretISO: Prefer UTC=0 = noon UTC");
@@ -2996,26 +3010,26 @@ static void testInterpretISODateTimeOffset()
 
     // Step 11: Reject — offset (+1h) doesn't match UTC (0) -> error
     {
-        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { 12, 0, 0, 0, 0, 0 }, false,
-            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Reject, 3600000000000LL, false,
+        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { 12, 0, 0, 0, 0, 0 }, UseStartOfDay::No,
+            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Reject, 3600000000000LL, MatchBehaviour::MatchMinutes,
             utc, TemporalDisambiguation::Compatible);
         TCHECK_TRUE(!r.has_value(), "interpretISO: Reject mismatch -> error");
     }
 
     // Step 10c: match-minutes — Africa/Monrovia has offset -44:30 in 1970; -45:00 (rounded) is accepted
     // temporal_rs: zdt_offset_match_minutes test
-    auto monroviaOpt = ISO8601::parseTemporalTimeZoneIdentifier("Africa/Monrovia"_s);
+    auto monroviaOpt = timeZoneFromIdentifier("Africa/Monrovia"_s);
     if (monroviaOpt) {
         constexpr int64_t minus44m30s = -(44 * 60 + 30) * 1000000000LL; // -44min 30sec in ns
         constexpr int64_t minus45m = -(45 * 60) * 1000000000LL; // -45min in ns
-        // Exact match (-44:30) accepted — has sub-minute precision -> matchMinutes=false (exact match only)
-        auto rExact = interpretISODateTimeOffset({ 1970, 1, 1 }, { 0, 0, 0, 0, 0, 0 }, false,
-            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Reject, minus44m30s, true,
+        // Exact match (-44:30) accepted — a sub-minute offset string means ~match-exactly~.
+        auto rExact = interpretISODateTimeOffset({ 1970, 1, 1 }, { 0, 0, 0, 0, 0, 0 }, UseStartOfDay::No,
+            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Reject, minus44m30s, MatchBehaviour::MatchExactly,
             *monroviaOpt, TemporalDisambiguation::Compatible);
         TCHECK_TRUE(rExact.has_value(), "interpretISO: Monrovia exact -44:30 accepted");
-        // Rounded match (-45:00) accepted with matchMinutes=true — no sub-minute precision -> matchMinutes=true
-        auto rRounded = interpretISODateTimeOffset({ 1970, 1, 1 }, { 0, 0, 0, 0, 0, 0 }, false,
-            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Reject, minus45m, false,
+        // Rounded match (-45:00) accepted under ~match-minutes~ — minute-precision offset string.
+        auto rRounded = interpretISODateTimeOffset({ 1970, 1, 1 }, { 0, 0, 0, 0, 0, 0 }, UseStartOfDay::No,
+            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Reject, minus45m, MatchBehaviour::MatchMinutes,
             *monroviaOpt, TemporalDisambiguation::Compatible);
         TCHECK_TRUE(rRounded.has_value(), "interpretISO: Monrovia rounded -45:00 accepted (match-minutes)");
     }
@@ -3038,7 +3052,7 @@ static void testTimeZoneICUWithIANA()
 {
     // America/New_York — standard time offset: -5h = -18000000000000 ns
     // Test with a winter date (no DST): 2020-01-15T12:00:00 UTC = 1579089600000000000 ns
-    auto nytzOpt = ISO8601::parseTemporalTimeZoneIdentifier("America/New_York"_s);
+    auto nytzOpt = timeZoneFromIdentifier("America/New_York"_s);
     if (!nytzOpt) {
         fprintf(stderr, "SKIP [IANA tests]: America/New_York not available\n");
         return;
@@ -3295,7 +3309,7 @@ static void testToZonedDateTime()
 {
     // temporal_rs: plain_date.rs::to_zoned_date_time
     // PlainDate 2020-01-01 -> ZDT with UTC -> epoch = 2020-01-01T00:00:00Z
-    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    auto utcOpt = timeZoneFromIdentifier("UTC"_s);
     if (!utcOpt) {
         fprintf(stderr, "SKIP [toZDT]: UTC not available\n");
         return;
@@ -3323,7 +3337,7 @@ static void testToZonedDateTimeError()
 {
     // temporal_rs: to_zoned_date_time_error — min date -271821-04-19 start-of-day is at or before min epoch.
 
-    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    auto utcOpt = timeZoneFromIdentifier("UTC"_s);
     if (!utcOpt) {
         fprintf(stderr, "SKIP [toZDTErr]: UTC not available\n");
         return;
@@ -3335,7 +3349,7 @@ static void testToZonedDateTimeError()
 static void testAddZonedDateTime()
 {
     // temporal_rs: basic_zdt_add (src/builtins/core/zoned_date_time/tests.rs)
-    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    auto utcOpt = timeZoneFromIdentifier("UTC"_s);
     if (!utcOpt) {
         fprintf(stderr, "SKIP [addZonedDateTime]: UTC not available\n");
         return;
@@ -3379,7 +3393,7 @@ static void testGetTimeZoneTransition()
     // temporal_rs: get_time_zone_transition (src/builtins/core/zoned_date_time/tests.rs)
 
     // 1. UTC-offset timezones have no transitions -> nullopt
-    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    auto utcOpt = timeZoneFromIdentifier("UTC"_s);
     if (!utcOpt) {
         fprintf(stderr, "SKIP [getTimeZoneTransition]: UTC not available\n");
         return;
@@ -3389,7 +3403,7 @@ static void testGetTimeZoneTransition()
     auto r2 = getTimeZoneTransition(*utcOpt, ISO8601::ExactTime(Int128(0)), TransitionDirection::Previous);
     TCHECK_TRUE(r2.has_value() && !r2->has_value(), "transition: UTC no previous");
     // UTC-offset +05:30 also has no transitions
-    auto plusOpt = ISO8601::parseTemporalTimeZoneIdentifier("+05:30"_s);
+    auto plusOpt = timeZoneFromIdentifier("+05:30"_s);
     if (plusOpt) {
         auto r3 = getTimeZoneTransition(*plusOpt, ISO8601::ExactTime(Int128(0)), TransitionDirection::Next);
         TCHECK_TRUE(r3.has_value() && !r3->has_value(), "transition: +05:30 no transitions");
@@ -3397,7 +3411,7 @@ static void testGetTimeZoneTransition()
 
     // 2. America/New_York DST transitions from a summer 2020 date
     // summer epoch: 2020-07-15T12:00:00Z = 1594814400000000000 ns
-    auto nyOpt = ISO8601::parseTemporalTimeZoneIdentifier("America/New_York"_s);
+    auto nyOpt = timeZoneFromIdentifier("America/New_York"_s);
     if (!nyOpt) {
         fprintf(stderr, "SKIP [getTimeZoneTransition]: America/New_York not available\n");
         return;
@@ -3422,7 +3436,7 @@ static void testGetTimeZoneTransition()
     // From temporal_rs test262 case: at 1970-01-01T00:00:00Z (epoch=0), London was on BST (+01:00).
     // TZDB has intermediate fake entries around 1968-1971 that don't change the UTC offset —
     // our 20-iteration skip loop must bypass them to find the real pre-BST transition.
-    auto londonOpt = ISO8601::parseTemporalTimeZoneIdentifier("Europe/London"_s);
+    auto londonOpt = timeZoneFromIdentifier("Europe/London"_s);
     if (!londonOpt) {
         fprintf(stderr, "SKIP [getTimeZoneTransition London]: Europe/London not available\n");
         return;
@@ -3446,20 +3460,28 @@ static void testGetTimeZoneTransition()
 static void testTimeZoneEquals()
 {
     // temporal_rs: canonicalize_equals (src/builtins/core/time_zone.rs)
+    // timeZoneEquals takes resolved identifiers, so each side goes through
+    // ToTemporalTimeZoneIdentifier first; an unresolvable identifier compares as unequal.
+    auto tzEquals = [](StringView id1, StringView id2) {
+        auto a = timeZoneFromIdentifier(id1);
+        auto b = timeZoneFromIdentifier(id2);
+        return a && b && timeZoneEquals(*a, *b);
+    };
+
     // 1. Identical string -> true
-    TCHECK_TRUE(timeZoneEquals("UTC"_s, "UTC"_s), "tzEquals: UTC=UTC");
-    TCHECK_TRUE(timeZoneEquals("+05:30"_s, "+05:30"_s), "tzEquals: +05:30=+05:30");
+    TCHECK_TRUE(tzEquals("UTC"_s, "UTC"_s), "tzEquals: UTC=UTC");
+    TCHECK_TRUE(tzEquals("+05:30"_s, "+05:30"_s), "tzEquals: +05:30=+05:30");
 
     // 2. Different strings -> false
-    TCHECK_TRUE(!timeZoneEquals("UTC"_s, "America/New_York"_s), "tzEquals: UTC!=NY");
-    TCHECK_TRUE(!timeZoneEquals("+05:30"_s, "+05:00"_s), "tzEquals: offset diff");
+    TCHECK_TRUE(!tzEquals("UTC"_s, "America/New_York"_s), "tzEquals: UTC!=NY");
+    TCHECK_TRUE(!tzEquals("+05:30"_s, "+05:00"_s), "tzEquals: offset diff");
 
     // 3. Offset vs named -> false
-    TCHECK_TRUE(!timeZoneEquals("+00:00"_s, "UTC"_s), "tzEquals: +00:00 != UTC (offset vs named)");
+    TCHECK_TRUE(!tzEquals("+00:00"_s, "UTC"_s), "tzEquals: +00:00 != UTC (offset vs named)");
 
     // 4. IANA aliases: Asia/Calcutta = Asia/Kolkata (canonicalized to same primary)
     // temporal_rs: canonicalize_equals test
-    TCHECK_TRUE(timeZoneEquals("Asia/Calcutta"_s, "Asia/Kolkata"_s), "tzEquals: Calcutta=Kolkata");
+    TCHECK_TRUE(tzEquals("Asia/Calcutta"_s, "Asia/Kolkata"_s), "tzEquals: Calcutta=Kolkata");
 }
 
 static void testPossibleEpochNsAtLimits()
@@ -3467,7 +3489,7 @@ static void testPossibleEpochNsAtLimits()
     // temporal_rs: test_possible_epoch_ns_at_limits (src/builtins/core/time_zone.rs)
     // At the min/max Temporal boundaries, getPossibleEpochNanosecondsFor must return exactly 1 candidate.
     // Just outside those boundaries, it must return empty (range error).
-    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    auto utcOpt = timeZoneFromIdentifier("UTC"_s);
     if (!utcOpt) {
         fprintf(stderr, "SKIP [epochNsLimits]: UTC not available\n");
         return;
@@ -3495,7 +3517,7 @@ static void testPossibleEpochNsAtLimits()
     TCHECK_TRUE(!rTooLate.has_value() || isGap(*rTooLate), "epochNsLimits: too-late = error/gap");
 
     // UTC offset timezone: +05:30 — same bounds should hold
-    auto plusOpt = ISO8601::parseTemporalTimeZoneIdentifier("+05:30"_s);
+    auto plusOpt = timeZoneFromIdentifier("+05:30"_s);
     if (plusOpt) {
         auto rPlusMin = getPossibleEpochNanosecondsFor(*plusOpt, { -271821, 4, 20 }, { 5, 30, 0, 0, 0, 0 });
         TCHECK_TRUE(rPlusMin.has_value() && std::holds_alternative<ISO8601::ExactTime>(*rPlusMin), "epochNsLimits: +05:30 min ok");
@@ -3567,7 +3589,7 @@ static void testNudgeFunctions()
     }
 
     // --- nudgeToZonedTime: UTC+0 timezone, P25H rounded to Hour ---
-    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    auto utcOpt = timeZoneFromIdentifier("UTC"_s);
     if (utcOpt) {
         ISO8601::PlainDate date { 2020, 1, 1 };
         ISO8601::PlainTime time;
@@ -3586,7 +3608,7 @@ static void testRoundRelativeToZonedDateTime()
     // round to largestUnit=Day -> expected: 1 day 1 hour
 
     // +04:30 = 4.5h = 16200s = 16200000000000 ns
-    auto tzOpt = ISO8601::parseTemporalTimeZoneIdentifier("+04:30"_s);
+    auto tzOpt = timeZoneFromIdentifier("+04:30"_s);
     if (!tzOpt) {
         fprintf(stderr, "SKIP [roundRelZDT]: +04:30 not available\n");
         return;
@@ -3611,7 +3633,7 @@ static void testDurationTotalZDT()
 {
     // temporal_rs: test_duration_total (ZDT path) — P2756H in months with DST differs from PlainDate path.
 
-    auto romeOpt = ISO8601::parseTemporalTimeZoneIdentifier("Europe/Rome"_s);
+    auto romeOpt = timeZoneFromIdentifier("Europe/Rome"_s);
     if (!romeOpt) {
         fprintf(stderr, "SKIP [totalZDT]: Europe/Rome not available\n");
         return;
@@ -3649,7 +3671,7 @@ static void testNudgePastEnd()
     // Zero duration, ZDT at max epoch (8.64e21 ns = 1e8 days * nsPerDay), round to Day/Minute
     // Rounding constructs end date = max + 1 day -> error
 
-    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    auto utcOpt = timeZoneFromIdentifier("UTC"_s);
     if (!utcOpt) {
         fprintf(stderr, "SKIP [nudgePast]: UTC not available\n");
         return;
@@ -3680,7 +3702,7 @@ static void testRoundZeroDurationZDT()
 {
     // temporal_rs: round_zero_duration with ZDT relativeTo
     // P0 duration, ZDT at UTC epoch=0, round to Day/Hour -> result is still zero
-    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    auto utcOpt = timeZoneFromIdentifier("UTC"_s);
     if (!utcOpt) {
         fprintf(stderr, "SKIP [roundZeroZDT]: UTC not available\n");
         return;
@@ -3700,7 +3722,7 @@ static void testRoundIncrementRegressionZDT()
     // temporal_rs: round_increment_regression_test ZDT path
     // P48H, round to Day, increment=2, with ZDT UTC at epoch=0
     // Expected: 2 days (same result as without relativeTo)
-    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    auto utcOpt = timeZoneFromIdentifier("UTC"_s);
     if (!utcOpt) {
         fprintf(stderr, "SKIP [roundIncZDT]: UTC not available\n");
         return;

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -626,15 +626,105 @@ static bool NODELETE canBeTimeZone(const StringParsingBuffer<CharacterType>& buf
     }
 }
 
+static bool isTZLeadingChar(char16_t character)
+{
+    // https://tc39.es/proposal-temporal/#prod-TZLeadingChar
+    // TZLeadingChar :::
+    //     Alpha
+    //     .
+    //     _
+    return isASCIIAlpha(character) || character == '.' || character == '_';
+}
+
+static bool isTZChar(char16_t character)
+{
+    // https://tc39.es/proposal-temporal/#prod-TZChar
+    // TZChar :::
+    //     TZLeadingChar
+    //     DecimalDigit
+    //     -
+    //     +
+    return isTZLeadingChar(character) || isASCIIDigit(character) || character == '-' || character == '+';
+}
+
+template<typename CharacterType>
+static std::optional<std::span<const CharacterType>> parseTimeZoneIANAName(StringParsingBuffer<CharacterType>& buffer)
+{
+    // https://tc39.es/proposal-temporal/#prod-TimeZoneIANAName
+    // TimeZoneIANAName :::
+    //     TimeZoneIANANameComponent
+    //     TimeZoneIANAName / TimeZoneIANANameComponent
+    // TimeZoneIANANameComponent :::
+    //     TZLeadingChar
+    //     TimeZoneIANANameComponent TZChar
+    //
+    //  Both left recursions flatten: '/'-separated components, each a TZLeadingChar then any number
+    //  of TZChars. atComponentStart still set at the end means empty or trailing '/'.
+    size_t length = 0;
+    bool atComponentStart = true;
+    while (length < buffer.lengthRemaining()) {
+        auto character = buffer[length];
+        if (character == '/') {
+            if (atComponentStart)
+                break;
+            atComponentStart = true;
+        } else if (atComponentStart ? isTZLeadingChar(character) : isTZChar(character))
+            atComponentStart = false;
+        else
+            break;
+        ++length;
+    }
+    if (atComponentStart)
+        return std::nullopt;
+    return buffer.consume(length);
+}
+
+// https://tc39.es/proposal-temporal/#sec-parsetimezoneidentifier
+template<typename CharacterType>
+static std::optional<TimeZoneIdentifierParseRecord> parseTimeZoneIdentifier(StringParsingBuffer<CharacterType>& buffer)
+{
+    // https://tc39.es/proposal-temporal/#prod-TimeZoneIdentifier
+    // TimeZoneIdentifier :::
+    //     UTCOffset[~SubMinutePrecision]
+    //     TimeZoneIANAName
+    //
+    // Step 1: the two alternatives are the attempts below. They are disjoint, and
+    // parseTimeZoneIANAName consumes nothing on failure, so either order gives the same answer.
+
+    // Step 3: If parseResult contains a |TimeZoneIANAName| Parse Node, then
+    if (auto name = parseTimeZoneIANAName(buffer)) {
+        // Steps 3.a-3.c: per 3.b's NOTE the name need not be available, so nothing is resolved here.
+        return TimeZoneIdentifierParseRecord { Vector<Latin1Character>(*name), std::nullopt };
+    }
+
+    // Steps 4-6: parseUTCOffset matches |UTCOffset[~SubMinutePrecision]| and converts it in one call.
+    auto offsetNanoseconds = parseUTCOffset(buffer, /* parseSubMinutePrecision */ false);
+
+    // Step 2: If parseResult is a List of errors, throw a RangeError exception.
+    if (!offsetNanoseconds)
+        return std::nullopt;
+
+    // Step 7: offsetMinutes = offsetNanoseconds / (60 × 10**9); exact under ~SubMinutePrecision.
+    // Step 8: Return the Record with [[Name]] ~empty~.
+    return TimeZoneIdentifierParseRecord { { }, *offsetNanoseconds / nsPerMinute };
+}
+
+std::optional<TimeZoneIdentifierParseRecord> parseTimeZoneIdentifier(StringView identifier)
+{
+    return readCharactersForParsing(identifier, [](auto buffer) -> std::optional<TimeZoneIdentifierParseRecord> {
+        auto result = parseTimeZoneIdentifier(buffer);
+        if (!result || !buffer.atEnd())
+            return std::nullopt;
+        return result;
+    });
+}
+
 template<typename CharacterType>
 static std::optional<Variant<Vector<Latin1Character>, int64_t>> parseTimeZoneAnnotation(StringParsingBuffer<CharacterType>& buffer)
 {
     // https://tc39.es/proposal-temporal/#prod-TimeZoneAnnotation
-    // TimeZoneAnnotation :
+    // TimeZoneAnnotation :::
     //     [ AnnotationCriticalFlag_opt TimeZoneIdentifier ]
-    // TimeZoneIdentifier :
-    //     UTCOffset_[~SubMinutePrecision]
-    //     TimeZoneIANAName
 
     if (buffer.lengthRemaining() < 3)
         return std::nullopt;
@@ -646,105 +736,20 @@ static std::optional<Variant<Vector<Latin1Character>, int64_t>> parseTimeZoneAnn
     if (*buffer == '!')
         buffer.advance();
 
-    switch (static_cast<char16_t>(*buffer)) {
-    case '+':
-    case '-': {
-        auto offset = parseUTCOffset(buffer, false);
-        if (!offset)
-            return std::nullopt;
-        if (buffer.atEnd())
-            return std::nullopt;
-        if (*buffer != ']')
-            return std::nullopt;
-        buffer.advance();
-        return offset.value();
-    }
-    default: {
-        // TZLeadingChar :
-        //     Alpha
-        //     .
-        //     _
-        //
-        // TZChar :
-        //     TZLeadingChar
-        //     DecimalDigit
-        //     -
-        //     +
-        //
-        // TimeZoneIANANameComponent :
-        //     TZLeadingChar
-        //     TimeZoneIANANameComponent TZChar
-        //
-        // TimeZoneIANAName :
-        //     TimeZoneIANANameComponent
-        //     TimeZoneIANAName / TimeZoneIANANameComponent
+    // |TimeZoneIdentifier| stops at ']' on its own: ']' is neither a |TZChar| nor part of a
+    // |UTCOffset|, so the follow-set check below is all this production adds.
+    auto identifier = parseTimeZoneIdentifier(buffer);
+    if (!identifier)
+        return std::nullopt;
 
-        unsigned nameLength = 0;
-        {
-            unsigned index = 0;
-            for (; index < buffer.lengthRemaining(); ++index) {
-                auto character = buffer[index];
-                if (character == ']')
-                    break;
-                if (!isASCIIAlpha(character) && !isASCIIDigit(character) && character != '.' && character != '_' && character != '-' && character != '+' && character != '/')
-                    return std::nullopt;
-            }
-            if (!index)
-                return std::nullopt;
-            nameLength = index;
-        }
+    if (buffer.atEnd() || *buffer != ']')
+        return std::nullopt;
+    buffer.advance();
 
-        auto isValidComponent = [&](unsigned start, unsigned end) {
-            unsigned componentLength = end - start;
-            if (!componentLength)
-                return false;
-            if (componentLength > 14)
-                return false;
-            if (componentLength == 1 && buffer[start] == '.')
-                return false;
-            if (componentLength == 2 && buffer[start] == '.' && buffer[start + 1] == '.')
-                return false;
-            return true;
-        };
-
-        unsigned currentNameComponentStartIndex = 0;
-        bool isLeadingCharacterInNameComponent = true;
-        for (unsigned index = 0; index < nameLength; ++index) {
-            auto character = buffer[index];
-            if (isLeadingCharacterInNameComponent) {
-                if (!(isASCIIAlpha(character) || character == '.' || character == '_'))
-                    return std::nullopt;
-
-                currentNameComponentStartIndex = index;
-                isLeadingCharacterInNameComponent = false;
-                continue;
-            }
-
-            if (character == '/') {
-                if (!isValidComponent(currentNameComponentStartIndex, index))
-                    return std::nullopt;
-                isLeadingCharacterInNameComponent = true;
-                continue;
-            }
-
-            if (!(isASCIIAlpha(character) || isASCIIDigit(character) || character == '.' || character == '_' || character == '-' || character == '+'))
-                return std::nullopt;
-        }
-        if (isLeadingCharacterInNameComponent)
-            return std::nullopt;
-        if (!isValidComponent(currentNameComponentStartIndex, nameLength))
-            return std::nullopt;
-
-        Vector<Latin1Character> result(buffer.consume(nameLength));
-
-        if (buffer.atEnd())
-            return std::nullopt;
-        if (*buffer != ']')
-            return std::nullopt;
-        buffer.advance();
-        return result;
-    }
-    }
+    // [[OffsetMinutes]] is minutes; m_nameOrOffset stores the offset in nanoseconds.
+    if (identifier->offsetMinutes)
+        return *identifier->offsetMinutes * nsPerMinute;
+    return WTF::move(identifier->name);
 }
 
 template<typename CharacterType>
@@ -1430,18 +1435,6 @@ std::optional<ParsedISODateTime> parseISODateTime(StringView string, TemporalPro
     };
 }
 
-// https://tc39.es/proposal-temporal/#sec-parsetimezoneidentifier
-// Strict version: accepts only a bare UTC offset or a bare IANA timezone name.
-// Does NOT accept full datetime strings with embedded timezone identifiers.
-std::optional<TimeZone> parseTimeZoneIdentifierStrict(StringView string)
-{
-    if (auto offset = parseUTCOffset(string, false))
-        return TimeZone::fromUTCOffset(*offset);
-    if (auto tzId = parseTimeZoneName(string))
-        return TimeZone::fromID(*tzId);
-    return std::nullopt;
-}
-
 uint8_t dayOfWeek(PlainDate plainDate)
 {
     Int128 dateDays = static_cast<Int128>(dateToDaysFrom1970(plainDate.year(), plainDate.month() - 1, plainDate.day()));
@@ -2073,49 +2066,50 @@ bool isValidISODate(double year, double month, double day)
     return true;
 }
 
-// temporal_rs: TimeZone::try_from_str (src/builtins/core/time_zone.rs)
 // https://tc39.es/proposal-temporal/#sec-temporal-parsetemporaltimezonestring
-std::optional<TimeZone> parseTemporalTimeZoneIdentifier(StringView string)
+std::optional<TimeZoneIdentifierParseRecord> parseTemporalTimeZoneString(StringView string)
 {
     // 1. Let parseResult be ParseText(StringToCodePoints(timeZoneString), TimeZoneIdentifier).
     // 2. If parseResult is a Parse Node, return ! ParseTimeZoneIdentifier(timeZoneString).
-    if (auto offset = parseUTCOffset(string, false))
-        return TimeZone::fromUTCOffset(*offset);
-    if (auto tzId = parseTimeZoneName(string))
-        return TimeZone::fromID(*tzId);
+    if (auto parse = parseTimeZoneIdentifier(string))
+        return parse;
 
     // 3. Let result be ? ParseISODateTime(timeZoneString,
-    //      « TemporalDateTimeString[+Zoned], TemporalInstantString »).
-    auto parsed = parseISODateTime(string, { TemporalProduction::DateTimeZoned, TemporalProduction::Instant });
+    //      « TemporalDateTimeString[+Zoned], TemporalDateTimeString[~Zoned], TemporalInstantString,
+    //        TemporalTimeString, TemporalMonthDayString, TemporalYearMonthString »).
+    auto parsed = parseISODateTime(string, {
+        TemporalProduction::DateTimeZoned,
+        TemporalProduction::DateTimeUnzoned,
+        TemporalProduction::Instant,
+        TemporalProduction::Time,
+        TemporalProduction::MonthDay,
+        TemporalProduction::YearMonth,
+    });
     if (!parsed || !parsed->timeZone)
         return std::nullopt;
 
     // 4. Let timeZoneResult be result.[[TimeZone]].
     const auto& tz = *parsed->timeZone;
 
-    // 5. If timeZoneResult.[[TimeZoneAnnotation]] is not ~empty~, return ! ParseTimeZoneIdentifier(...).
-    if (std::holds_alternative<int64_t>(tz.m_nameOrOffset))
-        return TimeZone::fromUTCOffset(std::get<int64_t>(tz.m_nameOrOffset));
-    const auto& name = std::get<Vector<Latin1Character>>(tz.m_nameOrOffset);
-    if (!name.isEmpty()) {
-        if (auto tzId = parseTimeZoneName(StringView(name.span())))
-            return TimeZone::fromID(*tzId);
-        return std::nullopt;
-    }
+    // 5. If timeZoneResult.[[TimeZoneAnnotation]] is not ~empty~, return ! ParseTimeZoneIdentifier(timeZoneResult.[[TimeZoneAnnotation]]).
+    if (auto* offsetNanoseconds = std::get_if<int64_t>(&tz.m_nameOrOffset))
+        return TimeZoneIdentifierParseRecord { { }, *offsetNanoseconds / nsPerMinute };
+    auto& annotationName = std::get<Vector<Latin1Character>>(tz.m_nameOrOffset);
+    if (!annotationName.isEmpty())
+        return TimeZoneIdentifierParseRecord { annotationName, std::nullopt };
 
     // 6. If timeZoneResult.[[Z]] is true, return ! ParseTimeZoneIdentifier("UTC").
     if (tz.m_z)
-        return TimeZone::fromID(utcTimeZoneID());
+        return TimeZoneIdentifierParseRecord { Vector<Latin1Character>("UTC"_span8), std::nullopt };
 
-    // 7-8. Let offsetString be timeZoneResult.[[OffsetString]]; return ? ParseTimeZoneIdentifier(offsetString).
-    //   ParseTimeZoneIdentifier uses UTCOffset[~SubMinutePrecision], so reject sub-minute offsets.
+    // 7. If timeZoneResult.[[OffsetString]] is not ~empty~, return ? ParseTimeZoneIdentifier(timeZoneResult.[[OffsetString]]).
     if (tz.m_offset) {
         if (tz.m_offsetHasSubMinutePrecision)
             return std::nullopt;
-        return TimeZone::fromUTCOffset(*tz.m_offset);
+        return TimeZoneIdentifierParseRecord { { }, *tz.m_offset / nsPerMinute };
     }
 
-    // 9. Throw a RangeError exception.
+    // 8. Throw a RangeError exception.
     return std::nullopt;
 }
 

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -484,11 +484,12 @@ private:
 };
 static_assert(sizeof(PlainYearMonth) == sizeof(PlainDate));
 
-// https://tc39.es/proposal-temporal/#sec-temporal-parsetemporaltimezonestring
-// Record { [[Z]], [[OffsetString]], [[Name]] }
+// https://tc39.es/proposal-temporal/#sec-temporal-iso-string-time-zone-parse-records
+// ISO String Time Zone Parse Record { [[Z]], [[OffsetString]], [[TimeZoneAnnotation]] }.
 struct TimeZoneRecord {
     bool m_z { false };
     std::optional<int64_t> m_offset;
+    // [[TimeZoneAnnotation]]; an empty Vector is ~empty~.
     Variant<Vector<Latin1Character>, int64_t> m_nameOrOffset;
     bool m_offsetHasSubMinutePrecision { false };
 };
@@ -504,8 +505,8 @@ struct RFC9557Annotation {
     RFC9557Value m_value;
 };
 
-// https://tc39.es/proposal-temporal/#sup-isvalidtimezonename
-std::optional<TimeZoneID> parseTimeZoneName(StringView);
+// https://tc39.es/proposal-temporal/#sec-getavailablenamedtimezoneidentifier
+JS_EXPORT_PRIVATE std::optional<TimeZoneID> parseTimeZoneName(StringView);
 std::optional<Duration> parseDuration(StringView);
 std::optional<int64_t> parseUTCOffset(StringView, bool parseSubMinutePrecision = true);
 std::optional<int64_t> parseUTCOffsetInMinutes(StringView);
@@ -538,9 +539,13 @@ struct ParsedISODateTime {
 
 JS_EXPORT_PRIVATE std::optional<ParsedISODateTime> parseISODateTime(StringView, TemporalProductionSet);
 
-std::optional<TimeZone> JS_EXPORT_PRIVATE parseTemporalTimeZoneIdentifier(StringView);
-// Strict variant: accepts only a bare UTC offset or bare IANA name — no embedded datetime strings.
-std::optional<TimeZone> parseTimeZoneIdentifierStrict(StringView);
+// https://tc39.es/proposal-temporal/#sec-temporal-time-zone-identifier-parse-records
+struct TimeZoneIdentifierParseRecord {
+    Vector<Latin1Character> name; // [[Name]]; an empty Vector is ~empty~.
+    std::optional<int64_t> offsetMinutes; // [[OffsetMinutes]]; std::nullopt means ~empty~.
+};
+
+std::optional<TimeZoneIdentifierParseRecord> parseTimeZoneIdentifier(StringView);
 uint8_t dayOfWeek(PlainDate);
 uint16_t NODELETE dayOfYear(PlainDate);
 uint8_t weeksInYear(int32_t year);
@@ -560,7 +565,7 @@ bool NODELETE isValidDuration(const Duration&);
 bool NODELETE isValidISODate(double, double, double);
 
 std::optional<ParsedMonthCode> NODELETE parseMonthCode(StringView);
-std::optional<TimeZone> JS_EXPORT_PRIVATE parseTemporalTimeZoneIdentifier(StringView);
+std::optional<TimeZoneIdentifierParseRecord> JS_EXPORT_PRIVATE parseTemporalTimeZoneString(StringView);
 
 bool isDateTimeWithinLimits(int32_t year, uint8_t month, uint8_t day, unsigned hour, unsigned minute, unsigned second, unsigned millisecond, unsigned microsecond, unsigned nanosecond);
 

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -246,161 +246,173 @@ static ISO8601::PlainDate calendarAwareDateAdd(JSGlobalObject* globalObject, Cal
     return calendarDateAdd(globalObject, calendarId, date, duration, overflow);
 }
 
-struct RelativeToRecord {
-    TemporalZonedDateTime* zonedRelativeTo { nullptr };
-    ISO8601::PlainDate plainDate;
-    bool hasPlainRelativeTo { false };
+struct PlainRelativeTo {
+    ISO8601::PlainDate date;
     CalendarID calendarId { iso8601CalendarID() };
 };
 
+struct RelativeToRecord {
+    TemporalZonedDateTime* zonedRelativeTo { nullptr }; // [[ZonedRelativeTo]]; nullptr is undefined.
+    std::optional<PlainRelativeTo> plainRelativeTo; // [[PlainRelativeTo]].
+};
+
+struct RelativeToParts {
+    ISO8601::PlainDate isoDate;
+    std::optional<ISO8601::PlainTime> time; // std::nullopt is ~start-of-day~.
+    CalendarID calendarId { iso8601CalendarID() };
+    std::optional<TimeZone> timeZone; // std::nullopt is ~unset~.
+    int64_t offsetStringNs { 0 };
+    OffsetBehaviour offsetBehaviour { OffsetBehaviour::Option };
+    TemporalCore::MatchBehaviour matchBehaviour { TemporalCore::MatchBehaviour::MatchExactly };
+};
+
 // https://tc39.es/proposal-temporal/#sec-temporal-gettemporalrelativetooption
-static RelativeToRecord toRelativeTemporalObject(JSGlobalObject* globalObject, JSObject* options)
+static RelativeToRecord getTemporalRelativeToOption(JSGlobalObject* globalObject, JSObject* options)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: Let value be ?Get(options, "relativeTo").
+    // Step 1: Let value be ? Get(options, "relativeTo").
     JSValue relativeToValue = options->get(globalObject, Identifier::fromString(vm, "relativeTo"_s));
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Step 2: If value is undefined, return {[[PlainRelativeTo]]: undefined, [[ZonedRelativeTo]]: undefined}.
+    // Step 2: If value is undefined, return the Record with both fields undefined.
     if (relativeToValue.isUndefined())
         return { };
 
-    // Steps 3-4: offsetBehaviour = ~option~, matchBehaviour = ~match-exactly~ (initial defaults).
+    // Steps 3-4: offsetBehaviour = ~option~; matchBehaviour = ~match-exactly~.
+    RelativeToParts parts;
+    String string; // Set by step 6 only; used for its error messages.
 
-    // Step 5: If value is an Object:
+    // Step 5: If value is an Object, then
     if (relativeToValue.isObject()) {
         JSObject* obj = asObject(relativeToValue);
         // Step 5.a: [[InitializedTemporalZonedDateTime]] → return { [[ZonedRelativeTo]]: value }.
-        if (obj->inherits<TemporalZonedDateTime>()) {
-            auto* zdt = uncheckedDowncast<TemporalZonedDateTime>(obj);
-            return RelativeToRecord { zdt, { }, false };
-        }
+        if (obj->inherits<TemporalZonedDateTime>())
+            return RelativeToRecord { uncheckedDowncast<TemporalZonedDateTime>(obj), std::nullopt };
 
         // Step 5.b: [[InitializedTemporalDate]] → return { [[PlainRelativeTo]]: value }.
         if (obj->inherits<TemporalPlainDate>()) {
             auto* pd = uncheckedDowncast<TemporalPlainDate>(obj);
-            return RelativeToRecord { nullptr, pd->plainDate(), true, pd->calendarID() };
+            return RelativeToRecord { nullptr, PlainRelativeTo { pd->plainDate(), pd->calendarID() } };
         }
-        // Step 5.c: [[InitializedTemporalDateTime]] → return { [[PlainRelativeTo]]: CreateTemporalDate(isoDate, calendar) }.
+
+        // Step 5.c: [[InitializedTemporalDateTime]] → return { [[PlainRelativeTo]]: CreateTemporalDate(...) }.
         if (obj->inherits<TemporalPlainDateTime>()) {
             auto* pdt = uncheckedDowncast<TemporalPlainDateTime>(obj);
-            return RelativeToRecord { nullptr, pdt->plainDate(), true, pdt->calendarID() };
+            return RelativeToRecord { nullptr, PlainRelativeTo { pdt->plainDate(), pdt->calendarID() } };
         }
+
         // Step 5.d: calendar = ? GetTemporalCalendarIdentifierWithISODefault(value).
-        CalendarID calendarId = getTemporalCalendarIdentifierWithISODefault(globalObject, obj);
+        parts.calendarId = getTemporalCalendarIdentifierWithISODefault(globalObject, obj);
         RETURN_IF_EXCEPTION(scope, { });
 
-        // Step 5.e: fields = ? PrepareCalendarFields(calendar, value,
-        //   «year,month,month-code,day», «hour,...,nanosecond,offset,time-zone», «»).
-        auto fields = readZonedDateTimeFieldsFromObject<ZonedDateTimeFieldMode::RelativeToDuration>(globalObject, obj, calendarId);
+        // Step 5.e: fields = ? PrepareCalendarFields(calendar, value, «year,month,month-code,day», «hour,...,nanosecond,offset,time-zone», «»).
+        auto fields = readZonedDateTimeFieldsFromObject<ZonedDateTimeFieldMode::RelativeToDuration>(globalObject, obj, parts.calendarId);
         RETURN_IF_EXCEPTION(scope, { });
 
+        // Step 5.f: result = ? InterpretTemporalDateTimeFields(calendar, fields, ~constrain~).
         TemporalCore::TimeFieldsIn timeFields { fields.hour, fields.minute, fields.second, fields.millisecond, fields.microsecond, fields.nanosecond };
-
-        // Step 5.g: timeZone = fields.[[TimeZone]]. Step 5.h-i: offsetBehaviour from offsetString.
-        if (fields.timeZonePresent) {
-            // Steps 8-9: compute offsetNs based on offsetBehaviour.
-            // Steps 10-12: epochNs = InterpretISODateTimeOffset(...); return ZonedRelativeTo.
-            TimeZone timeZone = fields.timeZone;
-
-            // Step 5.f: dateTimeResult = ? InterpretTemporalDateTimeFields(calendar, fields, ~constrain~).
-            auto pdt = interpretTemporalDateTimeFields(globalObject, calendarId, fields.dateFields, timeFields, TemporalOverflow::Constrain);
-            RETURN_IF_EXCEPTION(scope, { });
-            auto plainDate = pdt.date;
-            auto plainTime = pdt.time;
-
-            // offsetBehaviour = ~option~: find the candidate whose UTC offset exactly equals givenOffsetNs
-            // (offsetOption = ~reject~, matchBehaviour = ~match-exactly~ → steps 10-12).
-            if (fields.offsetNs) {
-                auto possible = TemporalCore::getPossibleEpochNanosecondsFor(timeZone, plainDate, plainTime);
-                if (!possible) [[unlikely]] {
-                    throwRangeError(globalObject, scope, possible.error().message);
-                    return { };
-                }
-                bool found = false;
-                ISO8601::ExactTime matchedEpoch;
-                for (auto& candidate : TemporalCore::epochCandidates(*possible)) {
-                    auto offsetResult = TemporalCore::getOffsetNanosecondsFor(timeZone, candidate);
-                    if (offsetResult && *offsetResult == *fields.offsetNs) {
-                        matchedEpoch = candidate;
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found) [[unlikely]] {
-                    throwRangeError(globalObject, scope, "offset does not agree with timezone for the given date/time"_s);
-                    return { };
-                }
-                auto* zdt = TemporalZonedDateTime::create(vm, globalObject->zonedDateTimeStructure(), matchedEpoch, WTF::move(timeZone), calendarId);
-                return RelativeToRecord { zdt, { }, false };
-            }
-
-            // offsetBehaviour = ~wall~ (step 9: offsetNs = 0): use ~compatible~ disambiguation.
-            auto epochNs = TemporalZonedDateTime::getEpochNanosecondsFor(globalObject, timeZone, plainDate, plainTime, TemporalDisambiguation::Compatible);
-            RETURN_IF_EXCEPTION(scope, { });
-
-            // Steps 11-12: zonedRelativeTo = CreateTemporalZonedDateTime; return.
-            auto* zdt = TemporalZonedDateTime::create(vm, globalObject->zonedDateTimeStructure(), *epochNs, WTF::move(timeZone), calendarId);
-            return RelativeToRecord { zdt, { }, false };
-        }
-
-        // Step 7: timeZone is ~unset~ → return { [[PlainRelativeTo]]: CreateTemporalDate(isoDate, calendar) }.
-        // Time fields were read for Proxy observability; we discard the regulated time here.
-        auto pdt = interpretTemporalDateTimeFields(globalObject, calendarId, fields.dateFields, timeFields, TemporalOverflow::Constrain);
+        auto pdt = interpretTemporalDateTimeFields(globalObject, parts.calendarId, fields.dateFields, timeFields, TemporalOverflow::Constrain);
         RETURN_IF_EXCEPTION(scope, { });
-        return RelativeToRecord { nullptr, pdt.date, true, calendarId };
-    }
 
-    // Step 6: If value is not a String, throw TypeError.
-    if (!relativeToValue.isString()) [[unlikely]] {
-        throwTypeError(globalObject, scope, "relativeTo must be a string or Temporal object"_s);
-        return { };
-    }
+        // Step 5.g: Let timeZone be fields.[[TimeZone]].
+        if (fields.timeZonePresent)
+            parts.timeZone = fields.timeZone;
 
-    // Step 7: Let result be ? ParseISODateTime(value, « TemporalDateTimeString[+Zoned], TemporalDateTimeString[~Zoned] »).
-    String string = relativeToValue.toWTFString(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
+        // Steps 5.h-i: offsetString = fields.[[OffsetString]]; if ~unset~, offsetBehaviour = ~wall~.
+        if (fields.offsetNs)
+            parts.offsetStringNs = *fields.offsetNs;
+        else
+            parts.offsetBehaviour = OffsetBehaviour::Wall;
 
-    auto parsed = ISO8601::parseISODateTime(string, { ISO8601::TemporalProduction::DateTimeZoned, ISO8601::TemporalProduction::DateTimeUnzoned });
-    if (!parsed) [[unlikely]] {
-        throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(200, string), "' is not a valid date or ZonedDateTime string"_s));
-        return { };
-    }
-    auto& [parsedDateOpt, parsedTimeOpt, parsedTzOpt, parsedCalOpt, matched, isShortForm] = *parsed;
-    ASSERT(parsedDateOpt);
-    const auto& parsedDate = *parsedDateOpt;
-
-    // Step 8: Let timeZone be result.[[TimeZone]].
-    // Steps 13-17 (ZDT path) vs step 12 (PlainDate path): DateTimeZoned matched → bracket present.
-    if (matched == ISO8601::TemporalProduction::DateTimeZoned) {
-        // Delegate to TemporalZonedDateTime::from which implements ToTemporalTimeZoneIdentifier
-        // + InterpretISODateTimeOffset.
-        auto* zdt = TemporalZonedDateTime::from(globalObject, relativeToValue, jsUndefined());
-        RETURN_IF_EXCEPTION(scope, { });
-        return RelativeToRecord { zdt, { }, false };
-    }
-    // DateTimeUnzoned matched → no Z, no bracket required → PlainDate path.
-
-    // Steps 9-11: calendar = result.[[Calendar]]; if ~empty~ → "iso8601"; CanonicalizeCalendar.
-    CalendarID calendarId = iso8601CalendarID();
-    if (parsedCalOpt) {
-        auto rawCal = StringView(*parsedCalOpt).convertToASCIILowercase();
-        auto canonicalized = isBuiltinCalendar(rawCal);
-        if (!canonicalized) [[unlikely]] {
-            throwRangeError(globalObject, scope, makeString("'"_s, rawCal, "' is not a valid calendar identifier"_s));
+        // Steps 5.j-k: isoDate = result.[[ISODate]]; time = result.[[Time]], never ~start-of-day~.
+        parts.isoDate = pdt.date;
+        parts.time = pdt.time;
+    } else {
+        // Step 6.a: If value is not a String, throw a TypeError exception.
+        if (!relativeToValue.isString()) [[unlikely]] {
+            throwTypeError(globalObject, scope, "relativeTo must be a string or Temporal object"_s);
             return { };
         }
-        calendarId = *canonicalized;
+
+        // Step 6.b: result = ? ParseISODateTime(value, « TemporalDateTimeString[+Zoned], TemporalDateTimeString[~Zoned] »).
+        string = relativeToValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        auto parsed = ISO8601::parseISODateTime(string, { ISO8601::TemporalProduction::DateTimeZoned, ISO8601::TemporalProduction::DateTimeUnzoned });
+        if (!parsed) [[unlikely]] {
+            throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(200, string), "' is not a valid date or ZonedDateTime string"_s));
+            return { };
+        }
+        auto& [parsedDateOpt, parsedTimeOpt, parsedTzOpt, parsedCalOpt, matched, isShortForm] = *parsed;
+        ASSERT(parsedDateOpt);
+
+        // Steps 6.c-6.f: the annotation is ~empty~ — so timeZone stays ~unset~ — exactly when the ~Zoned production matched, since only [+Zoned] accepts a bracket.
+        if (matched == ISO8601::TemporalProduction::DateTimeZoned) {
+            ASSERT(parsedTzOpt);
+            auto& tzRecord = *parsedTzOpt;
+            // Step 6.f.i: timeZone = ? ToTemporalTimeZoneIdentifier(annotation).
+            auto timeZoneOpt = timeZoneFromRecord(tzRecord);
+            if (!timeZoneOpt) [[unlikely]] {
+                throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(200, string), "' contains an invalid time zone identifier"_s));
+                return { };
+            }
+            parts.timeZone = *timeZoneOpt;
+
+            // Steps 6.f.ii-iii: Z → ~exact~; no offsetString → ~wall~.
+            if (tzRecord.m_z)
+                parts.offsetBehaviour = OffsetBehaviour::Exact;
+            else if (!tzRecord.m_offset)
+                parts.offsetBehaviour = OffsetBehaviour::Wall;
+            parts.offsetStringNs = tzRecord.m_offset.value_or(0);
+
+            // Steps 6.f.iv-v: ~match-minutes~, unless the offset has sub-minute precision.
+            parts.matchBehaviour = tzRecord.m_offsetHasSubMinutePrecision ? TemporalCore::MatchBehaviour::MatchExactly : TemporalCore::MatchBehaviour::MatchMinutes;
+        }
+
+        // Steps 6.g-i: calendar = result.[[Calendar]]; if ~empty~ → "iso8601"; CanonicalizeCalendar.
+        if (parsedCalOpt) {
+            auto rawCal = StringView(*parsedCalOpt).convertToASCIILowercase();
+            auto canonicalized = isBuiltinCalendar(rawCal);
+            if (!canonicalized) [[unlikely]] {
+                throwRangeError(globalObject, scope, makeString("'"_s, rawCal, "' is not a valid calendar identifier"_s));
+                return { };
+            }
+            parts.calendarId = *canonicalized;
+        }
+
+        // Steps 6.j-k: isoDate = CreateISODateRecord(...); time = result.[[Time]], which is ~start-of-day~ when the string had no time part.
+        parts.isoDate = *parsedDateOpt;
+        parts.time = parsedTimeOpt;
     }
 
-    // Step 12: timeZone is ~unset~ → return { [[PlainRelativeTo]]: CreateTemporalDate(isoDate, calendar) }.
-    if (!ISO8601::isDateTimeWithinLimits(parsedDate.year(), parsedDate.month(), parsedDate.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]] {
-        throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(200, string), "' is outside the representable range for a relativeTo parameter"_s));
+    // Step 7: If timeZone is ~unset~, plainDate = ? CreateTemporalDate(isoDate, calendar); return.
+    if (!parts.timeZone) {
+        // CreateTemporalDate Step 1. Step 5.f already made the identical check via CalendarDateFromFields Step 3, so only a step 6 string can reach the throw.
+        if (!ISO8601::isDateTimeWithinLimits(parts.isoDate.year(), parts.isoDate.month(), parts.isoDate.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]] {
+            ASSERT(!string.isNull());
+            throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(200, string), "' is outside the representable range for a relativeTo parameter"_s));
+            return { };
+        }
+        return RelativeToRecord { nullptr, PlainRelativeTo { parts.isoDate, parts.calendarId } };
+    }
+
+    // Steps 8-9: offsetNs = offsetBehaviour is ~option~ ? ParseDateTimeUTCOffset(offsetString) : 0.
+    int64_t offsetNs = parts.offsetBehaviour == OffsetBehaviour::Option ? parts.offsetStringNs : 0;
+
+    // Step 10: epochNanoseconds = ? InterpretISODateTimeOffset(isoDate, time, offsetBehaviour, offsetNs, timeZone, ~compatible~, ~reject~, matchBehaviour).
+    auto useStartOfDay = parts.time ? TemporalCore::UseStartOfDay::No : TemporalCore::UseStartOfDay::Yes;
+    auto epochNsResult = TemporalCore::interpretISODateTimeOffset(parts.isoDate, parts.time.value_or(ISO8601::PlainTime()),
+        useStartOfDay, parts.offsetBehaviour, TemporalOffsetDisambiguation::Reject, offsetNs,
+        parts.matchBehaviour, *parts.timeZone, TemporalDisambiguation::Compatible);
+    if (!epochNsResult) [[unlikely]] {
+        throwRangeError(globalObject, scope, epochNsResult.error().message);
         return { };
     }
-    return RelativeToRecord { nullptr, parsedDate, true, calendarId };
+
+    // Steps 11-12: zonedRelativeTo = ! CreateTemporalZonedDateTime(...); return.
+    auto* zdt = TemporalZonedDateTime::create(vm, globalObject->zonedDateTimeStructure(), *epochNsResult, WTF::move(*parts.timeZone), parts.calendarId);
+    return RelativeToRecord { zdt, std::nullopt };
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.duration.compare
@@ -423,7 +435,7 @@ JSValue TemporalDuration::compare(JSGlobalObject* globalObject, JSValue valueOne
     // Parse relativeTo — must happen before identity check per spec ordering.
     RelativeToRecord relativeTo;
     if (options) {
-        relativeTo = toRelativeTemporalObject(globalObject, options);
+        relativeTo = getTemporalRelativeToOption(globalObject, options);
         RETURN_IF_EXCEPTION(scope, { });
     }
 
@@ -469,23 +481,24 @@ JSValue TemporalDuration::compare(JSGlobalObject* globalObject, JSValue valueOne
         return jsNumber(timeDuration1 > timeDuration2 ? 1 : timeDuration1 < timeDuration2 ? -1 : 0);
     }
 
-    if (!relativeTo.hasPlainRelativeTo) [[unlikely]] {
+    if (!relativeTo.plainRelativeTo) [[unlikely]] {
         throwRangeError(globalObject, scope, "Cannot compare a duration of years, months, or weeks without a relativeTo option"_s);
         return { };
     }
 
     // PlainDate relativeTo: DateDurationDays(dateDuration, plainDate).
-    auto& plainDate = relativeTo.plainDate;
+    auto& plainDate = relativeTo.plainRelativeTo->date;
+    auto calendarId = relativeTo.plainRelativeTo->calendarId;
 
     ISO8601::Duration dateDuration1(one.years(), one.months(), one.weeks(), one.days(), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0));
-    auto endDate1 = calendarAwareDateAdd(globalObject, relativeTo.calendarId, plainDate, dateDuration1, TemporalOverflow::Constrain);
+    auto endDate1 = calendarAwareDateAdd(globalObject, calendarId, plainDate, dateDuration1, TemporalOverflow::Constrain);
     RETURN_IF_EXCEPTION(scope, { });
     auto daysDiff1 = TemporalCore::diffISODate(plainDate, endDate1, TemporalUnit::Day);
     auto timeDuration1 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(one).time(), daysDiff1.days());
     RETURN_IF_EXCEPTION(scope, { });
 
     ISO8601::Duration dateDuration2(two.years(), two.months(), two.weeks(), two.days(), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0));
-    auto endDate2 = calendarAwareDateAdd(globalObject, relativeTo.calendarId, plainDate, dateDuration2, TemporalOverflow::Constrain);
+    auto endDate2 = calendarAwareDateAdd(globalObject, calendarId, plainDate, dateDuration2, TemporalOverflow::Constrain);
     RETURN_IF_EXCEPTION(scope, { });
     auto daysDiff2 = TemporalCore::diffISODate(plainDate, endDate2, TemporalUnit::Day);
     auto timeDuration2 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(two).time(), daysDiff2.days());
@@ -791,7 +804,7 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
     // Steps 10-12: Let relativeToRecord = ? GetTemporalRelativeToOption(roundTo).
     RelativeToRecord relativeTo;
     if (options) {
-        relativeTo = toRelativeTemporalObject(globalObject, options);
+        relativeTo = getTemporalRelativeToOption(globalObject, options);
         RETURN_IF_EXCEPTION(scope, { });
     }
     // Step 13: Let roundingIncrement be ? GetRoundingIncrementOption(roundTo).
@@ -904,8 +917,9 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
     }
 
     // Step 28: If plainRelativeTo is not undefined:
-    if (relativeTo.hasPlainRelativeTo) {
-        auto& plainDate = relativeTo.plainDate;
+    if (relativeTo.plainRelativeTo) {
+        auto& plainDate = relativeTo.plainRelativeTo->date;
+        auto calendarId = relativeTo.plainRelativeTo->calendarId;
         ISO8601::PlainTime midnight;
 
         // Step 28.a: internalDuration = ToInternalDurationRecordWith24HourDays(duration).
@@ -913,14 +927,14 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
         RETURN_IF_EXCEPTION(scope, { });
 
         // Steps 28.b-e: AddTime + AdjustDateDurationRecord + CalendarDateAdd → {targetDate, targetTime}.
-        auto target = computePlainRelativeTarget(globalObject, relativeTo.calendarId, plainDate, internalDuration);
+        auto target = computePlainRelativeTarget(globalObject, calendarId, plainDate, internalDuration);
         RETURN_IF_EXCEPTION(scope, { });
         ASSERT(target);
 
         // Steps 28.f-g: isoDateTime = (plainDate, midnight); targetDateTime = (targetDate, targetTime).
         // Step 28.h: internalDuration = ? DifferencePlainDateTimeWithRounding(...).
         auto diffResult = TemporalCore::differencePlainDateTimeWithRounding(plainDate, midnight, target->targetDate, target->targetTime,
-            relativeTo.calendarId, largestUnit, smallestUnit, roundingMode, static_cast<double>(roundingIncrement));
+            calendarId, largestUnit, smallestUnit, roundingMode, static_cast<double>(roundingIncrement));
         if (!diffResult) [[unlikely]] {
             throwTemporalError(globalObject, scope, diffResult.error());
             return { };
@@ -980,7 +994,7 @@ double TemporalDuration::total(JSGlobalObject* globalObject, JSValue optionsValu
     // Steps 8-10: relativeTo. Spec NOTE: "relativeTo" parsed before "unit" (alphabetical).
     RelativeToRecord relativeTo;
     if (options) {
-        relativeTo = toRelativeTemporalObject(globalObject, options);
+        relativeTo = getTemporalRelativeToOption(globalObject, options);
         RETURN_IF_EXCEPTION(scope, 0);
         // Step 11: unit = ? GetTemporalUnitValuedOption(totalOf, "unit", unset).
         unitString = intlStringOption(globalObject, options, vm.propertyNames->unit, { }, { }, { });
@@ -995,7 +1009,7 @@ double TemporalDuration::total(JSGlobalObject* globalObject, JSValue optionsValu
     }
     TemporalUnit unit = unitType.value();
 
-    bool hasRelativeTo = relativeTo.zonedRelativeTo || relativeTo.hasPlainRelativeTo;
+    bool hasRelativeTo = relativeTo.zonedRelativeTo || relativeTo.plainRelativeTo;
 
     // Step 13: no relativeTo.
     if (!hasRelativeTo) {
@@ -1023,16 +1037,17 @@ double TemporalDuration::total(JSGlobalObject* globalObject, JSValue optionsValu
 
     // Step 15: plainRelativeTo path → DifferencePlainDateTimeWithTotal.
     {
-        auto& plainDate = relativeTo.plainDate;
+        auto& plainDate = relativeTo.plainRelativeTo->date;
+        auto calendarId = relativeTo.plainRelativeTo->calendarId;
         // Step 15.a: ToInternalDurationRecordWith24HourDays.
         auto internalDuration = toInternalDurationRecordWith24HourDays(globalObject, m_duration);
         RETURN_IF_EXCEPTION(scope, 0);
         // Steps 15.b-e: target {date, time}.
-        auto target = computePlainRelativeTarget(globalObject, relativeTo.calendarId, plainDate, internalDuration);
+        auto target = computePlainRelativeTarget(globalObject, calendarId, plainDate, internalDuration);
         RETURN_IF_EXCEPTION(scope, 0);
         ASSERT(target);
         // Steps 15.f-h: DifferencePlainDateTimeWithTotal.
-        auto result = differencePlainDateTimeWithTotal(globalObject, relativeTo.calendarId, plainDate, *target, unit);
+        auto result = differencePlainDateTimeWithTotal(globalObject, calendarId, plainDate, *target, unit);
         RETURN_IF_EXCEPTION(scope, 0);
         ASSERT(result);
         return *result;

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -24,6 +24,7 @@
 
 #include "FractionToDouble.h"
 #include "FunctionPrototype.h"
+#include "ISO8601.h"
 #include "IntlObjectInlines.h"
 #include "JSCJSValueInlines.h"
 #include "JSGlobalObject.h"
@@ -712,6 +713,19 @@ bool isPartialTemporalObject(JSGlobalObject* globalObject, JSValue value)
     return true;
 }
 
+std::optional<TimeZone> timeZoneFromIdentifierParseRecord(const ISO8601::TimeZoneIdentifierParseRecord& parseRecord)
+{
+    // If [[OffsetMinutes]] is not ~empty~, FormatOffsetTimeZoneIdentifier(offsetMinutes).
+    if (parseRecord.offsetMinutes)
+        return TimeZone::fromUTCOffset(*parseRecord.offsetMinutes * static_cast<int64_t>(ISO8601::ExactTime::nsPerMinute));
+
+    // Otherwise GetAvailableNamedTimeZoneIdentifier([[Name]]); ~empty~ is the caller's RangeError.
+    auto identifierRecord = ISO8601::parseTimeZoneName(parseRecord.name.span());
+    if (!identifierRecord) [[unlikely]]
+        return std::nullopt;
+    return TimeZone::fromID(*identifierRecord);
+}
+
 // https://tc39.es/proposal-temporal/#sec-temporal-totemporaltimezoneidentifier
 std::optional<TimeZone> toTemporalTimeZoneIdentifier(JSGlobalObject* globalObject, JSValue item)
 {
@@ -730,15 +744,22 @@ std::optional<TimeZone> toTemporalTimeZoneIdentifier(JSGlobalObject* globalObjec
     String tzString = asString(item)->value(globalObject);
     RETURN_IF_EXCEPTION(scope, std::nullopt);
 
-    // Steps 3-5: ParseTimeZoneIdentifier; the resulting TimeZone already carries the
-    // case-normalized, alias-preserving identifier (named) or canonical offset.
-    auto parsed = ISO8601::parseTemporalTimeZoneIdentifier(tzString);
-    if (!parsed) [[unlikely]] {
+    auto throwInvalidTimeZoneIdentifier = [&] {
         throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(100, tzString), "' is not a valid time zone identifier"_s));
         return std::nullopt;
-    }
+    };
 
-    return *parsed;
+    // Step 3: Let parseResult be ? ParseTemporalTimeZoneString(temporalTimeZoneLike).
+    auto parseResult = ISO8601::parseTemporalTimeZoneString(tzString);
+    if (!parseResult) [[unlikely]]
+        return throwInvalidTimeZoneIdentifier();
+
+    // Steps 4-9: offsetMinutes → FormatOffsetTimeZoneIdentifier; otherwise resolve [[Name]], with
+    //   step 8's RangeError for an unavailable one.
+    auto timeZone = timeZoneFromIdentifierParseRecord(*parseResult);
+    if (!timeZone) [[unlikely]]
+        return throwInvalidTimeZoneIdentifier();
+    return timeZone;
 }
 
 void throwTemporalError(JSGlobalObject* globalObject, ThrowScope& scope, const TemporalError& error)

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -29,6 +29,10 @@
 
 namespace JSC {
 
+namespace ISO8601 {
+struct TimeZoneIdentifierParseRecord;
+}
+
 class TemporalObject final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
@@ -125,6 +129,8 @@ TemporalOffsetDisambiguation toTemporalOffset(JSGlobalObject*, JSObject*, Tempor
 void throwTemporalError(JSGlobalObject*, ThrowScope&, const TemporalError&);
 
 std::optional<TimeZone> toTemporalTimeZoneIdentifier(JSGlobalObject*, JSValue);
+
+std::optional<TimeZone> timeZoneFromIdentifierParseRecord(const ISO8601::TimeZoneIdentifierParseRecord&);
 
 enum class TemporalConstructTarget : bool { Intrinsic, NewTarget };
 

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
@@ -135,26 +135,16 @@ ISO8601::PlainDateTime TemporalZonedDateTime::getLocalDateTime(JSGlobalObject* g
     return *result;
 }
 
-// Internal helper: extracts the runtime TimeZone handle from an already-parsed TimeZoneRecord.
-// Bracket annotation takes priority over Z, which takes priority over inline offset.
-// Returns nullopt if the record has no usable timezone info.
-static std::optional<TimeZone> timeZoneFromRecord(const ISO8601::TimeZoneRecord& tzRecord)
+std::optional<TimeZone> timeZoneFromRecord(const ISO8601::TimeZoneRecord& tzRecord)
 {
     auto& nameOrOffset = tzRecord.m_nameOrOffset;
-    if (std::holds_alternative<int64_t>(nameOrOffset))
-        return TimeZone::fromUTCOffset(std::get<int64_t>(nameOrOffset));
+    if (auto* offsetNanoseconds = std::get_if<int64_t>(&nameOrOffset))
+        return TimeZone::fromUTCOffset(*offsetNanoseconds);
     auto& name = std::get<Vector<Latin1Character>>(nameOrOffset);
-    if (!name.isEmpty()) {
-        if (auto tzId = ISO8601::parseTimeZoneName(StringView(name.span())))
-            return TimeZone::fromID(*tzId);
-        return std::nullopt; // invalid IANA name in bracket
-    }
-    // No bracket annotation: use Z or inline offset.
-    if (tzRecord.m_z)
-        return TimeZone::fromID(utcTimeZoneID());
-    if (tzRecord.m_offset)
-        return TimeZone::fromUTCOffset(*tzRecord.m_offset);
-    return std::nullopt;
+    ASSERT(!name.isEmpty());
+    if (auto tzId = ISO8601::parseTimeZoneName(name.span()))
+        return TimeZone::fromID(*tzId);
+    return std::nullopt; // invalid IANA name in bracket
 }
 
 // Aggregate of all inputs needed by the unified steps 6-12 epilogue in TemporalZonedDateTime::from().
@@ -167,8 +157,8 @@ struct ZDTEpochArgs {
     CalendarID calendarID;
     OffsetBehaviour offsetBehaviour;
     int64_t inlineOffsetNs { 0 };
-    bool offsetHasSubMinutePrecision { false };
-    bool useStartOfDay { false };
+    TemporalCore::MatchBehaviour matchBehaviour { TemporalCore::MatchBehaviour::MatchMinutes };
+    TemporalCore::UseStartOfDay useStartOfDay { TemporalCore::UseStartOfDay::No };
     TemporalDisambiguation disambiguation { TemporalDisambiguation::Compatible };
     TemporalOffsetDisambiguation offsetOpt { TemporalOffsetDisambiguation::Reject };
 };
@@ -183,9 +173,9 @@ static std::optional<ZDTEpochArgs> toEpochArgsFromString(JSGlobalObject* globalO
     String string = item->value(globalObject);
     RETURN_IF_EXCEPTION(scope, std::nullopt);
 
-    // Step 5.b: ParseISODateTime(item, « TemporalDateTimeString[+Zoned] »).
-    //   The DateTimeZoned production already requires a bracket TZ annotation, so the
-    //   "TimeZoneAnnotation Parse Node present" check (spec step 5.d) is satisfied by parsing.
+    // Step 5.b: Let result be ? ParseISODateTime(item, « TemporalDateTimeString[+Zoned] »).
+    //   [+Zoned] makes the bracket TimeZoneAnnotation grammatically mandatory, so this also
+    //   discharges Step 5.d's "Assert: annotation is not empty".
     auto parsed = ISO8601::parseISODateTime(string, ISO8601::TemporalProduction::DateTimeZoned);
     if (!parsed) [[unlikely]] {
         throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(100, string), "' is not a valid Temporal.ZonedDateTime string"_s));
@@ -196,7 +186,8 @@ static std::optional<ZDTEpochArgs> toEpochArgsFromString(JSGlobalObject* globalO
     auto plainDate = WTF::move(*plainDateOpt);
     auto& tzRecord = *tzRecordOptional;
 
-    // Step 5.e: timeZone = ? ToTemporalTimeZoneIdentifier(annotation). (fused into timeZoneFromRecord)
+    // Steps 5.c-5.e: annotation = result.[[TimeZone]].[[TimeZoneAnnotation]];
+    //   timeZone = ? ToTemporalTimeZoneIdentifier(annotation).
     auto timeZoneOpt = timeZoneFromRecord(tzRecord);
     if (!timeZoneOpt) [[unlikely]] {
         throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(100, string), "' contains an invalid time zone identifier"_s));
@@ -208,7 +199,7 @@ static std::optional<ZDTEpochArgs> toEpochArgsFromString(JSGlobalObject* globalO
     // Step 5.g: If result.[[TimeZone]].[[Z]] is true, set hasUTCDesignator to true.
     bool hasUTCDesignator = tzRecord.m_z;
     int64_t inlineOffsetNs = tzRecord.m_offset.value_or(0);
-    bool offsetHasSubMinutePrecision = tzRecord.m_offsetHasSubMinutePrecision;
+    auto matchBehaviour = tzRecord.m_offsetHasSubMinutePrecision ? TemporalCore::MatchBehaviour::MatchExactly : TemporalCore::MatchBehaviour::MatchMinutes;
 
     // Steps 5.h-5.j: calendar = result.[[Calendar]]; if empty → "iso8601"; CanonicalizeCalendar.
     CalendarID calendarID = iso8601CalendarID();
@@ -223,8 +214,8 @@ static std::optional<ZDTEpochArgs> toEpochArgsFromString(JSGlobalObject* globalO
         }
     }
 
-    // Step 5.k: matchBehaviour = ~match-minutes~ (folded into offsetHasSubMinutePrecision = false by default).
-    // Step 5.l: If offsetString has sub-minute precision, matchBehaviour = ~match-exactly~ (already in offsetHasSubMinutePrecision).
+    // Step 5.k: Set matchBehaviour to ~match-minutes~.
+    // Step 5.l: If offsetString has sub-minute precision, set matchBehaviour to ~match-exactly~.
 
     // Step 5.m: resolvedOptions = ? GetOptionsObject(options).
     // Steps 5.n-5.p: disambiguation, offsetOption, overflow (all read for spec observability).
@@ -259,7 +250,8 @@ static std::optional<ZDTEpochArgs> toEpochArgsFromString(JSGlobalObject* globalO
     else
         offsetBehaviour = OffsetBehaviour::Option;
 
-    bool useStartOfDay = !plainTimeOptional.has_value() && offsetBehaviour == OffsetBehaviour::Wall;
+    auto useStartOfDay = !plainTimeOptional.has_value() && offsetBehaviour == OffsetBehaviour::Wall
+        ? TemporalCore::UseStartOfDay::Yes : TemporalCore::UseStartOfDay::No;
 
     return ZDTEpochArgs {
         plainDate,
@@ -268,7 +260,7 @@ static std::optional<ZDTEpochArgs> toEpochArgsFromString(JSGlobalObject* globalO
         calendarID,
         offsetBehaviour,
         inlineOffsetNs,
-        offsetHasSubMinutePrecision,
+        matchBehaviour,
         useStartOfDay,
         disambiguation,
         offsetOpt
@@ -329,8 +321,8 @@ static std::optional<ZDTEpochArgs> toEpochArgsFromPropertyBag(JSGlobalObject* gl
     OffsetBehaviour offsetBehaviour = fields.offsetNs ? OffsetBehaviour::Option : OffsetBehaviour::Wall;
     int64_t inlineOffsetNs = fields.offsetNs.value_or(0);
     // Property bags always use ~match-exactly~ (spec step 4.j), so treat offset as sub-minute precision.
-    bool offsetHasSubMinutePrecision = true;
-    bool useStartOfDay = false;
+    auto matchBehaviour = TemporalCore::MatchBehaviour::MatchExactly;
+    auto useStartOfDay = TemporalCore::UseStartOfDay::No;
 
     return ZDTEpochArgs {
         plainDate,
@@ -339,7 +331,7 @@ static std::optional<ZDTEpochArgs> toEpochArgsFromPropertyBag(JSGlobalObject* gl
         calendarID,
         offsetBehaviour,
         inlineOffsetNs,
-        offsetHasSubMinutePrecision,
+        matchBehaviour,
         useStartOfDay,
         disambiguation,
         offsetOpt
@@ -360,7 +352,7 @@ TemporalZonedDateTime* TemporalZonedDateTime::from(JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Steps 1-3: _hasUTCDesignator_ = false, _matchBehaviour_ = ~match-exactly~ are deferred into
-    // ZDTEpochArgs.offsetHasSubMinutePrecision and ZDTEpochArgs.offsetBehaviour.
+    // ZDTEpochArgs.matchBehaviour and ZDTEpochArgs.offsetBehaviour.
     // Steps 4-5 reordered: String check (step 5) precedes ZDT check (step 4.a) because a value
     // cannot be both a String and have [[InitializedTemporalZonedDateTime]], so the order is unobservable.
 
@@ -415,7 +407,7 @@ TemporalZonedDateTime* TemporalZonedDateTime::from(JSGlobalObject* globalObject,
     auto exactTimeResult = TemporalCore::interpretISODateTimeOffset(
         args->plainDate, args->plainTime, args->useStartOfDay,
         args->offsetBehaviour, args->offsetOpt, args->inlineOffsetNs,
-        args->offsetHasSubMinutePrecision, args->timeZone, args->disambiguation);
+        args->matchBehaviour, args->timeZone, args->disambiguation);
     if (!exactTimeResult) [[unlikely]] {
         throwRangeError(globalObject, scope, exactTimeResult.error().message);
         return nullptr;

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.h
@@ -35,6 +35,8 @@
 
 namespace JSC {
 
+JS_EXPORT_PRIVATE std::optional<TimeZone> timeZoneFromRecord(const ISO8601::TimeZoneRecord&);
+
 class TemporalZonedDateTime final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimeConstructor.cpp
@@ -107,16 +107,21 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalZonedDateTime, (JSGlobalObject* global
     auto tzString = asString(tzValue)->value(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Step 5: Let _timeZoneParse_ be ? ParseTimeZoneIdentifier(_timeZone_).
-    // ParseTimeZoneIdentifier accepts |UTCOffset[~SubMinutePrecision]| or |TimeZoneIANAName|;
-    // datetime strings and "Z" are rejected (those use ParseTemporalTimeZoneString, not this AO).
-    auto parsedTZ = ISO8601::parseTimeZoneIdentifierStrict(tzString);
-    if (!parsedTZ) [[unlikely]]
+    auto throwInvalidTimeZoneIdentifier = [&] {
         return throwVMRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(100, tzString), "' is not a valid time zone identifier"_s));
+    };
 
-    // Steps 6-7: [[TimeZone]] = the parsed identifier in canonical case-normalized form
-    // (named zones) or formatted offset (UTC offsets). parseTimeZoneIdentifierStrict already
-    // produced both, with intlResolveTimeZoneID validating the named case (step 6b).
+    // Step 5: Let _timeZoneParse_ be ? ParseTimeZoneIdentifier(_timeZone_).
+    auto timeZoneParse = ISO8601::parseTimeZoneIdentifier(tzString);
+    if (!timeZoneParse) [[unlikely]]
+        return throwInvalidTimeZoneIdentifier();
+
+    // Steps 6-7: [[OffsetMinutes]] is ~empty~ → resolve [[Name]], with step 6.b's RangeError for an
+    //   unavailable one; otherwise FormatOffsetTimeZoneIdentifier([[OffsetMinutes]]).
+    auto timeZone = timeZoneFromIdentifierParseRecord(*timeZoneParse);
+    if (!timeZone) [[unlikely]]
+        return throwInvalidTimeZoneIdentifier();
+
     // Step 8: If _calendar_ is *undefined*, set _calendar_ to *"iso8601"*.
     // Step 9: If _calendar_ is not a String, throw *TypeError*.
     // Step 10: Set _calendar_ to ? CanonicalizeCalendar(_calendar_).
@@ -134,7 +139,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalZonedDateTime, (JSGlobalObject* global
     }
 
     // Step 11: Return ? CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_, NewTarget).
-    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalZonedDateTime(globalObject, exactTime, *parsedTZ, calendarID, { asObject(callFrame->newTarget()), callFrame->jsCallee() })));
+    RELEASE_AND_RETURN(scope, JSValue::encode(createTemporalZonedDateTime(globalObject, exactTime, *timeZone, calendarID, { asObject(callFrame->newTarget()), callFrame->jsCallee() })));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
@@ -538,9 +538,9 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncRound, (JSGlobalObjec
         // Step 20.b: offsetNanoseconds = GetOffsetNanosecondsFor(timeZone, thisNs).
         // Step 20.c: epochNanoseconds = ? InterpretISODateTimeOffset(...).
         auto epochNsResult = TemporalCore::interpretISODateTimeOffset(
-            roundedDate, roundedTime, /* useStartOfDay */ false,
+            roundedDate, roundedTime, TemporalCore::UseStartOfDay::No,
             OffsetBehaviour::Option, TemporalOffsetDisambiguation::Prefer,
-            *curOffsetResult, /* offsetHasSubMinutePrecision */ false,
+            *curOffsetResult, TemporalCore::MatchBehaviour::MatchMinutes,
             zdt->timeZone(), TemporalDisambiguation::Compatible);
         if (!epochNsResult) [[unlikely]] {
             throwTemporalError(globalObject, scope, epochNsResult.error());
@@ -721,8 +721,9 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncWith, (JSGlobalObject
     // Step 25: epochNanoseconds = ? InterpretISODateTimeOffset(dateTimeResult.[[ISODate]],
     //   dateTimeResult.[[Time]], ~option~, newOffsetNanoseconds, timeZone, disambiguation, offset,
     //   ~match-exactly~).
-    auto epochNsResult = TemporalCore::interpretISODateTimeOffset(newDate, newTime, /* useStartOfDay */ false,
-        OffsetBehaviour::Option, offsetOpt, givenOffsetNs, /* offsetHasSubMinutePrecision */ true, zdt->timeZone(), disambiguation);
+    auto epochNsResult = TemporalCore::interpretISODateTimeOffset(newDate, newTime, TemporalCore::UseStartOfDay::No,
+        OffsetBehaviour::Option, offsetOpt, givenOffsetNs,
+        TemporalCore::MatchBehaviour::MatchExactly, zdt->timeZone(), disambiguation);
     if (!epochNsResult) [[unlikely]] {
         throwTemporalError(globalObject, scope, epochNsResult.error());
         return { };

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -518,32 +518,21 @@ TemporalResult<ISO8601::ExactTime> addZonedDateTime(ISO8601::ExactTime startEpoc
 }
 
 // timeZoneEquals — temporal_rs: TimeZone::time_zone_equals_with_provider (src/builtins/core/time_zone.rs)
-// https://tc39.es/proposal-canonical-tz/#sec-temporal-timezoneequals
-// Spec operates on Time Zone Identifier records. Step 1 (Object identity) and steps 2-4
-// (canonicalization + SameValue on the canonical strings) are subsumed by JSC's TimeZone
-// representation: identical TimeZone values mean both sides resolved to the same record.
-// Step 7 (both named) reduces to primary-identifier comparison via intlPrimaryTimeZoneID.
-// Step 8 (both offset) reduces to numeric offset comparison — already covered by
-// TimeZone::operator== since offset records share m_id == offsetTimeZoneID.
-// Mixed kinds fall through to step 9 (false).
+// https://tc39.es/proposal-temporal/#sec-temporal-timezoneequals
 bool timeZoneEquals(const TimeZone& a, const TimeZone& b)
 {
+    // 1. If one is two, return true.
     if (a == b)
         return true;
-    if (a.isUTCOffset() || b.isUTCOffset())
-        return false;
-    return intlPrimaryTimeZoneID(a.id()) == intlPrimaryTimeZoneID(b.id());
-}
 
-bool timeZoneEquals(StringView id1, StringView id2)
-{
-    if (id1 == id2)
-        return true;
-    auto a = ISO8601::parseTemporalTimeZoneIdentifier(id1);
-    auto b = ISO8601::parseTemporalTimeZoneIdentifier(id2);
-    if (!a || !b)
-        return false;
-    return timeZoneEquals(*a, *b);
+    // 2. If neither one nor two is an offset time zone identifier, then
+    if (a.isUTCOffset() || b.isUTCOffset())
+        return false; // 4. Return false.
+
+    // 2.a-2.d. recordOne/recordTwo = GetAvailableNamedTimeZoneIdentifier(...); both are non-empty.
+    // 2.e. If recordOne.[[PrimaryIdentifier]] is recordTwo.[[PrimaryIdentifier]], return true.
+    // 4. Return false.
+    return intlPrimaryTimeZoneID(a.id()) == intlPrimaryTimeZoneID(b.id());
 }
 
 } // namespace TemporalCore

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.h
@@ -72,13 +72,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 JS_EXPORT_PRIVATE ISO8601::PlainDateTime exactTimeToLocalDateAndTime(ISO8601::ExactTime, int64_t offsetNs);
 
-// https://tc39.es/proposal-canonical-tz/#sec-temporal-timezoneequals
-// Fast path: both operands are already Time Zone Identifier Records. No parsing,
-// no string comparison — at most one array lookup per side to resolve aliases.
 JS_EXPORT_PRIVATE bool timeZoneEquals(const TimeZone&, const TimeZone&);
-// String form: parses each side to a TimeZone, then delegates. Returns false if
-// either input is not a syntactically valid identifier.
-JS_EXPORT_PRIVATE bool timeZoneEquals(StringView id1, StringView id2);
 
 JS_EXPORT_PRIVATE TemporalResult<int64_t> getOffsetNanosecondsFor(const TimeZone&, ISO8601::ExactTime);
 

--- a/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.cpp
@@ -44,16 +44,16 @@ namespace TemporalCore {
 TemporalResult<ISO8601::ExactTime> interpretISODateTimeOffset(
     const ISO8601::PlainDate& date,
     const ISO8601::PlainTime& time,
-    bool useStartOfDay,
+    UseStartOfDay useStartOfDay,
     OffsetBehaviour offsetBehaviour,
     TemporalOffsetDisambiguation offsetOpt,
     int64_t inlineOffsetNs,
-    bool offsetHasSubMinutePrecision,
+    MatchBehaviour matchBehaviour,
     const TimeZone& timeZone,
     TemporalDisambiguation disambiguation)
 {
     // Step 1: If time is start-of-day, then
-    if (useStartOfDay) {
+    if (useStartOfDay == UseStartOfDay::Yes) {
         ASSERT(offsetBehaviour == OffsetBehaviour::Wall); // 1.a
         ASSERT(!inlineOffsetNs); // 1.b
         return getStartOfDay(timeZone, date); // 1.c
@@ -94,7 +94,7 @@ TemporalResult<ISO8601::ExactTime> interpretISODateTimeOffset(
         return makeUnexpected(possible.error());
 
     // Step 10: For each element candidate of possibleEpochNs.
-    bool matchMinutes = !offsetHasSubMinutePrecision;
+    bool matchMinutes = matchBehaviour == MatchBehaviour::MatchMinutes;
     for (auto& candidate : epochCandidates(*possible)) {
         // Step 10a: candidateOffset = utcEpochNanoseconds - candidate.
         Int128 candidateOffset = utcEpochNs - candidate.epochNanoseconds();

--- a/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.h
@@ -38,14 +38,17 @@
 namespace JSC {
 namespace TemporalCore {
 
+enum class MatchBehaviour : bool { MatchMinutes, MatchExactly };
+enum class UseStartOfDay : bool { No, Yes };
+
 JS_EXPORT_PRIVATE TemporalResult<ISO8601::ExactTime> interpretISODateTimeOffset(
     const ISO8601::PlainDate&,
     const ISO8601::PlainTime&,
-    bool useStartOfDay,
+    UseStartOfDay,
     OffsetBehaviour,
     TemporalOffsetDisambiguation,
     int64_t inlineOffsetNs,
-    bool offsetHasSubMinutePrecision,
+    MatchBehaviour,
     const TimeZone&,
     TemporalDisambiguation);
 


### PR DESCRIPTION
#### 22a13eb9ee2fc782b1836cc15a906cabf3943ed6
<pre>
[JSC][Temporal] Align time zone identifier parsing with the spec&apos;s parse records
<a href="https://bugs.webkit.org/show_bug.cgi?id=321136">https://bugs.webkit.org/show_bug.cgi?id=321136</a>
<a href="https://rdar.apple.com/184169471">rdar://184169471</a>

Reviewed by Yusuke Suzuki.

Introduce ISO8601::TimeZoneIdentifierParseRecord, the spec&apos;s Time Zone
Identifier Parse Record { [[Name]], [[OffsetMinutes]] }, and return it from
parseTimeZoneIdentifier and parseTemporalTimeZoneString. Both previously
returned a resolved TimeZone, which fused ParseTimeZoneIdentifier step 3&apos;s
syntactic check with the caller&apos;s availability check.

ParseTemporalTimeZoneString step 3 accepts the bracket annotation on six
productions; only TemporalDateTimeString[+Zoned] and TemporalInstantString
were tried, so &quot;2024-12[Europe/Berlin]&quot;, &quot;--12-25[Europe/Berlin]&quot; and
&quot;12:00[Europe/Berlin]&quot; were rejected. Widening that list is also what makes
step 2&apos;s split load-bearing: &quot;T12+01&quot; is simultaneously a TimeZoneIANAName
and a TemporalTimeString with a UTCOffset, so once TemporalTimeString is in
the list, step 2 must commit to the named-zone reading on syntax alone and
reject it as unavailable, rather than resolving eagerly and letting step 3
yield &quot;+01:00&quot;.

Follow ISO8601.cpp&apos;s scanning idiom for the time zone productions: each parser
takes a StringParsingBuffer, consumes only on success, and returns the matched
text, leaving StringView at the entrypoints. parseTimeZoneIANAName replaces the
isTimeZoneIANAName predicate, so the annotation parser no longer pre-scans for
&apos;]&apos; to find the token boundary; &apos;]&apos; is not a TZChar, so the name parse now
finds its own end. parseTimeZoneAnnotation delegates to
parseTimeZoneIdentifier rather than re-implementing its two alternatives, and
the file reads in grammar order: TZLeadingChar/TZChar, TimeZoneIANAName,
TimeZoneIdentifier, TimeZoneAnnotation. The parsed annotation name stays an
owned Vector&lt;Latin1Character&gt; so a returned record never outlives a view of the
string it was parsed from.

Restructure GetTemporalRelativeToOption to match the AO&apos;s control flow. Its
steps 5 and 6 do not return, they assign and fall through to a shared tail in
steps 7-12, which had been inlined into both branches with silently differing
arguments. The branches now only assign, and the tail runs once.

Replace InterpretISODateTimeOffset&apos;s offsetHasSubMinutePrecision and
useStartOfDay bool parameters with MatchBehaviour and UseStartOfDay enums, and
extract timeZoneFromIdentifierParseRecord for the tail shared by
ToTemporalTimeZoneIdentifier steps 4-9 and the Temporal.ZonedDateTime
constructor steps 6-7.

The annotations &quot;[..]&quot;, &quot;[.]&quot;, &quot;[./.]&quot;, &quot;[../..]&quot; and
&quot;[CocoaCappuccinoMatcha]&quot; move from the rejected set to the accepted one:
proposal-temporal a8f6b0d3 (&quot;Editorial: Align time zone name syntax with
IXDTF&quot;) removed TimeZoneIANANameComponent&apos;s 14-character limit and its
exclusion of &quot;.&quot; and &quot;..&quot;.

Test:
* Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp:
* JSTests/stress/temporal-plaindate.js:
* JSTests/stress/temporal-plaindatetime.js:
* JSTests/stress/temporal-plaintime.js:
* JSTests/stress/temporal-timezone.js:

Canonical link: <a href="https://commits.webkit.org/318741@main">https://commits.webkit.org/318741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec0aff9fc8535a9002e62104d44a787d87bb1d5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189001 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb947a67-a819-45f8-bf9a-41d71d4e39ad) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139723 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120173 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08df5cde-c029-40d5-9973-59cdfb6b91df) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40326 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2145 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8959 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39978 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/307 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40444 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45715 "Build is in progress. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Found 27386 issues") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191219 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52779 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148960 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53459 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148706 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27205 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43384 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125730 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120578 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51977 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14958 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51362 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51603 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51423 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->