### PR TITLE
[Site Isolation] WebProcessProxy::m_sharedProcessDomains only tracks the first domain loaded in shared process

### DIFF
--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -93,6 +93,7 @@ void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataSto
         if (RefPtr frameProcess = protectedThis->m_sharedProcess.get()) {
             ASSERT(frameProcess->isSharedProcess());
             RELEASE_ASSERT(!frameProcess->process().isInProcessCache());
+            frameProcess->process().addSharedProcessDomain(site.domain());
             return completionHandler(frameProcess.get());
         }
 
@@ -112,6 +113,8 @@ Ref<FrameProcess> BrowsingContextGroup::ensureProcessForSite(const Site& site, c
     if (preferences.siteIsolationEnabled()) {
         if ((m_sharedProcess && m_sharedProcessSites.contains(site)) || process.isSharedProcess()) {
             ASSERT(&m_sharedProcess->process() == &process);
+            if (m_sharedProcessSites.add(site).isNewEntry)
+                process.addSharedProcessDomain(site.domain());
             return *m_sharedProcess;
         }
         if (RefPtr existingProcess = processForSite(site)) {

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2533,6 +2533,7 @@ void WebProcessProxy::didStartUsingProcessForSiteIsolation(const std::optional<W
 {
     if (!site) {
         ASSERT(m_site.error() == SiteState::NotYetSpecified || m_site.error() == SiteState::SharedProcess);
+        m_sharedProcessDomains.clear();
         m_site = makeUnexpected(SiteState::SharedProcess);
         m_sharedProcessMainFrameSite = mainFrameSite;
         return;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8506,7 +8506,9 @@ TEST(SiteIsolation, SharedProcessWebProcessCacheSharedProcessForSiteWithUserInte
     auto childFrameProcess1C = [webView mainFrame].childFrames[0].info._processIdentifier;
     auto childFrameProcess2C = [webView mainFrame].childFrames[1].info._processIdentifier;
     EXPECT_EQ(mainFrameProcessC, mainFrameProcess);
-    EXPECT_EQ(childFrameProcess1C, childFrameProcess1);
+    // The cached shared process hosted apple.com, which is now an isolated site, so it is
+    // discarded entirely rather than reused for webkit.org.
+    EXPECT_NE(childFrameProcess1C, childFrameProcess1);
     EXPECT_NE(childFrameProcess2C, childFrameProcess2);
 }
 


### PR DESCRIPTION
#### 4fdc110d65b5f351867640dc68c02bf90ecc7272
<pre>
[Site Isolation] WebProcessProxy::m_sharedProcessDomains only tracks the first domain loaded in shared process
<a href="https://bugs.webkit.org/show_bug.cgi?id=321137">https://bugs.webkit.org/show_bug.cgi?id=321137</a>
<a href="https://rdar.apple.com/183490258">rdar://183490258</a>

Reviewed by Ryosuke Niwa.

Under Site Isolation with the shared process enabled, WebProcessProxy::m_sharedProcessDomains was
only populated when a shared process was first created for a BrowsingContextGroup. When the same
shared process went on to host additional sites -- either because another site was admitted to the
group&apos;s already-assigned shared process, or because the process was reused for a site via
BrowsingContextGroup::ensureProcessForSite -- those domains were never added, so the set held at
most one domain no matter how many sites the process actually hosted.

Two independent checks consult this set, and the incomplete record broke both in opposite
directions:
- WebProcessPool::processForSite&apos;s process-cache reuse check refuses to reuse a cached shared
process that hosts a domain needing isolation. Since the recorded set couldn&apos;t see domains
admitted after the first, a cached process holding a domain with recorded user interaction could
still be reused.
- WebProcessProxy::allowsFirstPartyAccess() denies access for a hosted domain that isn&apos;t in the
recorded set. Legitimately-hosted-but-unrecorded domains were therefore wrongly denied first-party
access (e.g. for badging).

Record every domain as it is admitted to a shared process, not just the first, and clear the set
whenever a process is (re)assigned as a shared process for a BrowsingContextGroup so that domains
recorded for a previous group&apos;s use of the process don&apos;t leak into the new assignment&apos;s isolation
decisions.

* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::sharedProcessForSite):
(WebKit::BrowsingContextGroup::ensureProcessForSite):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didStartUsingProcessForSiteIsolation):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, SharedProcessWebProcessCacheSharedProcessForSiteWithUserInteraction)):
Updated expectation for the expected behavior after change.

Canonical link: <a href="https://commits.webkit.org/318750@main">https://commits.webkit.org/318750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01f03afa73546481980f64d598c2c890c3d1b7bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189027 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebf262ce-4e23-4e52-858b-7c6636222bfe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139742 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a073c8b-0d6e-485b-8776-e702c09ab1a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120194 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e465ab0-6e00-43c4-bb63-cb888019d55b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42001 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40349 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152401 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39999 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/333 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191245 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52805 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160012 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148982 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39975 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53485 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148728 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43403 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125757 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120612 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52003 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14979 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51388 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51629 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51449 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->