### PR TITLE
[JSC] RegExp trim fast path in `String#replace` is skipped once the caller tiers up to DFG/FTL

### DIFF
--- a/JSTests/microbenchmarks/string-replace-regexp-trim-end.js
+++ b/JSTests/microbenchmarks/string-replace-regexp-trim-end.js
@@ -1,0 +1,18 @@
+function test(str, re)
+{
+    return str.replace(re, "");
+}
+noInline(test);
+
+const strs = [];
+for (let k = 0; k < 16; k++)
+    strs.push("a".repeat(200 + k * 50) + " \t\n".repeat(k & 3));
+
+const re = /\s+$/;
+
+let result;
+for (let i = 0; i < 1000000; ++i)
+    result = test(strs[i & 15], re);
+
+if (test("hello   ", re) !== "hello")
+    throw new Error("bad result: " + test("hello   ", re));

--- a/JSTests/microbenchmarks/string-replace-regexp-trim-start.js
+++ b/JSTests/microbenchmarks/string-replace-regexp-trim-start.js
@@ -1,0 +1,18 @@
+function test(str, re)
+{
+    return str.replace(re, "");
+}
+noInline(test);
+
+const strs = [];
+for (let k = 0; k < 16; k++)
+    strs.push(" \t\n".repeat(k & 3) + "a".repeat(200 + k * 50));
+
+const re = /^\s+/;
+
+let result;
+for (let i = 0; i < 1000000; ++i)
+    result = test(strs[i & 15], re);
+
+if (test("   hello", re) !== "hello")
+    throw new Error("bad result: " + test("   hello", re));

--- a/JSTests/stress/trim-regexp-dfg.js
+++ b/JSTests/stress/trim-regexp-dfg.js
@@ -1,0 +1,53 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+const trimStart = /^\s+/;
+const trimEnd = /\s+$/;
+
+function testStart(string) {
+    return string.replace(trimStart, "");
+}
+noInline(testStart);
+
+function testEnd(string) {
+    return string.replace(trimEnd, "");
+}
+noInline(testEnd);
+
+function testOther(string) {
+    return string.replace(/Hello/, "");
+}
+noInline(testOther);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(testStart(" \t\n Hello"), "Hello");
+    shouldBe(RegExp.input, " \t\n Hello");
+    shouldBe(RegExp.leftContext, "");
+    shouldBe(RegExp.lastMatch, " \t\n ");
+    shouldBe(RegExp.rightContext, "Hello");
+
+    shouldBe(testEnd("Hello \t\n "), "Hello");
+    shouldBe(RegExp.input, "Hello \t\n ");
+    shouldBe(RegExp.leftContext, "Hello");
+    shouldBe(RegExp.lastMatch, " \t\n ");
+    shouldBe(RegExp.rightContext, "");
+
+    shouldBe(testStart("   "), "");
+    shouldBe(RegExp.input, "   ");
+    shouldBe(RegExp.lastMatch, "   ");
+
+    shouldBe(testEnd("   "), "");
+    shouldBe(RegExp.input, "   ");
+    shouldBe(RegExp.lastMatch, "   ");
+
+    shouldBe(testOther("errorHelloerror"), "errorerror");
+    shouldBe(testStart("Hello   "), "Hello   ");
+    shouldBe(testEnd("   Hello"), "   Hello");
+    shouldBe(testStart(""), "");
+    shouldBe(testEnd(""), "");
+    shouldBe(RegExp.input, "errorHelloerror");
+    shouldBe(RegExp.leftContext, "error");
+    shouldBe(RegExp.rightContext, "error");
+}

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -361,25 +361,6 @@ JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalObject, JSStrin
     }
 
     if (callData.type == CallData::Type::None) {
-        switch (regExp->specificPattern()) {
-        case Yarr::SpecificPattern::TrailingSpacesPlus:
-        case Yarr::SpecificPattern::LeadingSpacesPlus:
-        case Yarr::SpecificPattern::TrailingSpacesStar:
-        case Yarr::SpecificPattern::LeadingSpacesStar: {
-            if (!replacementString.isEmpty())
-                break;
-
-            if (auto* result = tryTrimSpaces(vm, globalObject, source, string, regExp))
-                return result;
-
-            break;
-        }
-        case Yarr::SpecificPattern::Atom:
-        case Yarr::SpecificPattern::Newlines:
-        case Yarr::SpecificPattern::None:
-            break;
-        }
-
         if (global) {
             JSString* replacementVal = replaceValue.isString() ? asString(replaceValue) : nullptr;
             RELEASE_AND_RETURN(scope, replaceAllWithStringUsingRegExpSearch(vm, globalObject, string, source, regExp, replacementVal, replacementString));

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -1517,6 +1517,11 @@ ALWAYS_INLINE JSString* replaceOneWithStringUsingRegExpSearch(VM& vm, JSGlobalOb
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    if (replacementString.isEmpty()) {
+        if (auto* result = tryTrimSpaces(vm, globalObject, source, string, regExp))
+            return result;
+    }
+
     int* ovector;
     MatchResult result = globalObject->regExpGlobalData().performMatch(globalObject, regExp, string, source, 0, &ovector);
     RETURN_IF_EXCEPTION(scope, nullptr);


### PR DESCRIPTION
#### 81a11702ef82c7a084d1a009dfa010b68e1e2981
<pre>
[JSC] RegExp trim fast path in `String#replace` is skipped once the caller tiers up to DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=321161">https://bugs.webkit.org/show_bug.cgi?id=321161</a>

Reviewed by Yusuke Suzuki.

291345@main added tryTrimSpaces() to replaceUsingRegExpSearch() so that
`str.replace(/^\s+/, &quot;&quot;)` and `str.replace(/\s+$/, &quot;&quot;)` avoid running the RegExp.
293816@main then made operationStringProtoFuncReplaceRegExpEmptyStr, which DFG/FTL
use for a constant empty replacement, call replaceOneWithStringUsingRegExpSearch()
directly, so the fast path has only been reachable from LLInt/Baseline since.

This patch moves the tryTrimSpaces() call into replaceOneWithStringUsingRegExpSearch(),
which both the runtime and the DFG operation go through, and removes the now-redundant
switch from replaceUsingRegExpSearch().

                                              Baseline                  Patched

string-replace-regexp-trim-end            75.2372+-0.4670     ^     14.5417+-0.2654        ^ definitely 5.1739x faster
string-replace-regexp-trim-start          61.0601+-0.8583     ^     13.5378+-0.3125        ^ definitely 4.5103x faster

Tests: JSTests/microbenchmarks/string-replace-regexp-trim-end.js
       JSTests/microbenchmarks/string-replace-regexp-trim-start.js
       JSTests/stress/trim-regexp-dfg.js

* JSTests/microbenchmarks/string-replace-regexp-trim-end.js: Added.
(test):
* JSTests/microbenchmarks/string-replace-regexp-trim-start.js: Added.
(test):
* JSTests/stress/trim-regexp-dfg.js: Added.
(shouldBe):
(testStart):
(testEnd):
(testOther):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::replaceUsingRegExpSearch):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::replaceOneWithStringUsingRegExpSearch):

Canonical link: <a href="https://commits.webkit.org/318745@main">https://commits.webkit.org/318745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64fb4f02fab38d13754c3d0b83eeb5eb90534a45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188920 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139659 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120105 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41926 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40269 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2081 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8899 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39917 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/227 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40365 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191140 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52700 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148892 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39972 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53380 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148637 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43324 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125651 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120465 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51898 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14896 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51283 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Running compile-webkit") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->