### PR TITLE
[css-writing-modes] Add WPT coverage for orthogonal atomic inline children of shrink-to-fit boxes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-002-expected.txt
@@ -1,0 +1,53 @@
+
+PASS 1: Shrink-to-fit inline-block with a child of orthogonal atomic inline
+PASS 2: Shrink-to-fit inline-block with a child of orthogonal atomic inline with borders
+PASS 3: Shrink-to-fit inline-block with a child of orthogonal atomic inline in inline-block
+PASS 4: Shrink-to-fit inline-block with a child of orthogonal atomic inline with borders in inline-block
+PASS 5: Shrink-to-fit float with a child of orthogonal atomic inline
+PASS 6: Shrink-to-fit float with a child of orthogonal atomic inline with borders
+PASS 7: Shrink-to-fit float with a child of orthogonal atomic inline in inline-block
+PASS 8: Shrink-to-fit float with a child of orthogonal atomic inline with borders in inline-block
+PASS 9: Shrink-to-fit table-cell with a child of orthogonal atomic inline
+PASS 10: Shrink-to-fit table-cell with a child of orthogonal atomic inline with borders
+PASS 11: Shrink-to-fit table-cell with a child of orthogonal atomic inline in inline-block
+PASS 12: Shrink-to-fit table-cell with a child of orthogonal atomic inline with borders in inline-block
+Test passes if the X-position of the left edge of the orange box and the right edge of the blue box are the same.
+
+If script is enabled, there should be one or more PASS and no FAIL.
+
+1: Shrink-to-fit inline-block with a child of orthogonal atomic inline
+
+HHZZ
+2: Shrink-to-fit inline-block with a child of orthogonal atomic inline with borders
+
+HHHZZ
+3: Shrink-to-fit inline-block with a child of orthogonal atomic inline in inline-block
+
+HHZZ
+4: Shrink-to-fit inline-block with a child of orthogonal atomic inline with borders in inline-block
+
+HHHZZ
+5: Shrink-to-fit float with a child of orthogonal atomic inline
+
+HHZZ
+6: Shrink-to-fit float with a child of orthogonal atomic inline with borders
+
+HHHZZ
+7: Shrink-to-fit float with a child of orthogonal atomic inline in inline-block
+
+HHZZ
+8: Shrink-to-fit float with a child of orthogonal atomic inline with borders in inline-block
+
+HHHZZ
+9: Shrink-to-fit table-cell with a child of orthogonal atomic inline
+
+HH	ZZ
+10: Shrink-to-fit table-cell with a child of orthogonal atomic inline with borders
+
+HHH	ZZ
+11: Shrink-to-fit table-cell with a child of orthogonal atomic inline in inline-block
+
+HH	ZZ
+12: Shrink-to-fit table-cell with a child of orthogonal atomic inline with borders in inline-block
+
+HHH	ZZ

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-002.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Writing Modes Test: Shrink-to-fit with an orthogonal atomic inline child</title>
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#orthogonal-flows" title="7.3. Orthogonal Flows">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-contribution">
+<meta name="assert" content="A shrink-to-fit box sized to an orthogonal atomic inline child uses that child's block-axis size as the child's intrinsic inline-size contribution.">
+<meta name="flags" content="ahem dom combo">
+<link rel="author" title="Karl Dubost" href="https://github.com/karlcow">
+<!-- Companion to orthogonal-parent-shrink-to-fit-001.html, which covers orthogonal
+     block and orthogonal inline children. This file covers the remaining case: an
+     orthogonal ATOMIC INLINE child (display:inline-block), which reaches a separate
+     intrinsic-width code path in some implementations.
+     See https://bugs.webkit.org/show_bug.cgi?id=187454 -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+.test {
+    border:thin solid;
+    font:20px/1 Ahem;
+}
+.target {
+    color:blue;
+    height:3em; /* height: 3em is not required. It keeps the test focused
+    exclusively on the shrink-to-fit algorithm. */
+    writing-mode:vertical-rl;
+}
+.border {
+    border-right:blue solid .5em;
+}
+.next {
+    color:orange;
+}
+.inline-block {
+    display:inline-block;
+}
+.float {
+    float:left;
+}
+h3 {
+    clear:both;
+}
+h3.fail {
+    color:red;
+}
+table {
+    border-spacing:0px;
+}
+td {
+    padding:0px;
+}
+</style>
+<div id="log"></div>
+<div id="container">
+<p>Test passes if the X-position of the <b>left</b> edge of the orange box and the <b>right</b> edge of the blue box are the same.
+<p>If script is enabled, there should be one or more PASS and no FAIL.
+<h3>1: Shrink-to-fit inline-block with a child of orthogonal atomic inline</h3>
+<div class="test">
+    <div class="inline-block"><span class="target inline-block">HH</span></div><span class="next">ZZ</span>
+</div>
+<h3>2: Shrink-to-fit inline-block with a child of orthogonal atomic inline with borders</h3>
+<div class="test">
+    <div class="inline-block"><span class="target inline-block border">HHH</span></div><span class="next">ZZ</span>
+</div>
+<h3>3: Shrink-to-fit inline-block with a child of orthogonal atomic inline in inline-block</h3>
+<div class="test">
+    <div class="inline-block"><div class="inline-block"><span class="target inline-block">HH</span></div></div><span class="next">ZZ</span>
+</div>
+<h3>4: Shrink-to-fit inline-block with a child of orthogonal atomic inline with borders in inline-block</h3>
+<div class="test">
+    <div class="inline-block"><div class="inline-block"><span class="target inline-block border">HHH</span></div></div><span class="next">ZZ</span>
+</div>
+<h3>5: Shrink-to-fit float with a child of orthogonal atomic inline</h3>
+<div class="test">
+    <div class="float"><span class="target inline-block">HH</span></div><span class="next">ZZ</span>
+</div>
+<h3>6: Shrink-to-fit float with a child of orthogonal atomic inline with borders</h3>
+<div class="test">
+    <div class="float"><span class="target inline-block border">HHH</span></div><span class="next">ZZ</span>
+</div>
+<h3>7: Shrink-to-fit float with a child of orthogonal atomic inline in inline-block</h3>
+<div class="test">
+    <div class="float"><div class="inline-block"><span class="target inline-block">HH</span></div></div><span class="next">ZZ</span>
+</div>
+<h3>8: Shrink-to-fit float with a child of orthogonal atomic inline with borders in inline-block</h3>
+<div class="test">
+    <div class="float"><div class="inline-block"><span class="target inline-block border">HHH</span></div></div><span class="next">ZZ</span>
+</div>
+<h3>9: Shrink-to-fit table-cell with a child of orthogonal atomic inline</h3>
+<div class="test">
+    <table><tr><td><span class="target inline-block">HH</span></td><td class="next">ZZ</td></tr></table>
+</div>
+<h3>10: Shrink-to-fit table-cell with a child of orthogonal atomic inline with borders</h3>
+<div class="test">
+    <table><tr><td><span class="target inline-block border">HHH</span></td><td class="next">ZZ</td></tr></table>
+</div>
+<h3>11: Shrink-to-fit table-cell with a child of orthogonal atomic inline in inline-block</h3>
+<div class="test">
+    <table><tr><td><div class="inline-block"><span class="target inline-block">HH</span></div></td><td class="next">ZZ</td></tr></table>
+</div>
+<h3>12: Shrink-to-fit table-cell with a child of orthogonal atomic inline with borders in inline-block</h3>
+<div class="test">
+    <table><tr><td><div class="inline-block"><span class="target inline-block border">HHH</span></div></td><td class="next">ZZ</td></tr></table>
+</div>
+</div>
+<script>
+run();
+
+function run() {
+    Array.prototype.forEach.call(document.querySelectorAll(".test"), function (node) {
+        var title = node.previousElementSibling.textContent;
+        test(function () {
+            try {
+                var targetNode = node.querySelector(".target");
+                var fontSize = parseFloat(getComputedStyle(targetNode).fontSize);
+                var targetBounds = targetNode.getBoundingClientRect();
+                assert_less_than_equal(targetBounds.width, fontSize * 2.01, "writing-mode is vertical")
+                var nextNode = node.querySelector(".next");
+                var nextBounds = nextNode.getBoundingClientRect();
+                assert_equals(nextBounds.left - targetBounds.right, 0, "the left edge of the orange box touches the right edge of the blue box");
+            } catch (e) {
+                node.previousElementSibling.classList.add("fail");
+                throw e;
+            }
+        }, title);
+    });
+    done();
+}
+</script>


### PR DESCRIPTION
#### 1f86c27b74cf2a1ad2c8d2b2b10e83892c302dfa
<pre>
[css-writing-modes] Add WPT coverage for orthogonal atomic inline children of shrink-to-fit boxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=187454">https://bugs.webkit.org/show_bug.cgi?id=187454</a>
<a href="https://rdar.apple.com/41980917">rdar://41980917</a>

Reviewed by Brent Fulgham.

The round language selector button in this bug no longer paints as a narrow
oval. 317781@main fixed it, so this change is tests only.

The page puts an atomic inline (display:inline-block) in vertical-lr inside a
shrink-to-fit inline-block label. The vertical child&apos;s horizontal extent is its
block axis size, and the label has to use that as the child&apos;s inline size
contribution. Before 317781@main an orthogonal child that had not been laid out
yet contributed only its border and padding, so the label collapsed to its own
0.5em of padding and the border-radius:50% background painted narrower than the
text inside it.

orthogonal-parent-shrink-to-fit-001.html already covers orthogonal block and
orthogonal inline children, but not an orthogonal atomic inline, which goes
through RenderBlockFlow::computeInlineIntrinsicLogicalWidths instead of
RenderBlock::computeBlockIntrinsicLogicalWidths. A regression limited to the
inline path would leave 001 passing. This is a sibling file rather than extra
subtests in 001, because 001&apos;s subtests are already mirrored one per file across
001a to 001x and the letter suffixes are used up.

12 subtests: inline-block, float and table-cell shrink-to-fit parents, each with
and without a border on the child, each with the child direct and nested in an
inline-block. Also checked against Safari Technology Preview 249, which predates
317781@main: all 12 fail there, the parent measuring 0px, or 10px with the 0.5em
border, against a 20px child. All 12 pass on trunk.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-002-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/318689@main">https://commits.webkit.org/318689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc64ada0e2095c037cd4ac58f19bd0b4eb0a259c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188878 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a22c1c4-7737-4b43-b939-39db9ee696f8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139624 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d3bb6dd-6be6-47fb-9b9d-9851b733c2d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43221 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160381 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120070 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8f5bc628-4a01-4721-95c2-7397b2ee59d5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152292 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39884 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/185 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191098 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148854 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39938 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53338 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148601 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43293 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120423 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51856 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14863 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51241 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51482 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51302 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->