### PR TITLE
Add a quirk to fetch YouTube and Netflix captions for Find in Video

### DIFF
--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -769,6 +769,8 @@ $(PROJECT_DIR)/Modules/modern-media-controls/gesture-recognizers/pinch.js
 $(PROJECT_DIR)/Modules/modern-media-controls/gesture-recognizers/tap.js
 $(PROJECT_DIR)/Modules/modern-media-controls/main.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/CNNCaptionQuirk.js
+$(PROJECT_DIR)/Modules/modern-media-controls/media/NetflixCaptionFetchQuirk.js
+$(PROJECT_DIR)/Modules/modern-media-controls/media/YouTubeCaptionFetchQuirk.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/airplay-support.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/audio-support.js

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -2338,6 +2338,8 @@ USER_AGENT_SCRIPTS = \
     ModernMediaControls.js \
 	$(WebCore)/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js \
 	$(WebCore)/Modules/modern-media-controls/media/CNNCaptionQuirk.js \
+	$(WebCore)/Modules/modern-media-controls/media/YouTubeCaptionFetchQuirk.js \
+	$(WebCore)/Modules/modern-media-controls/media/NetflixCaptionFetchQuirk.js \
 #
 
 USER_AGENT_SCRIPTS_FILES = \

--- a/Source/WebCore/Modules/modern-media-controls/media/NetflixCaptionFetchQuirk.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/NetflixCaptionFetchQuirk.js
@@ -1,0 +1,302 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Find in Video: Netflix caption fetch.
+//
+// Netflix delivers subtitles as TTML over XHR/fetch and caches each language (no request on a
+// switch-back), so we cache the parsed cues per language and follow the active language via Netflix's
+// player API, mirroring it into a single hidden text track for find-in-video.
+
+(function() {
+    "use strict";
+
+    // Parse a TTML document into [{ start, end, text }] in seconds, or null if it isn't TTML.
+    function parseCues(text)
+    {
+        if (!text || text.indexOf("<tt") === -1)
+            return null;
+
+        let doc;
+        try {
+            doc = new DOMParser().parseFromString(text, "application/xml");
+        } catch (e) {
+            return null;
+        }
+        if (!doc || doc.getElementsByTagName("parsererror").length)
+            return null;
+
+        const tt = doc.documentElement;
+        if (!tt)
+            return null;
+
+        const language = tt.getAttribute("xml:lang")
+            || tt.getAttributeNS("http://www.w3.org/XML/1998/namespace", "lang")
+            || "";
+
+        // TTML times may be tick-based, so read the tick rate if the document declares one.
+        const tickRate = parseFloat(tt.getAttribute("ttp:tickRate")
+            || tt.getAttributeNS("http://www.w3.org/ns/ttml#parameter", "tickRate")
+            || "0");
+
+        function toSeconds(value)
+        {
+            if (!value)
+                return NaN;
+            value = value.trim();
+            const last = value.charAt(value.length - 1);
+            if (last === "t")
+                return tickRate > 0 ? parseFloat(value) / tickRate : NaN;
+            if (last === "s")
+                return parseFloat(value);
+            const parts = value.split(":");
+            if (parts.length === 3)
+                return (+parts[0]) * 3600 + (+parts[1]) * 60 + parseFloat(parts[2]);
+            return parseFloat(value);
+        }
+
+        // Merge <p>s that share the same time range into a single cue.
+        const paragraphs = tt.getElementsByTagNameNS("*", "p");
+        const byRange = new Map();
+        for (let i = 0; i < paragraphs.length; ++i) {
+            const paragraph = paragraphs[i];
+            const start = toSeconds(paragraph.getAttribute("begin"));
+            const end = toSeconds(paragraph.getAttribute("end"));
+            if (!(end > start))
+                continue;
+            const text = (paragraph.textContent || "").replace(/\s+/g, " ").trim();
+            if (!text)
+                continue;
+            const key = start + "-" + end;
+            const existing = byRange.get(key);
+            if (existing)
+                existing.text += " " + text;
+            else
+                byRange.set(key, { start, end, text });
+        }
+
+        const cues = Array.from(byRange.values());
+        return cues.length ? { language, cues } : null;
+    }
+
+    const cueCache = new Map();
+    let boundVideo = null;
+    let injectedTrack = null;
+    let appliedCues = null;
+    let appliedVideoId = null;
+    let listening = false;
+    let pendingResults = [];
+
+    // Resolve the live player element, re-acquiring it if Netflix tore down the one we had.
+    function currentVideo()
+    {
+        if (boundVideo && boundVideo.isConnected)
+            return boundVideo;
+        const video = document.querySelector("video");
+        return video && video.isConnected ? video : null;
+    }
+
+    function setCues(cues)
+    {
+        const video = currentVideo();
+        if (!video)
+            return;
+        if (video !== boundVideo) {
+            boundVideo = video;
+            injectedTrack = null;
+        }
+        if (!injectedTrack)
+            injectedTrack = boundVideo.addTextTrack("captions", "WebKitFindInVideo");
+        clearTrack();
+        for (const cue of (cues || []))
+            injectedTrack.addCue(new VTTCue(cue.start, cue.end, cue.text));
+        injectedTrack.mode = "hidden";
+    }
+
+    window.__setupFindInVideoCaptionFetch = function(video) {
+        if (boundVideo === video)
+            return;
+        boundVideo = video;
+        injectedTrack = null;
+        // New element with an empty track: forget applied state and rebuild from the cache.
+        appliedCues = null;
+        applyActiveLanguage();
+    };
+
+    // The current playback via Netflix's player API: { videoId, language } where language is a bcp47
+    // code, "OFF" when disabled, or null when transitioning. null overall if the API isn't ready.
+    function session()
+    {
+        try {
+            const api = netflix.appContext.state.playerApp.getAPI();
+            const player = api.videoPlayer;
+            const sessionId = player.getAllPlayerSessionIds()[0];
+            if (!sessionId)
+                return null;
+            const track = player.getCurrentTextTrackBySessionId(sessionId);
+            let videoId = "";
+            try {
+                videoId = api.getVideoIdBySessionId(sessionId) || "";
+            } catch (e) { }
+            // Without a videoId the cache key would collapse across episodes, so treat it as not ready.
+            if (!videoId)
+                return null;
+            return {
+                videoId,
+                language: !track ? null : (track.isNoneTrack ? "OFF" : track.bcp47)
+            };
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function clearTrack()
+    {
+        while (injectedTrack && injectedTrack.cues && injectedTrack.cues.length)
+            injectedTrack.removeCue(injectedTrack.cues[0]);
+    }
+
+    // Mirror the active (videoId, language) transcript from the cache onto the track. On an episode
+    // change, evict other episodes' cues. Re-apply when the cues change or Netflix tore down our element.
+    function applyActiveLanguage()
+    {
+        const s = session();
+        if (!s)
+            return;
+        if (s.videoId !== appliedVideoId) {
+            appliedVideoId = s.videoId;
+            appliedCues = null;
+            clearTrack();
+            for (const key of cueCache.keys())
+                if (!key.startsWith(s.videoId + "\n"))
+                    cueCache.delete(key);
+        }
+        if (!s.language || s.language === "OFF")
+            return;
+        const trackIsLive = injectedTrack && boundVideo && boundVideo.isConnected;
+        const cues = cueCache.get(s.videoId + "\n" + s.language);
+        if (!cues || (cues === appliedCues && trackIsLive))
+            return;
+        setCues(cues);
+        appliedCues = cues;
+    }
+
+    // Drain transcripts that arrived before the player API was ready, then sync the active language.
+    function onPlayerStateChanged()
+    {
+        if (pendingResults.length) {
+            const results = pendingResults;
+            pendingResults = [];
+            for (const result of results)
+                cacheResult(result);
+        }
+        applyActiveLanguage();
+    }
+
+    // Netflix has no "captions changed" event, but its Redux store fires on the change (even while
+    // paused). Subscribe once, lazily, since the API isn't ready at document-start.
+    function ensureListening()
+    {
+        if (listening)
+            return;
+        try {
+            // Registering is the side effect we want, the return value varies, so treat a non-throwing call as subscribed.
+            netflix.appContext.state.playerApp.addChangeListener(onPlayerStateChanged);
+            listening = true;
+        } catch (e) { }
+        if (!listening) {
+            document.addEventListener("timeupdate", onPlayerStateChanged, true);
+            listening = true;
+        }
+    }
+
+    // Cache a fetched transcript under (videoId, active language), falling back to the TTML's own
+    // language for the language part, then apply it if it's the on-screen episode and language.
+    function cacheResult(result)
+    {
+        const s = session();
+        if (!s) {
+            // The transcript arrived before the player API was ready, retry once it is.
+            pendingResults.push(result);
+            ensureListening();
+            return;
+        }
+        const language = (s.language && s.language !== "OFF") ? s.language : result.language;
+        if (!language)
+            return;
+        cueCache.set(s.videoId + "\n" + language, result.cues);
+        ensureListening();
+        applyActiveLanguage();
+    }
+
+    function isXML(contentType)
+    {
+        return contentType && contentType.indexOf("xml") !== -1;
+    }
+
+    // Wrap the page's own XHR so we see the TTML responses. Hook each request object at most once,
+    // since Netflix reuses XHRs and re-opens them, which would otherwise stack a listener per open.
+    const hookedRequests = new WeakSet();
+    const originalOpen = XMLHttpRequest.prototype.open;
+    XMLHttpRequest.prototype.open = function() {
+        if (!hookedRequests.has(this)) {
+            hookedRequests.add(this);
+            this.addEventListener("load", function() {
+                try {
+                    if (!isXML(this.getResponseHeader("content-type")))
+                        return;
+                    let text = null;
+                    const responseType = this.responseType;
+                    if (responseType === "" || responseType === "text")
+                        text = this.responseText;
+                    else if (responseType === "arraybuffer" && this.response)
+                        text = new TextDecoder().decode(this.response);
+                    const result = parseCues(text);
+                    if (result)
+                        cacheResult(result);
+                } catch (e) { }
+            });
+        }
+        return originalOpen.apply(this, arguments);
+    };
+
+    // Netflix also fetches TTML via fetch(), so observe those responses too.
+    const originalFetch = window.fetch;
+    if (originalFetch) {
+        window.fetch = function() {
+            return originalFetch.apply(this, arguments).then(function(response) {
+                try {
+                    if (response && isXML(response.headers.get("content-type"))) {
+                        response.clone().text().then(function(text) {
+                            const result = parseCues(text);
+                            if (result)
+                                cacheResult(result);
+                        }).catch(function() { });
+                    }
+                } catch (e) { }
+                return response;
+            });
+        };
+    }
+})();

--- a/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionFetchQuirk.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionFetchQuirk.js
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Find in Video: YouTube caption fetch.
+//
+// YouTube doesn't expose its captions as <track> elements. They arrive as JSON3 "timedtext" responses
+// on the player's own XHR. This runs in the page's main world so it can wrap XMLHttpRequest before
+// the player issues those requests, then mirrors the captions into a hidden text track on the <video>
+// so find-in-video can search them without affecting YouTube's own caption rendering.
+
+(function() {
+    "use strict";
+
+    // Parse YouTube's JSON3 timedtext payload into [{ start, end, text }] in seconds.
+    function parseCues(responseText)
+    {
+        let data;
+        try {
+            data = JSON.parse(responseText);
+        } catch (e) {
+            return null;
+        }
+        if (!data || !Array.isArray(data.events))
+            return null;
+
+        const cues = [];
+        for (const event of data.events) {
+            if (!event.segs)
+                continue;
+            const text = event.segs.map(segment => segment.utf8 || "").join("").trim();
+            if (!text)
+                continue;
+            const start = event.tStartMs / 1000;
+            const end = (event.tStartMs + (event.dDurationMs || 0)) / 1000;
+            if (end > start)
+                cues.push({ start, end, text });
+        }
+        return cues.length ? cues : null;
+    }
+
+    let injectedTrack = null;
+    let trackVideo = null;
+
+    function clearTrack()
+    {
+        while (injectedTrack && injectedTrack.cues && injectedTrack.cues.length)
+            injectedTrack.removeCue(injectedTrack.cues[0]);
+    }
+
+    // The <video> currently on screen. The Shorts feed keeps several video elements alive and pauses the
+    // off-screen ones, so the playing element is the active short. Fall back to the most viewport-visible
+    // element when none is playing.
+    function activeVideo()
+    {
+        const videos = Array.from(document.querySelectorAll("video")).filter(v => v.isConnected);
+        if (videos.length <= 1)
+            return videos[0] || null;
+        const score = v => {
+            const r = v.getBoundingClientRect();
+            const w = Math.max(0, Math.min(r.right, window.innerWidth) - Math.max(r.left, 0));
+            const h = Math.max(0, Math.min(r.bottom, window.innerHeight) - Math.max(r.top, 0));
+            return (v.paused ? 0 : 1e12) + w * h;
+        };
+        return videos.reduce((best, v) => score(v) > score(best) ? v : best);
+    }
+
+    // Mirror the fetched cues onto a hidden track on the active player. If that element changed, empty
+    // the old one's track (a script-added track can't be removed) and start a new one.
+    function setCues(cues)
+    {
+        const video = activeVideo();
+        if (!video)
+            return;
+        if (injectedTrack && trackVideo !== video) {
+            clearTrack();
+            injectedTrack = null;
+        }
+        trackVideo = video;
+        if (!injectedTrack)
+            injectedTrack = video.addTextTrack("captions", "WebKitFindInVideo");
+        clearTrack();
+        for (const cue of (cues || []))
+            injectedTrack.addCue(new VTTCue(cue.start, cue.end, cue.text));
+        injectedTrack.mode = "hidden";
+    }
+
+    // The video currently being watched: /watch?v=ID or /shorts/ID.
+    function watchedVideoId()
+    {
+        const v = new URLSearchParams(location.search).get("v");
+        if (v)
+            return v;
+        const match = location.pathname.match(/^\/shorts\/([^/?#]+)/);
+        return match ? match[1] : null;
+    }
+
+    // Wrap the page's own XHR so we see the signed timedtext responses.
+    const originalOpen = XMLHttpRequest.prototype.open;
+    XMLHttpRequest.prototype.open = function(method, url) {
+        if (typeof url === "string" && url.includes("/api/timedtext")) {
+            this.addEventListener("load", () => {
+                try {
+                    if (this.status !== 200)
+                        return;
+                    const requestVideoId = new URL(url, location.href).searchParams.get("v");
+                    const onShorts = location.pathname.startsWith("/shorts/");
+                    if (!requestVideoId)
+                        return;
+                    // On Shorts the URL lags a swipe behind, but each fetch is for the short just opened, so
+                    // trust it. On the watch page the URL is accurate, so still ignore hover-preview fetches.
+                    if (!onShorts && requestVideoId !== watchedVideoId())
+                        return;
+                    let text = null;
+                    const responseType = this.responseType;
+                    if (responseType === "" || responseType === "text")
+                        text = this.responseText;
+                    else if (responseType === "arraybuffer" && this.response)
+                        text = new TextDecoder().decode(this.response);
+                    if (!text)
+                        return;
+                    const cues = parseCues(text);
+                    if (cues)
+                        setCues(cues);
+                } catch (e) { }
+            });
+        }
+        return originalOpen.apply(this, arguments);
+    };
+
+    // A new video starting on the tracked player shouldn't keep the previous one's cues.
+    document.addEventListener("loadstart", event => {
+        if (event.target === trackVideo)
+            clearTrack();
+    }, true);
+})();

--- a/Source/WebCore/PlatformCocoa.cmake
+++ b/Source/WebCore/PlatformCocoa.cmake
@@ -1576,6 +1576,8 @@ set(WebCore_USER_AGENT_SCRIPTS
     ${WebCore_DERIVED_SOURCES_DIR}/ModernMediaControls.js
     ${WEBCORE_DIR}/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
     ${WEBCORE_DIR}/Modules/modern-media-controls/media/CNNCaptionQuirk.js
+    ${WEBCORE_DIR}/Modules/modern-media-controls/media/YouTubeCaptionFetchQuirk.js
+    ${WEBCORE_DIR}/Modules/modern-media-controls/media/NetflixCaptionFetchQuirk.js
 )
 
 list(APPEND WebCoreTestSupport_LIBRARIES PRIVATE WebCore)

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -23208,6 +23208,8 @@
 		EBE095E3277D14C700804D61 /* PushSubscriptionIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PushSubscriptionIdentifier.h; sourceTree = "<group>"; };
 		EBE5B224245A26EE003A5A88 /* SQLiteStatementAutoResetScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQLiteStatementAutoResetScope.h; sourceTree = "<group>"; };
 		EBE5B227245A29CF003A5A88 /* SQLiteStatementAutoResetScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteStatementAutoResetScope.cpp; sourceTree = "<group>"; };
+		EBEEF8F9301F34CE00DB3007 /* NetflixCaptionFetchQuirk.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = NetflixCaptionFetchQuirk.js; sourceTree = "<group>"; };
+		EBEEF8FA301F34CE00DB3007 /* YouTubeCaptionFetchQuirk.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = YouTubeCaptionFetchQuirk.js; sourceTree = "<group>"; };
 		EBF5121A1696496C0056BD25 /* JSTypeConversions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSTypeConversions.cpp; sourceTree = "<group>"; };
 		EBF5121B1696496C0056BD25 /* JSTypeConversions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSTypeConversions.h; sourceTree = "<group>"; };
 		ECA680C61E67724500731D20 /* StringUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringUtilities.h; sourceTree = "<group>"; };
@@ -31918,6 +31920,7 @@
 				9551959225FA9E4C00F58CF0 /* media-document-controller.js */,
 				A1603D052C614198007D150C /* metadata-support.js */,
 				7177E2471DB80D2F00919A0B /* mute-support.js */,
+				EBEEF8F9301F34CE00DB3007 /* NetflixCaptionFetchQuirk.js */,
 				950C484925D6774200AB3D9C /* overflow-support.js */,
 				7130141D1DC9C08600CA3A88 /* pip-support.js */,
 				711FB0751DC7688F00C4C708 /* placard-support.js */,
@@ -31934,6 +31937,7 @@
 				71F936F71DD4F99B00922CC7 /* tracks-support.js */,
 				717F90571DC40ED60006F520 /* volume-support.js */,
 				9551959025FA9E3D00F58CF0 /* watchos-media-controls-support.js */,
+				EBEEF8FA301F34CE00DB3007 /* YouTubeCaptionFetchQuirk.js */,
 				CDBA1F352F8D9EB300D30314 /* YouTubeCaptionQuirk.js */,
 			);
 			path = media;

--- a/Source/WebCore/dom/DocumentMediaElement.cpp
+++ b/Source/WebCore/dom/DocumentMediaElement.cpp
@@ -134,50 +134,54 @@ bool DocumentMediaElement::ensureMediaControlsScript()
     return m_haveParsedMediaControlsScript;
 }
 
-bool DocumentMediaElement::ensureYouTubeQuirkScript()
+bool DocumentMediaElement::ensureScriptParsed(bool& haveParsed, String&& script, DOMWrapperWorld& world)
 {
-    if (m_haveParsedYouTubeQuirkScript)
+    if (haveParsed)
         return true;
 
     Ref document = this->document();
-    auto youTubeQuirkScript = RenderTheme::singleton().youTubeQuirkScript();
-    if (youTubeQuirkScript.isEmpty() || document->activeDOMObjectsAreSuspended() || document->activeDOMObjectsAreStopped())
+    if (script.isEmpty() || document->activeDOMObjectsAreSuspended() || document->activeDOMObjectsAreStopped())
         return false;
 
-    Ref world = mainThreadNormalWorldSingleton();
-    m_haveParsedYouTubeQuirkScript = setupAndCallJS([youTubeQuirkScript = WTF::move(youTubeQuirkScript)](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject&, ScriptController& scriptController, DOMWrapperWorld& world) {
+    haveParsed = setupAndCallJS([script = WTF::move(script)](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject&, ScriptController& scriptController, DOMWrapperWorld& world) {
         auto& vm = globalObject.vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        scriptController.evaluateInWorldIgnoringException(ScriptSourceCode(youTubeQuirkScript, JSC::SourceTaintedOrigin::Untainted), world);
+        scriptController.evaluateInWorldIgnoringException(ScriptSourceCode(script, JSC::SourceTaintedOrigin::Untainted), world);
         RETURN_IF_EXCEPTION(scope, false);
 
         return true;
     }, world);
-    return m_haveParsedYouTubeQuirkScript;
+    return haveParsed;
+}
+
+bool DocumentMediaElement::ensureYouTubeQuirkScript()
+{
+    return ensureScriptParsed(m_haveParsedYouTubeQuirkScript, RenderTheme::singleton().youTubeQuirkScript(), mainThreadNormalWorldSingleton());
 }
 
 bool DocumentMediaElement::ensureCNNQuirkScript()
 {
-    if (m_haveParsedCNNQuirkScript)
-        return true;
+    return ensureScriptParsed(m_haveParsedCNNQuirkScript, RenderTheme::singleton().cnnQuirkScript(), mainThreadNormalWorldSingleton());
+}
 
-    Ref document = this->document();
-    auto cnnQuirkScript = RenderTheme::singleton().cnnQuirkScript();
-    if (cnnQuirkScript.isEmpty() || document->activeDOMObjectsAreSuspended() || document->activeDOMObjectsAreStopped())
+bool DocumentMediaElement::ensureYouTubeCaptionFetchScript()
+{
+    return ensureScriptParsed(m_haveParsedYouTubeCaptionFetchScript, RenderTheme::singleton().youTubeCaptionFetchScript(), mainThreadNormalWorldSingleton());
+}
+
+bool DocumentMediaElement::ensureNetflixCaptionFetchScript()
+{
+    return ensureScriptParsed(m_haveParsedNetflixCaptionFetchScript, RenderTheme::singleton().netflixCaptionFetchScript(), mainThreadNormalWorldSingleton());
+}
+
+bool DocumentMediaElement::setupAndCallNetflixCaptionFetchJS(NOESCAPE const JSSetupFunction& task)
+{
+    if (!ensureNetflixCaptionFetchScript())
         return false;
 
     Ref world = mainThreadNormalWorldSingleton();
-    m_haveParsedCNNQuirkScript = setupAndCallJS([cnnQuirkScript = WTF::move(cnnQuirkScript)](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject&, ScriptController& scriptController, DOMWrapperWorld& world) {
-        auto& vm = globalObject.vm();
-        auto scope = DECLARE_THROW_SCOPE(vm);
-
-        scriptController.evaluateInWorldIgnoringException(ScriptSourceCode(cnnQuirkScript, JSC::SourceTaintedOrigin::Untainted), world);
-        RETURN_IF_EXCEPTION(scope, false);
-
-        return true;
-    }, world);
-    return m_haveParsedCNNQuirkScript;
+    return setupAndCallJS(task, world);
 }
 
 bool DocumentMediaElement::setupAndCallJS(NOESCAPE const JSSetupFunction& task, DOMWrapperWorld& world)

--- a/Source/WebCore/dom/DocumentMediaElement.h
+++ b/Source/WebCore/dom/DocumentMediaElement.h
@@ -55,6 +55,10 @@ public:
     bool setupAndCallYouTubeQuirkJS(NOESCAPE const JSSetupFunction&);
     bool setupAndCallCNNQuirkJS(NOESCAPE const JSSetupFunction&);
 
+    bool ensureYouTubeCaptionFetchScript();
+    bool ensureNetflixCaptionFetchScript();
+    bool setupAndCallNetflixCaptionFetchJS(NOESCAPE const JSSetupFunction&);
+
 private:
     bool isDocumentMediaElement() const final { return true; }
     static ASCIILiteral supplementName();
@@ -67,12 +71,15 @@ private:
 
     bool ensureYouTubeQuirkScript();
     bool ensureCNNQuirkScript();
+    bool ensureScriptParsed(bool& haveParsed, String&&, DOMWrapperWorld&);
 
     CheckedRef<Document> m_document;
     RefPtr<DOMWrapperWorld> m_isolatedWorld;
     bool m_haveParsedMediaControlsScript { false };
     bool m_haveParsedYouTubeQuirkScript { false };
     bool m_haveParsedCNNQuirkScript { false };
+    bool m_haveParsedYouTubeCaptionFetchScript { false };
+    bool m_haveParsedNetflixCaptionFetchScript { false };
 };
 
 }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1148,6 +1148,37 @@ Node::NeedsPostConnectionSteps HTMLMediaElement::insertionSteps(InsertionType in
     return NeedsPostConnectionSteps::Yes;
 }
 
+static DocumentMediaElement::JSSetupFunction callGlobalWithMediaElement(HTMLMediaElement& element, ASCIILiteral functionName)
+{
+    return [protectedElement = Ref { element }, functionName](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject& lexicalGlobalObject, ScriptController&, DOMWrapperWorld&) {
+        auto& vm = globalObject.vm();
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
+        auto functionValue = globalObject.get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, functionName));
+        if (scope.exception()) [[unlikely]]
+            return false;
+        if (functionValue.isUndefinedOrNull())
+            return false;
+
+        auto mediaJSWrapper = toJS(&lexicalGlobalObject, &globalObject, protectedElement.get());
+
+        JSC::MarkedArgumentBuffer argList;
+        argList.append(mediaJSWrapper);
+        ASSERT(!argList.hasOverflowed());
+
+        auto* function = functionValue.toObject(&lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, false);
+        auto callData = JSC::getCallData(function);
+        if (callData.type == JSC::CallData::Type::None)
+            return false;
+
+        JSC::call(&lexicalGlobalObject, function, callData, &globalObject, argList);
+
+        RETURN_IF_EXCEPTION(scope, false);
+        return true;
+    };
+}
+
 void HTMLMediaElement::postConnectionSteps()
 {
     Ref protectedThis { *this }; // prepareForLoad may result in a 'beforeload' event, which can make arbitrary DOM mutations.
@@ -1167,64 +1198,22 @@ void HTMLMediaElement::postConnectionSteps()
 
     configureMediaControls();
 
-    if (protect(document())->quirks().needsYouTubeCaptionsQuirk()) {
-        DocumentMediaElement::from(protect(document())).setupAndCallYouTubeQuirkJS([this](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject& lexicalGlobalObject, ScriptController&, DOMWrapperWorld&) {
-            auto& vm = globalObject.vm();
-            auto scope = DECLARE_THROW_SCOPE(vm);
+    Ref document = this->document();
+    auto& quirks = document->quirks();
+    bool findInVideo = document->settings().findInVideoEnabled();
 
-            auto functionValue = globalObject.get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, "setupCaptionMirroring"_s));
-            if (scope.exception()) [[unlikely]]
-                return false;
-            if (functionValue.isUndefinedOrNull())
-                return false;
+    bool needsYouTubeCaptions = quirks.needsYouTubeCaptionsQuirk();
+    bool needsCNN = quirks.needsCNNCaptionQuirk();
+    bool needsNetflixFetch = findInVideo && quirks.needsNetflixCaptionFetchQuirk();
 
-            auto mediaJSWrapper = toJS(&lexicalGlobalObject, &globalObject, *this);
-
-            JSC::MarkedArgumentBuffer argList;
-            argList.append(mediaJSWrapper);
-            ASSERT(!argList.hasOverflowed());
-
-            auto* function = functionValue.toObject(&lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(scope, false);
-            auto callData = JSC::getCallData(function);
-            if (callData.type == JSC::CallData::Type::None)
-                return false;
-
-            JSC::call(&lexicalGlobalObject, function, callData, &globalObject, argList);
-
-            RETURN_IF_EXCEPTION(scope, false);
-            return true;
-        });
-    }
-
-    if (protect(document())->quirks().needsCNNCaptionQuirk()) {
-        DocumentMediaElement::from(protect(document())).setupAndCallCNNQuirkJS([this](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject& lexicalGlobalObject, ScriptController&, DOMWrapperWorld&) {
-            auto& vm = globalObject.vm();
-            auto scope = DECLARE_THROW_SCOPE(vm);
-
-            auto functionValue = globalObject.get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, "setupCaptionMirroring"_s));
-            if (scope.exception()) [[unlikely]]
-                return false;
-            if (functionValue.isUndefinedOrNull())
-                return false;
-
-            auto mediaJSWrapper = toJS(&lexicalGlobalObject, &globalObject, *this);
-
-            JSC::MarkedArgumentBuffer argList;
-            argList.append(mediaJSWrapper);
-            ASSERT(!argList.hasOverflowed());
-
-            auto* function = functionValue.toObject(&lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(scope, false);
-            auto callData = JSC::getCallData(function);
-            if (callData.type == JSC::CallData::Type::None)
-                return false;
-
-            JSC::call(&lexicalGlobalObject, function, callData, &globalObject, argList);
-
-            RETURN_IF_EXCEPTION(scope, false);
-            return true;
-        });
+    if (needsYouTubeCaptions || needsCNN || needsNetflixFetch) {
+        auto& documentMediaElement = DocumentMediaElement::from(document);
+        if (needsYouTubeCaptions)
+            documentMediaElement.setupAndCallYouTubeQuirkJS(callGlobalWithMediaElement(*this, "setupCaptionMirroring"_s));
+        if (needsCNN)
+            documentMediaElement.setupAndCallCNNQuirkJS(callGlobalWithMediaElement(*this, "setupCaptionMirroring"_s));
+        if (needsNetflixFetch)
+            documentMediaElement.setupAndCallNetflixCaptionFetchJS(callGlobalWithMediaElement(*this, "__setupFindInVideoCaptionFetch"_s));
     }
 }
 
@@ -6000,9 +5989,15 @@ RefPtr<TextTrack> HTMLMediaElement::bestFindCaptionTrack() const
     return defaultTrack;
 }
 
+bool HTMLMediaElement::hasSiteRenderedCaptions() const
+{
+    Ref document = this->document();
+    return document->quirks().needsYouTubeCaptionFetchQuirk() || document->quirks().needsNetflixCaptionFetchQuirk();
+}
+
 void HTMLMediaElement::updateFindCaptionTrack()
 {
-    RefPtr best = hasShowingFindSearchableTextTrackExcept(m_findCaptionTrack.get()) ? nullptr : bestFindCaptionTrack();
+    RefPtr best = (hasSiteRenderedCaptions() || hasShowingFindSearchableTextTrackExcept(m_findCaptionTrack.get())) ? nullptr : bestFindCaptionTrack();
     if (m_findCaptionTrack == best)
         return;
 
@@ -6034,10 +6029,14 @@ Vector<MediaTime> HTMLMediaElement::findCueMatches(const String& target, FindOpt
 
     Vector<MediaTime> matches;
     if (RefPtr tracks = m_textTracks) {
+        bool searchSiteRenderedCaptions = hasSiteRenderedCaptions();
         MediaTime duration = durationMediaTime();
         for (unsigned i = 0; i < tracks->length(); ++i) {
             RefPtr track = tracks->item(i);
-            if (!track || track->mode() != TextTrack::Mode::Showing)
+            if (!track)
+                continue;
+            bool searchable = track->mode() == TextTrack::Mode::Showing || (searchSiteRenderedCaptions && track->trackType() == TextTrack::AddTrack && track->label() == "WebKitFindInVideo"_s);
+            if (!searchable)
                 continue;
             if (!isSubtitleOrCaptionTrackKind(track->kind()))
                 continue;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -449,6 +449,7 @@ public:
 
     void updateFindCaptionTrack();
     bool hasShowingFindSearchableTextTrackExcept(const TextTrack*) const;
+    bool hasSiteRenderedCaptions() const;
     RefPtr<TextTrack> bestFindCaptionTrack() const;
 
     void setSelectedTextTrack(TextTrack*);

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -45,6 +45,7 @@
 #include "DiagnosticLoggingClient.h"
 #include "DiagnosticLoggingKeys.h"
 #include "DocumentLoader.h"
+#include "DocumentMediaElement.h"
 #include "DocumentPrefetcher.h"
 #include "DocumentQuirks.h"
 #include "DocumentResourceLoader.h"
@@ -791,10 +792,38 @@ bool LocalFrame::hasUserContentProvider(const UserContentProvider& provider)
     return userContentProvider() == &provider;
 }
 
+#if ENABLE(VIDEO)
+// Injected at document-start: these sites fetch captions before <video> loads, so we hook early.
+static void injectCaptionFetchQuirkScripts(Document& document)
+{
+    if (!document.settings().findInVideoEnabled())
+        return;
+
+    auto& quirks = document.quirks();
+    bool needsYouTube = quirks.needsYouTubeCaptionFetchQuirk();
+    bool needsNetflix = quirks.needsNetflixCaptionFetchQuirk();
+    if (!needsYouTube && !needsNetflix)
+        return;
+
+    auto& mediaElement = DocumentMediaElement::from(document);
+    if (needsYouTube)
+        mediaElement.ensureYouTubeCaptionFetchScript();
+    if (needsNetflix)
+        mediaElement.ensureNetflixCaptionFetchScript();
+}
+#endif
+
 void LocalFrame::injectUserScripts(UserScriptInjectionTime injectionTime)
 {
     if (loader().stateMachine().creatingInitialEmptyDocument() && !settings().shouldInjectUserScriptsInInitialEmptyDocument())
         return;
+
+#if ENABLE(VIDEO)
+    if (injectionTime == UserScriptInjectionTime::DocumentStart) {
+        if (RefPtr document = this->document())
+            injectCaptionFetchQuirkScripts(*document);
+    }
+#endif
 
     RefPtr userContentProvider = this->userContentProvider();
     if (!userContentProvider)

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1625,6 +1625,29 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
     return Quirks::StorageAccessResult::ShouldNotCancelEvent;
 }
 
+bool Quirks::needsYouTubeCaptionFetchQuirk() const
+{
+#if PLATFORM(COCOA)
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsYouTubeCaptionFetchQuirk);
+#else
+    return false;
+#endif
+}
+
+bool Quirks::needsNetflixCaptionFetchQuirk() const
+{
+#if PLATFORM(COCOA)
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsNetflixCaptionFetchQuirk);
+#else
+    return false;
+#endif
+}
+
+
 // facebook.com: rdar://67273166
 // forbes.com:
 // reddit.com: rdar://80550715
@@ -3789,6 +3812,10 @@ static void handleNetflixQuirks(QuirksData& quirksData, const URL& /* quirksURL 
     quirksData.enableQuirks({
         // netflix.com https://bugs.webkit.org/show_bug.cgi?id=173030
         QuirksData::SiteSpecificQuirk::NeedsSeekingSupportDisabledQuirk,
+#if PLATFORM(COCOA)
+        // netflix.com: expose subtitles to find-in-video
+        QuirksData::SiteSpecificQuirk::NeedsNetflixCaptionFetchQuirk,
+#endif
 #if PLATFORM(VISION)
         QuirksData::SiteSpecificQuirk::NeedsNowPlayingFullscreenSwapQuirk,
 #endif
@@ -4027,6 +4054,8 @@ static void handleYouTubeQuirks(QuirksData& quirksData, const URL& quirksURL, co
         QuirksData::SiteSpecificQuirk::NeedsScrollbarWidthThinDisabledQuirk,
 #if PLATFORM(COCOA)
         QuirksData::SiteSpecificQuirk::NeedsYouTubeCaptionQuirk,
+        // youtube.com: expose captions to find-in-video
+        QuirksData::SiteSpecificQuirk::NeedsYouTubeCaptionFetchQuirk,
 #endif
 #if PLATFORM(IOS) || PLATFORM(VISION)
         // youtube.com: rdar://110097836

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -204,6 +204,9 @@ public:
 
     void triggerOptionalStorageAccessIframeQuirk(const URL& frameURL, CompletionHandler<void()>&&) const;
     StorageAccessResult triggerOptionalStorageAccessQuirk(Element&, const PlatformMouseEvent&, const AtomString& eventType, int, Element*, bool isParentProcessAFullWebBrowser, IsSyntheticClick) const;
+
+    bool needsYouTubeCaptionFetchQuirk() const;
+    bool needsNetflixCaptionFetchQuirk() const;
     void setSubFrameDomainsForStorageAccessQuirk(Vector<RegistrableDomain>&& domains) { m_subFrameDomainsForStorageAccessQuirk = WTF::move(domains); }
     const Vector<RegistrableDomain>& subFrameDomainsForStorageAccessQuirk() const LIFETIME_BOUND { return m_subFrameDomainsForStorageAccessQuirk; }
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -137,6 +137,8 @@ struct QuirksData {
         NeedsWebKitMediaTextTrackDisplayQuirk,
 #if PLATFORM(COCOA)
         NeedsYouTubeCaptionQuirk,
+        NeedsYouTubeCaptionFetchQuirk,
+        NeedsNetflixCaptionFetchQuirk,
 #endif
 #if PLATFORM(IOS_FAMILY)
         NeedsYouTubeEmbedAutoplayQuirk,

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -131,6 +131,8 @@ public:
     virtual String mediaControlsFormattedStringForDuration(double) { return String(); }
     virtual String youTubeQuirkScript() { return { }; }
     virtual String cnnQuirkScript() { return { }; }
+    virtual String youTubeCaptionFetchScript() { return { }; }
+    virtual String netflixCaptionFetchScript() { return { }; }
 #endif // ENABLE(VIDEO)
 #if ENABLE(ATTACHMENT_ELEMENT)
     virtual String attachmentStyleSheet() const;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -90,6 +90,8 @@ public:
     String mediaControlsFormattedStringForDuration(double) final;
     String youTubeQuirkScript() final;
     String cnnQuirkScript() final;
+    String youTubeCaptionFetchScript() final;
+    String netflixCaptionFetchScript() final;
 #endif
 
 #if ENABLE(FORM_CONTROL_REFRESH)
@@ -307,6 +309,8 @@ private:
     RetainPtr<NSDateComponentsFormatter> m_durationFormatter;
     String m_youTubeCaptionQuirkScript;
     String m_cnnCaptionQuirkScript;
+    String m_youTubeCaptionFetchScript;
+    String m_netflixCaptionFetchScript;
 #endif // ENABLE(VIDEO)
 };
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -1354,6 +1354,22 @@ String RenderThemeCocoa::cnnQuirkScript()
     return m_cnnCaptionQuirkScript;
 }
 
+String RenderThemeCocoa::youTubeCaptionFetchScript()
+{
+    if (!m_youTubeCaptionFetchScript)
+        m_youTubeCaptionFetchScript = StringImpl::createWithoutCopying(YouTubeCaptionFetchQuirkJavaScript);
+
+    return m_youTubeCaptionFetchScript;
+}
+
+String RenderThemeCocoa::netflixCaptionFetchScript()
+{
+    if (!m_netflixCaptionFetchScript)
+        m_netflixCaptionFetchScript = StringImpl::createWithoutCopying(NetflixCaptionFetchQuirkJavaScript);
+
+    return m_netflixCaptionFetchScript;
+}
+
 #endif // ENABLE(VIDEO)
 
 #if ENABLE(ATTACHMENT_ELEMENT)


### PR DESCRIPTION
#### c25ceb3ba909f267337d0cf5f8998fa7f24eee8f
<pre>
Add a quirk to fetch YouTube and Netflix captions for Find in Video
<a href="https://bugs.webkit.org/show_bug.cgi?id=321160">https://bugs.webkit.org/show_bug.cgi?id=321160</a>
<a href="https://rdar.apple.com/184197298">rdar://184197298</a>

Reviewed by NOBODY (OOPS!).

Find in Video searches a media element&apos;s text tracks, but YouTube and Netflix
don&apos;t expose their captions as &lt;track&gt; elements nor add them via JS.
They fetch caption data over the network and render it themselves.
So Find in Page had nothing to match against on those sites.

This adds two site-specific quirks (gated on the findInVideoEnabled setting)
that mirror each site&apos;s fetched captions into a hidden text track added to the
media element, so find-in-video can search them without affecting
the site&apos;s own caption rendering.

For YouTube we wrap XMLHttpRequest to read the player&apos;s JSON3 &quot;timedtext&quot; responses
and mirror the cues onto a hidden track on the current &lt;video&gt;.

For Netflix we wrap XHR/fetch to read TTML responses, caching cues per
(videoId, language) and following the active language via the player API (so cached
language switch-backs still work). Since Netflix fetches captions before the
&lt;video&gt; exists, the track is bound when the element connects.

The mirrored track is kind: &quot;captions&quot; and mode: &quot;hidden&quot; and labeled
&quot;WebKitFindInVideo&quot;, so findCueMatches searches it but it is never rendered.
The scripts run in the page&apos;s main world (required to hook the site&apos;s own
XHR/fetch) and are injected only when both the site quirk and the find-in-video
setting are on.

* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/modern-media-controls/media/NetflixCaptionFetchQuirk.js: Added.
(parseCues.toSeconds):
(parseCues):
(window.__setupFindInVideoCaptionFetch):
(session):
(clearTrack):
(applyActiveLanguage):
(onPlayerStateChanged):
(ensureListening):
(cacheResult):
(isXML):
(XMLHttpRequest.prototype.open):
(originalFetch.):
(originalFetch.window.fetch):
(setCues):
* Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionFetchQuirk.js: Added.
(parseCues):
(clearTrack):
(setCues):
(watchedVideoId):
(XMLHttpRequest.prototype.open):
(activeVideo):
* Source/WebCore/PlatformCocoa.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/DocumentMediaElement.cpp:
(WebCore::DocumentMediaElement::ensureScriptParsed):
(WebCore::DocumentMediaElement::ensureYouTubeQuirkScript):
(WebCore::DocumentMediaElement::ensureCNNQuirkScript):
(WebCore::DocumentMediaElement::ensureYouTubeCaptionFetchScript):
(WebCore::DocumentMediaElement::ensureNetflixCaptionFetchScript):
(WebCore::DocumentMediaElement::setupAndCallNetflixCaptionFetchJS):
* Source/WebCore/dom/DocumentMediaElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::callGlobalWithMediaElement):
(WebCore::HTMLMediaElement::postConnectionSteps):
(WebCore::HTMLMediaElement::hasSiteRenderedCaptions const):
(WebCore::HTMLMediaElement::updateFindCaptionTrack):
(WebCore::HTMLMediaElement::findCueMatches):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::injectCaptionFetchQuirkScripts):
(WebCore::LocalFrame::injectUserScripts):
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::youTubeCaptionFetchScript):
(WebCore::RenderTheme::netflixCaptionFetchScript):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::youTubeCaptionFetchScript):
(WebCore::RenderThemeCocoa::netflixCaptionFetchScript):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c25ceb3ba909f267337d0cf5f8998fa7f24eee8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144260 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140324 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97151 "3 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120775 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42653 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40965 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40637 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1310 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46486 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192085 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53553 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149661 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54240 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149391 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44037 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126503 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121560 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52757 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15624 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52139 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52377 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->