### PR TITLE
Nested @scope with :has(:scope ...) in <scope-start> picks scoping roots outside the outer scope

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt
@@ -12,6 +12,9 @@ PASS Multiple scopes from same @scope-rule, both limited
 PASS Nested scopes
 PASS Nested scopes, reverse
 PASS Nested scopes, with to-selector
+PASS Nested scopes, :has(:scope ...) in inner from-selector
+PASS Nested scopes, inner scoping root must be in the outer scope
+PASS Nested scopes, inner scoping root may be the outer scoping root
 PASS :scope selecting itself
 PASS The scoping limit is not in scope
 PASS Simulated inclusive scoping limit

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation.html
@@ -339,6 +339,69 @@ test_scope(document.currentScript, () => {
 <template>
   <style>
     @scope (.a) {
+      @scope (:has(:scope .b)) {
+        span { background-color: green; }
+      }
+    }
+  </style>
+  <div class=a>
+    <div class=c>
+      <span>not green</span>
+      <div class=b></div>
+    </div>
+  </div>
+</template>
+<script>
+test_scope(document.currentScript, () => {
+  // ':has(:scope .b)' can only match ancestors of the outer scoping root,
+  // which are never in the outer scope.
+  assert_not_green('.c > span');
+}, 'Nested scopes, :has(:scope ...) in inner from-selector');
+</script>
+
+<template>
+  <style>
+    @scope (.a) {
+      @scope (.b:has(:scope)) {
+        span { background-color: green; }
+      }
+    }
+  </style>
+  <div class=b>
+    <div class=a>
+      <span>not green</span>
+    </div>
+  </div>
+</template>
+<script>
+test_scope(document.currentScript, () => {
+  // The inner scoping root matches, but it is not in the outer scope.
+  assert_not_green('.a > span');
+}, 'Nested scopes, inner scoping root must be in the outer scope');
+</script>
+
+<template>
+  <style>
+    @scope (.a) {
+      @scope (:scope) {
+        span { background-color: green; }
+      }
+    }
+  </style>
+  <div class=a>
+    <span>green</span>
+  </div>
+</template>
+<script>
+test_scope(document.currentScript, () => {
+  // The scoping root is in its own scope.
+  assert_green('.a > span');
+}, 'Nested scopes, inner scoping root may be the outer scoping root');
+</script>
+
+<template>
+  <style>
+    @scope (.a) {
       :scope { background-color: green; }
     }
   </style>

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 2004-2005 Allan Sandfeld Jensen (kde@carewolf.com)
  * Copyright (C) 2006, 2007 Nicholas Shanks (webkit@nickshanks.com)
- * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  * Copyright (C) 2007, 2008 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
@@ -752,8 +752,11 @@ std::pair<bool, std::optional<Vector<ElementRuleCollector::ScopingRootWithDistan
                 }
                 for (const auto& selector : selectorList) {
                     auto appendIfMatch = [&] (std::optional<ScopingRootWithDistance> previousScopingRoot = { }) {
-                        if (previousScopingRoot)
+                        if (previousScopingRoot) {
+                            if (distance > previousScopingRoot->distance)
+                                return;
                             subContext.scope = previousScopingRoot->scopingRoot;
+                        }
                         // Reset visited flag for each scoping root evaluation
                         subContext.scopingRootMatchesVisited = false;
                         subContext.isEvaluatingScopingRoot = true;


### PR DESCRIPTION
#### f5cac74bf03a3b32a3fc08adef4768745714cc55
<pre>
Nested @scope with :has(:scope ...) in &lt;scope-start&gt; picks scoping roots outside the outer scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=281976">https://bugs.webkit.org/show_bug.cgi?id=281976</a>
<a href="https://rdar.apple.com/138495467">rdar://138495467</a>

Reviewed by Antti Koivisto.

Testcase:

      @scope (.outer:has(.bar)) {
        @scope (:has(:scope .baz)) {
          .foo { color: green; }
        }
      }

.foo is green, but &quot;:has(:scope .baz)&quot; requires its anchor to be an ancestor of
:scope, i.e. of .outer, and such an element is never in the outer scope, so the
inner @scope should produce no scoping root at all.

Per CSS Cascade 6, the prelude of a nested @scope is &quot;scoped by the selectors of
the outer one&quot; [1], and a scoped selector containing an explicit :scope &quot;is
interpreted as a non-relative selector (but the subject must still be in scope
to match)&quot; [2], in scope meaning &quot;an inclusive descendant of the scoping root&quot;
that is &quot;not an inclusive descendant of a scoping limit&quot; [3].

We only implement the relative half: a nested prelude normally gets an implicit
&quot;:scope &quot; prepended, which incidentally keeps the candidate root inside the
outer scope. That prepend is skipped when the prelude already contains :scope or
&amp;, including inside :has(), since CSSSelector::hasExplicitPseudoClassScope()
visits functional pseudo-classes. Skipping it is correct, but we then never
check the subject is in scope, so findScopingRoots() accepts any matching
ancestor -- here &lt;body&gt;, which .foo descends from.

Reject candidate scoping roots that are not inclusive descendants of the
enclosing scoping root. Both are on the ancestor chain of the element being
matched, so comparing distances is sufficient. Outer scoping limits need no
extra check: a limit between the outer root and the inner candidate also sits on
the path from the element, so the outer @scope has already rejected that root.

[1] <a href="https://www.w3.org/TR/css-cascade-6/#scope-scope">https://www.w3.org/TR/css-cascade-6/#scope-scope</a>
[2] <a href="https://www.w3.org/TR/css-cascade-6/#scoped-rules">https://www.w3.org/TR/css-cascade-6/#scoped-rules</a>
[3] <a href="https://www.w3.org/TR/css-cascade-6/#in-scope">https://www.w3.org/TR/css-cascade-6/#in-scope</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation.html:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):

Canonical link: <a href="https://commits.webkit.org/318711@main">https://commits.webkit.org/318711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b2fcc95b173ba9da6b4b5bf3d25d55d3191f7e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188906 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35e3b825-061b-47ba-ba97-e6355a2e2b69) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139650 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7d93dbf-13b5-4920-9c90-daca38041be2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120096 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/271369e2-acd3-4084-8e24-5560172822f8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41918 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40260 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; 7 api tests failed or timed out; 6 api tests failed or timed out") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39907 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/213 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45622 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191126 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148883 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39952 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53366 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148628 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43314 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125637 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120451 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51884 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14886 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51269 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51510 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51330 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->