### PR TITLE
Fix Borrow and BorrowedBytes bugs

### DIFF
--- a/Source/WTF/wtf/Borrow.h
+++ b/Source/WTF/wtf/Borrow.h
@@ -36,6 +36,23 @@
 
 namespace WTF {
 
+inline void assertIsOnStack(const void* object)
+{
+#if OS(DARWIN) && ASSERT_ENABLED
+    auto self = pthread_self();
+    void* origin = pthread_get_stackaddr_np(self);
+    rlim_t size = pthread_get_stacksize_np(self);
+    ASSERT(origin);
+    ASSERT(size);
+    auto top = reinterpret_cast<uintptr_t>(origin);
+    auto address = reinterpret_cast<uintptr_t>(object);
+    ASSERT(address < top);
+    ASSERT(top - address < size);
+#else
+    UNUSED_PARAM(object);
+#endif
+}
+
 /**
  * @brief Borrow is a scoped token that ensures a view into an object remains
  * valid even if the object performs internal destruction.
@@ -73,7 +90,7 @@ public:
         : m_ref(ref)
         , m_previous(m_ref.setIsBorrowed(true))
     {
-        assertIsOnStack();
+        assertIsOnStack(this);
     }
 
     ~Borrow()
@@ -97,18 +114,6 @@ public:
     }
 
 private:
-    void assertIsOnStack()
-    {
-#if OS(DARWIN) && ASSERT_ENABLED
-        auto self = pthread_self();
-        void* origin = pthread_get_stackaddr_np(self);
-        rlim_t size = pthread_get_stacksize_np(self);
-
-        ASSERT(origin, this < origin);
-        ASSERT(size, reinterpret_cast<uintptr_t>(origin) - reinterpret_cast<uintptr_t>(this) < size);
-#endif
-    }
-
     T& m_ref;
     bool m_previous { false };
 };

--- a/Source/WTF/wtf/BorrowedBytes.h
+++ b/Source/WTF/wtf/BorrowedBytes.h
@@ -135,6 +135,7 @@ private:
 } SWIFT_SHARED_REFERENCE(.ref, .deref);
 
 #if !defined(__swift__)
+
 class BorrowedBytesScopeBase {
     WTF_MAKE_NONCOPYABLE(BorrowedBytesScopeBase);
     WTF_FORBID_HEAP_ALLOCATION;
@@ -142,22 +143,19 @@ public:
     BorrowedBytes& bytes() LIFETIME_BOUND { return m_bytes.get(); }
 
 protected:
-    explicit BorrowedBytesScopeBase(std::span<const uint8_t> bytes)
+    explicit BorrowedBytesScopeBase(std::span<const uint8_t> bytes LIFETIME_BOUND)
         : m_bytes(BorrowedBytes::create(bytes))
     {
+        assertIsOnStack(this);
     }
 
     ~BorrowedBytesScopeBase()
     {
         // The borrow ends here. If anything on the Swift side stashed the view
         // beyond the synchronous call, the control block still carries an
-        // external reference at this point. Assert now, at the site that ends
-        // the borrow, so a stash bug crashes with a stack pointing at the
-        // premature end of the borrow rather than at some later, innocent
-        // reader. This is a debug-only ASSERT — in release the backstop is
-        // data()'s RELEASE_ASSERT(m_valid), which catches the same mistake at
-        // access time (once revoke() below has run) rather than here.
-        ASSERT(m_bytes->hasOneRef());
+        // external reference at this point. Crash here rather than relying on
+        // data()'s assertion, both for debuggability and thread safety.
+        RELEASE_ASSERT(m_bytes->hasOneRef());
         m_bytes->revoke();
     }
 

--- a/Source/WebCore/PAL/pal/crypto/WTFExtras.swift
+++ b/Source/WebCore/PAL/pal/crypto/WTFExtras.swift
@@ -50,8 +50,10 @@ extension WTF.BorrowedBytes: RandomAccessCollection {
 
     /// The byte at `position`.
     public subscript(position: Int) -> UInt8 {
-        // Safe: UnsafeRawBufferPointer's own subscript bounds-checks position and traps if it's out of range.
-        unsafe UnsafeRawBufferPointer(start: data(), count: size())[position]
+        precondition(position >= 0 && position < size(), "BorrowedBytes index out of range")
+        // Safe: position has just been bounds-checked against the same live span
+        // that data()/size() describe, and data() traps if the borrow was revoked.
+        return unsafe UnsafeRawBufferPointer(start: data(), count: size())[position]
     }
 }
 

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -39,6 +39,7 @@ set(TestWTF_SOURCES
     Tests/WTF/BitSet.cpp
     Tests/WTF/BitVector.cpp
     Tests/WTF/BloomFilter.cpp
+    Tests/WTF/Borrow.cpp
     Tests/WTF/BorrowedBytes.cpp
     Tests/WTF/BoxPtr.cpp
     Tests/WTF/BumpPointerAllocator.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1154,6 +1154,7 @@
 				WTF/BitSet.cpp,
 				WTF/BitVector.cpp,
 				WTF/BloomFilter.cpp,
+				WTF/Borrow.cpp,
 				WTF/BorrowedBytes.cpp,
 				WTF/BoxPtr.cpp,
 				WTF/BumpPointerAllocator.cpp,

--- a/Tools/TestWebKitAPI/Tests/WTF/Borrow.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Borrow.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/Borrow.h>
+
+#include "Helpers/Test.h"
+#include <wtf/CanBorrow.h>
+
+namespace TestWebKitAPI {
+
+// Implements the CanBorrow protocol by hand rather than inheriting from CanBorrow,
+// so that these tests can observe the borrowed flag instead of only crashing on it.
+class ObservableBorrowable {
+public:
+    bool isBorrowed() const { return m_isBorrowed; }
+    unsigned crashIfBorrowedCount() const { return m_crashIfBorrowedCount; }
+    int value() const { return m_value; }
+
+    void crashIfBorrowed() const { ++m_crashIfBorrowedCount; }
+    bool setIsBorrowed(bool isBorrowed) const { return std::exchange(m_isBorrowed, isBorrowed); }
+
+private:
+    int m_value { 42 };
+    mutable bool m_isBorrowed { false };
+    mutable unsigned m_crashIfBorrowedCount { 0 };
+};
+
+class Borrowable : public CanBorrow {
+public:
+    int value() const { return m_value; }
+
+private:
+    int m_value { 7 };
+};
+
+TEST(WTF_Borrow, BorrowMarksAndUnmarksTheObject)
+{
+    ObservableBorrowable object;
+    EXPECT_FALSE(object.isBorrowed());
+    {
+        Borrow borrow(object);
+        EXPECT_TRUE(object.isBorrowed());
+    }
+    EXPECT_FALSE(object.isBorrowed());
+}
+
+TEST(WTF_Borrow, BorrowExposesTheObject)
+{
+    ObservableBorrowable object;
+    Borrow borrow(object);
+
+    EXPECT_EQ(&borrow.get(), &object);
+    EXPECT_EQ(borrow->value(), 42);
+    EXPECT_EQ(&static_cast<ObservableBorrowable&>(borrow), &object);
+}
+
+TEST(WTF_Borrow, BorrowHelperFunction)
+{
+    ObservableBorrowable object;
+    EXPECT_EQ(borrow(object)->value(), 42);
+    EXPECT_FALSE(object.isBorrowed());
+}
+
+// The inner borrow restores the outer borrow's state rather than clearing it.
+TEST(WTF_Borrow, NestedBorrowsRestorePreviousState)
+{
+    ObservableBorrowable object;
+    {
+        Borrow outer(object);
+        {
+            Borrow inner(object);
+            EXPECT_TRUE(object.isBorrowed());
+        }
+        EXPECT_TRUE(object.isBorrowed());
+    }
+    EXPECT_FALSE(object.isBorrowed());
+}
+
+TEST(WTF_Borrow, CrashIfBorrowedIsReachedThroughTheProtocol)
+{
+    ObservableBorrowable object;
+    object.crashIfBorrowed();
+    EXPECT_EQ(object.crashIfBorrowedCount(), 1u);
+}
+
+TEST(WTF_Borrow, DestroyAfterBorrowEndsIsFine)
+{
+    auto object = makeUniqueWithoutFastMallocCheck<Borrowable>();
+    {
+        Borrow borrow(*object);
+        EXPECT_EQ(borrow->value(), 7);
+    }
+    object = nullptr;
+    EXPECT_FALSE(object);
+}
+
+// The CanBorrow assertions are debug-only for now; see the FIXMEs in CanBorrow.h.
+
+TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(DestroyWhileBorrowedCrashes))
+{
+    auto shouldCrash = [] {
+        auto* object = new Borrowable;
+        Borrow borrow(*object);
+        delete object;
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(CrashIfBorrowedWhileBorrowedCrashes))
+{
+    auto shouldCrash = [] {
+        Borrowable object;
+        Borrow borrow(object);
+        object.crashIfBorrowed();
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+// WTF_FORBID_HEAP_ALLOCATION rules out `new Borrow(...)`, but not embedding a Borrow
+// in a heap-allocated object, which would let the borrow outlive the borrowed object.
+#if OS(DARWIN)
+TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(HeapAllocatedBorrowCrashes))
+{
+    auto shouldCrash = [] {
+        struct Holder {
+            explicit Holder(Borrowable& object)
+                : borrow(object)
+            {
+            }
+            Borrow<Borrowable> borrow;
+        };
+        // Both deliberately leaked: the Holder constructor is expected to crash, and
+        // nothing else here may be destroyed while the borrow is outstanding, or the
+        // test would pass on the wrong assertion.
+        SUPPRESS_UNCOUNTED_LOCAL auto* object = new Borrowable;
+        SUPPRESS_UNCOUNTED_LOCAL auto* holder = new Holder(*object);
+        EXPECT_EQ(holder->borrow->value(), 7);
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+#endif
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/BorrowedBytes.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BorrowedBytes.cpp
@@ -117,12 +117,34 @@ TEST(WTF_BorrowedBytes, NestedVectorScopes)
     EXPECT_EQ(outer.bytes().size(), vector.size());
 }
 
-// A view stashed beyond the scope's lifetime is caught at scope destruction,
-// where the crash stack points at the too-early end of the borrow rather than
-// later at an innocent reader. This is a debug-only ASSERT (in release the
-// backstop is data()'s RELEASE_ASSERT at access time), so the death test only
-// runs when assertions are enabled.
-TEST(WTF_BorrowedBytesDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(StashedViewCrashesAtScopeEnd))
+TEST(WTF_BorrowedBytes, ViewIdentityIsPerScope)
+{
+    Vector<uint8_t> vector { 1, 2, 3 };
+    BorrowedVectorScope outer(vector);
+    EXPECT_EQ(&outer.bytes(), &outer.bytes());
+
+    RefPtr<BorrowedBytes> innerView;
+    {
+        BorrowedVectorScope inner(vector);
+        EXPECT_NE(&inner.bytes(), &outer.bytes());
+        innerView = &inner.bytes();
+        innerView = nullptr;
+    }
+
+    // The inner borrow ended, but the outer view is untouched and still readable.
+    EXPECT_EQ(outer.bytes().data(), vector.span().data());
+    EXPECT_EQ(outer.bytes().size(), vector.size());
+}
+
+// MARK: - The stash check
+//
+// A view stashed beyond the scope's lifetime is caught at scope destruction, where
+// the crash stack points at the too-early end of the borrow rather than later at an
+// innocent reader. These are RELEASE_ASSERTs, so unlike most of the Borrow machinery
+// they fire in release builds too — which is what makes them, rather than data()'s
+// revoked-flag check, the mitigation for a reference that escaped.
+
+TEST(WTF_BorrowedBytesDeathTest, StashedViewCrashesAtScopeEnd)
 {
     auto shouldCrash = [] {
         RefPtr<BorrowedBytes> stashed;
@@ -136,5 +158,73 @@ TEST(WTF_BorrowedBytesDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(StashedViewCras
     };
     ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
 }
+
+TEST(WTF_BorrowedBytesDeathTest, StashedViewOverASpanCrashesAtScopeEnd)
+{
+    auto shouldCrash = [] {
+        RefPtr<BorrowedBytes> stashed;
+        {
+            Vector<uint8_t> vector { 1, 2, 3 };
+            auto span = vector.span();
+            BorrowedSpanScope scope(span);
+            stashed = &scope.bytes();
+        }
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+TEST(WTF_BorrowedBytesDeathTest, ViewEscapedToTheHeapCrashesAtScopeEnd)
+{
+    auto shouldCrash = [] {
+        struct Escapee {
+            RefPtr<BorrowedBytes> bytes;
+        };
+        auto* escapee = new Escapee;
+        {
+            Vector<uint8_t> vector { 1, 2, 3 };
+            BorrowedVectorScope scope(vector);
+            escapee->bytes = &scope.bytes();
+        }
+        delete escapee;
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+TEST(WTF_BorrowedBytes, ViewEscapedToTheHeapAndReleasedInTimeIsFine)
+{
+    struct Escapee {
+        RefPtr<BorrowedBytes> bytes;
+    };
+    auto escapee = makeUniqueWithoutFastMallocCheck<Escapee>();
+    Vector<uint8_t> vector { 1, 2, 3 };
+    {
+        BorrowedVectorScope scope(vector);
+        escapee->bytes = &scope.bytes();
+        EXPECT_EQ(escapee->bytes->size(), vector.size());
+        escapee->bytes = nullptr;
+    }
+    EXPECT_FALSE(escapee->bytes);
+}
+
+#if OS(DARWIN)
+TEST(WTF_BorrowedBytesDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(HeapAllocatedScopeCrashes))
+{
+    auto shouldCrash = [] {
+        struct Holder {
+            explicit Holder(std::span<const uint8_t> bytes)
+                : scope(bytes)
+            {
+            }
+            BorrowedSpanScope scope;
+        };
+        Vector<uint8_t> vector { 1, 2, 3 };
+        // Deliberately leaked: the constructor is expected to crash, and if it
+        // somehow does not, destroying the Holder would crash for another reason.
+        SUPPRESS_UNCOUNTED_LOCAL auto* holder = new Holder(vector.span());
+        EXPECT_EQ(holder->scope.bytes().size(), vector.size());
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+#endif
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 90bb9d02b08e21cce5f0d88506febb34275855a1
<pre>
Fix Borrow and BorrowedBytes bugs
<a href="https://bugs.webkit.org/show_bug.cgi?id=321171">https://bugs.webkit.org/show_bug.cgi?id=321171</a>
<a href="https://rdar.apple.com/184218933">rdar://184218933</a>

Reviewed by Geoffrey Garen.

WTF::Borrow and WTF::BorrowedBytes are primitives to allow dynamically-checked
borrowing of things across the C++/Swift language boundary.

This commit fixes bugs in each.

* BorrowedBytes had a debug-only range check, which is now release mode too.
* In Borrow, there was an assertion that the Borrow was on the stack. This
  didn&apos;t work, due to passing multiple assertions to the ASSERT macro that
  supports only one.
* BorrowedBytes did not use such a check that it was on the stack. The stack
  check has been abstracted from Borrow and is now used from both.
  (It may be that in future this is redundant if we add static analysis to
  confirm that WTF_FORBID_HEAP_ALLOCATION are only ever embedded in other
  such WTF_FORBID_HEAP_ALLOCATION objects.)
* BorrowedBytes had a debug assertion that it was not still in use from
  Swift when it went out of scope. This has been boosted to be a release
  mode assertion too, partly for better debuggability but also for thread
  safety.

Various tests have been added for both.

Tests: Tools/TestWebKitAPI/Tests/WTF/Borrow.cpp
       Tools/TestWebKitAPI/Tests/WTF/BorrowedBytes.cpp

* Source/WTF/wtf/Borrow.h:
(WTF::assertIsOnStack):
(WTF::Borrow::Borrow):
(WTF::Borrow::assertIsOnStack): Deleted.
* Source/WTF/wtf/BorrowedBytes.h:
(WTF::BorrowedBytesScopeBase::BorrowedBytesScopeBase):
(WTF::BorrowedBytesScopeBase::~BorrowedBytesScopeBase):
* Source/WTF/wtf/Compiler.h:
* Source/WebCore/PAL/pal/crypto/WTFExtras.swift:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/Borrow.cpp: Added.
(TestWebKitAPI::ObservableBorrowable::isBorrowed const):
(TestWebKitAPI::ObservableBorrowable::crashIfBorrowedCount const):
(TestWebKitAPI::ObservableBorrowable::value const):
(TestWebKitAPI::ObservableBorrowable::crashIfBorrowed const):
(TestWebKitAPI::ObservableBorrowable::setIsBorrowed const):
(TestWebKitAPI::Borrowable::value const):
(TestWebKitAPI::TEST(WTF_Borrow, BorrowMarksAndUnmarksTheObject)):
(TestWebKitAPI::TEST(WTF_Borrow, BorrowExposesTheObject)):
(TestWebKitAPI::TEST(WTF_Borrow, BorrowHelperFunction)):
(TestWebKitAPI::TEST(WTF_Borrow, NestedBorrowsRestorePreviousState)):
(TestWebKitAPI::TEST(WTF_Borrow, CrashIfBorrowedIsReachedThroughTheProtocol)):
(TestWebKitAPI::TEST(WTF_Borrow, DestroyAfterBorrowEndsIsFine)):
(TestWebKitAPI::TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(DestroyWhileBorrowedCrashes)):
(TestWebKitAPI::TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(CrashIfBorrowedWhileBorrowedCrashes)):
(TestWebKitAPI::TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(HeapAllocatedBorrowCrashes)):
* Tools/TestWebKitAPI/Tests/WTF/BorrowedBytes.cpp:
(TestWebKitAPI::TEST(WTF_BorrowedBytes, ViewIdentityIsPerScope)):
(TestWebKitAPI::TEST(WTF_BorrowedBytesDeathTest, StashedViewCrashesAtScopeEnd)):
(TestWebKitAPI::TEST(WTF_BorrowedBytesDeathTest, StashedViewOverASpanCrashesAtScopeEnd)):
(TestWebKitAPI::TEST(WTF_BorrowedBytesDeathTest, ViewEscapedToTheHeapCrashesAtScopeEnd)):
(TestWebKitAPI::TEST(WTF_BorrowedBytes, ViewEscapedToTheHeapAndReleasedInTimeIsFine)):
(TestWebKitAPI::TEST(WTF_BorrowedBytesDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(HeapAllocatedScopeCrashes)):
(TestWebKitAPI::TEST(WTF_BorrowedBytesDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(StashedViewCrashesAtScopeEnd)): Deleted.

Canonical link: <a href="https://commits.webkit.org/318889@main">https://commits.webkit.org/318889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cacffc392dff921bbae85af8e5a2ba18a5665bb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179784 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144095 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/996538f0-b978-471e-9e60-149e07a9f785) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140237 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a526c1f1-0235-4599-b3fa-6c3d1780a740) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120688 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a7df0e1-e645-479c-9b0d-34b5e207ee95) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2657 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9464 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40501 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1070 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41059 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191838 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53393 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149516 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40052 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54074 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149250 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43903 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126346 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121377 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52591 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15492 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51976 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52217 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52037 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->