### PR TITLE
[Site Isolation] Web Inspector: Network domain NetworkLoadMetrics via IPC

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-metrics-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-metrics-expected.txt
@@ -1,0 +1,18 @@
+Test that NetworkLoadMetrics reach the frontend for loads in a cross-origin iframe and in the main frame under Site Isolation.
+
+
+
+== Running test suite: SiteIsolation.Network.Metrics
+-- Running test case: SiteIsolation.Network.Metrics.CrossOriginIFrame.ConnectionInfo
+PASS: Resource should have a network protocol.
+PASS: Resource should have a remote address.
+PASS: Resource should have a known network priority.
+
+-- Running test case: SiteIsolation.Network.Metrics.CrossOriginIFrame.TransferSizes
+PASS: Request headers transfer size should be nonzero.
+PASS: Response body transfer size should be nonzero.
+
+-- Running test case: SiteIsolation.Network.Metrics.MainFrame.ConnectionInfo
+PASS: Main frame resource should have a network protocol.
+PASS: Main frame request headers transfer size should be nonzero.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-metrics.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-metrics.html
@@ -1,0 +1,81 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.Metrics");
+
+    // Drives a fetch inside the cross-origin iframe and resolves once the resource has finished
+    // loading, so Network.loadingFinished (which carries the metrics) has certainly been handled.
+    async function finishedResourceFromCrossOriginIFrame() {
+        let frameTarget = await frameTargetForURLContaining("iframe-with-fetch.html");
+        InspectorTest.assert(frameTarget instanceof WI.FrameTarget, "Cross-origin fetch iframe frame target should exist.");
+        await waitForExpressionInTarget(frameTarget, "typeof triggerFetch === 'function'");
+
+        let resourceAddedPromise = WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded);
+        await frameTarget.RuntimeAgent.evaluate.invoke({expression: "triggerFetch()", objectGroup: "test"});
+        let resource = (await resourceAddedPromise).data.resource;
+
+        if (!resource.finished)
+            await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+
+        return resource;
+    }
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.Metrics.CrossOriginIFrame.ConnectionInfo",
+        description: "Network.loadingFinished from a cross-origin iframe should carry the NetworkLoadMetrics connection info (rdar://171758328).",
+        async test() {
+            let resource = await finishedResourceFromCrossOriginIFrame();
+
+            // Only assert presence, never the values: protocol string, IP address and connection
+            // identifier all vary by machine and by run.
+            InspectorTest.expectThat(!!resource.protocol, "Resource should have a network protocol.");
+            InspectorTest.expectThat(!!resource.remoteAddress, "Resource should have a remote address.");
+            InspectorTest.expectNotEqual(resource.priority, WI.Resource.NetworkPriority.Unknown, "Resource should have a known network priority.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.Metrics.CrossOriginIFrame.TransferSizes",
+        description: "The transfer sizes prove AdditionalNetworkLoadMetricsForWebInspector survived IPC, since WI.Resource only reads them when requestHeaderBytesSent is present.",
+        async test() {
+            let resource = await finishedResourceFromCrossOriginIFrame();
+
+            // WI.Resource.updateWithMetrics only populates these when the payload carried
+            // requestHeaderBytesSent, which in turn only arrives when the NetworkProcess captured
+            // the inspector-only metrics for this iframe's process. They default to NaN, so a
+            // nonzero value here means the whole additional-metrics path worked.
+            InspectorTest.expectGreaterThan(resource.requestHeadersTransferSize, 0, "Request headers transfer size should be nonzero.");
+            InspectorTest.expectGreaterThan(resource.responseBodyTransferSize, 0, "Response body transfer size should be nonzero.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.Metrics.MainFrame.ConnectionInfo",
+        description: "The main frame goes through the same FrameNetworkAgentProxy -> ProxyingNetworkAgent path under Site Isolation, so it must report metrics too.",
+        async test() {
+            let resourceAddedPromise = WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded);
+            InspectorTest.evaluateInPage("triggerMainFrameFetch()");
+            let resource = (await resourceAddedPromise).data.resource;
+
+            if (!resource.finished)
+                await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+
+            InspectorTest.expectThat(!!resource.protocol, "Main frame resource should have a network protocol.");
+            InspectorTest.expectGreaterThan(resource.requestHeadersTransferSize, 0, "Main frame request headers transfer size should be nonzero.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+
+function triggerMainFrameFetch() {
+    fetch("resources/data.json?" + Math.random());
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that NetworkLoadMetrics reach the frontend for loads in a cross-origin iframe and in the main frame under Site Isolation.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/network/resources/iframe-with-fetch.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-timing-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-timing-expected.txt
@@ -1,0 +1,16 @@
+Test that Network.ResourceTiming is populated under Site Isolation and that timestamps from different WebContent processes share one timebase.
+
+
+
+== Running test suite: SiteIsolation.Network.Timing
+-- Running test case: SiteIsolation.Network.Timing.CrossOriginIFrame.PhasesAreOrdered
+PASS: Timing should have a start time.
+PASS: fetchStart should not precede startTime.
+PASS: responseStart should not precede fetchStart.
+PASS: responseStart should not precede requestStart.
+PASS: The finish timestamp should not precede startTime.
+PASS: The finish timestamp should not precede responseStart.
+
+-- Running test case: SiteIsolation.Network.Timing.CrossOriginIFrame.SharesTimebaseWithMainFrame
+PASS: The later main frame load should not appear to start before the earlier cross-origin iframe load.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-timing.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-timing.html
@@ -1,0 +1,78 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.Timing");
+
+    async function finishedResourceFromCrossOriginIFrame() {
+        let frameTarget = await frameTargetForURLContaining("iframe-with-fetch.html");
+        InspectorTest.assert(frameTarget instanceof WI.FrameTarget, "Cross-origin fetch iframe frame target should exist.");
+        await waitForExpressionInTarget(frameTarget, "typeof triggerFetch === 'function'");
+
+        let resourceAddedPromise = WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded);
+        await frameTarget.RuntimeAgent.evaluate.invoke({expression: "triggerFetch()", objectGroup: "test"});
+        let resource = (await resourceAddedPromise).data.resource;
+
+        if (!resource.finished)
+            await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+
+        return resource;
+    }
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.Timing.CrossOriginIFrame.PhasesAreOrdered",
+        description: "Network.Response.timing should be populated for a cross-origin iframe load, with phases in a sane order (rdar://171758328).",
+        async test() {
+            let resource = await finishedResourceFromCrossOriginIFrame();
+            let timing = resource.timingData;
+
+            // Never print absolute times: startTime is raw monotonic seconds under Site Isolation,
+            // so its magnitude depends on machine uptime. Assert relationships only.
+            //
+            // startTime, fetchStart, requestStart and responseStart all come from the timing payload
+            // this patch added. responseEnd does not: WI.Resource.markAsFinished overwrites it with
+            // the Network.loadingFinished timestamp, so the check below is really a cross-check that
+            // the finish timestamp (now derived from NetworkLoadMetrics::responseEnd in the
+            // NetworkProcess) lands on the same timebase as the load start in the WebContent process.
+            InspectorTest.expectGreaterThan(timing.startTime, 0, "Timing should have a start time.");
+            InspectorTest.expectGreaterThanOrEqual(timing.fetchStart, timing.startTime, "fetchStart should not precede startTime.");
+            InspectorTest.expectGreaterThanOrEqual(timing.responseStart, timing.fetchStart, "responseStart should not precede fetchStart.");
+            InspectorTest.expectGreaterThanOrEqual(timing.responseStart, timing.requestStart, "responseStart should not precede requestStart.");
+            InspectorTest.expectGreaterThanOrEqual(timing.responseEnd, timing.startTime, "The finish timestamp should not precede startTime.");
+            InspectorTest.expectGreaterThanOrEqual(timing.responseEnd, timing.responseStart, "The finish timestamp should not precede responseStart.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.Timing.CrossOriginIFrame.SharesTimebaseWithMainFrame",
+        description: "Timestamps from two different WebContent processes must be comparable, which is why this path reports raw monotonic time instead of a per-frame execution stopwatch.",
+        async test() {
+            let iframeResource = await finishedResourceFromCrossOriginIFrame();
+
+            let resourceAddedPromise = WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded);
+            InspectorTest.evaluateInPage("triggerMainFrameFetch()");
+            let mainFrameResource = (await resourceAddedPromise).data.resource;
+            if (!mainFrameResource.finished)
+                await mainFrameResource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+
+            // The main frame fetch was started strictly after the iframe fetch finished. If the two
+            // processes were reporting on separate stopwatch epochs this ordering would not hold,
+            // and the Network waterfall would interleave them wrongly.
+            InspectorTest.expectGreaterThanOrEqual(mainFrameResource.timingData.startTime, iframeResource.timingData.startTime,
+                "The later main frame load should not appear to start before the earlier cross-origin iframe load.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+
+function triggerMainFrameFetch() {
+    fetch("resources/data.json?" + Math.random());
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that Network.ResourceTiming is populated under Site Isolation and that timestamps from different WebContent processes share one timebase.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/network/resources/iframe-with-fetch.html"></iframe>
+</body>

--- a/Source/WebCore/inspector/InspectorResourceUtilities.cpp
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.cpp
@@ -35,12 +35,14 @@
 #include "DocumentResourceLoader.h"
 #include "FetchOptions.h"
 #include "FrameLoader.h"
+#include "HTTPHeaderMap.h"
 #include "InspectorResourceType.h"
 #include "InspectorThreadableLoaderClient.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
 #include "MIMETypeRegistry.h"
 #include "MemoryCache.h"
+#include "NetworkLoadMetrics.h"
 #include "Page.h"
 #include "ResourceLoaderOptions.h"
 #include "ResourceRequest.h"
@@ -49,6 +51,7 @@
 #include "ThreadableLoader.h"
 #include <JavaScriptCore/ContentSearchUtilities.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <limits>
 #include <wtf/URL.h>
 
 namespace Inspector {
@@ -456,6 +459,102 @@ void loadResource(ScriptExecutionContext& context, const String& urlString, Load
     // loader while the load is still in flight.
     if (client->isActive())
         client->setLoader(WTF::move(loader));
+}
+
+Ref<Inspector::Protocol::Network::Headers> buildObjectForHeaders(const HTTPHeaderMap& headers)
+{
+    auto headersValue = Inspector::Protocol::Network::Headers::create().release();
+    auto headersObject = headersValue->asObject();
+    for (const auto& header : headers)
+        headersObject->setString(header.key, header.value);
+    return headersValue;
+}
+
+static Inspector::Protocol::Network::Metrics::Priority NODELETE toProtocol(NetworkLoadPriority priority)
+{
+    switch (priority) {
+    case NetworkLoadPriority::Low:
+        return Inspector::Protocol::Network::Metrics::Priority::Low;
+    case NetworkLoadPriority::Medium:
+        return Inspector::Protocol::Network::Metrics::Priority::Medium;
+    case NetworkLoadPriority::High:
+        return Inspector::Protocol::Network::Metrics::Priority::High;
+    case NetworkLoadPriority::Unknown:
+        break;
+    }
+
+    ASSERT_NOT_REACHED();
+    return Inspector::Protocol::Network::Metrics::Priority::Medium;
+}
+
+Ref<Inspector::Protocol::Network::Metrics> buildObjectForMetrics(const NetworkLoadMetrics& networkLoadMetrics)
+{
+    auto metrics = Inspector::Protocol::Network::Metrics::create().release();
+
+    if (!networkLoadMetrics.protocol.isNull())
+        metrics->setProtocol(networkLoadMetrics.protocol);
+
+    // The additional metrics are only captured while an inspector is attached
+    // (InspectorInstrumentation::firstFrontendCreated enables it in the NetworkProcess).
+    if (auto* additionalMetrics = networkLoadMetrics.additionalNetworkLoadMetricsForWebInspector.get()) {
+        if (additionalMetrics->priority != NetworkLoadPriority::Unknown)
+            metrics->setPriority(toProtocol(additionalMetrics->priority));
+        if (!additionalMetrics->remoteAddress.isNull())
+            metrics->setRemoteAddress(additionalMetrics->remoteAddress);
+        if (!additionalMetrics->connectionIdentifier.isNull())
+            metrics->setConnectionIdentifier(additionalMetrics->connectionIdentifier);
+        if (!additionalMetrics->requestHeaders.isEmpty())
+            metrics->setRequestHeaders(buildObjectForHeaders(additionalMetrics->requestHeaders));
+        if (additionalMetrics->requestHeaderBytesSent != std::numeric_limits<uint64_t>::max())
+            metrics->setRequestHeaderBytesSent(additionalMetrics->requestHeaderBytesSent);
+        if (additionalMetrics->requestBodyBytesSent != std::numeric_limits<uint64_t>::max())
+            metrics->setRequestBodyBytesSent(additionalMetrics->requestBodyBytesSent);
+        if (additionalMetrics->responseHeaderBytesReceived != std::numeric_limits<uint64_t>::max())
+            metrics->setResponseHeaderBytesReceived(additionalMetrics->responseHeaderBytesReceived);
+        metrics->setIsProxyConnection(additionalMetrics->isProxyConnection);
+    }
+
+    if (networkLoadMetrics.responseBodyBytesReceived != std::numeric_limits<uint64_t>::max())
+        metrics->setResponseBodyBytesReceived(networkLoadMetrics.responseBodyBytesReceived);
+    if (networkLoadMetrics.responseBodyDecodedSize != std::numeric_limits<uint64_t>::max())
+        metrics->setResponseBodyDecodedSize(networkLoadMetrics.responseBodyDecodedSize);
+
+    auto connectionPayload = Inspector::Protocol::Security::Connection::create().release();
+
+    if (auto* additionalMetrics = networkLoadMetrics.additionalNetworkLoadMetricsForWebInspector.get()) {
+        if (!additionalMetrics->tlsProtocol.isEmpty())
+            connectionPayload->setProtocol(additionalMetrics->tlsProtocol);
+        if (!additionalMetrics->tlsCipher.isEmpty())
+            connectionPayload->setCipher(additionalMetrics->tlsCipher);
+    }
+
+    metrics->setSecurityConnection(WTF::move(connectionPayload));
+
+    return metrics;
+}
+
+Ref<Inspector::Protocol::Network::ResourceTiming> buildObjectForTiming(const NetworkLoadMetrics& timing, MonotonicTime loadStartTime, NOESCAPE const Function<double(MonotonicTime)>& monotonicToProtocolSeconds)
+{
+    auto millisecondsSinceFetchStart = [&](const MonotonicTime& time) {
+        if (!time)
+            return 0.0;
+        return (time - timing.fetchStart).milliseconds();
+    };
+
+    return Inspector::Protocol::Network::ResourceTiming::create()
+        .setStartTime(monotonicToProtocolSeconds(loadStartTime))
+        .setRedirectStart(monotonicToProtocolSeconds(timing.redirectStart))
+        .setRedirectEnd(monotonicToProtocolSeconds(timing.fetchStart))
+        .setFetchStart(monotonicToProtocolSeconds(timing.fetchStart))
+        .setDomainLookupStart(millisecondsSinceFetchStart(timing.domainLookupStart))
+        .setDomainLookupEnd(millisecondsSinceFetchStart(timing.domainLookupEnd))
+        .setConnectStart(millisecondsSinceFetchStart(timing.connectStart))
+        .setConnectEnd(millisecondsSinceFetchStart(timing.connectEnd))
+        .setSecureConnectionStart(millisecondsSinceFetchStart(timing.secureConnectionStart))
+        .setRequestStart(millisecondsSinceFetchStart(timing.requestStart))
+        .setResponseStart(millisecondsSinceFetchStart(timing.responseStart))
+        .setResponseEnd(millisecondsSinceFetchStart(timing.responseEnd))
+        .release();
 }
 
 } // namespace ResourceUtilities

--- a/Source/WebCore/inspector/InspectorResourceUtilities.h
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.h
@@ -32,16 +32,21 @@
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <tuple>
+#include <wtf/Compiler.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
+#include <wtf/Function.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 class DocumentLoader;
 class FragmentedSharedBuffer;
+class HTTPHeaderMap;
 class LocalFrame;
+class NetworkLoadMetrics;
 class Page;
 class ScriptExecutionContext;
 class TextResourceDecoder;
@@ -126,6 +131,16 @@ WEBCORE_EXPORT bool shouldTreatAsText(const String& mimeType);
 WEBCORE_EXPORT Ref<WebCore::TextResourceDecoder> createTextDecoder(const String& mimeType, const String& textEncodingName);
 WEBCORE_EXPORT std::optional<String> textContentForCachedResource(WebCore::CachedResource&);
 WEBCORE_EXPORT bool cachedResourceContent(WebCore::CachedResource&, String* result, bool* base64Encoded);
+
+WEBCORE_EXPORT Ref<Inspector::Protocol::Network::Headers> buildObjectForHeaders(const WebCore::HTTPHeaderMap&);
+
+// Timebase-independent: every field is either a plain scalar or relative to the load itself.
+WEBCORE_EXPORT Ref<Inspector::Protocol::Network::Metrics> buildObjectForMetrics(const WebCore::NetworkLoadMetrics&);
+
+// ResourceTiming's first four fields are absolute protocol timestamps, so the caller supplies
+// monotonicToProtocolSeconds to express them in whichever timebase its target reports on. The
+// remaining fields are milliseconds relative to fetchStart and need no conversion.
+WEBCORE_EXPORT Ref<Inspector::Protocol::Network::ResourceTiming> buildObjectForTiming(const WebCore::NetworkLoadMetrics&, MonotonicTime loadStartTime, NOESCAPE const Function<double(MonotonicTime)>& monotonicToProtocolSeconds);
 
 // Loads url in the given context on behalf of the inspector, bypassing cross-origin checks (Network.loadResource).
 WEBCORE_EXPORT void loadResource(WebCore::ScriptExecutionContext&, const String& url, LoadResourceCompletionHandler&&);

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -142,103 +142,11 @@ void InspectorNetworkAgent::willDestroyFrontendAndBackend(Inspector::DisconnectR
     std::ignore = disable();
 }
 
-static Ref<Inspector::Protocol::Network::Headers> buildObjectForHeaders(const HTTPHeaderMap& headers)
-{
-    auto headersValue = Inspector::Protocol::Network::Headers::create().release();
-
-    auto headersObject = headersValue->asObject();
-    for (const auto& header : headers)
-        headersObject->setString(header.key, header.value);
-
-    return headersValue;
-}
-
 Ref<Inspector::Protocol::Network::ResourceTiming> InspectorNetworkAgent::buildObjectForTiming(const NetworkLoadMetrics& timing, ResourceLoader& resourceLoader)
 {
-    auto elapsedTimeSince = [&] (const MonotonicTime& time) {
+    return ResourceUtilities::buildObjectForTiming(timing, resourceLoader.loadTiming().startTime(), [&](MonotonicTime time) {
         return protect(environment())->executionStopwatch().elapsedTimeSince(time).seconds();
-    };
-    auto millisecondsSinceFetchStart = [&] (const MonotonicTime& time) {
-        if (!time)
-            return 0.0;
-        return (time - timing.fetchStart).milliseconds();
-    };
-
-    return Inspector::Protocol::Network::ResourceTiming::create()
-        .setStartTime(elapsedTimeSince(resourceLoader.loadTiming().startTime()))
-        .setRedirectStart(elapsedTimeSince(timing.redirectStart))
-        .setRedirectEnd(elapsedTimeSince(timing.fetchStart))
-        .setFetchStart(elapsedTimeSince(timing.fetchStart))
-        .setDomainLookupStart(millisecondsSinceFetchStart(timing.domainLookupStart))
-        .setDomainLookupEnd(millisecondsSinceFetchStart(timing.domainLookupEnd))
-        .setConnectStart(millisecondsSinceFetchStart(timing.connectStart))
-        .setConnectEnd(millisecondsSinceFetchStart(timing.connectEnd))
-        .setSecureConnectionStart(millisecondsSinceFetchStart(timing.secureConnectionStart))
-        .setRequestStart(millisecondsSinceFetchStart(timing.requestStart))
-        .setResponseStart(millisecondsSinceFetchStart(timing.responseStart))
-        .setResponseEnd(millisecondsSinceFetchStart(timing.responseEnd))
-        .release();
-}
-
-static Inspector::Protocol::Network::Metrics::Priority NODELETE toProtocol(NetworkLoadPriority priority)
-{
-    switch (priority) {
-    case NetworkLoadPriority::Low:
-        return Inspector::Protocol::Network::Metrics::Priority::Low;
-    case NetworkLoadPriority::Medium:
-        return Inspector::Protocol::Network::Metrics::Priority::Medium;
-    case NetworkLoadPriority::High:
-        return Inspector::Protocol::Network::Metrics::Priority::High;
-    case NetworkLoadPriority::Unknown:
-        break;
-    }
-
-    ASSERT_NOT_REACHED();
-    return Inspector::Protocol::Network::Metrics::Priority::Medium;
-}
-
-Ref<Inspector::Protocol::Network::Metrics> InspectorNetworkAgent::buildObjectForMetrics(const NetworkLoadMetrics& networkLoadMetrics)
-{
-    auto metrics = Inspector::Protocol::Network::Metrics::create().release();
-
-    if (!networkLoadMetrics.protocol.isNull())
-        metrics->setProtocol(networkLoadMetrics.protocol);
-    if (auto* additionalMetrics = networkLoadMetrics.additionalNetworkLoadMetricsForWebInspector.get()) {
-        if (additionalMetrics->priority != NetworkLoadPriority::Unknown)
-            metrics->setPriority(toProtocol(additionalMetrics->priority));
-        if (!additionalMetrics->remoteAddress.isNull())
-            metrics->setRemoteAddress(additionalMetrics->remoteAddress);
-        if (!additionalMetrics->connectionIdentifier.isNull())
-            metrics->setConnectionIdentifier(additionalMetrics->connectionIdentifier);
-        if (!additionalMetrics->requestHeaders.isEmpty())
-            metrics->setRequestHeaders(buildObjectForHeaders(additionalMetrics->requestHeaders));
-        if (additionalMetrics->requestHeaderBytesSent != std::numeric_limits<uint64_t>::max())
-            metrics->setRequestHeaderBytesSent(additionalMetrics->requestHeaderBytesSent);
-        if (additionalMetrics->requestBodyBytesSent != std::numeric_limits<uint64_t>::max())
-            metrics->setRequestBodyBytesSent(additionalMetrics->requestBodyBytesSent);
-        if (additionalMetrics->responseHeaderBytesReceived != std::numeric_limits<uint64_t>::max())
-            metrics->setResponseHeaderBytesReceived(additionalMetrics->responseHeaderBytesReceived);
-        metrics->setIsProxyConnection(additionalMetrics->isProxyConnection);
-    }
-
-    if (networkLoadMetrics.responseBodyBytesReceived != std::numeric_limits<uint64_t>::max())
-        metrics->setResponseBodyBytesReceived(networkLoadMetrics.responseBodyBytesReceived);
-    if (networkLoadMetrics.responseBodyDecodedSize != std::numeric_limits<uint64_t>::max())
-        metrics->setResponseBodyDecodedSize(networkLoadMetrics.responseBodyDecodedSize);
-
-    auto connectionPayload = Inspector::Protocol::Security::Connection::create()
-        .release();
-
-    if (auto* additionalMetrics = networkLoadMetrics.additionalNetworkLoadMetricsForWebInspector.get()) {
-        if (!additionalMetrics->tlsProtocol.isEmpty())
-            connectionPayload->setProtocol(additionalMetrics->tlsProtocol);
-        if (!additionalMetrics->tlsCipher.isEmpty())
-            connectionPayload->setCipher(additionalMetrics->tlsCipher);
-    }
-
-    metrics->setSecurityConnection(WTF::move(connectionPayload));
-
-    return metrics;
+    });
 }
 
 static Inspector::Protocol::Network::ReferrerPolicy NODELETE toProtocol(ReferrerPolicy referrerPolicy)
@@ -273,7 +181,7 @@ static Ref<Inspector::Protocol::Network::Request> buildObjectForResourceRequest(
     auto requestObject = Inspector::Protocol::Network::Request::create()
         .setUrl(request.url().string())
         .setMethod(request.httpMethod())
-        .setHeaders(buildObjectForHeaders(request.httpHeaderFields()))
+        .setHeaders(ResourceUtilities::buildObjectForHeaders(request.httpHeaderFields()))
         .release();
 
     if (request.httpBody() && !request.httpBody()->isEmpty()) {
@@ -325,7 +233,7 @@ RefPtr<Inspector::Protocol::Network::Response> InspectorNetworkAgent::buildObjec
         .setUrl(response.url().string())
         .setStatus(response.httpStatusCode())
         .setStatusText(response.httpStatusText())
-        .setHeaders(buildObjectForHeaders(response.httpHeaderFields()))
+        .setHeaders(ResourceUtilities::buildObjectForHeaders(response.httpHeaderFields()))
         .setMimeType(response.mimeType())
         .setSource(responseSource(response.source()))
         .release();
@@ -606,7 +514,7 @@ void InspectorNetworkAgent::didFinishLoading(ResourceLoaderIdentifier identifier
             realMetrics = platformStrategies()->loaderStrategy()->networkMetricsFromResourceLoadIdentifier(identifier).isolatedCopy();
         });
     }
-    auto metrics = buildObjectForMetrics(realMetrics ? *realMetrics : networkLoadMetrics);
+    auto metrics = ResourceUtilities::buildObjectForMetrics(realMetrics ? *realMetrics : networkLoadMetrics);
 
     m_frontendDispatcher->loadingFinished(requestId, elapsedFinishTime, sourceMappingURL, WTF::move(metrics));
 }
@@ -776,7 +684,7 @@ void InspectorNetworkAgent::willSendWebSocketHandshakeRequest(WebSocketChannelId
 void InspectorNetworkAgent::didSendWebSocketHandshakeRequest(WebSocketChannelIdentifier identifier, const ResourceRequest& request)
 {
     auto requestObject = Inspector::Protocol::Network::WebSocketRequest::create()
-        .setHeaders(buildObjectForHeaders(request.httpHeaderFields()))
+        .setHeaders(ResourceUtilities::buildObjectForHeaders(request.httpHeaderFields()))
         .release();
     m_frontendDispatcher->webSocketWillSendHandshakeRequest(IdentifiersFactory::requestId(identifier.toUInt64()), timestamp(), WallTime::now().secondsSinceEpoch().seconds(), WTF::move(requestObject));
 }
@@ -786,7 +694,7 @@ void InspectorNetworkAgent::didReceiveWebSocketHandshakeResponse(WebSocketChanne
     auto responseObject = Inspector::Protocol::Network::WebSocketResponse::create()
         .setStatus(response.httpStatusCode())
         .setStatusText(response.httpStatusText())
-        .setHeaders(buildObjectForHeaders(response.httpHeaderFields()))
+        .setHeaders(ResourceUtilities::buildObjectForHeaders(response.httpHeaderFields()))
         .release();
     m_frontendDispatcher->webSocketHandshakeResponseReceived(IdentifiersFactory::requestId(identifier.toUInt64()), timestamp(), WTF::move(responseObject));
 }

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -167,7 +167,6 @@ private:
 
     Ref<Inspector::Protocol::Network::Initiator> buildInitiatorObject(Document*, const ResourceRequest* = nullptr);
     Ref<Inspector::Protocol::Network::ResourceTiming> buildObjectForTiming(const NetworkLoadMetrics&, ResourceLoader&);
-    Ref<Inspector::Protocol::Network::Metrics> buildObjectForMetrics(const NetworkLoadMetrics&);
     RefPtr<Inspector::Protocol::Network::Response> buildObjectForResourceResponse(const ResourceResponse&, ResourceLoader*);
     Ref<Inspector::Protocol::Network::CachedResource> buildObjectForCachedResource(CachedResource*);
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -41,10 +41,14 @@
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <WebCore/HTTPHeaderMap.h>
 #include <WebCore/InspectorIdentifierRegistry.h>
+#include <WebCore/InspectorResourceUtilities.h>
+#include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/ProcessQualified.h>
+#include <optional>
 #include <tuple>
 #include <utility>
 #include <wtf/Expected.h>
+#include <wtf/MonotonicTime.h>
 
 namespace Inspector {
 
@@ -88,21 +92,12 @@ static Protocol::Page::ResourceType toProtocolResourceType(ResourceType type)
     return Protocol::Page::ResourceType::Other;
 }
 
-static Ref<Protocol::Network::Headers> buildObjectForHeaders(const HTTPHeaderMap& headers)
-{
-    auto headersValue = Protocol::Network::Headers::create().release();
-    auto headersObject = headersValue->asObject();
-    for (const auto& header : headers)
-        headersObject->setString(header.key, header.value);
-    return headersValue;
-}
-
 static Ref<Protocol::Network::Request> buildObjectForResourceRequest(const ResourceRequest& request)
 {
     auto requestObject = Protocol::Network::Request::create()
         .setUrl(request.url().string())
         .setMethod(request.httpMethod())
-        .setHeaders(buildObjectForHeaders(request.httpHeaderFields()))
+        .setHeaders(ResourceUtilities::buildObjectForHeaders(request.httpHeaderFields()))
         .release();
 
     if (RefPtr body = request.httpBody()) {
@@ -139,19 +134,36 @@ static Protocol::Network::Response::Source toProtocolResponseSource(ResourceResp
     return Protocol::Network::Response::Source::Unknown;
 }
 
-static RefPtr<Protocol::Network::Response> buildObjectForResourceResponse(const ResourceResponse& response)
+// Raw monotonic seconds, not seconds elapsed on an InspectorEnvironment stopwatch: timestamps here
+// come from several WebContent processes and have to share an epoch to land on one waterfall. See
+// ResourceUtilities::buildObjectForTiming.
+static double monotonicTimeToProtocolSeconds(MonotonicTime time)
+{
+    return time.secondsSinceEpoch().value();
+}
+
+static RefPtr<Protocol::Network::Response> buildObjectForResourceResponse(const ResourceResponse& response, std::optional<MonotonicTime> resourceLoadStartTime)
 {
     if (response.isNull())
         return nullptr;
 
-    return Protocol::Network::Response::create()
+    auto responseObject = Protocol::Network::Response::create()
         .setUrl(response.url().string())
         .setStatus(response.httpStatusCode())
         .setStatusText(response.httpStatusText())
-        .setHeaders(buildObjectForHeaders(response.httpHeaderFields()))
+        .setHeaders(ResourceUtilities::buildObjectForHeaders(response.httpHeaderFields()))
         .setMimeType(response.mimeType())
         .setSource(toProtocolResponseSource(response.source()))
         .release();
+
+    // No start time means there was no ResourceLoader, so there is no phase breakdown to report --
+    // the case for redirects and memory-cache hits. Matches the in-process agent.
+    if (resourceLoadStartTime) {
+        auto* metrics = response.deprecatedNetworkLoadMetricsOrNull();
+        responseObject->setTiming(ResourceUtilities::buildObjectForTiming(metrics ? *metrics : NetworkLoadMetrics::emptyMetrics(), *resourceLoadStartTime, monotonicTimeToProtocolSeconds));
+    }
+
+    return responseObject;
 }
 
 ProxyingNetworkAgent::ProxyingNetworkAgent(WebKit::WebPageAgentContext& context)
@@ -560,19 +572,19 @@ void ProxyingNetworkAgent::requestWillBeSent(ResourceID resourceID, FrameID fram
 
     RefPtr<Protocol::Network::Response> redirectResponseObject;
     if (redirectResponse)
-        redirectResponseObject = buildObjectForResourceResponse(*redirectResponse);
+        redirectResponseObject = buildObjectForResourceResponse(*redirectResponse, std::nullopt);
 
     m_frontendDispatcher->requestWillBeSent(requestId, frameIdString, loaderId, documentURL, WTF::move(requestObject), timestamp, walltime, WTF::move(initiatorObject), WTF::move(redirectResponseObject), toProtocolResourceType(resourceType), targetID);
 }
 
-void ProxyingNetworkAgent::responseReceived(ResourceID resourceID, FrameID frameID, const String& loaderId, const ResourceResponse& response, ResourceType resourceType, double timestamp)
+void ProxyingNetworkAgent::responseReceived(ResourceID resourceID, FrameID frameID, const String& loaderId, const ResourceResponse& response, ResourceType resourceType, double timestamp, std::optional<MonotonicTime> resourceLoadStartTime)
 {
     if (!m_enabled)
         return;
 
     auto requestId = IdentifierRegistry::protocolRequestId(resourceID.processIdentifier(), resourceID.object());
     auto frameIdString = IdentifierRegistry::protocolFrameId(frameID, resourceID.processIdentifier());
-    auto responseObject = buildObjectForResourceResponse(response);
+    auto responseObject = buildObjectForResourceResponse(response, resourceLoadStartTime);
 
     if (responseObject)
         m_frontendDispatcher->responseReceived(requestId, frameIdString, loaderId, timestamp, toProtocolResourceType(resourceType), responseObject.releaseNonNull());
@@ -587,14 +599,13 @@ void ProxyingNetworkAgent::dataReceived(ResourceID resourceID, int dataLength, i
     m_frontendDispatcher->dataReceived(requestId, timestamp, dataLength, encodedDataLength);
 }
 
-void ProxyingNetworkAgent::loadingFinished(ResourceID resourceID, double timestamp, const String& sourceMapURL)
+void ProxyingNetworkAgent::loadingFinished(ResourceID resourceID, double timestamp, const String& sourceMapURL, NetworkLoadMetrics&& metrics)
 {
     if (!m_enabled)
         return;
 
     auto requestId = IdentifierRegistry::protocolRequestId(resourceID.processIdentifier(), resourceID.object());
-    // FIXME: Add metrics parameter once we have NetworkLoadMetrics IPC.
-    m_frontendDispatcher->loadingFinished(requestId, timestamp, sourceMapURL, nullptr);
+    m_frontendDispatcher->loadingFinished(requestId, timestamp, sourceMapURL, ResourceUtilities::buildObjectForMetrics(metrics));
 }
 
 void ProxyingNetworkAgent::loadingFailed(ResourceID resourceID, double timestamp, const String& errorText, bool canceled)
@@ -619,7 +630,8 @@ void ProxyingNetworkAgent::requestServedFromMemoryCache(ResourceID resourceID, F
         .setBodySize(bodySize)
         .release();
 
-    if (auto responseObject = buildObjectForResourceResponse(response))
+    // A memory-cached resource never went to the network, so there is no load timing to report.
+    if (auto responseObject = buildObjectForResourceResponse(response, std::nullopt))
         cachedResourceObject->setResponse(responseObject.releaseNonNull());
 
     if (!sourceMapURL.isEmpty())

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
@@ -37,12 +37,18 @@
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ResourceResponse.h>
+#include <optional>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/JSONValues.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+class NetworkLoadMetrics;
+}
 
 namespace WebKit {
 class WebProcessProxy;
@@ -101,9 +107,9 @@ private:
 
     // IPC message handlers from WebProcess FrameNetworkAgentProxy
     void requestWillBeSent(ResourceID, FrameID, const String& loaderId, const String& targetID, const String& documentURL, const WebCore::ResourceRequest&, std::optional<WebCore::ResourceResponse>&&, ResourceType, double timestamp, double walltime);
-    void responseReceived(ResourceID, FrameID, const String& loaderId, const WebCore::ResourceResponse&, ResourceType, double timestamp);
+    void responseReceived(ResourceID, FrameID, const String& loaderId, const WebCore::ResourceResponse&, ResourceType, double timestamp, std::optional<MonotonicTime> resourceLoadStartTime);
     void dataReceived(ResourceID, int dataLength, int encodedDataLength, double timestamp);
-    void loadingFinished(ResourceID, double timestamp, const String& sourceMapURL);
+    void loadingFinished(ResourceID, double timestamp, const String& sourceMapURL, WebCore::NetworkLoadMetrics&&);
     void loadingFailed(ResourceID, double timestamp, const String& errorText, bool canceled);
     void requestServedFromMemoryCache(ResourceID, FrameID, const String& loaderId, const String& documentURL, const WebCore::ResourceResponse&, ResourceType, const String& sourceMapURL, uint64_t bodySize, double timestamp);
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.messages.in
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.messages.in
@@ -28,11 +28,11 @@
 messages -> Inspector::ProxyingNetworkAgent {
     RequestWillBeSent(WebCore::ScopedResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, String loaderId, String targetID, String documentURL, WebCore::ResourceRequest request, std::optional<WebCore::ResourceResponse> redirectResponse, Inspector::ResourceType resourceType, double timestamp, double walltime)
 
-    ResponseReceived(WebCore::ScopedResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, String loaderId, WebCore::ResourceResponse response, Inspector::ResourceType resourceType, double timestamp)
+    ResponseReceived(WebCore::ScopedResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, String loaderId, WebCore::ResourceResponse response, Inspector::ResourceType resourceType, double timestamp, std::optional<MonotonicTime> resourceLoadStartTime)
 
     DataReceived(WebCore::ScopedResourceLoaderIdentifier resourceID, int dataLength, int encodedDataLength, double timestamp)
 
-    LoadingFinished(WebCore::ScopedResourceLoaderIdentifier resourceID, double timestamp, String sourceMapURL)
+    LoadingFinished(WebCore::ScopedResourceLoaderIdentifier resourceID, double timestamp, String sourceMapURL, WebCore::NetworkLoadMetrics metrics)
 
     LoadingFailed(WebCore::ScopedResourceLoaderIdentifier resourceID, double timestamp, String errorText, bool canceled)
 

--- a/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
@@ -47,11 +47,19 @@
 #include <WebCore/InspectorResourceType.h>
 #include <WebCore/InspectorResourceUtilities.h>
 #include <WebCore/InstrumentingAgents.h>
+#include <WebCore/LoaderStrategy.h>
 #include <WebCore/LocalFrameInlines.h>
+#include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/Page.h>
 #include <WebCore/PageInspectorController.h>
+#include <WebCore/PlatformStrategies.h>
 #include <WebCore/ProcessQualified.h>
+#include <WebCore/ResourceLoadTiming.h>
+#include <WebCore/ResourceLoader.h>
 #include <WebCore/ResourceRequest.h>
+#include <optional>
+#include <wtf/MainThread.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WallTime.h>
 
@@ -237,7 +245,7 @@ void FrameNetworkAgentProxy::willSendRequestOfType(ResourceLoaderIdentifier reso
         page->identifier());
 }
 
-void FrameNetworkAgentProxy::didReceiveResponse(ResourceLoaderIdentifier resourceID, DocumentLoader* loader, const ResourceResponse& response, ResourceLoader*)
+void FrameNetworkAgentProxy::didReceiveResponse(ResourceLoaderIdentifier resourceID, DocumentLoader* loader, const ResourceResponse& response, ResourceLoader* resourceLoader)
 {
     if (!loader || !loader->frame() || !loader->frame()->document())
         return;
@@ -259,9 +267,15 @@ void FrameNetworkAgentProxy::didReceiveResponse(ResourceLoaderIdentifier resourc
     auto resourceType = resourceData ? resourceData->type() : ResourceType::Other;
     m_resourcesData->responseReceived(resourceID, response, resourceType);
 
+    // The rest of the phase breakdown travels inside the response's own NetworkLoadMetrics; only the
+    // start time has to be sent explicitly, since it lives on the ResourceLoader.
+    std::optional<MonotonicTime> resourceLoadStartTime;
+    if (resourceLoader)
+        resourceLoadStartTime = resourceLoader->loadTiming().startTime();
+
     protect(WebProcess::singleton().parentProcessConnection())->send(
         Messages::ProxyingNetworkAgent::ResponseReceived(
-            qualifyResourceID(resourceID), *frameID, loaderId, response, resourceType, timestamp),
+            qualifyResourceID(resourceID), *frameID, loaderId, response, resourceType, timestamp, resourceLoadStartTime),
         page->identifier());
 }
 
@@ -281,7 +295,7 @@ void FrameNetworkAgentProxy::didReceiveData(ResourceLoaderIdentifier resourceID,
         page->identifier());
 }
 
-void FrameNetworkAgentProxy::didFinishLoading(ResourceLoaderIdentifier resourceID, DocumentLoader* loader, const NetworkLoadMetrics&, ResourceLoader*)
+void FrameNetworkAgentProxy::didFinishLoading(ResourceLoaderIdentifier resourceID, DocumentLoader* loader, const NetworkLoadMetrics& networkLoadMetrics, ResourceLoader*)
 {
     if (!loader || !loader->frame() || !loader->frame()->document())
         return;
@@ -314,10 +328,28 @@ void FrameNetworkAgentProxy::didFinishLoading(ResourceLoaderIdentifier resourceI
             sourceMapURL = ContentSearchUtilities::findStylesheetSourceMapURL(resourceData->content());
     }
 
-    auto timestamp = MonotonicTime::now().secondsSinceEpoch().value();
+    // The metrics handed to this hook are usually incomplete in WebKit2: the load's real timing and
+    // byte counts are only known in the NetworkProcess. The inspector-only fields (priority, remote
+    // address, TLS, byte counts) are populated because enabling network instrumentation in this
+    // process turned on setCaptureExtraNetworkLoadMetricsEnabled.
+    //
+    // The sync IPC needs no thread hop, unlike in InspectorNetworkAgent, because frame network
+    // instrumentation is always on the main run loop while that agent also serves workers.
+    //
+    // The fetch is destructive -- takeNetworkLoadInformationMetrics removes the entry -- so it holds
+    // only while this is the process's sole consumer of a resource's metrics. Anything else in this
+    // process wanting them, such as a frame-target Network domain, has to share the fetch.
+    ASSERT(isMainRunLoop());
+    auto metrics = networkLoadMetrics.isComplete() ? networkLoadMetrics : platformStrategies()->loaderStrategy()->networkMetricsFromResourceLoadIdentifier(resourceID);
+
+    // responseEnd is when the load actually completed; now() would charge the bookkeeping above to
+    // the resource's load time. Fall back to the hook's copy, which the fetch above leaves behind
+    // when the NetworkProcess has no record for this identifier.
+    auto responseEnd = metrics.responseEnd ? metrics.responseEnd : networkLoadMetrics.responseEnd;
+    auto timestamp = (responseEnd ? responseEnd : MonotonicTime::now()).secondsSinceEpoch().value();
 
     protect(WebProcess::singleton().parentProcessConnection())->send(
-        Messages::ProxyingNetworkAgent::LoadingFinished(qualifyResourceID(resourceID), timestamp, sourceMapURL),
+        Messages::ProxyingNetworkAgent::LoadingFinished(qualifyResourceID(resourceID), timestamp, sourceMapURL, WTF::move(metrics)),
         page->identifier());
 }
 


### PR DESCRIPTION
#### 268def49991db0f620a985da19f7c4ce80a02fda
<pre>
[Site Isolation] Web Inspector: Network domain NetworkLoadMetrics via IPC
<a href="https://rdar.apple.com/171758328">rdar://171758328</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308893">https://bugs.webkit.org/show_bug.cgi?id=308893</a>

Reviewed by NOBODY (OOPS!).

Network.loadingFinished passed nullptr for its metrics and
Network.Response carried no timing object: both are built in the
UIProcess, while the data behind them exists only in the WebContent
process. The frontend had no transfer sizes, no priority or connection
info, and no phase breakdown for any resource loaded under Site
Isolation.

No new serialization code was required. NetworkLoadMetrics and
AdditionalNetworkLoadMetricsForWebInspector are already coded, and a
response&apos;s own metrics already travel inside ResourceResponseData, so
Response.timing&apos;s inputs were reaching the UIProcess all along and were
being dropped. LoadingFinished gains a NetworkLoadMetrics, and
ResponseReceived gains the load&apos;s start time, the one input not already
on the wire because it lives on the ResourceLoader.

The builders that turn metrics into protocol objects moved from
InspectorNetworkAgent into ResourceUtilities so the in-process agent
and the UIProcess proxy cannot drift as the protocol evolves.
buildObjectForMetrics is timebase-independent and is shared verbatim;
buildObjectForTiming is not, so it now takes a converter and each
caller supplies its own timebase.

The in-process agent reports seconds elapsed on its
InspectorEnvironment&apos;s execution stopwatch. That cannot work here:
each FrameInspectorController creates its own, so times from two frames
share no epoch. This path reports raw monotonic seconds instead,
matching the convention the existing FrameNetworkAgentProxy timestamps
had already adopted implicitly.

FrameNetworkAgentProxy fetches the complete metrics from the
NetworkProcess when the instrumentation hook&apos;s copy is incomplete,
which is the common case in WebKit2, and takes the finish timestamp
from responseEnd rather than the current time, falling back to the
hook&apos;s copy when the NetworkProcess has no record for the identifier.
That synchronous fetch is issued directly, since frame network
instrumentation always runs on the main run loop.

Tests: http/tests/site-isolation/inspector/network/cross-origin-iframe-network-metrics.html
       http/tests/site-isolation/inspector/network/cross-origin-iframe-network-timing.html

* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-metrics-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-metrics.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-timing-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-timing.html: Added.
* Source/WebCore/inspector/InspectorResourceUtilities.cpp:
(Inspector::ResourceUtilities::buildObjectForHeaders):
(Inspector::ResourceUtilities::toProtocol):
(Inspector::ResourceUtilities::buildObjectForMetrics):
(Inspector::ResourceUtilities::buildObjectForTiming):
* Source/WebCore/inspector/InspectorResourceUtilities.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::buildObjectForTiming):
(WebCore::buildObjectForResourceRequest):
(WebCore::InspectorNetworkAgent::buildObjectForResourceResponse):
(WebCore::InspectorNetworkAgent::didFinishLoading):
(WebCore::InspectorNetworkAgent::didSendWebSocketHandshakeRequest):
(WebCore::InspectorNetworkAgent::didReceiveWebSocketHandshakeResponse):
(WebCore::buildObjectForHeaders): Deleted.
(WebCore::InspectorNetworkAgent::buildObjectForMetrics): Deleted.
* Source/WebCore/inspector/agents/InspectorNetworkAgent.h:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp:
(Inspector::buildObjectForResourceRequest):
(Inspector::monotonicTimeToProtocolSeconds):
(Inspector::buildObjectForResourceResponse):
(Inspector::ProxyingNetworkAgent::requestWillBeSent):
(Inspector::ProxyingNetworkAgent::responseReceived):
(Inspector::ProxyingNetworkAgent::loadingFinished):
(Inspector::ProxyingNetworkAgent::requestServedFromMemoryCache):
(Inspector::buildObjectForHeaders): Deleted.
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.messages.in:
* Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp:
(WebKit::FrameNetworkAgentProxy::didReceiveResponse):
(WebKit::FrameNetworkAgentProxy::didFinishLoading):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/268def49991db0f620a985da19f7c4ce80a02fda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/55095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197741 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/152134 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/atp/2379bed0-b238-11f1-8c07-12be93f78c3f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/189411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/61096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146441 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/101216 "2 flakes 33 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/atp/2379bed0-b238-11f1-c1e2-00e924889c3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166912 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126949 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/atp/2379bed0-b238-11f1-73a2-e3fa4ea85f98) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48889 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46737 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/159181 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46532 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8853 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/53775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199793 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60980 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/166464 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/156121 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61696 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/43037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155775 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/50084 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133820 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/131398 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/60075 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21524 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59497 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59676 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59636 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->