### PR TITLE
[JSC] Use counting sort for `Array#sort`

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-sort-string-keys.js
+++ b/JSTests/microbenchmarks/array-prototype-sort-string-keys.js
@@ -1,0 +1,9 @@
+var keys = [];
+for (var i = 0; i < 40; ++i) {
+    var name = "";
+    for (var j = 0, x = i * 2654435761; j < 6; ++j, x = (x * 48271 + 12345) | 0)
+        name += String.fromCharCode(97 + ((x >>> 8) % 26));
+    keys.push(name + (i % 3 ? "Id" : "Name"));
+}
+for (var i = 0; i < 5e4; ++i)
+    keys.slice().sort();

--- a/JSTests/microbenchmarks/json-parse-short-string-ids.js
+++ b/JSTests/microbenchmarks/json-parse-short-string-ids.js
@@ -1,0 +1,33 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
+let seed = 12345;
+function next() {
+    seed = (seed + 0x9e3779b9) | 0;
+    let z = seed;
+    z = Math.imul(z ^ (z >>> 16), 0x85ebca6b);
+    z = Math.imul(z ^ (z >>> 13), 0xc2b2ae35);
+    return (z ^ (z >>> 16)) >>> 0;
+}
+
+const colors = ["red", "blue", "green", "black", "white"];
+const sizes = ["S", "M", "L", "XL"];
+const items = [];
+for (let i = 0; i < 2000; ++i) {
+    items.push({
+        id: "item-" + (1000 + next() % 9000) + "-" + colors[next() % colors.length],
+        sku: "SKU-" + (10000 + next() % 90000) + "-" + sizes[next() % sizes.length],
+        owner: "user-" + (next() % 100000).toString(36),
+        parent: "ord-" + (next() % 1e6),
+        status: next() & 1 ? "active" : "archived",
+    });
+}
+const json = JSON.stringify({ items });
+
+// Each payload carries a distinct set of short ID-like string values, as successive API responses would.
+const separators = "GHIJKLMNOPQRSTUVWXYZghijklmnopqrstuvwxyz";
+const payloads = [];
+for (let i = 0; i < separators.length; ++i)
+    payloads.push(json.replaceAll("-", separators[i]));
+
+for (let i = 0; i < 240; ++i)
+    JSON.parse(payloads[i % payloads.length]);

--- a/JSTests/stress/array-default-sort-radix-edge-cases.js
+++ b/JSTests/stress/array-default-sort-radix-edge-cases.js
@@ -1,0 +1,174 @@
+// Default (no-comparator) Array.prototype.sort must order elements like a comparator comparing
+// String(a) vs String(b) in code-unit order. Comparing serialized results (not identity) keeps
+// the legitimate instability of equal strings from causing false failures.
+
+function ser(arr) {
+    let parts = [];
+    for (let i = 0; i < arr.length; i++)
+        parts.push((i in arr) ? ("|" + String(arr[i])) : "|<hole>");
+    return parts.join("");
+}
+
+function refCmp(a, b) {
+    let sa = String(a), sb = String(b);
+    return sa < sb ? -1 : (sa > sb ? 1 : 0);
+}
+
+// slice() preserves holes and undefined, so each operation gets an independent copy
+// of the same input (objects are shared by reference, which is fine here).
+function check(arr, label) {
+    let a = arr.slice();
+    let lenBefore = a.length;
+    let sorted = a.sort();
+    if (sorted !== a)
+        throw new Error(label + ": sort() must return the same array");
+    if (a.length !== lenBefore)
+        throw new Error(label + ": length changed " + lenBefore + " -> " + a.length);
+    let expected = arr.slice().sort(refCmp);
+    if (ser(a) !== ser(expected))
+        throw new Error(label + ": order mismatch\n  got: " + ser(a).slice(0, 200) + "\n  exp: " + ser(expected).slice(0, 200));
+    // toSorted must not mutate the receiver, and must order like refCmp's toSorted.
+    // (toSorted reads holes as undefined, unlike in-place sort which keeps trailing holes,
+    // so it is compared against refCmp's toSorted rather than against sort.)
+    let src = arr.slice();
+    let copy = src.slice();
+    let ts = src.toSorted();
+    if (ser(src) !== ser(copy))
+        throw new Error(label + ": toSorted mutated the receiver");
+    let tsExpected = arr.slice().toSorted(refCmp);
+    if (ser(ts) !== ser(tsExpected))
+        throw new Error(label + ": toSorted mismatch\n  got: " + ser(ts).slice(0, 200) + "\n  exp: " + ser(tsExpected).slice(0, 200));
+}
+
+// --- Boundary around the radix threshold (14) and the depth cap (32 levels: 32 Latin-1 chars / 16 UTF-16 code units). ---
+for (let n = 0; n <= 40; n++) {
+    check(Array.from({ length: n }, (_, i) => (i * 2654435761) % 97), "numbers n=" + n);
+    check(Array.from({ length: n }, (_, i) => "s" + ((i * 40503) % 13)), "shortstr n=" + n);
+}
+
+// --- All identical strings (everything funnels into one bucket, then terminal bucket 0). ---
+for (let n of [1, 13, 14, 15, 100, 500]) {
+    check(Array.from({ length: n }, () => "same"), "identical-short n=" + n);
+    check(Array.from({ length: n }, () => "x".repeat(40)), "identical-deep n=" + n); // >32 chars -> depth cap
+    check(Array.from({ length: n }, () => "\u3042".repeat(20)), "identical-deep-16bit n=" + n); // >16 code units -> depth cap
+}
+
+// --- Empty strings, and prefixes of varying length (terminal buckets at many depths). ---
+check(["", "a", "ab", "abc", "a", "", "abcd", "ab", "abc", "abce", "abcz", "abca"], "prefix-ladder");
+(() => {
+    let a = [];
+    let words = ["", "a", "aa", "aaa", "aaaa", "ab", "aba", "abb", "b", "ba", "bb", "z", ""];
+    for (let i = 0; i < 50; i++) a.push(words[(i * 7) % words.length]);
+    check(a, "prefix-ladder-big");
+})();
+
+// --- Code-unit boundaries: NUL (byte 0), 0xFF/0x100 (high/low byte split), 0xFFFF. ---
+check(["\u0000", "\u0000\u0000", "", "\u0001", "\u0000a", "a", "a\u0000"], "nul-bytes");
+(() => {
+    let a = [];
+    for (let i = 0; i < 60; i++) {
+        // alternate code units that differ only in low byte vs only in high byte
+        let cu = (i % 2) ? (0x0100 + (i % 5)) : (0x0001 + (i % 5) * 0x0100);
+        a.push(String.fromCharCode(cu) + String.fromCharCode(0x00FF + (i % 3)));
+    }
+    check(a, "high-low-byte-split");
+})();
+(() => {
+    let a = [];
+    for (let i = 0; i < 64; i++)
+        a.push(String.fromCharCode((i * 0x3B) & 0xFF, 0xFF - (i % 3), i % 2 ? 0x00 : 0xFF) + "x");
+    a.push("\u0000", "\u00FF", "\u00FF\u00FF", "\u0000\u0000", "");
+    check(a, "latin1-full-byte-range");
+})();
+check(["\uFFFF", "\uFFFE", "\u0100", "\u00FF", "\u0000", "\u0001", "\uFFFF\u0000", "\uFFFF"], "wide-code-units");
+
+// --- Surrogate code units / non-BMP: default sort is code-unit order, not code-point order. ---
+check(["\uD800", "\uDFFF", "\uD7FF", "\uE000", "\uD800\uDC00", "\uDBFF\uDFFF", "a", "\uFFFF"], "surrogates");
+(() => {
+    let a = [];
+    for (let i = 0; i < 50; i++) a.push(String.fromCodePoint(0x1F600 + (i % 7)) + String.fromCharCode(97 + (i % 4)));
+    check(a, "non-bmp");
+})();
+
+// --- Numbers stringified: negatives, decimals, -0, Infinity, NaN. ---
+check([10, 9, 100, 1, 20, 2, 3, 30, 0, -1, -10, -2, 11, 21, 101, 110, 12, 13, 14, 15, 16, 17, 18, 19, 22, 23, 24, 25, 26, 27, 28, 29, 31, 32, 33], "number-string-order");
+check([Infinity, -Infinity, NaN, 0, -0, 1.5, 1.25, 1.125, 1e21, 1e-7, 0.1, 0.2, 100, 99, 9, NaN, Infinity], "special-numbers");
+
+// --- undefined and holes placement (must be: values, then undefined, then holes). ---
+check([3, undefined, 1, undefined, 2], "undefined-mix");
+(() => { let a = [5, 4, 3, 2, 1]; a[10] = 0; a[20] = 9; check(a, "sparse-holes"); })();
+(() => { let a = new Array(40); for (let i = 0; i < 40; i += 2) a[i] = (i * 13) % 50; a[5] = undefined; a[7] = undefined; check(a, "holes-and-undefined-big"); })();
+
+// --- Mixed types in one array (all funnel through ToString). ---
+check([true, false, null, 1, "1", "true", {}, [1, 2], "a", 0, "0", "", "[object Object]"], "mixed-types");
+(() => {
+    let a = [];
+    for (let i = 0; i < 60; i++) {
+        let r = i % 6;
+        a.push(r === 0 ? i : r === 1 ? String(i) : r === 2 ? (i % 2 === 0) : r === 3 ? { x: i } : r === 4 ? [i] : null);
+    }
+    check(a, "mixed-types-big");
+})();
+
+// --- Deep shared prefix beyond the depth cap (ordering must still be correct), 8-bit and 16-bit. ---
+(() => {
+    let a = [];
+    let base = "Z".repeat(40);
+    for (let i = 0; i < 80; i++) a.push(base + ((i * 31) % 17) + "tail");
+    check(a, "deep-prefix-ordering");
+    let b = [];
+    let base16 = "\u3042".repeat(20);
+    for (let i = 0; i < 80; i++) b.push(base16 + ((i * 31) % 17) + "tail");
+    check(b, "deep-prefix-ordering-16bit");
+})();
+
+// --- A single 16-bit string switches the whole sort to the UTF-16 byte path. ---
+(() => {
+    let a = [];
+    for (let i = 0; i < 80; i++) a.push("key" + ((i * 37) % 53));
+    a.push("key\u0100", "key\u00FF", "ke\uFFFF");
+    check(a, "one-16bit-among-8bit");
+})();
+
+// --- Randomized differential across alphabets and sizes (deterministic seed). ---
+let seed = 0x9e3779b9 >>> 0;
+function rnd() {
+    seed ^= seed << 13; seed >>>= 0;
+    seed ^= seed >> 17;
+    seed ^= seed << 5; seed >>>= 0;
+    return seed >>> 0;
+}
+for (let trial = 0; trial < testLoopCount / 10; trial++) {
+    let n = rnd() % 400;
+    let mode = rnd() % 5;
+    let a = new Array(n);
+    for (let i = 0; i < n; i++) {
+        if (mode === 0) a[i] = rnd() % 1000000;                       // numbers, small distinct prefix
+        else if (mode === 1) { let len = rnd() % 8, s = ""; for (let j = 0; j < len; j++) s += String.fromCharCode(97 + rnd() % 4); a[i] = s; } // tiny alphabet, many collisions
+        else if (mode === 2) { let len = 1 + rnd() % 6, s = ""; for (let j = 0; j < len; j++) s += String.fromCharCode(32 + rnd() % 200); a[i] = s; } // wide alphabet, BMP
+        else if (mode === 3) { let len = rnd() % 5, s = ""; for (let j = 0; j < len; j++) s += String.fromCharCode(0xD800 + rnd() % 0x800); a[i] = s; } // raw surrogate code units
+        else { let r = rnd() % 4; a[i] = r === 0 ? (rnd() % 50) : r === 1 ? String.fromCharCode(97 + rnd() % 5) : r === 2 ? undefined : null; } // mixed incl undefined
+    }
+    check(a, "rand trial=" + trial + " mode=" + mode + " n=" + n);
+}
+
+// --- Stability where the radix path guarantees it (shallow keys, n >= 14). ---
+// Distinct objects whose ToString collides on short keys keep insertion order: equal-key
+// runs are scattered stably and identical strings land in the terminal bucket in order.
+function checkStability(n, distinctKeys, label) {
+    let a = [];
+    for (let i = 0; i < n; i++) {
+        let key = "k" + (rnd() % distinctKeys);
+        let o = { id: i, key };
+        o.toString = function () { return this.key; };
+        a.push(o);
+    }
+    let expected = a.slice().sort((x, y) => x.key < y.key ? -1 : x.key > y.key ? 1 : x.id - y.id);
+    let got = a.slice().sort();
+    for (let i = 0; i < n; i++) {
+        if (got[i] !== expected[i])
+            throw new Error("stability mismatch [" + label + "] at i=" + i);
+    }
+}
+for (let trial = 0; trial < testLoopCount / 20; trial++)
+    checkStability(14 + rnd() % 400, 1 + rnd() % 8, "stab trial=" + trial);

--- a/JSTests/stress/json-parse-short-value-then-key.js
+++ b/JSTests/stress/json-parse-short-value-then-key.js
@@ -1,0 +1,66 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error("FAIL " + msg + ": got " + JSON.stringify(actual) + ", expected " + JSON.stringify(expected));
+}
+
+// A short string first seen as a value is cached without being atomized. The
+// same string later used as a key must still produce a working property, and a
+// subsequent value occurrence must still return the right string.
+for (let i = 0; i < 3; ++i) {
+    let r = JSON.parse('["prop_a1", {"prop_a1": 1}, {"prop_a1": 2, "z": 3}, "prop_a1", {"prop_a1": 4}]');
+    shouldBe(r[0], "prop_a1", "value before key");
+    shouldBe(r[1].prop_a1, 1, "key after value");
+    shouldBe(r[1][r[0]], 1, "computed lookup with parsed value");
+    shouldBe(Object.keys(r[1])[0], "prop_a1", "Object.keys");
+    shouldBe(r[2].prop_a1, 2, "key again (existing transition)");
+    shouldBe(r[2].z, 3, "second key");
+    shouldBe(r[3], "prop_a1", "value after key");
+    shouldBe(r[4].prop_a1, 4, "key after value after key");
+
+    let o = {};
+    o[r[3]] = 5;
+    shouldBe(o.prop_a1, 5, "parsed value used as a key elsewhere");
+    shouldBe("prop_a1" in r[1], true, "in");
+
+    fullGC();
+}
+
+// Value evicted by a colliding value, then used as key.
+{
+    let r = JSON.parse('["kQx", "kRx", {"kQx": 1, "kRx": 2}, "kQx", "kRx"]');
+    shouldBe(r[2].kQx, 1, "evicted value as key 1");
+    shouldBe(r[2].kRx, 2, "evicted value as key 2");
+    shouldBe(r[3], "kQx", "value after eviction 1");
+    shouldBe(r[4], "kRx", "value after eviction 2");
+}
+
+// 16-bit source with Latin-1 and non-Latin-1 short values and keys.
+{
+    let r = JSON.parse('["v\\u00e9", "v\\u3042", {"v\\u00e9": 1, "v\\u3042": 2}, "v\\u00e9", "v\\u3042", "いk", {"いk": 3}]');
+    shouldBe(r[0], "vé", "latin1 value");
+    shouldBe(r[1], "vあ", "utf16 value");
+    shouldBe(r[2]["vé"], 1, "latin1 key");
+    shouldBe(r[2]["vあ"], 2, "utf16 key");
+    shouldBe(r[3], "vé", "latin1 value again");
+    shouldBe(r[4], "vあ", "utf16 value again");
+    shouldBe(r[5], "いk", "utf16 source value");
+    shouldBe(r[6]["いk"], 3, "utf16 source key");
+
+    let s = JSON.parse('["\\u3042", "\\u3042", {"\\u3042": 1}, "\\u3042"]');
+    shouldBe(s[0], "あ", "single non-latin1 char value");
+    shouldBe(s[1], "あ", "single non-latin1 char value again");
+    shouldBe(s[2]["あ"], 1, "single non-latin1 char key");
+    shouldBe(s[3], "あ", "single non-latin1 char value after key");
+}
+
+// Repeated short values across many parses share content correctly across GCs.
+{
+    let json = JSON.stringify(Array.from({ length: 200 }, (_, i) => "id-" + (i % 7)));
+    for (let i = 0; i < 200; ++i) {
+        let r = JSON.parse(json);
+        for (let j = 0; j < r.length; j += 37)
+            shouldBe(r[j], "id-" + (j % 7), "repeated parse " + i + "/" + j);
+        if (i % 50 == 0)
+            edenGC();
+    }
+}

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -43,9 +43,9 @@
 #include "StableSort.h"
 #include "VMEntryScopeInlines.h"
 #include <algorithm>
+#include <array>
 #include <wtf/Assertions.h>
 #include <wtf/MathExtras.h>
-#include <wtf/StdMap.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -798,7 +798,18 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncSlice, (JSGlobalObject* globalObject, Cal
 }
 
 using SortJSValueVector = MarkedArgumentBufferWithSize<64>;
-using SortEntryVector = Vector<std::tuple<JSValue, String>>;
+
+struct SortEntry {
+    String string;
+    uint32_t index;
+};
+using SortEntryVector = Vector<SortEntry>;
+
+enum class All8Bit : bool { No, Yes };
+
+static constexpr unsigned radixSortThreshold = 14;
+static constexpr unsigned maxRadixLevel = 32;
+static constexpr unsigned radixBucketCount = 257;
 
 static ALWAYS_INLINE std::tuple<uint64_t, IndexingType, std::span<EncodedJSValue>> sortCompact(JSGlobalObject* globalObject, JSObject* thisObject, uint64_t length, SortJSValueVector& compactedRoot)
 {
@@ -890,32 +901,82 @@ static ALWAYS_INLINE std::tuple<uint64_t, IndexingType, std::span<EncodedJSValue
     return std::tuple { undefinedCount, ArrayWithContiguous, std::span { compactedRoot.data(), compactedRoot.size() } };
 }
 
-static unsigned sortBucketSort(std::span<EncodedJSValue> sorted, unsigned dst, SortEntryVector& bucket, unsigned depth)
+// Radix sort one byte per level. When every string is 8-bit the byte is the Latin-1 code unit itself; otherwise it is
+// the UTF-16 code unit split high byte first so bytes order like code units. Bucket 0 holds strings that already ended.
+// Ties in the leaf sort are broken by the original index for stability.
+template<All8Bit all8Bit>
+static void sortBucketSort(std::span<SortEntry> entries, std::span<SortEntry> scratch, unsigned level)
 {
-    if (bucket.size() < 32 || depth > 32) {
-        std::ranges::stable_sort(bucket, WTF::codePointCompareLessThan, [](const auto& element) {
-            return std::get<1>(element);
+    size_t size = entries.size();
+    unsigned depth = all8Bit == All8Bit::Yes ? level : (level >> 1);
+    if (size < radixSortThreshold || level > maxRadixLevel) {
+        if (size < 2)
+            return;
+        std::ranges::sort(entries, [&](const auto& a, const auto& b) {
+            std::strong_ordering ordering = std::strong_ordering::equal;
+            if constexpr (all8Bit == All8Bit::Yes)
+                ordering = codePointCompare(a.string.span8().subspan(depth), b.string.span8().subspan(depth));
+            else
+                ordering = codePointCompare(StringView(a.string).substring(depth), StringView(b.string).substring(depth));
+            if (is_neq(ordering))
+                return is_lt(ordering);
+            return a.index < b.index;
         });
-        for (auto& entry : bucket)
-            sorted[dst++] = JSValue::encode(std::get<0>(entry));
-        return dst;
+        return;
     }
 
-    StdMap<char16_t, SortEntryVector> buckets;
-    for (const auto& entry : bucket) {
-        if (std::get<1>(entry).length() == depth) {
-            sorted[dst++] = JSValue::encode(std::get<0>(entry));
-            continue;
+    auto keyOf = [&](const SortEntry& entry) -> unsigned {
+        const String& string = entry.string;
+        if (depth >= string.length())
+            return 0;
+        if constexpr (all8Bit == All8Bit::Yes)
+            return string.span8()[depth] + 1;
+        else {
+            char16_t codeUnit = string.codeUnitAt(depth);
+            return ((level & 1) ? (codeUnit & 0xFF) : (codeUnit >> 8)) + 1;
         }
+    };
 
-        char16_t character = std::get<1>(entry).codeUnitAt(depth);
-        buckets.insert(std::pair { character, SortEntryVector { } }).first->second.append(entry);
+    std::array<unsigned, radixBucketCount> counts { };
+    unsigned minBucket = radixBucketCount - 1;
+    unsigned maxBucket = 0;
+    for (const auto& entry : entries) {
+        unsigned key = keyOf(entry);
+        if (!counts[key]) {
+            minBucket = std::min(minBucket, key);
+            maxBucket = std::max(maxBucket, key);
+        }
+        ++counts[key];
     }
 
-    for (auto& entries : buckets)
-        dst = sortBucketSort(sorted, dst, entries.second, depth + 1);
+    if (minBucket == maxBucket) {
+        if (!minBucket)
+            return;
+        sortBucketSort<all8Bit>(entries, scratch, level + 1);
+        return;
+    }
 
-    return dst;
+    std::array<unsigned, radixBucketCount> cursors;
+    unsigned running = 0;
+    for (unsigned i = minBucket; i <= maxBucket; ++i) {
+        cursors[i] = running;
+        running += counts[i];
+    }
+
+    for (auto& entry : entries) {
+        unsigned key = keyOf(entry);
+        scratch[cursors[key]++] = WTF::move(entry);
+    }
+    for (size_t i = 0; i < size; ++i)
+        entries[i] = WTF::move(scratch[i]);
+
+    unsigned offset = 0;
+    for (unsigned i = minBucket; i <= maxBucket; ++i) {
+        unsigned count = counts[i];
+        if (i && count > 1)
+            sortBucketSort<all8Bit>(entries.subspan(offset, count), scratch, level + 1);
+        offset += count;
+    }
 }
 
 static ALWAYS_INLINE std::span<EncodedJSValue> sortStableSort(JSGlobalObject* globalObject, std::span<EncodedJSValue> compacted, std::span<EncodedJSValue> workingSet, JSObject* comparator)
@@ -1029,15 +1090,29 @@ static ALWAYS_INLINE void sortImpl(JSGlobalObject* globalObject, JSObject* thisO
     std::span<EncodedJSValue> sorted { sortedRoot.data(), sortedRoot.size() };
     std::span<EncodedJSValue> dest;
     if (isStringSort) {
-        SortEntryVector entries; // Keep in mind that all JSValues are also stored in SortJSValueVector (compacted). Thus, we do not need to keep them marked here.
-        entries.reserveInitialCapacity(compacted.size());
-        for (EncodedJSValue encodedValue : compacted) {
-            JSValue value = JSValue::decode(encodedValue);
-            String string = value.toWTFString(globalObject);
-            RETURN_IF_EXCEPTION(scope, void());
-            entries.append(std::tuple { value, WTF::move(string) });
+        SortEntryVector entries;
+        if (!entries.tryReserveInitialCapacity(compacted.size())) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return;
         }
-        sortBucketSort(sorted, 0, entries, 0);
+        bool all8Bit = true;
+        for (uint32_t index = 0; index < compacted.size(); ++index) {
+            String string = JSValue::decode(compacted[index]).toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, void());
+            all8Bit &= string.is8Bit();
+            entries.append({ WTF::move(string), index });
+        }
+        SortEntryVector scratchEntries;
+        if (entries.size() >= radixSortThreshold && !scratchEntries.tryGrow(entries.size())) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return;
+        }
+        if (all8Bit)
+            sortBucketSort<All8Bit::Yes>(entries.mutableSpan(), scratchEntries.mutableSpan(), 0);
+        else
+            sortBucketSort<All8Bit::No>(entries.mutableSpan(), scratchEntries.mutableSpan(), 0);
+        for (size_t index = 0; index < entries.size(); ++index)
+            sorted[index] = compacted[entries[index].index];
         dest = sorted;
     } else {
         dest = sortStableSort(globalObject, compacted, sorted, asObject(comparatorValue));


### PR DESCRIPTION
#### 6380373fc6a1a7651f2c4ce9159ee05093810394
<pre>
[JSC] Use counting sort for `Array#sort`
<a href="https://bugs.webkit.org/show_bug.cgi?id=317103">https://bugs.webkit.org/show_bug.cgi?id=317103</a>

Reviewed by Yusuke Suzuki.

Sorting an array of strings without a comparator is common, e.g. `Object.keys(obj).sort()`.
The current implementation partitions entries into a StdMap&lt;char16_t, Vector&gt; per character,
which allocates map nodes and grows bucket vectors at every depth.

This patch replaces it with an in-place counting sort over the UTF-16 byte stream, allocating
only a single scratch buffer for the whole sort. Buckets below radixSortThreshold are finished
with std::ranges::sort, breaking ties on equal strings by their original index, so the result
stays stable [1] without stable_sort&apos;s temporary buffer.

[1]: <a href="https://tc39.es/ecma262/#sec-array.prototype.sort">https://tc39.es/ecma262/#sec-array.prototype.sort</a>

                                                   baseline                    pr1

sort-custom-comparator                        118.8305+-0.4189     ^     91.7292+-2.2847        ^ definitely 1.2954x faster
array-prototype-sort-large-array               30.0766+-0.5206     ^      7.7445+-0.1864        ^ definitely 3.8836x faster
array-prototype-sort-string-keys               58.1619+-0.8397     ^     29.2567+-0.2513        ^ definitely 1.9880x faster
array-prototype-sort-small-array-comparator
                                                9.8417+-0.2049            9.7472+-0.2406
array-prototype-sort-large-array-comparator
                                                5.5050+-0.1057     ?      5.6815+-0.3862        ? might be 1.0321x slower
array-prototype-sort-large-array-comparator-double
                                                9.3065+-0.1118            9.0973+-0.2528          might be 1.0230x faster
array-prototype-sort-medium-array-comparator
                                               30.2638+-0.2000     ?     30.3275+-0.5047        ?
array-prototype-sort-medium-array              45.2888+-0.4573     ^     30.9154+-0.4568        ^ definitely 1.4649x faster
array-prototype-sort-small-array               15.3942+-0.3811     ^     12.7713+-0.2441        ^ definitely 1.2054x faster

Tests: JSTests/microbenchmarks/array-prototype-sort-string-keys.js
       JSTests/stress/array-default-sort-radix-edge-cases.js

* JSTests/microbenchmarks/array-prototype-sort-string-keys.js: Added.
* JSTests/stress/array-default-sort-radix-edge-cases.js: Added.
(ser):
(refCmp):
(rnd):
(trial.i.else):
(o.toString):
(checkStability):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::sortBucketSort):
(JSC::sortImpl):

Canonical link: <a href="https://commits.webkit.org/318743@main">https://commits.webkit.org/318743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cc88eb7e10f43057ec724dae7ef1a17100c84d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188966 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143444 "Build is in progress. Recent messages:") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139689 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/143444 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160450 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120136 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41960 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40303 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2111 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8935 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152360 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39954 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/272 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40409 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191184 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52744 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148928 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39969 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53424 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36580 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148674 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43358 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125695 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120525 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51942 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14933 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51327 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51388 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->