### PR TITLE
Canvas with float16 should use an extended DestinationColorSpace

### DIFF
--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -179,7 +179,7 @@ Ref<ByteArrayPixelBuffer> ImageData::byteArrayPixelBuffer() const
 Ref<Float16ArrayPixelBuffer> ImageData::float16ArrayPixelBuffer() const
 {
     Ref float16Data = m_data.asFloat16Array();
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA16F, toDestinationColorSpace(m_colorSpace) };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA16F, toExtendedDestinationColorSpace(m_colorSpace) };
     return Float16ArrayPixelBuffer::create(format, m_size, float16Data.get());
 }
 #endif // ENABLE(PIXEL_FORMAT_RGBA16F)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -72,6 +72,7 @@
 #include "PaintRenderingContext2D.h"
 #include "Path2D.h"
 #include "PixelBufferConversion.h"
+#include "PixelFormat.h"
 #include "RenderElement.h"
 #include "RenderImage.h"
 #include "RenderLayer.h"
@@ -2682,7 +2683,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
     if (!buffer)
         return ImageData::create(imageDataRect.width(), imageDataRect.height(), m_settings.colorSpace, settings);
 
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, outputPixelFormat, toDestinationColorSpace(computedColorSpace) };
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, outputPixelFormat, toDestinationColorSpace(computedColorSpace, allowExtendedColorSpace(outputPixelFormat)) };
     RefPtr pixelBuffer = buffer->getPixelBuffer(format, imageDataRect);
     if (!pixelBuffer) {
         scriptContext->addConsoleMessage(MessageSource::Rendering, MessageLevel::Error,
@@ -2690,7 +2691,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
         return Exception { ExceptionCode::InvalidStateError };
     }
 
-    ASSERT(pixelBuffer->format().colorSpace == toDestinationColorSpace(computedColorSpace));
+    ASSERT(pixelBuffer->format().colorSpace == toDestinationColorSpace(computedColorSpace, allowExtendedColorSpace(outputPixelFormat)));
 
     if (RefPtr imageData = ImageData::create(pixelBuffer.releaseNonNull(), outputImageDataPixelFormat))
         return { { imageData.releaseNonNull() } };
@@ -3186,9 +3187,21 @@ PixelFormat CanvasRenderingContext2DBase::pixelFormat() const
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+static constexpr AllowExtendedColorSpace allowExtendedColorSpace(CanvasRenderingContext2DSettings::ColorType colorType)
+{
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (colorType == CanvasRenderingContext2DSettings::ColorType::Float16)
+        return AllowExtendedColorSpace::Yes;
+#else
+    UNUSED_PARAM(colorType);
+#endif
+
+    return AllowExtendedColorSpace::No;
+}
+
 DestinationColorSpace CanvasRenderingContext2DBase::colorSpace() const
 {
-    return toDestinationColorSpace(m_settings.colorSpace);
+    return toDestinationColorSpace(m_settings.colorSpace, allowExtendedColorSpace(m_settings.colorType));
 }
 
 bool CanvasRenderingContext2DBase::willReadFrequently() const

--- a/Source/WebCore/html/canvas/PredefinedColorSpace.cpp
+++ b/Source/WebCore/html/canvas/PredefinedColorSpace.cpp
@@ -27,6 +27,7 @@
 #include "PredefinedColorSpace.h"
 
 #include "DestinationColorSpace.h"
+#include "PixelFormat.h"
 
 namespace WebCore {
 
@@ -49,6 +50,42 @@ DestinationColorSpace toDestinationColorSpace(PredefinedColorSpace colorSpace)
     return DestinationColorSpace::SRGB();
 }
 
+DestinationColorSpace toExtendedDestinationColorSpace(PredefinedColorSpace colorSpace)
+{
+    switch (colorSpace) {
+    case PredefinedColorSpace::SRGB:
+#if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
+        return DestinationColorSpace::ExtendedSRGB();
+#else
+        return DestinationColorSpace::SRGB();
+#endif
+    case PredefinedColorSpace::SRGBLinear:
+#if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
+        return DestinationColorSpace::ExtendedLinearSRGB();
+#else
+        return DestinationColorSpace::LinearSRGB();
+#endif
+#if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
+    case PredefinedColorSpace::DisplayP3:
+        return DestinationColorSpace::ExtendedDisplayP3();
+    case PredefinedColorSpace::DisplayP3Linear:
+        return DestinationColorSpace::ExtendedLinearDisplayP3();
+#endif
+    }
+
+    ASSERT_NOT_REACHED();
+#if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
+    return DestinationColorSpace::ExtendedSRGB();
+#else
+    return DestinationColorSpace::SRGB();
+#endif
+}
+
+DestinationColorSpace toDestinationColorSpace(PredefinedColorSpace colorSpace, AllowExtendedColorSpace allowExtendedColorSpace)
+{
+    return (allowExtendedColorSpace == AllowExtendedColorSpace::No) ? toDestinationColorSpace(colorSpace) : toExtendedDestinationColorSpace(colorSpace);
+}
+
 std::optional<PredefinedColorSpace> toPredefinedColorSpace(const DestinationColorSpace& colorSpace)
 {
     if (colorSpace == DestinationColorSpace::SRGB())
@@ -61,6 +98,20 @@ std::optional<PredefinedColorSpace> toPredefinedColorSpace(const DestinationColo
     if (colorSpace == DestinationColorSpace::LinearDisplayP3())
         return PredefinedColorSpace::DisplayP3Linear;
 #endif
+
+#if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
+    if (colorSpace == DestinationColorSpace::ExtendedSRGB())
+        return PredefinedColorSpace::SRGB;
+    if (colorSpace == DestinationColorSpace::ExtendedLinearSRGB())
+        return PredefinedColorSpace::SRGBLinear;
+#endif
+#if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
+    if (colorSpace == DestinationColorSpace::ExtendedDisplayP3())
+        return PredefinedColorSpace::DisplayP3;
+    if (colorSpace == DestinationColorSpace::ExtendedLinearDisplayP3())
+        return PredefinedColorSpace::DisplayP3Linear;
+#endif
+
     return std::nullopt;
 }
 

--- a/Source/WebCore/html/canvas/PredefinedColorSpace.h
+++ b/Source/WebCore/html/canvas/PredefinedColorSpace.h
@@ -41,6 +41,10 @@ enum class PredefinedColorSpace : uint8_t {
 };
 
 DestinationColorSpace toDestinationColorSpace(PredefinedColorSpace);
+DestinationColorSpace toExtendedDestinationColorSpace(PredefinedColorSpace);
+enum class AllowExtendedColorSpace : bool;
+DestinationColorSpace toDestinationColorSpace(PredefinedColorSpace, AllowExtendedColorSpace);
+
 std::optional<PredefinedColorSpace> toPredefinedColorSpace(const DestinationColorSpace&);
 
 }

--- a/Source/WebCore/platform/graphics/PixelFormat.h
+++ b/Source/WebCore/platform/graphics/PixelFormat.h
@@ -67,10 +67,10 @@ constexpr ContentsFormat convertToContentsFormat(PixelFormat format)
     case PixelFormat::RGBA16F:
         return ContentsFormat::RGBA16F;
 #endif
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-        return ContentsFormat::RGBA8;
     }
+
+    RELEASE_ASSERT_NOT_REACHED();
+    return ContentsFormat::RGBA8;
 }
 
 constexpr bool pixelFormatIsOpaque(PixelFormat format)
@@ -94,6 +94,31 @@ constexpr bool pixelFormatIsOpaque(PixelFormat format)
 
     ASSERT_NOT_REACHED();
     return false;
+}
+
+enum class AllowExtendedColorSpace : bool { No, Yes };
+
+constexpr AllowExtendedColorSpace allowExtendedColorSpace(PixelFormat format)
+{
+    switch (format) {
+    case PixelFormat::RGBA8:
+    case PixelFormat::BGRX8:
+    case PixelFormat::BGRA8:
+        return AllowExtendedColorSpace::No;
+#if ENABLE(PIXEL_FORMAT_RGB10)
+    case PixelFormat::RGB10:
+#endif
+#if ENABLE(PIXEL_FORMAT_RGB10A8)
+    case PixelFormat::RGB10A8:
+#endif
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    case PixelFormat::RGBA16F:
+#endif
+        return AllowExtendedColorSpace::Yes;
+    }
+
+    ASSERT_NOT_REACHED();
+    return AllowExtendedColorSpace::No;
 }
 
 WEBCORE_EXPORT TextStream& operator<<(TextStream&, PixelFormat);


### PR DESCRIPTION
#### dc865d0b61c4d846263311601091fe1b475c5921
<pre>
Canvas with float16 should use an extended DestinationColorSpace
<a href="https://bugs.webkit.org/show_bug.cgi?id=321163">https://bugs.webkit.org/show_bug.cgi?id=321163</a>
<a href="https://rdar.apple.com/184199283">rdar://184199283</a>

Reviewed by Mike Wyrzykowski.

When a canvas is using a ColorType like float16 that allows for extended
dynamic range, and the system supports the corresponding PixelFormat
natively, attempt to use an extended DestinationColorSpace if
available.

No new tests, as existing tests should fail if there is any visible
impact.

* Source/WebCore/html/ImageData.cpp:
(WebCore::ImageData::float16ArrayPixelBuffer const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::getImageData const):
(WebCore::allowExtendedColorSpace):
(WebCore::CanvasRenderingContext2DBase::colorSpace const):
* Source/WebCore/html/canvas/PredefinedColorSpace.cpp:
(WebCore::toExtendedDestinationColorSpace):
(WebCore::toDestinationColorSpace):
(WebCore::toPredefinedColorSpace):
* Source/WebCore/html/canvas/PredefinedColorSpace.h:
* Source/WebCore/platform/graphics/PixelFormat.h:
(WebCore::convertToContentsFormat):
(WebCore::allowExtendedColorSpace):

Canonical link: <a href="https://commits.webkit.org/318864@main">https://commits.webkit.org/318864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35e45f8f8c75ea64623aa676cd0c77117721c7a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179506 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143815 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c902764c-06c3-4e53-84ab-154e2bbdbf52) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139994 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96849 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49d9cb63-2148-47cb-8947-87a78ac19638) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120447 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/290afed7-8514-4f4e-b7a4-10ef47bd952f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42270 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40590 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40240 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/792 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191559 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53115 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149248 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40035 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53796 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148992 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43659 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126068 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120966 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52313 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15226 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51698 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51939 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51759 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->