### PR TITLE
Revert "Cherry-pick 318526@main (b49502648e6a). https://bugs.webkit.org/show_bug.cgi?id=319685"

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -9098,6 +9098,7 @@ UnifyDamagedRegions:
      WebKitLegacy:
        default: false
      WebKit:
+       "PLATFORM(GTK)": true
        default: false
      WebCore:
        default: false
@@ -9197,7 +9198,6 @@ UseDamagingInformationForCompositing:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
       default: false


### PR DESCRIPTION
#### 5df9abe996621b67826842244ac9ccbe958537f1
<pre>
Revert &quot;Cherry-pick 318526@main (b49502648e6a). <a href="https://bugs.webkit.org/show_bug.cgi?id=319685&quot">https://bugs.webkit.org/show_bug.cgi?id=319685&quot</a>;

Unreviewed revert.

This reverts commit 646a1e4e0d53f46359604e2f02ddc94cd87c3d52.

Canonical link: <a href="https://commits.webkit.org/317695.67@webkitglib/2.54">https://commits.webkit.org/317695.67@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f4c39fae206d6cfaf1d4b095212056e9ad016aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179171 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53110 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46905 "The change is no longer eligible for processing.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143480 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54403 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52820 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/189002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143480 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182128 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54403 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/46905 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54403 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/52820 "The change is no longer eligible for processing.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/46905 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54403 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46905 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/308 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/40445 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45716 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/52820 "The change is no longer eligible for processing.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/191220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52780 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/46905 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/191220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53460 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/46905 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/191220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27184 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53460 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125731 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120580 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/51978 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/46905 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51363 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51604 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51424 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->