### PR TITLE
[JSC] Remove many 32bit-only concept from JIT

### DIFF
--- a/Source/JavaScriptCore/bytecode/DataFormat.h
+++ b/Source/JavaScriptCore/bytecode/DataFormat.h
@@ -100,32 +100,6 @@ inline const char* dataFormatToString(DataFormat dataFormat)
     }
 }
 
-inline bool isJSFormat(DataFormat format, DataFormat expectedFormat)
-{
-    ASSERT(expectedFormat & DataFormatJS);
-    return (format | DataFormatJS) == expectedFormat;
-}
-
-inline bool isJSInt32(DataFormat format)
-{
-    return isJSFormat(format, DataFormatJSInt32);
-}
-
-inline bool isJSDouble(DataFormat format)
-{
-    return isJSFormat(format, DataFormatJSDouble);
-}
-
-inline bool isJSCell(DataFormat format)
-{
-    return isJSFormat(format, DataFormatJSCell);
-}
-
-inline bool isJSBoolean(DataFormat format)
-{
-    return isJSFormat(format, DataFormatJSBoolean);
-}
-
 } // namespace JSC
 
 namespace WTF {

--- a/Source/JavaScriptCore/bytecode/ValueRecovery.cpp
+++ b/Source/JavaScriptCore/bytecode/ValueRecovery.cpp
@@ -73,9 +73,6 @@ void ValueRecovery::dumpInContext(PrintStream& out, DumpContext* context) const
     case UnboxedStrictInt52InGPR:
         out.print("strictInt52(", gpr(), ")");
         return;
-    case UnboxedBooleanInGPR:
-        out.print("bool(", gpr(), ")");
-        return;
     case UnboxedCellInGPR:
         out.print("cell(", gpr(), ")");
         return;

--- a/Source/JavaScriptCore/bytecode/ValueRecovery.h
+++ b/Source/JavaScriptCore/bytecode/ValueRecovery.h
@@ -59,7 +59,6 @@ enum ValueRecoveryTechnique : uint8_t {
     UnboxedInt32InGPR,
     UnboxedInt52InGPR,
     UnboxedStrictInt52InGPR,
-    UnboxedBooleanInGPR,
     UnboxedCellInGPR,
     InFPR,
     UnboxedDoubleInFPR,
@@ -114,8 +113,6 @@ public:
             result.m_technique = UnboxedInt52InGPR;
         else if (dataFormat == DataFormatStrictInt52)
             result.m_technique = UnboxedStrictInt52InGPR;
-        else if (dataFormat == DataFormatBoolean)
-            result.m_technique = UnboxedBooleanInGPR;
         else if (dataFormat == DataFormatCell)
             result.m_technique = UnboxedCellInGPR;
         else
@@ -218,7 +215,6 @@ public:
         switch (m_technique) {
         case InGPR:
         case UnboxedInt32InGPR:
-        case UnboxedBooleanInGPR:
         case UnboxedCellInGPR:
         case UnboxedInt52InGPR:
         case UnboxedStrictInt52InGPR:
@@ -277,7 +273,6 @@ public:
         case UnboxedStrictInt52InGPR:
         case StrictInt52DisplacedInJSStack:
             return DataFormatStrictInt52;
-        case UnboxedBooleanInGPR:
         case BooleanDisplacedInJSStack:
             return DataFormatBoolean;
         case UnboxedCellInGPR:
@@ -358,7 +353,6 @@ public:
         switch (m_technique) {
         case InGPR:
         case UnboxedInt32InGPR:
-        case UnboxedBooleanInGPR:
         case UnboxedCellInGPR:
         case UnboxedInt52InGPR:
         case UnboxedStrictInt52InGPR:

--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.h
@@ -447,8 +447,7 @@ struct AbstractValue {
     // complex than the normal Epoch, because it knows how to track clobberStructures() and
     // observeInvalidationPoint() precisely using integer math.
     //
-    // One reason why it's here is to steal the 32-bit hole between m_arrayModes and m_value on
-    // 64-bit systems.
+    // One reason why it's here is to steal the 32-bit hole between m_arrayModes and m_value.
     AbstractValueClobberEpoch m_effectEpoch;
     
     // This is a proven constraint on the possible values that this value can

--- a/Source/JavaScriptCore/dfg/DFGGenerationInfo.h
+++ b/Source/JavaScriptCore/dfg/DFGGenerationInfo.h
@@ -105,10 +105,6 @@ public:
     {
         initGPR(node, useCount, gpr, DataFormatCell);
     }
-    void initBoolean(Node* node, uint32_t useCount, GPRReg gpr)
-    {
-        initGPR(node, useCount, gpr, DataFormatBoolean);
-    }
     void initDouble(Node* node, uint32_t useCount, FPRReg fpr)
     {
         ASSERT(fpr != InvalidFPRReg);
@@ -192,16 +188,6 @@ public:
         return registerFormat() == expectedFormat || spillFormat() == expectedFormat;
     }
     
-    bool isJSFormat(DataFormat expectedFormat)
-    {
-        return JSC::isJSFormat(registerFormat(), expectedFormat) || JSC::isJSFormat(spillFormat(), expectedFormat);
-    }
-    
-    bool isJSInt32()
-    {
-        return isJSFormat(DataFormatJSInt32);
-    }
-    
     bool isInt52()
     {
         return isFormat(DataFormatInt52);
@@ -210,21 +196,6 @@ public:
     bool isStrictInt52()
     {
         return isFormat(DataFormatStrictInt52);
-    }
-    
-    bool isJSDouble()
-    {
-        return isJSFormat(DataFormatJSDouble);
-    }
-    
-    bool isJSCell()
-    {
-        return isJSFormat(DataFormatJSCell);
-    }
-    
-    bool isJSBoolean()
-    {
-        return isJSFormat(DataFormatJSBoolean);
     }
     
     bool isUnknownJS()
@@ -316,10 +287,6 @@ public:
     void fillStrictInt52(VariableEventStreamBuilder& stream, GPRReg gpr)
     {
         fillGPR(stream, gpr, DataFormatStrictInt52);
-    }
-    void fillBoolean(VariableEventStreamBuilder& stream, GPRReg gpr)
-    {
-        fillGPR(stream, gpr, DataFormatBoolean);
     }
     void fillDouble(VariableEventStreamBuilder& stream, FPRReg fpr)
     {

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1056,11 +1056,6 @@ public:
         return isConstant() && constant()->value().isBoolean();
     }
      
-    bool asBoolean()
-    {
-        return constant()->value().asBoolean();
-    }
-
     bool isUndefinedOrNullConstant()
     {
         return isConstant() && constant()->value().isUndefinedOrNull();

--- a/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
@@ -313,31 +313,7 @@ void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, Byteco
         RELEASE_ASSERT(currentEntry.reg().isGPR());
         RegisterAtOffset* calleeSavesEntry = allCalleeSaves->find(currentEntry.reg());
         
-        if constexpr (CallerFrameAndPC::sizeInRegisters == 2)
-            *(std::bit_cast<intptr_t*>(pivot - 1) - currentEntry.offsetAsIndex()) = record->calleeSaveRegistersBuffer[calleeSavesEntry->offsetAsIndex()];
-        else {
-            // We need to adjust 4-bytes on 32-bits, otherwise we will clobber some parts of
-            // pivot[-1] when currentEntry.offsetAsIndex() returns -1. This region contains
-            // CallerFrameAndPC and if it is cloberred, we will have a corrupted stack.
-            // Also, we need to store callee-save registers swapped in pairs on scratch buffer,
-            // otherwise they will be swapped when copied to call frame during OSR Entry code.
-            // Here is how we would like to have the buffer configured:
-            //
-            // pivot[-4] = ArgumentCountIncludingThis
-            // pivot[-3] = Callee
-            // pivot[-2] = CodeBlock
-            // pivot[-1] = CallerFrameAndReturnPC
-            // pivot[0]  = csr1/csr0
-            // pivot[1]  = csr3/csr2
-            // ...
-            ASSERT(sizeof(intptr_t) == 4);
-            ASSERT(CallerFrameAndPC::sizeInRegisters == 1);
-            ASSERT(currentEntry.offsetAsIndex() < 0);
-
-            int offsetAsIndex = currentEntry.offsetAsIndex();
-            int properIndex = offsetAsIndex % 2 ? offsetAsIndex - 1 : offsetAsIndex + 1;
-            *(std::bit_cast<intptr_t*>(pivot - 1) + 1 - properIndex) = record->calleeSaveRegistersBuffer[calleeSavesEntry->offsetAsIndex()];
-        }
+        *(std::bit_cast<intptr_t*>(pivot - 1) - currentEntry.offsetAsIndex()) = record->calleeSaveRegistersBuffer[calleeSavesEntry->offsetAsIndex()];
     }
 #endif
 

--- a/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
@@ -662,7 +662,6 @@ void OSRExit::compileExit(CCallHelpers& jit, VM& vm, const OSRExit& exit, const 
         case Int32DisplacedInJSStack:
         case CellDisplacedInJSStack:
         case DoubleDisplacedInJSStack:
-        case UnboxedBooleanInGPR:
         case UnboxedInt32InGPR:
         case UnboxedCellInGPR:
         case UnboxedDoubleInFPR:

--- a/Source/JavaScriptCore/dfg/DFGSilentRegisterSavePlan.h
+++ b/Source/JavaScriptCore/dfg/DFGSilentRegisterSavePlan.h
@@ -36,7 +36,6 @@ namespace JSC { namespace DFG {
 
 enum SilentSpillAction {
     DoNothingForSpill,
-    Store32Tag,
     Store32Payload,
     StorePtr,
     Store64,
@@ -48,28 +47,17 @@ enum SilentFillAction {
     SetInt32Constant,
     SetInt52Constant,
     SetStrictInt52Constant,
-    SetBooleanConstant,
     SetCellConstant,
     SetTrustedJSConstant,
     SetJSConstant,
-    SetJSConstantTag,
-    SetJSConstantPayload,
-    SetInt32Tag,
-    SetCellTag,
-    SetBooleanTag,
     SetDoubleConstant,
-    Load32Tag,
     Load32Payload,
     Load32PayloadBoxInt,
-    Load32PayloadConvertToInt52,
-    Load32PayloadSignExtend,
     LoadPtr,
     Load64,
     Load64ShiftInt52Right,
     Load64ShiftInt52Left,
-    LoadDouble,
-    LoadDoubleBoxDouble,
-    LoadJSUnboxDouble
+    LoadDouble
 };
 
 class SilentRegisterSavePlan {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -770,17 +770,11 @@ SilentRegisterSavePlan SpeculativeJIT::silentSavePlanForGPR(VirtualRegister spil
         
     if (registerFormat == DataFormatInt32) {
         ASSERT(info.gpr() == source);
-        ASSERT(isJSInt32(info.registerFormat()));
         if (node->hasConstant()) {
             ASSERT(node->isInt32Constant());
             fillAction = SetInt32Constant;
         } else
             fillAction = Load32Payload;
-    } else if (registerFormat == DataFormatBoolean) {
-        RELEASE_ASSERT_NOT_REACHED();
-#if COMPILER_QUIRK(CONSIDERS_UNREACHABLE_CODE)
-        fillAction = DoNothingForFill;
-#endif
     } else if (registerFormat == DataFormatCell) {
         ASSERT(info.gpr() == source);
         if (node->hasConstant()) {
@@ -876,9 +870,6 @@ void SpeculativeJIT::silentSpillImpl(const SilentRegisterSavePlan& plan)
     switch (plan.spillAction()) {
     case DoNothingForSpill:
         break;
-    case Store32Tag:
-        store32(plan.gpr(), highWordFor(plan.node()->virtualRegister()));
-        break;
     case Store32Payload:
         store32(plan.gpr(), lowWordFor(plan.node()->virtualRegister()));
         break;
@@ -911,9 +902,6 @@ void SpeculativeJIT::silentFillImpl(const SilentRegisterSavePlan& plan)
     case SetStrictInt52Constant:
         move(Imm64(plan.node()->asAnyInt()), plan.gpr());
         break;
-    case SetBooleanConstant:
-        move(TrustedImm32(plan.node()->asBoolean()), plan.gpr());
-        break;
     case SetCellConstant:
         ASSERT(plan.node()->constant()->value().isCell());
         loadLinkableConstant(LinkableConstant(*this, plan.node()->constant()->value().asCell()), plan.gpr());
@@ -930,18 +918,6 @@ void SpeculativeJIT::silentFillImpl(const SilentRegisterSavePlan& plan)
     case Load32PayloadBoxInt:
         load32(lowWordFor(plan.node()->virtualRegister()), plan.gpr());
         or64(GPRInfo::numberTagRegister, plan.gpr());
-        break;
-    case Load32PayloadConvertToInt52:
-        load32(lowWordFor(plan.node()->virtualRegister()), plan.gpr());
-        signExtend32ToPtr(plan.gpr(), plan.gpr());
-        lshift64(TrustedImm32(JSValue::int52ShiftAmount), plan.gpr());
-        break;
-    case Load32PayloadSignExtend:
-        load32(lowWordFor(plan.node()->virtualRegister()), plan.gpr());
-        signExtend32ToPtr(plan.gpr(), plan.gpr());
-        break;
-    case Load32Tag:
-        load32(highWordFor(plan.node()->virtualRegister()), plan.gpr());
         break;
     case Load32Payload:
         load32(lowWordFor(plan.node()->virtualRegister()), plan.gpr());
@@ -2758,7 +2734,6 @@ GeneratedOperandType SpeculativeJIT::checkGeneratedTypeForToInt32(Node* node)
     case DataFormatStorage:
         RELEASE_ASSERT_NOT_REACHED();
 
-    case DataFormatBoolean:
     case DataFormatCell:
         terminateSpeculativeExecution(Uncountable, JSValueRegs(), nullptr);
         return GeneratedOperandTypeUnknown;
@@ -16539,7 +16514,7 @@ void SpeculativeJIT::compileExtractFromTuple(Node* node)
         ASSERT(info.isFormat(DataFormatInt32) || info.isFormat(DataFormatJSInt32));
         break;
     case NodeResultBoolean:
-        ASSERT(info.isFormat(DataFormatBoolean) || info.isFormat(DataFormatJSBoolean));
+        ASSERT(info.isFormat(DataFormatJSBoolean));
         break;
     case NodeResultStorage:
         ASSERT(info.isFormat(DataFormatStorage));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -91,7 +91,6 @@ private:
         SpillOrderCell     = 4, // needs spill
         SpillOrderStorage  = 4, // needs spill
         SpillOrderInteger  = 5, // needs spill and box
-        SpillOrderBoolean  = 5, // needs spill and box
         SpillOrderDouble   = 6, // needs spill and convert
     };
 
@@ -470,13 +469,9 @@ public:
         }
             
         default:
-            // The following code handles JSValues, int32s, and cells.
             RELEASE_ASSERT(spillFormat == DataFormatCell || spillFormat & DataFormatJS);
             
             GPRReg reg = info.gpr();
-            // We need to box int32 and cell values, but boxing a cell is a no-op.
-            if (spillFormat == DataFormatInt32)
-                or64(GPRInfo::numberTagRegister, reg);
             
             // Spill the value, and record it as spilled in its boxed form.
             store64(reg, JITCompiler::addressFor(spillMe));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -146,7 +146,6 @@ GPRReg SpeculativeJIT::fillJSValue(Edge edge)
         return gpr;
     }
         
-    case DataFormatBoolean:
     case DataFormatStorage:
     case DataFormatDouble:
     case DataFormatInt52:
@@ -1266,7 +1265,6 @@ GPRReg SpeculativeJIT::fillSpeculateInt32Internal(Edge edge, DataFormat& returnF
         
     case DataFormatJSDouble:
     case DataFormatCell:
-    case DataFormatBoolean:
     case DataFormatJSCell:
     case DataFormatJSBoolean:
     case DataFormatDouble:
@@ -1508,7 +1506,6 @@ GPRReg SpeculativeJIT::fillSpeculateCell(Edge edge)
     case DataFormatInt32:
     case DataFormatJSDouble:
     case DataFormatJSBoolean:
-    case DataFormatBoolean:
     case DataFormatDouble:
     case DataFormatStorage:
     case DataFormatInt52:
@@ -1566,7 +1563,6 @@ GPRReg SpeculativeJIT::fillSpeculateBoolean(Edge edge)
         return gpr;
     }
 
-    case DataFormatBoolean:
     case DataFormatJSBoolean: {
         GPRReg gpr = info.gpr();
         m_gprs.lock(gpr);
@@ -1704,7 +1700,6 @@ GPRReg SpeculativeJIT::fillSpeculateBigInt32(Edge edge)
         return gpr;
     }
 
-    case DataFormatBoolean:
     case DataFormatJSBoolean:
     case DataFormatJSInt32:
     case DataFormatInt32:

--- a/Source/JavaScriptCore/dfg/DFGUseKind.h
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.h
@@ -38,9 +38,9 @@ enum UseKind : uint8_t {
     // The DFG has 3 representations of values used:
 
     // 1. The JSValue representation for a JSValue that must be stored in a GP
-    //    register (or a GP register pair), and follows rules for boxing and unboxing
-    //    that allow the JSValue to be stored as either fully boxed JSValues, or
-    //    unboxed Int32, Booleans, Cells, etc. in 32-bit as appropriate.
+    //    register, and follows rules for boxing and unboxing that allow the
+    //    JSValue to be stored as either fully boxed JSValues, or unboxed Int32,
+    //    Cells, etc. as appropriate.
     UntypedUse, // UntypedUse must come first (value 0).
     Int32Use,
     KnownInt32Use,

--- a/Source/JavaScriptCore/dfg/DFGVariableEvent.h
+++ b/Source/JavaScriptCore/dfg/DFGVariableEvent.h
@@ -255,7 +255,7 @@ private:
     Packed<WhichType> m_which;
     
     // For BirthToFill, Fill:
-    //   - The GPR or FPR, or a GPR pair.
+    //   - The GPR or FPR.
     // For BirthToSpill, Spill:
     //   - The virtual register.
     // For MovHintEvent, SetLocalEvent:

--- a/Source/JavaScriptCore/dfg/DFGVariableEventStream.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVariableEventStream.cpp
@@ -48,7 +48,7 @@ void VariableEventStreamBuilder::logEvent(const VariableEvent& event)
 namespace {
 
 struct MinifiedGenerationInfo {
-    bool filled; // true -> in gpr/fpr/pair, false -> spilled
+    bool filled; // true -> in gpr/fpr, false -> spilled
     bool alive;
     VariableRepresentation u;
     DataFormat format;

--- a/Source/JavaScriptCore/jit/CallFrameShuffler64.cpp
+++ b/Source/JavaScriptCore/jit/CallFrameShuffler64.cpp
@@ -53,9 +53,6 @@ DataFormat CallFrameShuffler::emitStore(
     case UnboxedStrictInt52InGPR:
         m_jit.storePtr(cachedRecovery.recovery().gpr(), address);
         return DataFormatStrictInt52;
-    case UnboxedBooleanInGPR:
-        m_jit.storePtr(cachedRecovery.recovery().gpr(), address);
-        return DataFormatBoolean;
     case UnboxedCellInGPR:
         m_jit.storePtr(cachedRecovery.recovery().gpr(), address);
         return DataFormatCell;
@@ -122,16 +119,6 @@ void CallFrameShuffler::emitBox(CachedRecovery& cachedRecovery)
                 dataLog(" into ", cachedRecovery.recovery(), "\n");
             break;
         }
-        case DataFormatBoolean:
-            if (verbose)
-                dataLog("   * Boxing ", cachedRecovery.recovery());
-            m_jit.add32(MacroAssembler::TrustedImm32(JSValue::ValueFalse),
-                cachedRecovery.recovery().gpr());
-            cachedRecovery.setRecovery(
-                ValueRecovery::inGPR(cachedRecovery.recovery().gpr(), DataFormatJS));
-            if (verbose)
-                dataLog(" into ", cachedRecovery.recovery(), "\n");
-            return;
         default:
             return;
         }

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -332,7 +332,6 @@ namespace JSC {
         ECMAMode ecmaMode(Op);
 
         void emitGetVirtualRegister(VirtualRegister src, JSValueRegs dst);
-        void emitGetVirtualRegisterPayload(VirtualRegister src, RegisterID dst);
         void emitPutVirtualRegister(VirtualRegister dst, JSValueRegs src);
 
         // Machine register variants purely for convenience

--- a/Source/JavaScriptCore/jit/JITArithmetic.cpp
+++ b/Source/JavaScriptCore/jit/JITArithmetic.cpp
@@ -289,18 +289,18 @@ void JIT::emit_compareUnsignedAndJump(const JSInstruction* instruction, Relation
 void JIT::emit_compareUnsignedAndJumpImpl(VirtualRegister op1, VirtualRegister op2, unsigned target, RelationalCondition condition)
 {
     if (isOperandConstantInt(op2)) {
-        emitGetVirtualRegisterPayload(op1, regT0);
+        emitGetVirtualRegister(op1, regT0);
         jitAssertIsJSInt32(regT0);
         int32_t op2imm = getOperandConstantInt(op2);
         addJump(branch32(condition, regT0, Imm32(op2imm)), target);
     } else if (isOperandConstantInt(op1)) {
-        emitGetVirtualRegisterPayload(op2, regT1);
+        emitGetVirtualRegister(op2, regT1);
         jitAssertIsJSInt32(regT1);
         int32_t op1imm = getOperandConstantInt(op1);
         addJump(branch32(commute(condition), regT1, Imm32(op1imm)), target);
     } else {
-        emitGetVirtualRegisterPayload(op1, regT0);
-        emitGetVirtualRegisterPayload(op2, regT1);
+        emitGetVirtualRegister(op1, regT0);
+        emitGetVirtualRegister(op2, regT1);
         jitAssertIsJSInt32(regT0);
         jitAssertIsJSInt32(regT1);
         addJump(branch32(condition, regT0, regT1), target);
@@ -320,16 +320,16 @@ void JIT::emit_compareUnsigned(const JSInstruction* instruction, RelationalCondi
 void JIT::emit_compareUnsignedImpl(VirtualRegister dst, VirtualRegister op1, VirtualRegister op2, RelationalCondition condition)
 {
     if (isOperandConstantInt(op2)) {
-        emitGetVirtualRegisterPayload(op1, regT0);
+        emitGetVirtualRegister(op1, regT0);
         int32_t op2imm = getOperandConstantInt(op2);
         compare32(condition, regT0, Imm32(op2imm), regT0);
     } else if (isOperandConstantInt(op1)) {
-        emitGetVirtualRegisterPayload(op2, regT0);
+        emitGetVirtualRegister(op2, regT0);
         int32_t op1imm = getOperandConstantInt(op1);
         compare32(commute(condition), regT0, Imm32(op1imm), regT0);
     } else {
-        emitGetVirtualRegisterPayload(op1, regT0);
-        emitGetVirtualRegisterPayload(op2, regT1);
+        emitGetVirtualRegister(op1, regT0);
+        emitGetVirtualRegister(op2, regT1);
         compare32(condition, regT0, regT1, regT0);
     }
     boxBoolean(regT0, jsRegT10);

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -160,7 +160,7 @@ void JIT::compileCallDirectEval(const OpCallDirectEval& bytecode)
     resetSP();
 
     emitGetVirtualRegister(bytecode.m_thisValue, thisValueJSR);
-    emitGetVirtualRegisterPayload(bytecode.m_scope, scopeGPR);
+    emitGetVirtualRegister(bytecode.m_scope, scopeGPR);
     loadPtr(addressFor(CallFrameSlot::codeBlock), codeBlockGPR);
     move(TrustedImm32(m_bytecodeIndex.asBits()), bytecodeIndexGPR);
     callOperation(selectCallDirectEvalOperation(bytecode.m_lexicallyScopedFeatures), calleeFrameGPR, scopeGPR, thisValueJSR, codeBlockGPR, bytecodeIndexGPR);
@@ -614,8 +614,8 @@ void JIT::emit_op_async_iterator_next(const JSInstruction* instruction)
     constexpr GPRReg iteratorGPR = preferredArgumentGPR<SlowOperation, 1>();
     constexpr GPRReg driverGPR = preferredArgumentGPR<SlowOperation, 2>();
     constexpr JSValueRegs resumeValueJSR = preferredArgumentJSR<SlowOperation, 3>();
-    emitGetVirtualRegisterPayload(bytecode.m_iterator, iteratorGPR);
-    emitGetVirtualRegisterPayload(bytecode.m_driver, driverGPR);
+    emitGetVirtualRegister(bytecode.m_iterator, iteratorGPR);
+    emitGetVirtualRegister(bytecode.m_driver, driverGPR);
     if (bytecode.m_hasValue)
         emitGetVirtualRegister(resumeValueOperandFor(bytecode), resumeValueJSR);
     else
@@ -677,7 +677,7 @@ void JIT::emit_op_instanceof(const JSInstruction* instruction)
         shuffleJSRs<1>({ GetById::resultJSR }, { Instanceof::Custom::hasInstanceJSR });
         loadGlobalObject(Instanceof::Custom::globalObjectGPR);
         emitGetVirtualRegister(bytecode.m_value, Instanceof::Custom::valueJSR);
-        emitGetVirtualRegisterPayload(bytecode.m_constructor, Instanceof::Custom::constructorGPR);
+        emitGetVirtualRegister(bytecode.m_constructor, Instanceof::Custom::constructorGPR);
 
         addSlowCase(branchPtr(NotEqual,
             Instanceof::Custom::hasInstanceJSR.payloadGPR(),

--- a/Source/JavaScriptCore/jit/JITInlines.h
+++ b/Source/JavaScriptCore/jit/JITInlines.h
@@ -375,11 +375,6 @@ ALWAYS_INLINE void JIT::emitPutVirtualRegister(VirtualRegister dst, JSValueRegs 
     storeValue(from, addressFor(dst));
 }
 
-ALWAYS_INLINE void JIT::emitGetVirtualRegisterPayload(VirtualRegister src, RegisterID dst)
-{
-    emitGetVirtualRegister(src, JSValueRegs { dst });
-}
-
 ALWAYS_INLINE void JIT::emitGetVirtualRegister(VirtualRegister src, RegisterID dst)
 {
     emitGetVirtualRegister(src, JSValueRegs { dst });

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -355,7 +355,7 @@ void JIT::emit_op_set_function_name(const JSInstruction* currentInstruction)
     constexpr GPRReg functionGPR = preferredArgumentGPR<SlowOperation, 1>();
     constexpr JSValueRegs nameJSR = preferredArgumentJSR<SlowOperation, 2>();
 
-    emitGetVirtualRegisterPayload(bytecode.m_function, functionGPR);
+    emitGetVirtualRegister(bytecode.m_function, functionGPR);
     emitGetVirtualRegister(bytecode.m_name, nameJSR);
     loadGlobalObject(globalObjectGPR);
     callOperation(operationSetFunctionName, globalObjectGPR, functionGPR, nameJSR);
@@ -1201,7 +1201,7 @@ void JIT::emit_op_get_parent_scope(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpGetParentScope>();
     VirtualRegister currentScope = bytecode.m_scope;
-    emitGetVirtualRegisterPayload(currentScope, regT0);
+    emitGetVirtualRegister(currentScope, regT0);
     loadPtr(Address(regT0, JSScope::offsetOfNext()), regT0);
     boxCell(regT0, jsRegT10);
     emitPutVirtualRegister(bytecode.m_dst, jsRegT10);
@@ -1585,7 +1585,7 @@ void JIT::emit_op_create_this(const JSInstruction* currentInstruction)
     RegisterID cachedFunctionReg = regT4;
     RegisterID scratchReg = regT3;
 
-    emitGetVirtualRegisterPayload(callee, calleeReg);
+    emitGetVirtualRegister(callee, calleeReg);
     addSlowCase(branchIfNotFunction(calleeReg));
     loadPtr(Address(calleeReg, JSFunction::offsetOfExecutableOrRareData()), rareDataReg);
     addSlowCase(branchTestPtr(Zero, rareDataReg, TrustedImm32(JSFunction::rareDataTag)));
@@ -1809,7 +1809,7 @@ void JIT::emitNewFuncCommon(const JSInstruction* currentInstruction)
     auto* unlinkedExecutable = m_unlinkedCodeBlock->functionDecl(bytecode.m_functionDecl);
 
     loadGlobalObject(argumentGPR0);
-    emitGetVirtualRegisterPayload(bytecode.m_scope, argumentGPR1);
+    emitGetVirtualRegister(bytecode.m_scope, argumentGPR1);
     auto constant = addToConstantPool(JITConstantPool::Type::FunctionDecl, std::bit_cast<void*>(static_cast<uintptr_t>(bytecode.m_functionDecl)));
     loadConstant(constant, argumentGPR2);
 
@@ -1856,7 +1856,7 @@ void JIT::emitNewFuncExprCommon(const JSInstruction* currentInstruction)
     auto* unlinkedExecutable = m_unlinkedCodeBlock->functionExpr(bytecode.m_functionDecl);
 
     loadGlobalObject(argumentGPR0);
-    emitGetVirtualRegisterPayload(bytecode.m_scope, argumentGPR1);
+    emitGetVirtualRegister(bytecode.m_scope, argumentGPR1);
     auto constant = addToConstantPool(JITConstantPool::Type::FunctionExpr, std::bit_cast<void*>(static_cast<uintptr_t>(bytecode.m_functionDecl)));
     loadConstant(constant, argumentGPR2);
 
@@ -1937,8 +1937,8 @@ void JIT::emit_op_create_lexical_environment(const JSInstruction* currentInstruc
     JSValue value = m_unlinkedCodeBlock->getConstant(initialValue);
 
     loadGlobalObject(argumentGPR0);
-    emitGetVirtualRegisterPayload(scope, argumentGPR1);
-    emitGetVirtualRegisterPayload(symbolTable, argumentGPR2);
+    emitGetVirtualRegister(scope, argumentGPR1);
+    emitGetVirtualRegister(symbolTable, argumentGPR2);
     callOperationNoExceptionCheck(value == jsUndefined() ? operationCreateLexicalEnvironmentUndefined : operationCreateLexicalEnvironmentTDZ, dst, argumentGPR0, argumentGPR1, argumentGPR2);
 }
 
@@ -1958,7 +1958,7 @@ void JIT::emit_op_create_scoped_arguments(const JSInstruction* currentInstructio
     VirtualRegister scope = bytecode.m_scope;
 
     loadGlobalObject(argumentGPR0);
-    emitGetVirtualRegisterPayload(scope, argumentGPR1);
+    emitGetVirtualRegister(scope, argumentGPR1);
     callOperationNoExceptionCheck(operationCreateScopedArgumentsBaseline, dst, argumentGPR0, argumentGPR1);
 }
 
@@ -2047,7 +2047,7 @@ void JIT::emit_op_log_shadow_chicken_prologue(const JSInstruction* currentInstru
     GPRReg scratch1Reg = nonArgGPR0; // This must be a non-argument register.
     GPRReg scratch2Reg = regT2;
     ensureShadowChickenPacket(vm(), shadowPacketReg, scratch1Reg, scratch2Reg);
-    emitGetVirtualRegisterPayload(bytecode.m_scope, regT3);
+    emitGetVirtualRegister(bytecode.m_scope, regT3);
     logShadowChickenProloguePacket(shadowPacketReg, scratch1Reg, regT3);
 }
 
@@ -2065,7 +2065,7 @@ void JIT::emit_op_log_shadow_chicken_tail(const JSInstruction* currentInstructio
         ensureShadowChickenPacket(vm(), shadowPacketReg, scratch1Reg, scratch2Reg);
     }
     emitGetVirtualRegister(bytecode.m_thisValue, jsRegT32);
-    emitGetVirtualRegisterPayload(bytecode.m_scope, regT4);
+    emitGetVirtualRegister(bytecode.m_scope, regT4);
     loadPtr(addressFor(CallFrameSlot::codeBlock), regT1);
     logShadowChickenTailPacket(shadowPacketReg, jsRegT32, regT4, regT1, CallSiteIndex(m_bytecodeIndex));
 }

--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -345,9 +345,9 @@ void JIT::emitSlow_op_put_private_name(const JSInstruction*, Vector<SlowCaseEntr
 void JIT::emit_op_put_getter_by_id(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpPutGetterById>();
-    emitGetVirtualRegisterPayload(bytecode.m_base, regT0);
+    emitGetVirtualRegister(bytecode.m_base, regT0);
     int32_t options = bytecode.m_attributes;
-    emitGetVirtualRegisterPayload(bytecode.m_accessor, regT1);
+    emitGetVirtualRegister(bytecode.m_accessor, regT1);
     loadGlobalObject(regT2);
     callOperation(operationPutGetterById, regT2, regT0, TrustedImmPtr(m_unlinkedCodeBlock->identifier(bytecode.m_property).impl()), options, regT1);
 }
@@ -355,9 +355,9 @@ void JIT::emit_op_put_getter_by_id(const JSInstruction* currentInstruction)
 void JIT::emit_op_put_setter_by_id(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpPutSetterById>();
-    emitGetVirtualRegisterPayload(bytecode.m_base, regT0);
+    emitGetVirtualRegister(bytecode.m_base, regT0);
     int32_t options = bytecode.m_attributes;
-    emitGetVirtualRegisterPayload(bytecode.m_accessor, regT1);
+    emitGetVirtualRegister(bytecode.m_accessor, regT1);
     loadGlobalObject(regT2);
     callOperation(operationPutSetterById, regT2, regT0, TrustedImmPtr(m_unlinkedCodeBlock->identifier(bytecode.m_property).impl()), options, regT1);
 }
@@ -365,10 +365,10 @@ void JIT::emit_op_put_setter_by_id(const JSInstruction* currentInstruction)
 void JIT::emit_op_put_getter_setter_by_id(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpPutGetterSetterById>();
-    emitGetVirtualRegisterPayload(bytecode.m_base, regT0);
+    emitGetVirtualRegister(bytecode.m_base, regT0);
     int32_t attribute = bytecode.m_attributes;
-    emitGetVirtualRegisterPayload(bytecode.m_getter, regT1);
-    emitGetVirtualRegisterPayload(bytecode.m_setter, regT2);
+    emitGetVirtualRegister(bytecode.m_getter, regT1);
+    emitGetVirtualRegister(bytecode.m_setter, regT2);
     loadGlobalObject(regT3);
     callOperation(operationPutGetterSetter, regT3, regT0, TrustedImmPtr(m_unlinkedCodeBlock->identifier(bytecode.m_property).impl()), attribute, regT1, regT2);
 }
@@ -384,10 +384,10 @@ void JIT::emit_op_put_getter_by_val(const JSInstruction* currentInstruction)
     // Attributes in argument 3
     constexpr GPRReg setterGPR = preferredArgumentGPR<SlowOperation, 4>();
 
-    emitGetVirtualRegisterPayload(bytecode.m_base, baseGPR);
+    emitGetVirtualRegister(bytecode.m_base, baseGPR);
     emitGetVirtualRegister(bytecode.m_property, propertyJSR);
     int32_t attributes = bytecode.m_attributes;
-    emitGetVirtualRegisterPayload(bytecode.m_accessor, setterGPR);
+    emitGetVirtualRegister(bytecode.m_accessor, setterGPR);
     loadGlobalObject(globalObjectGPR);
     callOperation(operationPutGetterByVal, globalObjectGPR, baseGPR, propertyJSR, attributes, setterGPR);
 }
@@ -403,10 +403,10 @@ void JIT::emit_op_put_setter_by_val(const JSInstruction* currentInstruction)
     // Attributes in argument 3
     constexpr GPRReg setterGPR = preferredArgumentGPR<SlowOperation, 4>();
 
-    emitGetVirtualRegisterPayload(bytecode.m_base, baseGPR);
+    emitGetVirtualRegister(bytecode.m_base, baseGPR);
     emitGetVirtualRegister(bytecode.m_property, propertyJSR);
     int32_t attributes = bytecode.m_attributes;
-    emitGetVirtualRegisterPayload(bytecode.m_accessor, setterGPR);
+    emitGetVirtualRegister(bytecode.m_accessor, setterGPR);
     loadGlobalObject(globalObjectGPR);
     callOperation(operationPutSetterByVal, globalObjectGPR, baseGPR, propertyJSR, attributes, setterGPR);
 }
@@ -915,7 +915,7 @@ void JIT::emit_op_resolve_scope(const JSInstruction* currentInstruction)
     if (profiledResolveType == ModuleVar)
         loadPtrFromMetadata(bytecode, Metadata::offsetOfLexicalEnvironment(), returnValueGPR);
     else if (profiledResolveType == ClosureVar) {
-        emitGetVirtualRegisterPayload(scope, scopeGPR);
+        emitGetVirtualRegister(scope, scopeGPR);
         static_assert(scopeGPR == returnValueGPR);
         unsigned localScopeDepth = bytecode.metadata(m_profiledCodeBlock).m_localScopeDepth;
         if (localScopeDepth < 8) {
@@ -978,7 +978,7 @@ void JIT::emit_op_resolve_scope(const JSInstruction* currentInstruction)
             else
                 code = vm().getCTIStub(generateOpResolveScopeThunk<GlobalVar>);
 
-            emitGetVirtualRegisterPayload(scope, scopeGPR);
+            emitGetVirtualRegister(scope, scopeGPR);
             move(TrustedImm32(bytecodeOffset), bytecodeOffsetGPR);
             nearCallThunk(CodeLocationLabel { code.retaggedCode<NoPtrTag>() });
             break;
@@ -1029,7 +1029,7 @@ void JIT::emitSlow_op_resolve_scope(const JSInstruction* currentInstruction, Vec
     else
         code = vm().getCTIStub(generateOpResolveScopeThunk<GlobalVar>);
 
-    emitGetVirtualRegisterPayload(scope, scopeGPR);
+    emitGetVirtualRegister(scope, scopeGPR);
     move(TrustedImm32(bytecodeOffset), bytecodeOffsetGPR);
     nearCallThunk(CodeLocationLabel { code.retaggedCode<NoPtrTag>() });
 }
@@ -1225,7 +1225,7 @@ void JIT::emit_op_get_from_scope(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::GetFromScope::scratch1GPR;
 
     if (profiledResolveType == ClosureVar) {
-        emitGetVirtualRegisterPayload(scope, scopeGPR);
+        emitGetVirtualRegister(scope, scopeGPR);
         loadPtrFromMetadata(bytecode, Metadata::offsetOfOperand(), scratch1GPR);
         loadValue(BaseIndex(scopeGPR, scratch1GPR, TimesEight, JSLexicalEnvironment::offsetOfVariables()), returnValueJSR);
     } else {
@@ -1250,7 +1250,7 @@ void JIT::emit_op_get_from_scope(const JSInstruction* currentInstruction)
         case GlobalProperty: {
             addSlowCase(branch32(NotEqual, scratch1GPR, TrustedImm32(profiledResolveType)));
             load32(structureIDAddress, scratch1GPR);
-            emitGetVirtualRegisterPayload(scope, scopeGPR);
+            emitGetVirtualRegister(scope, scopeGPR);
             addSlowCase(branch32(NotEqual, Address(scopeGPR, JSCell::structureIDOffset()), scratch1GPR));
             loadPtr(operandAddress, scratch1GPR);
             loadPtr(Address(scopeGPR, JSObject::butterflyOffset()), scopeGPR);
@@ -1294,7 +1294,7 @@ void JIT::emit_op_get_from_scope(const JSInstruction* currentInstruction)
             else
                 code = vm().getCTIStub(generateOpGetFromScopeThunk<GlobalVar>);
 
-            emitGetVirtualRegisterPayload(scope, scopeGPR);
+            emitGetVirtualRegister(scope, scopeGPR);
             move(TrustedImm32(bytecodeOffset), bytecodeOffsetGPR);
             nearCallThunk(CodeLocationLabel { code.retaggedCode<NoPtrTag>() });
             break;
@@ -1344,7 +1344,7 @@ void JIT::emitSlow_op_get_from_scope(const JSInstruction* currentInstruction, Ve
     else
         code = vm().getCTIStub(generateOpGetFromScopeThunk<GlobalVar>);
 
-    emitGetVirtualRegisterPayload(scope, scopeGPR);
+    emitGetVirtualRegister(scope, scopeGPR);
     addPtr(TrustedImm32(metadataOffset), GPRInfo::metadataTableRegister, metadataGPR);
     move(TrustedImm32(bytecodeOffset), bytecodeOffsetGPR);
     nearCallThunk(CodeLocationLabel { code.retaggedCode<NoPtrTag>() });
@@ -1562,7 +1562,7 @@ void JIT::emit_op_put_to_scope(const JSInstruction* currentInstruction)
             constexpr GPRReg scratch1GPR2 = regT4;
             static_assert(noOverlap(valueJSR, scopeGPR, scratch1GPR1, scratch1GPR2));
             load32(structureIDAddress, scratch1GPR1);
-            emitGetVirtualRegisterPayload(scope, scopeGPR);
+            emitGetVirtualRegister(scope, scopeGPR);
             addSlowCase(branch32(NotEqual, Address(scopeGPR, JSCell::structureIDOffset()), scratch1GPR1));
 
             emitGetVirtualRegister(value, valueJSR);
@@ -1614,7 +1614,7 @@ void JIT::emit_op_put_to_scope(const JSInstruction* currentInstruction)
             loadPtr(operandAddress, regT2);
             emitNotifyWriteWatchpoint(regT3);
             emitGetVirtualRegister(value, jsRegT10);
-            emitGetVirtualRegisterPayload(scope, regT3);
+            emitGetVirtualRegister(scope, regT3);
             storeValue(jsRegT10, BaseIndex(regT3, regT2, TimesEight, JSLexicalEnvironment::offsetOfVariables()));
 
             emitWriteBarrier(scope, value, ShouldFilterValue);
@@ -1744,7 +1744,7 @@ void JIT::emit_op_get_from_arguments(const JSInstruction* currentInstruction)
     VirtualRegister arguments = bytecode.m_arguments;
     int index = bytecode.m_index;
 
-    emitGetVirtualRegisterPayload(arguments, regT0);
+    emitGetVirtualRegister(arguments, regT0);
     loadValue(Address(regT0, DirectArguments::storageOffset() + index * sizeof(WriteBarrier<Unknown>)), jsRegT10);
     emitValueProfilingSite(bytecode, jsRegT10);
     emitPutVirtualRegister(dst, jsRegT10);
@@ -1758,7 +1758,7 @@ void JIT::emit_op_put_to_arguments(const JSInstruction* currentInstruction)
     VirtualRegister value = bytecode.m_value;
 
     static_assert(noOverlap(regT2, jsRegT10));
-    emitGetVirtualRegisterPayload(arguments, regT2);
+    emitGetVirtualRegister(arguments, regT2);
     emitGetVirtualRegister(value, jsRegT10);
     storeValue(jsRegT10, Address(regT2, DirectArguments::storageOffset() + index * sizeof(WriteBarrier<Unknown>)));
 
@@ -1772,7 +1772,7 @@ void JIT::emit_op_get_internal_field(const JSInstruction* currentInstruction)
     VirtualRegister base = bytecode.m_base;
     unsigned index = bytecode.m_index;
 
-    emitGetVirtualRegisterPayload(base, regT0);
+    emitGetVirtualRegister(base, regT0);
     loadValue(Address(regT0, JSInternalFieldObjectImpl<>::offsetOfInternalField(index)), jsRegT10);
 
     emitValueProfilingSite(bytecode, jsRegT10);
@@ -1787,7 +1787,7 @@ void JIT::emit_op_put_internal_field(const JSInstruction* currentInstruction)
     unsigned index = bytecode.m_index;
 
     static_assert(noOverlap(regT2, jsRegT10));
-    emitGetVirtualRegisterPayload(base, regT2);
+    emitGetVirtualRegister(base, regT2);
     emitGetVirtualRegister(value, jsRegT10);
     storeValue(jsRegT10, Address(regT2, JSInternalFieldObjectImpl<>::offsetOfInternalField(index)));
     emitWriteBarrier(base, value, ShouldFilterValue);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -131,11 +131,6 @@ bool Location::isGPR() const
     return m_kind == Gpr;
 }
 
-bool Location::isGPR2() const
-{
-    return m_kind == Gpr2;
-}
-
 bool Location::isFPR() const
 {
     return m_kind == Fpr;
@@ -223,18 +218,6 @@ FPRReg Location::asFPR() const
     return m_fpr;
 }
 
-GPRReg Location::asGPRlo() const
-{
-    ASSERT(isGPR2());
-    return m_gprlo;
-}
-
-GPRReg Location::asGPRhi() const
-{
-    ASSERT(isGPR2());
-    return m_gprhi;
-}
-
 void Location::dump(PrintStream& out) const
 {
     switch (m_kind) {
@@ -256,9 +239,6 @@ void Location::dump(PrintStream& out) const
     case StackArgument:
         out.print("StackArgument(", m_offset, ")");
         break;
-    case Gpr2:
-        out.print("GPR2(", m_gprhi, ",", m_gprlo, ")");
-        break;
     }
 }
 
@@ -269,8 +249,6 @@ bool Location::operator==(Location other) const
     switch (m_kind) {
     case Gpr:
         return m_gpr == other.m_gpr;
-    case Gpr2:
-        return m_gprlo == other.m_gprlo && m_gprhi == other.m_gprhi;
     case Fpr:
         return m_fpr == other.m_fpr;
     case Stack:
@@ -4367,8 +4345,6 @@ void BBQJIT::saveValuesAcrossCallAndPassArguments(const Args& arguments, const C
                 binding = bindingFor(paramLocation.asGPR());
             else if (paramLocation.isFPR())
                 binding = bindingFor(paramLocation.asFPR());
-            else if (paramLocation.isGPR2())
-                binding = bindingFor(paramLocation.asGPRhi());
             if (!binding.toValue().isNone())
                 flushValue(binding.toValue());
         }
@@ -4405,8 +4381,6 @@ void BBQJIT::returnValuesFromCall(Vector<Value, N>& results, const RTT& function
                 currentBinding = bindingFor(returnLocation.asGPR());
             else if (returnLocation.isFPR())
                 currentBinding = bindingFor(returnLocation.asFPR());
-            else if (returnLocation.isGPR2())
-                currentBinding = bindingFor(returnLocation.asGPRhi());
             // There's no way to preserve an abritrary scratch over a call so we shouldn't try to do so.
             ASSERT(!currentBinding.isScratch());
         } else {
@@ -5099,10 +5073,7 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
 
         if (operandLocation.isGPR())
             liveScratchGPRs.add(operandLocation.asGPR(), IgnoreVectors);
-        else if (operandLocation.isGPR2()) {
-            liveScratchGPRs.add(operandLocation.asGPRlo(), IgnoreVectors);
-            liveScratchGPRs.add(operandLocation.asGPRhi(), IgnoreVectors);
-        } else if (operandLocation.isFPR())
+        else if (operandLocation.isFPR())
             liveScratchFPRs.add(operandLocation.asFPR(), operand.type() == TypeKind::V128 ? Width128 : Width64);
     }
     if (!liveScratchFPRs.contains(scratches.fpr(0), IgnoreVectors))
@@ -5359,10 +5330,7 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
             emitMove(left, leftLocation = Location::fromFPR(wasmScratchFPR));
         if (leftLocation.isGPR())
             liveScratchGPRs.add(leftLocation.asGPR(), IgnoreVectors);
-        else if (leftLocation.isGPR2()) {
-            liveScratchGPRs.add(leftLocation.asGPRlo(), IgnoreVectors);
-            liveScratchGPRs.add(leftLocation.asGPRhi(), IgnoreVectors);
-        } else if (leftLocation.isFPR())
+        else if (leftLocation.isFPR())
             liveScratchFPRs.add(leftLocation.asFPR(), left.type() == TypeKind::V128 ? Width128 : Width64);
 
         if (!right.isConst())
@@ -5371,10 +5339,7 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
             emitMove(right, rightLocation = Location::fromFPR(wasmScratchFPR));
         if (rightLocation.isGPR())
             liveScratchGPRs.add(rightLocation.asGPR(), IgnoreVectors);
-        else if (rightLocation.isGPR2()) {
-            liveScratchGPRs.add(rightLocation.asGPRlo(), IgnoreVectors);
-            liveScratchGPRs.add(rightLocation.asGPRhi(), IgnoreVectors);
-        } else if (rightLocation.isFPR())
+        else if (rightLocation.isFPR())
             liveScratchFPRs.add(rightLocation.asFPR(), right.type() == TypeKind::V128 ? Width128 : Width64);
     }
     consume(left);
@@ -5558,9 +5523,6 @@ void BBQJIT::setLRUKey(Location location, LocalOrTempIndex key)
         m_gprAllocator.setSpillHint(location.asGPR(), key);
     } else if (location.isFPR()) {
         m_fprAllocator.setSpillHint(location.asFPR(), key);
-    } else if (location.isGPR2()) {
-        m_gprAllocator.setSpillHint(location.asGPRhi(), key);
-        m_gprAllocator.setSpillHint(location.asGPRlo(), key);
     }
 }
 
@@ -5582,10 +5544,8 @@ Location BBQJIT::allocateWithHint(Value value, Location hint)
     Location result;
     if (value.isFloat())
         result = Location::fromFPR(m_fprAllocator.allocate(*this, RegisterBinding::fromValue(value), nextLRUKey(), hint.isFPR() ? hint.asFPR() : InvalidFPRReg));
-    else if (!typeNeedsGPR2(value.type()))
-        result = Location::fromGPR(m_gprAllocator.allocate(*this, RegisterBinding::fromValue(value), nextLRUKey(), hint.isGPR() ? hint.asGPR() : InvalidGPRReg));
     else
-        RELEASE_ASSERT_NOT_REACHED();
+        result = Location::fromGPR(m_gprAllocator.allocate(*this, RegisterBinding::fromValue(value), nextLRUKey(), hint.isGPR() ? hint.asGPR() : InvalidGPRReg));
 
     if (value.isLocal())
         currentControlData().touch(value.asLocal());
@@ -5679,13 +5639,6 @@ Location BBQJIT::bind(Value value, Location loc)
             if (m_fprAllocator.freeRegisters().contains(loc.asFPR(), Width::Width128))
                 m_fprAllocator.bind(loc.asFPR(), RegisterBinding::fromValue(value), std::nullopt);
             ASSERT(bindingFor(loc.asFPR()) == RegisterBinding::fromValue(value));
-        } else if (loc.isGPR2()) {
-            if (m_gprAllocator.freeRegisters().contains(loc.asGPRlo(), IgnoreVectors))
-                m_gprAllocator.bind(loc.asGPRlo(), RegisterBinding::fromValue(value), std::nullopt);
-            ASSERT(bindingFor(loc.asGPRlo()) == RegisterBinding::fromValue(value));
-            if (m_gprAllocator.freeRegisters().contains(loc.asGPRhi(), IgnoreVectors))
-                m_gprAllocator.bind(loc.asGPRhi(), RegisterBinding::fromValue(value), std::nullopt);
-            ASSERT(bindingFor(loc.asGPRhi()) == RegisterBinding::fromValue(value));
         } else {
             if (m_gprAllocator.freeRegisters().contains(loc.asGPR(), IgnoreVectors))
                 m_gprAllocator.bind(loc.asGPR(), RegisterBinding::fromValue(value), std::nullopt);
@@ -5714,10 +5667,6 @@ void BBQJIT::unbind(Value value, Location loc)
         m_fprAllocator.unbind(loc.asFPR());
     else if (loc.isGPR())
         m_gprAllocator.unbind(loc.asGPR());
-    else if (loc.isGPR2()) {
-        m_gprAllocator.unbind(loc.asGPRlo());
-        m_gprAllocator.unbind(loc.asGPRhi());
-    }
     if (value.isLocal())
         m_locals[value.asLocal()] = m_localSlots[value.asLocal()];
     else if (value.isTemp())

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -74,7 +74,6 @@ public:
     static_assert(maxFunctionLocals < 1 << LocalIndexBits);
 
     static constexpr GPRReg wasmScratchGPR = GPRInfo::nonPreservedNonArgumentGPR0; // Scratch registers to hold temporaries in operations.
-    static constexpr GPRReg wasmScratchGPR2 = InvalidGPRReg;
     static constexpr FPRReg wasmScratchFPR = FPRInfo::nonPreservedNonArgumentFPR0;
 
 #if CPU(X86_64)
@@ -94,8 +93,7 @@ public:
             Gpr = 2,
             Fpr = 3,
             Global = 4,
-            StackArgument = 5,
-            Gpr2 = 6
+            StackArgument = 5
         };
 
         Location()
@@ -110,8 +108,6 @@ public:
 
         static Location NODELETE fromGPR(GPRReg gpr);
 
-        static Location fromGPR2(GPRReg hi, GPRReg lo);
-
         static Location NODELETE fromFPR(FPRReg fpr);
 
         static Location NODELETE fromGlobal(int32_t globalOffset);
@@ -123,8 +119,6 @@ public:
         bool NODELETE isNone() const;
 
         bool NODELETE isGPR() const;
-
-        bool NODELETE isGPR2() const;
 
         bool NODELETE isFPR() const;
 
@@ -156,10 +150,6 @@ public:
         FPRReg NODELETE asFPR() const;
         Reg asReg() const { return isGPR() ? Reg(asGPR()) : Reg(asFPR()); }
 
-        GPRReg NODELETE asGPRlo() const;
-
-        GPRReg NODELETE asGPRhi() const;
-
         void dump(PrintStream& out) const;
 
         bool NODELETE operator==(Location other) const;
@@ -182,10 +172,6 @@ public:
                 Kind m_padFpr;
                 FPRReg m_fpr;
             };
-            struct {
-                Kind m_padGpr2;
-                GPRReg m_gprhi, m_gprlo;
-            };
         };
     };
 
@@ -196,8 +182,6 @@ public:
     static TypeKind NODELETE pointerType();
 
     static bool NODELETE isFloatingPointType(TypeKind type);
-
-    static bool typeNeedsGPR2(TypeKind type);
 
 public:
     static uint32_t sizeOfType(TypeKind type);
@@ -397,18 +381,11 @@ public:
             : m_kind(None)
         { }
 
-        int32_t asI64hi() const;
-
-        int32_t asI64lo() const;
-
         void dump(PrintStream& out) const;
 
     private:
         union {
             int32_t m_i32;
-            struct {
-                int32_t lo, hi;
-            } m_i32_pair;
             int64_t m_i64;
             float m_f32;
             double m_f64;
@@ -637,10 +614,6 @@ public:
                 m_preserved.add(location.asGPR(), IgnoreVectors);
             else if (location.isFPR())
                 m_preserved.add(location.asFPR(), Width::Width128);
-            else if (location.isGPR2()) {
-                m_preserved.add(location.asGPRlo(), IgnoreVectors);
-                m_preserved.add(location.asGPRhi(), IgnoreVectors);
-            }
             initializedPreservedSet(args...);
         }
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -39,11 +39,6 @@
 
 namespace JSC { namespace Wasm { namespace BBQJITImpl {
 
-ALWAYS_INLINE bool BBQJIT::typeNeedsGPR2(TypeKind)
-{
-    return false;
-}
-
 template<typename Functor>
 auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint64_t uoffset, uint32_t sizeOfOperation, uint8_t memoryIndex, Functor&& functor) -> decltype(auto)
 {


### PR DESCRIPTION
#### bf1dab73b14dafe56b0e5a9f987fdf8ca4f4ee66
<pre>
[JSC] Remove many 32bit-only concept from JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=321164">https://bugs.webkit.org/show_bug.cgi?id=321164</a>
<a href="https://rdar.apple.com/184200996">rdar://184200996</a>

Reviewed by Sosuke Suzuki.

We remove many GPR pairs which are only used for 32bit&apos;s JSValue
representation. Also remove various DFG formats which are only used
in 32bit. Additionally, dropping 32bit-only-related OSR entry code.

* Source/JavaScriptCore/bytecode/DataFormat.h:
(JSC::isJSFormat): Deleted.
(JSC::isJSInt32): Deleted.
(JSC::isJSDouble): Deleted.
(JSC::isJSCell): Deleted.
(JSC::isJSBoolean): Deleted.
* Source/JavaScriptCore/bytecode/ValueRecovery.cpp:
(JSC::ValueRecovery::dumpInContext const):
* Source/JavaScriptCore/bytecode/ValueRecovery.h:
(JSC::ValueRecovery::inGPR):
(JSC::ValueRecovery::isInGPR const):
(JSC::ValueRecovery::dataFormat const):
(JSC::ValueRecovery::forEachReg):
* Source/JavaScriptCore/dfg/DFGAbstractValue.h:
* Source/JavaScriptCore/dfg/DFGGenerationInfo.h:
(JSC::DFG::GenerationInfo::initCell):
(JSC::DFG::GenerationInfo::fillStrictInt52):
(JSC::DFG::GenerationInfo::initBoolean): Deleted.
(JSC::DFG::GenerationInfo::isJSFormat): Deleted.
(JSC::DFG::GenerationInfo::isJSInt32): Deleted.
(JSC::DFG::GenerationInfo::isJSDouble): Deleted.
(JSC::DFG::GenerationInfo::isJSCell): Deleted.
(JSC::DFG::GenerationInfo::isJSBoolean): Deleted.
(JSC::DFG::GenerationInfo::fillBoolean): Deleted.
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::asBoolean): Deleted.
* Source/JavaScriptCore/dfg/DFGOSREntry.cpp:
(JSC::DFG::prepareOSREntry):
* Source/JavaScriptCore/dfg/DFGOSRExit.cpp:
(JSC::DFG::OSRExit::compileExit):
* Source/JavaScriptCore/dfg/DFGSilentRegisterSavePlan.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::silentSavePlanForGPR):
(JSC::DFG::SpeculativeJIT::silentSpillImpl):
(JSC::DFG::SpeculativeJIT::silentFillImpl):
(JSC::DFG::SpeculativeJIT::checkGeneratedTypeForToInt32):
(JSC::DFG::SpeculativeJIT::compileExtractFromTuple):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
(JSC::DFG::SpeculativeJIT::spill):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::fillJSValue):
(JSC::DFG::SpeculativeJIT::fillSpeculateInt32Internal):
(JSC::DFG::SpeculativeJIT::fillSpeculateCell):
(JSC::DFG::SpeculativeJIT::fillSpeculateBoolean):
(JSC::DFG::SpeculativeJIT::fillSpeculateBigInt32):
* Source/JavaScriptCore/dfg/DFGUseKind.h:
* Source/JavaScriptCore/dfg/DFGVariableEvent.h:
* Source/JavaScriptCore/dfg/DFGVariableEventStream.cpp:
* Source/JavaScriptCore/jit/CallFrameShuffler64.cpp:
(JSC::CallFrameShuffler::emitStore):
(JSC::CallFrameShuffler::emitBox):
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITArithmetic.cpp:
(JSC::JIT::emit_compareUnsignedAndJumpImpl):
(JSC::JIT::emit_compareUnsignedImpl):
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::compileCallDirectEval):
(JSC::JIT::emit_op_async_iterator_next):
(JSC::JIT::emit_op_instanceof):
* Source/JavaScriptCore/jit/JITInlines.h:
(JSC::JIT::emitGetVirtualRegisterPayload): Deleted.
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emit_op_set_function_name):
(JSC::JIT::emit_op_get_parent_scope):
(JSC::JIT::emit_op_create_this):
(JSC::JIT::emitNewFuncCommon):
(JSC::JIT::emitNewFuncExprCommon):
(JSC::JIT::emit_op_create_lexical_environment):
(JSC::JIT::emit_op_create_scoped_arguments):
(JSC::JIT::emit_op_log_shadow_chicken_prologue):
(JSC::JIT::emit_op_log_shadow_chicken_tail):
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::emit_op_put_getter_by_id):
(JSC::JIT::emit_op_put_setter_by_id):
(JSC::JIT::emit_op_put_getter_setter_by_id):
(JSC::JIT::emit_op_put_getter_by_val):
(JSC::JIT::emit_op_put_setter_by_val):
(JSC::JIT::emit_op_resolve_scope):
(JSC::JIT::emitSlow_op_resolve_scope):
(JSC::JIT::emit_op_get_from_scope):
(JSC::JIT::emitSlow_op_get_from_scope):
(JSC::JIT::emit_op_put_to_scope):
(JSC::JIT::emit_op_get_from_arguments):
(JSC::JIT::emit_op_put_to_arguments):
(JSC::JIT::emit_op_get_internal_field):
(JSC::JIT::emit_op_put_internal_field):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::Location::dump const):
(JSC::Wasm::BBQJITImpl::Location::operator== const):
(JSC::Wasm::BBQJITImpl::BBQJIT::saveValuesAcrossCallAndPassArguments):
(JSC::Wasm::BBQJITImpl::BBQJIT::returnValuesFromCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::addFusedIfCompare):
(JSC::Wasm::BBQJITImpl::BBQJIT::setLRUKey):
(JSC::Wasm::BBQJITImpl::BBQJIT::allocateWithHint):
(JSC::Wasm::BBQJITImpl::BBQJIT::bind):
(JSC::Wasm::BBQJITImpl::BBQJIT::unbind):
(JSC::Wasm::BBQJITImpl::Location::isGPR2 const): Deleted.
(JSC::Wasm::BBQJITImpl::Location::asGPRlo const): Deleted.
(JSC::Wasm::BBQJITImpl::Location::asGPRhi const): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::ScratchScope::initializedPreservedSet):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::typeNeedsGPR2): Deleted.

Canonical link: <a href="https://commits.webkit.org/318721@main">https://commits.webkit.org/318721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f7a8b839470a3f443be3c2be36dfcc08dc1760a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188930 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c107251c-8f6c-4122-bf47-72bb9390afc7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139671 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cdb7a6b5-be0d-4813-b055-793c0fad66c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120118 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4057bc2-e689-4a38-abbb-04b92d7ac2f5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41937 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40281 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2093 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8911 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152337 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39929 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/237 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40375 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191150 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52710 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148901 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53390 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148647 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27190 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43336 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125661 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120475 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51908 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14908 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51293 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51534 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51354 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->