### PR TITLE
ctx.font does not re-resolve relative font sizes when set to the same string after the canvas element's style changed

### DIFF
--- a/LayoutTests/fast/canvas/canvas-font-relative-size-restyle-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-font-relative-size-restyle-expected.txt
@@ -1,0 +1,9 @@
+
+PASS Re-setting the same percentage font string picks up the new font-size of the canvas
+PASS Re-setting the same em font string picks up the new font-size of the canvas
+PASS Re-setting the same relative font string picks up a font-size inherited from an ancestor
+PASS The font used for measuring and drawing is re-resolved, not just the serialization
+PASS Absolute font sizes are not affected by the font-size of the canvas
+PASS Changing the font-size of the canvas does not by itself re-resolve the font
+PASS Save and restore keep the font resolved at the time each state was saved
+

--- a/LayoutTests/fast/canvas/canvas-font-relative-size-restyle.html
+++ b/LayoutTests/fast/canvas/canvas-font-relative-size-restyle.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<title>Setting CanvasRenderingContext2D.font to the same string re-resolves relative sizes against the current style</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<div id="container" style="font-size: 10px">
+    <canvas id="canvas" style="font-size: inherit"></canvas>
+</div>
+<script>
+const container = document.getElementById('container');
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+
+function reset()
+{
+    container.style.fontSize = '10px';
+    canvas.style.fontSize = 'inherit';
+    ctx.font = '10px sans-serif';
+}
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    canvas.style.fontSize = '10px';
+    ctx.font = '100% sans-serif';
+    assert_equals(ctx.font, '10px sans-serif', 'resolved against the initial font-size');
+
+    canvas.style.fontSize = '40px';
+    ctx.font = '100% sans-serif';
+    assert_equals(ctx.font, '40px sans-serif', 'resolved against the updated font-size');
+}, 'Re-setting the same percentage font string picks up the new font-size of the canvas');
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    canvas.style.fontSize = '10px';
+    ctx.font = '2em sans-serif';
+    assert_equals(ctx.font, '20px sans-serif', 'resolved against the initial font-size');
+
+    canvas.style.fontSize = '15px';
+    ctx.font = '2em sans-serif';
+    assert_equals(ctx.font, '30px sans-serif', 'resolved against the updated font-size');
+}, 'Re-setting the same em font string picks up the new font-size of the canvas');
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    ctx.font = '100% sans-serif';
+    assert_equals(ctx.font, '10px sans-serif', 'resolved against the initial inherited font-size');
+
+    container.style.fontSize = '25px';
+    ctx.font = '100% sans-serif';
+    assert_equals(ctx.font, '25px sans-serif', 'resolved against the updated inherited font-size');
+}, 'Re-setting the same relative font string picks up a font-size inherited from an ancestor');
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    canvas.style.fontSize = '10px';
+    ctx.font = '100% sans-serif';
+    const smallWidth = ctx.measureText('WebKit').width;
+    assert_greater_than(smallWidth, 0, 'text has a non-zero width');
+
+    canvas.style.fontSize = '40px';
+    ctx.font = '100% sans-serif';
+    const largeWidth = ctx.measureText('WebKit').width;
+    assert_approx_equals(largeWidth, smallWidth * 4, smallWidth * 0.25, 'width scales with the resolved font size');
+}, 'The font used for measuring and drawing is re-resolved, not just the serialization');
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    canvas.style.fontSize = '10px';
+    ctx.font = '20px sans-serif';
+    assert_equals(ctx.font, '20px sans-serif', 'absolute size is unaffected by the element font-size');
+
+    canvas.style.fontSize = '40px';
+    ctx.font = '20px sans-serif';
+    assert_equals(ctx.font, '20px sans-serif', 'absolute size stays put across a font-size change');
+}, 'Absolute font sizes are not affected by the font-size of the canvas');
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    canvas.style.fontSize = '10px';
+    ctx.font = '100% sans-serif';
+    assert_equals(ctx.font, '10px sans-serif', 'resolved against the initial font-size');
+
+    // Relative values are resolved when the font is set, so changing the style without setting the
+    // font again must not change the font of the context.
+    canvas.style.fontSize = '40px';
+    canvas.offsetTop;
+    assert_equals(ctx.font, '10px sans-serif', 'unchanged until the font is set again');
+}, 'Changing the font-size of the canvas does not by itself re-resolve the font');
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    canvas.style.fontSize = '10px';
+    ctx.font = '100% sans-serif';
+    ctx.save();
+
+    canvas.style.fontSize = '40px';
+    ctx.font = '100% sans-serif';
+    assert_equals(ctx.font, '40px sans-serif', 'resolved against the updated font-size');
+
+    ctx.restore();
+    assert_equals(ctx.font, '10px sans-serif', 'restored to the previously resolved font');
+}, 'Save and restore keep the font resolved at the time each state was saved');
+</script>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -221,18 +221,12 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
     if (newFont.isEmpty())
         return;
 
-    if (newFont == state().unparsedFont && state().font.realized())
-        return;
-
     Ref canvas = this->canvas();
     Ref document = canvas->document();
 
-    // According to http://lists.w3.org/Archives/Public/public-html/2009Jul/0947.html,
-    // the "inherit" and "initial" values must be ignored. CSSPropertyParserHelpers::parseUnresolvedFont() ignores these.
-    auto unresolvedFont = CSSPropertyParserHelpers::parseUnresolvedFont(newFont, document.get(), strictToCSSParserMode(!usesCSSCompatibilityParseMode()));
-    if (!unresolvedFont)
-        return;
-
+    // Relative values in the font shorthand ('%', 'em', 'larger', ...) are resolved against the
+    // canvas element's computed style at the time the font is set, so setting the same string again
+    // has to re-resolve if that style changed in the meantime.
     FontCascadeDescription fontDescription;
     if (CheckedPtr computedStyle = canvas->computedStyle())
         fontDescription = FontCascadeDescription { computedStyle->fontDescription() };
@@ -243,15 +237,25 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
         fontDescription.setComputedSize(DefaultFontSize);
     }
 
+    if (newFont == state().unparsedFont && state().font.realized() && fontDescription == state().fontResolutionBase)
+        return;
+
+    // According to http://lists.w3.org/Archives/Public/public-html/2009Jul/0947.html,
+    // the "inherit" and "initial" values must be ignored. CSSPropertyParserHelpers::parseUnresolvedFont() ignores these.
+    auto unresolvedFont = CSSPropertyParserHelpers::parseUnresolvedFont(newFont, document.get(), strictToCSSParserMode(!usesCSSCompatibilityParseMode()));
+    if (!unresolvedFont)
+        return;
+
     // Map the <canvas> font into the text style. If the font uses keywords like larger/smaller, these will work
     // relative to the canvas.
-    auto fontCascade = Style::resolveForUnresolvedFont(*unresolvedFont, WTF::move(fontDescription), document.get());
+    auto fontCascade = Style::resolveForUnresolvedFont(*unresolvedFont, FontCascadeDescription { fontDescription }, document.get());
     if (!fontCascade)
         return;
 
     String newFontSafeCopy(newFont); // Create a string copy since newFont can be deleted inside realizeSaves.
     realizeSaves();
     modifiableState().unparsedFont = newFontSafeCopy;
+    modifiableState().fontResolutionBase = WTF::move(fontDescription);
 
     modifiableState().font.initialize(protect(document->fontSelector()), *fontCascade);
     ASSERT(state().font.realized());

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -335,6 +335,9 @@ public:
 
         String unparsedFont;
         FontProxy font;
+        // The font description `unparsedFont` was resolved against. Relative values in the font
+        // shorthand depend on it, so `font` is stale once it no longer matches the canvas element.
+        FontCascadeDescription fontResolutionBase;
 
         RefPtr<CanvasLayerContextSwitcher> targetSwitcher;
 


### PR DESCRIPTION
#### b0089a4add643baa29ec693a70008a30729adaf8
<pre>
ctx.font does not re-resolve relative font sizes when set to the same string after the canvas element&apos;s style changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=321156">https://bugs.webkit.org/show_bug.cgi?id=321156</a>
<a href="https://rdar.apple.com/184194378">rdar://184194378</a>

Reviewed by Gerald Squelart.

Relative values in the canvas font shorthand (&apos;%&apos;, &apos;em&apos;, &apos;ex&apos;, &apos;larger&apos;, ...) are
resolved against the computed style of the canvas element at the time the font is
set. CanvasRenderingContext2D::setFontWithoutUpdatingStyle() memoized that work on
the unparsed font string alone, so assigning the same string again was treated as a
no-op even when the element&apos;s font-size had changed in between, leaving the context
with a font resolved against a stale style. Nothing else invalidates it either: the
only invalidation path is FontProxy::fontsNeedUpdate(), which fires for web font
loads rather than for style changes on the canvas.

This is easy to hit in practice, because a page that varies the size through CSS has
no reason to vary the font string:

    canvas.style.fontSize = &quot;40px&quot;;
    ctx.font = &quot;100% Georgia&quot;; // Ignored if &quot;100% Georgia&quot; was already set.

Compute the base font description before the early return and record it in the
canvas state, so the memoized font is only reused when both the string and the
description it was resolved against still match.

Test: fast/canvas/canvas-font-relative-size-restyle.html

* LayoutTests/fast/canvas/canvas-font-relative-size-restyle-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-font-relative-size-restyle.html: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::setFontWithoutUpdatingStyle):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:

Canonical link: <a href="https://commits.webkit.org/318753@main">https://commits.webkit.org/318753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a426c01475c537fe0fd1cd2caa40fc8f9ecbb9b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188909 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec8c594a-bf27-48c8-9acd-1e0e98fc22cf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139653 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92e8862d-92dc-4a7f-9354-70bcdec73801) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160408 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120099 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b995d525-d62c-4fb0-9ecc-c0e0b2c02664) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41919 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40262 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39911 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/216 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191129 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148885 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39979 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53369 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148630 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43317 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125640 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120454 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51887 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14890 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51272 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51513 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51333 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->