### PR TITLE
Borrow vectors wherever possible in PAL Crypto

### DIFF
--- a/Source/WebCore/PAL/pal/crypto/CryptoEDKeyBridging.cpp
+++ b/Source/WebCore/PAL/pal/crypto/CryptoEDKeyBridging.cpp
@@ -41,24 +41,24 @@ VectorUInt8 generatePrivateKeyKeyAgreement(EdKeyAgreementAlgorithm algorithm)
     return pal::EdKey::generatePrivateKeyKeyAgreement(algorithm);
 }
 
-CryptoOperationReturnValue privateToPublic(EdSigningAlgorithm algorithm, SpanConstUInt8 privateKey)
+CryptoOperationReturnValue privateToPublic(EdSigningAlgorithm algorithm, const VectorUInt8& privateKey)
 {
-    return pal::EdKey::privateToPublic(algorithm, escapableSpan(privateKey));
+    return pal::EdKey::privateToPublic(algorithm, escapableSpan(borrow(privateKey)->span()));
 }
 
-CryptoOperationReturnValue privateToPublicKeyAgreement(EdKeyAgreementAlgorithm algorithm, SpanConstUInt8 privateKey)
+CryptoOperationReturnValue privateToPublicKeyAgreement(EdKeyAgreementAlgorithm algorithm, const VectorUInt8& privateKey)
 {
-    return pal::EdKey::privateToPublicKeyAgreement(algorithm, escapableSpan(privateKey));
+    return pal::EdKey::privateToPublicKeyAgreement(algorithm, escapableSpan(borrow(privateKey)->span()));
 }
 
-bool validateKeyPair(EdSigningAlgorithm algorithm, SpanConstUInt8 privateKey, SpanConstUInt8 publicKey)
+bool validateKeyPair(EdSigningAlgorithm algorithm, const VectorUInt8& privateKey, const VectorUInt8& publicKey)
 {
-    return pal::EdKey::validateKeyPair(algorithm, escapableSpan(privateKey), escapableSpan(publicKey));
+    return pal::EdKey::validateKeyPair(algorithm, escapableSpan(borrow(privateKey)->span()), escapableSpan(borrow(publicKey)->span()));
 }
 
-bool validateKeyPairKeyAgreement(EdKeyAgreementAlgorithm algorithm, SpanConstUInt8 privateKey, SpanConstUInt8 publicKey)
+bool validateKeyPairKeyAgreement(EdKeyAgreementAlgorithm algorithm, const VectorUInt8& privateKey, const VectorUInt8& publicKey)
 {
-    return pal::EdKey::validateKeyPairKeyAgreement(algorithm, escapableSpan(privateKey), escapableSpan(publicKey));
+    return pal::EdKey::validateKeyPairKeyAgreement(algorithm, escapableSpan(borrow(privateKey)->span()), escapableSpan(borrow(publicKey)->span()));
 }
 
 } // namespace PAL::Crypto::EdKey

--- a/Source/WebCore/PAL/pal/crypto/CryptoEDKeyBridging.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoEDKeyBridging.h
@@ -33,12 +33,12 @@ VectorUInt8 generatePrivateKey(EdSigningAlgorithm);
 
 VectorUInt8 generatePrivateKeyKeyAgreement(EdKeyAgreementAlgorithm);
 
-CryptoOperationReturnValue privateToPublic(EdSigningAlgorithm, SpanConstUInt8 privateKey);
+CryptoOperationReturnValue privateToPublic(EdSigningAlgorithm, const VectorUInt8& privateKey);
 
-CryptoOperationReturnValue privateToPublicKeyAgreement(EdKeyAgreementAlgorithm, SpanConstUInt8 privateKey);
+CryptoOperationReturnValue privateToPublicKeyAgreement(EdKeyAgreementAlgorithm, const VectorUInt8& privateKey);
 
-bool validateKeyPair(EdSigningAlgorithm, SpanConstUInt8 privateKey, SpanConstUInt8 publicKey);
+bool validateKeyPair(EdSigningAlgorithm, const VectorUInt8& privateKey, const VectorUInt8& publicKey);
 
-bool validateKeyPairKeyAgreement(EdKeyAgreementAlgorithm, SpanConstUInt8 privateKey, SpanConstUInt8 publicKey);
+bool validateKeyPairKeyAgreement(EdKeyAgreementAlgorithm, const VectorUInt8& privateKey, const VectorUInt8& publicKey);
 
 } // namespace PAL::Crypto::EdKey

--- a/Source/WebCore/PAL/pal/crypto/PlatformECKey.cpp
+++ b/Source/WebCore/PAL/pal/crypto/PlatformECKey.cpp
@@ -52,14 +52,14 @@ CryptoOperationReturnValue PlatformECKey::deriveBits(const PlatformECKey& public
     return m_key->deriveBits(publicKey.m_key.get());
 }
 
-CryptoOperationReturnValue PlatformECKey::sign(SpanConstUInt8 message, CryptoDigestHashFunction hashFunction) const
+CryptoOperationReturnValue PlatformECKey::sign(const VectorUInt8& message, CryptoDigestHashFunction hashFunction) const
 {
-    return m_key->sign(escapableSpan(message), hashFunction);
+    return m_key->sign(escapableSpan(borrow(message)->span()), hashFunction);
 }
 
-CryptoOperationReturnValue PlatformECKey::doVerify(SpanConstUInt8 message, SpanConstUInt8 signature, CryptoDigestHashFunction hashFunction) const
+CryptoOperationReturnValue PlatformECKey::doVerify(const VectorUInt8& message, const VectorUInt8& signature, CryptoDigestHashFunction hashFunction) const
 {
-    return m_key->verify(escapableSpan(message), escapableSpan(signature), hashFunction);
+    return m_key->verify(escapableSpan(borrow(message)->span()), escapableSpan(borrow(signature)->span()), hashFunction);
 }
 
 PlatformECKey PlatformECKey::toPub() const
@@ -77,27 +77,27 @@ CryptoOperationReturnValue PlatformECKey::exportX963Private() const
     return m_key->exportX963Private();
 }
 
-std::optional<PlatformECKey> PlatformECKey::importX963Pub(SpanConstUInt8 data, NamedCurve curve)
+std::optional<PlatformECKey> PlatformECKey::importX963Pub(const VectorUInt8& data, NamedCurve curve)
 {
-    auto result = pal::ECKey::importX963Pub(escapableSpan(data), curve);
+    auto result = pal::ECKey::importX963Pub(escapableSpan(borrow(data)->span()), curve);
     if (result)
         return { { result.get() } };
 
     return std::nullopt;
 }
 
-std::optional<PlatformECKey> PlatformECKey::importX963Private(SpanConstUInt8 data, NamedCurve curve)
+std::optional<PlatformECKey> PlatformECKey::importX963Private(const VectorUInt8& data, NamedCurve curve)
 {
-    auto result = pal::ECKey::importX963Private(escapableSpan(data), curve);
+    auto result = pal::ECKey::importX963Private(escapableSpan(borrow(data)->span()), curve);
     if (result)
         return { { result.get() } };
 
     return std::nullopt;
 }
 
-std::optional<PlatformECKey> PlatformECKey::importCompressedPub(SpanConstUInt8 data, NamedCurve curve)
+std::optional<PlatformECKey> PlatformECKey::importCompressedPub(const VectorUInt8& data, size_t offset, NamedCurve curve)
 {
-    auto result = pal::ECKey::importCompressedPub(escapableSpan(data), curve);
+    auto result = pal::ECKey::importCompressedPub(escapableSpan(borrow(data)->span().subspan(offset)), curve);
     if (result)
         return { { result.get() } };
 

--- a/Source/WebCore/PAL/pal/crypto/PlatformECKey.h
+++ b/Source/WebCore/PAL/pal/crypto/PlatformECKey.h
@@ -50,9 +50,9 @@ public:
 
     CryptoOperationReturnValue deriveBits(const PlatformECKey& publicKey) const;
 
-    CryptoOperationReturnValue sign(SpanConstUInt8 message, CryptoDigestHashFunction) const;
+    CryptoOperationReturnValue sign(const VectorUInt8& message, CryptoDigestHashFunction) const;
 
-    CryptoOperationReturnValue doVerify(SpanConstUInt8 message, SpanConstUInt8 signature, CryptoDigestHashFunction) const;
+    CryptoOperationReturnValue doVerify(const VectorUInt8& message, const VectorUInt8& signature, CryptoDigestHashFunction) const;
 
     PlatformECKey toPub() const;
 
@@ -60,11 +60,11 @@ public:
 
     CryptoOperationReturnValue exportX963Private() const;
 
-    static std::optional<PlatformECKey> importX963Pub(SpanConstUInt8, NamedCurve);
+    static std::optional<PlatformECKey> importX963Pub(const VectorUInt8&, NamedCurve);
 
-    static std::optional<PlatformECKey> importX963Private(SpanConstUInt8, NamedCurve);
+    static std::optional<PlatformECKey> importX963Private(const VectorUInt8&, NamedCurve);
 
-    static std::optional<PlatformECKey> importCompressedPub(SpanConstUInt8, NamedCurve);
+    static std::optional<PlatformECKey> importCompressedPub(const VectorUInt8&, size_t offset, NamedCurve);
 
 private:
     PlatformECKey(const pal::ECKey&);

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp
@@ -41,7 +41,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSACryptoKit(CryptoAlgorithmIdentifier
 {
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    auto rv = key.sign(data.span(), toCKHashFunction(hash));
+    auto rv = key.sign(data, toCKHashFunction(hash));
     if (rv.errorCode != PAL::Crypto::Error::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
@@ -51,7 +51,7 @@ static ExceptionOr<bool> verifyECDSACryptoKit(CryptoAlgorithmIdentifier hash, co
 {
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    return key.doVerify(data.span(), signature.span(), toCKHashFunction(hash)).errorCode == PAL::Crypto::Error::Success;
+    return key.doVerify(data, signature, toCKHashFunction(hash)).errorCode == PAL::Crypto::Error::Success;
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)

--- a/Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp
@@ -109,7 +109,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier ide
     if (!doesUncompressedPointMatchNamedCurve(curve, keyData.size()))
         return nullptr;
 
-    auto rv = PAL::Crypto::PlatformECKey::importX963Pub(keyData.span(), curve);
+    auto rv = PAL::Crypto::PlatformECKey::importX963Pub(keyData, curve);
     if (!rv)
         return nullptr;
     return create(identifier, curve, CryptoKeyType::Public, WTF::move(*rv), extractable, usages);
@@ -149,7 +149,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentif
     binaryInput.appendVector(y);
     binaryInput.appendVector(d);
 
-    auto rv = PAL::Crypto::PlatformECKey::importX963Private(binaryInput.span(), curve);
+    auto rv = PAL::Crypto::PlatformECKey::importX963Private(binaryInput, curve);
     if (!rv)
         return nullptr;
     return create(identifier, curve, CryptoKeyType::Private, WTF::move(*rv), extractable, usages);
@@ -242,7 +242,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier id
         return platformImportRaw(identifier, curve, Vector<uint8_t>(keyData.subspan(index, keyData.size() - index)), extractable, usages);
 
     // CryptoKit can read pure compressed so no need for index++ here.
-    auto rv = PAL::Crypto::PlatformECKey::importCompressedPub(keyData.subspan(index, keyData.size() - index), curve);
+    auto rv = PAL::Crypto::PlatformECKey::importCompressedPub(keyData, index, curve);
     if (!rv)
         return nullptr;
     return create(identifier, curve, CryptoKeyType::Public, WTF::move(*rv), extractable, usages);
@@ -344,7 +344,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier i
         return nullptr;
     keyBinary.append(keyData.subspan(privateKeyPos, privateKeySize));
 
-    auto rv = PAL::Crypto::PlatformECKey::importX963Private(keyBinary.span(), curve);
+    auto rv = PAL::Crypto::PlatformECKey::importX963Private(keyBinary, curve);
     if (!rv)
         return nullptr;
     return create(identifier, curve, CryptoKeyType::Private, WTF::move(*rv), extractable, usages);

--- a/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
@@ -52,7 +52,7 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
     case CryptoAlgorithmIdentifier::Ed25519: {
         auto privateKeyPlatform = PAL::Crypto::EdKey::generatePrivateKey(PAL::Crypto::EdSigningAlgorithm::ED25519);
         RELEASE_ASSERT(privateKeyPlatform.size() == 32);
-        auto publicKeyPlatformRv = PAL::Crypto::EdKey::privateToPublic(PAL::Crypto::EdSigningAlgorithm::ED25519, privateKeyPlatform.span());
+        auto publicKeyPlatformRv = PAL::Crypto::EdKey::privateToPublic(PAL::Crypto::EdSigningAlgorithm::ED25519, privateKeyPlatform);
         if (publicKeyPlatformRv.errorCode != PAL::Crypto::Error::Success)
             return std::nullopt;
         bool isPublicKeyExtractable = true;
@@ -65,7 +65,7 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
     case CryptoAlgorithmIdentifier::X25519: {
         auto privateKeyPlatform = PAL::Crypto::EdKey::generatePrivateKeyKeyAgreement(PAL::Crypto::EdKeyAgreementAlgorithm::X25519);
         RELEASE_ASSERT(privateKeyPlatform.size() == 32);
-        auto publicKeyPlatformRv = PAL::Crypto::EdKey::privateToPublicKeyAgreement(PAL::Crypto::EdKeyAgreementAlgorithm::X25519, privateKeyPlatform.span());
+        auto publicKeyPlatformRv = PAL::Crypto::EdKey::privateToPublicKeyAgreement(PAL::Crypto::EdKeyAgreementAlgorithm::X25519, privateKeyPlatform);
         if (publicKeyPlatformRv.errorCode != PAL::Crypto::Error::Success)
             return std::nullopt;
         bool isPublicKeyExtractable = true;
@@ -91,9 +91,9 @@ bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier identifier,
 
     switch (identifier) {
     case CryptoAlgorithmIdentifier::Ed25519:
-        return PAL::Crypto::EdKey::validateKeyPair(PAL::Crypto::EdSigningAlgorithm::ED25519, privateKey.span(), publicKey.span());
+        return PAL::Crypto::EdKey::validateKeyPair(PAL::Crypto::EdSigningAlgorithm::ED25519, privateKey, publicKey);
     case CryptoAlgorithmIdentifier::X25519:
-        return PAL::Crypto::EdKey::validateKeyPairKeyAgreement(PAL::Crypto::EdKeyAgreementAlgorithm::X25519, privateKey.span(), publicKey.span());
+        return PAL::Crypto::EdKey::validateKeyPairKeyAgreement(PAL::Crypto::EdKeyAgreementAlgorithm::X25519, privateKey, publicKey);
     default:
         RELEASE_ASSERT_NOT_REACHED();
         return false;
@@ -357,12 +357,12 @@ String CryptoKeyOKP::generateJwkX() const
     ASSERT(type() == CryptoKeyType::Private);
     switch (namedCurve()) {
     case NamedCurve::Ed25519: {
-        auto publicKeyPlatformRv = PAL::Crypto::EdKey::privateToPublic(PAL::Crypto::EdSigningAlgorithm::ED25519, platformKey().span());
+        auto publicKeyPlatformRv = PAL::Crypto::EdKey::privateToPublic(PAL::Crypto::EdSigningAlgorithm::ED25519, platformKey());
         RELEASE_ASSERT(publicKeyPlatformRv.errorCode == PAL::Crypto::Error::Success);
         return base64URLEncodeToString(publicKeyPlatformRv.result.span());
     }
     case NamedCurve::X25519: {
-        auto publicKeyPlatformRv = PAL::Crypto::EdKey::privateToPublicKeyAgreement(PAL::Crypto::EdKeyAgreementAlgorithm::X25519, platformKey().span());
+        auto publicKeyPlatformRv = PAL::Crypto::EdKey::privateToPublicKeyAgreement(PAL::Crypto::EdKeyAgreementAlgorithm::X25519, platformKey());
         RELEASE_ASSERT(publicKeyPlatformRv.errorCode == PAL::Crypto::Error::Success);
         return base64URLEncodeToString(publicKeyPlatformRv.result.span());
     }


### PR DESCRIPTION
#### 74b4c68442b679c01593c67966182f01e0650948
<pre>
Borrow vectors wherever possible in PAL Crypto
<a href="https://bugs.webkit.org/show_bug.cgi?id=321179">https://bugs.webkit.org/show_bug.cgi?id=321179</a>
<a href="https://rdar.apple.com/184230601">rdar://184230601</a>

Reviewed by Richard Robinson.

We&apos;re building primitives to allow ranges of bytes to be passed safely from C++
to Swift. Swift will now crash cleanly if a C++ vector is structurally modified
while its data is in scope in Swift.

This only works for Vectors, not raw spans. Modify PAL crypto to pass vectors
around instead of spans wherever possible, so that we get the benefit of this
dynamic lifetime enforcement.

* Source/WebCore/PAL/pal/crypto/CryptoEDKeyBridging.cpp:
(PAL::Crypto::EdKey::privateToPublic):
(PAL::Crypto::EdKey::privateToPublicKeyAgreement):
(PAL::Crypto::EdKey::validateKeyPair):
(PAL::Crypto::EdKey::validateKeyPairKeyAgreement):
* Source/WebCore/PAL/pal/crypto/CryptoEDKeyBridging.h:
* Source/WebCore/PAL/pal/crypto/PlatformECKey.cpp:
(PAL::Crypto::PlatformECKey::sign const):
(PAL::Crypto::PlatformECKey::doVerify const):
(PAL::Crypto::PlatformECKey::importX963Pub):
(PAL::Crypto::PlatformECKey::importX963Private):
(PAL::Crypto::PlatformECKey::importCompressedPub):
* Source/WebCore/PAL/pal/crypto/PlatformECKey.h:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp:
(WebCore::signECDSACryptoKit):
(WebCore::verifyECDSACryptoKit):
* Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp:
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformImportPkcs8):
* Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):
(WebCore::CryptoKeyOKP::generateJwkX const):

Canonical link: <a href="https://commits.webkit.org/319587@main">https://commits.webkit.org/319587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e3c8c61ce4b59b46343118a9c50cea8923adfbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191989 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146093 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa578124-5996-45ad-9bca-3f288ae03faa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141885 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05ffe7b2-5f41-46df-bd55-f2d09cc2892c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122320 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b7e00c26-5cba-477f-b78e-3c09f0be5409) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44255 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42527 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154652 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42158 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3150 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193915 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55381 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151296 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40551 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56070 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151000 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45576 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128353 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124099 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54583 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17154 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53965 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54204 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54030 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->