### PR TITLE
REGRESSION(311768@main): :focus-visible incorrectly shown after focus() inside a focused ancestor

### DIFF
--- a/LayoutTests/fast/selectors/focus-visible-script-focus-after-dialog-dismiss-expected.txt
+++ b/LayoutTests/fast/selectors/focus-visible-script-focus-after-dialog-dismiss-expected.txt
@@ -1,0 +1,6 @@
+Dismissing a modal dialog by clicking a close button inside it, and restoring focus to the element that opened it, should not show :focus-visible on that element.
+
+Open
+
+PASS focus() restored after dismissing a modal <dialog> should not show :focus-visible
+

--- a/LayoutTests/fast/selectors/focus-visible-script-focus-after-dialog-dismiss.html
+++ b/LayoutTests/fast/selectors/focus-visible-script-focus-after-dialog-dismiss.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>:focus-visible should not match when focus is restored after dismissing a modal dialog</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        *:focus,
+        *:focus-visible {
+            outline: none;
+        }
+        #trigger:focus-visible {
+            outline: 3px solid red;
+        }
+        #close {
+            width: 60px;
+            height: 30px;
+        }
+    </style>
+</head>
+<body>
+    <p>Dismissing a modal dialog by clicking a close button inside it, and restoring focus to the
+    element that opened it, should not show :focus-visible on that element.</p>
+
+    <button id="trigger" type="button">Open</button>
+
+    <dialog id="dialog">
+        <button id="close" type="button" aria-label="Close"></button>
+    </dialog>
+
+    <script>
+    // showModal()'s focusing steps reset the document's recorded focus trigger,
+    // so unlike the [tabindex] variant of this test, this one does not
+    // depend on being the document's first interaction.
+    promise_test(async t => {
+        const trigger = document.getElementById("trigger");
+        const dialog = document.getElementById("dialog");
+        const close = document.getElementById("close");
+        t.add_cleanup(() => { if (dialog.open) dialog.close(); trigger.blur(); });
+
+        dialog.showModal();
+        dialog.focus();
+
+        // The dialog itself must be focused: an open <dialog> can be focused by clicking, so a
+        // click inside it finds an ancestor that can take focus yet leaves the focus unchanged.
+        assert_equals(document.activeElement, dialog, "dialog should be focused while open");
+
+        close.addEventListener("click", () => { dialog.close(); trigger.focus(); }, { once: true });
+
+        // #close is empty, so the click lands on the button itself, and clicking a <button> does
+        // not focus it on macOS or iOS.
+        const rect = close.getBoundingClientRect();
+        await UIHelper.activateAt(rect.x + rect.width / 2, rect.y + rect.height / 2);
+
+        assert_equals(document.activeElement, trigger, "trigger should be focused after dismissal");
+        assert_false(trigger.matches(":focus-visible"),
+            ":focus-visible should not match on the opener after focus() restored from dismissing the dialog");
+    }, "focus() restored after dismissing a modal <dialog> should not show :focus-visible");
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/selectors/focus-visible-script-focus-inside-focused-ancestor-expected.txt
+++ b/LayoutTests/fast/selectors/focus-visible-script-focus-inside-focused-ancestor-expected.txt
@@ -1,0 +1,7 @@
+Clicking a button that is not mouse-focusable should record a click focus trigger, even when the button is inside an ancestor which is focusable and already focused, so that a later element.focus() does not show :focus-visible.
+
+Open
+
+
+PASS focus() after clicking a non-mouse-focusable button inside an already-focused ancestor should not show :focus-visible
+

--- a/LayoutTests/fast/selectors/focus-visible-script-focus-inside-focused-ancestor.html
+++ b/LayoutTests/fast/selectors/focus-visible-script-focus-inside-focused-ancestor.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>:focus-visible should not match after focus() following a click inside a focused ancestor</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        *:focus,
+        *:focus-visible {
+            outline: none;
+        }
+        #trigger:focus-visible {
+            outline: 3px solid red;
+        }
+        #close {
+            width: 60px;
+            height: 30px;
+        }
+    </style>
+</head>
+<body>
+    <p>Clicking a button that is not mouse-focusable should record a click focus trigger, even when
+    the button is inside an ancestor which is focusable and already focused, so that a later
+    element.focus() does not show :focus-visible.</p>
+
+    <button id="trigger" type="button">Open</button>
+
+    <div id="container" tabindex="-1"><button id="close" type="button"></button></div>
+
+    <script>
+    // This must be the document's first user interaction. Once a click has been recorded, nothing
+    // resets it -- a programmatic focus() deliberately leaves the recorded trigger alone -- so a
+    // second click-based test in this document would pass regardless of the behavior under test.
+    promise_test(async t => {
+        const trigger = document.getElementById("trigger");
+        const container = document.getElementById("container");
+        const close = document.getElementById("close");
+
+        // Focusing by script does not record a click trigger, so the container is focused but the
+        // document has still never seen a click.
+        container.focus();
+        assert_equals(document.activeElement, container, "container should be focused");
+
+        close.addEventListener("click", () => { trigger.focus(); }, { once: true });
+
+        // #close is empty, so the click lands on the button itself, and clicking a <button> does
+        // not focus it on macOS or iOS.
+        const rect = close.getBoundingClientRect();
+        await UIHelper.activateAt(rect.x + rect.width / 2, rect.y + rect.height / 2);
+
+        assert_equals(document.activeElement, trigger, "trigger should be focused");
+        assert_false(trigger.matches(":focus-visible"),
+            ":focus-visible should not match on trigger after focus() from a click on a button inside an already-focused ancestor");
+    }, "focus() after clicking a non-mouse-focusable button inside an already-focused ancestor should not show :focus-visible");
+    </script>
+</body>
+</html>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3409,8 +3409,9 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
     // Form control elements are not mouse focusable on some platforms (see HTMLFormControlElement::isMouseFocusable())
     // which makes us behave differently than other browsers when a button is clicked,
     // because the button is not actually focused so we don't set the latest FocusTrigger.
-    if (!element && m_elementUnderMouse) {
-        for (RefPtr ancestor = m_elementUnderMouse.get(); ancestor; ancestor = ancestor->parentElementInComposedTree()) {
+    if (m_elementUnderMouse) {
+        // Stop at element: setFocusedElement records the trigger for it, unless it is already focused.
+        for (RefPtr ancestor = m_elementUnderMouse.get(); ancestor && ancestor != element; ancestor = ancestor->parentElementInComposedTree()) {
             if (is<HTMLFormControlElement>(*ancestor) && !ancestor->isMouseFocusable()) {
                 frame->document()->setLatestFocusTrigger(FocusTrigger::Click);
                 break;


### PR DESCRIPTION
#### a1678ffa5ff18d2173b0f871d794ba57b34d7efd
<pre>
REGRESSION(311768@main): :focus-visible incorrectly shown after focus() inside a focused ancestor
<a href="https://bugs.webkit.org/show_bug.cgi?id=321157">https://bugs.webkit.org/show_bug.cgi?id=321157</a>
<a href="https://rdar.apple.com/181570771">rdar://181570771</a>

Reviewed by Abrar Rahman Protyasha.

Buttons are not mouse-focusable on macOS/iOS, so a workaround records
that the last focus trigger was a click. 311768@main stopped that
workaround from running when the clicked button sits inside an ancestor
that can take focus, such as a &lt;dialog&gt;. Usually the ancestor is focused
instead and the click is recorded there, but not when it is already
focused. Nothing recorded the click, so the programmatic focus() that
followed showed :focus-visible.

music.apple.com opens its now-playing player as a &lt;dialog&gt;. Dismissing
it left a red focus ring on the mini player.

Walk the ancestors only up to the element that will be focused, instead
of skipping the workaround whenever there is one.

Tests: fast/selectors/focus-visible-script-focus-after-dialog-dismiss.html
       fast/selectors/focus-visible-script-focus-inside-focused-ancestor.html

* LayoutTests/fast/selectors/focus-visible-script-focus-after-dialog-dismiss-expected.txt: Added.
* LayoutTests/fast/selectors/focus-visible-script-focus-after-dialog-dismiss.html: Added.
* LayoutTests/fast/selectors/focus-visible-script-focus-inside-focused-ancestor-expected.txt: Added.
* LayoutTests/fast/selectors/focus-visible-script-focus-inside-focused-ancestor.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::dispatchMouseEvent):

Canonical link: <a href="https://commits.webkit.org/318775@main">https://commits.webkit.org/318775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca6185b4ee41abbd0ea02fbc142f01730d4be80d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188929 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e38d85e4-0258-49f8-9ebf-aa5395c0f61f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139668 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5bfb25a4-a2c9-43e6-9ee2-68a3d40deb1a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120114 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1fd44b7e-54b7-4772-a8d5-a9ca342d07e7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41935 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40280 "Passed tests") | | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152335 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; 1 api test failed or timed out; re-run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39928 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/236 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191149 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148900 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39992 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53389 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148645 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43335 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125660 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120474 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51907 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14907 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51292 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51533 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51353 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->