### PR TITLE
testdriver-vendor.js uses frame-local coordinates for action origins inside a subframe

### DIFF
--- a/LayoutTests/http/wpt/testdriver/subframe-element-origin-expected.txt
+++ b/LayoutTests/http/wpt/testdriver/subframe-element-origin-expected.txt
@@ -1,0 +1,3 @@
+
+PASS an element origin inside a subframe is shifted into root-view coordinates
+

--- a/LayoutTests/http/wpt/testdriver/subframe-element-origin.html
+++ b/LayoutTests/http/wpt/testdriver/subframe-element-origin.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>testdriver-vendor.js: element origin inside a subframe</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="log"></div>
+<iframe id="frame" style="position: absolute; left: 200px; top: 200px; width: 150px; height: 150px; border: none"
+    srcdoc="<body style='margin: 0'><div id='target' style='width: 100px; height: 100px; background: green'></div>"></iframe>
+<script>
+promise_test(async () => {
+    const frame = document.getElementById("frame");
+    await new Promise(resolve => frame.addEventListener("load", resolve, { once: true }));
+    const target = frame.contentDocument.getElementById("target");
+    assert_true(!!frame.contentWindow.internals, "internals is available in the subframe");
+
+    let clickedTarget = null;
+    frame.contentWindow.addEventListener("click", event => clickedTarget = event.target, true);
+
+    // The origin's frame-local center is (50, 50), which lands outside the <iframe> in the
+    // top window unless it is shifted into root-view coordinates.
+    await new test_driver.Actions()
+        .pointerMove(0, 0, { origin: target })
+        .pointerDown()
+        .pointerUp()
+        .send();
+
+    assert_equals(clickedTarget, target, "click landed on the element used as the action origin");
+}, "an element origin inside a subframe is shifted into root-view coordinates");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_mouse-expected.txt
@@ -1,10 +1,8 @@
 
 done
 
-Harness Error (FAIL), message = Unhandled rejection: assert_unreached: missing pointermove event Reached unreachable code
-
 PASS Test pointer events in the main document
-FAIL Test pointer events in an iframe assert_unreached: missing pointerover event Reached unreachable code
+PASS Test pointer events in an iframe
 PASS mouse pointerover event is a PointerEvent event
 PASS mouse pointerover.isTrusted value is true
 PASS mouse pointerover.composed value is valid
@@ -55,4 +53,54 @@ PASS mouse pointerleave.bubbles value is valid
 PASS mouse pointerleave.cancelable value is valid
 PASS mouse pointerleave.pressure value is valid
 PASS mouse pointerleave properties for pointerType = mouse
+PASS Inner Frame mouse pointerover event is a PointerEvent event
+PASS Inner Frame mouse pointerover.isTrusted value is true
+PASS Inner Frame mouse pointerover.composed value is valid
+PASS Inner Frame mouse pointerover.bubbles value is valid
+PASS Inner Frame mouse pointerover.cancelable value is valid
+PASS Inner Frame mouse pointerover.pressure value is valid
+PASS Inner Frame mouse pointerover properties for pointerType = mouse
+PASS Inner Frame mouse pointerenter event is a PointerEvent event
+PASS Inner Frame mouse pointerenter.isTrusted value is true
+PASS Inner Frame mouse pointerenter.composed value is valid
+PASS Inner Frame mouse pointerenter.bubbles value is valid
+PASS Inner Frame mouse pointerenter.cancelable value is valid
+PASS Inner Frame mouse pointerenter.pressure value is valid
+PASS Inner Frame mouse pointerenter properties for pointerType = mouse
+PASS Inner Frame mouse pointermove event is a PointerEvent event
+PASS Inner Frame mouse pointermove.isTrusted value is true
+PASS Inner Frame mouse pointermove.composed value is valid
+PASS Inner Frame mouse pointermove.bubbles value is valid
+PASS Inner Frame mouse pointermove.cancelable value is valid
+PASS Inner Frame mouse pointermove.pressure value is valid
+PASS Inner Frame mouse pointermove properties for pointerType = mouse
+PASS Inner Frame mouse pointerdown event is a PointerEvent event
+PASS Inner Frame mouse pointerdown.isTrusted value is true
+PASS Inner Frame mouse pointerdown.composed value is valid
+PASS Inner Frame mouse pointerdown.bubbles value is valid
+PASS Inner Frame mouse pointerdown.cancelable value is valid
+PASS Inner Frame mouse pointerdown.pressure value is valid
+PASS Inner Frame mouse pointerdown properties for pointerType = mouse
+PASS Inner Frame mouse pointerup event is a PointerEvent event
+PASS Inner Frame mouse pointerup.isTrusted value is true
+PASS Inner Frame mouse pointerup.composed value is valid
+PASS Inner Frame mouse pointerup.bubbles value is valid
+PASS Inner Frame mouse pointerup.cancelable value is valid
+PASS Inner Frame mouse pointerup.pressure value is valid
+PASS Inner Frame mouse pointerup properties for pointerType = mouse
+PASS Inner Frame mouse pointerup properties for pointerup
+PASS Inner Frame mouse pointerout event is a PointerEvent event
+PASS Inner Frame mouse pointerout.isTrusted value is true
+PASS Inner Frame mouse pointerout.composed value is valid
+PASS Inner Frame mouse pointerout.bubbles value is valid
+PASS Inner Frame mouse pointerout.cancelable value is valid
+PASS Inner Frame mouse pointerout.pressure value is valid
+PASS Inner Frame mouse pointerout properties for pointerType = mouse
+PASS Inner Frame mouse pointerleave event is a PointerEvent event
+PASS Inner Frame mouse pointerleave.isTrusted value is true
+PASS Inner Frame mouse pointerleave.composed value is valid
+PASS Inner Frame mouse pointerleave.bubbles value is valid
+PASS Inner Frame mouse pointerleave.cancelable value is valid
+PASS Inner Frame mouse pointerleave.pressure value is valid
+PASS Inner Frame mouse pointerleave properties for pointerType = mouse
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_mouse-nonstandard-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_mouse-nonstandard-expected.txt
@@ -1,10 +1,8 @@
 
 done
 
-Harness Error (FAIL), message = Unhandled rejection: assert_unreached: missing pointermove event Reached unreachable code
-
 PASS Test pointer events in the main document
-FAIL Test pointer events in an iframe assert_unreached: missing pointerover event Reached unreachable code
+PASS Test pointer events in an iframe
 PASS mouse pointerover.fromElement value is null
 PASS mouse pointerover.toElement value is null
 PASS mouse pointerenter.fromElement value is null
@@ -19,4 +17,18 @@ PASS mouse pointerout.fromElement value is null
 PASS mouse pointerout.toElement value is null
 PASS mouse pointerleave.fromElement value is null
 PASS mouse pointerleave.toElement value is null
+PASS Inner Frame mouse pointerover.fromElement value is null
+PASS Inner Frame mouse pointerover.toElement value is null
+PASS Inner Frame mouse pointerenter.fromElement value is null
+PASS Inner Frame mouse pointerenter.toElement value is null
+PASS Inner Frame mouse pointermove.fromElement value is null
+PASS Inner Frame mouse pointermove.toElement value is null
+PASS Inner Frame mouse pointerdown.fromElement value is null
+PASS Inner Frame mouse pointerdown.toElement value is null
+PASS Inner Frame mouse pointerup.fromElement value is null
+PASS Inner Frame mouse pointerup.toElement value is null
+PASS Inner Frame mouse pointerout.fromElement value is null
+PASS Inner Frame mouse pointerout.toElement value is null
+PASS Inner Frame mouse pointerleave.fromElement value is null
+PASS Inner Frame mouse pointerleave.toElement value is null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_mouse-right-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_mouse-right-expected.txt
@@ -1,10 +1,8 @@
 
 done
 
-Harness Error (FAIL), message = Unhandled rejection: assert_unreached: missing pointermove event Reached unreachable code
-
 PASS Test pointer events in the main document
-FAIL Test pointer events in an iframe assert_unreached: missing pointerover event Reached unreachable code
+PASS Test pointer events in an iframe
 PASS mouse pointerover event is a PointerEvent event
 PASS mouse pointerover.isTrusted value is true
 PASS mouse pointerover.composed value is valid
@@ -55,4 +53,54 @@ PASS mouse pointerleave.bubbles value is valid
 PASS mouse pointerleave.cancelable value is valid
 PASS mouse pointerleave.pressure value is valid
 PASS mouse pointerleave properties for pointerType = mouse
+PASS Inner Frame mouse pointerover event is a PointerEvent event
+PASS Inner Frame mouse pointerover.isTrusted value is true
+PASS Inner Frame mouse pointerover.composed value is valid
+PASS Inner Frame mouse pointerover.bubbles value is valid
+PASS Inner Frame mouse pointerover.cancelable value is valid
+PASS Inner Frame mouse pointerover.pressure value is valid
+PASS Inner Frame mouse pointerover properties for pointerType = mouse
+PASS Inner Frame mouse pointerenter event is a PointerEvent event
+PASS Inner Frame mouse pointerenter.isTrusted value is true
+PASS Inner Frame mouse pointerenter.composed value is valid
+PASS Inner Frame mouse pointerenter.bubbles value is valid
+PASS Inner Frame mouse pointerenter.cancelable value is valid
+PASS Inner Frame mouse pointerenter.pressure value is valid
+PASS Inner Frame mouse pointerenter properties for pointerType = mouse
+PASS Inner Frame mouse pointermove event is a PointerEvent event
+PASS Inner Frame mouse pointermove.isTrusted value is true
+PASS Inner Frame mouse pointermove.composed value is valid
+PASS Inner Frame mouse pointermove.bubbles value is valid
+PASS Inner Frame mouse pointermove.cancelable value is valid
+PASS Inner Frame mouse pointermove.pressure value is valid
+PASS Inner Frame mouse pointermove properties for pointerType = mouse
+PASS Inner Frame mouse pointerdown event is a PointerEvent event
+PASS Inner Frame mouse pointerdown.isTrusted value is true
+PASS Inner Frame mouse pointerdown.composed value is valid
+PASS Inner Frame mouse pointerdown.bubbles value is valid
+PASS Inner Frame mouse pointerdown.cancelable value is valid
+PASS Inner Frame mouse pointerdown.pressure value is valid
+PASS Inner Frame mouse pointerdown properties for pointerType = mouse
+PASS Inner Frame mouse pointerup event is a PointerEvent event
+PASS Inner Frame mouse pointerup.isTrusted value is true
+PASS Inner Frame mouse pointerup.composed value is valid
+PASS Inner Frame mouse pointerup.bubbles value is valid
+PASS Inner Frame mouse pointerup.cancelable value is valid
+PASS Inner Frame mouse pointerup.pressure value is valid
+PASS Inner Frame mouse pointerup properties for pointerType = mouse
+PASS Inner Frame mouse pointerup properties for pointerup
+PASS Inner Frame mouse pointerout event is a PointerEvent event
+PASS Inner Frame mouse pointerout.isTrusted value is true
+PASS Inner Frame mouse pointerout.composed value is valid
+PASS Inner Frame mouse pointerout.bubbles value is valid
+PASS Inner Frame mouse pointerout.cancelable value is valid
+PASS Inner Frame mouse pointerout.pressure value is valid
+PASS Inner Frame mouse pointerout properties for pointerType = mouse
+PASS Inner Frame mouse pointerleave event is a PointerEvent event
+PASS Inner Frame mouse pointerleave.isTrusted value is true
+PASS Inner Frame mouse pointerleave.composed value is valid
+PASS Inner Frame mouse pointerleave.bubbles value is valid
+PASS Inner Frame mouse pointerleave.cancelable value is valid
+PASS Inner Frame mouse pointerleave.pressure value is valid
+PASS Inner Frame mouse pointerleave properties for pointerType = mouse
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_mouse-right-nonstandard-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_mouse-right-nonstandard-expected.txt
@@ -1,10 +1,8 @@
 
 done
 
-Harness Error (FAIL), message = Unhandled rejection: assert_unreached: missing pointermove event Reached unreachable code
-
 PASS Test pointer events in the main document
-FAIL Test pointer events in an iframe assert_unreached: missing pointerover event Reached unreachable code
+PASS Test pointer events in an iframe
 PASS mouse pointerover.fromElement value is null
 PASS mouse pointerover.toElement value is null
 PASS mouse pointerenter.fromElement value is null
@@ -19,4 +17,18 @@ PASS mouse pointerout.fromElement value is null
 PASS mouse pointerout.toElement value is null
 PASS mouse pointerleave.fromElement value is null
 PASS mouse pointerleave.toElement value is null
+PASS Inner Frame mouse pointerover.fromElement value is null
+PASS Inner Frame mouse pointerover.toElement value is null
+PASS Inner Frame mouse pointerenter.fromElement value is null
+PASS Inner Frame mouse pointerenter.toElement value is null
+PASS Inner Frame mouse pointermove.fromElement value is null
+PASS Inner Frame mouse pointermove.toElement value is null
+PASS Inner Frame mouse pointerdown.fromElement value is null
+PASS Inner Frame mouse pointerdown.toElement value is null
+PASS Inner Frame mouse pointerup.fromElement value is null
+PASS Inner Frame mouse pointerup.toElement value is null
+PASS Inner Frame mouse pointerout.fromElement value is null
+PASS Inner Frame mouse pointerout.toElement value is null
+PASS Inner Frame mouse pointerleave.fromElement value is null
+PASS Inner Frame mouse pointerleave.toElement value is null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_pen-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_pen-expected.txt
@@ -1,10 +1,8 @@
 
 done
 
-Harness Error (FAIL), message = Unhandled rejection: assert_unreached: missing pointermove event Reached unreachable code
-
 PASS Test pointer events in the main document
-FAIL Test pointer events in an iframe assert_unreached: missing pointerover event Reached unreachable code
+PASS Test pointer events in an iframe
 PASS mouse pointerover event is a PointerEvent event
 PASS mouse pointerover.isTrusted value is true
 PASS mouse pointerover.composed value is valid
@@ -55,4 +53,54 @@ PASS mouse pointerleave.bubbles value is valid
 PASS mouse pointerleave.cancelable value is valid
 PASS mouse pointerleave.pressure value is valid
 PASS mouse pointerleave properties for pointerType = mouse
+PASS Inner Frame mouse pointerover event is a PointerEvent event
+PASS Inner Frame mouse pointerover.isTrusted value is true
+PASS Inner Frame mouse pointerover.composed value is valid
+PASS Inner Frame mouse pointerover.bubbles value is valid
+PASS Inner Frame mouse pointerover.cancelable value is valid
+PASS Inner Frame mouse pointerover.pressure value is valid
+PASS Inner Frame mouse pointerover properties for pointerType = mouse
+PASS Inner Frame mouse pointerenter event is a PointerEvent event
+PASS Inner Frame mouse pointerenter.isTrusted value is true
+PASS Inner Frame mouse pointerenter.composed value is valid
+PASS Inner Frame mouse pointerenter.bubbles value is valid
+PASS Inner Frame mouse pointerenter.cancelable value is valid
+PASS Inner Frame mouse pointerenter.pressure value is valid
+PASS Inner Frame mouse pointerenter properties for pointerType = mouse
+PASS Inner Frame mouse pointermove event is a PointerEvent event
+PASS Inner Frame mouse pointermove.isTrusted value is true
+PASS Inner Frame mouse pointermove.composed value is valid
+PASS Inner Frame mouse pointermove.bubbles value is valid
+PASS Inner Frame mouse pointermove.cancelable value is valid
+PASS Inner Frame mouse pointermove.pressure value is valid
+PASS Inner Frame mouse pointermove properties for pointerType = mouse
+PASS Inner Frame mouse pointerdown event is a PointerEvent event
+PASS Inner Frame mouse pointerdown.isTrusted value is true
+PASS Inner Frame mouse pointerdown.composed value is valid
+PASS Inner Frame mouse pointerdown.bubbles value is valid
+PASS Inner Frame mouse pointerdown.cancelable value is valid
+PASS Inner Frame mouse pointerdown.pressure value is valid
+PASS Inner Frame mouse pointerdown properties for pointerType = mouse
+PASS Inner Frame mouse pointerup event is a PointerEvent event
+PASS Inner Frame mouse pointerup.isTrusted value is true
+PASS Inner Frame mouse pointerup.composed value is valid
+PASS Inner Frame mouse pointerup.bubbles value is valid
+PASS Inner Frame mouse pointerup.cancelable value is valid
+PASS Inner Frame mouse pointerup.pressure value is valid
+PASS Inner Frame mouse pointerup properties for pointerType = mouse
+PASS Inner Frame mouse pointerup properties for pointerup
+PASS Inner Frame mouse pointerout event is a PointerEvent event
+PASS Inner Frame mouse pointerout.isTrusted value is true
+PASS Inner Frame mouse pointerout.composed value is valid
+PASS Inner Frame mouse pointerout.bubbles value is valid
+PASS Inner Frame mouse pointerout.cancelable value is valid
+PASS Inner Frame mouse pointerout.pressure value is valid
+PASS Inner Frame mouse pointerout properties for pointerType = mouse
+PASS Inner Frame mouse pointerleave event is a PointerEvent event
+PASS Inner Frame mouse pointerleave.isTrusted value is true
+PASS Inner Frame mouse pointerleave.composed value is valid
+PASS Inner Frame mouse pointerleave.bubbles value is valid
+PASS Inner Frame mouse pointerleave.cancelable value is valid
+PASS Inner Frame mouse pointerleave.pressure value is valid
+PASS Inner Frame mouse pointerleave properties for pointerType = mouse
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_pen-nonstandard-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_pen-nonstandard-expected.txt
@@ -1,10 +1,8 @@
 
 done
 
-Harness Error (FAIL), message = Unhandled rejection: assert_unreached: missing pointermove event Reached unreachable code
-
 PASS Test pointer events in the main document
-FAIL Test pointer events in an iframe assert_unreached: missing pointerover event Reached unreachable code
+PASS Test pointer events in an iframe
 PASS mouse pointerover.fromElement value is null
 PASS mouse pointerover.toElement value is null
 PASS mouse pointerenter.fromElement value is null
@@ -19,4 +17,18 @@ PASS mouse pointerout.fromElement value is null
 PASS mouse pointerout.toElement value is null
 PASS mouse pointerleave.fromElement value is null
 PASS mouse pointerleave.toElement value is null
+PASS Inner Frame mouse pointerover.fromElement value is null
+PASS Inner Frame mouse pointerover.toElement value is null
+PASS Inner Frame mouse pointerenter.fromElement value is null
+PASS Inner Frame mouse pointerenter.toElement value is null
+PASS Inner Frame mouse pointermove.fromElement value is null
+PASS Inner Frame mouse pointermove.toElement value is null
+PASS Inner Frame mouse pointerdown.fromElement value is null
+PASS Inner Frame mouse pointerdown.toElement value is null
+PASS Inner Frame mouse pointerup.fromElement value is null
+PASS Inner Frame mouse pointerup.toElement value is null
+PASS Inner Frame mouse pointerout.fromElement value is null
+PASS Inner Frame mouse pointerout.toElement value is null
+PASS Inner Frame mouse pointerleave.fromElement value is null
+PASS Inner Frame mouse pointerleave.toElement value is null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_pen-right-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_pen-right-expected.txt
@@ -1,10 +1,8 @@
 
 done
 
-Harness Error (FAIL), message = Unhandled rejection: assert_unreached: missing pointermove event Reached unreachable code
-
 PASS Test pointer events in the main document
-FAIL Test pointer events in an iframe assert_unreached: missing pointerover event Reached unreachable code
+PASS Test pointer events in an iframe
 PASS mouse pointerover event is a PointerEvent event
 PASS mouse pointerover.isTrusted value is true
 PASS mouse pointerover.composed value is valid
@@ -55,4 +53,54 @@ PASS mouse pointerleave.bubbles value is valid
 PASS mouse pointerleave.cancelable value is valid
 PASS mouse pointerleave.pressure value is valid
 PASS mouse pointerleave properties for pointerType = mouse
+PASS Inner Frame mouse pointerover event is a PointerEvent event
+PASS Inner Frame mouse pointerover.isTrusted value is true
+PASS Inner Frame mouse pointerover.composed value is valid
+PASS Inner Frame mouse pointerover.bubbles value is valid
+PASS Inner Frame mouse pointerover.cancelable value is valid
+PASS Inner Frame mouse pointerover.pressure value is valid
+PASS Inner Frame mouse pointerover properties for pointerType = mouse
+PASS Inner Frame mouse pointerenter event is a PointerEvent event
+PASS Inner Frame mouse pointerenter.isTrusted value is true
+PASS Inner Frame mouse pointerenter.composed value is valid
+PASS Inner Frame mouse pointerenter.bubbles value is valid
+PASS Inner Frame mouse pointerenter.cancelable value is valid
+PASS Inner Frame mouse pointerenter.pressure value is valid
+PASS Inner Frame mouse pointerenter properties for pointerType = mouse
+PASS Inner Frame mouse pointermove event is a PointerEvent event
+PASS Inner Frame mouse pointermove.isTrusted value is true
+PASS Inner Frame mouse pointermove.composed value is valid
+PASS Inner Frame mouse pointermove.bubbles value is valid
+PASS Inner Frame mouse pointermove.cancelable value is valid
+PASS Inner Frame mouse pointermove.pressure value is valid
+PASS Inner Frame mouse pointermove properties for pointerType = mouse
+PASS Inner Frame mouse pointerdown event is a PointerEvent event
+PASS Inner Frame mouse pointerdown.isTrusted value is true
+PASS Inner Frame mouse pointerdown.composed value is valid
+PASS Inner Frame mouse pointerdown.bubbles value is valid
+PASS Inner Frame mouse pointerdown.cancelable value is valid
+PASS Inner Frame mouse pointerdown.pressure value is valid
+PASS Inner Frame mouse pointerdown properties for pointerType = mouse
+PASS Inner Frame mouse pointerup event is a PointerEvent event
+PASS Inner Frame mouse pointerup.isTrusted value is true
+PASS Inner Frame mouse pointerup.composed value is valid
+PASS Inner Frame mouse pointerup.bubbles value is valid
+PASS Inner Frame mouse pointerup.cancelable value is valid
+PASS Inner Frame mouse pointerup.pressure value is valid
+PASS Inner Frame mouse pointerup properties for pointerType = mouse
+PASS Inner Frame mouse pointerup properties for pointerup
+PASS Inner Frame mouse pointerout event is a PointerEvent event
+PASS Inner Frame mouse pointerout.isTrusted value is true
+PASS Inner Frame mouse pointerout.composed value is valid
+PASS Inner Frame mouse pointerout.bubbles value is valid
+PASS Inner Frame mouse pointerout.cancelable value is valid
+PASS Inner Frame mouse pointerout.pressure value is valid
+PASS Inner Frame mouse pointerout properties for pointerType = mouse
+PASS Inner Frame mouse pointerleave event is a PointerEvent event
+PASS Inner Frame mouse pointerleave.isTrusted value is true
+PASS Inner Frame mouse pointerleave.composed value is valid
+PASS Inner Frame mouse pointerleave.bubbles value is valid
+PASS Inner Frame mouse pointerleave.cancelable value is valid
+PASS Inner Frame mouse pointerleave.pressure value is valid
+PASS Inner Frame mouse pointerleave properties for pointerType = mouse
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_pen-right-nonstandard-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_pen-right-nonstandard-expected.txt
@@ -1,10 +1,8 @@
 
 done
 
-Harness Error (FAIL), message = Unhandled rejection: assert_unreached: missing pointermove event Reached unreachable code
-
 PASS Test pointer events in the main document
-FAIL Test pointer events in an iframe assert_unreached: missing pointerover event Reached unreachable code
+PASS Test pointer events in an iframe
 PASS mouse pointerover.fromElement value is null
 PASS mouse pointerover.toElement value is null
 PASS mouse pointerenter.fromElement value is null
@@ -19,4 +17,18 @@ PASS mouse pointerout.fromElement value is null
 PASS mouse pointerout.toElement value is null
 PASS mouse pointerleave.fromElement value is null
 PASS mouse pointerleave.toElement value is null
+PASS Inner Frame mouse pointerover.fromElement value is null
+PASS Inner Frame mouse pointerover.toElement value is null
+PASS Inner Frame mouse pointerenter.fromElement value is null
+PASS Inner Frame mouse pointerenter.toElement value is null
+PASS Inner Frame mouse pointermove.fromElement value is null
+PASS Inner Frame mouse pointermove.toElement value is null
+PASS Inner Frame mouse pointerdown.fromElement value is null
+PASS Inner Frame mouse pointerdown.toElement value is null
+PASS Inner Frame mouse pointerup.fromElement value is null
+PASS Inner Frame mouse pointerup.toElement value is null
+PASS Inner Frame mouse pointerout.fromElement value is null
+PASS Inner Frame mouse pointerout.toElement value is null
+PASS Inner Frame mouse pointerleave.fromElement value is null
+PASS Inner Frame mouse pointerleave.toElement value is null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture_pointerType=mouse&preventDefault=-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture_pointerType=mouse&preventDefault=-expected.txt
@@ -8,5 +8,10 @@ PASS Test in the topmost document: "mousedown" event should be fired on expected
 PASS Test in the topmost document: "pointerup" event should be fired on expected target
 PASS Test in the topmost document: "mouseup" event should be fired on expected target
 PASS Test in the topmost document: "click" event should be fired on expected target
-FAIL Test in the iframe: all expected events should be fired assert_array_equals: lengths differ, expected array ["pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 5, got [] length 0
+PASS Test in the iframe: all expected events should be fired
+PASS Test in the iframe: "pointerdown" event should be fired on expected target
+PASS Test in the iframe: "mousedown" event should be fired on expected target
+PASS Test in the iframe: "pointerup" event should be fired on expected target
+PASS Test in the iframe: "mouseup" event should be fired on expected target
+PASS Test in the iframe: "click" event should be fired on expected target
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture_pointerType=mouse&preventDefault=pointerdown-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture_pointerType=mouse&preventDefault=pointerdown-expected.txt
@@ -6,5 +6,8 @@ PASS Test in the topmost document: all expected events should be fired
 PASS Test in the topmost document: "pointerdown" event should be fired on expected target
 PASS Test in the topmost document: "pointerup" event should be fired on expected target
 PASS Test in the topmost document: "click" event should be fired on expected target
-FAIL Test in the iframe: all expected events should be fired assert_array_equals: lengths differ, expected array ["pointerdown", "pointerup", "click"] length 3, got [] length 0
+PASS Test in the iframe: all expected events should be fired
+PASS Test in the iframe: "pointerdown" event should be fired on expected target
+PASS Test in the iframe: "pointerup" event should be fired on expected target
+PASS Test in the iframe: "click" event should be fired on expected target
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_is_a_pointerevent_mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_is_a_pointerevent_mouse-expected.txt
@@ -1,9 +1,7 @@
 
 
-Harness Error (TIMEOUT), message = null
-
 PASS click using mouse is a PointerEvent with correct properties
 PASS click using mouse is a PointerEvent with correct properties when no other PointerEvent listeners are present
 PASS click using mouse is a PointerEvent with correct properties using non-pointing device
-TIMEOUT click using mouse is a PointerEvent with correct properties in a subframe Test timed out
+PASS click using mouse is a PointerEvent with correct properties in a subframe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate_remove_target.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate_remove_target.https-expected.txt
@@ -2,5 +2,5 @@
 
 FAIL "pointermove" and its preceding boundary events should be fired on parent if "pointerrawupdate" event listener removes its target assert_equals: expected "pointerover@target,pointerrawupdate@target,pointerover@container,pointermove@container" but got "pointerover@target,pointermove@target"
 FAIL "pointermove" and its preceding boundary events should be fired on ancestor if "pointerrawupdate" event listener removes its target parent assert_equals: expected "pointerover@target,pointerrawupdate@target,pointerover@container,pointermove@container" but got "pointerover@target,pointermove@target"
-FAIL "pointermove" and its preceding boundary events should be fired on parent if "pointerrawupdate" event listener removes its document assert_equals: expected "pointerover@target, pointerrawupdate@target, pointerover@container, pointermove@container" but got "pointerover@container, pointermove@container"
+FAIL "pointermove" and its preceding boundary events should be fired on parent if "pointerrawupdate" event listener removes its document assert_equals: expected "pointerover@target, pointerrawupdate@target, pointerover@container, pointermove@container" but got "pointerover@target, pointermove@target"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_pointermove_in_pointerlock-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_pointermove_in_pointerlock-expected.txt
@@ -8,8 +8,6 @@ Move your mouse.
 
 
 
-Harness Error (TIMEOUT), message = null
-
 PASS pointermove event received
-NOTRUN pointermove event received inner frame
+PASS pointermove event received inner frame
 

--- a/LayoutTests/resources/testdriver-vendor.js
+++ b/LayoutTests/resources/testdriver-vendor.js
@@ -24,6 +24,40 @@ function pause(duration) {
 }
 
 /**
+ * Compute the offset to add to an action's coordinates for the action's origin.
+ *
+ * For an element origin that is the center of the element's bounding box, in root-view
+ * coordinates: events are dispatched from the top window, so an origin inside a subframe must be
+ * shifted out of that frame's coordinate space. The shift ignores CSS transforms on an ancestor
+ * <iframe> (webkit.org/b/318752). Any other origin ("viewport") contributes no offset.
+ *
+ * @param {Element | String | undefined} origin
+ * @returns {{ x: Number, y: Number }}
+ */
+function originOffset(origin)
+{
+    const originWindow = origin?.ownerDocument?.defaultView;
+    if (!originWindow || !(origin instanceof originWindow.Element))
+        return { x: 0, y: 0 };
+
+    const bounds = origin.getBoundingClientRect();
+    logDebug(`${origin.id} [${bounds.left}, ${bounds.top}, ${bounds.width}, ${bounds.height}]`);
+
+    const offset = {
+        x: bounds.left + (bounds.width / 2.0),
+        y: bounds.top + (bounds.height / 2.0),
+    };
+
+    if (originWindow !== originWindow.top && originWindow.internals) {
+        const rootViewBounds = originWindow.internals.boundingBoxInRootViewCoordinates(origin);
+        offset.x += rootViewBounds.left - bounds.left;
+        offset.y += rootViewBounds.top - bounds.top;
+    }
+
+    return offset;
+}
+
+/**
  *
  * @param {object[]} actions
  * @param {"pointerMove" | "pointerDown" | "pointerUp" | "pause"} pointerType
@@ -38,14 +72,7 @@ async function dispatchMouseActions(actions, pointerType)
     for (let action of actions) {
         switch (action.type) {
         case "pointerMove":
-            const origin = { x: 0, y: 0 };
-            const actionWindow = action.origin?.ownerDocument?.defaultView;
-            if (actionWindow && action.origin instanceof actionWindow.Element) {
-                const bounds = action.origin.getBoundingClientRect();
-                logDebug(`${action.origin.id} [${bounds.left}, ${bounds.top}, ${bounds.width}, ${bounds.height}]`);
-                origin.x = bounds.left + (bounds.width / 2.0);
-                origin.y = bounds.top + (bounds.height / 2.0);
-            }
+            const origin = originOffset(action.origin);
             logDebug(`eventSender.mouseMoveTo(${action.x + origin.x}, ${action.y + origin.y})`);
             await eventSender.asyncMouseMoveTo(action.x + origin.x, action.y + origin.y, pointerType);
             break;
@@ -104,12 +131,9 @@ async function dispatchTouchActions(actions, options = { insertPauseAfterPointer
         switch (action.type) {
         case "pointerMove":
             touch.phase = "moved";
-            const actionWindow = action.origin?.ownerDocument?.defaultView;
-            if (actionWindow && action.origin instanceof actionWindow.Element) {
-                const bounds = action.origin.getBoundingClientRect();
-                touch.x += bounds.left + (bounds.width / 2.0);
-                touch.y += bounds.top + (bounds.height / 2.0);
-            }
+            const offset = originOffset(action.origin);
+            touch.x += offset.x;
+            touch.y += offset.y;
             break;
         case "pointerDown":
             pointerDown = true;
@@ -240,13 +264,9 @@ async function dispatchWheelActions(actions)
             if (duration === undefined)
                 duration = computeTickDuration(actions, "wheel");
  
-            const originWindow = origin?.ownerDocument?.defaultView;
-            if (originWindow && origin instanceof originWindow.Element) {
-                const bounds = origin.getBoundingClientRect();
-                logDebug(() => `${origin.id} [${bounds.left}, ${bounds.top}, ${bounds.width}, ${bounds.height}]`);
-                x += bounds.left + (bounds.width / 2.0);
-                y += bounds.top + (bounds.height / 2.0);
-            }
+            const offset = originOffset(origin);
+            x += offset.x;
+            y += offset.y;
 
             const eventInterval = 1000. / 60.; // Matches the hardcoded interval in sendEventStream()
             const eventCount = Math.ceil(duration / eventInterval);


### PR DESCRIPTION
#### 7ac897a607fe5e61d2282cddb53aa62151d4112f
<pre>
testdriver-vendor.js uses frame-local coordinates for action origins inside a subframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=321140">https://bugs.webkit.org/show_bug.cgi?id=321140</a>
<a href="https://rdar.apple.com/184172049">rdar://184172049</a>

Reviewed by NOBODY (OOPS!).

Actions are hit-tested from the top window, but dispatchMouseActions(),
dispatchTouchActions() and dispatchWheelActions() each took the center of the
origin element&apos;s getBoundingClientRect() as-is. For an origin inside a
subframe those coordinates are frame-local, so the events landed wherever that
point happens to be in the top window instead of on the element, usually
missing the frame entirely.

test_driver_internal.click() already handles this by adding the element&apos;s
frame-to-root-view offset to the frame-local point. Factor that out into
originOffset() and use it for all three dispatchers, so the mouse, touch and
wheel paths agree with click(). A top-window origin computes exactly the same
point as before; only subframe origins change.

This does not fix ancestor &lt;iframe&gt; CSS transforms, which the frame-view
mapping does not compose (webkit.org/b/318752); as with click(), it composes
frame position and scroll only.

Rebaseline the pointerevents tests whose subframe subtests now actually run.
Their subframe halves previously reported missing events, empty event lists,
TIMEOUT or NOTRUN, and now pass. pointerevent_pointerrawupdate_remove_target
.https.html keeps a failure because WebKit does not fire pointerrawupdate.

* LayoutTests/http/wpt/testdriver/subframe-element-origin-expected.txt: Added.
* LayoutTests/http/wpt/testdriver/subframe-element-origin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_mouse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_mouse-nonstandard-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_mouse-right-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_mouse-right-nonstandard-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_pen-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_pen-nonstandard-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_pen-right-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_pen-right-nonstandard-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture_pointerType=mouse&amp;preventDefault=-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture_pointerType=mouse&amp;preventDefault=pointerdown-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_is_a_pointerevent_mouse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate_remove_target.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_pointermove_in_pointerlock-expected.txt:
* LayoutTests/resources/testdriver-vendor.js:
(async dispatchMouseActions):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ac897a607fe5e61d2282cddb53aa62151d4112f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188858 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143338 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f78edfd2-0485-4a40-bc9d-4506d9cad5a4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139602 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96744 "3 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16c4fb20-fd80-4c3a-b025-c43f4b272df3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181986 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43199 "Found 1 new test failure: http/wpt/testdriver/subframe-element-origin.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120048 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46014138-b8c8-4ebe-82c1-8b3861c931d0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41870 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40217 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39860 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/165 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191078 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159874 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148833 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53318 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148577 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43270 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120403 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51836 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14839 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51221 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51462 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->