### PR TITLE
[AppKit Gestures] Add a few more API tests to test clicking the PDF HUD

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView+Testing.swift
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView+Testing.swift
@@ -50,6 +50,11 @@ extension WKAlternatePDFHUDView {
             fatalError()
         }
     }
+
+    @objc(_hideForTesting)
+    private func hideForTesting() {
+        // FIXME: Implement `WKAlternatePDFHUDView.hide`.
+    }
 }
 
 #endif // ENABLE_PDF_HUD

--- a/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift
@@ -179,6 +179,13 @@ extension WKDefaultPDFHUDView {
     // For testing only.
     // swift-format-ignore: NoLeadingUnderscores
     @objc
+    private func _hideForTesting() {
+        hideTimerFired()
+    }
+
+    // For testing only.
+    // swift-format-ignore: NoLeadingUnderscores
+    @objc
     private func _performAction(forControl controlName: String) {
         switch controlName {
         case "minus.magnifyingglass":

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
@@ -45,6 +45,19 @@ extension WebPage {
         case toggleUnderline = "ToggleUnderline"
     }
 
+    /// The main frame tree node of this page.
+    public var mainFrame: _WKFrameTreeNode? {
+        get async {
+            await backingWebView._frames()
+        }
+    }
+
+    /// The scale factor by which the page scales content relative to its bounds.
+    public var pageZoom: Double {
+        get { backingWebView.pageZoom }
+        set { backingWebView.pageZoom = newValue }
+    }
+
     /// Suspends execution of the current context until the next presentation update has occurred for this page.
     public func waitForNextPresentationUpdate() async {
         await withCheckedContinuation { continuation in
@@ -53,6 +66,13 @@ extension WebPage {
             })
         }
     }
+
+    #if WTF_PLATFORM_MAC
+    /// The set of views containing the PDF HUDs within the page, if any.
+    public var pdfHUDs: Set<NSView> {
+        backingWebView._pdfHUDs()
+    }
+    #endif // WTF_PLATFORM_MAC
 
     /// Configures a specific preference for the engine to use.
     ///
@@ -94,13 +114,6 @@ extension WebPage {
         await waitForNextPresentationUpdate()
     }
 
-    /// The main frame tree node of this page.
-    public var mainFrame: _WKFrameTreeNode? {
-        get async {
-            await backingWebView._frames()
-        }
-    }
-
     /// Perform the specified edit command on the webpage, optionally with an argument provided to the command.
     ///
     /// - Parameters:
@@ -112,7 +125,6 @@ extension WebPage {
     }
 
     #if WTF_PLATFORM_MAC
-
     /// Determines if the specified point is located above a visible scrollbar.
     ///
     /// - Parameter locationInView: The point in view coordinates to test.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -505,9 +505,12 @@ extension AppKitGesturesTests.Basic {
     }
 
     @Test(
-        .bug("https://webkit.org/b/314804", "Triple click does not generate a line selection on PDF")
+        .bug("https://webkit.org/b/314804", "Triple click does not generate a line selection on PDF"),
+        arguments: [true, false]
     )
-    func tripleClickingInPDFSelectsLine() async throws {
+    func tripleClickingInPDFSelectsLine(useAlternatePDFHUD: Bool) async throws {
+        page.setWebFeature("UseAlternatePDFHUD", enabled: useAlternatePDFHUD)
+
         let pdfURL = try #require(Bundle.testResources.url(forResource: "test", withExtension: "pdf"))
         try await page.load(pdfURL).wait()
         await page.waitForNextPresentationUpdate()
@@ -527,6 +530,68 @@ extension AppKitGesturesTests.Basic {
 
         let selectedText = await page.copySelection()
         #expect(selectedText == "Test PDF Content")
+    }
+
+    @Test(arguments: [true, false])
+    func clickingOnPDFHUDButtonPerformsAction(useAlternatePDFHUD: Bool) async throws {
+        page.setWebFeature("UseAlternatePDFHUD", enabled: useAlternatePDFHUD)
+
+        let pdfURL = try #require(Bundle.testResources.url(forResource: "test", withExtension: "pdf"))
+        try await page.load(pdfURL).wait()
+        await page.waitForNextPresentationUpdate()
+
+        let hud = try #require(page.pdfHUDs.first?.subviews.first)
+        let hudCenterInWindow = hud.convert(CGPoint(x: hud.bounds.midX, y: hud.bounds.midY), to: nil)
+        let hudCenterInScreen = screenBounds(ofPointInWindowCoordinates: hudCenterInWindow)
+        let zoomInButton = NSPoint(x: hudCenterInScreen.x - 20, y: hudCenterInScreen.y)
+
+        let scaleBeforeZooming = page.pageZoom
+
+        await recap.play { composer in
+            composer._wk_click(at: zoomInButton, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+        }
+
+        let scaleAfterZooming = page.pageZoom
+
+        #expect(scaleAfterZooming > scaleBeforeZooming)
+    }
+
+    @Test(arguments: [false])
+    func clickingOnPDFShowsHUD(useAlternatePDFHUD: Bool) async throws {
+        page.setWebFeature("UseAlternatePDFHUD", enabled: useAlternatePDFHUD)
+
+        let pdfURL = try #require(Bundle.testResources.url(forResource: "test", withExtension: "pdf"))
+        try await page.load(pdfURL).wait()
+        await page.waitForNextPresentationUpdate()
+
+        let clickPoint = screenBounds(ofPointInWindowCoordinates: .init(x: 100, y: 350))
+
+        let hud = try #require(page.pdfHUDs.first)
+
+        unsafe hud.perform(Selector(("_hideForTesting")))
+
+        // Reach in to the view hierarchy and get the view whose opacity actually changes,
+        // which is dependent on the implementation.
+        // FIXME: Depending on implementation-specific details like this is very not great.
+
+        let visibleView =
+            if useAlternatePDFHUD {
+                try #require(hud.subviews.first?.subviews.first)
+            } else {
+                try #require(hud.subviews.first)
+            }
+
+        try await Task.sleep(for: .seconds(1))
+        #expect(visibleView.alphaValue == 0)
+
+        await recap.play { composer in
+            composer._wk_click(at: clickPoint, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+        }
+
+        try await Task.sleep(for: .seconds(1))
+        #expect(visibleView.alphaValue == 1)
     }
 
     @Test(arguments: [0.1, 0.5, 0.9])


### PR DESCRIPTION
#### 968a3d30b9eb13dccbbf4b52ad217e00095891db
<pre>
[AppKit Gestures] Add a few more API tests to test clicking the PDF HUD
<a href="https://bugs.webkit.org/show_bug.cgi?id=321158">https://bugs.webkit.org/show_bug.cgi?id=321158</a>
<a href="https://rdar.apple.com/184195190">rdar://184195190</a>

Reviewed by Abrar Rahman Protyasha.

Just adding some tests.

* Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift:
(mainFrame):
(pageZoom):
(pdfHUDs):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:
(AppKitGesturesTests.tripleClickingInPDFSelectsLine(_:)):
(AppKitGesturesTests.clickingOnPDFHUDButtonPerformsAction(_:)):
(AppKitGesturesTests.clickingOnPDFShowsHUD(_:)):
(AppKitGesturesTests.tripleClickingInPDFSelectsLine): Deleted.

Canonical link: <a href="https://commits.webkit.org/318731@main">https://commits.webkit.org/318731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3140075a22d5e4640e78b52b48e3d224e5a0a01f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179112 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188941 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2cb0a34b-c860-45f4-91ea-050e21b493f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180975 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54344 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139677 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1257d2a3-0937-42e5-b920-9b4e6fdeabd1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160435 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120124 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/585aa5a5-d74d-4345-a2da-82381c1c2b4f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41946 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40289 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39939 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/249 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191161 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52721 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148909 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39941 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53401 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36564 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148655 "Found 1 new API test failure: TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27197 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43345 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125672 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120486 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51919 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14917 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51304 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51545 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51365 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->