### PR TITLE
Implement slot assignment handling for moveBefore()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-from-light-to-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-from-light-to-shadow-expected.txt
@@ -1,4 +1,3 @@
-Text in light DOM
 
-FAIL moveBefore-from-light-to-shadow assert_true: expected true got false
+PASS moveBefore-from-light-to-shadow
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/slotchange-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/slotchange-events-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Moving default content into a slot fires 'slotchange' event
 PASS Moving default content out of a slot fires 'slotchange' event
-FAIL Moving a slottable into and out out of a custom element fires 'slotchange' event promise_test: Unhandled rejection with value: "Timeout; slotchange (whiling moving an element in) was not fired"
-FAIL Moving a slot runs the assign slottables algorithm promise_test: Unhandled rejection with value: "Timeout; slotchange was not fired2"
+PASS Moving a slottable into and out out of a custom element fires 'slotchange' event
+PASS Moving a slot runs the assign slottables algorithm
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -71,6 +71,7 @@
 #include "SlotAssignment.h"
 #include "StaticNodeList.h"
 #include "TemplateContentDocumentFragment.h"
+#include "Text.h"
 #include <algorithm>
 #include <wtf/TZoneMallocInlines.h>
 #include "AsyncNodeDeletionQueueInlines.h"
@@ -1491,6 +1492,9 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
 
     RefPtr oldPreviousSibling = node.previousSibling();
     RefPtr oldNextSibling = node.nextSibling();
+    bool treeScopeChanged = &node.treeScope() != &treeScope();
+    RefPtr<HTMLSlotElement> oldAssignedSlot = node.assignedSlot();
+    RefPtr movedElement = dynamicDowncast<Element>(node);
 
     auto removalChildChange = makeChildChangeForRemoval(node, ChildChange::Source::API);
 
@@ -1500,6 +1504,22 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         ChildListMutationScope(*oldParent).willRemoveChild(node);
         nodeDocument->nodeWillBeMoved(node);
+
+        if (oldParent->isShadowRoot() || oldParent->isInShadowTree()) [[unlikely]]
+            oldParent->containingShadowRoot()->resolveSlotsBeforeNodeInsertionOrRemoval();
+        if (isShadowRoot() || isInShadowTree()) [[unlikely]]
+            containingShadowRoot()->resolveSlotsBeforeNodeInsertionOrRemoval();
+
+        if (oldParent->hasShadowRootContainingSlots()) [[unlikely]]
+            protect(oldParent->shadowRoot())->willRemoveAssignedNode(node);
+
+        if (treeScopeChanged) {
+            if (RefPtr slot = dynamicDowncast<HTMLSlotElement>(node); slot && oldParent->isInShadowTree()) {
+                RefPtr oldShadowRoot = oldParent->containingShadowRoot();
+                ASSERT(oldShadowRoot);
+                oldShadowRoot->removeSlotElementByName(slot->attributeWithoutSynchronization(HTMLNames::nameAttr), *slot, *oldParent);
+            }
+        }
 
         if (oldNextSibling) {
             oldNextSibling->setPreviousSibling(oldPreviousSibling.get());
@@ -1522,7 +1542,12 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
         InspectorInstrumentation::didRemoveDOMNode(nodeDocument, node);
         node.setParentNode(nullptr);
 
-        // FIXME(281223): Handle slot assignments and live ranges.
+        if (movedElement) {
+            if (RefPtr shadowRoot = oldParent->shadowRoot())
+                shadowRoot->hostChildElementDidMove(*movedElement);
+        }
+
+        // FIXME(281223): Handle live ranges.
 
         if (refChild)
             insertBeforeCommon(*refChild, node);
@@ -1531,7 +1556,30 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
         // FIXME(319588): Handle inspector DOM breakpoints (e.g. InspectorInstrumentation::willInsertDOMNode)
         InspectorInstrumentation::didInsertDOMNode(protect(document()), node);
 
+        if (movedElement) {
+            if (RefPtr shadowRoot = this->shadowRoot())
+                shadowRoot->hostChildElementDidMove(*movedElement);
+        }
+
+        RefPtr newAssignedSlot = node.assignedSlot();
+        auto shouldTearDownMovedNodeRenderer = [](HTMLSlotElement* slot) {
+            RefPtr shadowRoot = slot ? slot->containingShadowRoot() : nullptr;
+            return shadowRoot && shadowRoot->mode() != ShadowRootMode::UserAgent;
+        };
+        if (oldAssignedSlot != newAssignedSlot && (shouldTearDownMovedNodeRenderer(oldAssignedSlot.get()) || shouldTearDownMovedNodeRenderer(newAssignedSlot.get()))) {
+            if (movedElement)
+                RenderTreeUpdater::tearDownRenderers(*movedElement);
+            else if (RefPtr text = dynamicDowncast<Text>(node))
+                RenderTreeUpdater::tearDownRenderer(*text);
+        }
+
         node.setTreeScopeRecursively(treeScope());
+        if (treeScopeChanged) {
+            if (RefPtr slot = dynamicDowncast<HTMLSlotElement>(node); slot && slot->isInShadowTree()) {
+                if (RefPtr shadowRoot = slot->containingShadowRoot())
+                    shadowRoot->addSlotElementByName(slot->attributeWithoutSynchronization(HTMLNames::nameAttr), *slot);
+            }
+        }
         node.updateAncestorConnectedSubframeCountForInsertion();
         ChildListMutationScope(*this).childAdded(node);
     }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1525,6 +1525,11 @@ void Node::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemo
 
 void Node::movingSteps(bool, ContainerNode&)
 {
+    if (isInShadowTree())
+        setEventTargetFlag(EventTargetFlag::IsInShadowTree);
+    else
+        clearEventTargetFlag(EventTargetFlag::IsInShadowTree);
+
     invalidateStyle(Style::Validity::SubtreeInvalid, Style::InvalidationMode::InsertedIntoAncestor);
 }
 

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -137,6 +137,7 @@ public:
     inline void didRemoveAllChildrenOfShadowHost(); // Defined in SlotAssignment.h
     inline void didMutateTextNodesOfShadowHost(); // Defined in SlotAssignment.h
     inline void hostChildElementDidChange(const Element&); // Defined in SlotAssignment.h
+    inline void hostChildElementDidMove(const Element&); // Defined in SlotAssignment.h
     inline void hostChildElementDidChangeSlotAttribute(Element&, const AtomString& oldValue, const AtomString& newValue); // Defined in SlotAssignment.h
 
     const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* assignedNodesForSlot(const HTMLSlotElement&);

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -303,7 +303,7 @@ void NamedSlotAssignment::slotFallbackDidChange(HTMLSlotElement& slotElement, Sh
         slotElement.enqueueSlotChangeEvent();
 }
 
-void NamedSlotAssignment::didChangeSlot(const AtomString& slotAttrValue, ShadowRoot& shadowRoot)
+void NamedSlotAssignment::didChangeSlot(const AtomString& slotAttrValue, ShadowRoot& shadowRoot, SlotChangeInvalidation slotChangeInvalidation)
 {
     auto& slotName = slotNameFromAttributeValue(slotAttrValue);
     auto* slot = m_slots.get(slotName);
@@ -312,7 +312,8 @@ void NamedSlotAssignment::didChangeSlot(const AtomString& slotAttrValue, ShadowR
 
     ASSERT(shadowRoot.host());
     Ref shadowRootHost = *shadowRoot.host();
-    RenderTreeUpdater::tearDownRenderersAfterSlotChange(shadowRootHost);
+    if (slotChangeInvalidation == SlotChangeInvalidation::TearDownRenderers)
+        RenderTreeUpdater::tearDownRenderersAfterSlotChange(shadowRootHost);
     shadowRootHost->invalidateStyleForSubtree();
 
     auto assignedNodes = std::exchange(slot->assignedNodes, { });
@@ -349,6 +350,11 @@ void NamedSlotAssignment::didMutateTextNodesOfShadowHost(ShadowRoot& shadowRoot)
 void NamedSlotAssignment::hostChildElementDidChange(const Element& childElement, ShadowRoot& shadowRoot)
 {
     didChangeSlot(childElement.attributeWithoutSynchronization(slotAttr), shadowRoot);
+}
+
+void NamedSlotAssignment::hostChildElementDidMove(const Element& childElement, ShadowRoot& shadowRoot)
+{
+    didChangeSlot(childElement.attributeWithoutSynchronization(slotAttr), shadowRoot, SlotChangeInvalidation::PreserveRenderers);
 }
 
 void NamedSlotAssignment::hostChildElementDidChangeSlotAttribute(Element& element, const AtomString& oldValue, const AtomString& newValue, ShadowRoot& shadowRoot)
@@ -609,6 +615,11 @@ void ManualSlotAssignment::hostChildElementDidChange(const Element&, ShadowRoot&
     ++m_slottableVersion;
 }
 
+void ManualSlotAssignment::hostChildElementDidMove(const Element&, ShadowRoot&)
+{
+    ++m_slottableVersion;
+}
+
 void ManualSlotAssignment::hostChildElementDidChangeSlotAttribute(Element&, const AtomString&, const AtomString&, ShadowRoot&)
 {
 }
@@ -631,5 +642,3 @@ void ManualSlotAssignment::didMutateTextNodesOfShadowHost(ShadowRoot&)
 }
 
 }
-
-

--- a/Source/WebCore/dom/SlotAssignment.h
+++ b/Source/WebCore/dom/SlotAssignment.h
@@ -64,6 +64,7 @@ public:
     virtual void slotFallbackDidChange(HTMLSlotElement&, ShadowRoot&) = 0;
 
     virtual void hostChildElementDidChange(const Element&, ShadowRoot&) = 0;
+    virtual void hostChildElementDidMove(const Element&, ShadowRoot&) = 0;
     virtual void hostChildElementDidChangeSlotAttribute(Element&, const AtomString& oldValue, const AtomString& newValue, ShadowRoot&) = 0;
 
     virtual void willRemoveAssignedNode(Node&, ShadowRoot&) = 0;
@@ -87,7 +88,8 @@ public:
     static const AtomString& defaultSlotName() { return emptyAtom(); }
 
 protected:
-    void didChangeSlot(const AtomString&, ShadowRoot&);
+    enum class SlotChangeInvalidation { PreserveRenderers, TearDownRenderers };
+    void didChangeSlot(const AtomString&, ShadowRoot&, SlotChangeInvalidation = SlotChangeInvalidation::TearDownRenderers);
 
 private:
     HTMLSlotElement* NODELETE findAssignedSlot(const Node&) final;
@@ -105,6 +107,7 @@ private:
     void didRemoveAllChildrenOfShadowHost(ShadowRoot&) final;
     void didMutateTextNodesOfShadowHost(ShadowRoot&) final;
     void hostChildElementDidChange(const Element&, ShadowRoot&) override;
+    void hostChildElementDidMove(const Element&, ShadowRoot&) override;
     void hostChildElementDidChangeSlotAttribute(Element&, const AtomString& oldValue, const AtomString& newValue, ShadowRoot&) final;
 
     struct Slot {
@@ -157,6 +160,7 @@ public:
     void slotFallbackDidChange(HTMLSlotElement&, ShadowRoot&) final;
 
     void hostChildElementDidChange(const Element&, ShadowRoot&) final;
+    void hostChildElementDidMove(const Element&, ShadowRoot&) final;
     void hostChildElementDidChangeSlotAttribute(Element&, const AtomString&, const AtomString&, ShadowRoot&) final;
 
     void willRemoveAssignedNode(Node&, ShadowRoot&) final;
@@ -221,6 +225,12 @@ inline void ShadowRoot::hostChildElementDidChange(const Element& childElement)
 {
     if (m_slotAssignment) [[unlikely]]
         m_slotAssignment->hostChildElementDidChange(childElement, *this);
+}
+
+inline void ShadowRoot::hostChildElementDidMove(const Element& childElement)
+{
+    if (m_slotAssignment) [[unlikely]]
+        m_slotAssignment->hostChildElementDidMove(childElement, *this);
 }
 
 inline void ShadowRoot::hostChildElementDidChangeSlotAttribute(Element& element, const AtomString& oldValue, const AtomString& newValue)

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -64,6 +64,7 @@ static const AtomString& summarySlotName()
 class DetailsSlotAssignment final : public NamedSlotAssignment {
 private:
     void hostChildElementDidChange(const Element&, ShadowRoot&) override;
+    void hostChildElementDidMove(const Element&, ShadowRoot&) override;
     const AtomString& NODELETE slotNameForHostChild(const Node&) const override;
 };
 
@@ -80,6 +81,19 @@ void DetailsSlotAssignment::hostChildElementDidChange(const Element& childElemen
         }
     } else
         didChangeSlot(NamedSlotAssignment::defaultSlotName(), shadowRoot);
+}
+
+void DetailsSlotAssignment::hostChildElementDidMove(const Element& childElement, ShadowRoot& shadowRoot)
+{
+    if (is<HTMLSummaryElement>(childElement)) {
+        didChangeSlot(summarySlotName(), shadowRoot, SlotChangeInvalidation::PreserveRenderers);
+
+        if (RefPtr associatedDetails = dynamicDowncast<HTMLDetailsElement>(shadowRoot.host())) {
+            if (CheckedPtr cache = protect(associatedDetails->document())->existingAXObjectCache())
+                cache->onDetailsSummarySlotChange(*associatedDetails);
+        }
+    } else
+        didChangeSlot(NamedSlotAssignment::defaultSlotName(), shadowRoot, SlotChangeInvalidation::PreserveRenderers);
 }
 
 SUPPRESS_NODELETE const AtomString& NODELETE DetailsSlotAssignment::slotNameForHostChild(const Node& child) const

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -113,6 +113,7 @@ static bool NODELETE isFirstElementChildButton(const Node& child)
 class SelectSlotAssignment final : public NamedSlotAssignment {
 private:
     void hostChildElementDidChange(const Element&, ShadowRoot&) final;
+    void hostChildElementDidMove(const Element&, ShadowRoot&) final;
     const AtomString& NODELETE slotNameForHostChild(const Node&) const final;
 };
 
@@ -124,6 +125,14 @@ void SelectSlotAssignment::hostChildElementDidChange(const Element& childElement
         didChangeSlot(buttonSlotName(), shadowRoot);
     } else
         didChangeSlot(NamedSlotAssignment::defaultSlotName(), shadowRoot);
+}
+
+void SelectSlotAssignment::hostChildElementDidMove(const Element& childElement, ShadowRoot& shadowRoot)
+{
+    if (is<HTMLButtonElement>(childElement))
+        didChangeSlot(buttonSlotName(), shadowRoot, SlotChangeInvalidation::PreserveRenderers);
+    else
+        didChangeSlot(NamedSlotAssignment::defaultSlotName(), shadowRoot, SlotChangeInvalidation::PreserveRenderers);
 }
 
 SUPPRESS_NODELETE const AtomString& SelectSlotAssignment::slotNameForHostChild(const Node& child) const


### PR DESCRIPTION
#### 140685440a32ac824cf5074fee354067524fccaa
<pre>
Implement slot assignment handling for moveBefore()
<a href="https://bugs.webkit.org/show_bug.cgi?id=321178">https://bugs.webkit.org/show_bug.cgi?id=321178</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

This PR handles slot assignment changes as part of moveBefore(). Special handling is needed for renderer teardowns else test cases crash.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-from-light-to-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/slotchange-events-expected.txt:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::moveBefore):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::movingSteps):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::NamedSlotAssignment::didChangeSlot):
(WebCore::NamedSlotAssignment::hostChildElementDidMove):
(WebCore::ManualSlotAssignment::hostChildElementDidMove):
* Source/WebCore/dom/SlotAssignment.h:
(WebCore::ShadowRoot::hostChildElementDidMove):
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::DetailsSlotAssignment::hostChildElementDidMove):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::SelectSlotAssignment::hostChildElementDidMove):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/140685440a32ac824cf5074fee354067524fccaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191777 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145880 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141710 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98360 "3 flakes 12 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122147 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44075 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42348 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41990 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2937 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193704 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55170 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151116 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55859 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150819 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45398 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128142 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123821 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54372 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16984 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53754 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53993 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->