### PR TITLE
Web Inspector: Canvas: distinguish configured WebGPU `<canvas>` from CSS canvas client nodes

### DIFF
--- a/LayoutTests/inspector/canvas/requestClientNodes-css-expected.txt
+++ b/LayoutTests/inspector/canvas/requestClientNodes-css-expected.txt
@@ -1,13 +1,13 @@
 Test that CanvasAgent tracks changes in the client nodes of a CSS canvas.
 
 
-== Running test suite: Canvas.requestClientNodes.CSS
--- Running test case: Canvas.requestClientNodes.CSS.Create
+== Running test suite: Canvas.requestCSSCanvasClientNodes.CSS
+-- Running test case: Canvas.requestCSSCanvasClientNodes.CSS.Create
 PASS: Canvas with created client should have CSS name "css-canvas".
-PASS: There should be one client node.
+PASS: There should be one CSS canvas node.
 PASS: Client node "div" is valid.
 
--- Running test case: Canvas.requestClientNodes.CSS.Destroy
+-- Running test case: Canvas.requestCSSCanvasClientNodes.CSS.Destroy
 PASS: Canvas with destroyed client should have CSS name "css-canvas".
-PASS: There should be no client nodes.
+PASS: There should be no CSS canvas nodes.
 

--- a/LayoutTests/inspector/canvas/requestClientNodes-css.html
+++ b/LayoutTests/inspector/canvas/requestClientNodes-css.html
@@ -25,7 +25,7 @@ function destroyClients() {
 }
 
 function test() {
-    let suite = InspectorTest.createAsyncSuite("Canvas.requestClientNodes.CSS");
+    let suite = InspectorTest.createAsyncSuite("Canvas.requestCSSCanvasClientNodes.CSS");
 
     function logClientNodes(clientNodes) {
         for (let clientNode of clientNodes) {
@@ -37,38 +37,34 @@ function test() {
     }
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.CSS.Create",
+        name: "Canvas.requestCSSCanvasClientNodes.CSS.Create",
         description: "Check that creating a CSS canvas client node is tracked correctly.",
-        test(resolve, reject) {
-            WI.Canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged)
-            .then((event) => {
-                event.target.requestClientNodes((clientNodes) => {
-                    InspectorTest.expectShallowEqual(event.target.cssCanvasNames, ["css-canvas"], `Canvas with created client should have CSS name "css-canvas".`);
-                    InspectorTest.expectEqual(clientNodes.length, 1, "There should be one client node.");
-                    logClientNodes(clientNodes);
-                    resolve();
-                });
-            });
+        async test() {
+            let cssCanvasClientNodesChangedPromise = WI.Canvas.awaitEvent(WI.Canvas.Event.CSSCanvasClientNodesChanged);
 
             InspectorTest.evaluateInPage(`createClient()`);
+
+            let event = await cssCanvasClientNodesChangedPromise;
+            let cssCanvasClientNodes = await event.target.requestCSSCanvasClientNodes();
+            InspectorTest.expectShallowEqual(event.target.cssCanvasNames, ["css-canvas"], `Canvas with created client should have CSS name "css-canvas".`);
+            InspectorTest.expectEqual(cssCanvasClientNodes.length, 1, "There should be one CSS canvas node.");
+            logClientNodes(cssCanvasClientNodes);
         }
     });
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.CSS.Destroy",
+        name: "Canvas.requestCSSCanvasClientNodes.CSS.Destroy",
         description: "Check that destroying a CSS canvas client node is tracked correctly.",
-        test(resolve, reject) {
-            WI.Canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged)
-            .then((event) => {
-                event.target.requestClientNodes((clientNodes) => {
-                    InspectorTest.expectShallowEqual(event.target.cssCanvasNames, ["css-canvas"], `Canvas with destroyed client should have CSS name "css-canvas".`);
-                    InspectorTest.expectEqual(clientNodes.length, 0, "There should be no client nodes.");
-                    logClientNodes(clientNodes);
-                    resolve();
-                });
-            });
+        async test() {
+            let cssCanvasClientNodesChangedPromise = WI.Canvas.awaitEvent(WI.Canvas.Event.CSSCanvasClientNodesChanged);
 
             InspectorTest.evaluateInPage(`destroyClients()`);
+
+            let event = await cssCanvasClientNodesChangedPromise;
+            let cssCanvasClientNodes = await event.target.requestCSSCanvasClientNodes();
+            InspectorTest.expectShallowEqual(event.target.cssCanvasNames, ["css-canvas"], `Canvas with destroyed client should have CSS name "css-canvas".`);
+            InspectorTest.expectEqual(cssCanvasClientNodes.length, 0, "There should be no CSS canvas nodes.");
+            logClientNodes(cssCanvasClientNodes);
         }
     });
 

--- a/LayoutTests/inspector/canvas/requestClientNodes-expected.txt
+++ b/LayoutTests/inspector/canvas/requestClientNodes-expected.txt
@@ -1,12 +1,12 @@
 Test that CanvasAgent tracks changes in the client nodes of a CSS canvas.
 
 
-== Running test suite: Canvas.requestClientNodes
--- Running test case: Canvas.requestClientNodes.Initial.Canvas2D
-PASS: There should initially be no client nodes.
+== Running test suite: Canvas.requestCSSCanvasClientNodes
+-- Running test case: Canvas.requestCSSCanvasClientNodes.Initial.Canvas2D
+PASS: There should initially be no CSS canvas nodes.
 
--- Running test case: CCanvas.requestClientNodes.Initial.OffscreenCanvas2D
-PASS: There should initially be no client nodes.
+-- Running test case: Canvas.requestCSSCanvasClientNodes.Initial.OffscreenCanvas2D
+PASS: There should initially be no CSS canvas nodes.
 
 -- Running test case: Canvas.CSSCanvasClients.InvalidCanvasId
 PASS: Should produce an error.

--- a/LayoutTests/inspector/canvas/requestClientNodes-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/requestClientNodes-webgpu-expected.txt
@@ -1,84 +1,88 @@
-Test that CanvasAgent tracks GPUCanvasContext client nodes for WebGPU devices.
+Test that CanvasAgent tracks configured canvases and CSS canvas nodes for WebGPU devices.
 
 
-== Running test suite: Canvas.requestClientNodes.WebGPU
--- Running test case: Canvas.requestClientNodes.WebGPU.Initial
-PASS: GPUDevice should initially have no client nodes.
+== Running test suite: Canvas.requestCSSCanvasClientNodes.WebGPU
+-- Running test case: Canvas.requestCSSCanvasClientNodes.WebGPU.Initial
+PASS: GPUDevice should initially have no CSS canvas nodes.
 PASS: GPUDevice should initially have no CSS canvas names.
 PASS: GPUDevice should not have a size.
-PASS: GPUDevice should initially have no canvas node.
+PASS: GPUDevice should initially have no configured canvas nodes.
 
--- Running test case: Canvas.requestClientNodes.WebGPU.Configure
-PASS: Client nodes changed for the expected Canvas.
-PASS: GPUDevice should have one client node.
-PASS: Client node should be the configured canvas element.
-PASS: GPUDevice should resolve its only canvas node.
+-- Running test case: Canvas.requestCSSCanvasClientNodes.WebGPU.Configure
+PASS: Nodes changed for the expected Canvas.
+PASS: GPUDevice should have no CSS canvas nodes.
+PASS: GPUDevice should have one configured canvas node.
+PASS: Canvas node should be the configured canvas element.
 PASS: GPUDevice should not have multiple canvas sizes.
 PASS: GPUDevice width should be 10.
 PASS: GPUDevice height should be 20.
 PASS: GPUCanvasContext should not create a separate Canvas.
 
--- Running test case: Canvas.requestClientNodes.WebGPU.MultipleCanvasesSameSize
-PASS: Client nodes changed for the expected Canvas.
-PASS: GPUDevice should have two client nodes.
+-- Running test case: Canvas.requestCSSCanvasClientNodes.WebGPU.MultipleCanvasesSameSize
+PASS: Nodes changed for the expected Canvas.
+PASS: GPUDevice should still have no CSS canvas nodes.
+PASS: GPUDevice should have two configured canvas nodes.
 PASS: GPUDevice should include the original canvas element.
 PASS: GPUDevice should include the additional canvas element.
-PASS: GPUDevice should not resolve a canvas node when multiple canvases are bound.
 PASS: GPUDevice should not have multiple canvas sizes.
 PASS: GPUDevice width should be 10.
 PASS: GPUDevice height should be 20.
 PASS: Two GPUCanvasContexts should still create only one Canvas.
 
--- Running test case: Canvas.requestClientNodes.WebGPU.CoalesceChangesUntilRequest
-PASS: Client nodes changed for the expected Canvas.
-PASS: Client node changes should only be reported once before requestClientNodes.
-PASS: GPUDevice should report its final client nodes.
+-- Running test case: Canvas.requestCSSCanvasClientNodes.WebGPU.CoalesceChangesUntilRequest
+PASS: Nodes changed for the expected Canvas.
+PASS: Node changes should only be reported once before requesting updated nodes.
+PASS: GPUDevice should report no CSS canvas nodes.
+PASS: GPUDevice should report its final configured canvas nodes.
 
--- Running test case: Canvas.requestClientNodes.WebGPU.MultipleCanvasesDifferentSizes
+-- Running test case: Canvas.requestCSSCanvasClientNodes.WebGPU.MultipleCanvasesDifferentSizes
 PASS: Size changed for the expected Canvas.
 PASS: GPUDevice should have multiple canvas sizes.
 PASS: GPUDevice should expose all canvas sizes.
-PASS: GPUDevice should not resolve a canvas node when multiple canvases are bound.
+PASS: GPUDevice should continue to resolve both configured canvas nodes.
 
--- Running test case: Canvas.requestClientNodes.WebGPU.ReturnToUniqueCanvas
-PASS: Client nodes changed after unconfiguring one canvas.
-PASS: GPUDevice should retain one client node.
-PASS: Remaining client node should be the original canvas element.
-PASS: GPUDevice should again resolve its only canvas node.
+-- Running test case: Canvas.requestCSSCanvasClientNodes.WebGPU.ReturnToUniqueCanvas
+PASS: Nodes changed after unconfiguring one canvas.
+PASS: GPUDevice should retain no CSS canvas nodes.
+PASS: GPUDevice should retain one configured canvas node.
+PASS: Remaining canvas node should be the original canvas element.
 PASS: GPUDevice should not have multiple canvas sizes.
 PASS: GPUDevice width should be 10.
 PASS: GPUDevice height should be 20.
 PASS: Unconfiguring one client should preserve the single GPUDevice Canvas.
 
--- Running test case: Canvas.requestClientNodes.WebGPU.Unconfigure
-PASS: Client nodes changed for the expected Canvas.
-PASS: GPUDevice should again have no client nodes.
+-- Running test case: Canvas.requestCSSCanvasClientNodes.WebGPU.Unconfigure
+PASS: Nodes changed for the expected Canvas.
+PASS: GPUDevice should again have no CSS canvas nodes.
 PASS: GPUDevice should not have a size.
-PASS: GPUDevice should again have no canvas node.
+PASS: GPUDevice should again have no configured canvas nodes.
 
--- Running test case: Canvas.requestClientNodes.WebGPU.CSSCanvas
-PASS: Client nodes changed for the expected Canvas.
-PASS: GPUDevice should not update its CSS canvas names before requestClientNodes.
-PASS: GPUDevice should include its CSS canvas name.
-PASS: GPUDevice should have one CSS canvas client node.
-PASS: Client node should be the CSS canvas consumer.
+-- Running test case: Canvas.requestCSSCanvasClientNodes.WebGPU.CSSCanvas
+PASS: Nodes changed for the expected Canvas.
+PASS: CSS canvas names changed for the expected Canvas.
+PASS: GPUDevice should update its CSS canvas names without a request.
+PASS: GPUDevice should have one CSS canvas node.
+PASS: CSS canvas node should be the CSS canvas consumer.
+PASS: GPUDevice should have one configured CSS canvas node.
+PASS: Canvas node should be the configured CSS canvas element.
 PASS: GPUDevice should not have multiple canvas sizes.
 PASS: GPUDevice width should be 30.
 PASS: GPUDevice height should be 40.
 
--- Running test case: Canvas.requestClientNodes.WebGPU.CSSCanvasUnconfigure
-PASS: Client nodes changed for the expected Canvas.
-PASS: GPUDevice should preserve its CSS canvas names before requestClientNodes.
-PASS: GPUDevice should no longer have CSS canvas names.
-PASS: GPUDevice should no longer have CSS canvas client nodes.
+-- Running test case: Canvas.requestCSSCanvasClientNodes.WebGPU.CSSCanvasUnconfigure
+PASS: Nodes changed for the expected Canvas.
+PASS: CSS canvas names changed for the expected Canvas.
+PASS: GPUDevice should clear its CSS canvas names without a request.
+PASS: GPUDevice should no longer have CSS canvas nodes.
+PASS: GPUDevice should no longer have configured canvas nodes.
 PASS: GPUDevice should not have a size.
 
--- Running test case: Canvas.requestClientNodes.WebGPU.OffscreenCanvas
-PASS: Client nodes changed for the expected Canvas.
-PASS: OffscreenCanvas should not create a DOM client node.
+-- Running test case: Canvas.requestCSSCanvasClientNodes.WebGPU.OffscreenCanvas
+PASS: Nodes changed for the expected Canvas.
+PASS: OffscreenCanvas should not create a CSS canvas node.
 PASS: GPUDevice should not have multiple canvas sizes.
 PASS: GPUDevice width should be 4.
 PASS: GPUDevice height should be 4.
-PASS: OffscreenCanvas should not create a canvas node.
+PASS: OffscreenCanvas should not create a configured canvas node.
 PASS: OffscreenCanvas GPUCanvasContext should not create a separate Canvas.
 

--- a/LayoutTests/inspector/canvas/requestClientNodes-webgpu.html
+++ b/LayoutTests/inspector/canvas/requestClientNodes-webgpu.html
@@ -94,13 +94,13 @@ function configureOffscreenClient() {
 }
 
 function test() {
-    let suite = InspectorTest.createAsyncSuite("Canvas.requestClientNodes.WebGPU");
+    let suite = InspectorTest.createAsyncSuite("Canvas.requestCSSCanvasClientNodes.WebGPU");
     let canvas = Array.from(WI.canvasManager.canvasCollection).find((canvas) => canvas.contextType === WI.Canvas.ContextType.WebGPU);
     let cssCanvasName;
     InspectorTest.assert(canvas, "There should be a WebGPU Canvas.");
 
-    function requestClientNodes() {
-        return new Promise((resolve) => canvas.requestClientNodes(resolve));
+    function requestCSSCanvasClientNodes() {
+        return canvas.requestCSSCanvasClientNodes();
     }
 
     function waitForSize(predicate) {
@@ -127,79 +127,82 @@ function test() {
     }
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.WebGPU.Initial",
-        description: "Check that an unused GPUDevice has no client nodes.",
+        name: "Canvas.requestCSSCanvasClientNodes.WebGPU.Initial",
+        description: "Check that an unused GPUDevice has no canvas nodes.",
         async test() {
-            let clientNodes = await requestClientNodes();
-            InspectorTest.expectEqual(clientNodes.length, 0, "GPUDevice should initially have no client nodes.");
+            let cssCanvasClientNodes = await requestCSSCanvasClientNodes();
+            InspectorTest.expectEqual(cssCanvasClientNodes.length, 0, "GPUDevice should initially have no CSS canvas nodes.");
             InspectorTest.expectShallowEqual(canvas.cssCanvasNames, [], "GPUDevice should initially have no CSS canvas names.");
             expectNoSize();
-            InspectorTest.expectNull(await canvas.requestNode(), "GPUDevice should initially have no canvas node.");
+            InspectorTest.expectEqual((await canvas.requestNodes()).length, 0, "GPUDevice should initially have no configured canvas nodes.");
         },
     });
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.WebGPU.Configure",
-        description: "Check that configuring a GPUCanvasContext adds its canvas as a GPUDevice client node.",
+        name: "Canvas.requestCSSCanvasClientNodes.WebGPU.Configure",
+        description: "Check that configuring a GPUCanvasContext adds its canvas as a GPUDevice canvas node.",
         async test() {
-            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let nodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.NodesChanged);
             let sizeChangedPromise = waitForSize(() => canvas.sizes.length === 1 && canvas.sizes[0].width === 10 && canvas.sizes[0].height === 20);
             InspectorTest.evaluateInPage(`configureClient()`);
 
-            let event = await clientNodesChangedPromise;
+            let event = await nodesChangedPromise;
             await sizeChangedPromise;
-            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
-            let clientNodes = await requestClientNodes();
-            InspectorTest.expectEqual(clientNodes.length, 1, "GPUDevice should have one client node.");
-            InspectorTest.expectEqual(clientNodes[0].appropriateSelectorFor(), "canvas#webgpu-client", "Client node should be the configured canvas element.");
-            InspectorTest.expectEqual((await canvas.requestNode())?.appropriateSelectorFor(), "canvas#webgpu-client", "GPUDevice should resolve its only canvas node.");
+            InspectorTest.expectEqual(event.target, canvas, "Nodes changed for the expected Canvas.");
+            let cssCanvasClientNodes = await requestCSSCanvasClientNodes();
+            InspectorTest.expectEqual(cssCanvasClientNodes.length, 0, "GPUDevice should have no CSS canvas nodes.");
+            let nodes = await canvas.requestNodes();
+            InspectorTest.expectEqual(nodes.length, 1, "GPUDevice should have one configured canvas node.");
+            InspectorTest.expectEqual(nodes[0].appropriateSelectorFor(), "canvas#webgpu-client", "Canvas node should be the configured canvas element.");
             expectSize(10, 20);
             InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "GPUCanvasContext should not create a separate Canvas.");
         },
     });
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.WebGPU.MultipleCanvasesSameSize",
-        description: "Check that one GPUDevice simultaneously tracks multiple same-sized canvas client nodes.",
+        name: "Canvas.requestCSSCanvasClientNodes.WebGPU.MultipleCanvasesSameSize",
+        description: "Check that one GPUDevice simultaneously tracks multiple same-sized canvas nodes.",
         async test() {
-            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let nodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.NodesChanged);
             InspectorTest.evaluateInPage(`configureAdditionalClient()`);
 
-            let event = await clientNodesChangedPromise;
-            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
-            let clientNodes = await requestClientNodes();
-            InspectorTest.expectEqual(clientNodes.length, 2, "GPUDevice should have two client nodes.");
-            let selectors = new Set(clientNodes.map((node) => node.appropriateSelectorFor()));
+            let event = await nodesChangedPromise;
+            InspectorTest.expectEqual(event.target, canvas, "Nodes changed for the expected Canvas.");
+            let cssCanvasClientNodes = await requestCSSCanvasClientNodes();
+            InspectorTest.expectEqual(cssCanvasClientNodes.length, 0, "GPUDevice should still have no CSS canvas nodes.");
+            let nodes = await canvas.requestNodes();
+            InspectorTest.expectEqual(nodes.length, 2, "GPUDevice should have two configured canvas nodes.");
+            let selectors = new Set(nodes.map((node) => node.appropriateSelectorFor()));
             InspectorTest.expectTrue(selectors.has("canvas#webgpu-client"), "GPUDevice should include the original canvas element.");
             InspectorTest.expectTrue(selectors.has("canvas#additional-webgpu-client"), "GPUDevice should include the additional canvas element.");
-            InspectorTest.expectNull(await canvas.requestNode(), "GPUDevice should not resolve a canvas node when multiple canvases are bound.");
             expectSize(10, 20);
             InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "Two GPUCanvasContexts should still create only one Canvas.");
         },
     });
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.WebGPU.CoalesceChangesUntilRequest",
-        description: "Check that client node changes are only reported once until the frontend requests the updated nodes.",
+        name: "Canvas.requestCSSCanvasClientNodes.WebGPU.CoalesceChangesUntilRequest",
+        description: "Check that node changes are only reported once until the frontend requests the updated nodes.",
         async test() {
-            let clientNodesChangedCount = 0;
-            let listener = canvas.addEventListener(WI.Canvas.Event.ClientNodesChanged, () => ++clientNodesChangedCount);
-            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let nodesChangedCount = 0;
+            let listener = canvas.addEventListener(WI.Canvas.Event.NodesChanged, () => ++nodesChangedCount);
+            let nodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.NodesChanged);
             await InspectorTest.evaluateInPage(`unconfigureAdditionalClient()`);
 
-            let event = await clientNodesChangedPromise;
+            let event = await nodesChangedPromise;
             await InspectorTest.evaluateInPage(`configureAdditionalClient()`);
-            canvas.removeEventListener(WI.Canvas.Event.ClientNodesChanged, listener);
+            canvas.removeEventListener(WI.Canvas.Event.NodesChanged, listener);
 
-            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
-            InspectorTest.expectEqual(clientNodesChangedCount, 1, "Client node changes should only be reported once before requestClientNodes.");
-            let clientNodes = await requestClientNodes();
-            InspectorTest.expectEqual(clientNodes.length, 2, "GPUDevice should report its final client nodes.");
+            InspectorTest.expectEqual(event.target, canvas, "Nodes changed for the expected Canvas.");
+            InspectorTest.expectEqual(nodesChangedCount, 1, "Node changes should only be reported once before requesting updated nodes.");
+            let cssCanvasClientNodes = await requestCSSCanvasClientNodes();
+            InspectorTest.expectEqual(cssCanvasClientNodes.length, 0, "GPUDevice should report no CSS canvas nodes.");
+            InspectorTest.expectEqual((await canvas.requestNodes()).length, 2, "GPUDevice should report its final configured canvas nodes.");
         },
     });
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.WebGPU.MultipleCanvasesDifferentSizes",
+        name: "Canvas.requestCSSCanvasClientNodes.WebGPU.MultipleCanvasesDifferentSizes",
         description: "Check that one GPUDevice reports when its canvas clients have different sizes.",
         async test() {
             let sizeChangedPromise = waitForSize(() => canvas.sizes.length > 1);
@@ -209,103 +212,112 @@ function test() {
             InspectorTest.expectEqual(event.target, canvas, "Size changed for the expected Canvas.");
             InspectorTest.expectTrue(canvas.sizes.length > 1, "GPUDevice should have multiple canvas sizes.");
             InspectorTest.expectShallowEqual(canvas.sizes.map((size) => [size.width, size.height]).sort(), [[10, 20], [20, 20]], "GPUDevice should expose all canvas sizes.");
-            InspectorTest.expectNull(await canvas.requestNode(), "GPUDevice should not resolve a canvas node when multiple canvases are bound.");
+            InspectorTest.expectEqual((await canvas.requestNodes()).length, 2, "GPUDevice should continue to resolve both configured canvas nodes.");
         },
     });
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.WebGPU.ReturnToUniqueCanvas",
+        name: "Canvas.requestCSSCanvasClientNodes.WebGPU.ReturnToUniqueCanvas",
         description: "Check that unconfiguring one of multiple canvas clients restores the remaining canvas metadata.",
         async test() {
-            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let nodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.NodesChanged);
             let sizeChangedPromise = waitForSize(() => canvas.sizes.length === 1 && canvas.sizes[0].width === 10 && canvas.sizes[0].height === 20);
             InspectorTest.evaluateInPage(`unconfigureAdditionalClient()`);
 
-            let event = await clientNodesChangedPromise;
+            let event = await nodesChangedPromise;
             await sizeChangedPromise;
-            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed after unconfiguring one canvas.");
-            let clientNodes = await requestClientNodes();
-            InspectorTest.expectEqual(clientNodes.length, 1, "GPUDevice should retain one client node.");
-            InspectorTest.expectEqual(clientNodes[0].appropriateSelectorFor(), "canvas#webgpu-client", "Remaining client node should be the original canvas element.");
-            InspectorTest.expectEqual((await canvas.requestNode())?.appropriateSelectorFor(), "canvas#webgpu-client", "GPUDevice should again resolve its only canvas node.");
+            InspectorTest.expectEqual(event.target, canvas, "Nodes changed after unconfiguring one canvas.");
+            let cssCanvasClientNodes = await requestCSSCanvasClientNodes();
+            InspectorTest.expectEqual(cssCanvasClientNodes.length, 0, "GPUDevice should retain no CSS canvas nodes.");
+            let nodes = await canvas.requestNodes();
+            InspectorTest.expectEqual(nodes.length, 1, "GPUDevice should retain one configured canvas node.");
+            InspectorTest.expectEqual(nodes[0].appropriateSelectorFor(), "canvas#webgpu-client", "Remaining canvas node should be the original canvas element.");
             expectSize(10, 20);
             InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "Unconfiguring one client should preserve the single GPUDevice Canvas.");
         },
     });
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.WebGPU.Unconfigure",
-        description: "Check that unconfiguring a GPUCanvasContext removes its canvas from the GPUDevice client nodes.",
+        name: "Canvas.requestCSSCanvasClientNodes.WebGPU.Unconfigure",
+        description: "Check that unconfiguring a GPUCanvasContext removes its canvas from the GPUDevice canvas nodes.",
         async test() {
-            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let nodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.NodesChanged);
             let sizeChangedPromise = waitForSize(() => !canvas.sizes.length);
             InspectorTest.evaluateInPage(`unconfigureClient()`);
 
-            let event = await clientNodesChangedPromise;
+            let event = await nodesChangedPromise;
             await sizeChangedPromise;
-            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
-            let clientNodes = await requestClientNodes();
-            InspectorTest.expectEqual(clientNodes.length, 0, "GPUDevice should again have no client nodes.");
+            InspectorTest.expectEqual(event.target, canvas, "Nodes changed for the expected Canvas.");
+            let cssCanvasClientNodes = await requestCSSCanvasClientNodes();
+            InspectorTest.expectEqual(cssCanvasClientNodes.length, 0, "GPUDevice should again have no CSS canvas nodes.");
             expectNoSize();
-            InspectorTest.expectNull(await canvas.requestNode(), "GPUDevice should again have no canvas node.");
+            InspectorTest.expectEqual((await canvas.requestNodes()).length, 0, "GPUDevice should again have no configured canvas nodes.");
         },
     });
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.WebGPU.CSSCanvas",
-        description: "Check that a CSS WebGPU canvas reports its name and CSS client node.",
+        name: "Canvas.requestCSSCanvasClientNodes.WebGPU.CSSCanvas",
+        description: "Check that a CSS WebGPU canvas reports its name, configured canvas, and CSS canvas node.",
         async test() {
-            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let nodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.NodesChanged);
+            let cssCanvasNamesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.CSSCanvasNamesChanged);
             let sizeChangedPromise = waitForSize(() => canvas.sizes.length === 1 && canvas.sizes[0].width === 30 && canvas.sizes[0].height === 40);
             InspectorTest.evaluateInPage(`configureCSSClient()`);
 
-            let event = await clientNodesChangedPromise;
+            let event = await nodesChangedPromise;
+            let cssCanvasNamesChangedEvent = await cssCanvasNamesChangedPromise;
             await sizeChangedPromise;
             cssCanvasName = await InspectorTest.evaluateInPage(`cssCanvasName`);
-            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
-            InspectorTest.expectShallowEqual(canvas.cssCanvasNames, [], "GPUDevice should not update its CSS canvas names before requestClientNodes.");
-            let clientNodes = await requestClientNodes();
-            InspectorTest.expectShallowEqual(canvas.cssCanvasNames, [cssCanvasName], "GPUDevice should include its CSS canvas name.");
-            InspectorTest.expectEqual(clientNodes.length, 1, "GPUDevice should have one CSS canvas client node.");
-            InspectorTest.expectEqual(clientNodes[0].appropriateSelectorFor(), "div#webgpu-css-client", "Client node should be the CSS canvas consumer.");
+            InspectorTest.expectEqual(event.target, canvas, "Nodes changed for the expected Canvas.");
+            InspectorTest.expectEqual(cssCanvasNamesChangedEvent.target, canvas, "CSS canvas names changed for the expected Canvas.");
+            InspectorTest.expectShallowEqual(canvas.cssCanvasNames, [cssCanvasName], "GPUDevice should update its CSS canvas names without a request.");
+            let cssCanvasClientNodes = await requestCSSCanvasClientNodes();
+            InspectorTest.expectEqual(cssCanvasClientNodes.length, 1, "GPUDevice should have one CSS canvas node.");
+            InspectorTest.expectEqual(cssCanvasClientNodes[0].appropriateSelectorFor(), "div#webgpu-css-client", "CSS canvas node should be the CSS canvas consumer.");
+            let nodes = await canvas.requestNodes();
+            InspectorTest.expectEqual(nodes.length, 1, "GPUDevice should have one configured CSS canvas node.");
+            InspectorTest.expectEqual(nodes[0].appropriateSelectorFor(), "canvas", "Canvas node should be the configured CSS canvas element.");
             expectSize(30, 40);
         },
     });
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.WebGPU.CSSCanvasUnconfigure",
-        description: "Check that unconfiguring a CSS WebGPU canvas clears its name and client node.",
+        name: "Canvas.requestCSSCanvasClientNodes.WebGPU.CSSCanvasUnconfigure",
+        description: "Check that unconfiguring a CSS WebGPU canvas clears its name and nodes.",
         async test() {
-            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let nodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.NodesChanged);
+            let cssCanvasNamesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.CSSCanvasNamesChanged);
             let sizeChangedPromise = waitForSize(() => !canvas.sizes.length);
             InspectorTest.evaluateInPage(`unconfigureCSSClient()`);
 
-            let event = await clientNodesChangedPromise;
+            let event = await nodesChangedPromise;
+            let cssCanvasNamesChangedEvent = await cssCanvasNamesChangedPromise;
             await sizeChangedPromise;
-            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
-            InspectorTest.expectShallowEqual(canvas.cssCanvasNames, [cssCanvasName], "GPUDevice should preserve its CSS canvas names before requestClientNodes.");
-            let clientNodes = await requestClientNodes();
-            InspectorTest.expectShallowEqual(canvas.cssCanvasNames, [], "GPUDevice should no longer have CSS canvas names.");
-            InspectorTest.expectEqual(clientNodes.length, 0, "GPUDevice should no longer have CSS canvas client nodes.");
+            InspectorTest.expectEqual(event.target, canvas, "Nodes changed for the expected Canvas.");
+            InspectorTest.expectEqual(cssCanvasNamesChangedEvent.target, canvas, "CSS canvas names changed for the expected Canvas.");
+            InspectorTest.expectShallowEqual(canvas.cssCanvasNames, [], "GPUDevice should clear its CSS canvas names without a request.");
+            let cssCanvasClientNodes = await requestCSSCanvasClientNodes();
+            InspectorTest.expectEqual(cssCanvasClientNodes.length, 0, "GPUDevice should no longer have CSS canvas nodes.");
+            InspectorTest.expectEqual((await canvas.requestNodes()).length, 0, "GPUDevice should no longer have configured canvas nodes.");
             expectNoSize();
         },
     });
 
     suite.addTestCase({
-        name: "Canvas.requestClientNodes.WebGPU.OffscreenCanvas",
-        description: "Check that an OffscreenCanvas can use the GPUDevice without creating a DOM client node or a separate Canvas.",
+        name: "Canvas.requestCSSCanvasClientNodes.WebGPU.OffscreenCanvas",
+        description: "Check that an OffscreenCanvas can use the GPUDevice without creating a DOM node or a separate Canvas.",
         async test() {
-            let clientNodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.ClientNodesChanged);
+            let nodesChangedPromise = canvas.awaitEvent(WI.Canvas.Event.NodesChanged);
             let sizeChangedPromise = waitForSize(() => canvas.sizes.length === 1 && canvas.sizes[0].width === 4 && canvas.sizes[0].height === 4);
             InspectorTest.evaluateInPage(`configureOffscreenClient()`);
 
-            let event = await clientNodesChangedPromise;
+            let event = await nodesChangedPromise;
             await sizeChangedPromise;
-            InspectorTest.expectEqual(event.target, canvas, "Client nodes changed for the expected Canvas.");
-            let clientNodes = await requestClientNodes();
-            InspectorTest.expectEqual(clientNodes.length, 0, "OffscreenCanvas should not create a DOM client node.");
+            InspectorTest.expectEqual(event.target, canvas, "Nodes changed for the expected Canvas.");
+            let cssCanvasClientNodes = await requestCSSCanvasClientNodes();
+            InspectorTest.expectEqual(cssCanvasClientNodes.length, 0, "OffscreenCanvas should not create a CSS canvas node.");
             expectSize(4, 4);
-            InspectorTest.expectNull(await canvas.requestNode(), "OffscreenCanvas should not create a canvas node.");
+            InspectorTest.expectEqual((await canvas.requestNodes()).length, 0, "OffscreenCanvas should not create a configured canvas node.");
             InspectorTest.expectEqual(WI.canvasManager.canvasCollection.size, 1, "OffscreenCanvas GPUCanvasContext should not create a separate Canvas.");
         },
     });
@@ -315,6 +327,6 @@ function test() {
 </script>
 </head>
 <body onload="window.testRunner?.waitUntilDone(); load()">
-    <p>Test that CanvasAgent tracks GPUCanvasContext client nodes for WebGPU devices.</p>
+    <p>Test that CanvasAgent tracks configured canvases and CSS canvas nodes for WebGPU devices.</p>
 </body>
 </html>

--- a/LayoutTests/inspector/canvas/requestClientNodes.html
+++ b/LayoutTests/inspector/canvas/requestClientNodes.html
@@ -13,39 +13,34 @@ function load() {
 }
 
 function test() {
-    let suite = InspectorTest.createAsyncSuite("Canvas.requestClientNodes");
+    let suite = InspectorTest.createAsyncSuite("Canvas.requestCSSCanvasClientNodes");
     function addTestCase({name, contextType}) {
         suite.addTestCase({
             name,
             description: "Check that creating a CSS canvas client node is tracked correctly.",
-            test(resolve, reject) {
+            async test() {
                 let canvas = Array.from(WI.canvasManager.canvasCollection).find((canvas) => canvas.contextType === contextType);
-                if (!canvas) {
-                    reject(`Missing canvas for type ${contextType}.`);
-                    return;
-                }
-                canvas.requestClientNodes((clientNodes) => {
-                    InspectorTest.expectEqual(clientNodes.length, 0, "There should initially be no client nodes.");
-                    resolve();
-                });
+                if (!canvas)
+                    throw `Missing canvas for type ${contextType}.`;
+
+                let cssCanvasClientNodes = await canvas.requestCSSCanvasClientNodes();
+                InspectorTest.expectEqual(cssCanvasClientNodes.length, 0, "There should initially be no CSS canvas nodes.");
             }
         });
     };
 
-    addTestCase({name: "Canvas.requestClientNodes.Initial.Canvas2D", contextType: WI.Canvas.ContextType.Canvas2D});
+    addTestCase({name: "Canvas.requestCSSCanvasClientNodes.Initial.Canvas2D", contextType: WI.Canvas.ContextType.Canvas2D});
     if (window.OffscreenCanvas)
-        addTestCase({name: "CCanvas.requestClientNodes.Initial.OffscreenCanvas2D", contextType: WI.Canvas.ContextType.OffscreenCanvas2D});
+        addTestCase({name: "Canvas.requestCSSCanvasClientNodes.Initial.OffscreenCanvas2D", contextType: WI.Canvas.ContextType.OffscreenCanvas2D});
 
     suite.addTestCase({
         name: "Canvas.CSSCanvasClients.InvalidCanvasId",
         description: "Invalid canvas identifiers should cause an error.",
-        test(resolve, reject) {
+        async test() {
             const canvasId = "DOES_NOT_EXIST";
-            CanvasAgent.requestClientNodes(canvasId, (error, clientNodeIds) => {
-                InspectorTest.expectThat(error, "Should produce an error.");
-                InspectorTest.log("Error: " + error);
-                resolve();
-            });
+            let error = await CanvasAgent.requestCSSCanvasClientNodes(canvasId).then(() => null, (error) => error);
+            InspectorTest.expectThat(error, "Should produce an error.");
+            InspectorTest.log("Error: " + error.message);
         }
     });
 

--- a/LayoutTests/inspector/canvas/requestNode-expected.txt
+++ b/LayoutTests/inspector/canvas/requestNode-expected.txt
@@ -1,16 +1,19 @@
-Test that CanvasAgent.requestNode can properly resolve the owner canvas node.
+Test that CanvasAgent.requestNodes can properly resolve canvas nodes.
 
 
-== Running test suite: Canvas.requestNode
--- Running test case: Canvas.requestNode.validCanvasId
+== Running test suite: Canvas.requestNodes
+-- Running test case: Canvas.requestNodes.validCanvasId
+PASS: Canvas "CSS canvas “css”" has one node.
 PASS: Canvas "CSS canvas “css”" has node with valid id.
 PASS: Canvas "CSS canvas “css”" has node with type "CANVAS".
+PASS: Canvas "Canvas 1" has one node.
 PASS: Canvas "Canvas 1" has node with valid id.
 PASS: Canvas "Canvas 1" has node with type "CANVAS".
+PASS: Canvas "Canvas 2" has one node.
 PASS: Canvas "Canvas 2" has node with valid id.
 PASS: Canvas "Canvas 2" has node with type "CANVAS".
 
--- Running test case: Canvas.requestNode.invalidCanvasId
+-- Running test case: Canvas.requestNodes.invalidCanvasId
 PASS: Should produce an error.
 Error: Missing canvas for given canvasId
 

--- a/LayoutTests/inspector/canvas/requestNode.html
+++ b/LayoutTests/inspector/canvas/requestNode.html
@@ -12,11 +12,11 @@ function load() {
 }
 
 function test() {
-    let suite = InspectorTest.createAsyncSuite("Canvas.requestNode");
+    let suite = InspectorTest.createAsyncSuite("Canvas.requestNodes");
 
     suite.addTestCase({
-        name: "Canvas.requestNode.validCanvasId",
-        description: "Get the node id for each canvas on the page.",
+        name: "Canvas.requestNodes.validCanvasId",
+        description: "Get the node ids for each canvas on the page.",
         test(resolve, reject) {
             let canvases = Array.from(WI.canvasManager.canvasCollection);
             let expectedLength = canvases.length;
@@ -26,8 +26,8 @@ function test() {
 
             function finish() {
                 let results = {};
-                for (let [canvas, node] of nodesMap)
-                    results[canvas.displayName] = node;
+                for (let [canvas, nodes] of nodesMap)
+                    results[canvas.displayName] = nodes;
 
                 let keys = Object.keys(results);
                 InspectorTest.assert(keys.length === nodesMap.size, "No display name collisions");
@@ -36,8 +36,10 @@ function test() {
                 // events are sent in a different order than the above.
                 keys.sort();
                 for (let displayName of keys) {
-                    InspectorTest.expectThat(results[displayName], `Canvas "${displayName}" has node with valid id.`);
-                    InspectorTest.expectEqual(results[displayName].nodeName(), "CANVAS", `Canvas "${displayName}" has node with type "CANVAS".`);
+                    let nodes = results[displayName];
+                    InspectorTest.expectEqual(nodes.length, 1, `Canvas "${displayName}" has one node.`);
+                    InspectorTest.expectThat(nodes[0], `Canvas "${displayName}" has node with valid id.`);
+                    InspectorTest.expectEqual(nodes[0].nodeName(), "CANVAS", `Canvas "${displayName}" has node with type "CANVAS".`);
                 }
 
                 resolve();
@@ -45,13 +47,13 @@ function test() {
 
             canvases.forEach((canvas) => {
                 WI.domManager.requestDocument((documentNode) => {
-                    CanvasAgent.requestNode(canvas.identifier, (error, nodeId) => {
+                    CanvasAgent.requestNodes(canvas.identifier, (error, nodeIds) => {
                         if (error) {
                             reject(error);
                             return;
                         }
 
-                        nodesMap.set(canvas, WI.domManager.nodeForId(nodeId));
+                        nodesMap.set(canvas, nodeIds.map((nodeId) => WI.domManager.nodeForId(nodeId)));
                         if (nodesMap.size === expectedLength)
                             finish();
                     });
@@ -63,11 +65,11 @@ function test() {
     // ------
 
     suite.addTestCase({
-        name: "Canvas.requestNode.invalidCanvasId",
+        name: "Canvas.requestNodes.invalidCanvasId",
         description: "Invalid canvas identifiers should cause an error.",
         test(resolve, reject) {
             const canvasId = "DOES_NOT_EXIST";
-            CanvasAgent.requestNode(canvasId, (error) => {
+            CanvasAgent.requestNodes(canvasId, (error) => {
                 InspectorTest.expectThat(error, "Should produce an error.");
                 InspectorTest.log("Error: " + error);
                 resolve();
@@ -83,7 +85,7 @@ function test() {
 </style>
 </head>
 <body onload="load()">
-<p>Test that CanvasAgent.requestNode can properly resolve the owner canvas node.</p>
+<p>Test that CanvasAgent.requestNodes can properly resolve canvas nodes.</p>
 <canvas id="onscreen"></canvas>
 </body>
 </html>

--- a/LayoutTests/inspector/canvas/worker-webgpu-expected.txt
+++ b/LayoutTests/inspector/canvas/worker-webgpu-expected.txt
@@ -8,7 +8,8 @@ PASS: WebGPU Canvas should belong to the Worker target.
 PASS: Worker Canvas should use the GPUDevice label as its display name.
 PASS: Payload should have type "object".
 PASS: Payload should have className "GPUDevice".
-PASS: Worker GPUDevice should have no DOM client nodes.
+PASS: Worker GPUDevice should have no DOM nodes.
+PASS: Worker GPUDevice should have no CSS canvas nodes.
 PASS: Worker GPUDevice should have the size of its OffscreenCanvas.
 PASS: Worker WebGPU Canvas content should not be empty.
 

--- a/LayoutTests/inspector/canvas/worker-webgpu.html
+++ b/LayoutTests/inspector/canvas/worker-webgpu.html
@@ -46,8 +46,10 @@ async function test() {
             InspectorTest.expectEqual(object.type, "object", `Payload should have type "object".`);
             InspectorTest.expectEqual(object.className, "GPUDevice", `Payload should have className "GPUDevice".`);
 
-            let clientNodes = await new Promise((resolve) => canvas.requestClientNodes(resolve));
-            InspectorTest.expectEqual(clientNodes.length, 0, "Worker GPUDevice should have no DOM client nodes.");
+            let nodes = await canvas.requestNodes();
+            InspectorTest.expectEqual(nodes.length, 0, "Worker GPUDevice should have no DOM nodes.");
+            let cssCanvasClientNodes = await canvas.requestCSSCanvasClientNodes();
+            InspectorTest.expectEqual(cssCanvasClientNodes.length, 0, "Worker GPUDevice should have no CSS canvas nodes.");
             InspectorTest.expectTrue(canvas.sizes.length === 1 && canvas.sizes[0].equals(new WI.Size(4, 4)), "Worker GPUDevice should have the size of its OffscreenCanvas.");
 
             let content = await canvas.requestContent();

--- a/Source/JavaScriptCore/inspector/protocol/Canvas.json
+++ b/Source/JavaScriptCore/inspector/protocol/Canvas.json
@@ -67,7 +67,6 @@
                 { "name": "canvasId", "$ref": "CanvasId", "description": "Canvas identifier." },
                 { "name": "contextType", "$ref": "ContextType", "description": "The type of rendering context backing the canvas." },
                 { "name": "sizes", "type": "array", "items": { "$ref": "GenericTypes.Size" }, "optional": true },
-                { "name": "nodeId", "$ref": "DOM.NodeId", "optional": true, "description": "The corresponding DOM node id." },
                 { "name": "cssCanvasNames", "type": "array", "items": { "type": "string" }, "optional": true, "description": "The CSS canvas identifiers, for canvases created with <code>document.getCSSCanvasContext</code>." },
                 { "name": "contextAttributes", "$ref": "ContextAttributes", "optional": true, "description": "Context attributes for rendering contexts." },
                 { "name": "features", "type": "array", "items": { "type": "string" }, "optional": true, "description": "Enabled WebGPU device features." },
@@ -99,14 +98,14 @@
             "description": "Disables Canvas domain events."
         },
         {
-            "name": "requestNode",
-            "description": "Gets the NodeId for the canvas node with the given CanvasId.",
+            "name": "requestNodes",
+            "description": "Gets the NodeIds for the canvas nodes with the given CanvasId.",
             "targetTypes": ["page"],
             "parameters": [
                 { "name": "canvasId", "$ref": "CanvasId", "description": "Canvas identifier." }
             ],
             "returns": [
-                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Node identifier for given canvas." }
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "DOM.NodeId" }, "description": "Node identifiers for the given canvas." }
             ]
         },
         {
@@ -120,15 +119,14 @@
             ]
         },
         {
-            "name": "requestClientNodes",
-            "description": "Gets all <code>-webkit-canvas</code> nodes or active <code>HTMLCanvasElement</code> for a <code>WebGPUDevice</code>.",
+            "name": "requestCSSCanvasClientNodes",
+            "description": "Gets all nodes using a <code>-webkit-canvas</code> image associated with the given CanvasId.",
             "targetTypes": ["page"],
             "parameters": [
                 { "name": "canvasId", "$ref": "CanvasId" }
             ],
             "returns": [
-                { "name": "clientNodeIds", "type": "array", "items": { "$ref": "DOM.NodeId" } },
-                { "name": "cssCanvasNames", "type": "array", "items": { "type": "string" }, "description": "The CSS canvas identifiers, for canvases created with <code>document.getCSSCanvasContext</code>." }
+                { "name": "clientNodeIds", "type": "array", "items": { "$ref": "DOM.NodeId" } }
             ]
         },
         {
@@ -240,10 +238,25 @@
             ]
         },
         {
-            "name": "clientNodesChanged",
+            "name": "nodesChanged",
             "targetTypes": ["page"],
             "parameters": [
                 { "name": "canvasId", "$ref": "CanvasId", "description": "Identifier of canvas that changed." }
+            ]
+        },
+        {
+            "name": "cssCanvasClientNodesChanged",
+            "targetTypes": ["page"],
+            "parameters": [
+                { "name": "canvasId", "$ref": "CanvasId", "description": "Identifier of canvas that changed." }
+            ]
+        },
+        {
+            "name": "cssCanvasNamesChanged",
+            "targetTypes": ["page"],
+            "parameters": [
+                { "name": "canvasId", "$ref": "CanvasId", "description": "Identifier of canvas that changed." },
+                { "name": "cssCanvasNames", "type": "array", "items": { "type": "string" }, "description": "The CSS canvas identifiers, for canvases created with <code>document.getCSSCanvasContext</code>." }
             ]
         },
         {

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -149,7 +149,6 @@ inspector/agents/InspectorNetworkAgent.cpp
 inspector/agents/InspectorPageAgent.cpp
 inspector/agents/WebHeapAgent.cpp
 inspector/agents/frame/FrameCSSAgent.cpp
-inspector/agents/page/PageCanvasAgent.cpp
 inspector/agents/page/PageRuntimeAgent.cpp
 inspector/agents/worker/WorkerAuditAgent.cpp
 inspector/agents/worker/WorkerDebuggerAgent.cpp

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -158,33 +158,30 @@ static bool canvasContextMatchesDevice(const CanvasRenderingContext& context, co
     return gpuCanvasContext && gpuCanvasContext->device() == &device;
 }
 
-HTMLCanvasElement* InspectorCanvas::canvasElement() const
+HashSet<HTMLCanvasElement*> InspectorCanvas::canvasElements() const
 {
     return WTF::switchOn(m_context,
         [](const WeakRef<CanvasRenderingContext>& weakContext) {
             Ref context = weakContext;
-            return dynamicDowncast<HTMLCanvasElement>(context->canvasBase());
+
+            HashSet<HTMLCanvasElement*> canvasElements;
+            if (RefPtr canvasElement = dynamicDowncast<HTMLCanvasElement>(context->canvasBase()))
+                canvasElements.add(canvasElement);
+            return canvasElements;
         },
         [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>& weakDevice) {
             Ref device = weakDevice;
 
-            RefPtr<HTMLCanvasElement> canvasElement;
+            HashSet<HTMLCanvasElement*> canvasElements;
             Locker locker { CanvasRenderingContext::instancesLock() };
             for (SUPPRESS_UNCOUNTED_ARG auto* context : CanvasRenderingContext::instances()) {
                 if (!context->isContextThread() || !canvasContextMatchesDevice(*context, device))
                     continue;
 
-                RefPtr currentCanvasElement = dynamicDowncast<HTMLCanvasElement>(context->canvasBase());
-                if (!currentCanvasElement)
-                    continue;
-
-                if (canvasElement) {
-                    canvasElement = nullptr;
-                    break;
-                }
-                canvasElement = currentCanvasElement;
+                if (RefPtr canvasElement = dynamicDowncast<HTMLCanvasElement>(context->canvasBase()))
+                    canvasElements.add(canvasElement);
             }
-            return canvasElement.unsafeGet();
+            return canvasElements;
         }
     );
 }
@@ -293,7 +290,7 @@ JSC::JSValue InspectorCanvas::resolveContext(JSC::JSGlobalObject* exec)
     );
 }
 
-HashSet<Element*> InspectorCanvas::clientNodes() const
+HashSet<Element*> InspectorCanvas::cssCanvasClientNodes() const
 {
     return WTF::switchOn(m_context,
         [](const WeakRef<CanvasRenderingContext>& weakContext) {
@@ -302,22 +299,16 @@ HashSet<Element*> InspectorCanvas::clientNodes() const
         },
         [](const WeakRef<GPUDevice, WeakPtrImplWithEventTargetData>& weakDevice) {
             Ref device = weakDevice;
-            HashSet<Element*> clientNodes;
+            HashSet<Element*> cssCanvasClientNodes;
             Locker locker { CanvasRenderingContext::instancesLock() };
             for (SUPPRESS_UNCOUNTED_ARG auto* context : CanvasRenderingContext::instances()) {
                 if (!context->isContextThread() || !canvasContextMatchesDevice(*context, device))
                     continue;
 
-                if (RefPtr canvasElement = dynamicDowncast<HTMLCanvasElement>(context->canvasBase())) {
-                    if (canvasElement->document().nameForCSSCanvasElement(*canvasElement).isEmpty())
-                        clientNodes.add(canvasElement);
-                    else {
-                        for (auto& clientNode : context->canvasBase().cssCanvasClients())
-                            clientNodes.add(clientNode);
-                    }
-                }
+                for (auto& cssCanvasClientNode : context->canvasBase().cssCanvasClients())
+                    cssCanvasClientNodes.add(cssCanvasClientNode);
             }
-            return clientNodes;
+            return cssCanvasClientNodes;
         }
     );
 }
@@ -671,8 +662,6 @@ Ref<Inspector::Protocol::Canvas::Canvas> InspectorCanvas::buildObjectForCanvas(b
                 .setCanvasId(m_identifier)
                 .setContextType(contextType)
                 .release();
-
-            // FIXME: <https://webkit.org/b/178282> Web Inspector: send a DOM node with each Canvas payload and eliminate Canvas.requestNode
 
             if (auto attributes = buildObjectForCanvasContextAttributes(context))
                 result->setContextAttributes(attributes.releaseNonNull());

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -73,7 +73,7 @@ public:
     CanvasRenderingContext* canvasContext() const;
     GPUDevice* deviceContext() const;
 
-    HTMLCanvasElement* canvasElement() const;
+    HashSet<HTMLCanvasElement*> canvasElements() const;
 
     Vector<IntSize> sizes() const;
     Vector<String> cssCanvasNames() const;
@@ -82,7 +82,7 @@ public:
 
     JSC::JSValue resolveContext(JSC::JSGlobalObject*);
 
-    HashSet<Element*> clientNodes() const;
+    HashSet<Element*> cssCanvasClientNodes() const;
     size_t memoryCost() const;
 
     void canvasChanged();

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
@@ -85,28 +85,7 @@ void PageCanvasAgent::internalDisable()
     InspectorCanvasAgent::internalDisable();
 }
 
-Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> PageCanvasAgent::requestNode(const Inspector::Protocol::Canvas::CanvasId& canvasId)
-{
-    Inspector::Protocol::ErrorString errorString;
-
-    auto inspectorCanvas = assertInspectorCanvas(errorString, canvasId);
-    if (!inspectorCanvas)
-        return makeUnexpected(errorString);
-
-    RefPtr node = inspectorCanvas->canvasElement();
-    if (!node)
-        return makeUnexpected("Missing element of canvas for given canvasId"_s);
-
-    // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
-    Ref agents = m_instrumentingAgents.get();
-    int documentNodeId = agents->persistentDOMAgent()->boundNodeId(protect(node->document()).ptr());
-    if (!documentNodeId)
-        return makeUnexpected("Document must have been requested"_s);
-
-    return agents->persistentDOMAgent()->pushNodeToFrontend(errorString, documentNodeId, node);
-}
-
-Inspector::Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>, Ref<JSON::ArrayOf<String>>>> PageCanvasAgent::requestClientNodes(const Inspector::Protocol::Canvas::CanvasId& canvasId)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> PageCanvasAgent::requestNodes(const Inspector::Protocol::Canvas::CanvasId& canvasId)
 {
     Inspector::Protocol::ErrorString errorString;
 
@@ -118,20 +97,47 @@ Inspector::Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Inspector::Proto
     if (!inspectorCanvas)
         return makeUnexpected(errorString);
 
-    auto clientNodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
-    for (auto& clientNode : inspectorCanvas->clientNodes()) {
+    auto nodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
+    for (RefPtr canvasElement : inspectorCanvas->canvasElements()) {
         // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
-        if (auto documentNodeId = domAgent->boundNodeId(protect(clientNode->document()).ptr()))
-            clientNodeIds->addItem(domAgent->pushNodeToFrontend(errorString, documentNodeId, clientNode));
+        auto documentNodeId = domAgent->boundNodeId(protect(canvasElement->document()).ptr());
+        if (!documentNodeId)
+            return makeUnexpected("Document must have been requested"_s);
+
+        auto currentNodeId = domAgent->pushNodeToFrontend(errorString, documentNodeId, canvasElement);
+        if (!currentNodeId)
+            return makeUnexpected(errorString);
+
+        nodeIds->addItem(currentNodeId);
     }
 
-    Ref cssCanvasNamesPayload = JSON::ArrayOf<String>::create();
-    for (auto& cssCanvasName : inspectorCanvas->cssCanvasNames())
-        cssCanvasNamesPayload->addItem(cssCanvasName);
+    m_pendingNodesChange.remove(*inspectorCanvas);
 
-    m_inspectorCanvasesWithPendingClientNodesChange.remove(*inspectorCanvas);
+    return nodeIds;
+}
 
-    return { { WTF::move(clientNodeIds), WTF::move(cssCanvasNamesPayload) } };
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> PageCanvasAgent::requestCSSCanvasClientNodes(const Inspector::Protocol::Canvas::CanvasId& canvasId)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    CheckedPtr domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    if (!domAgent)
+        return makeUnexpected("DOM domain must be enabled"_s);
+
+    auto inspectorCanvas = assertInspectorCanvas(errorString, canvasId);
+    if (!inspectorCanvas)
+        return makeUnexpected(errorString);
+
+    auto nodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
+    for (RefPtr cssCanvasClientNode : inspectorCanvas->cssCanvasClientNodes()) {
+        // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
+        if (auto documentNodeId = domAgent->boundNodeId(protect(cssCanvasClientNode->document()).ptr()))
+            nodeIds->addItem(domAgent->pushNodeToFrontend(errorString, documentNodeId, cssCanvasClientNode));
+    }
+
+    m_pendingCSSCanvasClientNodesChange.remove(*inspectorCanvas);
+
+    return nodeIds;
 }
 
 void PageCanvasAgent::frameNavigated(LocalFrame& frame)
@@ -145,9 +151,11 @@ void PageCanvasAgent::frameNavigated(LocalFrame& frame)
     for (auto& inspectorCanvas : m_identifierToInspectorCanvas.values()) {
         if (!inspectorCanvas->canvasContext())
             continue;
-        if (RefPtr canvasElement = inspectorCanvas->canvasElement()) {
-            if (canvasElement->document().frame() == &frame)
+        for (RefPtr canvasElement : inspectorCanvas->canvasElements()) {
+            if (canvasElement->document().frame() == &frame) {
                 inspectorCanvases.append(inspectorCanvas.ptr());
+                break;
+            }
         }
     }
     for (RefPtr inspectorCanvas : inspectorCanvases)
@@ -175,7 +183,7 @@ void PageCanvasAgent::didChangeCSSCanvasClientNodes(CanvasBase& canvasBase)
     if (!inspectorCanvas)
         return;
 
-    dispatchClientNodesChanged(*inspectorCanvas);
+    dispatchCSSCanvasClientNodesChanged(*inspectorCanvas);
 }
 
 void PageCanvasAgent::didChangeGPUDeviceClientNodes(GPUDevice& device)
@@ -186,41 +194,33 @@ void PageCanvasAgent::didChangeGPUDeviceClientNodes(GPUDevice& device)
     if (!inspectorCanvas)
         return;
 
-    dispatchClientNodesChanged(*inspectorCanvas);
+    dispatchCSSCanvasNamesChanged(*inspectorCanvas);
+    dispatchCSSCanvasClientNodesChanged(*inspectorCanvas);
+    dispatchNodesChanged(*inspectorCanvas);
 }
 
-Ref<Inspector::Protocol::Canvas::Canvas> PageCanvasAgent::buildObjectForCanvas(InspectorCanvas& inspectorCanvas, bool captureBacktrace)
+void PageCanvasAgent::dispatchNodesChanged(InspectorCanvas& inspectorCanvas)
 {
-    Ref result = InspectorCanvasAgent::buildObjectForCanvas(inspectorCanvas, captureBacktrace);
-
-    RefPtr canvasElement = inspectorCanvas.canvasElement();
-    if (auto nodeId = nodeIdForCanvas(canvasElement))
-        result->setNodeId(*nodeId);
-
-    return result;
-}
-
-std::optional<Inspector::Protocol::DOM::NodeId> PageCanvasAgent::nodeIdForCanvas(HTMLCanvasElement* canvasElement)
-{
-    if (!canvasElement)
-        return std::nullopt;
-
-    CheckedPtr domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
-    if (!domAgent)
-        return std::nullopt;
-
-    auto nodeId = domAgent->pushNodeToFrontend(canvasElement);
-    if (!nodeId)
-        return std::nullopt;
-    return nodeId;
-}
-
-void PageCanvasAgent::dispatchClientNodesChanged(InspectorCanvas& inspectorCanvas)
-{
-    if (!m_inspectorCanvasesWithPendingClientNodesChange.add(inspectorCanvas).isNewEntry)
+    if (!m_pendingNodesChange.add(inspectorCanvas).isNewEntry)
         return;
 
-    m_frontendDispatcher->clientNodesChanged(inspectorCanvas.identifier());
+    m_frontendDispatcher->nodesChanged(inspectorCanvas.identifier());
+}
+
+void PageCanvasAgent::dispatchCSSCanvasClientNodesChanged(InspectorCanvas& inspectorCanvas)
+{
+    if (!m_pendingCSSCanvasClientNodesChange.add(inspectorCanvas).isNewEntry)
+        return;
+
+    m_frontendDispatcher->cssCanvasClientNodesChanged(inspectorCanvas.identifier());
+}
+
+void PageCanvasAgent::dispatchCSSCanvasNamesChanged(InspectorCanvas& inspectorCanvas)
+{
+    Ref cssCanvasNames = JSON::ArrayOf<String>::create();
+    for (auto& cssCanvasName : inspectorCanvas.cssCanvasNames())
+        cssCanvasNames->addItem(cssCanvasName);
+    m_frontendDispatcher->cssCanvasNamesChanged(inspectorCanvas.identifier(), WTF::move(cssCanvasNames));
 }
 
 bool PageCanvasAgent::matchesCurrentContext(ScriptExecutionContext* scriptExecutionContext) const

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.h
@@ -43,8 +43,8 @@ public:
     ~PageCanvasAgent();
 
     // CanvasBackendDispatcherHandler
-    Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> requestNode(const Inspector::Protocol::Canvas::CanvasId&) override;
-    Inspector::Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>, Ref<JSON::ArrayOf<String>>>> requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&) override;
+    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> requestNodes(const Inspector::Protocol::Canvas::CanvasId&) override;
+    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> requestCSSCanvasClientNodes(const Inspector::Protocol::Canvas::CanvasId&) override;
 
     // InspectorInstrumentation
     void frameNavigated(LocalFrame&);
@@ -57,14 +57,15 @@ private:
     void internalEnable() override;
     void internalDisable() override;
 
-    Ref<Inspector::Protocol::Canvas::Canvas> buildObjectForCanvas(InspectorCanvas&, bool captureBacktrace) override;
-    std::optional<Inspector::Protocol::DOM::NodeId> nodeIdForCanvas(HTMLCanvasElement*);
-    void dispatchClientNodesChanged(InspectorCanvas&);
+    void dispatchNodesChanged(InspectorCanvas&);
+    void dispatchCSSCanvasClientNodesChanged(InspectorCanvas&);
+    void dispatchCSSCanvasNamesChanged(InspectorCanvas&);
 
     bool matchesCurrentContext(ScriptExecutionContext*) const override;
 
     WeakRef<Page> m_inspectedPage;
-    WeakHashSet<InspectorCanvas> m_inspectorCanvasesWithPendingClientNodesChange;
+    WeakHashSet<InspectorCanvas> m_pendingNodesChange;
+    WeakHashSet<InspectorCanvas> m_pendingCSSCanvasClientNodesChange;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp
@@ -44,12 +44,12 @@ WorkerCanvasAgent::WorkerCanvasAgent(WorkerAgentContext& context)
 
 WorkerCanvasAgent::~WorkerCanvasAgent() = default;
 
-Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> WorkerCanvasAgent::requestNode(const Inspector::Protocol::Canvas::CanvasId&)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> WorkerCanvasAgent::requestNodes(const Inspector::Protocol::Canvas::CanvasId&)
 {
     return makeUnexpected("Not supported"_s);
 }
 
-Inspector::Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>, Ref<JSON::ArrayOf<String>>>> WorkerCanvasAgent::requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> WorkerCanvasAgent::requestCSSCanvasClientNodes(const Inspector::Protocol::Canvas::CanvasId&)
 {
     return makeUnexpected("Not supported"_s);
 }

--- a/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.h
@@ -41,8 +41,8 @@ public:
     ~WorkerCanvasAgent();
 
     // CanvasBackendDispatcherHandler
-    Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> requestNode(const Inspector::Protocol::Canvas::CanvasId&) override;
-    Inspector::Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>, Ref<JSON::ArrayOf<String>>>> requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&) override;
+    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> requestNodes(const Inspector::Protocol::Canvas::CanvasId&) override;
+    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> requestCSSCanvasClientNodes(const Inspector::Protocol::Canvas::CanvasId&) override;
 
 private:
     bool matchesCurrentContext(ScriptExecutionContext*) const override;

--- a/Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js
@@ -206,13 +206,31 @@ WI.CanvasManager = class CanvasManager extends WI.Object
         canvas.memoryChanged(memoryCost);
     }
 
-    clientNodesChanged(target, canvasIdentifier)
+    nodesChanged(target, canvasIdentifier)
     {
         let canvas = this._canvasForIdentifier(target, canvasIdentifier);
         if (!canvas)
             return;
 
-        canvas.clientNodesChanged();
+        canvas.nodesChanged();
+    }
+
+    cssCanvasClientNodesChanged(target, canvasIdentifier)
+    {
+        let canvas = this._canvasForIdentifier(target, canvasIdentifier);
+        if (!canvas)
+            return;
+
+        canvas.cssCanvasClientNodesChanged();
+    }
+
+    cssCanvasNamesChanged(target, canvasIdentifier, cssCanvasNames)
+    {
+        let canvas = this._canvasForIdentifier(target, canvasIdentifier);
+        if (!canvas)
+            return;
+
+        canvas.cssCanvasNamesChanged(cssCanvasNames);
     }
 
     recordingStarted(target, canvasIdentifier, initiator)

--- a/Source/WebInspectorUI/UserInterface/Models/Canvas.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Canvas.js
@@ -25,7 +25,7 @@
 
 WI.Canvas = class Canvas extends WI.Object
 {
-    constructor(target, identifier, contextType, sizes, {domNode, cssCanvasNames, contextAttributes, features, memoryCost, stackTrace, displayName} = {})
+    constructor(target, identifier, contextType, sizes, {cssCanvasNames, contextAttributes, features, memoryCost, stackTrace, displayName} = {})
     {
         super();
 
@@ -40,7 +40,7 @@ WI.Canvas = class Canvas extends WI.Object
         this._identifier = identifier;
         this._contextType = contextType;
         this._sizes = sizes;
-        this._domNode = domNode || null;
+        this._domNodes = [];
         this._cssCanvasNames = cssCanvasNames || [];
         this._contextAttributes = contextAttributes || {};
         this._features = features || [];
@@ -49,15 +49,15 @@ WI.Canvas = class Canvas extends WI.Object
         this._stackTrace = stackTrace || null;
         this._displayName = displayName || "";
 
-        this._clientNodes = null;
-        this._requestClientNodesCallbacks = [];
-
         this._shaderProgramCollection = new WI.ShaderProgramCollection;
         this._recordingCollection = new WI.RecordingCollection;
 
         this._nextShaderProgramDisplayNumber = null;
 
-        this._requestNodePromise = this._domNode ? Promise.resolve(this._domNode) : null;
+        this._requestNodesPromise = null;
+
+        this._cssCanvasClientNodes = [];
+        this._requestCSSCanvasClientNodesPromise = null;
 
         this._recordingState = WI.Canvas.RecordingState.Inactive;
         this._recordingFrames = [];
@@ -67,8 +67,8 @@ WI.Canvas = class Canvas extends WI.Object
         if (!InspectorBackend.hasEvent("Canvas.canvasSizeChanged")) {
             console.assert(!sizes.length);
 
-            this.requestNode().then((node) => {
-                if (node) {
+            this.requestNodes().then((nodes) => {
+                for (let node of nodes) {
                     node.addEventListener(WI.DOMNode.Event.AttributeModified, this._calculateSize, this);
                     node.addEventListener(WI.DOMNode.Event.AttributeRemoved, this._calculateSize, this);
                 }
@@ -128,7 +128,6 @@ WI.Canvas = class Canvas extends WI.Object
             payload.stackTrace = {callFrames: payload.backtrace};
 
         return new WI.Canvas(target, payload.canvasId, contextType, sizes, {
-            domNode: WI.Canvas._domNodeForId(target, payload.nodeId),
             cssCanvasNames,
             contextAttributes: payload.contextAttributes,
             features: payload.features,
@@ -140,8 +139,6 @@ WI.Canvas = class Canvas extends WI.Object
 
     static _domNodeForId(target, nodeId)
     {
-        if (!nodeId)
-            return null;
         if (target instanceof WI.FrameTarget)
             return WI.domManager.nodeForIdInFrameTarget(nodeId, target);
         return WI.domManager.nodeForId(nodeId);
@@ -233,8 +230,8 @@ WI.Canvas = class Canvas extends WI.Object
         if (this._cssCanvasNames.length === 1)
             return WI.UIString("CSS canvas \u201C%s\u201D").format(this._cssCanvasNames[0]);
 
-        if (this._domNode) {
-            let idSelector = this._domNode.escapedIdSelector;
+        if (this._domNodes.length === 1) {
+            let idSelector = this._domNodes[0].escapedIdSelector;
             if (idSelector)
                 return WI.UIString("Canvas %s").format(idSelector);
         }
@@ -264,40 +261,30 @@ WI.Canvas = class Canvas extends WI.Object
         return this._contextType === Canvas.ContextType.WebGL2 || this._contextType === Canvas.ContextType.OffscreenWebGL2;
     }
 
-    requestNode()
+    requestNodes()
     {
-        if (!this._requestNodePromise) {
-            let promise = new Promise((resolve, reject) => {
+        if (!this._requestNodesPromise) {
+            let requestPromise;
+            // COMPATIBILITY (macOS X.Y, iOS X.Y): `Canvas.requestNode` was renamed to `Canvas.requestNodes`.
+            if (this._target.hasCommand("Canvas.requestNode")) {
                 WI.domManager.ensureDocument();
+                requestPromise = this._target.CanvasAgent.requestNode(this._identifier).then(({nodeId}) => ({nodeIds: nodeId ? [nodeId] : []}));
+            } else if (this._target.hasCommand("Canvas.requestNodes")) {
+                WI.domManager.ensureDocument();
+                requestPromise = this._target.CanvasAgent.requestNodes(this._identifier);
+            } else
+                requestPromise = Promise.resolve({nodeIds: []});
 
-                if (!this._target.hasCommand("Canvas.requestNode")) {
-                    resolve(null);
-                    return;
-                }
+            let promise = requestPromise.then(({nodeIds}) => {
+                if (promise !== this._requestNodesPromise)
+                    return this._domNodes;
 
-                this._target.CanvasAgent.requestNode(this._identifier, (error, nodeId) => {
-                    if (promise !== this._requestNodePromise) {
-                        resolve(this._domNode);
-                        return;
-                    }
-
-                    if (error) {
-                        resolve(null);
-                        return;
-                    }
-
-                    this._domNode = WI.Canvas._domNodeForId(this._target, nodeId);
-                    if (!this._domNode) {
-                        resolve(null);
-                        return;
-                    }
-
-                    resolve(this._domNode);
-                });
-            });
-            this._requestNodePromise = promise;
+                this._domNodes = nodeIds.map((nodeId) => WI.Canvas._domNodeForId(this._target, nodeId));
+                return this._domNodes;
+            }, () => promise === this._requestNodesPromise ? [] : this._domNodes);
+            this._requestNodesPromise = promise;
         }
-        return this._requestNodePromise;
+        return this._requestNodesPromise;
     }
 
     requestContent()
@@ -305,46 +292,43 @@ WI.Canvas = class Canvas extends WI.Object
         return this._target.CanvasAgent.requestContent(this._identifier).then((result) => result.content).catch((error) => console.error(error));
     }
 
-    requestClientNodes(callback)
+    requestCSSCanvasClientNodes()
     {
-        if (this._clientNodes) {
-            callback(this._clientNodes);
-            return;
+        if (!this._requestCSSCanvasClientNodesPromise) {
+            let requestPromise;
+            // COMPATIBILITY (macOS X.Y, iOS X.Y): `Canvas.requestCSSCanvasClientNodes` was temporarily renamed to `Canvas.requestClientNodes`.
+            if (this._target.hasCommand("Canvas.requestClientNodes")) {
+                WI.domManager.ensureDocument();
+                requestPromise = this._target.CanvasAgent.requestClientNodes(this._identifier);
+            } else if (this._target.hasCommand("Canvas.requestCSSCanvasClientNodes")) {
+                WI.domManager.ensureDocument();
+                requestPromise = this._target.CanvasAgent.requestCSSCanvasClientNodes(this._identifier);
+            } else
+                requestPromise = Promise.resolve({clientNodeIds: []});
+
+            let promise = requestPromise.then(({clientNodeIds}) => {
+                if (promise !== this._requestCSSCanvasClientNodesPromise)
+                    return this._cssCanvasClientNodes;
+
+                this._cssCanvasClientNodes = clientNodeIds.map((clientNodeId) => WI.Canvas._domNodeForId(this._target, clientNodeId));
+                return this._cssCanvasClientNodes;
+            }, () => promise === this._requestCSSCanvasClientNodesPromise ? [] : this._cssCanvasClientNodes);
+            this._requestCSSCanvasClientNodesPromise = promise;
         }
+        return this._requestCSSCanvasClientNodesPromise;
+    }
 
-        this._requestClientNodesCallbacks.push(callback);
-        if (this._requestClientNodesCallbacks.length > 1)
-            return;
-
-        WI.domManager.ensureDocument();
-
-        let wrappedCallback = (error, clientNodeIds, cssCanvasNames) => {
-            let clientNodes = [];
-            if (!error) {
-                if (cssCanvasNames)
-                    this._cssCanvasNames = cssCanvasNames;
-
-                this._clientNodes = clientNodes = clientNodeIds.map((clientNodeId) => WI.Canvas._domNodeForId(this._target, clientNodeId));
-            }
-
-            let callbacks = this._requestClientNodesCallbacks;
-            this._requestClientNodesCallbacks = [];
-            for (let callback of callbacks)
-                callback(clientNodes);
-        };
-
-        if (this._target.hasCommand("Canvas.requestClientNodes")) {
-            this._target.CanvasAgent.requestClientNodes(this._identifier, wrappedCallback);
-            return;
-        }
-
-        // COMPATIBILITY (iOS 13): Canvas.requestCSSCanvasClientNodes was renamed to Canvas.requestClientNodes.
-        if (this._target.hasCommand("Canvas.requestCSSCanvasClientNodes")) {
-            this._target.CanvasAgent.requestCSSCanvasClientNodes(this._identifier, wrappedCallback);
-            return;
-        }
-
-        wrappedCallback(null, []);
+    highlight()
+    {
+        Promise.all([
+            (!this._cssCanvasNames.length || this._contextType === Canvas.ContextType.WebGPU) ? this.requestNodes() : [],
+            (this._cssCanvasNames.length || this._contextType === Canvas.ContextType.WebGPU) ? this.requestCSSCanvasClientNodes() : [],
+        ]).then((nodesLists) => {
+            let nodes = nodesLists.flat();
+            if (!nodes.length)
+                return;
+            WI.domManager.highlightDOMNodeList(nodes);
+        });
     }
 
     startRecording(singleFrame)
@@ -373,9 +357,9 @@ WI.Canvas = class Canvas extends WI.Object
     saveIdentityToCookie(cookie)
     {
         if (this._cssCanvasNames.length)
-            cookie[WI.Canvas.CSSCanvasNameCookieKey] = this._cssCanvasNames.join(",");
-        else if (this._domNode)
-            cookie[WI.Canvas.NodePathCookieKey] = this._domNode.path;
+            cookie[WI.Canvas.CSSCanvasNameCookieKey] = JSON.stringify(this._cssCanvasNames);
+        else if (this._domNodes.length)
+            cookie[WI.Canvas.NodePathCookieKey] = JSON.stringify(this._domNodes.map((domNode) => domNode.path));
 
     }
 
@@ -415,16 +399,37 @@ WI.Canvas = class Canvas extends WI.Object
         this.dispatchEventToListeners(WI.Canvas.Event.ExtensionEnabled, {extension});
     }
 
-    clientNodesChanged()
+    nodesChanged()
     {
         // Called from WI.CanvasManager.
 
-        if (this._contextType === Canvas.ContextType.WebGPU)
-            this._requestNodePromise = null;
+        this._requestNodesPromise = null;
 
-        this._clientNodes = null;
+        this.dispatchEventToListeners(Canvas.Event.NodesChanged);
+    }
 
-        this.dispatchEventToListeners(Canvas.Event.ClientNodesChanged);
+    cssCanvasClientNodesChanged()
+    {
+        // Called from WI.CanvasManager.
+
+        this._cssCanvasClientNodes = null;
+        this._requestCSSCanvasClientNodesPromise = null;
+
+        this.dispatchEventToListeners(Canvas.Event.CSSCanvasClientNodesChanged);
+    }
+
+    cssCanvasNamesChanged(cssCanvasNames)
+    {
+        // Called from WI.CanvasManager.
+
+        console.assert(Array.isArray(cssCanvasNames), cssCanvasNames);
+
+        if (Array.shallowEqual(this._cssCanvasNames, cssCanvasNames))
+            return;
+
+        this._cssCanvasNames = cssCanvasNames;
+
+        this.dispatchEventToListeners(Canvas.Event.CSSCanvasNamesChanged);
     }
 
     recordingStarted(initiator)
@@ -545,7 +550,9 @@ WI.Canvas.Event = {
     SizeChanged: "canvas-size-changed",
     MemoryChanged: "canvas-memory-changed",
     ExtensionEnabled: "canvas-extension-enabled",
-    ClientNodesChanged: "canvas-client-nodes-changed",
+    NodesChanged: "canvas-nodes-changed",
+    CSSCanvasClientNodesChanged: "canvas-css-canvas-client-nodes-changed",
+    CSSCanvasNamesChanged: "canvas-css-canvas-names-changed",
     RecordingStarted: "canvas-recording-started",
     RecordingProgress: "canvas-recording-progress",
     RecordingStopped: "canvas-recording-stopped",

--- a/Source/WebInspectorUI/UserInterface/Protocol/CanvasObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/CanvasObserver.js
@@ -51,9 +51,19 @@ WI.CanvasObserver = class CanvasObserver extends InspectorBackend.Dispatcher
         WI.canvasManager.canvasMemoryChanged(this._target, canvasId, memoryCost);
     }
 
-    clientNodesChanged(canvasId)
+    nodesChanged(canvasId)
     {
-        WI.canvasManager.clientNodesChanged(this._target, canvasId);
+        WI.canvasManager.nodesChanged(this._target, canvasId);
+    }
+
+    cssCanvasClientNodesChanged(canvasId)
+    {
+        WI.canvasManager.cssCanvasClientNodesChanged(this._target, canvasId);
+    }
+
+    cssCanvasNamesChanged(canvasId, cssCanvasNames)
+    {
+        WI.canvasManager.cssCanvasNamesChanged(this._target, canvasId, cssCanvasNames);
     }
 
     recordingStarted(canvasId, initiator)
@@ -93,9 +103,9 @@ WI.CanvasObserver = class CanvasObserver extends InspectorBackend.Dispatcher
         WI.canvasManager.programDeleted(this._target, programId);
     }
 
-    // COMPATIBILITY (iOS 13): Canvas.events.cssCanvasClientNodesChanged was renamed to Canvas.events.clientNodesChanged.
-    cssCanvasClientNodesChanged(canvasId)
+    // COMPATIBILITY (macOS X.Y, iOS X.Y): `Canvas.clientNodesChanged` was renamed to `Canvas.cssCanvasClientNodesChanged`.
+    clientNodesChanged(canvasId)
     {
-        WI.canvasManager.clientNodesChanged(this._target, canvasId);
+        WI.canvasManager.cssCanvasClientNodesChanged(this._target, canvasId);
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js
@@ -40,8 +40,8 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
         this._memoryCostElement = null;
         this._pendingContent = null;
         this._pixelSizeElement = null;
-        this._canvasNode = null;
-        this._requestNodePromise = null;
+        this._canvasNodes = [];
+        this._requestNodesPromise = null;
 
         this._refreshButtonNavigationItem = new WI.ButtonNavigationItem("refresh", WI.UIString("Refresh"), "Images/ReloadFull.svg", 13, 13);
         this._refreshButtonNavigationItem.visibilityPriority = WI.NavigationItem.VisibilityPriority.Low;
@@ -206,7 +206,7 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
 
         this.representedObject.addEventListener(WI.Canvas.Event.SizeChanged, this._updateSize, this);
         this.representedObject.addEventListener(WI.Canvas.Event.MemoryChanged, this._updateMemoryCost, this);
-        this.representedObject.addEventListener(WI.Canvas.Event.ClientNodesChanged, this._updateCanvasNode, this);
+        this.representedObject.addEventListener(WI.Canvas.Event.NodesChanged, this._updateCanvasNode, this);
         this.representedObject.addEventListener(WI.Canvas.Event.RecordingStarted, this.needsLayout, this);
         this.representedObject.addEventListener(WI.Canvas.Event.RecordingProgress, this.needsLayout, this);
         this.representedObject.addEventListener(WI.Canvas.Event.RecordingStopped, this.needsLayout, this);
@@ -226,7 +226,7 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
     {
         this.representedObject.removeEventListener(WI.Canvas.Event.SizeChanged, this._updateSize, this);
         this.representedObject.removeEventListener(WI.Canvas.Event.MemoryChanged, this._updateMemoryCost, this);
-        this.representedObject.removeEventListener(WI.Canvas.Event.ClientNodesChanged, this._updateCanvasNode, this);
+        this.representedObject.removeEventListener(WI.Canvas.Event.NodesChanged, this._updateCanvasNode, this);
         this.representedObject.removeEventListener(WI.Canvas.Event.RecordingStarted, this.needsLayout, this);
         this.representedObject.removeEventListener(WI.Canvas.Event.RecordingProgress, this.needsLayout, this);
         this.representedObject.removeEventListener(WI.Canvas.Event.RecordingStopped, this.needsLayout, this);
@@ -235,8 +235,8 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
         this.representedObject.shaderProgramCollection.removeEventListener(WI.Collection.Event.ItemAdded, this.needsLayout, this);
         this.representedObject.shaderProgramCollection.removeEventListener(WI.Collection.Event.ItemRemoved, this.needsLayout, this);
 
-        this._canvasNode = null;
-        this._requestNodePromise = null;
+        this._canvasNodes = [];
+        this._requestNodesPromise = null;
 
         WI.settings.showImageGrid.removeEventListener(WI.Setting.Event.Changed, this._updateImageGrid, this);
 
@@ -283,8 +283,8 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
 
         contextMenu.appendSeparator();
 
-        if (this._canvasNode)
-            WI.appendContextMenuItemsForDOMNode(contextMenu, this._canvasNode);
+        if (this._canvasNodes.length === 1)
+            WI.appendContextMenuItemsForDOMNode(contextMenu, this._canvasNodes[0]);
     }
 
     _showGridButtonClicked()
@@ -316,24 +316,15 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
 
     _updateCanvasNode()
     {
-        this._canvasNode = null;
+        this._canvasNodes = [];
 
-        let requestNode = () => {
-            let requestNodePromise = this.representedObject.requestNode();
-            this._requestNodePromise = requestNodePromise;
-            requestNodePromise.then((node) => {
-                if (this._requestNodePromise !== requestNodePromise)
-                    return;
-                this._canvasNode = node;
-            });
-        };
-
-        if (this.representedObject.cssCanvasNames.length || this.representedObject.contextType === WI.Canvas.ContextType.WebGPU) {
-            this.representedObject.requestClientNodes(requestNode);
-            return;
-        }
-
-        requestNode();
+        let requestNodesPromise = this.representedObject.requestNodes();
+        this._requestNodesPromise = requestNodesPromise;
+        requestNodesPromise.then((nodes) => {
+            if (this._requestNodesPromise !== requestNodesPromise)
+                return;
+            this._canvasNodes = nodes;
+        });
     }
 
     _updateMemoryCost()

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.js
@@ -32,7 +32,7 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         this.element.classList.add("canvas");
 
         this._canvas = null;
-        this._nodeRequestPromise = null;
+        this._nodesRequestPromise = null;
 
         this._sections = [];
         this._emptyContentPlaceholder = null;
@@ -68,13 +68,15 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         if (canvas === this._canvas)
             return;
 
-        this._nodeRequestPromise = null;
+        this._nodesRequestPromise = null;
 
         if (this._canvas) {
             this._canvas.removeEventListener(WI.Canvas.Event.MemoryChanged, this._canvasMemoryChanged, this);
             this._canvas.removeEventListener(WI.Canvas.Event.ExtensionEnabled, this._refreshExtensionsSection, this);
             this._canvas.removeEventListener(WI.Canvas.Event.SizeChanged, this._refreshSourceSection, this);
-            this._canvas.removeEventListener(WI.Canvas.Event.ClientNodesChanged, this._handleClientNodesChanged, this);
+            this._canvas.removeEventListener(WI.Canvas.Event.NodesChanged, this._handleNodesChanged, this);
+            this._canvas.removeEventListener(WI.Canvas.Event.CSSCanvasClientNodesChanged, this._handleCSSCanvasClientNodesChanged, this);
+            this._canvas.removeEventListener(WI.Canvas.Event.CSSCanvasNamesChanged, this._handleCSSCanvasNamesChanged, this);
         }
 
         this._canvas = canvas || null;
@@ -83,7 +85,9 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
             this._canvas.addEventListener(WI.Canvas.Event.MemoryChanged, this._canvasMemoryChanged, this);
             this._canvas.addEventListener(WI.Canvas.Event.ExtensionEnabled, this._refreshExtensionsSection, this);
             this._canvas.addEventListener(WI.Canvas.Event.SizeChanged, this._refreshSourceSection, this);
-            this._canvas.addEventListener(WI.Canvas.Event.ClientNodesChanged, this._handleClientNodesChanged, this);
+            this._canvas.addEventListener(WI.Canvas.Event.NodesChanged, this._handleNodesChanged, this);
+            this._canvas.addEventListener(WI.Canvas.Event.CSSCanvasClientNodesChanged, this._handleCSSCanvasClientNodesChanged, this);
+            this._canvas.addEventListener(WI.Canvas.Event.CSSCanvasNamesChanged, this._handleCSSCanvasNamesChanged, this);
         }
 
         this.needsLayout();
@@ -104,7 +108,7 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         identitySection.groups = [new WI.DetailsSectionGroup([this._nameRow, this._typeRow, this._memoryRow])];
         this._sections.push(identitySection);
 
-        this._nodeRow = new WI.DetailsSectionSimpleRow(WI.UIString("Node"));
+        this._nodeRow = new WI.DetailsSectionSimpleRow(WI.UIString("Nodes"));
         this._cssCanvasRow = new WI.DetailsSectionSimpleRow(WI.UIString("CSS Canvas"));
         this._widthRow = new WI.DetailsSectionSimpleRow(WI.UIString("Width"));
         this._heightRow = new WI.DetailsSectionSimpleRow(WI.UIString("Height"));
@@ -198,24 +202,23 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
 
         this._detachedRow.value = null;
 
-        if (this._canvas.cssCanvasNames.length)
-            this._nodeRow.value = null;
-        else {
-            let nodeRequestPromise = this._canvas.requestNode();
-            this._nodeRequestPromise = nodeRequestPromise;
-            this._nodeRequestPromise.then((node) => {
-                if (this._nodeRequestPromise !== nodeRequestPromise)
-                    return;
+        let nodesRequestPromise = this._canvas.requestNodes();
+        this._nodesRequestPromise = nodesRequestPromise;
+        this._nodesRequestPromise.then((nodes) => {
+            if (this._nodesRequestPromise !== nodesRequestPromise)
+                return;
 
-                if (!node) {
-                    this._nodeRow.value = null;
-                    return;
-                }
+            if (!nodes.length) {
+                this._nodeRow.value = null;
+                return;
+            }
 
-                this._nodeRow.value = WI.linkifyNodeReference(node);
-                this._detachedRow.value = node.parentNode ? null : WI.UIString("Yes");
-            });
-        }
+            let fragment = document.createDocumentFragment();
+            for (let node of nodes)
+                fragment.appendChild(WI.linkifyNodeReference(node));
+            this._nodeRow.value = fragment;
+            this._detachedRow.value = nodes.some((node) => !node.parentNode) ? WI.UIString("Yes") : null;
+        });
 
         this._cssCanvasRow.value = this._canvas.cssCanvasNames.join(", ") || null;
 
@@ -287,7 +290,7 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         if (!this.didInitialLayout)
             return;
 
-        if (!this._canvas.cssCanvasNames.length && this._canvas.contextType !== WI.Canvas.ContextType.WebGPU) {
+        if (!this._canvas.cssCanvasNames.length) {
             this._clientsSection.element.hidden = true;
             return;
         }
@@ -296,15 +299,13 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
 
         this._clientsSection.element.hidden = false;
 
-        this._canvas.requestClientNodes((clientNodes) => {
-            this._refreshSourceSection();
-
-            if (!clientNodes.length)
+        this._canvas.requestCSSCanvasClientNodes().then((cssCanvasClientNodes) => {
+            if (!cssCanvasClientNodes.length)
                 return;
 
             let fragment = document.createDocumentFragment();
-            for (let clientNode of clientNodes)
-                fragment.appendChild(WI.linkifyNodeReference(clientNode));
+            for (let cssCanvasClientNode of cssCanvasClientNodes)
+                fragment.appendChild(WI.linkifyNodeReference(cssCanvasClientNode));
             this._clientNodesRow.value = fragment;
         });
     }
@@ -334,11 +335,28 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         this._formatMemoryRow();
     }
 
-    _handleClientNodesChanged(event)
+    _handleNodesChanged(event)
     {
         if (!this.didInitialLayout)
             return;
 
+        this._refreshSourceSection();
+    }
+
+    _handleCSSCanvasClientNodesChanged(event)
+    {
+        if (!this.didInitialLayout)
+            return;
+
+        this._refreshClientsSection();
+    }
+
+    _handleCSSCanvasNamesChanged(event)
+    {
+        if (!this.didInitialLayout)
+            return;
+
+        this._refreshSourceSection();
         this._refreshClientsSection();
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.js
@@ -151,19 +151,7 @@ WI.CanvasOverviewContentView = class CanvasOverviewContentView extends WI.Collec
         if (!(contentView instanceof WI.CanvasContentView))
             return;
 
-        let canvas = contentView.representedObject;
-        if (canvas.cssCanvasNames.length || canvas.contextType === WI.Canvas.ContextType.WebGPU) {
-            canvas.requestClientNodes((clientNodes) => {
-                WI.domManager.highlightDOMNodeList(clientNodes);
-            });
-            return;
-        }
-
-        canvas.requestNode().then((node) => {
-            if (!node || !node.ownerDocument)
-                return;
-            node.highlight();
-        });
+        contentView.representedObject.highlight();
     }
 
     _contentViewMouseLeave(event)

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasTreeElement.js
@@ -114,18 +114,7 @@ WI.CanvasTreeElement = class CanvasTreeElement extends WI.FolderizedTreeElement
 
     _handleMouseOver(event)
     {
-        if (this.representedObject.cssCanvasNames.length || this.representedObject.contextType === WI.Canvas.ContextType.WebGPU) {
-            this.representedObject.requestClientNodes((clientNodes) => {
-                WI.domManager.highlightDOMNodeList(clientNodes);
-            });
-        } else {
-            this.representedObject.requestNode((node) => {
-                if (!node || !node.ownerDocument)
-                    return;
-
-                node.highlight();
-            });
-        }
+        this.representedObject.highlight();
     }
 
     _handleMouseOut(event)


### PR DESCRIPTION
#### af624adbb3bc34102a4e7f99703c9d1350e8fc66
<pre>
Web Inspector: Canvas: distinguish configured WebGPU `&lt;canvas&gt;` from CSS canvas client nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=321150">https://bugs.webkit.org/show_bug.cgi?id=321150</a>

Reviewed by Mike Wyrzykowski.

* Source/JavaScriptCore/inspector/protocol/Canvas.json:
* Source/WebCore/inspector/InspectorCanvas.h:
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::canvasElements const): Renamed from `canvasElement`.
(WebCore::InspectorCanvas::cssCanvasClientNodes const): Renamed from `clientNodes`.
(WebCore::InspectorCanvas::buildObjectForCanvas):
* Source/WebCore/inspector/agents/page/PageCanvasAgent.h:
* Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp:
(WebCore::PageCanvasAgent::requestNodes): Renamed from `requestNode`.
(WebCore::PageCanvasAgent::requestCSSCanvasClientNodes): Renamed from `requestClientNodes`.
(WebCore::PageCanvasAgent::frameNavigated):
(WebCore::PageCanvasAgent::didChangeCSSCanvasClientNodes):
(WebCore::PageCanvasAgent::didChangeGPUDeviceClientNodes):
(WebCore::PageCanvasAgent::buildObjectForCanvas): Deleted.
(WebCore::PageCanvasAgent::nodeIdForCanvas): Deleted.
(WebCore::PageCanvasAgent::dispatchNodesChanged): Added.
(WebCore::PageCanvasAgent::dispatchCSSCanvasClientNodesChanged): Renamed from `dispatchClientNodesChanged`.
(WebCore::PageCanvasAgent::dispatchCSSCanvasNamesChanged): Added.
* Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp:
(WebCore::WorkerCanvasAgent::requestNodes): Renamed from `requestNode`.
(WebCore::WorkerCanvasAgent::requestCSSCanvasClientNodes): Renamed from `requestClientNodes`.
Return every `HTMLCanvasElement` configured with a `GPUDevice` from `Canvas.requestNodes`, while `Canvas.requestCSSCanvasClientNodes` only returns nodes that consume CSS canvas images.
Push DOM nodes via `Canvas.nodesChanged` instead of including it in the initial `Canvas`.

* Source/WebInspectorUI/UserInterface/Protocol/CanvasObserver.js:
(WI.CanvasObserver.prototype.nodesChanged): Added.
(WI.CanvasObserver.prototype.cssCanvasClientNodesChanged):
(WI.CanvasObserver.prototype.cssCanvasNamesChanged): Added.
(WI.CanvasObserver.prototype.clientNodesChanged):
* Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js:
(WI.CanvasManager.prototype.nodesChanged): Renamed from `clientNodesChanged`.
(WI.CanvasManager.prototype.cssCanvasClientNodesChanged): Added.
(WI.CanvasManager.prototype.cssCanvasNamesChanged): Added.
* Source/WebInspectorUI/UserInterface/Models/Canvas.js:
(WI.Canvas.prototype.constructor):
(WI.Canvas.fromPayload):
(WI.Canvas.prototype.get displayName):
(WI.Canvas.prototype.requestNodes): Renamed from `requestNode`.
(WI.Canvas.prototype.requestCSSCanvasClientNodes): Renamed from `requestClientNodes`.
(WI.Canvas.prototype.highlight): Added.
(WI.Canvas.prototype.saveIdentityToCookie):
(WI.Canvas.prototype.nodesChanged): Renamed from `clientNodesChanged`.
(WI.Canvas.prototype.cssCanvasClientNodesChanged): Added.
(WI.Canvas.prototype.cssCanvasNamesChanged): Added.
(WI.Canvas.Event):
Update CSS canvas names only from `Canvas.cssCanvasNamesChanged`.
Centralize hover highlighting logic instead of repeating it in a few places.

* Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js:
(WI.CanvasContentView.prototype.constructor):
(WI.CanvasContentView.prototype.attached):
(WI.CanvasContentView.prototype.detached):
(WI.CanvasContentView.prototype._populateCanvasElementButtonContextMenu):
(WI.CanvasContentView.prototype._updateCanvasNode):
* Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.js:
(WI.CanvasDetailsSidebarPanel.prototype.constructor):
(WI.CanvasDetailsSidebarPanel.prototype.set canvas):
(WI.CanvasDetailsSidebarPanel.prototype.initialLayout):
(WI.CanvasDetailsSidebarPanel.prototype._refreshSourceSection):
(WI.CanvasDetailsSidebarPanel.prototype._refreshClientsSection):
(WI.CanvasDetailsSidebarPanel.prototype._handleNodesChanged): Added.
(WI.CanvasDetailsSidebarPanel.prototype._handleCSSCanvasClientNodesChanged): Renamed from `_handleClientNodesChanged`.
(WI.CanvasDetailsSidebarPanel.prototype._handleCSSCanvasNamesChanged): Added.
* Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.js:
(WI.CanvasOverviewContentView.prototype._contentViewMouseEnter):
* Source/WebInspectorUI/UserInterface/Views/CanvasTreeElement.js:
(WI.CanvasTreeElement.prototype._handleMouseOver):
Display every configured node in the &quot;Source&quot; section.
Refresh the &quot;Source&quot; and &quot;Client&quot; sections from their corresponding events.

* LayoutTests/inspector/canvas/requestNode.html:
* LayoutTests/inspector/canvas/requestNode-expected.txt:
* LayoutTests/inspector/canvas/requestClientNodes.html:
* LayoutTests/inspector/canvas/requestClientNodes-expected.txt:
* LayoutTests/inspector/canvas/requestClientNodes-css.html:
* LayoutTests/inspector/canvas/requestClientNodes-css-expected.txt:
* LayoutTests/inspector/canvas/requestClientNodes-webgpu.html:
* LayoutTests/inspector/canvas/requestClientNodes-webgpu-expected.txt:
* LayoutTests/inspector/canvas/worker-webgpu.html:
* LayoutTests/inspector/canvas/worker-webgpu-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318794@main">https://commits.webkit.org/318794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca26724fe70831d42c74c16180db4d2f2795daf2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188924 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143404 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139664 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120110 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41933 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40275 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2086 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8906 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39924 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/231 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40369 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191144 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/178498 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148897 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40005 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53384 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36550 "343 new passes 21 flakes 22 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148642 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43331 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125655 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120469 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51902 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14903 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->