### PR TITLE
Web Inspector: [SI] emit DOMStorage events for cross-origin iframes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/storage/dom-storage-commands-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/dom-storage-commands-frame-target-expected.txt
@@ -1,0 +1,168 @@
+Tests DOMStorage get/set/remove/clear commands against a cross-origin iframe's storage under Site Isolation.
+
+
+
+== Running test suite: SiteIsolation.DOMStorage.Commands
+-- Running test case: Setup
+PASS: Should find the cross-origin frame target.
+PASS: The iframe should be cross-origin to the main frame.
+PASS: The frame target should expose the DOMStorage domain.
+PASS: getDOMStorageItems should be available on a frame target.
+PASS: setDOMStorageItem should be available on a frame target.
+PASS: removeDOMStorageItem should be available on a frame target.
+PASS: clearDOMStorageItems should be available on a frame target.
+
+-- Running test case: SiteIsolation.DOMStorage.Commands.Session.getDOMStorageItems
+
+Getting DOM storage entries...
+[
+  [
+    "foo",
+    "bar"
+  ]
+]
+
+PASS: Should have a DOMStorageObject for the iframe's sessionStorage.
+
+-- Running test case: SiteIsolation.DOMStorage.Commands.Session.setDOMStorageItem
+
+Getting DOM storage entries...
+[
+  [
+    "foo",
+    "bar"
+  ]
+]
+
+Setting key 'asd' with value 'new'...
+
+Getting DOM storage entries...
+[
+  [
+    "asd",
+    "new"
+  ],
+  [
+    "foo",
+    "bar"
+  ]
+]
+
+PASS: The value should be readable from inside the cross-origin frame itself.
+
+-- Running test case: SiteIsolation.DOMStorage.Commands.Session.removeDOMStorageItem
+
+Getting DOM storage entries...
+[
+  [
+    "foo",
+    "bar"
+  ]
+]
+
+Removing 'foo'...
+
+Getting DOM storage entries...
+[]
+
+PASS: 'foo' should be gone inside the cross-origin frame itself.
+
+-- Running test case: SiteIsolation.DOMStorage.Commands.Session.clearDOMStorageItems
+
+Getting DOM storage entries...
+[
+  [
+    "foo",
+    "bar"
+  ]
+]
+
+Clearing storage...
+
+Getting DOM storage entries...
+[]
+
+PASS: The cross-origin frame's storage should be empty in its own process.
+
+-- Running test case: SiteIsolation.DOMStorage.Commands.Session.DoesNotTouchMainFrame
+PASS: The iframe should have its own key.
+PASS: The iframe should NOT see the main frame's key.
+PASS: The main frame should NOT see the iframe's key.
+
+-- Running test case: SiteIsolation.DOMStorage.Commands.Local.getDOMStorageItems
+
+Getting DOM storage entries...
+[
+  [
+    "foo",
+    "bar"
+  ]
+]
+
+PASS: Should have a DOMStorageObject for the iframe's localStorage.
+
+-- Running test case: SiteIsolation.DOMStorage.Commands.Local.setDOMStorageItem
+
+Getting DOM storage entries...
+[
+  [
+    "foo",
+    "bar"
+  ]
+]
+
+Setting key 'asd' with value 'new'...
+
+Getting DOM storage entries...
+[
+  [
+    "asd",
+    "new"
+  ],
+  [
+    "foo",
+    "bar"
+  ]
+]
+
+PASS: The value should be readable from inside the cross-origin frame itself.
+
+-- Running test case: SiteIsolation.DOMStorage.Commands.Local.removeDOMStorageItem
+
+Getting DOM storage entries...
+[
+  [
+    "foo",
+    "bar"
+  ]
+]
+
+Removing 'foo'...
+
+Getting DOM storage entries...
+[]
+
+PASS: 'foo' should be gone inside the cross-origin frame itself.
+
+-- Running test case: SiteIsolation.DOMStorage.Commands.Local.clearDOMStorageItems
+
+Getting DOM storage entries...
+[
+  [
+    "foo",
+    "bar"
+  ]
+]
+
+Clearing storage...
+
+Getting DOM storage entries...
+[]
+
+PASS: The cross-origin frame's storage should be empty in its own process.
+
+-- Running test case: SiteIsolation.DOMStorage.Commands.Local.DoesNotTouchMainFrame
+PASS: The iframe should have its own key.
+PASS: The iframe should NOT see the main frame's key.
+PASS: The main frame should NOT see the iframe's key.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/dom-storage-commands-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/dom-storage-commands-frame-target.html
@@ -1,0 +1,144 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script src="resources/site-isolation-storage-test-utilities.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOMStorage.Commands");
+
+    let frameTarget = null;
+    let frameOrigin = null;
+
+    function frameStorage(isLocalStorage) {
+        return InspectorTest.SiteIsolationStorage.objectForOrigin(frameOrigin, isLocalStorage);
+    }
+
+    function readInFrame(storageName) {
+        return InspectorTest.SiteIsolationStorage.readInFrame(frameTarget, storageName);
+    }
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Find the cross-origin frame target and reset its storage to a known state.",
+        async test() {
+            frameTarget = await frameTargetForURLContaining("dom-storage-frame.html");
+            InspectorTest.expectNotNull(frameTarget, "Should find the cross-origin frame target.");
+
+            let {result} = await frameTarget.RuntimeAgent.evaluate.invoke({expression: "origin", objectGroup: "test", returnByValue: true});
+            frameOrigin = result.value;
+            InspectorTest.expectNotEqual(frameOrigin, WI.networkManager.mainFrame.securityOrigin, "The iframe should be cross-origin to the main frame.");
+
+            InspectorTest.expectThat(frameTarget.hasDomain("DOMStorage"), "The frame target should expose the DOMStorage domain.");
+            InspectorTest.expectThat(frameTarget.hasCommand("DOMStorage.getDOMStorageItems"), "getDOMStorageItems should be available on a frame target.");
+            InspectorTest.expectThat(frameTarget.hasCommand("DOMStorage.setDOMStorageItem"), "setDOMStorageItem should be available on a frame target.");
+            InspectorTest.expectThat(frameTarget.hasCommand("DOMStorage.removeDOMStorageItem"), "removeDOMStorageItem should be available on a frame target.");
+            InspectorTest.expectThat(frameTarget.hasCommand("DOMStorage.clearDOMStorageItems"), "clearDOMStorageItems should be available on a frame target.");
+        }
+    });
+
+    function addCommandTestCases(isLocalStorage) {
+        let storageName = isLocalStorage ? "localStorage" : "sessionStorage";
+        let prefix = `SiteIsolation.DOMStorage.Commands.${isLocalStorage ? "Local" : "Session"}`;
+
+        // Re-seeds so no case depends on an earlier one, and repopulates the entry cache that
+        // removeItem() asserts against.
+        async function seedAndLogEntries() {
+            await InspectorTest.SiteIsolationStorage.evaluateInFrame(frameTarget, "clearStorages()");
+            let domStorage = frameStorage(isLocalStorage);
+            await InspectorTest.SiteIsolationStorage.logEntries(domStorage);
+            return domStorage;
+        }
+
+        suite.addTestCase({
+            name: `${prefix}.getDOMStorageItems`,
+            description: `getDOMStorageItems should read the cross-origin frame's ${storageName}.`,
+            async test() {
+                let domStorage = await seedAndLogEntries();
+                InspectorTest.expectNotNull(domStorage, `Should have a DOMStorageObject for the iframe's ${storageName}.`);
+            }
+        });
+
+        suite.addTestCase({
+            name: `${prefix}.setDOMStorageItem`,
+            description: `setDOMStorageItem should write into the cross-origin frame's ${storageName}, in its own process.`,
+            async test() {
+                let domStorage = await seedAndLogEntries();
+
+                InspectorTest.log("Setting key 'asd' with value 'new'...");
+                await domStorage.setItem("asd", "new");
+
+                await InspectorTest.SiteIsolationStorage.logEntries(domStorage);
+
+                let inFrame = await readInFrame(storageName);
+                InspectorTest.expectEqual(inFrame["asd"], "new", "The value should be readable from inside the cross-origin frame itself.");
+            }
+        });
+
+        suite.addTestCase({
+            name: `${prefix}.removeDOMStorageItem`,
+            description: `removeDOMStorageItem should remove from the cross-origin frame's ${storageName}.`,
+            async test() {
+                let domStorage = await seedAndLogEntries();
+
+                InspectorTest.log("Removing 'foo'...");
+                await domStorage.removeItem("foo");
+
+                await InspectorTest.SiteIsolationStorage.logEntries(domStorage);
+
+                let inFrame = await readInFrame(storageName);
+                InspectorTest.expectEqual(inFrame["foo"], undefined, "'foo' should be gone inside the cross-origin frame itself.");
+            }
+        });
+
+        suite.addTestCase({
+            name: `${prefix}.clearDOMStorageItems`,
+            description: `clearDOMStorageItems should empty the cross-origin frame's ${storageName}.`,
+            async test() {
+                let domStorage = await seedAndLogEntries();
+
+                InspectorTest.log("Clearing storage...");
+                await domStorage.clear();
+
+                await InspectorTest.SiteIsolationStorage.logEntries(domStorage);
+
+                let inFrame = await readInFrame(storageName);
+                InspectorTest.expectEqual(Object.keys(inFrame).length, 0, "The cross-origin frame's storage should be empty in its own process.");
+            }
+        });
+
+        suite.addTestCase({
+            name: `${prefix}.DoesNotTouchMainFrame`,
+            description: `Writing the iframe's ${storageName} must not alter the main frame's same-named storage.`,
+            async test() {
+                // Awaited so it is ordered before the frame-target write on the other connection.
+                await InspectorTest.evaluateInPage(`${storageName}.clear(); ${storageName}.setItem("mainKey", "mainValue")`);
+
+                await frameStorage(isLocalStorage).setItem("frameKey", "frameValue");
+
+                let inFrame = await readInFrame(storageName);
+                InspectorTest.expectEqual(inFrame["frameKey"], "frameValue", "The iframe should have its own key.");
+                InspectorTest.expectEqual(inFrame["mainKey"], undefined, "The iframe should NOT see the main frame's key.");
+
+                let mainValue = await InspectorTest.evaluateInPage(`${storageName}.getItem("frameKey")`);
+                InspectorTest.expectNull(mainValue, "The main frame should NOT see the iframe's key.");
+            }
+        });
+    }
+
+    addCommandTestCases(false);
+    addCommandTestCases(true);
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests DOMStorage get/set/remove/clear commands against a cross-origin iframe's storage under Site Isolation.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/storage/resources/dom-storage-frame.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/dom-storage-events-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/dom-storage-events-frame-target-expected.txt
@@ -1,0 +1,63 @@
+Tests that DOMStorage change events from a cross-origin iframe reach the frontend under Site Isolation, exactly once, and without crossing origins.
+
+
+
+== Running test suite: SiteIsolation.DOMStorage.Events
+-- Running test case: Setup
+PASS: Should find the cross-origin frame target.
+PASS: The iframe should be cross-origin to the main frame.
+PASS: Should have a DOMStorageObject for the iframe's sessionStorage.
+PASS: The iframe's sessionStorage object should be bound to the cross-origin frame target.
+PASS: Should have a separate DOMStorageObject for the main frame's sessionStorage.
+PASS: Should have a DOMStorageObject for the iframe's localStorage.
+PASS: The iframe's localStorage object should be bound to the cross-origin frame target.
+PASS: Should have a separate DOMStorageObject for the main frame's localStorage.
+
+-- Running test case: SiteIsolation.DOMStorage.Events.Session.ItemAdded
+PASS: Should add key 'added'.
+PASS: Should have value 'value1'.
+
+-- Running test case: SiteIsolation.DOMStorage.Events.Session.ItemUpdated
+PASS: Should update key 'added'.
+PASS: Should have oldValue 'value1'.
+PASS: Should have newValue 'value2'.
+
+-- Running test case: SiteIsolation.DOMStorage.Events.Session.ItemRemoved
+PASS: Should remove key 'added'.
+
+-- Running test case: SiteIsolation.DOMStorage.Events.Session.ItemsCleared
+PASS: Should fire ItemsCleared.
+PASS: Entries should be empty after clear.
+
+-- Running test case: SiteIsolation.DOMStorage.Events.Session.DeliveredExactlyOnce
+PASS: The iframe's object should receive exactly one ItemAdded.
+PASS: The main frame's object should receive no event for the iframe's write.
+
+-- Running test case: SiteIsolation.DOMStorage.Events.Session.MainFrameStillWorks
+PASS: The main frame's object should receive its own write.
+PASS: The iframe's object should not receive the main frame's write.
+
+-- Running test case: SiteIsolation.DOMStorage.Events.Local.ItemAdded
+PASS: Should add key 'added'.
+PASS: Should have value 'value1'.
+
+-- Running test case: SiteIsolation.DOMStorage.Events.Local.ItemUpdated
+PASS: Should update key 'added'.
+PASS: Should have oldValue 'value1'.
+PASS: Should have newValue 'value2'.
+
+-- Running test case: SiteIsolation.DOMStorage.Events.Local.ItemRemoved
+PASS: Should remove key 'added'.
+
+-- Running test case: SiteIsolation.DOMStorage.Events.Local.ItemsCleared
+PASS: Should fire ItemsCleared.
+PASS: Entries should be empty after clear.
+
+-- Running test case: SiteIsolation.DOMStorage.Events.Local.DeliveredExactlyOnce
+PASS: The iframe's object should receive exactly one ItemAdded.
+PASS: The main frame's object should receive no event for the iframe's write.
+
+-- Running test case: SiteIsolation.DOMStorage.Events.Local.MainFrameStillWorks
+PASS: The main frame's object should receive its own write.
+PASS: The iframe's object should not receive the main frame's write.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/dom-storage-events-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/dom-storage-events-frame-target.html
@@ -1,0 +1,200 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script src="resources/site-isolation-storage-test-utilities.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOMStorage.Events");
+
+    let frameTarget = null;
+    let frameOrigin = null;
+    let mainOrigin = null;
+
+    function evaluateInFrame(expression) {
+        return InspectorTest.SiteIsolationStorage.evaluateInFrame(frameTarget, expression);
+    }
+
+    // Not awaited: the awaited event is what orders these tests. Swallow rejections so a failure
+    // surfaces as a timeout on awaitEvent rather than an unhandled rejection.
+    function writeInFrame(expression) {
+        evaluateInFrame(expression).catch(() => { });
+    }
+
+    // A duplicate event is already queued ahead of these replies, so this orders rather than
+    // waits on a clock.
+    function flushConnections() {
+        return Promise.all([
+            evaluateInFrame("1"),
+            InspectorTest.evaluateInPage("1"),
+        ]);
+    }
+
+    function frameStorage(isLocalStorage) {
+        return InspectorTest.SiteIsolationStorage.objectForOrigin(frameOrigin, isLocalStorage);
+    }
+
+    function mainStorage(isLocalStorage) {
+        return InspectorTest.SiteIsolationStorage.objectForOrigin(mainOrigin, isLocalStorage);
+    }
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Find the cross-origin frame target and confirm it owns a distinct origin.",
+        async test() {
+            frameTarget = await frameTargetForURLContaining("dom-storage-frame.html");
+            InspectorTest.expectNotNull(frameTarget, "Should find the cross-origin frame target.");
+
+            let {result} = await frameTarget.RuntimeAgent.evaluate.invoke({expression: "origin", objectGroup: "test", returnByValue: true});
+            frameOrigin = result.value;
+            mainOrigin = WI.networkManager.mainFrame.securityOrigin;
+
+            InspectorTest.expectNotEqual(frameOrigin, mainOrigin, "The iframe should be cross-origin to the main frame.");
+
+            // Empty, not seeded: a seeding write emits an ItemAdded that could satisfy the first
+            // case's awaitEvent. localStorage also persists across runs.
+            await evaluateInFrame("resetStorages()");
+            await InspectorTest.evaluateInPage("sessionStorage.clear(); localStorage.clear()");
+
+            for (let isLocalStorage of [false, true]) {
+                let label = isLocalStorage ? "localStorage" : "sessionStorage";
+                let domStorage = frameStorage(isLocalStorage);
+                InspectorTest.expectNotNull(domStorage, `Should have a DOMStorageObject for the iframe's ${label}.`);
+                if (domStorage)
+                    InspectorTest.expectEqual(domStorage.target, frameTarget, `The iframe's ${label} object should be bound to the cross-origin frame target.`);
+
+                InspectorTest.expectNotNull(mainStorage(isLocalStorage), `Should have a separate DOMStorageObject for the main frame's ${label}.`);
+            }
+        }
+    });
+
+    function addEventTestCases(isLocalStorage) {
+        let storageName = isLocalStorage ? "localStorage" : "sessionStorage";
+        let prefix = `SiteIsolation.DOMStorage.Events.${isLocalStorage ? "Local" : "Session"}`;
+
+        suite.addTestCase({
+            name: `${prefix}.ItemAdded`,
+            description: `Adding an item inside the cross-origin frame should fire domStorageItemAdded for ${storageName}.`,
+            async test() {
+                let domStorage = frameStorage(isLocalStorage);
+                let eventPromise = domStorage.awaitEvent(WI.DOMStorageObject.Event.ItemAdded);
+                writeInFrame(`addItem(${storageName})`);
+
+                let {data} = await eventPromise;
+                InspectorTest.expectEqual(data.key, "added", "Should add key 'added'.");
+                InspectorTest.expectEqual(data.value, "value1", "Should have value 'value1'.");
+            }
+        });
+
+        suite.addTestCase({
+            name: `${prefix}.ItemUpdated`,
+            description: `Updating an item inside the cross-origin frame should fire domStorageItemUpdated for ${storageName}.`,
+            async test() {
+                let domStorage = frameStorage(isLocalStorage);
+                let eventPromise = domStorage.awaitEvent(WI.DOMStorageObject.Event.ItemUpdated);
+                writeInFrame(`updateItem(${storageName})`);
+
+                let {data} = await eventPromise;
+                InspectorTest.expectEqual(data.key, "added", "Should update key 'added'.");
+                InspectorTest.expectEqual(data.oldValue, "value1", "Should have oldValue 'value1'.");
+                InspectorTest.expectEqual(data.newValue, "value2", "Should have newValue 'value2'.");
+            }
+        });
+
+        suite.addTestCase({
+            name: `${prefix}.ItemRemoved`,
+            description: `Removing an item inside the cross-origin frame should fire domStorageItemRemoved for ${storageName}.`,
+            async test() {
+                let domStorage = frameStorage(isLocalStorage);
+                let eventPromise = domStorage.awaitEvent(WI.DOMStorageObject.Event.ItemRemoved);
+                writeInFrame(`removeItem(${storageName})`);
+
+                let {data} = await eventPromise;
+                InspectorTest.expectEqual(data.key, "added", "Should remove key 'added'.");
+            }
+        });
+
+        suite.addTestCase({
+            name: `${prefix}.ItemsCleared`,
+            description: `Clearing the cross-origin frame's ${storageName} should fire domStorageItemsCleared.`,
+            async test() {
+                let domStorage = frameStorage(isLocalStorage);
+                let eventPromise = domStorage.awaitEvent(WI.DOMStorageObject.Event.ItemsCleared);
+                writeInFrame(`clearItems(${storageName})`);
+
+                await eventPromise;
+                InspectorTest.pass("Should fire ItemsCleared.");
+                InspectorTest.expectEqual(domStorage.entries.size, 0, "Entries should be empty after clear.");
+            }
+        });
+
+        suite.addTestCase({
+            name: `${prefix}.DeliveredExactlyOnce`,
+            description: `A single ${storageName} write in the cross-origin frame should produce exactly one event, on the iframe's object only.`,
+            async test() {
+                let frameObject = frameStorage(isLocalStorage);
+                let mainObject = mainStorage(isLocalStorage);
+
+                let frameCount = 0;
+                let mainCount = 0;
+                let countFrame = () => { frameCount++; };
+                let countMain = () => { mainCount++; };
+
+                frameObject.addEventListener(WI.DOMStorageObject.Event.ItemAdded, countFrame);
+                mainObject.addEventListener(WI.DOMStorageObject.Event.ItemAdded, countMain);
+
+                let eventPromise = frameObject.awaitEvent(WI.DOMStorageObject.Event.ItemAdded);
+                writeInFrame(`${storageName}.setItem("once", "1")`);
+                await eventPromise;
+
+                await flushConnections();
+
+                frameObject.removeEventListener(WI.DOMStorageObject.Event.ItemAdded, countFrame);
+                mainObject.removeEventListener(WI.DOMStorageObject.Event.ItemAdded, countMain);
+
+                InspectorTest.expectEqual(frameCount, 1, "The iframe's object should receive exactly one ItemAdded.");
+                InspectorTest.expectEqual(mainCount, 0, "The main frame's object should receive no event for the iframe's write.");
+            }
+        });
+
+        suite.addTestCase({
+            name: `${prefix}.MainFrameStillWorks`,
+            description: `A ${storageName} write in the main frame should still reach the main frame's object, not the iframe's.`,
+            async test() {
+                let frameObject = frameStorage(isLocalStorage);
+                let mainObject = mainStorage(isLocalStorage);
+
+                let strayCount = 0;
+                let countStray = () => { strayCount++; };
+                frameObject.addEventListener(WI.DOMStorageObject.Event.ItemAdded, countStray);
+
+                let eventPromise = mainObject.awaitEvent(WI.DOMStorageObject.Event.ItemAdded);
+                InspectorTest.evaluateInPage(`${storageName}.setItem("mainOnly", "1")`);
+
+                let {data} = await eventPromise;
+                InspectorTest.expectEqual(data.key, "mainOnly", "The main frame's object should receive its own write.");
+
+                await flushConnections();
+                frameObject.removeEventListener(WI.DOMStorageObject.Event.ItemAdded, countStray);
+
+                InspectorTest.expectEqual(strayCount, 0, "The iframe's object should not receive the main frame's write.");
+            }
+        });
+    }
+
+    addEventTestCases(false);
+    addEventTestCases(true);
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that DOMStorage change events from a cross-origin iframe reach the frontend under Site Isolation, exactly once, and without crossing origins.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/storage/resources/dom-storage-frame.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/resources/dom-storage-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/resources/dom-storage-frame.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>
+<p>Cross-origin frame that owns its own DOM storage.</p>
+<script>
+// Runs in the cross-origin iframe's own process, so these areas exist only there.
+
+// Matches clearStorages() in LayoutTests/inspector/storage/resources/storage-utilities.js.
+function clearStorages() {
+    sessionStorage.clear();
+    sessionStorage.setItem("foo", "bar");
+
+    localStorage.clear();
+    localStorage.setItem("foo", "bar");
+}
+
+// Used by the events test: a seeding write would emit a stray ItemAdded.
+function resetStorages() {
+    sessionStorage.clear();
+    localStorage.clear();
+}
+
+function addItem(storage) {
+    storage.setItem("added", "value1");
+}
+
+function updateItem(storage) {
+    storage.setItem("added", "value2");
+}
+
+function removeItem(storage) {
+    storage.removeItem("added");
+}
+
+function clearItems(storage) {
+    // Clearing an already-empty area dispatches no event.
+    storage.setItem("toClear", "value");
+    storage.clear();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/resources/site-isolation-storage-test-utilities.js
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/resources/site-isolation-storage-test-utilities.js
@@ -1,0 +1,30 @@
+TestPage.registerInitializer(() => {
+    InspectorTest.SiteIsolationStorage = {};
+
+    // getDOMStorageItems returns StorageMap (HashMap) order, which is not stable; sort so the
+    // expectations file is deterministic.
+    InspectorTest.SiteIsolationStorage.logEntries = async function(storage) {
+        InspectorTest.newline();
+        InspectorTest.log("Getting DOM storage entries...");
+        let [error, entries] = await promisify((callback) => { storage.getEntries(callback); });
+        InspectorTest.assert(!error, error);
+        InspectorTest.json(entries.slice().sort((a, b) => a[0].localeCompare(b[0])));
+        InspectorTest.newline();
+    };
+
+    InspectorTest.SiteIsolationStorage.readInFrame = async function(frameTarget, storageName) {
+        let expression = `JSON.stringify(Object.fromEntries(Object.entries(${storageName})))`;
+        let {result} = await frameTarget.RuntimeAgent.evaluate.invoke({expression, objectGroup: "test", returnByValue: true});
+        return JSON.parse(result.value);
+    };
+
+    InspectorTest.SiteIsolationStorage.evaluateInFrame = function(frameTarget, expression) {
+        return frameTarget.RuntimeAgent.evaluate.invoke({expression, objectGroup: "test"});
+    };
+
+    InspectorTest.SiteIsolationStorage.objectForOrigin = function(securityOrigin, isLocalStorage) {
+        return WI.domStorageManager.domStorageObjects.find((domStorage) => {
+            return domStorage.isLocalStorage() === isLocalStorage && domStorage.id.securityOrigin === securityOrigin;
+        }) || null;
+    };
+});

--- a/Source/JavaScriptCore/inspector/protocol/DOMStorage.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOMStorage.json
@@ -55,7 +55,6 @@
         },
         {
             "name": "clearDOMStorageItems",
-            "targetTypes": ["page"],
             "parameters": [
                 { "name": "storageId", "$ref": "StorageId" }
             ]

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -42,6 +42,7 @@
 #include "EventTargetInlines.h"
 #include "FrameCSSAgent.h"
 #include "FrameDOMAgent.h"
+#include "FrameDOMStorageAgent.h"
 #include "FrameDebuggerAgent.h"
 #include "FrameInspectorController.h"
 #include "FrameRuntimeAgent.h"
@@ -79,6 +80,7 @@
 #include "RenderView.h"
 #include "ScriptController.h"
 #include "ScriptExecutionContext.h"
+#include "SecurityOrigin.h"
 #include "ServiceWorkerGlobalScope.h"
 #include "WebConsoleAgent.h"
 #include "WebDebuggerAgent.h"
@@ -1179,8 +1181,27 @@ void InspectorInstrumentation::consoleStopRecordingCanvasImpl(InstrumentingAgent
         canvasAgent->consoleStopRecordingCanvas(device);
 }
 
-void InspectorInstrumentation::didDispatchDOMStorageEventImpl(InstrumentingAgents& instrumentingAgents, const String& key, const String& oldValue, const String& newValue, StorageType storageType, const SecurityOrigin& securityOrigin)
+void InspectorInstrumentation::didDispatchDOMStorageEventImpl(InstrumentingAgents& instrumentingAgents, Page& page, const String& key, const String& oldValue, const String& newValue, StorageType storageType, const SecurityOrigin& securityOrigin)
 {
+    // Notify at most one agent: same-origin frames share a StorageArea, and the frontend keys
+    // DOMStorageObject on the StorageId alone.
+    CheckedPtr<FrameDOMStorageAgent> frameDOMStorageAgent;
+    page.forEachLocalFrame([&](LocalFrame& frame) {
+        if (frameDOMStorageAgent)
+            return;
+
+        RefPtr document = frame.document();
+        if (!document || !document->securityOrigin().equal(securityOrigin))
+            return;
+
+        frameDOMStorageAgent = frame.inspectorController().instrumentingAgents().enabledFrameDOMStorageAgent();
+    });
+
+    if (frameDOMStorageAgent) {
+        frameDOMStorageAgent->didDispatchDOMStorageEvent(key, oldValue, newValue, storageType, securityOrigin);
+        return;
+    }
+
     if (auto* domStorageAgent = instrumentingAgents.enabledDOMStorageAgent())
         domStorageAgent->didDispatchDOMStorageEvent(key, oldValue, newValue, storageType, securityOrigin);
 }

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -522,7 +522,7 @@ private:
     static void willFireObserverCallbackImpl(InstrumentingAgents&, const String&);
     static void didFireObserverCallbackImpl(InstrumentingAgents&);
 
-    static void didDispatchDOMStorageEventImpl(InstrumentingAgents&, const String& key, const String& oldValue, const String& newValue, StorageType, const SecurityOrigin&);
+    static void didDispatchDOMStorageEventImpl(InstrumentingAgents&, Page&, const String& key, const String& oldValue, const String& newValue, StorageType, const SecurityOrigin&);
 
     static bool shouldWaitForDebuggerOnStartImpl(InstrumentingAgents&);
     static void workerStartedImpl(InstrumentingAgents&, WorkerInspectorProxy&);
@@ -1378,7 +1378,7 @@ inline void InspectorInstrumentation::interceptResponse(const LocalFrame& frame,
 inline void InspectorInstrumentation::didDispatchDOMStorageEvent(Page& page, const String& key, const String& oldValue, const String& newValue, StorageType storageType, const SecurityOrigin& securityOrigin)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    didDispatchDOMStorageEventImpl(protect(instrumentingAgents(page)), key, oldValue, newValue, storageType, securityOrigin);
+    didDispatchDOMStorageEventImpl(protect(instrumentingAgents(page)), page, key, oldValue, newValue, storageType, securityOrigin);
 }
 
 inline bool InspectorInstrumentation::shouldWaitForDebuggerOnStart(ScriptExecutionContext& context)

--- a/Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.cpp
@@ -29,6 +29,7 @@
 #include "DOMException.h"
 #include "Document.h"
 #include "DocumentPage.h"
+#include "InspectorDOMStorageAgent.h"
 #include "InstrumentingAgents.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
@@ -152,6 +153,21 @@ Inspector::CommandResult<void> FrameDOMStorageAgent::clearDOMStorageItems(Ref<JS
     storageArea->clear(*frame);
 
     return { };
+}
+
+void FrameDOMStorageAgent::didDispatchDOMStorageEvent(const String& key, const String& oldValue, const String& newValue, StorageType storageType, const SecurityOrigin& securityOrigin)
+{
+    // Shared with the page-level agent so both emit an identical StorageId for the same event.
+    auto id = InspectorDOMStorageAgent::storageId(securityOrigin, storageType == StorageType::Local);
+
+    if (key.isNull())
+        m_frontendDispatcher->domStorageItemsCleared(WTF::move(id));
+    else if (newValue.isNull())
+        m_frontendDispatcher->domStorageItemRemoved(WTF::move(id), key);
+    else if (oldValue.isNull())
+        m_frontendDispatcher->domStorageItemAdded(WTF::move(id), key, newValue);
+    else
+        m_frontendDispatcher->domStorageItemUpdated(WTF::move(id), key, oldValue, newValue);
 }
 
 RefPtr<StorageArea> FrameDOMStorageAgent::findStorageArea(Inspector::Protocol::ErrorString& errorString, const JSON::Object& storageId, RefPtr<LocalFrame>& targetFrame)

--- a/Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "InspectorWebAgentBase.h"
+#include "StorageType.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -39,6 +40,7 @@ class DOMStorageFrontendDispatcher;
 namespace WebCore {
 
 class LocalFrame;
+class SecurityOrigin;
 class StorageArea;
 
 // FrameDOMStorageAgent is the per-frame DOMStorage agent for Site Isolation. Each
@@ -65,6 +67,9 @@ public:
     Inspector::CommandResult<void> setDOMStorageItem(Ref<JSON::Object>&& storageId, const String& key, const String& value) override;
     Inspector::CommandResult<void> removeDOMStorageItem(Ref<JSON::Object>&& storageId, const String& key) override;
     Inspector::CommandResult<void> clearDOMStorageItems(Ref<JSON::Object>&& storageId) override;
+
+    // InspectorInstrumentation
+    void didDispatchDOMStorageEvent(const String& key, const String& oldValue, const String& newValue, StorageType, const SecurityOrigin&);
 
 private:
     RefPtr<StorageArea> findStorageArea(Inspector::Protocol::ErrorString&, const JSON::Object& storageId, RefPtr<LocalFrame>& targetFrame);

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMStorageManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMStorageManager.js
@@ -89,6 +89,7 @@ WI.DOMStorageManager = class DOMStorageManager extends WI.Object
 
         WI.Frame.addEventListener(WI.Frame.Event.MainResourceDidChange, this._mainResourceDidChange, this);
         WI.Frame.addEventListener(WI.Frame.Event.SecurityOriginDidChange, this._securityOriginDidChange, this);
+        WI.FrameTarget.addEventListener(WI.FrameTarget.Event.ExecutionContextAdded, this._frameTargetExecutionContextAdded, this);
     }
 
     disable()
@@ -104,6 +105,7 @@ WI.DOMStorageManager = class DOMStorageManager extends WI.Object
 
         WI.Frame.removeEventListener(WI.Frame.Event.MainResourceDidChange, this._mainResourceDidChange, this);
         WI.Frame.removeEventListener(WI.Frame.Event.SecurityOriginDidChange, this._securityOriginDidChange, this);
+        WI.FrameTarget.removeEventListener(WI.FrameTarget.Event.ExecutionContextAdded, this._frameTargetExecutionContextAdded, this);
 
         this._reset();
     }
@@ -196,18 +198,33 @@ WI.DOMStorageManager = class DOMStorageManager extends WI.Object
 
         // FIXME: Consider passing the other parts of the origin along.
 
+        let target = this._frameTargetForFrame(frame);
+
         let addDOMStorage = (isLocalStorage) => {
             let identifier = {securityOrigin: frame.securityOrigin, isLocalStorage};
             if (this._domStorageForIdentifier(identifier))
                 return;
 
-            let domStorage = new WI.DOMStorageObject(identifier, frame.mainResource.urlComponents.host, identifier.isLocalStorage);
+            let domStorage = new WI.DOMStorageObject(identifier, frame.mainResource.urlComponents.host, identifier.isLocalStorage, {target});
             let domStorageObjects = identifier.isLocalStorage ? this._localStorageObjects : this._sessionStorageObjects;
             domStorageObjects.set(identifier.securityOrigin, domStorage);
             this.dispatchEventToListeners(DOMStorageManager.Event.DOMStorageObjectWasAdded, {domStorage});
         };
         addDOMStorage(true);
         addDOMStorage(false);
+    }
+
+    _frameTargetForFrame(frame)
+    {
+        for (let target of WI.targets) {
+            if (!(target instanceof WI.FrameTarget))
+                continue;
+
+            if (target.executionContext?.frame === frame)
+                return target;
+        }
+
+        return null;
     }
 
     _addCookieStorageIfNeeded(frame)
@@ -247,6 +264,35 @@ WI.DOMStorageManager = class DOMStorageManager extends WI.Object
         console.assert(event.target instanceof WI.Frame);
 
         this._addDOMStorageIfNeeded(event.target);
+    }
+
+    _frameTargetExecutionContextAdded(event)
+    {
+        if (!this._enabled)
+            return;
+
+        let target = event.target;
+        let frame = target.executionContext?.frame;
+        if (!frame || !frame.securityOrigin)
+            return;
+
+        this._setTargetForOrigin(frame.securityOrigin, target);
+        this._addDOMStorageIfNeeded(frame);
+    }
+
+    _setTargetForOrigin(securityOrigin, target)
+    {
+        for (let isLocalStorage of [true, false]) {
+            let domStorage = this._domStorageForIdentifier({securityOrigin, isLocalStorage});
+            if (!domStorage)
+                continue;
+
+            // Objects are keyed by origin, targets by frame; two frames in different processes
+            // sharing an origin would rebind the same object.
+            console.assert(!domStorage.target || domStorage.target === target || domStorage.target === WI.assumingMainTarget(), domStorage.target, target);
+
+            domStorage.target = target;
+        }
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Models/DOMStorageObject.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMStorageObject.js
@@ -25,13 +25,16 @@
 
 WI.DOMStorageObject = class DOMStorageObject extends WI.Object
 {
-    constructor(id, host, isLocalStorage)
+    constructor(id, host, isLocalStorage, {target} = {})
     {
         super();
 
         this._id = id;
         this._host = host;
         this._isLocalStorage = isLocalStorage;
+
+        this._target = target ?? null;
+
         this._entries = new Map;
     }
 
@@ -40,6 +43,21 @@ WI.DOMStorageObject = class DOMStorageObject extends WI.Object
     get id() { return this._id; }
     get host() { return this._host; }
     get entries() { return this._entries; }
+
+    get target()
+    {
+        // The frame target dies with its frame; fall back rather than use a dead connection.
+        if (this._target && !this._target.isDestroyed)
+            return this._target;
+        return WI.assumingMainTarget();
+    }
+
+    set target(target)
+    {
+        console.assert(!target || target instanceof WI.FrameTarget, target);
+
+        this._target = target ?? null;
+    }
 
     saveIdentityToCookie(cookie)
     {
@@ -69,7 +87,7 @@ WI.DOMStorageObject = class DOMStorageObject extends WI.Object
             callback(error, entries);
         }
 
-        let target = WI.assumingMainTarget();
+        let target = this.target;
         target.DOMStorageAgent.getDOMStorageItems(this._id, innerCallback.bind(this));
     }
 
@@ -77,19 +95,19 @@ WI.DOMStorageObject = class DOMStorageObject extends WI.Object
     {
         console.assert(this._entries.has(key));
 
-        let target = WI.assumingMainTarget();
+        let target = this.target;
         return target.DOMStorageAgent.removeDOMStorageItem(this._id, key);
     }
 
     setItem(key, value)
     {
-        let target = WI.assumingMainTarget();
+        let target = this.target;
         return target.DOMStorageAgent.setDOMStorageItem(this._id, key, value);
     }
 
     clear()
     {
-        let target = WI.assumingMainTarget();
+        let target = this.target;
 
         // COMPATIBILITY (iOS 13.4): DOMStorage.clearDOMStorageItems did not exist yet.
         if (!target.hasCommand("DOMStorage.clearDOMStorageItems")) {


### PR DESCRIPTION
#### f94f53f9211ddc0c34c867e269613e2086475e5c
<pre>
Web Inspector: [SI] emit DOMStorage events for cross-origin iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=316801">https://bugs.webkit.org/show_bug.cgi?id=316801</a>
<a href="https://rdar.apple.com/179249741">rdar://179249741</a>

Reviewed by NOBODY (OOPS!).

Web Inspector&apos;s Storage tab showed nothing for a cross-origin iframe&apos;s
localStorage and sessionStorage, and never updated when that storage changed.

InspectorDOMStorageAgent locates an area by walking the frame tree by security origin, which skips RemoteFrames. FrameDOMStorageAgent already implemented the four commands against its own frame, but nothing reached it.

- didDispatchDOMStorageEventImpl finds the local frame whose document origin
matches the event&apos;s and dispatches to its FrameDOMStorageAgent, falling back to
the page agent when no frame agent owns the origin. It notifies at most one
agent: same-origin frames share a StorageArea and the frontend keys
DOMStorageObject on the StorageId alone.

- FrameDOMStorageAgent::didDispatchDOMStorageEvent builds its StorageId with the
page agent&apos;s helper so both emit an identical key.

- DOMStorageObject holds the target owning its origin and issues all four
commands against it. DOMStorageManager resolves that target from each
FrameTarget&apos;s execution context, and rebinds on ExecutionContextAdded since
that context can arrive after the frame&apos;s SecurityOriginDidChange.

- clearDOMStorageItems declared targetTypes [&quot;page&quot;], so it was not exposed on
frame targets. It now inherits the domain&apos;s types, matching the other three
commands; that also exposes it to itml, which already has the other three.

Two tests, mirroring LayoutTests/inspector/storage/ against an out-of-process
iframe: commands covers get/set/remove/clear for both storage types, verified
through the agent and inside the iframe&apos;s own process; events covers all four
events for both types, plus exactly-once delivery and no cross-origin leakage.

Tests: http/tests/site-isolation/inspector/storage/dom-storage-commands-frame-target.html
       http/tests/site-isolation/inspector/storage/dom-storage-events-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/storage/dom-storage-commands-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/dom-storage-commands-frame-target.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/dom-storage-events-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/dom-storage-events-frame-target.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/resources/dom-storage-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/resources/site-isolation-storage-test-utilities.js: Added.
(TestPage.registerInitializer.async InspectorTest):
(TestPage.registerInitializer.InspectorTest.SiteIsolationStorage.logEntries):
(TestPage.registerInitializer.async let):
(TestPage.registerInitializer.InspectorTest.SiteIsolationStorage.readInFrame):
(TestPage.registerInitializer.InspectorTest.SiteIsolationStorage.evaluateInFrame):
(TestPage.registerInitializer.InspectorTest.SiteIsolationStorage.objectForOrigin):
(TestPage.registerInitializer):
* Source/JavaScriptCore/inspector/protocol/DOMStorage.json:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didDispatchDOMStorageEventImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didDispatchDOMStorageEvent):
* Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.cpp:
(WebCore::FrameDOMStorageAgent::didDispatchDOMStorageEvent):
* Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.h:
* Source/WebInspectorUI/UserInterface/Controllers/DOMStorageManager.js:
(WI.DOMStorageManager.prototype.enable):
(WI.DOMStorageManager.prototype.disable):
(WI.DOMStorageManager.prototype._addDOMStorageIfNeeded):
(WI.DOMStorageManager.prototype._frameTargetForFrame):
(WI.DOMStorageManager.prototype._frameTargetExecutionContextAdded):
(WI.DOMStorageManager.prototype._setTargetForOrigin):
(WI.DOMStorageManager):
* Source/WebInspectorUI/UserInterface/Models/DOMStorageObject.js:
(WI.DOMStorageObject.prototype.get target):
(WI.DOMStorageObject.prototype.set target):
(WI.DOMStorageObject.prototype.getEntries):
(WI.DOMStorageObject.prototype.removeItem):
(WI.DOMStorageObject.prototype.setItem):
(WI.DOMStorageObject.prototype.clear):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f94f53f9211ddc0c34c867e269613e2086475e5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143342 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5e2aba8-0ead-4d06-a965-3861fd79cf3b) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180896 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139611 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96745 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f46a8aa-9f19-4e4b-b6ec-12c38157086d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160364 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120057 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4a133572-f05e-4b6d-8841-377c8afa1715) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41879 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40219 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2033 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8849 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39867 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/169 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40307 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191082 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148858 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53322 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148585 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43277 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125736 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120407 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51840 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14846 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51225 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51466 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51286 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->