### PR TITLE
ViewGestureController magnification gesture handling should not need to be fed a NSEvent instance

### DIFF
--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -225,7 +225,7 @@ class WebKit::WebGestureEvent : WebKit::WebEvent {
     ScrollByPixelWheelEvent
 };
 
-[Nested] enum class WebKit::WebWheelEvent::Phase : uint8_t {
+enum class WebKit::WebEventPhase : uint8_t {
     None,
     Began,
     Stationary,

--- a/Source/WebKit/Shared/WebEventPhase.h
+++ b/Source/WebKit/Shared/WebEventPhase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,49 +25,17 @@
 
 #pragma once
 
-#if ENABLE(MAC_GESTURE_EVENTS)
-
-#include "WebEvent.h"
-#include "WebEventPhase.h"
-#include <WebCore/FloatPoint.h>
-#include <WebCore/FloatSize.h>
-#include <WebCore/IntPoint.h>
-#include <WebCore/IntSize.h>
-#include <wtf/text/WTFString.h>
-
-namespace IPC {
-class Decoder;
-class Encoder;
-}
-
 namespace WebKit {
 
-class WebGestureEvent : public WebEvent {
-public:
-    using Phase = WebEventPhase;
-
-    WebGestureEvent(WebEvent&& event, WebCore::IntPoint position, float gestureScale, float gestureRotation)
-        : WebEvent(WTF::move(event))
-        , m_position(position)
-        , m_gestureScale(gestureScale)
-        , m_gestureRotation(gestureRotation)
-    {
-        ASSERT(isGestureEventType(type()));
-    }
-
-    WebCore::IntPoint position() const { return m_position; }
-
-    float gestureScale() const { return m_gestureScale; }
-    float gestureRotation() const { return m_gestureRotation; }
-
-private:
-    bool isGestureEventType(WebEventType) const;
-
-    WebCore::IntPoint m_position;
-    float m_gestureScale;
-    float m_gestureRotation;
+enum class WebEventPhase : uint8_t {
+    None,
+    Began,
+    Stationary,
+    Changed,
+    Ended,
+    Cancelled,
+    MayBegin,
+    WillBegin,
 };
 
 } // namespace WebKit
-
-#endif // ENABLE(MAC_GESTURE_EVENTS)

--- a/Source/WebKit/Shared/WebWheelEvent.h
+++ b/Source/WebKit/Shared/WebWheelEvent.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "WebEvent.h"
+#include "WebEventPhase.h"
 #include <WebCore/FloatSize.h>
 #include <WebCore/IntPoint.h>
 
@@ -43,16 +44,7 @@ public:
         ScrollByPixelWheelEvent
     };
 
-    enum class Phase : uint8_t {
-        None,
-        Began,
-        Stationary,
-        Changed,
-        Ended,
-        Cancelled,
-        MayBegin,
-        WillBegin,
-    };
+    using Phase = WebEventPhase;
 
     enum class MomentumEndType : uint8_t {
         Unknown,

--- a/Source/WebKit/Shared/mac/WebEventFactory.h
+++ b/Source/WebKit/Shared/mac/WebEventFactory.h
@@ -44,6 +44,8 @@ namespace WebKit {
 // FIXME: This is not needed in the WebProcess and should be moved to be a peer
 // of WKView.
 
+enum class WebEventPhase : uint8_t;
+
 class WebEventFactory {
 public:
 #if USE(APPKIT)
@@ -57,6 +59,8 @@ public:
     static NSInteger NODELETE toNSButtonNumber(WebKit::WebMouseEventButton);
 
     static OptionSet<WebKit::WebEventModifier> NODELETE toWebEventModifierFlags(NSEventModifierFlags);
+
+    static WebEventPhase phaseForEvent(NSEvent *);
 #endif
 #endif // USE(APPKIT)
 };

--- a/Source/WebKit/Shared/mac/WebEventFactory.mm
+++ b/Source/WebKit/Shared/mac/WebEventFactory.mm
@@ -41,9 +41,9 @@
 
 namespace WebKit {
 
-static WebWheelEvent::Phase phaseForEvent(NSEvent *event)
+WebEventPhase WebEventFactory::phaseForEvent(NSEvent *event)
 {
-    using enum WebWheelEvent::Phase;
+    using enum WebEventPhase;
 
     auto phase = None;
     if ([event phase] & NSEventPhaseBegan)

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -110,6 +110,8 @@ class WebBackForwardListItem;
 class WebPageProxy;
 class WebProcessProxy;
 
+enum class WebEventPhase : uint8_t;
+
 class ViewGestureController final : public IPC::MessageReceiver, public RefCounted<ViewGestureController> {
     WTF_MAKE_TZONE_ALLOCATED(ViewGestureController);
     WTF_MAKE_NONCOPYABLE(ViewGestureController);
@@ -164,7 +166,7 @@ public:
 #endif
 
 #if PLATFORM(MAC)
-    void handleMagnificationGestureEvent(PlatformMagnificationEvent, WebCore::FloatPoint origin);
+    void handleMagnificationGesture(double scale, WebEventPhase, WebCore::FloatPoint origin);
     void handleSmartMagnificationGesture(WebCore::FloatPoint gestureLocationInViewCoordinates);
 
     void gestureEventWasNotHandledByWebCore(PlatformMagnificationEvent, WebCore::FloatPoint origin);

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -45,6 +45,8 @@
 #import "ViewGestureGeometryCollectorMessages.h"
 #import "ViewSnapshotStore.h"
 #import "WebBackForwardList.h"
+#import "WebEventFactory.h"
+#import "WebEventPhase.h"
 #import "WebPageGroup.h"
 #import "WebPageMessages.h"
 #import "WebPageProxy.h"
@@ -129,10 +131,10 @@ double ViewGestureController::resistanceForDelta(double deltaScale, double curre
 void ViewGestureController::gestureEventWasNotHandledByWebCore(NSEvent *event, FloatPoint origin)
 {
     if (event.type == NSEventTypeMagnify)
-        handleMagnificationGestureEvent(event, origin);
+        handleMagnificationGesture(event.magnification, WebEventFactory::phaseForEvent(event), origin);
 }
 
-void ViewGestureController::handleMagnificationGestureEvent(NSEvent *event, FloatPoint origin)
+void ViewGestureController::handleMagnificationGesture(double scale, WebEventPhase phase, FloatPoint origin)
 {
     RefPtr page = m_webPageProxy.get();
     if (!page)
@@ -144,7 +146,7 @@ void ViewGestureController::handleMagnificationGestureEvent(NSEvent *event, Floa
     ASSERT(m_activeGestureType == ViewGestureType::None || m_activeGestureType == ViewGestureType::Magnification);
 
     if (m_activeGestureType == ViewGestureType::None) {
-        if (event.phase != NSEventPhaseBegan)
+        if (phase != WebEventPhase::Began)
             return;
 
         // FIXME: We drop the first frame of the gesture on the floor, because we don't have the visible content bounds yet.
@@ -162,7 +164,6 @@ void ViewGestureController::handleMagnificationGestureEvent(NSEvent *event, Floa
     auto minMagnification = page->minPageZoomFactor();
     auto maxMagnification = page->maxPageZoomFactor();
 
-    double scale = event.magnification;
     double scaleWithResistance = resistanceForDelta(scale, m_magnification, minMagnification, maxMagnification) * scale;
 
     auto minElasticMagnification = minMagnification * 0.75;
@@ -171,13 +172,13 @@ void ViewGestureController::handleMagnificationGestureEvent(NSEvent *event, Floa
     m_magnification += m_magnification * scaleWithResistance;
     m_magnification = std::min(std::max(m_magnification, minElasticMagnification), maxElasticMagnification);
 
-    LOG_WITH_STREAM(ViewGestures, stream << "ViewGestureController::handleMagnificationGestureEvent - gesture scale " << scale << " with resistance " << scaleWithResistance << " clamped to " << m_magnification << " origin in view coords " << origin);
+    LOG_WITH_STREAM(ViewGestures, stream << "ViewGestureController::handleMagnificationGesture - gesture scale " << scale << " with resistance " << scaleWithResistance << " clamped to " << m_magnification << " origin in view coords " << origin);
 
     m_magnificationOrigin = origin;
 
     applyMagnification();
 
-    if (event.phase == NSEventPhaseEnded || event.phase == NSEventPhaseCancelled)
+    if (phase == WebEventPhase::Ended || phase == WebEventPhase::Cancelled)
         endMagnificationGesture();
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5740,16 +5740,18 @@ void WebViewImpl::magnifyWithEvent(NSEvent *event)
 
     Ref gestureController = ensureGestureController();
 
+    auto magnification = event.magnification;
+    auto phase = WebEventFactory::phaseForEvent(event);
 #if ENABLE(MAC_GESTURE_EVENTS)
     if (gestureController->hasActiveMagnificationGesture()) {
-        gestureController->handleMagnificationGestureEvent(event, [m_view.get() convertPoint:event.locationInWindow fromView:nil]);
+        gestureController->handleMagnificationGesture(magnification, phase, [m_view.get() convertPoint:event.locationInWindow fromView:nil]);
         return;
     }
 
     if (auto webEvent = NativeWebGestureEvent::create(event, m_view.getAutoreleased()))
         m_page->handleGestureEvent(*webEvent);
 #else
-    gestureController->handleMagnificationGestureEvent(event, [m_view.get() convertPoint:event.locationInWindow fromView:nil]);
+    gestureController->handleMagnificationGesture(magnification, phase, [m_view.get() convertPoint:event.locationInWindow fromView:nil]);
 #endif
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1001,6 +1001,7 @@
 		3399E1562B59F0F0008BFB60 /* WebExtensionAPIWebRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 3399E1552B59F0E5008BFB60 /* WebExtensionAPIWebRequest.h */; };
 		33AE61252B20F13B00E1C215 /* PDFKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 3178AF9720E2A7F80074DE94 /* PDFKitSPI.h */; };
 		33B5A80C2AFD298100A15D40 /* WebExtensionFrameParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 33B5A80B2AFD298100A15D40 /* WebExtensionFrameParameters.h */; };
+		33D78DB13023F8D400F5EFCB /* WebEventPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 33D78DB03023F8D400F5EFCB /* WebEventPhase.h */; };
 		33F6833E293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 33F6833D293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h */; };
 		370F34A31829BE1E009027C8 /* WKNavigationData.h in Headers */ = {isa = PBXBuildFile; fileRef = 370F34A11829BE1E009027C8 /* WKNavigationData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		370F34A51829BEA3009027C8 /* WKNavigationDataInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 370F34A41829BEA3009027C8 /* WKNavigationDataInternal.h */; };
@@ -5436,6 +5437,7 @@
 		33B5A80D2AFD2B2300A15D40 /* WebExtensionFrameParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionFrameParameters.serialization.in; sourceTree = "<group>"; };
 		33B5A80E2AFD5DE800A15D40 /* WebExtensionContextAPIWebNavigationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIWebNavigationCocoa.mm; sourceTree = "<group>"; };
 		33D059A42A1EEEDC009AFE71 /* WebEventModifier.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebEventModifier.cpp; sourceTree = "<group>"; };
+		33D78DB03023F8D400F5EFCB /* WebEventPhase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebEventPhase.h; sourceTree = "<group>"; };
 		33DAECEC2B99D052005C596E /* PDFDataDetectorItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDFDataDetectorItem.h; sourceTree = "<group>"; };
 		33DAECED2B99D05A005C596E /* PDFDataDetectorItem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PDFDataDetectorItem.mm; sourceTree = "<group>"; };
 		33DAECEE2B9AAE91005C596E /* PDFDataDetectorOverlayController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDFDataDetectorOverlayController.h; sourceTree = "<group>"; };
@@ -10590,6 +10592,7 @@
 				BC032DB110F4380F0058C15A /* WebEventConversion.h */,
 				33D059A42A1EEEDC009AFE71 /* WebEventModifier.cpp */,
 				86DD518F28EF28E800DF2A58 /* WebEventModifier.h */,
+				33D78DB03023F8D400F5EFCB /* WebEventPhase.h */,
 				F4CBF79D2A6ADF5400C066BF /* WebEventType.h */,
 				E5309B7D27A2872F00B10631 /* WebFindOptions.cpp */,
 				1A90C1ED1264FD50003E44D4 /* WebFindOptions.h */,
@@ -19016,6 +19019,7 @@
 				BC032DBB10F4380F0058C15A /* WebEventConversion.h in Headers */,
 				BC111B5D112F629800337BAB /* WebEventFactory.h in Headers */,
 				86DD519028EF28E800DF2A58 /* WebEventModifier.h in Headers */,
+				33D78DB13023F8D400F5EFCB /* WebEventPhase.h in Headers */,
 				F4CBF79E2A6ADF7E00C066BF /* WebEventType.h in Headers */,
 				1CF0C94E2AC380C400EC82F2 /* WebExtensionAction.h in Headers */,
 				5147233B2C9E88A300B2DBA5 /* WebExtensionActionClickBehavior.h in Headers */,

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1294,7 +1294,7 @@ void UnifiedPDFPlugin::setPageScaleFactor(double scale, std::optional<WebCore::I
     }
 
     if (origin) {
-        // Compensate for the subtraction of content insets that happens in ViewGestureController::handleMagnificationGestureEvent();
+        // Compensate for the subtraction of content insets that happens in ViewGestureController magnification gesture handling.
         // origin is not in root view coordinates.
         if (RefPtr frameView = m_frame->coreLocalFrame()->view()) {
             auto obscuredContentInsets = frameView->obscuredContentInsets();


### PR DESCRIPTION
#### 3807854541383b0fe6b7ac5115fd2859aedac5a1
<pre>
ViewGestureController magnification gesture handling should not need to be fed a NSEvent instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=321134">https://bugs.webkit.org/show_bug.cgi?id=321134</a>
<a href="https://rdar.apple.com/184167170">rdar://184167170</a>

Reviewed by Richard Robinson.

The ViewGestureController::handleMagnificationGesture[Event] entry point
for gesture handling currently takes an NSEvent argument, but really it
only does so to read off the magnification, phase, and type fields of
the event. As such, we change this method so that callers have to pass
in these individual bits.

This will aid us in a forthcoming change where we need to bring up
support for gesture handling without a backing NSEvent.

Another noteworthy refactor in this patch is to pull out WebWheelEvent&apos;s
phase enum into a standalone WebEventPhase enum, which both wheel and
gesture events can adopt.

* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventPhase.h:
* Source/WebKit/Shared/WebWheelEvent.h:
* Source/WebKit/Shared/mac/WebEventFactory.h:
* Source/WebKit/Shared/mac/WebEventFactory.mm:
(WebKit::WebEventFactory::phaseForEvent):
(WebKit::phaseForEvent): Deleted.
* Source/WebKit/Shared/mac/WebGestureEvent.h:
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::gestureEventWasNotHandledByWebCore):
(WebKit::ViewGestureController::handleMagnificationGesture):
(WebKit::ViewGestureController::handleMagnificationGestureEvent): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::magnifyWithEvent):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::setPageScaleFactor):

Drop the now misnamed ViewGestureController method reference and instead
just mention the relevant codepath.

Canonical link: <a href="https://commits.webkit.org/318693@main">https://commits.webkit.org/318693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30fccb13bb9ee4ba16e45b8b5d3d281830a77a26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188889 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d5e1e6cd-341c-4632-a532-ee93216c039a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139635 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3387f39f-eb7f-4d2c-8168-906998489106) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120081 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6eb3250-936a-47b5-bfff-4a79703b8dcf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39894 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/196 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45605 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191109 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52669 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148865 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53349 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148610 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27170 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43301 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125620 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120434 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51867 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14873 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51252 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51493 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51313 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->