### PR TITLE
[WebTransport] Incoming datagram bursts are dropped because delivery bypasses the event loop

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6843,11 +6843,7 @@ imported/w3c/web-platform-tests/webtransport/streams-close.https.any.servicework
 imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker.html [ Skip ]
 
-# Backend gaps (datagram flow-control, getStats, close, historical).
-imported/w3c/web-platform-tests/webtransport/datagrams.https.any.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/datagrams.https.any.serviceworker.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/datagrams.https.any.sharedworker.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/datagrams.https.any.worker.html [ Skip ]
+# Backend gaps (getStats, close, historical).
 imported/w3c/web-platform-tests/webtransport/stats.https.any.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/stats.https.any.serviceworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/stats.https.any.sharedworker.html [ Skip ]

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -210,7 +210,13 @@ void WebTransport::suspend(ReasonForSuspension why)
 
 void WebTransport::receiveDatagram(std::span<const uint8_t> datagram, bool withFin, std::optional<Exception>&& exception)
 {
-    m_datagramSource->receiveDatagram(datagram, withFin, WTF::move(exception));
+    if (m_state == State::Closed || m_state == State::Failed)
+        return;
+
+    // A burst delivered inline evicts itself, since IPC dispatch runs many messages per turn with no microtask checkpoint.
+    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [datagram = Vector(datagram), withFin, exception = WTF::move(exception)](auto& transport) mutable {
+        transport.m_datagramSource->receiveDatagram(datagram.span(), withFin, WTF::move(exception));
+    });
 }
 
 void WebTransport::receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier identifier)


### PR DESCRIPTION
#### 083734c95c0b96991e4e97f1bff0de02ccb17830
<pre>
[WebTransport] Incoming datagram bursts are dropped because delivery bypasses the event loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=321176">https://bugs.webkit.org/show_bug.cgi?id=321176</a>
<a href="https://rdar.apple.com/184224552">rdar://184224552</a>

Reviewed by Brady Eidson.

WebTransport::receiveDatagram handed the datagram to the source straight from IPC dispatch. IPC
dispatches many messages per run loop turn with no microtask checkpoint in between, so a pending
read() could not resolve and pull the next datagram mid-batch. Every arrival after the first
therefore evicted the previous one from the incoming queue, and only the first and last datagram of
a burst ever reached script.

Deliver through the event loop instead, so a microtask checkpoint runs between datagrams and the
reader drains one before the next is queued. Also add the m_state check that the other receive
handlers already have.

The incoming queue bound is unchanged. NetworkTransportSession still forwards every datagram as an
individual unbounded IPC, so honoring the bound there remains the real backpressure fix.

Covered by existing tests: imported/w3c/web-platform-tests/webtransport/datagrams.https.any.html
and its worker variants, un-skipped here.

* LayoutTests/TestExpectations:
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::receiveDatagram):

Canonical link: <a href="https://commits.webkit.org/318747@main">https://commits.webkit.org/318747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8f8df98a74b6769eaf7784b52bdb6152e81ed68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188986 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6fcf88d5-55b0-4113-b76a-fbe06868bfd6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139706 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8699191-78b3-46dc-bff9-2eaef456f33a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120153 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f48440e9-146d-4107-88fb-c767aa3a7fdc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41973 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40316 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152373 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39968 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/292 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45700 "Build is in progress. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Found 27387 issues") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191204 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52764 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148945 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39973 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53444 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36594 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/cookies/same-site/popup-same-site-with-post-form.html, http/tests/media/media-element-frame-destroyed-crash.html, http/tests/misc/policy-delegate-called-twice.html, http/tests/navigation/post-basic.html, http/tests/resourceLoadStatistics/do-not-block-top-level-navigation-redirect.html, http/tests/security/cannot-read-cssrules.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/iframe-srcdoc-external-script.html, http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148691 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43374 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125715 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120558 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51962 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14947 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51347 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51588 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51408 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->