### PR TITLE
CSSProperties.json references to SVG 2 spec needs to be updated

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -912,7 +912,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#TextRenderingProperty"
             }
         },
         "font-feature-settings": {
@@ -4260,7 +4260,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationProperty"
             }
         },
         "color-interpolation-filters": {
@@ -4281,7 +4281,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/painting.html#ColorInterpolationFiltersProperty"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationFiltersProperty"
             }
         },
         "content": {
@@ -4918,7 +4918,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint"
             }
         },
         "fill-opacity": {
@@ -5153,11 +5153,11 @@
                 "crisp-edges",
                 {
                     "value": "optimizeSpeed",
-                    "url": "https://svgwg.org/svg2-draft/painting.html#ImageRenderingProperty"
+                    "url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ImageRenderingProperty"
                 },
                 {
                     "value": "optimizeQuality",
-                    "url": "https://svgwg.org/svg2-draft/painting.html#ImageRenderingProperty"
+                    "url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ImageRenderingProperty"
                 },
                 {
                     "value": "-webkit-crisp-edges",
@@ -7926,7 +7926,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty"
             }
         },
         "portal-transform": {
@@ -8009,7 +8009,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/geometry.html#R"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#R"
             }
         },
         "resize": {
@@ -8120,7 +8120,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/geometry.html#RX"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"
             }
         },
         "ry": {
@@ -8137,7 +8137,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/geometry.html#RY"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"
             }
         },
         "shape-rendering": {
@@ -8159,7 +8159,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ShapeRenderingProperty"
             }
         },
         "stop-color": {
@@ -8174,7 +8174,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/pservers.html#StopColorProperty"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopColorProperty"
             }
         },
         "stop-opacity": {
@@ -8189,7 +8189,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopOpacityProperty"
             }
         },
         "stroke": {
@@ -8222,7 +8222,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingStrokePaint"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingStrokePaint"
             }
         },
         "stroke-dasharray": {
@@ -8246,7 +8246,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/painting.html#StrokeDashing"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashing"
             }
         },
         "stroke-dashoffset": {
@@ -8262,7 +8262,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashoffsetProperty"
             }
         },
         "stroke-linecap": {
@@ -8286,7 +8286,7 @@
                 "category": "css-text-fill-and-stroke",
                 "url": "https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-linecap",
                 "obsolete-category": "svg",
-                "obsolete-url": "https://svgwg.org/svg2-draft/painting.html#LineCaps"
+                "obsolete-url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#LineCaps"
             }
         },
         "stroke-linejoin": {
@@ -8311,7 +8311,7 @@
                 "category": "css-text-fill-and-stroke",
                 "url": "https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-linejoin",
                 "obsolete-category": "svg",
-                "obsolete-url": "https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty"
+                "obsolete-url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeLinejoinProperty"
             }
         },
         "stroke-miterlimit": {
@@ -8332,7 +8332,7 @@
                 "category": "css-text-fill-and-stroke",
                 "url": "https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-miterlimit",
                 "obsolete-category": "svg",
-                "obsolete-url": "https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty"
+                "obsolete-url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeMiterlimitProperty"
             }
         },
         "stroke-opacity": {
@@ -8348,7 +8348,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeOpacityProperty"
             }
         },
         "stroke-color": {
@@ -8392,7 +8392,7 @@
                 "category": "css-text-fill-and-stroke",
                 "url": "https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-width",
                 "obsolete-category": "svg",
-                "obsolete-url": "https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty"
+                "obsolete-url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeWidthProperty"
             }
         },
         "speak-as": {
@@ -8572,7 +8572,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/text.html#TextAnchorProperty"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchorProperty"
             }
         },
         "text-group-align": {
@@ -9008,7 +9008,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#VectorEffectProperty"
             }
         },
         "vertical-align": {
@@ -9321,7 +9321,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/geometry.html#X"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#X"
             }
         },
         "y": {
@@ -9335,7 +9335,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://svgwg.org/svg2-draft/geometry.html#Y"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#Y"
             }
         },
         "z-index": {


### PR DESCRIPTION
CSSProperties.json references to SVG 2 spec needs to be updated
https://bugs.webkit.org/show_bug.cgi?id=312952

Reviewed by NOBODY (OOPS!).

The svgwg.org domain is no longer controlled by the W3C or the
SVG WG, and the specifications hosted there are outdated. Point the
25 SVG 2 references in CSSProperties.json at the W3C-hosted copy.
This only changes documentation URLs in the `specification` metadata;
no generated code or runtime behaviour is affected.

* Source/WebCore/css/CSSProperties.json:
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbe48fe89d72f664d68ab2672422d54d2fe38e11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188970 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143448 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52788 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139693 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results; 1 failures; Compiled WebKit; 1 failures; Passed layout tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96759 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120140 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41964 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40307 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152364 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39957 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/276 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191188 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52748 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148931 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53428 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148677 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43362 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125699 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120533 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51946 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14936 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51331 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51572 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51392 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->