### PR TITLE
[SwiftBrowser] Typing webkit.org in the URL bar leads to a failed provisional navigation

### DIFF
--- a/Tools/SwiftBrowser/Source/Extensions/String+Extras.swift
+++ b/Tools/SwiftBrowser/Source/Extensions/String+Extras.swift
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+
+extension String {
+    /// Returns the string with an `http://` scheme prepended, unless it already
+    /// carries a scheme (`foo://`, `data:`, or `about:`).
+    func addingProtocolIfNecessary() -> String {
+        if contains("://") || hasPrefix("data:") || hasPrefix("about:") {
+            return self
+        }
+        return "http://\(self)"
+    }
+}

--- a/Tools/SwiftBrowser/Source/Extensions/URL+Extras.swift
+++ b/Tools/SwiftBrowser/Source/Extensions/URL+Extras.swift
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import WebKit_Private.WebNSURLExtras
+
+extension URL {
+    /// First, infer a scheme if one is missing, then run WebKit's
+    /// user-typed-string parser (IDN, whitespace handling, etc.).
+    ///
+    /// Returns `nil` on a parse error.
+    init?(userTypedString string: String) {
+        guard let url = NSURL._webkit_URL(withUserTypedString: string.addingProtocolIfNecessary()) else {
+            return nil
+        }
+        self = url as URL
+    }
+}

--- a/Tools/SwiftBrowser/Source/SwiftBrowser.swift
+++ b/Tools/SwiftBrowser/Source/SwiftBrowser.swift
@@ -38,13 +38,6 @@ struct SwiftBrowserApp: App {
     @State
     private var mostRecentURL: URL? = nil
 
-    private static func addProtocolIfNecessary(to address: String) -> String {
-        if address.contains("://") || address.hasPrefix("data:") || address.hasPrefix("about:") {
-            return address
-        }
-        return "http://\(address)"
-    }
-
     var body: some Scene {
         WindowGroup(for: CodableURLRequest.self) { $request in
             BrowserView(
@@ -55,10 +48,7 @@ struct SwiftBrowserApp: App {
         } defaultValue: {
             // FIXME: <https://webkit.org/b/293859> BrowserView does not reflect URL argument passed to SwiftBrowser.app.
             let parsedURL = CommandLine.value(for: "--url")
-                .flatMap {
-                    let withProtocol = Self.addProtocolIfNecessary(to: $0)
-                    return URL(string: withProtocol)
-                }
+                .flatMap { URL(userTypedString: $0) }
             let url = parsedURL ?? URL(string: homepage)!
             return CodableURLRequest(.init(url: url))
         }

--- a/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
@@ -169,7 +169,9 @@ final class BrowserViewModel {
     }
 
     func navigateToSubmittedURL() {
-        guard let url = URL(string: displayedURL) else {
+        displayedURL = displayedURL.addingProtocolIfNecessary()
+
+        guard let url = URL(userTypedString: displayedURL) else {
             return
         }
 


### PR DESCRIPTION
#### ac7682f55397b55d5f1bdea768e98ed85fb29a76
<pre>
[SwiftBrowser] Typing webkit.org in the URL bar leads to a failed provisional navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=321172">https://bugs.webkit.org/show_bug.cgi?id=321172</a>
<a href="https://rdar.apple.com/184219290">rdar://184219290</a>

Reviewed by Richard Robinson.

Currently, typing a URL with only the host and not the protocol scheme
produces a failed provisional navigation, since WebKit expectedly does
not know what to do with a URL request consisting of a URL without a
protocol.

In this patch, we remedy the situation by following precedent set by
MiniBrowser and (a) tacking on, as needed,  a `<a href="http://`">http://`</a> to URLs entered
in the address bar, and (b) passing the URL through -[NSURL
_webkit_URLWithUserTypedString:].

To facilitate these changes, we introduce two extensions to String and
URL, which simply provide convenient wrappers for (a) and (b).

* Tools/SwiftBrowser/Source/Extensions/String+Extras.swift: Added.
(String.addingProtocolIfNecessary):
* Tools/SwiftBrowser/Source/Extensions/URL+Extras.swift: Added.
* Tools/SwiftBrowser/Source/SwiftBrowser.swift:
(SwiftBrowserApp.body):
(SwiftBrowserApp.addProtocolIfNecessary(to:)): Deleted.
* Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift:
(BrowserViewModel.navigateToSubmittedURL):

Canonical link: <a href="https://commits.webkit.org/318730@main">https://commits.webkit.org/318730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f00ef8738ac89d90fa679435cc32df5d12edae36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188971 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a8188ea-b7a7-47ef-831c-6b52edaa440a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139694 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55b7b072-7ac6-4a30-9a74-d0d8ee9c7a68) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120141 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/703a153f-30ee-4450-924c-000d35303638) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41963 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40308 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8940 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152363 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39959 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/277 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191189 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52749 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148933 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53429 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148679 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27195 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43365 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120534 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51947 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14938 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51332 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51573 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->