### PR TITLE
[JSC] `JSON.stringify` fast path should accept final objects with non `Object` prototypes

### DIFF
--- a/JSTests/microbenchmarks/json-stringify-class-instances.js
+++ b/JSTests/microbenchmarks/json-stringify-class-instances.js
@@ -1,0 +1,38 @@
+class Address {
+    constructor(i) {
+        this.street = "Street " + i;
+        this.city = "City";
+        this.zip = 10000 + i;
+    }
+}
+
+class User {
+    constructor(i) {
+        this.id = i;
+        this.name = "user" + i;
+        this.email = "user" + i + "@example.com";
+        this.active = (i & 1) === 0;
+        this.address = new Address(i);
+        this.tags = ["a", "b", "c"];
+    }
+    get displayName() { return this.name.toUpperCase(); }
+    greet() { return "hi " + this.name; }
+}
+
+class Admin extends User {
+    constructor(i) {
+        super(i);
+        this.level = i % 5;
+    }
+}
+
+let users = [];
+for (let i = 0; i < 40; ++i)
+    users.push((i % 4) === 0 ? new Admin(i) : new User(i));
+let payload = { ok: true, count: users.length, data: users };
+
+let result;
+for (let i = 0; i < 2e4; ++i)
+    result = JSON.stringify(payload);
+if (result.length !== JSON.stringify(JSON.parse(result)).length)
+    throw new Error("bad");

--- a/JSTests/stress/json-stringify-fast-path-custom-prototype-edge-cases.js
+++ b/JSTests/stress/json-stringify-fast-path-custom-prototype-edge-cases.js
@@ -1,0 +1,481 @@
+//@ requireOptions("--useDollarVM=true")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function shouldThrow(func, errorMessage) {
+    let errorThrown = false;
+    try {
+        func();
+    } catch (error) {
+        errorThrown = true;
+        if (String(error) !== errorMessage)
+            throw new Error("bad error: " + String(error));
+    }
+    if (!errorThrown)
+        throw new Error("not thrown");
+}
+
+// Warm the fast path against an instance so its structure caches "no toJSON", then mutate.
+function warm(value, expected) {
+    for (let i = 0; i < 20; ++i)
+        shouldBe(JSON.stringify(value), expected);
+}
+
+// toJSON appears on the prototype through every route that can add a property.
+{
+    class C { constructor() { this.x = 1; } }
+    let c = new C;
+    warm(c, `{"x":1}`);
+    C.prototype.toJSON = () => "assign";
+    shouldBe(JSON.stringify(c), `"assign"`);
+    delete C.prototype.toJSON;
+    warm(c, `{"x":1}`);
+    Object.defineProperty(C.prototype, "toJSON", { value: () => "define", configurable: true, enumerable: false, writable: true });
+    shouldBe(JSON.stringify(c), `"define"`);
+    delete C.prototype.toJSON;
+    warm(c, `{"x":1}`);
+    Object.assign(C.prototype, { toJSON: () => "Object.assign" });
+    shouldBe(JSON.stringify(c), `"Object.assign"`);
+    delete C.prototype.toJSON;
+    warm(c, `{"x":1}`);
+    Reflect.set(C.prototype, "toJSON", () => "Reflect.set");
+    shouldBe(JSON.stringify(c), `"Reflect.set"`);
+    delete C.prototype.toJSON;
+    warm(c, `{"x":1}`);
+    C.prototype["to" + "JSON"] = () => "computed";
+    shouldBe(JSON.stringify(c), `"computed"`);
+}
+
+// toJSON replaced in place (same structure, different value).
+{
+    class C { constructor() { this.x = 1; } toJSON() { return "v1"; } }
+    let c = new C;
+    warm(c, `"v1"`);
+    C.prototype.toJSON = () => "v2";
+    shouldBe(JSON.stringify(c), `"v2"`);
+    C.prototype.toJSON = undefined;
+    shouldBe(JSON.stringify(c), `{"x":1}`);
+    C.prototype.toJSON = null;
+    shouldBe(JSON.stringify(c), `{"x":1}`);
+    C.prototype.toJSON = 42;
+    shouldBe(JSON.stringify(c), `{"x":1}`);
+    C.prototype.toJSON = () => "v3";
+    shouldBe(JSON.stringify(c), `"v3"`);
+}
+
+// toJSON as accessor on the prototype: getter must run once per serialization, with the instance as receiver.
+{
+    let receivers = [];
+    class C { constructor() { this.x = 1; } }
+    Object.defineProperty(C.prototype, "toJSON", { get() { receivers.push(this); return function () { return this.x * 10; }; }, configurable: true });
+    let a = new C, b = new C;
+    b.x = 2;
+    shouldBe(JSON.stringify([a, b, a]), `[10,20,10]`);
+    shouldBe(receivers.length, 3);
+    shouldBe(receivers[0], a);
+    shouldBe(receivers[1], b);
+    shouldBe(receivers[2], a);
+
+    // Getter that mutates the holder mid-serialization.
+    class D { constructor() { this.p = 1; this.q = 2; } }
+    Object.defineProperty(D.prototype, "toJSON", { get() { delete this.q; this.r = 3; return undefined; }, configurable: true });
+    shouldBe(JSON.stringify(new D), `{"p":1,"r":3}`);
+}
+
+// Prototype swapped after warm-up.
+{
+    class C { constructor() { this.x = 1; } }
+    let c = new C;
+    warm(c, `{"x":1}`);
+    Object.setPrototypeOf(c, { toJSON() { return "swapped instance proto"; } });
+    shouldBe(JSON.stringify(c), `"swapped instance proto"`);
+
+    class D { constructor() { this.x = 1; } }
+    let d = new D;
+    warm(d, `{"x":1}`);
+    Object.setPrototypeOf(D.prototype, { toJSON() { return "swapped grandparent"; } });
+    shouldBe(JSON.stringify(d), `"swapped grandparent"`);
+    Object.setPrototypeOf(D.prototype, Object.prototype);
+    shouldBe(JSON.stringify(d), `{"x":1}`);
+    Object.setPrototypeOf(D.prototype, null);
+    shouldBe(JSON.stringify(d), `{"x":1}`);
+}
+
+// Deep chain: toJSON inserted at every level in turn.
+{
+    const depth = 12;
+    let protos = [Object.create(null)];
+    for (let i = 1; i < depth; ++i)
+        protos.push(Object.create(protos[i - 1]));
+    let leaf = Object.create(protos[depth - 1]);
+    leaf.v = 1;
+    warm({ leaf }, `{"leaf":{"v":1}}`);
+    for (let i = 0; i < depth; ++i) {
+        protos[i].toJSON = () => "level" + i;
+        shouldBe(JSON.stringify({ leaf }), `{"leaf":"level${i}"}`);
+        delete protos[i].toJSON;
+        shouldBe(JSON.stringify({ leaf }), `{"leaf":{"v":1}}`);
+    }
+}
+
+// Many distinct classes in one payload; toJSON added to one in the middle afterwards.
+{
+    let classes = [];
+    for (let i = 0; i < 30; ++i)
+        classes.push(eval(`(class K${i} { constructor() { this.i = ${i}; } })`));
+    let payload = classes.map((K) => new K);
+    let expected = "[" + classes.map((_, i) => `{"i":${i}}`).join(",") + "]";
+    warm(payload, expected);
+    classes[17].prototype.toJSON = function () { return -this.i; };
+    shouldBe(JSON.stringify(payload), expected.replace(`{"i":17}`, `-17`));
+}
+
+// Same class, instances with divergent structures (property order / extra props / deletes).
+{
+    class C { constructor(flip) { if (flip) { this.b = 2; this.a = 1; } else { this.a = 1; this.b = 2; } } }
+    let x = new C(false), y = new C(true), z = new C(false);
+    z.c = 3;
+    delete z.a;
+    warm([x, y, z], `[{"a":1,"b":2},{"b":2,"a":1},{"b":2,"c":3}]`);
+    C.prototype.toJSON = function () { return Object.keys(this).join(""); };
+    shouldBe(JSON.stringify([x, y, z]), `["ab","ba","bc"]`);
+}
+
+// Dictionary-mode prototype and dictionary-mode instance.
+{
+    class C { constructor() { this.x = 1; } }
+    for (let i = 0; i < 100; ++i)
+        C.prototype["m" + i] = i;
+    for (let i = 0; i < 100; ++i)
+        delete C.prototype["m" + i];
+    let c = new C;
+    warm(c, `{"x":1}`);
+    C.prototype.toJSON = () => "dict proto";
+    shouldBe(JSON.stringify(c), `"dict proto"`);
+    delete C.prototype.toJSON;
+    warm(c, `{"x":1}`);
+
+    $vm.toUncacheableDictionary(C.prototype);
+    warm(c, `{"x":1}`);
+    C.prototype.toJSON = () => "uncacheable dict proto";
+    shouldBe(JSON.stringify(c), `"uncacheable dict proto"`);
+    delete C.prototype.toJSON;
+    shouldBe(JSON.stringify(c), `{"x":1}`);
+
+    class D { constructor() { this.x = 1; } }
+    let d = new D;
+    for (let i = 0; i < 100; ++i)
+        d["k" + i] = i;
+    for (let i = 0; i < 100; ++i)
+        delete d["k" + i];
+    warm({ d }, `{"d":{"x":1}}`);
+    D.prototype.toJSON = () => "dict instance";
+    shouldBe(JSON.stringify({ d }), `{"d":"dict instance"}`);
+}
+
+// Frozen / sealed / non-extensible prototypes and instances.
+{
+    class C { constructor() { this.x = 1; } }
+    Object.freeze(C.prototype);
+    let c = new C;
+    warm(c, `{"x":1}`);
+    shouldBe(JSON.stringify(Object.freeze(new C)), `{"x":1}`);
+    shouldBe(JSON.stringify(Object.seal(new C)), `{"x":1}`);
+    shouldBe(JSON.stringify(Object.preventExtensions(new C)), `{"x":1}`);
+
+    class D { constructor() { this.x = 1; } }
+    Object.defineProperty(D.prototype, "toJSON", { value() { return "frozen toJSON"; }, writable: false, configurable: false });
+    Object.freeze(D.prototype);
+    shouldBe(JSON.stringify(new D), `"frozen toJSON"`);
+}
+
+// Objects in the chain whose property lookup is not side-effect-free must be observed.
+{
+    // Proxy as immediate prototype.
+    let traps = [];
+    let handler = {
+        get(t, k, r) { traps.push("get:" + String(k)); return Reflect.get(t, k, r); },
+        has(t, k) { traps.push("has:" + String(k)); return Reflect.has(t, k); },
+        getOwnPropertyDescriptor(t, k) { traps.push("gopd:" + String(k)); return Reflect.getOwnPropertyDescriptor(t, k); },
+        ownKeys(t) { traps.push("ownKeys"); return Reflect.ownKeys(t); },
+        getPrototypeOf(t) { traps.push("getPrototypeOf"); return Reflect.getPrototypeOf(t); },
+    };
+    let o = Object.create(new Proxy({}, handler));
+    o.a = 1;
+    for (let i = 0; i < 5; ++i) {
+        traps.length = 0;
+        shouldBe(JSON.stringify({ o }), `{"o":{"a":1}}`);
+        shouldBe(traps.join(","), `get:toJSON`);
+    }
+
+    // Proxy further up the chain, returning a toJSON.
+    let mid = Object.create(new Proxy({}, { get(t, k) { if (k === "toJSON") return () => "from proxy"; } }));
+    let leaf = Object.create(mid);
+    leaf.b = 2;
+    shouldBe(JSON.stringify({ leaf }), `{"leaf":"from proxy"}`);
+
+    // Revoked proxy in the chain.
+    let { proxy, revoke } = Proxy.revocable({}, {});
+    let r = Object.create(proxy);
+    r.c = 3;
+    shouldBe(JSON.stringify({ r }), `{"r":{"c":3}}`);
+    revoke();
+    shouldThrow(() => JSON.stringify({ r }), "TypeError: Proxy has already been revoked. No more operations are allowed to be performed on it");
+
+    // $vm ImpureGetter (overridesGetOwnPropertySlot) in the chain, delegating to an object with toJSON.
+    let delegate = { toJSON() { return "impure"; } };
+    let ig = Object.create($vm.createImpureGetter(delegate));
+    ig.d = 4;
+    shouldBe(JSON.stringify({ ig }), `{"ig":"impure"}`);
+    let ig2 = Object.create($vm.createImpureGetter({}));
+    ig2.d = 4;
+    shouldBe(JSON.stringify({ ig2 }), `{"ig2":{"d":4}}`);
+}
+
+// Built-in prototypes with lazily reified static property tables in the chain.
+{
+    let g = createGlobalObject();
+    let { Object: GO, Date: GD, JSON: GJ } = g;
+    // Fresh realm so nothing has reified Date.prototype.toJSON yet.
+    let o = GO.create(GD.prototype);
+    o.x = 1;
+    shouldThrow(() => GJ.stringify({ o }), "TypeError: Type error");
+    shouldThrow(() => GJ.stringify(o), "TypeError: Type error");
+    let oo = GO.create(GO.create(GD.prototype));
+    oo.y = 2;
+    shouldThrow(() => GJ.stringify({ oo }), "TypeError: Type error");
+
+    // A static-table prototype without toJSON is fine (RegExp.prototype has a static table but no toJSON).
+    let p = Object.create(RegExp.prototype);
+    p.z = 3;
+    warm({ p }, `{"p":{"z":3}}`);
+    RegExp.prototype.toJSON = () => "regexp proto";
+    shouldBe(JSON.stringify({ p }), `{"p":"regexp proto"}`);
+    delete RegExp.prototype.toJSON;
+}
+
+// Non-final ObjectType cells with custom prototypes must keep slow-path semantics.
+{
+    class C { constructor() { this.x = 1; } }
+    let bi = Object.setPrototypeOf(Object(1n), C.prototype);
+    shouldThrow(() => JSON.stringify({ bi }), "TypeError: JSON.stringify cannot serialize BigInt.");
+    C.prototype.toJSON = function () { return typeof this; };
+    shouldBe(JSON.stringify({ bi }), `{"bi":"object"}`);
+    delete C.prototype.toJSON;
+
+    let sym = Object.setPrototypeOf(Object(Symbol("s")), C.prototype);
+    shouldBe(JSON.stringify({ sym }), `{"sym":{}}`);
+
+    let num = Object.setPrototypeOf(new Number(7), C.prototype);
+    shouldBe(JSON.stringify({ num }), `{"num":null}`);
+    let num2 = Object.setPrototypeOf(new Number(7), { valueOf() { return 8; } });
+    shouldBe(JSON.stringify({ num2 }), `{"num2":8}`);
+
+    let bool = Object.setPrototypeOf(new Boolean(false), C.prototype);
+    shouldBe(JSON.stringify({ bool }), `{"bool":false}`);
+
+    let str = Object.setPrototypeOf(new String("s"), { toString() { return "custom toString"; } });
+    shouldBe(JSON.stringify({ str }), `{"str":"custom toString"}`);
+
+    let raw = JSON.rawJSON("123");
+    shouldBe(Object.getPrototypeOf(raw), null);
+    shouldBe(JSON.stringify({ raw }), `{"raw":123}`);
+
+    let err = new TypeError("m");
+    shouldBe(JSON.stringify({ err }), `{"err":{}}`);
+    let re = /x/;
+    re.k = 1;
+    shouldBe(JSON.stringify({ re }), `{"re":{"k":1}}`);
+    let map = new Map;
+    map.k = 1;
+    shouldBe(JSON.stringify({ map }), `{"map":{"k":1}}`);
+    let date = new Date(0);
+    shouldBe(JSON.stringify({ date }), `{"date":"1970-01-01T00:00:00.000Z"}`);
+}
+
+// Callable / arguments / namespace-like objects with custom or null prototypes.
+{
+    let f = Object.setPrototypeOf(function () { }, null);
+    f.x = 1;
+    shouldBe(JSON.stringify({ f }), `{}`);
+    shouldBe(JSON.stringify([f]), `[null]`);
+    let bound = Object.setPrototypeOf((function () { }).bind(), { toJSON() { return "bound"; } });
+    shouldBe(JSON.stringify({ bound }), `{"bound":"bound"}`);
+    let args = (function () { return arguments; })(1, 2);
+    Object.setPrototypeOf(args, null);
+    shouldBe(JSON.stringify(args), `{"0":1,"1":2}`);
+}
+
+// Own-property shapes on custom-prototype instances that the fast path must reject or handle.
+{
+    class C { constructor() { this.x = 1; } }
+
+    let indexed = new C;
+    indexed[0] = "zero";
+    shouldBe(JSON.stringify(indexed), `{"0":"zero","x":1}`);
+
+    let withGetter = new C;
+    let calls = 0;
+    Object.defineProperty(withGetter, "g", { get() { calls++; return "got"; }, enumerable: true });
+    shouldBe(JSON.stringify(withGetter), `{"x":1,"g":"got"}`);
+    shouldBe(calls, 1);
+
+    let withSymbol = new C;
+    withSymbol[Symbol("s")] = 1;
+    withSymbol.y = 2;
+    shouldBe(JSON.stringify(withSymbol), `{"x":1,"y":2}`);
+
+    let withNonEnumerable = new C;
+    Object.defineProperty(withNonEnumerable, "hidden", { value: 1, enumerable: false });
+    withNonEnumerable.y = 2;
+    shouldBe(JSON.stringify(withNonEnumerable), `{"x":1,"y":2}`);
+
+    let ownToJSON = new C;
+    ownToJSON.toJSON = () => "own enumerable";
+    shouldBe(JSON.stringify({ ownToJSON }), `{"ownToJSON":"own enumerable"}`);
+    let ownHiddenToJSON = new C;
+    Object.defineProperty(ownHiddenToJSON, "toJSON", { value: () => "own non-enumerable", enumerable: false });
+    shouldBe(JSON.stringify({ ownHiddenToJSON }), `{"ownHiddenToJSON":"own non-enumerable"}`);
+    let ownNonCallableToJSON = new C;
+    ownNonCallableToJSON.toJSON = "not callable";
+    shouldBe(JSON.stringify(ownNonCallableToJSON), `{"x":1,"toJSON":"not callable"}`);
+
+    let undefinedAndFunctionValues = new C;
+    undefinedAndFunctionValues.u = undefined;
+    undefinedAndFunctionValues.fn = function () { };
+    undefinedAndFunctionValues.s = Symbol();
+    undefinedAndFunctionValues.y = 2;
+    shouldBe(JSON.stringify(undefinedAndFunctionValues), `{"x":1,"y":2}`);
+
+    let escapes = new C;
+    escapes["key\n"] = "v\"\\";
+    shouldBe(JSON.stringify(escapes), `{"x":1,"key\\n":"v\\"\\\\\\u0001"}`);
+
+    let sixteenBit = new C;
+    sixteenBit.name = "日本語";
+    sixteenBit["キー"] = 1;
+    shouldBe(JSON.stringify(sixteenBit), `{"x":1,"name":"日本語","キー":1}`);
+
+    class Big { constructor() { for (let i = 0; i < 200; ++i) this["p" + i] = i; } }
+    let big = new Big;
+    shouldBe(JSON.stringify(big), JSON.stringify(Object.assign({}, big)));
+    shouldBe(JSON.parse(JSON.stringify(big)).p199, 199);
+
+    class P { #priv = 42; constructor() { this.pub = 1; } static has(o) { return #priv in o; } }
+    shouldBe(JSON.stringify(new P), `{"pub":1}`);
+    shouldBe(P.has(JSON.parse(JSON.stringify(new P))), false);
+}
+
+// Enumerable data on the prototype never leaks; shadowing works.
+{
+    let proto = { inherited: "no", shadowed: "proto" };
+    let o = Object.create(proto);
+    o.shadowed = "own";
+    warm(o, `{"shadowed":"own"}`);
+    Object.defineProperty(proto, "accessor", { get() { throw new Error("prototype getter must not run"); }, enumerable: true });
+    shouldBe(JSON.stringify(o), `{"shadowed":"own"}`);
+}
+
+// Object.prototype.toJSON interacts with custom-prototype instances (chain ends at Object.prototype) but not null-prototype ones.
+{
+    class C { constructor() { this.x = 1; } }
+    let c = new C;
+    let n = Object.create(null);
+    n.x = 1;
+    let each = () => [c, n, {}].map((v) => JSON.stringify(v)).join("|");
+    for (let i = 0; i < 20; ++i)
+        shouldBe(each(), `{"x":1}|{"x":1}|{}`);
+    Object.prototype.toJSON = function () { return "OP"; };
+    shouldBe(each(), `"OP"|{"x":1}|"OP"`);
+    delete Object.prototype.toJSON;
+    for (let i = 0; i < 20; ++i)
+        shouldBe(each(), `{"x":1}|{"x":1}|{}`);
+    Object.defineProperty(Object.prototype, "toJSON", { get() { return () => "OP getter"; }, configurable: true });
+    shouldBe(each(), `"OP getter"|{"x":1}|"OP getter"`);
+    delete Object.prototype.toJSON;
+    shouldBe(each(), `{"x":1}|{"x":1}|{}`);
+}
+
+// Cross-realm instances and prototypes.
+{
+    let g = createGlobalObject();
+    g.eval(`var R = class R { constructor() { this.r = 1; } }; var inst = new R; var plain = { p: 1 };`);
+    shouldBe(JSON.stringify({ a: g.inst, b: g.plain }), `{"a":{"r":1},"b":{"p":1}}`);
+    shouldBe(g.JSON.stringify({ a: g.inst, b: g.plain }), `{"a":{"r":1},"b":{"p":1}}`);
+    g.R.prototype.toJSON = () => "other realm";
+    shouldBe(JSON.stringify({ a: g.inst }), `{"a":"other realm"}`);
+    delete g.R.prototype.toJSON;
+    g.Object.prototype.toJSON = () => "other realm OP";
+    shouldBe(JSON.stringify({ a: g.inst, b: g.plain, c: {} }), `{"a":"other realm OP","b":"other realm OP","c":{}}`);
+    delete g.Object.prototype.toJSON;
+
+    let mixed = Object.create(g.inst);
+    mixed.m = 1;
+    shouldBe(JSON.stringify(mixed), `{"m":1}`);
+    g.R.prototype.toJSON = () => "via other realm chain";
+    shouldBe(JSON.stringify(mixed), `"via other realm chain"`);
+}
+
+// toJSON receives the key and correct receiver on the fast->slow handoff; result feeds back into serialization.
+{
+    let seen = [];
+    class C { constructor(v) { this.v = v; } }
+    C.prototype.toJSON = function (key) { seen.push(key); return { wrapped: this.v, nested: new D(this.v) }; };
+    class D { constructor(v) { this.d = v; } }
+    shouldBe(JSON.stringify({ a: new C(1), list: [new C(2)] }), `{"a":{"wrapped":1,"nested":{"d":1}},"list":[{"wrapped":2,"nested":{"d":2}}]}`);
+    shouldBe(seen.join(","), `a,0`);
+    D.prototype.toJSON = function (key) { seen.push("D:" + key); return this.d * 100; };
+    shouldBe(JSON.stringify(new C(3)), `{"wrapped":3,"nested":300}`);
+    shouldBe(seen.join(","), `a,0,,D:nested`);
+}
+
+// Interaction with gap / replacer arguments (replacer always takes the slow path; gap has its own fast path).
+{
+    class C { constructor() { this.x = 1; this.y = new D; } }
+    class D { constructor() { this.z = 2; } }
+    shouldBe(JSON.stringify(new C, null, 2), `{\n  "x": 1,\n  "y": {\n    "z": 2\n  }\n}`);
+    shouldBe(JSON.stringify(new C, null, "--"), `{\n--"x": 1,\n--"y": {\n----"z": 2\n--}\n}`);
+    shouldBe(JSON.stringify(new C, ["y", "z"]), `{"y":{"z":2}}`);
+    shouldBe(JSON.stringify(new C, (k, v) => (v instanceof D ? "replaced" : v)), `{"x":1,"y":"replaced"}`);
+    D.prototype.toJSON = () => "tj";
+    shouldBe(JSON.stringify(new C, null, 1), `{\n "x": 1,\n "y": "tj"\n}`);
+}
+
+// Large payload that overflows the static buffer mid-way through custom-prototype instances, then toJSON added.
+{
+    class Row { constructor(i) { this.id = i; this.label = "row-" + i + "-".repeat(50); } }
+    let rows = [];
+    for (let i = 0; i < 400; ++i)
+        rows.push(new Row(i));
+    let s = JSON.stringify(rows);
+    shouldBe(s.length > 8192, true);
+    shouldBe(JSON.parse(s)[399].id, 399);
+    Row.prototype.toJSON = function () { return this.id; };
+    shouldBe(JSON.stringify(rows), "[" + rows.map((r) => r.id).join(",") + "]");
+}
+
+// Cyclic structure through custom-prototype instances still throws.
+{
+    class N { constructor() { this.next = null; } }
+    let a = new N, b = new N;
+    a.next = b;
+    b.next = a;
+    shouldThrow(() => JSON.stringify(a), "TypeError: JSON.stringify cannot serialize cyclic structures.");
+}
+
+// has-poly-proto structures (created by repeatedly instantiating a class defined inside a function).
+{
+    function make(v) {
+        class Poly { constructor() { this.v = v; } }
+        return new Poly;
+    }
+    let objs = [];
+    for (let i = 0; i < 50; ++i)
+        objs.push(make(i));
+    shouldBe(JSON.stringify(objs), "[" + objs.map((o) => `{"v":${o.v}}`).join(",") + "]");
+    Object.getPrototypeOf(objs[10]).toJSON = () => "poly10";
+    shouldBe(JSON.stringify([objs[9], objs[10], objs[11]]), `[{"v":9},"poly10",{"v":11}]`);
+}

--- a/JSTests/stress/json-stringify-fast-path-custom-prototype.js
+++ b/JSTests/stress/json-stringify-fast-path-custom-prototype.js
@@ -1,0 +1,122 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function shouldThrow(func, errorMessage) {
+    let errorThrown = false;
+    try {
+        func();
+    } catch (error) {
+        errorThrown = true;
+        if (String(error) !== errorMessage)
+            throw new Error("bad error: " + String(error));
+    }
+    if (!errorThrown)
+        throw new Error("not thrown");
+}
+
+// These must run before anything reifies Date.prototype's static toJSON.
+{
+    Object.setPrototypeOf(Array.prototype, Date.prototype);
+    shouldThrow(() => JSON.stringify([]), "TypeError: Type error");
+    shouldThrow(() => JSON.stringify({ a: [] }), "TypeError: Type error");
+    Object.setPrototypeOf(Array.prototype, Object.prototype);
+    shouldBe(JSON.stringify([]), `[]`);
+}
+
+{
+    class X { constructor() { this.a = 1; } }
+    Object.setPrototypeOf(X.prototype, Date.prototype);
+    shouldThrow(() => JSON.stringify(new X), "TypeError: Type error");
+    shouldThrow(() => JSON.stringify({ v: new X }), "TypeError: Type error");
+    let o = { b: 2 };
+    Object.setPrototypeOf(o, Date.prototype);
+    shouldThrow(() => JSON.stringify({ o }), "TypeError: Type error");
+}
+
+class A { constructor() { this.x = 1; } method() { } get accessor() { return 0; } }
+class AA extends A { constructor() { super(); this.y = 2; } }
+for (let i = 0; i < 10; ++i) {
+    shouldBe(JSON.stringify(new A), `{"x":1}`);
+    shouldBe(JSON.stringify({ a: new A, b: [new AA] }), `{"a":{"x":1},"b":[{"x":1,"y":2}]}`);
+    shouldBe(JSON.stringify(new AA, null, 1), `{\n "x": 1,\n "y": 2\n}`);
+}
+
+{
+    class C { constructor() { this.x = 1; } }
+    let c = new C;
+    for (let i = 0; i < 10; ++i)
+        shouldBe(JSON.stringify(c), `{"x":1}`);
+    C.prototype.toJSON = function () { return 42; };
+    shouldBe(JSON.stringify(c), `42`);
+    shouldBe(JSON.stringify({ c }), `{"c":42}`);
+    delete C.prototype.toJSON;
+    shouldBe(JSON.stringify(c), `{"x":1}`);
+    Object.defineProperty(C.prototype, "toJSON", { value() { return "non-enumerable"; }, enumerable: false, configurable: true });
+    shouldBe(JSON.stringify(c), `"non-enumerable"`);
+}
+
+{
+    class D0 { }
+    class D1 extends D0 { constructor() { super(); this.y = 2; } }
+    let d = new D1;
+    for (let i = 0; i < 10; ++i)
+        shouldBe(JSON.stringify(d), `{"y":2}`);
+    D0.prototype.toJSON = () => "D0";
+    shouldBe(JSON.stringify(d), `"D0"`);
+}
+
+{
+    let count = 0;
+    class E { constructor() { this.z = 3; } }
+    Object.defineProperty(E.prototype, "toJSON", { get() { count++; return undefined; }, configurable: true });
+    for (let i = 0; i < 10; ++i)
+        shouldBe(JSON.stringify(new E), `{"z":3}`);
+    shouldBe(count, 10);
+}
+
+{
+    let n = Object.create(null);
+    n.k = 1;
+    for (let i = 0; i < 10; ++i)
+        shouldBe(JSON.stringify({ n }), `{"n":{"k":1}}`);
+}
+
+{
+    let proto = { inherited: 1 };
+    let o = Object.create(proto);
+    o.own = 2;
+    for (let i = 0; i < 10; ++i)
+        shouldBe(JSON.stringify(o), `{"own":2}`);
+    proto.toJSON = () => "P";
+    shouldBe(JSON.stringify(o), `"P"`);
+}
+
+{
+    let log = [];
+    let p = new Proxy({}, { get(t, k, r) { log.push(String(k)); return Reflect.get(t, k, r); } });
+    let q = Object.create(p);
+    q.a = 1;
+    shouldBe(JSON.stringify(q), `{"a":1}`);
+    shouldBe(log.includes("toJSON"), true);
+}
+
+{
+    class G { constructor() { this.b = Object(1n); } }
+    shouldThrow(() => JSON.stringify(new G), "TypeError: JSON.stringify cannot serialize BigInt.");
+    shouldBe(JSON.stringify({ s: Object.setPrototypeOf(new String("s"), A.prototype) }), `{"s":"[object String]"}`);
+    shouldBe(JSON.stringify({ b: Object.setPrototypeOf(new Boolean(true), A.prototype) }), `{"b":true}`);
+}
+
+{
+    class F { constructor() { this.w = 4; } }
+    let f = new F;
+    for (let i = 0; i < 10; ++i)
+        shouldBe(JSON.stringify(f), `{"w":4}`);
+    Object.prototype.toJSON = function () { return "OP"; };
+    shouldBe(JSON.stringify(f), `"OP"`);
+    shouldBe(JSON.stringify({}), `"OP"`);
+    delete Object.prototype.toJSON;
+    shouldBe(JSON.stringify(f), `{"w":4}`);
+}

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1453,11 +1453,16 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             recordFailure("hasPolyProto"_s);
             return;
         }
-        if (structure.storedPrototype() != m_globalObject.objectPrototype()) [[unlikely]] {
-            recordFailure("non-standard object prototype"_s);
-            return;
-        }
-        if (!m_checkedObjectPrototype) {
+        if (structure.storedPrototype() != m_globalObject.objectPrototype()) {
+            if (cell.type() != FinalObjectType) [[unlikely]] {
+                recordFailure("non-final object with non-standard prototype"_s);
+                return;
+            }
+            if (mayHaveToJSON(object)) [[unlikely]] {
+                recordFailure("object may have toJSON"_s);
+                return;
+            }
+        } else if (!m_checkedObjectPrototype) {
             if (mayHaveToJSON(*m_globalObject.objectPrototype())) [[unlikely]] {
                 recordFailure("object prototype may have toJSON"_s);
                 return;
@@ -1511,8 +1516,8 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
 
             // The structure cannot transition mid-iteration on FastStringifier's case.
             // canPerformFastPropertyEnumeration ruled out getters/setters and
-            // the prototype is the original Object.prototype with no toJSON, so
-            // there is no JS observable to mutate the structure.
+            // mayHaveToJSON ruled out a toJSON / getter / Proxy on the prototype chain,
+            // so there is no JS observable to mutate the structure.
             ASSERT(object.structure() == &structure);
 
             JSValue value = object.getDirect(entry.offset());

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -354,7 +354,7 @@ inline bool JSObject::noSideEffectMayHaveNonIndexProperty(VM& vm, PropertyName p
         unsigned attributes;
         if (isValidOffset(structure.get(vm, propertyName, attributes))) [[unlikely]]
             return true;
-        if (hasNonReifiedStaticProperties()) {
+        if (object->hasNonReifiedStaticProperties()) {
             for (auto* ancestorClass = object->classInfo(); ancestorClass; ancestorClass = ancestorClass->parentClass) {
                 if (auto* table = ancestorClass->staticPropHashTable; table && table->entry(propertyName)) [[unlikely]]
                     return true;


### PR DESCRIPTION
#### 4f3ecec97431e17f44f275c201a8ba068500c9e5
<pre>
[JSC] `JSON.stringify` fast path should accept final objects with non `Object` prototypes
<a href="https://bugs.webkit.org/show_bug.cgi?id=321151">https://bugs.webkit.org/show_bug.cgi?id=321151</a>

Reviewed by Yusuke Suzuki.

FastStringifier bails out for any object whose prototype is not Object.prototype,
so a single class instance in the payload reruns the whole serialization on the
slow path. Since the prototype only matters for the toJSON lookup, allow
FinalObjectType cells with other prototypes when mayHaveToJSON() says the chain
has no toJSON.

This also fixes noSideEffectMayHaveNonIndexProperty() checking
hasNonReifiedStaticProperties() on `this` instead of the current chain entry,
which missed a non-reified static toJSON (e.g. Date.prototype) in the middle of
the chain.

                                               base                    patched

json-stringify-class-instances              252.0789+-4.5854     ^     71.6873+-0.8488        ^ definitely 3.5164x faster

Tests: JSTests/microbenchmarks/json-stringify-class-instances.js
       JSTests/stress/json-stringify-fast-path-custom-prototype-edge-cases.js
       JSTests/stress/json-stringify-fast-path-custom-prototype.js

* JSTests/microbenchmarks/json-stringify-class-instances.js: Added.
(Address):
(User):
(User.prototype.get displayName):
(User.prototype.greet):
(Admin):
* JSTests/stress/json-stringify-fast-path-custom-prototype-edge-cases.js: Added.
(shouldBe):
(shouldThrow):
(warm):
(shouldBe.C):
(shouldBe.C.prototype.toJSON):
(shouldBe.D):
(shouldBe.get let):
(shouldBe.get shouldBe):
(get shouldBe):
(get shouldBe.D):
(shouldBe.prototype.let.expected.string_appeared_here.classes.map):
(shouldBe.classes.17.prototype.toJSON):
(C.prototype.toJSON):
(shouldBe.JSON.stringify.C):
(shouldBe.JSON.stringify):
(shouldBe.let.handler.get traps):
(C):
(let.num2.Object.setPrototypeOf.new.Number):
(let.str.Object.setPrototypeOf.new.String):
(shouldBe.JSON.stringify.let.args):
(shouldBe.undefinedAndFunctionValues.fn):
(shouldBe.):
* JSTests/stress/json-stringify-fast-path-custom-prototype.js: Added.
(shouldBe):
(shouldThrow):
(throw.new.Error):
(shouldBe.X):
(prototype.method):
(prototype.get accessor):
(AA):
(i.shouldBe.JSON.stringify):
(shouldBe.JSON.stringify.C):
(shouldBe.JSON.stringify.C.prototype.toJSON):
(shouldBe.JSON.stringify):
(shouldBe.D0):
(shouldBe.D1):
(shouldBe.E):
(shouldBe.get for):
(shouldBe.get let):
(shouldBe.G):
(Object.prototype.toJSON):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::bufferMode&gt;::append):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::noSideEffectMayHaveNonIndexProperty):

Canonical link: <a href="https://commits.webkit.org/318697@main">https://commits.webkit.org/318697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b62de0127813460cb23c37712489002f80fb507f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188894 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139644 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120090 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2066 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8881 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152304 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39899 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/201 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40339 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45610 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191114 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52674 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148872 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39943 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53354 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36525 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148617 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43309 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125625 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120439 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51872 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14878 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51257 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51498 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->