### PR TITLE
[WebXR][OpenXR]

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -271,7 +271,8 @@ void WebXROpaqueFramebuffer::endFrame()
         return;
     }
 #else
-    if (auto sync = gl->createExternalSync({ })) {
+    auto* displayAttachmentSet = reusableDisplayAttachmentsAtIndex(m_currentDisplayAttachmentIndex);
+    if (auto sync = gl->createExternalSync(displayAttachmentSet ? GCGLExternalImage { (*displayAttachmentSet)[0].colorBuffer.image } : 0)) {
         m_fenceFD = gl->exportExternalSync(sync);
         gl->deleteExternalSync(sync);
         return;

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -81,9 +81,19 @@ static GL::ExternalImageSource makeExternalImageSource(const PlatformXR::FrameDa
 #else
 static GL::ExternalImageSource makeExternalImageSource(PlatformXR::FrameData::ExternalTexture& imageSource, const IntSize& size)
 {
-#if OS(ANDROID)
+#if OS(ANDROID) && !USE(OPENXR_VULKAN)
     return GraphicsContextGLExternalImageSource {
         .hardwareBuffer = imageSource,
+        .size = size,
+    };
+#elif USE(OPENXR_VULKAN)
+    return GraphicsContextGLExternalImageSource {
+        .memory = WTF::move(imageSource.memory),
+        .allocationSize = imageSource.allocationSize,
+        .internalFormat = imageSource.glInternalFormat,
+        .renderFinishedSemaphore = WTF::move(imageSource.renderFinishedSemaphore),
+        .deviceUUID = imageSource.deviceUUID,
+        .driverUUID = imageSource.driverUUID,
         .size = size,
     };
 #else
@@ -95,7 +105,7 @@ static GL::ExternalImageSource makeExternalImageSource(PlatformXR::FrameData::Ex
         .modifier = imageSource.modifier,
         .size = size
     };
-#endif // OS(ANDROID)
+#endif // OS(ANDROID) && !USE(OPENXR_VULKAN)
 }
 #endif
 

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
@@ -222,10 +222,20 @@ static void createAndBindCompositorTexture(GL& gl, WebXRExternalImage& externalI
 static GL::ExternalImageSource makeExternalImageSource(PlatformXR::FrameData::ExternalTexture& imageSource, const IntSize& size)
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
-#if OS(ANDROID)
+#if OS(ANDROID) && !USE(OPENXR_VULKAN)
     return GraphicsContextGLExternalImageSource {
         .hardwareBuffer = imageSource,
-        .size = size,
+        .size = size
+    };
+#elif USE(OPENXR_VULKAN)
+    return GraphicsContextGLExternalImageSource {
+        .memory = WTF::move(imageSource.memory),
+        .allocationSize = imageSource.allocationSize,
+        .internalFormat = imageSource.glInternalFormat,
+        .renderFinishedSemaphore = WTF::move(imageSource.renderFinishedSemaphore),
+        .deviceUUID = imageSource.deviceUUID,
+        .driverUUID = imageSource.driverUUID,
+        .size = size
     };
 #else
     return GraphicsContextGLExternalImageSource {
@@ -236,12 +246,12 @@ static GL::ExternalImageSource makeExternalImageSource(PlatformXR::FrameData::Ex
         .modifier = imageSource.modifier,
         .size = size
     };
-#endif // OS(ANDROID)
+#endif // OS(ANDROID) && !USE(OPENXR_VULKAN)
 #else
     UNUSED_PARAM(imageSource);
     UNUSED_PARAM(size);
     return GraphicsContextGLExternalImageSource { };
-#endif
+#endif // PLATFORM(GTK) || PLATFORM(WPE)
 }
 
 void WebXRWebGLSharedImageSwapchain::bindCompositorTexturesForDisplay(GraphicsContextGL& gl, PlatformXR::FrameData::LayerData& layerData)

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
@@ -135,7 +135,7 @@ void WebXRWebGLSwapchain::clearTextureIfNeeded(const IntRect& viewport, std::opt
 void WebXRWebGLSwapchain::signalEndFrame(GraphicsContextGL& gl, PlatformXR::DeviceLayer& layerData)
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    if (auto sync = gl.createExternalSync({ })) {
+    if (auto sync = gl.createExternalSync(currentExternalImage())) {
         layerData.fenceFD = gl.exportExternalSync(sync);
         gl.deleteExternalSync(sync);
         return;
@@ -319,6 +319,15 @@ void WebXRWebGLSharedImageSwapchain::endFrame(PlatformXR::DeviceLayer& layerData
     signalEndFrame(*gl, layerData);
 }
 
+GCGLExternalImage WebXRWebGLSharedImageSwapchain::currentExternalImage() const
+{
+    if (m_displayImagesSets.isEmpty())
+        return 0;
+
+    RELEASE_ASSERT(m_displayImagesSets.size() > m_currentImageIndex);
+    return m_displayImagesSets[m_currentImageIndex].colorBuffer.image;
+}
+
 void WebXRExternalImage::destroyImage(GraphicsContextGL& gl)
 {
     gl.deleteTexture(tex);
@@ -481,6 +490,13 @@ void WebXRWebGLStaticImageSwapchain::endFrame(PlatformXR::DeviceLayer&)
 
 }
 
+GCGLExternalImage WebXRWebGLStaticImageSwapchain::currentExternalImage() const
+{
+    // Nothing here is shared with the compositor, so endFrame() has nothing to hand back and never signals.
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
 bool WebXRWebGLStaticImageSwapchain::allTexturesAreBound() const
 {
     size_t expected = m_imageAttributes.textureType == GL::TEXTURE_CUBE_MAP ? m_imageCount * m_imageAttributes.arrayLength : m_imageCount;
@@ -585,6 +601,15 @@ void WebXRWebGLMultiTextureSwapchain::endFrame(PlatformXR::DeviceLayer& layerDat
 
     blitToSharedImage(*gl);
     signalEndFrame(*gl, layerData);
+}
+
+GCGLExternalImage WebXRWebGLMultiTextureSwapchain::currentExternalImage() const
+{
+    if (m_textureSets.isEmpty())
+        return 0;
+
+    RELEASE_ASSERT(m_textureSets.size() > m_currentImageIndex);
+    return m_textureSets[m_currentImageIndex].sharedImage.colorBuffer.image;
 }
 
 bool WebXRWebGLMultiTextureSwapchain::allTexturesAreBound() const

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
@@ -108,6 +108,8 @@ protected:
     void setupExternalImage(const PlatformXR::FrameData::LayerSetupData&);
     void signalEndFrame(GraphicsContextGL&, PlatformXR::DeviceLayer&);
 
+    virtual GCGLExternalImage currentExternalImage() const = 0;
+
     PlatformXR::LayerHandle m_handle;
     RefPtr<WebGLRenderingContextBase> m_context;
 
@@ -137,6 +139,7 @@ private:
     WebXRWebGLSharedImageSwapchain(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum format, IntSize initialSize, bool clearOnAccess, size_t imageCount);
 
     const WebXRExternalImages* reusableTextures(const PlatformXR::FrameData::ExternalTextureData&) const;
+    GCGLExternalImage currentExternalImage() const final;
     void releaseTexturesAtIndex(size_t index);
     void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&);
     const WebXRExternalImages* reusableTexturesAtIndex(size_t);
@@ -179,6 +182,7 @@ public:
 
 private:
     WebXRWebGLStaticImageSwapchain(WebGLRenderingContextBase&, StaticImageAttributes);
+    GCGLExternalImage currentExternalImage() const final;
     void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&);
     void releaseDisplayImagesAtIndex(size_t);
     void clearTextureRegion(GraphicsContextGL&, const IntRect& viewport, std::optional<GCGLint> slice) override;
@@ -219,6 +223,7 @@ protected:
 
     void releaseTexturesAtIndex(size_t);
     const WebXRExternalImages* reusableTextures(const PlatformXR::FrameData::ExternalTextureData&) const;
+    GCGLExternalImage currentExternalImage() const final;
 
     virtual void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&) = 0;
     virtual void blitToSharedImage(GraphicsContextGL&) = 0;

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -99,15 +99,22 @@ using GraphicsContextGLExternalSyncSource = std::tuple<MachSendRight, uint64_t>;
 #elif PLATFORM(GTK) || PLATFORM(WPE)
 
 struct GraphicsContextGLExternalImageSource {
-#if OS(ANDROID)
+#if OS(ANDROID) && !USE(OPENXR_VULKAN)
     RefPtr<AHardwareBuffer> hardwareBuffer;
+#elif USE(OPENXR_VULKAN)
+    WTF::UnixFileDescriptor memory;
+    uint64_t allocationSize { 0 };
+    GCGLenum internalFormat { 0 };
+    WTF::UnixFileDescriptor renderFinishedSemaphore;
+    std::array<uint64_t, 2> deviceUUID { };
+    std::array<uint64_t, 2> driverUUID { };
 #else
     Vector<WTF::UnixFileDescriptor> fds;
     Vector<uint32_t> strides;
     Vector<uint32_t> offsets;
     uint32_t fourcc;
     uint64_t modifier;
-#endif // OS(ANDROID)
+#endif
     WebCore::IntSize size;
 };
 using GraphicsContextGLExternalSyncSource = int;
@@ -760,6 +767,11 @@ public:
 
     // GL_EXT_texture_format_BGRA8888 enums
     static constexpr GCGLenum BGRA_EXT = 0x80E1;
+
+    // GL_EXT_memory_object and GL_EXT_semaphore enums
+    static constexpr GCGLenum DEDICATED_MEMORY_OBJECT_EXT = 0x9581;
+    static constexpr GCGLenum HANDLE_TYPE_OPAQUE_FD_EXT = 0x9586;
+    static constexpr GCGLenum LAYOUT_TRANSFER_SRC_EXT = 0x9592;
 
     // GL_ARB_robustness enums
     static constexpr GCGLenum GUILTY_CONTEXT_RESET_ARB = 0x8253;
@@ -1700,7 +1712,6 @@ public:
     // Computes the bytes per image element for a format and type.
     // Returns zero if format or type is an invalid enum.
     WEBCORE_EXPORT static unsigned NODELETE computeBytesPerGroup(GCGLenum format, GCGLenum type);
-
 
     struct PixelRectangleSizes {
         unsigned initialSkipBytes { 0 };

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -117,7 +117,7 @@ struct GraphicsContextGLExternalImageSource {
 #endif
     WebCore::IntSize size;
 };
-using GraphicsContextGLExternalSyncSource = int;
+using GraphicsContextGLExternalSyncSource = GCGLExternalImage;
 
 #else
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -296,7 +296,7 @@ public:
     void getActiveUniformBlockiv(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) final;
 #if ENABLE(WEBXR)
     GCGLExternalImage createExternalImage(ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) override;
-    void deleteExternalImage(GCGLExternalImage) final;
+    void deleteExternalImage(GCGLExternalImage) override;
     void bindExternalImage(GCGLenum target, GCGLExternalImage) override;
     GCGLExternalSync createExternalSync(ExternalSyncSource&&) override;
     void deleteExternalSync(GCGLExternalSync) final;

--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -642,11 +642,26 @@ const GLContext::GLExtensions& GLContext::glExtensions() const
         m_glExtensions.APPLE_sync = isExtensionSupported(extensionsString, "GL_APPLE_sync");
         m_glExtensions.OES_packed_depth_stencil = isExtensionSupported(extensionsString, "GL_OES_packed_depth_stencil");
         m_glExtensions.EXT_YUV_target = isExtensionSupported(extensionsString, "GL_EXT_YUV_target");
-#if USE(VULKAN)
         m_glExtensions.EXT_memory_object = isExtensionSupported(extensionsString, "GL_EXT_memory_object");
-#endif
     });
     return m_glExtensions;
+}
+
+std::optional<GLContext::DeviceIdentity> GLContext::deviceIdentity() const
+{
+    if (!glExtensions().EXT_memory_object)
+        return std::nullopt;
+
+    GLint deviceUUIDCount = 0;
+    glGetIntegerv(GL_NUM_DEVICE_UUIDS_EXT, &deviceUUIDCount);
+    if (deviceUUIDCount != 1)
+        return std::nullopt;
+
+    static_assert(DeviceIdentity::uuidSize == GL_UUID_SIZE_EXT);
+    DeviceIdentity identity;
+    glGetUnsignedBytei_vEXT(GL_DEVICE_UUID_EXT, 0, identity.deviceUUID.data());
+    glGetUnsignedBytevEXT(GL_DRIVER_UUID_EXT, identity.driverUUID.data());
+    return identity;
 }
 
 GLContext::ScopedGLContext::ScopedGLContext(std::unique_ptr<GLContext>&& context)

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -102,11 +102,16 @@ public:
         bool APPLE_sync { false };
         bool OES_packed_depth_stencil { false };
         bool EXT_YUV_target { false };
-#if USE(VULKAN)
         bool EXT_memory_object { false };
-#endif
     };
     const GLExtensions& glExtensions() const;
+
+    struct DeviceIdentity {
+        static constexpr size_t uuidSize = 16; // GL_UUID_SIZE_EXT, checked in GLContext.cpp.
+        std::array<uint8_t, uuidSize> deviceUUID { };
+        std::array<uint8_t, uuidSize> driverUUID { };
+    };
+    std::optional<DeviceIdentity> deviceIdentity() const;
 
     class ScopedGLContext {
         WTF_MAKE_NONCOPYABLE(ScopedGLContext);

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
@@ -257,6 +257,7 @@ void GraphicsContextGLTextureMapperGBM::prepareForDisplayWithFinishedSignal(Func
 }
 
 #if ENABLE(WEBXR)
+#if !USE(OPENXR_VULKAN)
 GCGLExternalImage GraphicsContextGLTextureMapperGBM::createExternalImage(ExternalImageSource&& source, GCGLenum, GCGLint)
 {
     GraphicsContextGLExternalImageSource imageSource = WTF::move(source);
@@ -285,6 +286,7 @@ GCGLExternalImage GraphicsContextGLTextureMapperGBM::createExternalImage(Externa
     m_eglImages.add(newName, eglImage);
     return newName;
 }
+#endif // !USE(OPENXR_VULKAN)
 
 void GraphicsContextGLTextureMapperGBM::bindExternalImage(GCGLenum target, GCGLExternalImage image)
 {

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
@@ -288,24 +288,6 @@ GCGLExternalImage GraphicsContextGLTextureMapperGBM::createExternalImage(Externa
 }
 #endif // !USE(OPENXR_VULKAN)
 
-void GraphicsContextGLTextureMapperGBM::bindExternalImage(GCGLenum target, GCGLExternalImage image)
-{
-    if (!makeContextCurrent())
-        return;
-    EGLImage eglImage = EGL_NO_IMAGE_KHR;
-    if (image) {
-        eglImage = m_eglImages.get(image);
-        if (!eglImage) {
-            addError(GCGLErrorCode::InvalidOperation);
-            return;
-        }
-    }
-    if (target == RENDERBUFFER)
-        GL_EGLImageTargetRenderbufferStorageOES(RENDERBUFFER, eglImage);
-    else
-        GL_EGLImageTargetTexture2DOES(target, eglImage);
-}
-
 bool GraphicsContextGLTextureMapperGBM::enableRequiredWebXRExtensions()
 {
     if (!makeContextCurrent())
@@ -318,7 +300,13 @@ bool GraphicsContextGLTextureMapperGBM::enableRequiredWebXRExtensionsImpl()
 {
     return enableExtensionsImpl({
         "GL_OES_EGL_image"_s,
-        "GL_OES_EGL_image_external"_s
+        "GL_OES_EGL_image_external"_s,
+#if USE(OPENXR_VULKAN)
+        "GL_EXT_memory_object"_s,
+        "GL_EXT_memory_object_fd"_s,
+        "GL_EXT_semaphore"_s,
+        "GL_EXT_semaphore_fd"_s,
+#endif
     });
 }
 #endif // ENABLE(WEBXR)

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h
@@ -51,7 +51,6 @@ public:
 #if !USE(OPENXR_VULKAN)
     GCGLExternalImage createExternalImage(ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) final;
 #endif
-    void bindExternalImage(GCGLenum target, GCGLExternalImage) final;
     bool enableRequiredWebXRExtensions() final;
 #endif
 

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h
@@ -48,7 +48,9 @@ public:
     DMABufBuffer* displayBuffer() { return m_displayBuffer.dmabuf.get(); }
 
 #if ENABLE(WEBXR)
+#if !USE(OPENXR_VULKAN)
     GCGLExternalImage createExternalImage(ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) final;
+#endif
     void bindExternalImage(GCGLenum target, GCGLExternalImage) final;
     bool enableRequiredWebXRExtensions() final;
 #endif

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -35,8 +35,11 @@
 #include "Logging.h"
 #include "PixelBuffer.h"
 #include "PlatformDisplay.h"
+#include <wtf/HexNumber.h>
+#include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/StringBuilder.h>
 
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
 #include "VideoFrame.h"
@@ -457,11 +460,18 @@ unsigned GraphicsContextGLTextureMapperANGLE::glVersion() const
 }
 
 #if ENABLE(WEBXR)
-GCGLExternalSync GraphicsContextGLTextureMapperANGLE::createExternalSync(ExternalSyncSource&&)
+GCGLExternalSync GraphicsContextGLTextureMapperANGLE::createExternalSync(ExternalSyncSource&& image)
 {
     const auto& display = PlatformDisplay::sharedDisplay();
     if (!display.eglCheckVersion(1, 5) || !display.eglExtensions().ANDROID_native_fence_sync)
         return { };
+
+#if USE(OPENXR_VULKAN)
+    if (!handBackExternalImage(image))
+        return { };
+#else
+    UNUSED_PARAM(image);
+#endif
 
     auto eglSync = EGL_CreateSync(m_displayObj, EGL_SYNC_NATIVE_FENCE_ANDROID, nullptr);
     if (!eglSync) {
@@ -473,6 +483,24 @@ GCGLExternalSync GraphicsContextGLTextureMapperANGLE::createExternalSync(Externa
     auto newName = ++m_nextExternalSyncName;
     m_eglSyncs.add(newName, eglSync);
     return newName;
+}
+
+void GraphicsContextGLTextureMapperANGLE::bindExternalImage(GCGLenum target, GCGLExternalImage image)
+{
+    if (!makeContextCurrent())
+        return;
+    EGLImage eglImage = EGL_NO_IMAGE_KHR;
+    if (image) {
+        eglImage = m_eglImages.get(image);
+        if (!eglImage) {
+            addError(GCGLErrorCode::InvalidOperation);
+            return;
+        }
+    }
+    if (target == RENDERBUFFER)
+        GL_EGLImageTargetRenderbufferStorageOES(RENDERBUFFER, eglImage);
+    else
+        GL_EGLImageTargetTexture2DOES(target, eglImage);
 }
 
 #if USE(OPENXR)
@@ -489,6 +517,136 @@ UnixFileDescriptor GraphicsContextGLTextureMapperANGLE::exportExternalSync(GCGLE
 
     return UnixFileDescriptor { EGL_DupNativeFenceFDANDROID(m_displayObj, eglSync), UnixFileDescriptor::Adopt };
 }
+
+#if USE(OPENXR_VULKAN)
+static bool matchesExternalDeviceIdentity(std::span<const uint64_t, 2> deviceUUID, std::span<const uint64_t, 2> driverUUID)
+{
+    // ANGLE leaves glGetUnsignedBytevEXT unimplemented, so the UUIDs come from the same native EGL display.
+    auto* context = PlatformDisplay::sharedDisplay().sharingGLContext();
+    if (!context)
+        return false;
+
+    GLContext::ScopedGLContextCurrent scopedContext(*context);
+    auto identity = context->deviceIdentity();
+    if (!identity) {
+        RELEASE_LOG_ERROR(XR, "matchesExternalDeviceIdentity: the GL driver does not report device and driver UUIDs, so an opaque fd cannot be imported");
+        return false;
+    }
+
+    if (equalSpans(std::span<const uint8_t> { identity->deviceUUID }, asByteSpan(deviceUUID))
+        && equalSpans(std::span<const uint8_t> { identity->driverUUID }, asByteSpan(driverUUID)))
+        return true;
+
+    auto loggingString = [](std::span<const uint8_t> uuid) {
+        StringBuilder builder;
+        for (auto byte : uuid)
+            builder.append(hex(byte, 2, Lowercase));
+        return builder.toString().utf8();
+    };
+    RELEASE_LOG_ERROR(XR, "matchesExternalDeviceIdentity: exporter device %s driver %s but this GL context is device %s driver %s",
+        loggingString(asByteSpan(deviceUUID)).data(), loggingString(asByteSpan(driverUUID)).data(),
+        loggingString(identity->deviceUUID).data(), loggingString(identity->driverUUID).data());
+    return false;
+}
+
+#define RETURN_IF_GL_ERROR(source, operation) do { \
+        auto error = GL_GetError(); \
+        if (error != NO_ERROR) { \
+            RELEASE_LOG_ERROR(XR, "%s: " operation " failed with GL error 0x%04x (allocationSize %" PRIu64 ", internalFormat 0x%04x, %dx%d)", \
+                __func__, error, (source).allocationSize, (source).internalFormat, (source).size.width(), (source).size.height()); \
+            return { }; \
+        } \
+    } while (0)
+
+GCGLExternalImage GraphicsContextGLTextureMapperANGLE::createExternalImage(ExternalImageSource&& source, GCGLenum, GCGLint)
+{
+    if (!matchesExternalDeviceIdentity(source.deviceUUID, source.driverUUID))
+        return { };
+
+    if (!makeContextCurrent())
+        return { };
+
+    OpaqueFDImageObjects objects;
+    auto deleteObjectsOnError = makeScopeExit([&] {
+        deleteOpaqueFDImageObjects(objects);
+    });
+
+    GL_CreateMemoryObjectsEXT(1, &objects.memoryObject);
+    RETURN_IF_GL_ERROR(source, "glCreateMemoryObjectsEXT");
+
+    // Matches the exporter's dedicated allocation. If the two disagree the import is invalid.
+    GCGLint dedicated = 1;
+    GL_MemoryObjectParameterivEXT(objects.memoryObject, DEDICATED_MEMORY_OBJECT_EXT, &dedicated);
+    RETURN_IF_GL_ERROR(source, "glMemoryObjectParameterivEXT");
+
+    // glImportMemoryFdEXT takes ownership of the descriptor.
+    GL_ImportMemoryFdEXT(objects.memoryObject, source.allocationSize, HANDLE_TYPE_OPAQUE_FD_EXT, source.memory.release());
+    RETURN_IF_GL_ERROR(source, "glImportMemoryFdEXT");
+
+    GL_GenTextures(1, &objects.texture);
+    GL_BindTexture(TEXTURE_2D, objects.texture);
+    GL_TexStorageMem2DEXT(TEXTURE_2D, 1, source.internalFormat, source.size.width(), source.size.height(), objects.memoryObject, 0);
+    RETURN_IF_GL_ERROR(source, "glTexStorageMem2DEXT");
+
+    GL_GenSemaphoresEXT(1, &objects.renderFinishedSemaphore);
+    GL_ImportSemaphoreFdEXT(objects.renderFinishedSemaphore, HANDLE_TYPE_OPAQUE_FD_EXT, source.renderFinishedSemaphore.release());
+    RETURN_IF_GL_ERROR(source, "glImportSemaphoreFdEXT");
+
+    // The texture only exists because GL_EXT_memory_object cannot back a renderbuffer directly. Wrapping it in an EGLImage lets
+    // everything above bind it exactly like an imported dma-buf, at the cost of one extra object per swapchain image.
+    std::array<EGLAttrib, 3> imageAttributes { EGL_GL_TEXTURE_LEVEL, 0, EGL_NONE };
+    auto eglImage = EGL_CreateImage(m_displayObj, m_contextObj, EGL_GL_TEXTURE_2D, reinterpret_cast<EGLClientBuffer>(static_cast<uintptr_t>(objects.texture)), imageAttributes.data());
+    if (!eglImage) {
+        RELEASE_LOG_ERROR(XR, "%s: eglCreateImage failed with EGL error 0x%04x", __func__, EGL_GetError());
+        return { };
+    }
+
+    deleteObjectsOnError.release();
+    auto name = ++m_nextExternalImageName;
+    m_eglImages.add(name, eglImage);
+    m_opaqueFDImages.add(name, objects);
+    return name;
+}
+#undef RETURN_IF_GL_ERROR
+
+void GraphicsContextGLTextureMapperANGLE::deleteOpaqueFDImageObjects(OpaqueFDImageObjects& objects)
+{
+    if (objects.renderFinishedSemaphore)
+        GL_DeleteSemaphoresEXT(1, &objects.renderFinishedSemaphore);
+    if (objects.memoryObject)
+        GL_DeleteMemoryObjectsEXT(1, &objects.memoryObject);
+    if (objects.texture)
+        GL_DeleteTextures(1, &objects.texture);
+}
+
+void GraphicsContextGLTextureMapperANGLE::deleteExternalImage(GCGLExternalImage image)
+{
+    if (image && makeContextCurrent()) {
+        auto objects = m_opaqueFDImages.take(image);
+        deleteOpaqueFDImageObjects(objects);
+    }
+
+    GraphicsContextGLANGLE::deleteExternalImage(image);
+}
+
+bool GraphicsContextGLTextureMapperANGLE::handBackExternalImage(GCGLExternalImage image)
+{
+    auto entry = m_opaqueFDImages.find(image);
+    if (entry == m_opaqueFDImages.end()) {
+        RELEASE_LOG_ERROR(XR, "handBackExternalImage: %u is not an imported image, so this frame cannot be handed back", image);
+        return false;
+    }
+
+    if (!makeContextCurrent())
+        return false;
+
+    // Signals the semaphore the exporting process waits on and names the layout it reads the image in, which GL has no other way of stating.
+    // Nothing acquires it back as the UIProcess does not hand the image out again until it has finished reading it.
+    GCGLenum layout = LAYOUT_TRANSFER_SRC_EXT;
+    GL_SignalSemaphoreEXT(entry->value.renderFinishedSemaphore, 0, nullptr, 1, &entry->value.texture, &layout);
+    return true;
+}
+#endif
 #endif
 
 bool GraphicsContextGLTextureMapperANGLE::addFoveation(IntSize, IntSize, IntSize, std::span<const GCGLfloat>, std::span<const GCGLfloat>, std::span<const GCGLfloat>)
@@ -514,7 +672,13 @@ bool GraphicsContextGLTextureMapperANGLE::enableRequiredWebXRExtensions()
         "GL_ANGLE_framebuffer_blit"_s,
         "GL_EXT_discard_framebuffer"_s,
         "GL_OES_EGL_image"_s,
-        "GL_OES_rgb8_rgba8"_s
+        "GL_OES_rgb8_rgba8"_s,
+#if USE(OPENXR_VULKAN)
+        "GL_EXT_memory_object"_s,
+        "GL_EXT_memory_object_fd"_s,
+        "GL_EXT_semaphore"_s,
+        "GL_EXT_semaphore_fd"_s,
+#endif
     });
 }
 #endif

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -59,8 +59,13 @@ public:
 
 #if ENABLE(WEBXR)
     GCGLExternalSync createExternalSync(ExternalSyncSource&&) final;
+    void bindExternalImage(GCGLenum target, GCGLExternalImage) final;
 #if USE(OPENXR)
     WTF::UnixFileDescriptor exportExternalSync(GCGLExternalSync) final;
+#if USE(OPENXR_VULKAN)
+    GCGLExternalImage createExternalImage(ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) override;
+    void deleteExternalImage(GCGLExternalImage) final;
+#endif
 #endif
 
     bool addFoveation(IntSize, IntSize, IntSize, std::span<const GCGLfloat>, std::span<const GCGLfloat>, std::span<const GCGLfloat>) final;
@@ -94,6 +99,18 @@ private:
     GCGLuint m_compositorTexture { 0 };
     bool m_isCompositorTextureInitialized { false };
     mutable unsigned m_version { 0 };
+
+#if ENABLE(WEBXR) && USE(OPENXR_VULKAN)
+    bool handBackExternalImage(GCGLExternalImage);
+
+    struct OpaqueFDImageObjects {
+        GCGLuint memoryObject { 0 };
+        PlatformGLObject texture { 0 };
+        GCGLuint renderFinishedSemaphore { 0 };
+    };
+    void deleteOpaqueFDImageObjects(OpaqueFDImageObjects&);
+    HashMap<GCGLExternalImage, OpaqueFDImageObjects, IntHash<GCGLExternalImage>, WTF::UnsignedWithZeroKeyHashTraits<GCGLExternalImage>> m_opaqueFDImages;
+#endif
 
 #if USE(COORDINATED_GRAPHICS) && USE(LIBEPOXY)
     GCGLuint m_textureID { 0 };

--- a/Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp
@@ -377,29 +377,19 @@ Result<PhysicalDevice> Instance::deviceForDisplay(PlatformDisplay& display)
     //
     if (auto* context = display.sharingGLContext()) {
         GLContext::ScopedGLContextCurrent scopedContext(*context);
-        RELEASE_LOG_DEBUG(Vulkan, "deviceForDisplay: GL_EXT_memory_object = %s", context->glExtensions().EXT_memory_object ? "yes" : "no");
-        if (context->glExtensions().EXT_memory_object) {
-            GLint deviceUUIDCount = 0;
-            glGetIntegerv(GL_NUM_DEVICE_UUIDS_EXT, &deviceUUIDCount);
-            RELEASE_LOG_DEBUG(Vulkan, "deviceForDisplay: found %d device UUIDs", deviceUUIDCount);
-            if (deviceUUIDCount == 1) {
-                std::array<GLubyte, GL_UUID_SIZE_EXT> deviceUUID;
-                glGetUnsignedBytei_vEXT(GL_DEVICE_UUID_EXT, 0, deviceUUID.data());
-
-                std::array<GLubyte, GL_UUID_SIZE_EXT> driverUUID;
-                glGetUnsignedBytei_vEXT(GL_DRIVER_UUID_EXT, 0, driverUUID.data());
-
-                auto index = devices->findIf([&deviceUUID, &driverUUID](const auto& deviceInfo) {
-                    PhysicalDeviceProperties properties;
-                    auto idProperties = properties.next<PhysicalDeviceIDProperties>();
-                    deviceInfo.fillProperties(properties);
-                    return equalSpans(std::span(deviceUUID), idProperties.deviceUUID())
-                        && equalSpans(std::span(driverUUID), idProperties.driverUUID());
-                });
-                if (index != notFound) {
-                    RELEASE_LOG_DEBUG(Vulkan, "deviceForDisplay: matched device/driver UUIDs");
-                    return devices->at(index);
-                }
+        auto identity = context->deviceIdentity();
+        RELEASE_LOG_DEBUG(Vulkan, "deviceForDisplay: GL device identity = %s", identity ? "available" : "unavailable");
+        if (identity) {
+            auto index = devices->findIf([&identity](const auto& deviceInfo) {
+                PhysicalDeviceProperties properties;
+                auto idProperties = properties.next<PhysicalDeviceIDProperties>();
+                deviceInfo.fillProperties(properties);
+                return equalSpans(std::span<const uint8_t> { identity->deviceUUID }, idProperties.deviceUUID())
+                    && equalSpans(std::span<const uint8_t> { identity->driverUUID }, idProperties.driverUUID());
+            });
+            if (index != notFound) {
+                RELEASE_LOG_DEBUG(Vulkan, "deviceForDisplay: matched device/driver UUIDs");
+                return devices->at(index);
             }
         }
     }

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -303,7 +303,6 @@ struct LayerInfo {
     size_t numImages { 1 };
 };
 
-
 #if ENABLE(WEBXR_HIT_TEST)
 struct Ray {
     WebCore::FloatPoint3D origin;
@@ -385,24 +384,41 @@ struct FrameData {
 #endif
     };
 
-#if OS(ANDROID)
+#if OS(ANDROID) && !USE(OPENXR_VULKAN)
     using ExternalTexture = RefPtr<AHardwareBuffer>;
-#else
+#elif PLATFORM(COCOA)
     struct ExternalTexture {
-#if PLATFORM(COCOA)
         MachSendRight handle;
         bool isSharedTexture { false };
 
         explicit operator bool() const { return !!handle; }
+    };
+#else
+    struct ExternalTexture {
+#if USE(OPENXR_VULKAN)
+        WTF::UnixFileDescriptor memory;
+        uint64_t allocationSize { 0 };
+        uint32_t glInternalFormat { 0 };
+        WTF::UnixFileDescriptor renderFinishedSemaphore;
+        // 16 bytes each, carried as integer pairs because a byte-typed array is an opaque data type to the serialization generator and would need a justification entry in opaque_ipc_types.tracking.in.
+        std::array<uint64_t, 2> deviceUUID { };
+        std::array<uint64_t, 2> driverUUID { };
 #else
         Vector<WTF::UnixFileDescriptor> fds;
         Vector<uint32_t> strides;
         Vector<uint32_t> offsets;
         uint32_t fourcc;
         uint64_t modifier;
-
-        explicit operator bool() const { return !fds.isEmpty(); }
 #endif
+
+        explicit operator bool() const
+        {
+#if USE(OPENXR_VULKAN)
+            return !!memory;
+#else
+            return !fds.isEmpty();
+#endif
+        }
     };
 #endif
 

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -369,6 +369,9 @@ endif ()
 
 if (USE_OPENXR)
    list(APPEND WebKit_LIBRARIES OpenXR::openxr_loader)
+   if (XR_USE_GRAPHICS_API_VULKAN)
+       list(APPEND WebKit_LIBRARIES volk::volk)
+   endif ()
 endif ()
 
 if (USE_LIBWEBRTC)

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -490,6 +490,9 @@ endif ()
 
 if (USE_OPENXR)
    list(APPEND WebKit_LIBRARIES OpenXR::openxr_loader)
+   if (XR_USE_GRAPHICS_API_VULKAN)
+       list(APPEND WebKit_LIBRARIES volk::volk)
+   endif ()
 endif ()
 
 if (ENABLE_BUBBLEWRAP_SANDBOX)

--- a/Source/WebKit/Shared/WebGL.serialization.in
+++ b/Source/WebKit/Shared/WebGL.serialization.in
@@ -124,7 +124,7 @@ using WebCore::GraphicsContextGL::ExternalSyncSource = std::tuple<MachSendRight,
     WebCore::IntSize size;
 };
 using WebCore::GraphicsContextGL::ExternalImageSource = WebCore::GraphicsContextGLExternalImageSource;
-using WebCore::GraphicsContextGL::ExternalSyncSource = int
+using WebCore::GraphicsContextGL::ExternalSyncSource = GCGLExternalImage
 #else
 using WebCore::GraphicsContextGL::ExternalImageSource = int
 using WebCore::GraphicsContextGL::ExternalSyncSource = int

--- a/Source/WebKit/Shared/WebGL.serialization.in
+++ b/Source/WebKit/Shared/WebGL.serialization.in
@@ -103,9 +103,18 @@ using WebCore::GraphicsContextGL::ExternalSyncSource = std::tuple<MachSendRight,
 #if !PLATFORM(COCOA)
 #if (PLATFORM(GTK) || PLATFORM(WPE))
 [CustomHeader] struct WebCore::GraphicsContextGLExternalImageSource {
-#if OS(ANDROID)
+#if OS(ANDROID) && !USE(OPENXR_VULKAN)
     RefPtr<AHardwareBuffer> hardwareBuffer;
-#else
+#endif
+#if USE(OPENXR_VULKAN)
+    WTF::UnixFileDescriptor memory;
+    uint64_t allocationSize;
+    GCGLenum internalFormat;
+    WTF::UnixFileDescriptor renderFinishedSemaphore;
+    std::array<uint64_t, 2> deviceUUID;
+    std::array<uint64_t, 2> driverUUID;
+#endif
+#if !OS(ANDROID) && !USE(OPENXR_VULKAN)
     Vector<WTF::UnixFileDescriptor> fds;
     Vector<uint32_t> strides;
     Vector<uint32_t> offsets;
@@ -115,10 +124,11 @@ using WebCore::GraphicsContextGL::ExternalSyncSource = std::tuple<MachSendRight,
     WebCore::IntSize size;
 };
 using WebCore::GraphicsContextGL::ExternalImageSource = WebCore::GraphicsContextGLExternalImageSource;
+using WebCore::GraphicsContextGL::ExternalSyncSource = int
 #else
 using WebCore::GraphicsContextGL::ExternalImageSource = int
-#endif
 using WebCore::GraphicsContextGL::ExternalSyncSource = int
+#endif
 #endif
 
 header: <WebCore/GraphicsContextGLAttributes.h>

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -144,13 +144,21 @@ header: <WebCore/PlatformXR.h>
 #endif
 };
 
-#if !OS(ANDROID)
+#if !OS(ANDROID) || USE(OPENXR_VULKAN)
 [Nested, RValue] struct PlatformXR::FrameData::ExternalTexture {
 #if PLATFORM(COCOA)
     MachSendRight handle;
     bool isSharedTexture;
 #endif
-#if !PLATFORM(COCOA)
+#if !PLATFORM(COCOA) && USE(OPENXR_VULKAN)
+    WTF::UnixFileDescriptor memory;
+    uint64_t allocationSize;
+    uint32_t glInternalFormat;
+    WTF::UnixFileDescriptor renderFinishedSemaphore;
+    std::array<uint64_t, 2> deviceUUID;
+    std::array<uint64_t, 2> driverUUID;
+#endif
+#if !PLATFORM(COCOA) && !USE(OPENXR_VULKAN)
     Vector<WTF::UnixFileDescriptor> fds;
     Vector<uint32_t> strides;
     Vector<uint32_t> offsets;
@@ -158,7 +166,7 @@ header: <WebCore/PlatformXR.h>
     uint64_t modifier;
 #endif
 };
-#endif // !OS(ANDROID)
+#endif // !OS(ANDROID) || USE(OPENXR_VULKAN)
 
 [Nested, RValue] struct PlatformXR::FrameData::ExternalTextureData {
     uint64_t reusableTextureIndex;

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -313,6 +313,7 @@ UIProcess/soup/WebProcessPoolSoup.cpp
 
 UIProcess/XR/openxr/OpenXRExtensions.cpp
 UIProcess/XR/openxr/OpenXRGraphicsBindingOpenGLES.cpp
+UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
 UIProcess/XR/openxr/OpenXRHitTestManager.cpp
 UIProcess/XR/openxr/OpenXRInput.cpp
 UIProcess/XR/openxr/OpenXRInputSource.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -300,6 +300,7 @@ UIProcess/wpe/WebContextMenuProxyWPE.cpp
 
 UIProcess/XR/openxr/OpenXRExtensions.cpp
 UIProcess/XR/openxr/OpenXRGraphicsBindingOpenGLES.cpp
+UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
 UIProcess/XR/openxr/OpenXRHitTestManager.cpp
 UIProcess/XR/openxr/OpenXRInput.cpp
 UIProcess/XR/openxr/OpenXRInputSource.cpp

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp
@@ -90,6 +90,16 @@ bool OpenXRExtensions::loadMethods(XrInstance instance)
         return false;
     }
 #endif
+#if defined(XR_USE_GRAPHICS_API_VULKAN)
+    xrGetInstanceProcAddr(instance, "xrGetVulkanGraphicsRequirements2KHR", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrGetVulkanGraphicsRequirements2KHR));
+    xrGetInstanceProcAddr(instance, "xrCreateVulkanInstanceKHR", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrCreateVulkanInstanceKHR));
+    xrGetInstanceProcAddr(instance, "xrGetVulkanGraphicsDevice2KHR", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrGetVulkanGraphicsDevice2KHR));
+    xrGetInstanceProcAddr(instance, "xrCreateVulkanDeviceKHR", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrCreateVulkanDeviceKHR));
+    if (!m_methods->xrGetVulkanGraphicsRequirements2KHR || !m_methods->xrCreateVulkanInstanceKHR || !m_methods->xrGetVulkanGraphicsDevice2KHR || !m_methods->xrCreateVulkanDeviceKHR) {
+        LOG(XR, "Failed to load the KHR_vulkan_enable2 functions");
+        return false;
+    }
+#endif
 #if defined(XR_EXT_hand_tracking)
     if (isExtensionSupported(XR_EXT_HAND_TRACKING_EXTENSION_NAME ""_span)) {
         xrGetInstanceProcAddr(instance, "xrCreateHandTrackerEXT", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrCreateHandTrackerEXT));

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
@@ -42,6 +42,11 @@ typedef void (*(*PFNEGLGETPROCADDRESSPROC)(const char *))(void);
 #include <jni.h>
 #endif
 
+// The Vulkan types need to be defined before including openxr_platform.h
+#if defined(XR_USE_GRAPHICS_API_VULKAN)
+#include <volk.h>
+#endif
+
 #include <openxr/openxr_platform.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
@@ -57,6 +62,12 @@ public:
 #endif
 #if defined(XR_USE_GRAPHICS_API_OPENGL_ES)
     PFN_xrGetOpenGLESGraphicsRequirementsKHR xrGetOpenGLESGraphicsRequirementsKHR { nullptr };
+#endif
+#if defined(XR_USE_GRAPHICS_API_VULKAN)
+    PFN_xrGetVulkanGraphicsRequirements2KHR xrGetVulkanGraphicsRequirements2KHR { nullptr };
+    PFN_xrCreateVulkanInstanceKHR xrCreateVulkanInstanceKHR { nullptr };
+    PFN_xrGetVulkanGraphicsDevice2KHR xrGetVulkanGraphicsDevice2KHR { nullptr };
+    PFN_xrCreateVulkanDeviceKHR xrCreateVulkanDeviceKHR { nullptr };
 #endif
 #if defined(XR_EXT_hand_tracking)
     PFN_xrCreateHandTrackerEXT xrCreateHandTrackerEXT { nullptr };

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
@@ -33,12 +33,18 @@
 #include <array>
 #include <bit>
 #include <cstring>
-#include <drm_fourcc.h>
 #include <utility>
 #include <wtf/RunLoop.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/unix/UnixFileDescriptor.h>
+
+#if USE(GBM)
+#include <drm_fourcc.h>
+#endif
+#if OS(ANDROID)
+#include <android/hardware_buffer.h>
+#endif
 
 namespace WebKit {
 
@@ -175,17 +181,22 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
     }
     m_queueFamilyIndex = *graphicsFamily;
 
-    // Extensions required to export our own images as dma-bufs to the web process, to import the web process' frame fence as a
-    // semaphore, and to acquire/release queue-family ownership of the externally-written image (VK_QUEUE_FAMILY_FOREIGN_EXT).
-    // The OpenXR runtime appends its own required extensions on top of these. If the device cannot provide them,
-    // xrCreateVulkanDeviceKHR fails below and no session is created, which is intended: the binding has no usable path without
-    // them.
-    static constexpr std::array<const char*, 4> deviceExtensions { {
-        VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
-        VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME,
+    // Extensions to hand our own images to the web process, to import the web process' frame fence as a semaphore, and to
+    // acquire/release queue-family ownership of the externally-written image (VK_QUEUE_FAMILY_FOREIGN_EXT). The external-memory
+    // extension differs per platform: a dma-buf on Linux/GBM, an AHardwareBuffer on Android (its other dependencies — YCbCr
+    // conversion, bind-memory2, dedicated allocation — are core from Vulkan 1.1, which we always request). The OpenXR runtime
+    // appends its own required extensions on top. If the device cannot provide these, xrCreateVulkanDeviceKHR fails below and no
+    // session is created, which is intended: the binding has no usable path without them.
+    Vector<const char*> requiredExtensions {
         VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
         VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME,
-    } };
+    };
+#if USE(GBM)
+    requiredExtensions.append(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
+    requiredExtensions.append(VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME);
+#elif OS(ANDROID)
+    requiredExtensions.append(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+#endif
 
     // Report which device the runtime selected and whether it advertises the extensions we need, so a
     // VK_ERROR_EXTENSION_NOT_PRESENT from xrCreateVulkanDeviceKHR below points at the actual cause (e.g. the runtime picked a
@@ -197,13 +208,28 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
     m_instanceTable.vkEnumerateDeviceExtensionProperties(m_vkPhysicalDevice, nullptr, &availableExtensionCount, nullptr);
     Vector<VkExtensionProperties> availableExtensions(availableExtensionCount);
     m_instanceTable.vkEnumerateDeviceExtensionProperties(m_vkPhysicalDevice, nullptr, &availableExtensionCount, availableExtensions.mutableSpan().data());
-    for (auto* required : deviceExtensions) {
-        bool available = availableExtensions.containsIf([&](const auto& extension) {
-            return StringView::fromLatin1(extension.extensionName) == StringView::fromLatin1(required);
+    auto isExtensionAvailable = [&](const char* name) {
+        return availableExtensions.containsIf([&](const auto& extension) {
+            return StringView::fromLatin1(extension.extensionName) == StringView::fromLatin1(name);
         });
-        if (!available)
+    };
+
+    Vector<const char*> enabledExtensions;
+    for (auto* required : requiredExtensions) {
+        if (!isExtensionAvailable(required))
             LOG(XR, "OpenXR Vulkan: required device extension %s not supported by '%s'", required, physicalDeviceProperties.deviceName);
+        enabledExtensions.append(required);
     }
+#if USE(GBM)
+    // VK_EXT_image_drm_format_modifier is optional (exportImageAsDMABuf falls back to a linear image without it); its
+    // VK_KHR_image_format_list dependency is core from Vulkan 1.2 but must be enabled explicitly on 1.1.
+    if (isExtensionAvailable(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME)) {
+        enabledExtensions.append(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
+        if (isExtensionAvailable(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME))
+            enabledExtensions.append(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
+        m_supportsDRMModifiers = true;
+    }
+#endif // USE(GBM)
 
     const float queuePriority = 1.0f;
     VkDeviceQueueCreateInfo queueCreateInfo { };
@@ -216,8 +242,8 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
     vkDeviceCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
     vkDeviceCreateInfo.queueCreateInfoCount = 1;
     vkDeviceCreateInfo.pQueueCreateInfos = &queueCreateInfo;
-    vkDeviceCreateInfo.enabledExtensionCount = deviceExtensions.size();
-    vkDeviceCreateInfo.ppEnabledExtensionNames = deviceExtensions.data();
+    vkDeviceCreateInfo.enabledExtensionCount = static_cast<uint32_t>(enabledExtensions.size());
+    vkDeviceCreateInfo.ppEnabledExtensionNames = enabledExtensions.span().data();
 
     auto xrDeviceCreateInfo = createOpenXRStruct<XrVulkanDeviceCreateInfoKHR, XR_TYPE_VULKAN_DEVICE_CREATE_INFO_KHR>();
     xrDeviceCreateInfo.systemId = systemId;
@@ -354,6 +380,7 @@ void OpenXRGraphicsBindingVulkan::destroyExportedImage(ExportedImage& exportedIm
     exportedImage = { };
 }
 
+#if USE(GBM) || OS(ANDROID)
 static std::optional<uint32_t> findMemoryType(const VolkInstanceTable& instanceTable, VkPhysicalDevice physicalDevice, uint32_t memoryTypeBits, VkMemoryPropertyFlags properties)
 {
     VkPhysicalDeviceMemoryProperties memoryProperties;
@@ -367,7 +394,9 @@ static std::optional<uint32_t> findMemoryType(const VolkInstanceTable& instanceT
     }
     return std::nullopt;
 }
+#endif // USE(GBM) || OS(ANDROID)
 
+#if USE(GBM)
 static uint32_t drmFourCCForVkFormat(VkFormat format)
 {
     switch (format) {
@@ -381,22 +410,113 @@ static uint32_t drmFourCCForVkFormat(VkFormat format)
         return DRM_FORMAT_INVALID;
     }
 }
+#endif // USE(GBM)
+
+bool OpenXRGraphicsBindingVulkan::createExportedImageSyncObjects(ExportedImage& exportedImage)
+{
+    // The fence starts signaled so the first commitFrame() that reuses this image waits on it without a special case.
+    VkFenceCreateInfo fenceCreateInfo { };
+    fenceCreateInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    fenceCreateInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+    if (m_deviceTable.vkCreateFence(m_vkDevice, &fenceCreateInfo, nullptr, &exportedImage.inFlightFence) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateFence failed for exported texture");
+        return false;
+    }
+
+    VkSemaphoreCreateInfo semaphoreCreateInfo { };
+    semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+    if (m_deviceTable.vkCreateSemaphore(m_vkDevice, &semaphoreCreateInfo, nullptr, &exportedImage.acquireSemaphore) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateSemaphore failed for exported texture");
+        return false;
+    }
+    return true;
+}
 
 std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulkan::exportTexture(uint64_t image, const OpenXRSwapchain& swapchain, TextureType type, uint32_t width, uint32_t height)
 {
     ASSERT(m_vkDevice != VK_NULL_HANDLE);
 
-    switch (type) {
-    case TextureType::Texture2D:
-        return exportTexture2D(image, swapchain, width, height);
-    case TextureType::Cubemap:
+    if (type != TextureType::Texture2D) {
         // FIXME: cube layers are not implemented yet for the Vulkan binding.
-        break;
+        return std::nullopt;
     }
+
+#if USE(GBM)
+    return exportImageAsDMABuf(image, swapchain, width, height);
+#elif OS(ANDROID)
+    // Android shares the buffer as an AHardwareBuffer instead of a DMABuf.
+    return exportImageAsAHardwareBuffer(image, swapchain, width, height);
+#else
+    // No external-texture path without GBM (DMABuf) or Android (AHardwareBuffer), so nothing is exported.
+    UNUSED_PARAM(image);
+    UNUSED_PARAM(swapchain);
+    UNUSED_PARAM(type);
+    UNUSED_PARAM(width);
+    UNUSED_PARAM(height);
     return std::nullopt;
+#endif
 }
 
-std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulkan::exportTexture2D(uint64_t swapchainImage, const OpenXRSwapchain& swapchain, uint32_t width, uint32_t height)
+#if USE(GBM)
+Vector<VkDrmFormatModifierPropertiesEXT> OpenXRGraphicsBindingVulkan::supportedExportDRMModifiers(VkFormat format, VkImageUsageFlags usage) const
+{
+    VkDrmFormatModifierPropertiesListEXT modifierList { };
+    modifierList.sType = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT;
+    VkFormatProperties2 formatProperties { };
+    formatProperties.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+    formatProperties.pNext = &modifierList;
+    m_instanceTable.vkGetPhysicalDeviceFormatProperties2(m_vkPhysicalDevice, format, &formatProperties);
+    Vector<VkDrmFormatModifierPropertiesEXT> allModifiers(modifierList.drmFormatModifierCount);
+    modifierList.pDrmFormatModifierProperties = allModifiers.mutableSpan().data();
+    m_instanceTable.vkGetPhysicalDeviceFormatProperties2(m_vkPhysicalDevice, format, &formatProperties);
+
+    VkFormatFeatureFlags requiredFeatures = 0;
+    if (usage & VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
+        requiredFeatures |= VK_FORMAT_FEATURE_TRANSFER_SRC_BIT;
+    if (usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT)
+        requiredFeatures |= VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
+    if (usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
+        requiredFeatures |= VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT;
+    if (usage & VK_IMAGE_USAGE_SAMPLED_BIT)
+        requiredFeatures |= VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
+    Vector<VkDrmFormatModifierPropertiesEXT> result;
+    for (const auto& properties : allModifiers) {
+        if ((properties.drmFormatModifierTilingFeatures & requiredFeatures) != requiredFeatures)
+            continue;
+
+        VkPhysicalDeviceImageDrmFormatModifierInfoEXT modifierInfo { };
+        modifierInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT;
+        modifierInfo.drmFormatModifier = properties.drmFormatModifier;
+        modifierInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+        VkPhysicalDeviceExternalImageFormatInfo externalInfo { };
+        externalInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO;
+        externalInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+        externalInfo.pNext = &modifierInfo;
+
+        VkPhysicalDeviceImageFormatInfo2 imageFormatInfo { };
+        imageFormatInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2;
+        imageFormatInfo.pNext = &externalInfo;
+        imageFormatInfo.format = format;
+        imageFormatInfo.type = VK_IMAGE_TYPE_2D;
+        imageFormatInfo.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
+        imageFormatInfo.usage = usage;
+
+        VkExternalImageFormatProperties externalFormatProperties { };
+        externalFormatProperties.sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES;
+        VkImageFormatProperties2 imageFormatProperties { };
+        imageFormatProperties.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
+        imageFormatProperties.pNext = &externalFormatProperties;
+        if (m_instanceTable.vkGetPhysicalDeviceImageFormatProperties2(m_vkPhysicalDevice, &imageFormatInfo, &imageFormatProperties) != VK_SUCCESS)
+            continue;
+        if (!(externalFormatProperties.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT))
+            continue;
+        result.append(properties);
+    }
+    return result;
+}
+
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulkan::exportImageAsDMABuf(uint64_t swapchainImage, const OpenXRSwapchain& swapchain, uint32_t width, uint32_t height)
 {
     auto format = static_cast<VkFormat>(swapchain.format());
     auto fourcc = drmFourCCForVkFormat(format);
@@ -405,37 +525,40 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulka
         return std::nullopt;
     }
 
+    // Only TRANSFER_SRC, not COLOR_ATTACHMENT: Vulkan merely transfer-reads this image for the commit blit, while the web
+    // process renders into the exported DMABuf via GL/EGL, and linear-tiled images generally do not support COLOR_ATTACHMENT.
+    // The tiled DRM-modifier path is the validation-clean way to export a DMABuf; the linear fallback is tolerated but not
+    // advertised where the modifier extension is missing, so it renders but emits VUID-VkImageCreateInfo-pNext-00990.
+    // FIXME: the chosen modifier is one our device supports; it is not yet intersected with the modifiers the web process' EGL
+    // import can consume (that needs the consumer's list plumbed across IPC). On a single GPU the sets overlap in practice.
+    static constexpr VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    auto modifierProperties = m_supportsDRMModifiers ? supportedExportDRMModifiers(format, usage) : Vector<VkDrmFormatModifierPropertiesEXT> { };
+    Vector<uint64_t> modifiers = modifierProperties.map([](const auto& properties) {
+        return properties.drmFormatModifier;
+    });
+    bool useModifiers = !modifiers.isEmpty();
+
     VkExternalMemoryImageCreateInfo externalMemoryImageInfo { };
     externalMemoryImageInfo.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
     externalMemoryImageInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
 
-    // Linear tiling, exported as a DRM_FORMAT_MOD_LINEAR dma-buf. This avoids depending on VK_EXT_image_drm_format_modifier,
-    // which not every driver advertises, and is the most widely importable layout on the web process side. We only ever read
-    // this image as a transfer source (the web process renders into it via the dma-buf), so TRANSFER_SRC is enough.
-    //
-    // FIXME: prefer VK_EXT_image_drm_format_modifier when it is available, falling back to linear otherwise. This image is a
-    // render target the web process draws into every frame (per swapchain image, at the headset's refresh rate), so a tiled
-    // or otherwise optimal layout is worth the added complexity:
-    //   a) Performance: linear is the slowest layout for the GPU to render into and sample/copy from; a vendor-tiled modifier
-    //      has far better cache locality for those per-frame operations.
-    //   b) Bandwidth: some modifiers enable framebuffer compression (e.g. AMD DCC), cutting the memory traffic of both the
-    //      web process' rendering and our commitFrame copy.
-    //   c) Explicit layout negotiation: producer and consumer agree on the exact memory layout instead of relying on linear
-    //      being universally importable.
-    // Doing this correctly means creating the image with the intersection of the modifiers our device supports and the ones
-    // the consumer (the web process' dma-buf import) can handle, which requires plumbing the consumer's supported-modifier
-    // list here; linear stays as the fallback.
+    VkImageDrmFormatModifierListCreateInfoEXT modifierListInfo { };
+    modifierListInfo.sType = VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT;
+    modifierListInfo.pNext = &externalMemoryImageInfo;
+    modifierListInfo.drmFormatModifierCount = static_cast<uint32_t>(modifiers.size());
+    modifierListInfo.pDrmFormatModifiers = modifiers.span().data();
+
     VkImageCreateInfo imageCreateInfo { };
     imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-    imageCreateInfo.pNext = &externalMemoryImageInfo;
+    imageCreateInfo.pNext = useModifiers ? static_cast<const void*>(&modifierListInfo) : static_cast<const void*>(&externalMemoryImageInfo);
     imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
     imageCreateInfo.format = format;
     imageCreateInfo.extent = { width, height, 1 };
     imageCreateInfo.mipLevels = 1;
     imageCreateInfo.arrayLayers = 1;
     imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-    imageCreateInfo.tiling = VK_IMAGE_TILING_LINEAR;
-    imageCreateInfo.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    imageCreateInfo.tiling = useModifiers ? VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT : VK_IMAGE_TILING_LINEAR;
+    imageCreateInfo.usage = usage;
     imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
@@ -445,7 +568,7 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulka
     exportedImage.format = format;
 
     if (m_deviceTable.vkCreateImage(m_vkDevice, &imageCreateInfo, nullptr, &exportedImage.image) != VK_SUCCESS) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateImage failed for exported texture");
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateImage failed for exported texture (useModifiers=%d)", useModifiers);
         return std::nullopt;
     }
 
@@ -486,52 +609,189 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulka
         return std::nullopt;
     }
 
-    // Single-plane linear layout: the row pitch and offset of the colour plane fully describe it.
-    VkImageSubresource subresource { };
-    subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    VkSubresourceLayout layout { };
-    m_deviceTable.vkGetImageSubresourceLayout(m_vkDevice, exportedImage.image, &subresource, &layout);
+    uint64_t modifier = DRM_FORMAT_MOD_LINEAR;
+    uint32_t planeCount = 1;
+    if (useModifiers) {
+        VkImageDrmFormatModifierPropertiesEXT chosenModifier { };
+        chosenModifier.sType = VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT;
+        if (m_deviceTable.vkGetImageDrmFormatModifierPropertiesEXT(m_vkDevice, exportedImage.image, &chosenModifier) != VK_SUCCESS) {
+            RELEASE_LOG(XR, "OpenXR Vulkan: vkGetImageDrmFormatModifierPropertiesEXT failed for exported texture");
+            return std::nullopt;
+        }
+        modifier = chosenModifier.drmFormatModifier;
+        for (const auto& properties : modifierProperties) {
+            if (properties.drmFormatModifier == modifier) {
+                planeCount = properties.drmFormatModifierPlaneCount;
+                break;
+            }
+        }
+        if (!planeCount || planeCount > 4) {
+            RELEASE_LOG(XR, "OpenXR Vulkan: unexpected plane count %u for exported texture", planeCount);
+            return std::nullopt;
+        }
+    }
 
+    // All planes share the single dedicated allocation, so one exported fd is duplicated per plane. The planes differ only by offset and stride.
     VkMemoryGetFdInfoKHR getFdInfo { };
     getFdInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
     getFdInfo.memory = exportedImage.memory;
     getFdInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
-
     int dmaBufFd = -1;
     if (m_deviceTable.vkGetMemoryFdKHR(m_vkDevice, &getFdInfo, &dmaBufFd) != VK_SUCCESS || dmaBufFd < 0) {
         RELEASE_LOG(XR, "OpenXR Vulkan: vkGetMemoryFdKHR failed for exported texture");
         return std::nullopt;
     }
+    WTF::UnixFileDescriptor primaryDescriptor { dmaBufFd, WTF::UnixFileDescriptor::Adopt };
 
-    // Per-image synchronization objects. The fence starts signaled so the first commitFrame() that reuses this image waits on
-    // it without a special case. (On failure cleanupOnError destroys whatever was created.)
-    VkFenceCreateInfo fenceCreateInfo { };
-    fenceCreateInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-    fenceCreateInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-    if (m_deviceTable.vkCreateFence(m_vkDevice, &fenceCreateInfo, nullptr, &exportedImage.inFlightFence) != VK_SUCCESS) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateFence failed for exported texture");
-        return std::nullopt;
+    Vector<WTF::UnixFileDescriptor> fds;
+    Vector<uint32_t> strides;
+    Vector<uint32_t> offsets;
+    for (uint32_t plane = 0; plane < planeCount; ++plane) {
+        // A modifier image exposes each plane via a MEMORY_PLANE aspect (bits run consecutively from MEMORY_PLANE_0); a linear image has a single colour plane.
+        VkImageSubresource subresource { };
+        subresource.aspectMask = useModifiers ? static_cast<VkImageAspectFlagBits>(VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT << plane) : VK_IMAGE_ASPECT_COLOR_BIT;
+        VkSubresourceLayout layout { };
+        m_deviceTable.vkGetImageSubresourceLayout(m_vkDevice, exportedImage.image, &subresource, &layout);
+        auto duplicated = primaryDescriptor.duplicate();
+        if (!duplicated) {
+            RELEASE_LOG(XR, "OpenXR Vulkan: failed to duplicate DMABuf fd for plane %u", plane);
+            return std::nullopt;
+        }
+        fds.append(WTF::move(duplicated));
+        strides.append(static_cast<uint32_t>(layout.rowPitch));
+        offsets.append(static_cast<uint32_t>(layout.offset));
     }
 
-    VkSemaphoreCreateInfo semaphoreCreateInfo { };
-    semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-    if (m_deviceTable.vkCreateSemaphore(m_vkDevice, &semaphoreCreateInfo, nullptr, &exportedImage.acquireSemaphore) != VK_SUCCESS) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateSemaphore failed for exported texture");
+    if (!createExportedImageSyncObjects(exportedImage))
         return std::nullopt;
-    }
 
     cleanupOnError.release();
     m_exportedImages.set(swapchainImage, WTF::move(exportedImage));
 
-    Vector<WTF::UnixFileDescriptor> fds;
-    fds.append(WTF::UnixFileDescriptor { dmaBufFd, WTF::UnixFileDescriptor::Adopt });
     return PlatformXR::FrameData::ExternalTexture {
         .fds = WTF::move(fds),
-        .strides = { static_cast<uint32_t>(layout.rowPitch) },
-        .offsets = { static_cast<uint32_t>(layout.offset) },
+        .strides = WTF::move(strides),
+        .offsets = WTF::move(offsets),
         .fourcc = fourcc,
-        .modifier = DRM_FORMAT_MOD_LINEAR,
+        .modifier = modifier,
     };
+}
+#endif // USE(GBM)
+
+#if OS(ANDROID)
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulkan::exportImageAsAHardwareBuffer(uint64_t swapchainImage, const OpenXRSwapchain& swapchain, uint32_t width, uint32_t height)
+{
+    auto format = static_cast<VkFormat>(swapchain.format());
+
+    // The WebProcess renders into the AHardwareBuffer as a colour target and we transfer read it at commit, so it needs
+    // COLOR_ATTACHMENT | TRANSFER_SRC. COLOR_ATTACHMENT is what makes the exported buffer carry the GPU_FRAMEBUFFER usage
+    // that the GL consumer needs.
+    static constexpr VkImageUsageFlags usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+
+    VkExternalMemoryImageCreateInfo externalMemoryImageInfo { };
+    externalMemoryImageInfo.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+    externalMemoryImageInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
+
+    VkImageCreateInfo imageCreateInfo { };
+    imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageCreateInfo.pNext = &externalMemoryImageInfo;
+    imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageCreateInfo.format = format;
+    imageCreateInfo.extent = { width, height, 1 };
+    imageCreateInfo.mipLevels = 1;
+    imageCreateInfo.arrayLayers = 1;
+    imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+    imageCreateInfo.usage = usage;
+    imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    ExportedImage exportedImage;
+    exportedImage.width = width;
+    exportedImage.height = height;
+    exportedImage.format = format;
+    if (m_deviceTable.vkCreateImage(m_vkDevice, &imageCreateInfo, nullptr, &exportedImage.image) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateImage failed for exported AHardwareBuffer texture");
+        return std::nullopt;
+    }
+
+    auto cleanupOnError = makeScopeExit([&] {
+        destroyExportedImage(exportedImage);
+    });
+
+    VkMemoryRequirements memoryRequirements;
+    m_deviceTable.vkGetImageMemoryRequirements(m_vkDevice, exportedImage.image, &memoryRequirements);
+    auto memoryTypeIndex = findMemoryType(m_instanceTable, m_vkPhysicalDevice, memoryRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    if (!memoryTypeIndex) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: no suitable memory type for exported AHardwareBuffer texture");
+        return std::nullopt;
+    }
+
+    // AHardwareBuffer export requires a dedicated allocation.
+    VkMemoryDedicatedAllocateInfo dedicatedAllocateInfo { };
+    dedicatedAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+    dedicatedAllocateInfo.image = exportedImage.image;
+
+    VkExportMemoryAllocateInfo exportAllocateInfo { };
+    exportAllocateInfo.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO;
+    exportAllocateInfo.pNext = &dedicatedAllocateInfo;
+    exportAllocateInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
+
+    VkMemoryAllocateInfo memoryAllocateInfo { };
+    memoryAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    memoryAllocateInfo.pNext = &exportAllocateInfo;
+    memoryAllocateInfo.allocationSize = memoryRequirements.size;
+    memoryAllocateInfo.memoryTypeIndex = *memoryTypeIndex;
+    if (m_deviceTable.vkAllocateMemory(m_vkDevice, &memoryAllocateInfo, nullptr, &exportedImage.memory) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkAllocateMemory failed for exported AHardwareBuffer texture");
+        return std::nullopt;
+    }
+    if (m_deviceTable.vkBindImageMemory(m_vkDevice, exportedImage.image, exportedImage.memory, 0) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkBindImageMemory failed for exported AHardwareBuffer texture");
+        return std::nullopt;
+    }
+
+    // Pull the AHardwareBuffer out of the memory; it comes with one acquired reference that adoptRef transfers to the caller.
+    // Resolve the function via vkGetDeviceProcAddr rather than the device table so this does not depend on volk having been built
+    // with VK_USE_PLATFORM_ANDROID_KHR.
+    auto vkGetMemoryAndroidHardwareBuffer = reinterpret_cast<PFN_vkGetMemoryAndroidHardwareBufferANDROID>(m_instanceTable.vkGetDeviceProcAddr(m_vkDevice, "vkGetMemoryAndroidHardwareBufferANDROID"));
+    if (!vkGetMemoryAndroidHardwareBuffer) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkGetMemoryAndroidHardwareBufferANDROID is not available");
+        return std::nullopt;
+    }
+    VkMemoryGetAndroidHardwareBufferInfoANDROID getInfo { };
+    getInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID;
+    getInfo.memory = exportedImage.memory;
+    AHardwareBuffer* buffer = nullptr;
+    if (vkGetMemoryAndroidHardwareBuffer(m_vkDevice, &getInfo, &buffer) != VK_SUCCESS || !buffer) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkGetMemoryAndroidHardwareBufferANDROID failed for exported texture");
+        return std::nullopt;
+    }
+    // Adopt the acquired reference now so it is released automatically on any early return below.
+    RefPtr<AHardwareBuffer> hardwareBuffer = adoptRef(buffer);
+
+    if (!createExportedImageSyncObjects(exportedImage))
+        return std::nullopt;
+
+    cleanupOnError.release();
+    m_exportedImages.set(swapchainImage, WTF::move(exportedImage));
+    return hardwareBuffer;
+}
+#endif // OS(ANDROID)
+
+static VkImageMemoryBarrier makeImageBarrier(VkImage image, VkImageLayout oldLayout, VkImageLayout newLayout, VkAccessFlags srcAccess, VkAccessFlags dstAccess, uint32_t srcQueueFamily = VK_QUEUE_FAMILY_IGNORED, uint32_t dstQueueFamily = VK_QUEUE_FAMILY_IGNORED, uint32_t layerCount = 1)
+{
+    VkImageMemoryBarrier barrier { };
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.oldLayout = oldLayout;
+    barrier.newLayout = newLayout;
+    barrier.srcQueueFamilyIndex = srcQueueFamily;
+    barrier.dstQueueFamilyIndex = dstQueueFamily;
+    barrier.image = image;
+    barrier.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, layerCount };
+    barrier.srcAccessMask = srcAccess;
+    barrier.dstAccessMask = dstAccess;
+    return barrier;
 }
 
 bool OpenXRGraphicsBindingVulkan::recordBlitCommandBuffer(ExportedImage& exportedImage, VkImage swapchainImage)
@@ -548,20 +808,6 @@ bool OpenXRGraphicsBindingVulkan::recordBlitCommandBuffer(ExportedImage& exporte
         return false;
     }
 
-    auto makeBarrier = [](VkImage image, VkImageLayout oldLayout, VkImageLayout newLayout, VkAccessFlags srcAccess, VkAccessFlags dstAccess, uint32_t srcQueueFamily = VK_QUEUE_FAMILY_IGNORED, uint32_t dstQueueFamily = VK_QUEUE_FAMILY_IGNORED) {
-        VkImageMemoryBarrier barrier { };
-        barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-        barrier.oldLayout = oldLayout;
-        barrier.newLayout = newLayout;
-        barrier.srcQueueFamilyIndex = srcQueueFamily;
-        barrier.dstQueueFamilyIndex = dstQueueFamily;
-        barrier.image = image;
-        barrier.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
-        barrier.srcAccessMask = srcAccess;
-        barrier.dstAccessMask = dstAccess;
-        return barrier;
-    };
-
     VkCommandBufferBeginInfo beginInfo { };
     beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
     // No VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT: this buffer is recorded once and resubmitted on every commit.
@@ -573,8 +819,8 @@ bool OpenXRGraphicsBindingVulkan::recordBlitCommandBuffer(ExportedImage& exporte
     // matches the externally-written linear DMABuf. The swapchain image is owned by our own device and fully overwritten by the
     // blit, so it can start from UNDEFINED with no ownership transfer.
     std::array<VkImageMemoryBarrier, 2> preBlitBarriers { {
-        makeBarrier(exportedImage.image, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL, 0, VK_ACCESS_TRANSFER_READ_BIT, VK_QUEUE_FAMILY_FOREIGN_EXT, m_queueFamilyIndex),
-        makeBarrier(swapchainImage, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 0, VK_ACCESS_TRANSFER_WRITE_BIT),
+        makeImageBarrier(exportedImage.image, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL, 0, VK_ACCESS_TRANSFER_READ_BIT, VK_QUEUE_FAMILY_FOREIGN_EXT, m_queueFamilyIndex),
+        makeImageBarrier(swapchainImage, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 0, VK_ACCESS_TRANSFER_WRITE_BIT),
     } };
     m_deviceTable.vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, preBlitBarriers.size(), preBlitBarriers.data());
 
@@ -582,20 +828,19 @@ bool OpenXRGraphicsBindingVulkan::recordBlitCommandBuffer(ExportedImage& exporte
     // Vulkan (and therefore the runtime's swapchain image) uses the top left. We blit rather than copy so the destination's
     // Y offsets can be inverted, correcting the flip in the same pass (vkCmdCopyImage cannot flip). The transfer is 1:1 in
     // size and format so NEAREST adds no filtering, and the Y inversion itself costs nothing beyond the blit.
-    VkImageBlit blitRegion { };
-    blitRegion.srcSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
-    blitRegion.srcOffsets[0] = { 0, 0, 0 };
-    blitRegion.srcOffsets[1] = { static_cast<int32_t>(exportedImage.width), static_cast<int32_t>(exportedImage.height), 1 };
-    blitRegion.dstSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
-    blitRegion.dstOffsets[0] = { 0, static_cast<int32_t>(exportedImage.height), 0 };
-    blitRegion.dstOffsets[1] = { static_cast<int32_t>(exportedImage.width), 0, 1 };
+    VkImageBlit blitRegion {
+        .srcSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 },
+        .srcOffsets = { { 0, 0, 0 }, { static_cast<int32_t>(exportedImage.width), static_cast<int32_t>(exportedImage.height), 1 } },
+        .dstSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 },
+        .dstOffsets = { { 0, static_cast<int32_t>(exportedImage.height), 0 }, { static_cast<int32_t>(exportedImage.width), 0, 1 } },
+    };
     m_deviceTable.vkCmdBlitImage(commandBuffer, exportedImage.image, VK_IMAGE_LAYOUT_GENERAL, swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blitRegion, VK_FILTER_NEAREST);
 
     // Transition the swapchain image to COLOR_ATTACHMENT_OPTIMAL, which the runtime expects when it is released, and release
     // ownership of the exported image back to the foreign (OpenGL) producer so it can render into it again next frame.
     std::array<VkImageMemoryBarrier, 2> postBlitBarriers { {
-        makeBarrier(swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT),
-        makeBarrier(exportedImage.image, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL, VK_ACCESS_TRANSFER_READ_BIT, 0, m_queueFamilyIndex, VK_QUEUE_FAMILY_FOREIGN_EXT),
+        makeImageBarrier(swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT),
+        makeImageBarrier(exportedImage.image, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL, VK_ACCESS_TRANSFER_READ_BIT, 0, m_queueFamilyIndex, VK_QUEUE_FAMILY_FOREIGN_EXT),
     } };
     m_deviceTable.vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, postBlitBarriers.size(), postBlitBarriers.data());
 
@@ -635,7 +880,7 @@ void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwa
     m_deviceTable.vkWaitForFences(m_vkDevice, 1, &exportedImage.inFlightFence, VK_TRUE, UINT64_MAX);
     m_deviceTable.vkResetFences(m_vkDevice, 1, &exportedImage.inFlightFence);
 
-    // Import the web process' render-completion fence (stashed by waitFrameFence()) into this image's semaphore so the blit can
+    // Import the WebProcess render-completion fence (stashed by waitFrameFence()) into this image's semaphore so the copy can
     // wait on it on the GPU. SYNC_FD payloads are temporary and consumed by the wait, and the fence wait above guarantees the
     // previous wait on this semaphore has already executed, so re-importing here is safe.
     bool waitOnAcquireFence = false;
@@ -666,7 +911,8 @@ void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwa
     }
     submitInfo.commandBufferCount = 1;
     submitInfo.pCommandBuffers = &exportedImage.commandBuffer;
-    m_deviceTable.vkQueueSubmit(m_vkQueue, 1, &submitInfo, exportedImage.inFlightFence);
+    if (auto submitResult = m_deviceTable.vkQueueSubmit(m_vkQueue, 1, &submitInfo, exportedImage.inFlightFence); submitResult != VK_SUCCESS)
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkQueueSubmit failed (%d)", submitResult);
 }
 
 void OpenXRGraphicsBindingVulkan::waitFrameFence(WTF::UnixFileDescriptor&& fenceFD)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
@@ -42,18 +42,10 @@
 #include <wtf/text/StringView.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
-#if USE(GBM)
-#include <drm_fourcc.h>
-#endif
-#if OS(ANDROID)
-#include <android/hardware_buffer.h>
-#endif
-
 namespace WebKit {
 
-// Vulkan non-dispatchable handles (VkImage, VkDeviceMemory, ...) are 8 bytes on every architecture (a pointer where pointers
-// are 64-bit, a uint64_t otherwise). bit_cast copies the raw bytes and is correct for both representations, unlike a
-// reinterpret_cast that would assume a pointer.
+// Vulkan non-dispatchable handles (VkImage, VkDeviceMemory, ...) are 8 bytes on every architecture (a pointer where pointers are 64-bit, a uint64_t otherwise).
+// bit_cast copies the raw bytes so is correct for both representations (reinterpret_cast would assume a pointer).
 static_assert(sizeof(VkImage) == sizeof(uint64_t), "VkImage is expected to be a 64-bit handle");
 
 static inline uint64_t toHandle(VkImage image)
@@ -89,10 +81,9 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL vulkanDebugUtilsCallback(VkDebugUtilsMessa
     else if (messageTypes & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)
         typeLabel = "performance";
 
-    // Registering a messenger makes the layer report through it instead of its own default output.
     LOG(XR, "OpenXR Vulkan [%s/%s] %s", severityLabel, typeLabel, callbackData->pMessage);
 
-    // Always VK_FALSE: returning VK_TRUE aborts the offending call, which would turn a diagnostic into a behaviour change.
+    // Always VK_FALSE because returning VK_TRUE aborts the offending call, which would turn a diagnostic into a behaviour change.
     return VK_FALSE;
 }
 
@@ -121,9 +112,8 @@ Vector<ASCIILiteral> OpenXRGraphicsBindingVulkan::requiredInstanceExtensions() c
 bool OpenXRGraphicsBindingVulkan::initializeDisplay(bool)
 {
     ASSERT(RunLoop::isMain());
-    // Unlike the OpenGLES binding, Vulkan must create its instance and device through the OpenXR runtime
-    // (xrCreateVulkan{Instance|Device}KHR), which requires the OpenXR instance and system to already exist. That work is
-    // deferred to initializeForSession() so there is nothing to set up before instance creation here.
+    // Unlike the OpenGLES binding, Vulkan must create its instance and device through the OpenXR runtime (xrCreateVulkan{Instance|Device}KHR), which requires the OpenXR instance
+    // and system to already exist. That work is deferred to initializeForSession() so there is nothing to set up before instance creation here.
     return true;
 }
 
@@ -147,14 +137,21 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
     uint32_t apiMajor = VK_API_VERSION_MAJOR(loaderVersion);
     uint32_t apiMinor = VK_API_VERSION_MINOR(loaderVersion);
 
-    // maxApiVersionSupported might return non-sensical large values standing for "no maximum". This could wrap into
-    // a version below 1.1 and hide extensions whose dependencies are core from 1.1, so protect against that.
+    // maxApiVersionSupported might return non-sensical large values standing for "no maximum" (as in the case of Monado for desktop). This could wrap into a version
+    // below 1.1 and hide extensions whose dependencies are core from 1.1, so protect against that.
     static constexpr uint32_t plausibleMajorLimit = 8;
     auto maxMajor = static_cast<uint32_t>(XR_VERSION_MAJOR(graphicsRequirements.maxApiVersionSupported));
     auto maxMinor = static_cast<uint32_t>(XR_VERSION_MINOR(graphicsRequirements.maxApiVersionSupported));
     if (maxMajor <= plausibleMajorLimit && (maxMajor < apiMajor || (maxMajor == apiMajor && maxMinor < apiMinor))) {
         apiMajor = maxMajor;
         apiMinor = maxMinor;
+    }
+
+    // The binding calls Vulkan 1.1 core entry points unconditionally, vkGetPhysicalDeviceProperties2 for the device and driver UUIDs and
+    // VkMemoryDedicatedAllocateInfo for the export, so below that there is nothing to fallback to and the instance would be unusable.
+    if (apiMajor < 1 || (apiMajor == 1 && !apiMinor)) {
+        LOG(XR, "OpenXR Vulkan: Vulkan %u.%u is available but this binding requires at least 1.1", apiMajor, apiMinor);
+        return false;
     }
 
     auto minMajor = static_cast<uint32_t>(XR_VERSION_MAJOR(graphicsRequirements.minApiVersionSupported));
@@ -167,7 +164,7 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
     const uint32_t apiVersion = VK_MAKE_API_VERSION(0, apiMajor, apiMinor, 0);
     VkApplicationInfo applicationInfo { };
     applicationInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-    applicationInfo.pApplicationName = "WebKitWebXR";
+    applicationInfo.pApplicationName = "WebKit";
     applicationInfo.apiVersion = apiVersion;
 
     Vector<const char*> instanceLayers;
@@ -198,8 +195,7 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
     }
     volkLoadInstanceTable(&m_instanceTable, m_vkInstance);
 
-    // After volkLoadInstanceTable, which resolves vkCreateDebugUtilsMessengerEXT. Messages from instance creation itself are
-    // reported by the layer directly rather than through the messenger.
+    // After volkLoadInstanceTable which resolves vkCreateDebugUtilsMessengerEXT. Messages from instance creation itself are reported directly by the layer.
     if (validationEnabled)
         createDebugMessenger();
 
@@ -230,57 +226,35 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
     }
     m_queueFamilyIndex = *graphicsFamily;
 
-    // Extensions to hand our own images to the web process, to import the web process' frame fence as a semaphore, and to
-    // acquire/release queue-family ownership of the externally-written image (VK_QUEUE_FAMILY_FOREIGN_EXT). The external-memory
-    // extension differs per platform: a dma-buf on Linux/GBM, an AHardwareBuffer on Android (its other dependencies — YCbCr
-    // conversion, bind-memory2, dedicated allocation — are core from Vulkan 1.1, which we always request). The OpenXR runtime
-    // appends its own required extensions on top. If the device cannot provide these, xrCreateVulkanDeviceKHR fails below and no
-    // session is created, which is intended: the binding has no usable path without them.
-    Vector<const char*> requiredExtensions {
+    // Extensions to hand our own images to the WebProcess and to import its frame fence as a semaphore. Everything else the sharing needs (external memory and semaphores
+    // in general, dedicated allocation, bind-memory2...) is core from Vulkan 1.1, which the instance created above is required to be.
+    Vector<const char*> requiredVulkanExtensions {
         VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
-        VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME,
+        VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
     };
-#if USE(GBM)
-    requiredExtensions.append(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
-    requiredExtensions.append(VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME);
-#elif OS(ANDROID)
-    requiredExtensions.append(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
-#endif
 
-    // Report which device the runtime selected and whether it advertises the extensions we need, so a
-    // VK_ERROR_EXTENSION_NOT_PRESENT from xrCreateVulkanDeviceKHR below points at the actual cause (e.g. the runtime picked a
-    // software device that lacks dma-buf export) rather than a guess.
+    // Report which device the runtime selected and whether it advertises the extensions we need, so a VK_ERROR_EXTENSION_NOT_PRESENT from xrCreateVulkanDeviceKHR below points
+    // at the actual cause (e.g. the runtime picked a software device that lacks DMABuf export) rather than a guess.
     VkPhysicalDeviceProperties physicalDeviceProperties;
     m_instanceTable.vkGetPhysicalDeviceProperties(m_vkPhysicalDevice, &physicalDeviceProperties);
     LOG(XR, "OpenXR Vulkan: runtime selected device '%s'", physicalDeviceProperties.deviceName);
-    logDeviceAndDriverUUIDs(physicalDeviceProperties.deviceName);
+    readDeviceAndDriverUUIDs(physicalDeviceProperties.deviceName);
     uint32_t availableExtensionCount = 0;
     m_instanceTable.vkEnumerateDeviceExtensionProperties(m_vkPhysicalDevice, nullptr, &availableExtensionCount, nullptr);
-    Vector<VkExtensionProperties> availableExtensions(availableExtensionCount);
-    m_instanceTable.vkEnumerateDeviceExtensionProperties(m_vkPhysicalDevice, nullptr, &availableExtensionCount, availableExtensions.mutableSpan().data());
-    auto isExtensionAvailable = [&](const char* name) {
-        return availableExtensions.containsIf([&](const auto& extension) {
+    Vector<VkExtensionProperties> availableVulkanExtensions(availableExtensionCount);
+    m_instanceTable.vkEnumerateDeviceExtensionProperties(m_vkPhysicalDevice, nullptr, &availableExtensionCount, availableVulkanExtensions.mutableSpan().data());
+    auto isVulkanExtensionAvailable = [&](const char* name) {
+        return availableVulkanExtensions.containsIf([&](const auto& extension) {
             return StringView::fromLatin1(extension.extensionName) == StringView::fromLatin1(name);
         });
     };
 
-    Vector<const char*> enabledExtensions;
-    for (auto* required : requiredExtensions) {
-        if (!isExtensionAvailable(required))
+    Vector<const char*> enabledVulkanExtensions;
+    for (auto* required : requiredVulkanExtensions) {
+        if (!isVulkanExtensionAvailable(required))
             LOG(XR, "OpenXR Vulkan: required device extension %s not supported by '%s'", required, physicalDeviceProperties.deviceName);
-        enabledExtensions.append(required);
+        enabledVulkanExtensions.append(required);
     }
-#if USE(GBM)
-    // VK_EXT_image_drm_format_modifier is optional (exportImageAsDMABuf falls back to a linear image without it); its
-    // VK_KHR_image_format_list dependency is core from Vulkan 1.2 but must be enabled explicitly on 1.1.
-    if (isExtensionAvailable(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME)) {
-        enabledExtensions.append(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
-        if (isExtensionAvailable(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME))
-            enabledExtensions.append(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
-        m_supportsDRMModifiers = true;
-    }
-#endif // USE(GBM)
-
     const float queuePriority = 1.0f;
     VkDeviceQueueCreateInfo queueCreateInfo { };
     queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
@@ -292,8 +266,8 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
     vkDeviceCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
     vkDeviceCreateInfo.queueCreateInfoCount = 1;
     vkDeviceCreateInfo.pQueueCreateInfos = &queueCreateInfo;
-    vkDeviceCreateInfo.enabledExtensionCount = static_cast<uint32_t>(enabledExtensions.size());
-    vkDeviceCreateInfo.ppEnabledExtensionNames = enabledExtensions.span().data();
+    vkDeviceCreateInfo.enabledExtensionCount = static_cast<uint32_t>(enabledVulkanExtensions.size());
+    vkDeviceCreateInfo.ppEnabledExtensionNames = enabledVulkanExtensions.span().data();
 
     auto xrDeviceCreateInfo = createOpenXRStruct<XrVulkanDeviceCreateInfoKHR, XR_TYPE_VULKAN_DEVICE_CREATE_INFO_KHR>();
     xrDeviceCreateInfo.systemId = systemId;
@@ -313,8 +287,7 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
 
     VkCommandPoolCreateInfo poolCreateInfo { };
     poolCreateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-    // The per-swapchain-image commit command buffers are recorded once and never reset or re-recorded, so no pool flags are
-    // needed; they are freed in bulk when the pool is destroyed.
+    // The per-swapchain-image commit command buffers are recorded once and never reset or re-recorded, so no pool flags are needed. They are freed in bulk when the pool is destroyed.
     poolCreateInfo.flags = 0;
     poolCreateInfo.queueFamilyIndex = m_queueFamilyIndex;
     if (m_deviceTable.vkCreateCommandPool(m_vkDevice, &poolCreateInfo, nullptr, &m_commandPool) != VK_SUCCESS) {
@@ -332,18 +305,26 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
     return true;
 }
 
-void OpenXRGraphicsBindingVulkan::logDeviceAndDriverUUIDs(const char* deviceName) const
+void OpenXRGraphicsBindingVulkan::readDeviceAndDriverUUIDs(const char* deviceName)
 {
-    // The device the runtime dictates has to be the one the web process' consumer imports on, and for handle types that are
-    // driver-private (opaque fd) the driver must match too, not just the device. A full check needs the consumer's UUIDs
-    // carried over IPC, which is the same missing plumbing as the modifier intersection; until then, report ours so the two
-    // sides can be compared from a single log.
+    // The device the runtime dictates has to be the one the WebProcess imports on, and for handle types that are driver private (the opaque fds) the driver
+    // must match too, not just the device. EXT_external_objects makes that comparison the defined legality test, so these travel with every exported handle and
+    // the WebProcess refuses anything it cannot match.
     VkPhysicalDeviceIDProperties idProperties { };
     idProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
     VkPhysicalDeviceProperties2 properties2 { };
     properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
     properties2.pNext = &idProperties;
     m_instanceTable.vkGetPhysicalDeviceProperties2(m_vkPhysicalDevice, &properties2);
+
+    auto pack = [](std::span<const uint8_t, VK_UUID_SIZE> uuid) {
+        std::array<uint64_t, 2> packed { };
+        static_assert(sizeof(packed) == VK_UUID_SIZE);
+        memcpySpan(asMutableByteSpan(std::span<uint64_t, 2> { packed }), uuid);
+        return packed;
+    };
+    m_deviceUUID = pack(std::span<const uint8_t, VK_UUID_SIZE> { idProperties.deviceUUID });
+    m_driverUUID = pack(std::span<const uint8_t, VK_UUID_SIZE> { idProperties.driverUUID });
 
     [[maybe_unused]] auto toHex = [](std::span<const uint8_t, VK_UUID_SIZE> uuid) {
         static constexpr std::array<char, 16> hexDigits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
@@ -360,8 +341,7 @@ void OpenXRGraphicsBindingVulkan::logDeviceAndDriverUUIDs(const char* deviceName
         toHex(std::span<const uint8_t, VK_UUID_SIZE> { idProperties.driverUUID }).data());
 }
 
-// Optional diagnostics, opt-in via WEBKIT_WEBXR_VULKAN_VALIDATION. Requires the validation layer and VK_EXT_debug_utils
-// to be enabled at instance creation.
+// Optional diagnostics, opt-in via WEBKIT_WEBXR_VULKAN_VALIDATION. Requires the validation layer and VK_EXT_debug_utils to be enabled at instance creation.
 bool OpenXRGraphicsBindingVulkan::configureValidation(Vector<const char*>& layers, Vector<const char*>& extensions, VkValidationFeaturesEXT& features)
 {
     auto value = StringView::fromLatin1(getenv("WEBKIT_WEBXR_VULKAN_VALIDATION"));
@@ -394,9 +374,8 @@ bool OpenXRGraphicsBindingVulkan::configureValidation(Vector<const char*>& layer
     layers.append("VK_LAYER_KHRONOS_validation");
     extensions.append(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 
-    // VK_EXT_validation_features is provided by the layer, not the driver, so it is absent from the unfiltered instance
-    // extension list and must be queried against the layer. Enabling it when absent fails instance creation, and chaining
-    // VkValidationFeaturesEXT without enabling it is invalid, so require it first.
+    // VK_EXT_validation_features is provided by the layer, not the driver, so it is absent from the unfiltered instance extension list and must be queried
+    // against the layer. Enabling it when absent fails instance creation, and chaining VkValidationFeaturesEXT without enabling it is invalid, so require it first.
     uint32_t layerExtensionCount = 0;
     vkEnumerateInstanceExtensionProperties("VK_LAYER_KHRONOS_validation", &layerExtensionCount, nullptr);
     Vector<VkExtensionProperties> layerExtensions(layerExtensionCount);
@@ -454,13 +433,10 @@ const void* OpenXRGraphicsBindingVulkan::sessionGraphicsBinding() const
 
 int64_t OpenXRGraphicsBindingVulkan::selectColorFormat(const Vector<int64_t>& supportedFormats, bool) const
 {
-    // OpenXR reports Vulkan swapchain formats as VkFormat values. Prefer 8-bit RGBA; alpha is kept
-    // even when not requested, mirroring the OpenGLES binding (the channel is simply ignored).
-    //
-    // UNORM is preferred over SRGB deliberately. The content arrives already sRGB-encoded from the web process and is copied
-    // through verbatim, so an SRGB swapchain would have the compositor decode it on sample and the values would be wrong. The
-    // consequence is that the compositor blends and reprojects encoded rather than linear values, which is the same trade-off
-    // other WebXR implementations make; changing it would require the web process to hand over linear content.
+    // OpenXR reports Vulkan swapchain formats as VkFormat values. Prefer 8-bit RGBA. alpha is kept even when not requested, mirroring the OpenGLES binding.
+    // UNORM is preferred over SRGB because the exported image shares the swapchain's format and the copy between them has to stay verbatim: the web process hands
+    // over sRGB-encoded bytes in a plain RGBA8 texture, and an sRGB format would have GL convert on access. The cost is that the runtime's compositor treats the
+    // contents as linear, so any blending or reprojection it does happens on encoded values.
     static constexpr std::array<int64_t, 4> preferredFormats { {
         VK_FORMAT_R8G8B8A8_UNORM,
         VK_FORMAT_B8G8R8A8_UNORM,
@@ -544,6 +520,8 @@ void OpenXRGraphicsBindingVulkan::destroyExportedImage(ExportedImage& exportedIm
     ASSERT(m_vkDevice != VK_NULL_HANDLE);
     if (exportedImage.acquireSemaphore != VK_NULL_HANDLE)
         m_deviceTable.vkDestroySemaphore(m_vkDevice, exportedImage.acquireSemaphore, nullptr);
+    if (exportedImage.renderFinishedSemaphore != VK_NULL_HANDLE)
+        m_deviceTable.vkDestroySemaphore(m_vkDevice, exportedImage.renderFinishedSemaphore, nullptr);
     if (exportedImage.inFlightFence != VK_NULL_HANDLE)
         m_deviceTable.vkDestroyFence(m_vkDevice, exportedImage.inFlightFence, nullptr);
     if (exportedImage.image != VK_NULL_HANDLE)
@@ -554,7 +532,6 @@ void OpenXRGraphicsBindingVulkan::destroyExportedImage(ExportedImage& exportedIm
     exportedImage = { };
 }
 
-#if USE(GBM) || OS(ANDROID)
 static std::optional<uint32_t> findMemoryType(const VolkInstanceTable& instanceTable, VkPhysicalDevice physicalDevice, uint32_t memoryTypeBits, VkMemoryPropertyFlags properties)
 {
     VkPhysicalDeviceMemoryProperties memoryProperties;
@@ -568,23 +545,89 @@ static std::optional<uint32_t> findMemoryType(const VolkInstanceTable& instanceT
     }
     return std::nullopt;
 }
-#endif // USE(GBM) || OS(ANDROID)
 
-#if USE(GBM)
-static uint32_t drmFourCCForVkFormat(VkFormat format)
+static constexpr uint32_t glRGBA8 = 0x8058;
+static uint32_t glInternalFormatForVkFormat(VkFormat format)
 {
     switch (format) {
     case VK_FORMAT_R8G8B8A8_UNORM:
-    case VK_FORMAT_R8G8B8A8_SRGB:
-        return DRM_FORMAT_ABGR8888;
-    case VK_FORMAT_B8G8R8A8_UNORM:
-    case VK_FORMAT_B8G8R8A8_SRGB:
-        return DRM_FORMAT_ARGB8888;
+        return glRGBA8;
     default:
-        return DRM_FORMAT_INVALID;
+        return 0;
     }
 }
-#endif // USE(GBM)
+
+// An image shared with GL must be created with every usage its format supports: GL cannot state which usages it assumed, and the layout a driver picks for
+// VK_IMAGE_TILING_OPTIMAL depends on them, so anything less leaves the two sides agreeing on the layout by coincidence. The GL_EXT_memory_object spec puts it as
+// "all supported usage flags must be specified". This mirrors the same derivation in ANGLE's vk::GetMaximalImageUsageFlags().
+VkImageUsageFlags OpenXRGraphicsBindingVulkan::maximalImageUsageFlags(VkFormat format) const
+{
+    VkFormatProperties2 formatProperties { };
+    formatProperties.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+    m_instanceTable.vkGetPhysicalDeviceFormatProperties2(m_vkPhysicalDevice, format, &formatProperties);
+    auto features = formatProperties.formatProperties.optimalTilingFeatures;
+
+    VkImageUsageFlags usage = VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
+    if (features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)
+        usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
+    if (features & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)
+        usage |= VK_IMAGE_USAGE_STORAGE_BIT;
+    if (features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)
+        usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    if (features & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
+        usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+    if (features & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)
+        usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    if (features & VK_FORMAT_FEATURE_TRANSFER_DST_BIT)
+        usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    return usage;
+}
+
+bool OpenXRGraphicsBindingVulkan::supportsOpaqueFDSharing(VkFormat format, VkImageUsageFlags usage) const
+{
+    VkPhysicalDeviceExternalImageFormatInfo externalImageFormatInfo { };
+    externalImageFormatInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO;
+    externalImageFormatInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+
+    VkPhysicalDeviceImageFormatInfo2 imageFormatInfo { };
+    imageFormatInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2;
+    imageFormatInfo.pNext = &externalImageFormatInfo;
+    imageFormatInfo.format = format;
+    imageFormatInfo.type = VK_IMAGE_TYPE_2D;
+    imageFormatInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+    imageFormatInfo.usage = usage;
+
+    VkExternalImageFormatProperties externalImageFormatProperties { };
+    externalImageFormatProperties.sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES;
+    VkImageFormatProperties2 imageFormatProperties { };
+    imageFormatProperties.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
+    imageFormatProperties.pNext = &externalImageFormatProperties;
+
+    if (m_instanceTable.vkGetPhysicalDeviceImageFormatProperties2(m_vkPhysicalDevice, &imageFormatInfo, &imageFormatProperties) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: format %d with usage 0x%x is not creatable at all", format, usage);
+        return false;
+    }
+    if (!(externalImageFormatProperties.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT)) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: format %d with usage 0x%x is not exportable as an opaque fd", format, usage);
+        return false;
+    }
+
+    // The semaphores must cross the process boundary in both directions, so unlike the memory they have to be importable too.
+    VkPhysicalDeviceExternalSemaphoreInfo semaphoreInfo { };
+    semaphoreInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO;
+    semaphoreInfo.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+    VkExternalSemaphoreProperties semaphoreProperties { };
+    semaphoreProperties.sType = VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES;
+    m_instanceTable.vkGetPhysicalDeviceExternalSemaphoreProperties(m_vkPhysicalDevice, &semaphoreInfo, &semaphoreProperties);
+
+    static constexpr VkExternalSemaphoreFeatureFlags requiredSemaphoreFeatures = VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT;
+    if ((semaphoreProperties.externalSemaphoreFeatures & requiredSemaphoreFeatures) != requiredSemaphoreFeatures) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: opaque fd semaphores are not both exportable and importable");
+        return false;
+    }
+
+    return true;
+}
 
 bool OpenXRGraphicsBindingVulkan::createExportedImageSyncObjects(ExportedImage& exportedImage)
 {
@@ -609,7 +652,31 @@ bool OpenXRGraphicsBindingVulkan::createExportedImageSyncObjects(ExportedImage& 
     return true;
 }
 
-std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulkan::exportTexture(uint64_t image, const OpenXRSwapchain& swapchain, TextureType type, uint32_t width, uint32_t height)
+// Both directions of the handover are ordinary binary semaphores, only their exportability is special. GL_EXT_semaphore_fd cannot be exported, so the WebProcess imports these
+// instead of creating its own.
+bool OpenXRGraphicsBindingVulkan::createExportedImageSharingSemaphores(ExportedImage& exportedImage)
+{
+    VkExportSemaphoreCreateInfo exportSemaphoreInfo { };
+    exportSemaphoreInfo.sType = VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO;
+    exportSemaphoreInfo.handleTypes = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+
+    VkSemaphoreCreateInfo semaphoreCreateInfo { };
+    semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+    semaphoreCreateInfo.pNext = &exportSemaphoreInfo;
+
+    if (m_deviceTable.vkCreateSemaphore(m_vkDevice, &semaphoreCreateInfo, nullptr, &exportedImage.renderFinishedSemaphore) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateSemaphore failed for the exported image's render-finished semaphore");
+        return false;
+    }
+
+    setDebugName(VK_OBJECT_TYPE_SEMAPHORE, toDebugHandle(exportedImage.renderFinishedSemaphore), "WebXR exported image render-finished semaphore");
+    return true;
+}
+
+// Shares the image purely in Vulkan terms, its memory is exported as an opaque fd and the WebOrocess imports it with GL_EXT_memory_object_fd (no DMABuf, GBM, AHardwareBuffer...).
+// Three things make this legal: 1. the two drivers must report the same device and driver UUIDs (enforced on the WebProcess), the image must carry every usage its format supports (see
+// maximalImageUsageFlags() above), and the format must have an exact GL counterpart.
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulkan::exportTexture(uint64_t swapchainImage, const OpenXRSwapchain& swapchain, TextureType type, uint32_t width, uint32_t height)
 {
     ASSERT(m_vkDevice != VK_NULL_HANDLE);
 
@@ -618,258 +685,20 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulka
         return std::nullopt;
     }
 
-#if USE(GBM)
-    return exportImageAsDMABuf(image, swapchain, width, height);
-#elif OS(ANDROID)
-    // Android shares the buffer as an AHardwareBuffer instead of a DMABuf.
-    return exportImageAsAHardwareBuffer(image, swapchain, width, height);
-#else
-    // No external-texture path without GBM (DMABuf) or Android (AHardwareBuffer), so nothing is exported.
-    UNUSED_PARAM(image);
-    UNUSED_PARAM(swapchain);
-    UNUSED_PARAM(type);
-    UNUSED_PARAM(width);
-    UNUSED_PARAM(height);
-    return std::nullopt;
-#endif
-}
-
-#if USE(GBM)
-Vector<VkDrmFormatModifierPropertiesEXT> OpenXRGraphicsBindingVulkan::supportedExportDRMModifiers(VkFormat format, VkImageUsageFlags usage) const
-{
-    VkDrmFormatModifierPropertiesListEXT modifierList { };
-    modifierList.sType = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT;
-    VkFormatProperties2 formatProperties { };
-    formatProperties.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
-    formatProperties.pNext = &modifierList;
-    m_instanceTable.vkGetPhysicalDeviceFormatProperties2(m_vkPhysicalDevice, format, &formatProperties);
-    Vector<VkDrmFormatModifierPropertiesEXT> allModifiers(modifierList.drmFormatModifierCount);
-    modifierList.pDrmFormatModifierProperties = allModifiers.mutableSpan().data();
-    m_instanceTable.vkGetPhysicalDeviceFormatProperties2(m_vkPhysicalDevice, format, &formatProperties);
-
-    VkFormatFeatureFlags requiredFeatures = 0;
-    if (usage & VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
-        requiredFeatures |= VK_FORMAT_FEATURE_TRANSFER_SRC_BIT;
-    if (usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT)
-        requiredFeatures |= VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    if (usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
-        requiredFeatures |= VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT;
-    if (usage & VK_IMAGE_USAGE_SAMPLED_BIT)
-        requiredFeatures |= VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
-    Vector<VkDrmFormatModifierPropertiesEXT> result;
-    for (const auto& properties : allModifiers) {
-        if ((properties.drmFormatModifierTilingFeatures & requiredFeatures) != requiredFeatures)
-            continue;
-
-        VkPhysicalDeviceImageDrmFormatModifierInfoEXT modifierInfo { };
-        modifierInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT;
-        modifierInfo.drmFormatModifier = properties.drmFormatModifier;
-        modifierInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-        VkPhysicalDeviceExternalImageFormatInfo externalInfo { };
-        externalInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO;
-        externalInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
-        externalInfo.pNext = &modifierInfo;
-
-        VkPhysicalDeviceImageFormatInfo2 imageFormatInfo { };
-        imageFormatInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2;
-        imageFormatInfo.pNext = &externalInfo;
-        imageFormatInfo.format = format;
-        imageFormatInfo.type = VK_IMAGE_TYPE_2D;
-        imageFormatInfo.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
-        imageFormatInfo.usage = usage;
-
-        VkExternalImageFormatProperties externalFormatProperties { };
-        externalFormatProperties.sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES;
-        VkImageFormatProperties2 imageFormatProperties { };
-        imageFormatProperties.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
-        imageFormatProperties.pNext = &externalFormatProperties;
-        if (m_instanceTable.vkGetPhysicalDeviceImageFormatProperties2(m_vkPhysicalDevice, &imageFormatInfo, &imageFormatProperties) != VK_SUCCESS)
-            continue;
-        if (!(externalFormatProperties.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT))
-            continue;
-        result.append(properties);
-    }
-    return result;
-}
-
-std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulkan::exportImageAsDMABuf(uint64_t swapchainImage, const OpenXRSwapchain& swapchain, uint32_t width, uint32_t height)
-{
     auto format = static_cast<VkFormat>(swapchain.format());
-    auto fourcc = drmFourCCForVkFormat(format);
-    if (fourcc == DRM_FORMAT_INVALID) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: unsupported swapchain format %d for dma-buf export", format);
+    auto glInternalFormat = glInternalFormatForVkFormat(format);
+    if (!glInternalFormat) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: swapchain format %d has no exact GL counterpart, refusing to share it as an opaque fd", format);
         return std::nullopt;
     }
 
-    // Only TRANSFER_SRC as Vulkan merely transfer reads this image for the commit blit, while the WebProcess
-    // renders into the exported image via OpenGL/EGL, independently of the Vulkan usage. The tiled DRM-modifier path is
-    // the validation-clean way to export a DMABuf. The linear fallback is tolerated but not advertised where the modifier
-    // extension is missing, so it renders but emits VUID-VkImageCreateInfo-pNext-00990.
-    // FIXME: the chosen modifier is one our device supports; it is not yet intersected with the modifiers the web process' EGL
-    // import can consume (that needs the consumer's list plumbed across IPC). On a single GPU the sets overlap in practice.
-    static constexpr VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    auto modifierProperties = m_supportsDRMModifiers ? supportedExportDRMModifiers(format, usage) : Vector<VkDrmFormatModifierPropertiesEXT> { };
-    Vector<uint64_t> modifiers = modifierProperties.map([](const auto& properties) {
-        return properties.drmFormatModifier;
-    });
-    bool useModifiers = !modifiers.isEmpty();
+    auto usage = maximalImageUsageFlags(format);
+    if (!supportsOpaqueFDSharing(format, usage))
+        return std::nullopt;
 
     VkExternalMemoryImageCreateInfo externalMemoryImageInfo { };
     externalMemoryImageInfo.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
-    externalMemoryImageInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
-
-    VkImageDrmFormatModifierListCreateInfoEXT modifierListInfo { };
-    modifierListInfo.sType = VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT;
-    modifierListInfo.pNext = &externalMemoryImageInfo;
-    modifierListInfo.drmFormatModifierCount = static_cast<uint32_t>(modifiers.size());
-    modifierListInfo.pDrmFormatModifiers = modifiers.span().data();
-
-    VkImageCreateInfo imageCreateInfo { };
-    imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-    imageCreateInfo.pNext = useModifiers ? static_cast<const void*>(&modifierListInfo) : static_cast<const void*>(&externalMemoryImageInfo);
-    imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
-    imageCreateInfo.format = format;
-    imageCreateInfo.extent = { width, height, 1 };
-    imageCreateInfo.mipLevels = 1;
-    imageCreateInfo.arrayLayers = 1;
-    imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-    imageCreateInfo.tiling = useModifiers ? VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT : VK_IMAGE_TILING_LINEAR;
-    imageCreateInfo.usage = usage;
-    imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-
-    ExportedImage exportedImage;
-    exportedImage.width = width;
-    exportedImage.height = height;
-    exportedImage.format = format;
-
-    if (m_deviceTable.vkCreateImage(m_vkDevice, &imageCreateInfo, nullptr, &exportedImage.image) != VK_SUCCESS) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateImage failed for exported texture (useModifiers=%d)", useModifiers);
-        return std::nullopt;
-    }
-    setDebugName(VK_OBJECT_TYPE_IMAGE, toHandle(exportedImage.image), "WebXR exported image");
-
-    auto cleanupOnError = makeScopeExit([&] {
-        destroyExportedImage(exportedImage);
-    });
-
-    VkMemoryRequirements memoryRequirements;
-    m_deviceTable.vkGetImageMemoryRequirements(m_vkDevice, exportedImage.image, &memoryRequirements);
-
-    auto memoryTypeIndex = findMemoryType(m_instanceTable, m_vkPhysicalDevice, memoryRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-    if (!memoryTypeIndex) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: no suitable memory type for exported texture");
-        return std::nullopt;
-    }
-
-    VkMemoryDedicatedAllocateInfo dedicatedAllocateInfo { };
-    dedicatedAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
-    dedicatedAllocateInfo.image = exportedImage.image;
-
-    VkExportMemoryAllocateInfo exportAllocateInfo { };
-    exportAllocateInfo.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO;
-    exportAllocateInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
-    exportAllocateInfo.pNext = &dedicatedAllocateInfo;
-
-    VkMemoryAllocateInfo memoryAllocateInfo { };
-    memoryAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    memoryAllocateInfo.pNext = &exportAllocateInfo;
-    memoryAllocateInfo.allocationSize = memoryRequirements.size;
-    memoryAllocateInfo.memoryTypeIndex = *memoryTypeIndex;
-
-    if (m_deviceTable.vkAllocateMemory(m_vkDevice, &memoryAllocateInfo, nullptr, &exportedImage.memory) != VK_SUCCESS) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkAllocateMemory failed for exported texture");
-        return std::nullopt;
-    }
-    setDebugName(VK_OBJECT_TYPE_DEVICE_MEMORY, toDebugHandle(exportedImage.memory), "WebXR exported image memory");
-    if (m_deviceTable.vkBindImageMemory(m_vkDevice, exportedImage.image, exportedImage.memory, 0) != VK_SUCCESS) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkBindImageMemory failed for exported texture");
-        return std::nullopt;
-    }
-
-    uint64_t modifier = DRM_FORMAT_MOD_LINEAR;
-    uint32_t planeCount = 1;
-    if (useModifiers) {
-        VkImageDrmFormatModifierPropertiesEXT chosenModifier { };
-        chosenModifier.sType = VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT;
-        if (m_deviceTable.vkGetImageDrmFormatModifierPropertiesEXT(m_vkDevice, exportedImage.image, &chosenModifier) != VK_SUCCESS) {
-            RELEASE_LOG(XR, "OpenXR Vulkan: vkGetImageDrmFormatModifierPropertiesEXT failed for exported texture");
-            return std::nullopt;
-        }
-        modifier = chosenModifier.drmFormatModifier;
-        for (const auto& properties : modifierProperties) {
-            if (properties.drmFormatModifier == modifier) {
-                planeCount = properties.drmFormatModifierPlaneCount;
-                break;
-            }
-        }
-        if (!planeCount || planeCount > 4) {
-            RELEASE_LOG(XR, "OpenXR Vulkan: unexpected plane count %u for exported texture", planeCount);
-            return std::nullopt;
-        }
-    }
-
-    // All planes share the single dedicated allocation, so one exported fd is duplicated per plane. The planes differ only by offset and stride.
-    VkMemoryGetFdInfoKHR getFdInfo { };
-    getFdInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
-    getFdInfo.memory = exportedImage.memory;
-    getFdInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
-    int dmaBufFd = -1;
-    if (m_deviceTable.vkGetMemoryFdKHR(m_vkDevice, &getFdInfo, &dmaBufFd) != VK_SUCCESS || dmaBufFd < 0) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkGetMemoryFdKHR failed for exported texture");
-        return std::nullopt;
-    }
-    WTF::UnixFileDescriptor primaryDescriptor { dmaBufFd, WTF::UnixFileDescriptor::Adopt };
-
-    Vector<WTF::UnixFileDescriptor> fds;
-    Vector<uint32_t> strides;
-    Vector<uint32_t> offsets;
-    for (uint32_t plane = 0; plane < planeCount; ++plane) {
-        // A modifier image exposes each plane via a MEMORY_PLANE aspect (bits run consecutively from MEMORY_PLANE_0); a linear image has a single colour plane.
-        VkImageSubresource subresource { };
-        subresource.aspectMask = useModifiers ? static_cast<VkImageAspectFlagBits>(VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT << plane) : VK_IMAGE_ASPECT_COLOR_BIT;
-        VkSubresourceLayout layout { };
-        m_deviceTable.vkGetImageSubresourceLayout(m_vkDevice, exportedImage.image, &subresource, &layout);
-        auto duplicated = primaryDescriptor.duplicate();
-        if (!duplicated) {
-            RELEASE_LOG(XR, "OpenXR Vulkan: failed to duplicate DMABuf fd for plane %u", plane);
-            return std::nullopt;
-        }
-        fds.append(WTF::move(duplicated));
-        strides.append(static_cast<uint32_t>(layout.rowPitch));
-        offsets.append(static_cast<uint32_t>(layout.offset));
-    }
-
-    if (!createExportedImageSyncObjects(exportedImage))
-        return std::nullopt;
-
-    cleanupOnError.release();
-    m_exportedImages.set(swapchainImage, WTF::move(exportedImage));
-
-    return PlatformXR::FrameData::ExternalTexture {
-        .fds = WTF::move(fds),
-        .strides = WTF::move(strides),
-        .offsets = WTF::move(offsets),
-        .fourcc = fourcc,
-        .modifier = modifier,
-    };
-}
-#endif // USE(GBM)
-
-#if OS(ANDROID)
-std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulkan::exportImageAsAHardwareBuffer(uint64_t swapchainImage, const OpenXRSwapchain& swapchain, uint32_t width, uint32_t height)
-{
-    auto format = static_cast<VkFormat>(swapchain.format());
-
-    // The WebProcess renders into the AHardwareBuffer as a colour target and we transfer read it at commit, so it needs
-    // COLOR_ATTACHMENT | TRANSFER_SRC. COLOR_ATTACHMENT is what makes the exported buffer carry the GPU_FRAMEBUFFER usage
-    // that the GL consumer needs.
-    static constexpr VkImageUsageFlags usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-
-    VkExternalMemoryImageCreateInfo externalMemoryImageInfo { };
-    externalMemoryImageInfo.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
-    externalMemoryImageInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
+    externalMemoryImageInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
     VkImageCreateInfo imageCreateInfo { };
     imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -889,10 +718,12 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulka
     exportedImage.width = width;
     exportedImage.height = height;
     exportedImage.format = format;
+
     if (m_deviceTable.vkCreateImage(m_vkDevice, &imageCreateInfo, nullptr, &exportedImage.image) != VK_SUCCESS) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateImage failed for exported AHardwareBuffer texture");
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateImage failed for the opaque fd exported texture");
         return std::nullopt;
     }
+    setDebugName(VK_OBJECT_TYPE_IMAGE, toHandle(exportedImage.image), "WebXR exported image");
 
     auto cleanupOnError = makeScopeExit([&] {
         destroyExportedImage(exportedImage);
@@ -900,13 +731,14 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulka
 
     VkMemoryRequirements memoryRequirements;
     m_deviceTable.vkGetImageMemoryRequirements(m_vkDevice, exportedImage.image, &memoryRequirements);
+
     auto memoryTypeIndex = findMemoryType(m_instanceTable, m_vkPhysicalDevice, memoryRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     if (!memoryTypeIndex) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: no suitable memory type for exported AHardwareBuffer texture");
+        RELEASE_LOG(XR, "OpenXR Vulkan: no suitable memory type for the opaque fd exported texture");
         return std::nullopt;
     }
 
-    // AHardwareBuffer export requires a dedicated allocation.
+    // Dedicated and the consumer sets GL_DEDICATED_MEMORY_OBJECT_EXT to match. Both sides have to agree on whether the allocation belongs to this one image or the import is invalid.
     VkMemoryDedicatedAllocateInfo dedicatedAllocateInfo { };
     dedicatedAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
     dedicatedAllocateInfo.image = exportedImage.image;
@@ -914,49 +746,68 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulka
     VkExportMemoryAllocateInfo exportAllocateInfo { };
     exportAllocateInfo.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO;
     exportAllocateInfo.pNext = &dedicatedAllocateInfo;
-    exportAllocateInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
+    exportAllocateInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
-    VkMemoryAllocateInfo memoryAllocateInfo { };
-    memoryAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    memoryAllocateInfo.pNext = &exportAllocateInfo;
-    memoryAllocateInfo.allocationSize = memoryRequirements.size;
-    memoryAllocateInfo.memoryTypeIndex = *memoryTypeIndex;
-    if (m_deviceTable.vkAllocateMemory(m_vkDevice, &memoryAllocateInfo, nullptr, &exportedImage.memory) != VK_SUCCESS) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkAllocateMemory failed for exported AHardwareBuffer texture");
+    VkMemoryAllocateInfo allocateInfo { };
+    allocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    allocateInfo.pNext = &exportAllocateInfo;
+    allocateInfo.allocationSize = memoryRequirements.size;
+    allocateInfo.memoryTypeIndex = *memoryTypeIndex;
+
+    if (m_deviceTable.vkAllocateMemory(m_vkDevice, &allocateInfo, nullptr, &exportedImage.memory) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkAllocateMemory failed for the opaque fd exported texture");
         return std::nullopt;
     }
+    setDebugName(VK_OBJECT_TYPE_DEVICE_MEMORY, toDebugHandle(exportedImage.memory), "WebXR exported image memory");
+
     if (m_deviceTable.vkBindImageMemory(m_vkDevice, exportedImage.image, exportedImage.memory, 0) != VK_SUCCESS) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkBindImageMemory failed for exported AHardwareBuffer texture");
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkBindImageMemory failed for the opaque fd exported texture");
         return std::nullopt;
     }
 
-    // Pull the AHardwareBuffer out of the memory; it comes with one acquired reference that adoptRef transfers to the caller.
-    // Resolve the function via vkGetDeviceProcAddr rather than the device table so this does not depend on volk having been built
-    // with VK_USE_PLATFORM_ANDROID_KHR.
-    auto vkGetMemoryAndroidHardwareBuffer = reinterpret_cast<PFN_vkGetMemoryAndroidHardwareBufferANDROID>(m_instanceTable.vkGetDeviceProcAddr(m_vkDevice, "vkGetMemoryAndroidHardwareBufferANDROID"));
-    if (!vkGetMemoryAndroidHardwareBuffer) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkGetMemoryAndroidHardwareBufferANDROID is not available");
+    VkMemoryGetFdInfoKHR memoryGetFdInfo { };
+    memoryGetFdInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
+    memoryGetFdInfo.memory = exportedImage.memory;
+    memoryGetFdInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+    int memoryFd = -1;
+    if (m_deviceTable.vkGetMemoryFdKHR(m_vkDevice, &memoryGetFdInfo, &memoryFd) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkGetMemoryFdKHR failed for the opaque fd exported texture");
         return std::nullopt;
     }
-    VkMemoryGetAndroidHardwareBufferInfoANDROID getInfo { };
-    getInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID;
-    getInfo.memory = exportedImage.memory;
-    AHardwareBuffer* buffer = nullptr;
-    if (vkGetMemoryAndroidHardwareBuffer(m_vkDevice, &getInfo, &buffer) != VK_SUCCESS || !buffer) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkGetMemoryAndroidHardwareBufferANDROID failed for exported texture");
-        return std::nullopt;
-    }
-    // Adopt the acquired reference now so it is released automatically on any early return below.
-    RefPtr<AHardwareBuffer> hardwareBuffer = adoptRef(buffer);
+    WTF::UnixFileDescriptor memoryDescriptor { memoryFd, WTF::UnixFileDescriptor::Adopt };
 
-    if (!createExportedImageSyncObjects(exportedImage))
+    if (!createExportedImageSyncObjects(exportedImage) || !createExportedImageSharingSemaphores(exportedImage))
         return std::nullopt;
+
+    auto exportSemaphore = [&](VkSemaphore semaphore) -> WTF::UnixFileDescriptor {
+        VkSemaphoreGetFdInfoKHR semaphoreGetFdInfo { };
+        semaphoreGetFdInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR;
+        semaphoreGetFdInfo.semaphore = semaphore;
+        semaphoreGetFdInfo.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+        int fd = -1;
+        if (m_deviceTable.vkGetSemaphoreFdKHR(m_vkDevice, &semaphoreGetFdInfo, &fd) != VK_SUCCESS)
+            return { };
+        return WTF::UnixFileDescriptor { fd, WTF::UnixFileDescriptor::Adopt };
+    };
+
+    auto renderFinishedDescriptor = exportSemaphore(exportedImage.renderFinishedSemaphore);
+    if (!renderFinishedDescriptor) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkGetSemaphoreFdKHR failed for the exported image's render-finished semaphore");
+        return std::nullopt;
+    }
 
     cleanupOnError.release();
     m_exportedImages.set(swapchainImage, WTF::move(exportedImage));
-    return hardwareBuffer;
+
+    return PlatformXR::FrameData::ExternalTexture {
+        .memory = WTF::move(memoryDescriptor),
+        .allocationSize = memoryRequirements.size,
+        .glInternalFormat = glInternalFormat,
+        .renderFinishedSemaphore = WTF::move(renderFinishedDescriptor),
+        .deviceUUID = m_deviceUUID,
+        .driverUUID = m_driverUUID,
+    };
 }
-#endif // OS(ANDROID)
 
 static VkImageMemoryBarrier makeImageBarrier(VkImage image, VkImageLayout oldLayout, VkImageLayout newLayout, VkAccessFlags srcAccess, VkAccessFlags dstAccess, uint32_t srcQueueFamily = VK_QUEUE_FAMILY_IGNORED, uint32_t dstQueueFamily = VK_QUEUE_FAMILY_IGNORED, uint32_t layerCount = 1)
 {
@@ -973,6 +824,13 @@ static VkImageMemoryBarrier makeImageBarrier(VkImage image, VkImageLayout oldLay
     return barrier;
 }
 
+// Vulkan has none of GL's implicit ordering: the GPU may overlap and reorder work, its caches are not coherent between stages, and an image is stored in a layout
+// chosen for how it is about to be used. So every access here has to be stated, which is what the barriers below do. One VkImageMemoryBarrier covers three separate
+// things at once, and each of the three is why one of its arguments exists:
+//   1. Execution. The stage masks passed to vkCmdPipelineBarrier order the work recorded before it against the work recorded after it.
+//   2. Memory. srcAccessMask flushes the writer's caches and dstAccessMask invalidates the reader's, because ordering alone does not make the bytes visible.
+//   3. Layout. The driver may physically rearrange the image between oldLayout and newLayout. GL has no such concept, which is why the consumer has to name the
+//      layout it leaves the shared image in when it signals its semaphore, and why that layout is repeated on this side rather than inferred.
 bool OpenXRGraphicsBindingVulkan::recordBlitCommandBuffer(ExportedImage& exportedImage, VkImage swapchainImage)
 {
     VkCommandBufferAllocateInfo commandBufferAllocateInfo { };
@@ -989,37 +847,33 @@ bool OpenXRGraphicsBindingVulkan::recordBlitCommandBuffer(ExportedImage& exporte
 
     VkCommandBufferBeginInfo beginInfo { };
     beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-    // No VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT: this buffer is recorded once and resubmitted on every commit.
+    // No VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT as this buffer is recorded once and resubmitted on every commit.
     m_deviceTable.vkBeginCommandBuffer(commandBuffer, &beginInfo);
 
-    // The exported image was written by the WebProcess through an external (OpenGL) DMABuf import, so acquire queue family
-    // ownership of it from VK_QUEUE_FAMILY_FOREIGN_EXT before reading. We keep it in VK_IMAGE_LAYOUT_GENERAL throughout: GENERAL
-    // preserves the foreign contents (UNDEFINED would let the driver discard them) and imposes no Vulkan-specific tiling, which
-    // matches the externally-written linear DMABuf. The swapchain image is owned by our own device and fully overwritten by the
-    // blit, so it can start from UNDEFINED with no ownership transfer.
+    // Neither barrier transfers queue family ownership, as both images are only ever touched by drivers on this device. The exported image is already in
+    // VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL because the consumer left it there, spelling that layout GL_LAYOUT_TRANSFER_SRC_EXT since GL has none of its own, so this barrier
+    // does not transition it and exists only to make its writes visible to the transfer read. The swapchain image is ours and the blit overwrites all of it, so it starts from UNDEFINED.
     std::array<VkImageMemoryBarrier, 2> preBlitBarriers { {
-        makeImageBarrier(exportedImage.image, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL, 0, VK_ACCESS_TRANSFER_READ_BIT, VK_QUEUE_FAMILY_FOREIGN_EXT, m_queueFamilyIndex),
+        makeImageBarrier(exportedImage.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 0, VK_ACCESS_TRANSFER_READ_BIT),
         makeImageBarrier(swapchainImage, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 0, VK_ACCESS_TRANSFER_WRITE_BIT),
     } };
     m_deviceTable.vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, preBlitBarriers.size(), preBlitBarriers.data());
 
-    // The WebProcess renders into the exported image with OpenGL, whose framebuffer origin is the bottom left, whereas
-    // Vulkan (and therefore the runtime's swapchain image) uses the top left. We blit rather than copy so the destination's
-    // Y offsets can be inverted, correcting the flip in the same pass (vkCmdCopyImage cannot flip). The transfer is 1:1 in
-    // size and format so NEAREST adds no filtering, and the Y inversion itself costs nothing beyond the blit.
+    // The WebProcess renders into the exported image with OpenGL, whose framebuffer origin is the bottom left, whereas Vulkan (and therefore the runtime's swapchain image)
+    // uses the top left. We blit rather than copy so the destination's Y offsets can be inverted, correcting the flip in the same pass (vkCmdCopyImage cannot flip).
+    // The transfer is 1:1 in size and format so NEAREST adds no filtering, and the Y inversion itself costs nothing beyond the blit.
     VkImageBlit blitRegion {
         .srcSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 },
         .srcOffsets = { { 0, 0, 0 }, { static_cast<int32_t>(exportedImage.width), static_cast<int32_t>(exportedImage.height), 1 } },
         .dstSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 },
         .dstOffsets = { { 0, static_cast<int32_t>(exportedImage.height), 0 }, { static_cast<int32_t>(exportedImage.width), 0, 1 } },
     };
-    m_deviceTable.vkCmdBlitImage(commandBuffer, exportedImage.image, VK_IMAGE_LAYOUT_GENERAL, swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blitRegion, VK_FILTER_NEAREST);
+    m_deviceTable.vkCmdBlitImage(commandBuffer, exportedImage.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blitRegion, VK_FILTER_NEAREST);
 
-    // Transition the swapchain image to COLOR_ATTACHMENT_OPTIMAL, which the runtime expects when it is released, and release
-    // ownership of the exported image back to the foreign (OpenGL) producer so it can render into it again next frame.
-    std::array<VkImageMemoryBarrier, 2> postBlitBarriers { {
+    // Transition the swapchain image to COLOR_ATTACHMENT_OPTIMAL, which the runtime expects when it is released. The exported image
+    // needs nothing, it stays in TRANSFER_SRC_OPTIMAL, which is what the consumer leaves it in and what the next blit reads it as.
+    std::array<VkImageMemoryBarrier, 1> postBlitBarriers { {
         makeImageBarrier(swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT),
-        makeImageBarrier(exportedImage.image, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL, VK_ACCESS_TRANSFER_READ_BIT, 0, m_queueFamilyIndex, VK_QUEUE_FAMILY_FOREIGN_EXT),
     } };
     m_deviceTable.vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, postBlitBarriers.size(), postBlitBarriers.data());
 
@@ -1045,6 +899,14 @@ void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwa
         return;
     auto& exportedImage = exportedImageIterator->value;
 
+    // No fence means the consumer did not release this image, so there is no renderFinished signal outstanding and nothing was rendered.
+    // The two are produced together on purpose, waiting on an unsignalled binary semaphore would wedge the queue, and this is what
+    // lets us know a signal exists without a separate flag over IPC.
+    if (!pendingFenceFD) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: no frame fence for this commit, the consumer did not hand the image back");
+        return;
+    }
+
     VkImage swapchainImage = toVkImage(swapchain.acquiredTexture());
     ASSERT(swapchainImage != VK_NULL_HANDLE);
 
@@ -1054,8 +916,7 @@ void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwa
 
     // Wait for this image's previous submission to retire before reusing its command buffer and acquire semaphore, then reset
     // the fence for this frame's submission. The fence was created signaled and the image was last used a full swapchain cycle
-    // ago, so this almost always returns immediately; it only blocks if the GPU has fallen behind by the swapchain depth. This
-    // is what lets us drop the per-frame vkQueueWaitIdle and overlap CPU and GPU work.
+    // ago, so this almost always returns immediately; it only blocks if the GPU has fallen behind by the swapchain depth.
     m_deviceTable.vkWaitForFences(m_vkDevice, 1, &exportedImage.inFlightFence, VK_TRUE, UINT64_MAX);
     m_deviceTable.vkResetFences(m_vkDevice, 1, &exportedImage.inFlightFence);
 
@@ -1078,16 +939,19 @@ void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwa
             RELEASE_LOG(XR, "OpenXR Vulkan: vkImportSemaphoreFdKHR failed; frame fence ignored");
     }
 
-    // The blit waits on the GPU for the WebProcess to finish rendering into the exported image (TRANSFER stage, where the
-    // blit reads), and signals inFlightFence on completion so the next reuse of this image can wait on it.
-    VkPipelineStageFlags acquireWaitStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    // The blit waits for the consumer on two counts: renderFinishedSemaphore is the other half of its glSignalSemaphoreEXT, and
+    // acquireSemaphore carries the render completion fence. Waiting on both is redundant in the common case but neither implies the
+    // other, and the wait is free once the work is done. inFlightFence is signalled so the next reuse of this image can tell the
+    // previous submission has retired. Nothing has to be signalled for the consumer: xrWaitSwapchainImage will not let it render into
+    // this image again until the runtime has finished with the swapchain image this blit writes, which cannot happen before the blit
+    // completes.
+    std::array<VkSemaphore, 2> waitSemaphores { exportedImage.renderFinishedSemaphore, exportedImage.acquireSemaphore };
+    std::array<VkPipelineStageFlags, 2> waitStages { VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT };
     VkSubmitInfo submitInfo { };
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-    if (waitOnAcquireFence) {
-        submitInfo.waitSemaphoreCount = 1;
-        submitInfo.pWaitSemaphores = &exportedImage.acquireSemaphore;
-        submitInfo.pWaitDstStageMask = &acquireWaitStage;
-    }
+    submitInfo.waitSemaphoreCount = waitOnAcquireFence ? 2 : 1;
+    submitInfo.pWaitSemaphores = waitSemaphores.data();
+    submitInfo.pWaitDstStageMask = waitStages.data();
     submitInfo.commandBufferCount = 1;
     submitInfo.pCommandBuffers = &exportedImage.commandBuffer;
     if (auto submitResult = m_deviceTable.vkQueueSubmit(m_vkQueue, 1, &submitInfo, exportedImage.inFlightFence); submitResult != VK_SUCCESS)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
@@ -237,7 +237,9 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
 
     VkCommandPoolCreateInfo poolCreateInfo { };
     poolCreateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-    poolCreateInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    // The per-swapchain-image commit command buffers are recorded once and never reset or re-recorded, so no pool flags are
+    // needed; they are freed in bulk when the pool is destroyed.
+    poolCreateInfo.flags = 0;
     poolCreateInfo.queueFamilyIndex = m_queueFamilyIndex;
     if (m_deviceTable.vkCreateCommandPool(m_vkDevice, &poolCreateInfo, nullptr, &m_commandPool) != VK_SUCCESS) {
         LOG(XR, "Failed to create the Vulkan command pool.");
@@ -521,25 +523,8 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulka
     };
 }
 
-void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwapchain& swapchain, TextureType type, const Vector<uint64_t>&)
+bool OpenXRGraphicsBindingVulkan::recordBlitCommandBuffer(ExportedImage& exportedImage, VkImage swapchainImage)
 {
-    // Consume any fence imported by waitFrameFence() for this commit. Snapshot it up front so the
-    // early returns below don't leave a stale payload waiting on the next layer's commit.
-    bool waitOnAcquireFence = std::exchange(m_acquireSemaphorePending, false);
-
-    if (type != TextureType::Texture2D)
-        return;
-
-    ASSERT(m_vkDevice != VK_NULL_HANDLE);
-
-    auto exportedImageIterator = m_exportedImages.find(keyImage);
-    if (exportedImageIterator == m_exportedImages.end())
-        return;
-    const auto& exportedImage = exportedImageIterator->value;
-
-    VkImage swapchainImage = toVkImage(swapchain.acquiredTexture());
-    ASSERT(swapchainImage != VK_NULL_HANDLE);
-
     VkCommandBufferAllocateInfo commandBufferAllocateInfo { };
     commandBufferAllocateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
     commandBufferAllocateInfo.commandPool = m_commandPool;
@@ -548,17 +533,9 @@ void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwa
 
     VkCommandBuffer commandBuffer = VK_NULL_HANDLE;
     if (m_deviceTable.vkAllocateCommandBuffers(m_vkDevice, &commandBufferAllocateInfo, &commandBuffer) != VK_SUCCESS) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: failed to allocate command buffer for commit");
-        return;
+        RELEASE_LOG(XR, "OpenXR Vulkan: failed to allocate commit command buffer");
+        return false;
     }
-    auto freeCommandBuffer = makeScopeExit([&] {
-        m_deviceTable.vkFreeCommandBuffers(m_vkDevice, m_commandPool, 1, &commandBuffer);
-    });
-
-    VkCommandBufferBeginInfo beginInfo { };
-    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-    m_deviceTable.vkBeginCommandBuffer(commandBuffer, &beginInfo);
 
     auto makeBarrier = [](VkImage image, VkImageLayout oldLayout, VkImageLayout newLayout, VkAccessFlags srcAccess, VkAccessFlags dstAccess, uint32_t srcQueueFamily = VK_QUEUE_FAMILY_IGNORED, uint32_t dstQueueFamily = VK_QUEUE_FAMILY_IGNORED) {
         VkImageMemoryBarrier barrier { };
@@ -573,6 +550,11 @@ void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwa
         barrier.dstAccessMask = dstAccess;
         return barrier;
     };
+
+    VkCommandBufferBeginInfo beginInfo { };
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    // No VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT: this buffer is recorded once and resubmitted on every commit.
+    m_deviceTable.vkBeginCommandBuffer(commandBuffer, &beginInfo);
 
     // The exported image was written by the WebProcess through an external (OpenGL) DMABuf import, so acquire queue family
     // ownership of it from VK_QUEUE_FAMILY_FOREIGN_EXT before reading. We keep it in VK_IMAGE_LAYOUT_GENERAL throughout: GENERAL
@@ -608,6 +590,35 @@ void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwa
 
     m_deviceTable.vkEndCommandBuffer(commandBuffer);
 
+    exportedImage.commandBuffer = commandBuffer;
+    return true;
+}
+
+void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwapchain& swapchain, TextureType type, const Vector<uint64_t>&)
+{
+    // Consume any fence imported by waitFrameFence() for this commit. Snapshot it up front so the
+    // early returns below don't leave a stale payload waiting on the next layer's commit.
+    bool waitOnAcquireFence = std::exchange(m_acquireSemaphorePending, false);
+
+    if (type != TextureType::Texture2D)
+        return;
+
+    ASSERT(m_vkDevice != VK_NULL_HANDLE);
+
+    auto exportedImageIterator = m_exportedImages.find(keyImage);
+    if (exportedImageIterator == m_exportedImages.end())
+        return;
+    auto& exportedImage = exportedImageIterator->value;
+
+    VkImage swapchainImage = toVkImage(swapchain.acquiredTexture());
+    ASSERT(swapchainImage != VK_NULL_HANDLE);
+
+    // The blit is identical every time this swapchain image is acquired (fixed source/destination images and region), so its
+    // command buffer is recorded once and resubmitted on every commit. Reuse is safe because the per-frame vkQueueWaitIdle below
+    // guarantees the previous submission completed before this one is resubmitted.
+    if (exportedImage.commandBuffer == VK_NULL_HANDLE && !recordBlitCommandBuffer(exportedImage, swapchainImage))
+        return;
+
     // Make the blit wait, on the GPU, for the web process to finish rendering into the exported image
     // (the fence imported by waitFrameFence()). TRANSFER stage because the blit reads at transfer time.
     VkPipelineStageFlags acquireWaitStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
@@ -619,7 +630,7 @@ void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwa
         submitInfo.pWaitDstStageMask = &acquireWaitStage;
     }
     submitInfo.commandBufferCount = 1;
-    submitInfo.pCommandBuffers = &commandBuffer;
+    submitInfo.pCommandBuffers = &exportedImage.commandBuffer;
     m_deviceTable.vkQueueSubmit(m_vkQueue, 1, &submitInfo, VK_NULL_HANDLE);
 
     // FIXME: perf — a per-frame queue wait serializes CPU and GPU. The eventual path should let the runtime synchronize on

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
@@ -1,0 +1,662 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "OpenXRGraphicsBindingVulkan.h"
+
+#if ENABLE(WEBXR) && USE(OPENXR) && defined(XR_USE_GRAPHICS_API_VULKAN)
+
+#include "OpenXRExtensions.h"
+#include "OpenXRSwapchain.h"
+#include <array>
+#include <bit>
+#include <cstring>
+#include <drm_fourcc.h>
+#include <utility>
+#include <wtf/RunLoop.h>
+#include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+
+namespace WebKit {
+
+// Vulkan non-dispatchable handles (VkImage, VkDeviceMemory, ...) are 8 bytes on every architecture (a pointer where pointers
+// are 64-bit, a uint64_t otherwise). bit_cast copies the raw bytes and is correct for both representations, unlike a
+// reinterpret_cast that would assume a pointer.
+static_assert(sizeof(VkImage) == sizeof(uint64_t), "VkImage is expected to be a 64-bit handle");
+
+static inline uint64_t toHandle(VkImage image)
+{
+    return std::bit_cast<uint64_t>(image);
+}
+
+static inline VkImage toVkImage(uint64_t handle)
+{
+    return std::bit_cast<VkImage>(handle);
+}
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRGraphicsBindingVulkan);
+
+std::unique_ptr<OpenXRGraphicsBindingVulkan> OpenXRGraphicsBindingVulkan::create()
+{
+    return std::unique_ptr<OpenXRGraphicsBindingVulkan>(new OpenXRGraphicsBindingVulkan());
+}
+
+OpenXRGraphicsBindingVulkan::OpenXRGraphicsBindingVulkan() = default;
+
+OpenXRGraphicsBindingVulkan::~OpenXRGraphicsBindingVulkan()
+{
+    ASSERT(m_vkDevice == VK_NULL_HANDLE);
+}
+
+Vector<ASCIILiteral> OpenXRGraphicsBindingVulkan::requiredInstanceExtensions() const
+{
+    Vector<ASCIILiteral> extensions;
+    if (OpenXRExtensions::singleton().isExtensionSupported(XR_KHR_VULKAN_ENABLE2_EXTENSION_NAME ""_span))
+        extensions.append(XR_KHR_VULKAN_ENABLE2_EXTENSION_NAME ""_s);
+    return extensions;
+}
+
+bool OpenXRGraphicsBindingVulkan::initializeDisplay(bool)
+{
+    ASSERT(RunLoop::isMain());
+    // Unlike the OpenGLES binding, Vulkan must create its instance and device through the OpenXR runtime
+    // (xrCreateVulkan{Instance|Device}KHR), which requires the OpenXR instance and system to already exist. That work is
+    // deferred to initializeForSession() so there is nothing to set up before instance creation here.
+    return true;
+}
+
+bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSystemId systemId)
+{
+    ASSERT(!RunLoop::isMain());
+
+    const auto& methods = OpenXRExtensions::singleton().methods();
+
+    auto graphicsRequirements = createOpenXRStruct<XrGraphicsRequirementsVulkanKHR, XR_TYPE_GRAPHICS_REQUIREMENTS_VULKAN2_KHR>();
+    CHECK_XRCMD(methods.xrGetVulkanGraphicsRequirements2KHR(instance, systemId, &graphicsRequirements));
+
+    if (volkInitialize() != VK_SUCCESS) {
+        LOG(XR, "Failed to initialize Volk for the OpenXR Vulkan binding.");
+        return false;
+    }
+
+    uint32_t loaderVersion = VK_API_VERSION_1_0;
+    if (vkEnumerateInstanceVersion)
+        vkEnumerateInstanceVersion(&loaderVersion);
+    uint32_t apiMajor = VK_API_VERSION_MAJOR(loaderVersion);
+    uint32_t apiMinor = VK_API_VERSION_MINOR(loaderVersion);
+
+    // maxApiVersionSupported might return non-sensical large values standing for "no maximum". This could wrap into
+    // a version below 1.1 and hide extensions whose dependencies are core from 1.1, so protect against that.
+    static constexpr uint32_t plausibleMajorLimit = 8;
+    auto maxMajor = static_cast<uint32_t>(XR_VERSION_MAJOR(graphicsRequirements.maxApiVersionSupported));
+    auto maxMinor = static_cast<uint32_t>(XR_VERSION_MINOR(graphicsRequirements.maxApiVersionSupported));
+    if (maxMajor <= plausibleMajorLimit && (maxMajor < apiMajor || (maxMajor == apiMajor && maxMinor < apiMinor))) {
+        apiMajor = maxMajor;
+        apiMinor = maxMinor;
+    }
+
+    auto minMajor = static_cast<uint32_t>(XR_VERSION_MAJOR(graphicsRequirements.minApiVersionSupported));
+    auto minMinor = static_cast<uint32_t>(XR_VERSION_MINOR(graphicsRequirements.minApiVersionSupported));
+    if (apiMajor < minMajor || (apiMajor == minMajor && apiMinor < minMinor)) {
+        LOG(XR, "OpenXR Vulkan: Vulkan %u.%u is available but the runtime requires at least %u.%u", apiMajor, apiMinor, minMajor, minMinor);
+        return false;
+    }
+
+    const uint32_t apiVersion = VK_MAKE_API_VERSION(0, apiMajor, apiMinor, 0);
+    VkApplicationInfo applicationInfo { };
+    applicationInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    applicationInfo.pApplicationName = "WebKitWebXR";
+    applicationInfo.apiVersion = apiVersion;
+
+    VkInstanceCreateInfo vkInstanceCreateInfo { };
+    vkInstanceCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    vkInstanceCreateInfo.pApplicationInfo = &applicationInfo;
+
+    auto xrInstanceCreateInfo = createOpenXRStruct<XrVulkanInstanceCreateInfoKHR, XR_TYPE_VULKAN_INSTANCE_CREATE_INFO_KHR>();
+    xrInstanceCreateInfo.systemId = systemId;
+    xrInstanceCreateInfo.pfnGetInstanceProcAddr = vkGetInstanceProcAddr;
+    xrInstanceCreateInfo.vulkanCreateInfo = &vkInstanceCreateInfo;
+
+    VkResult vkResult = VK_SUCCESS;
+    CHECK_XRCMD(methods.xrCreateVulkanInstanceKHR(instance, &xrInstanceCreateInfo, &m_vkInstance, &vkResult));
+    if (vkResult != VK_SUCCESS || m_vkInstance == VK_NULL_HANDLE) {
+        LOG(XR, "xrCreateVulkanInstanceKHR() failed (VkResult %d).", vkResult);
+        return false;
+    }
+    volkLoadInstanceTable(&m_instanceTable, m_vkInstance);
+
+    auto deviceGetInfo = createOpenXRStruct<XrVulkanGraphicsDeviceGetInfoKHR, XR_TYPE_VULKAN_GRAPHICS_DEVICE_GET_INFO_KHR>();
+    deviceGetInfo.systemId = systemId;
+    deviceGetInfo.vulkanInstance = m_vkInstance;
+    CHECK_XRCMD(methods.xrGetVulkanGraphicsDevice2KHR(instance, &deviceGetInfo, &m_vkPhysicalDevice));
+    if (m_vkPhysicalDevice == VK_NULL_HANDLE) {
+        LOG(XR, "xrGetVulkanGraphicsDevice2KHR() returned a null physical device.");
+        return false;
+    }
+
+    uint32_t queueFamilyCount = 0;
+    m_instanceTable.vkGetPhysicalDeviceQueueFamilyProperties(m_vkPhysicalDevice, &queueFamilyCount, nullptr);
+    Vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
+    m_instanceTable.vkGetPhysicalDeviceQueueFamilyProperties(m_vkPhysicalDevice, &queueFamilyCount, queueFamilies.mutableSpan().data());
+
+    std::optional<uint32_t> graphicsFamily;
+    for (uint32_t i = 0; i < queueFamilyCount; ++i) {
+        if (queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+            graphicsFamily = i;
+            break;
+        }
+    }
+    if (!graphicsFamily) {
+        LOG(XR, "No graphics-capable Vulkan queue family found.");
+        return false;
+    }
+    m_queueFamilyIndex = *graphicsFamily;
+
+    // Extensions required to export our own images as dma-bufs to the web process, to import the web process' frame fence as a
+    // semaphore, and to acquire/release queue-family ownership of the externally-written image (VK_QUEUE_FAMILY_FOREIGN_EXT).
+    // The OpenXR runtime appends its own required extensions on top of these. If the device cannot provide them,
+    // xrCreateVulkanDeviceKHR fails below and no session is created, which is intended: the binding has no usable path without
+    // them.
+    static constexpr std::array<const char*, 4> deviceExtensions { {
+        VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+        VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME,
+        VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
+        VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME,
+    } };
+
+    // Report which device the runtime selected and whether it advertises the extensions we need, so a
+    // VK_ERROR_EXTENSION_NOT_PRESENT from xrCreateVulkanDeviceKHR below points at the actual cause (e.g. the runtime picked a
+    // software device that lacks dma-buf export) rather than a guess.
+    VkPhysicalDeviceProperties physicalDeviceProperties;
+    m_instanceTable.vkGetPhysicalDeviceProperties(m_vkPhysicalDevice, &physicalDeviceProperties);
+    LOG(XR, "OpenXR Vulkan: runtime selected device '%s'", physicalDeviceProperties.deviceName);
+    uint32_t availableExtensionCount = 0;
+    m_instanceTable.vkEnumerateDeviceExtensionProperties(m_vkPhysicalDevice, nullptr, &availableExtensionCount, nullptr);
+    Vector<VkExtensionProperties> availableExtensions(availableExtensionCount);
+    m_instanceTable.vkEnumerateDeviceExtensionProperties(m_vkPhysicalDevice, nullptr, &availableExtensionCount, availableExtensions.mutableSpan().data());
+    for (auto* required : deviceExtensions) {
+        bool available = availableExtensions.containsIf([&](const auto& extension) {
+            return StringView::fromLatin1(extension.extensionName) == StringView::fromLatin1(required);
+        });
+        if (!available)
+            LOG(XR, "OpenXR Vulkan: required device extension %s not supported by '%s'", required, physicalDeviceProperties.deviceName);
+    }
+
+    const float queuePriority = 1.0f;
+    VkDeviceQueueCreateInfo queueCreateInfo { };
+    queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    queueCreateInfo.queueFamilyIndex = m_queueFamilyIndex;
+    queueCreateInfo.queueCount = 1;
+    queueCreateInfo.pQueuePriorities = &queuePriority;
+
+    VkDeviceCreateInfo vkDeviceCreateInfo { };
+    vkDeviceCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    vkDeviceCreateInfo.queueCreateInfoCount = 1;
+    vkDeviceCreateInfo.pQueueCreateInfos = &queueCreateInfo;
+    vkDeviceCreateInfo.enabledExtensionCount = deviceExtensions.size();
+    vkDeviceCreateInfo.ppEnabledExtensionNames = deviceExtensions.data();
+
+    auto xrDeviceCreateInfo = createOpenXRStruct<XrVulkanDeviceCreateInfoKHR, XR_TYPE_VULKAN_DEVICE_CREATE_INFO_KHR>();
+    xrDeviceCreateInfo.systemId = systemId;
+    xrDeviceCreateInfo.pfnGetInstanceProcAddr = vkGetInstanceProcAddr;
+    xrDeviceCreateInfo.vulkanPhysicalDevice = m_vkPhysicalDevice;
+    xrDeviceCreateInfo.vulkanCreateInfo = &vkDeviceCreateInfo;
+
+    vkResult = VK_SUCCESS;
+    CHECK_XRCMD(methods.xrCreateVulkanDeviceKHR(instance, &xrDeviceCreateInfo, &m_vkDevice, &vkResult));
+    if (vkResult != VK_SUCCESS || m_vkDevice == VK_NULL_HANDLE) {
+        LOG(XR, "xrCreateVulkanDeviceKHR() failed (VkResult %d).", vkResult);
+        return false;
+    }
+    volkLoadDeviceTable(&m_deviceTable, m_vkDevice);
+
+    m_deviceTable.vkGetDeviceQueue(m_vkDevice, m_queueFamilyIndex, 0, &m_vkQueue);
+
+    VkCommandPoolCreateInfo poolCreateInfo { };
+    poolCreateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    poolCreateInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    poolCreateInfo.queueFamilyIndex = m_queueFamilyIndex;
+    if (m_deviceTable.vkCreateCommandPool(m_vkDevice, &poolCreateInfo, nullptr, &m_commandPool) != VK_SUCCESS) {
+        LOG(XR, "Failed to create the Vulkan command pool.");
+        return false;
+    }
+
+    VkSemaphoreCreateInfo semaphoreCreateInfo { };
+    semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+    if (m_deviceTable.vkCreateSemaphore(m_vkDevice, &semaphoreCreateInfo, nullptr, &m_acquireSemaphore) != VK_SUCCESS) {
+        LOG(XR, "Failed to create the Vulkan frame-fence semaphore.");
+        return false;
+    }
+
+    m_graphicsBinding = createOpenXRStruct<XrGraphicsBindingVulkanKHR, XR_TYPE_GRAPHICS_BINDING_VULKAN2_KHR>();
+    m_graphicsBinding.instance = m_vkInstance;
+    m_graphicsBinding.physicalDevice = m_vkPhysicalDevice;
+    m_graphicsBinding.device = m_vkDevice;
+    m_graphicsBinding.queueFamilyIndex = m_queueFamilyIndex;
+    m_graphicsBinding.queueIndex = 0;
+
+    return true;
+}
+
+const void* OpenXRGraphicsBindingVulkan::sessionGraphicsBinding() const
+{
+    return &m_graphicsBinding;
+}
+
+int64_t OpenXRGraphicsBindingVulkan::selectColorFormat(const Vector<int64_t>& supportedFormats, bool) const
+{
+    // OpenXR reports Vulkan swapchain formats as VkFormat values. Prefer 8-bit RGBA; alpha is kept
+    // even when not requested, mirroring the OpenGLES binding (the channel is simply ignored).
+    //
+    // UNORM is preferred over SRGB deliberately. The content arrives already sRGB-encoded from the web process and is copied
+    // through verbatim, so an SRGB swapchain would have the compositor decode it on sample and the values would be wrong. The
+    // consequence is that the compositor blends and reprojects encoded rather than linear values, which is the same trade-off
+    // other WebXR implementations make; changing it would require the web process to hand over linear content.
+    static constexpr std::array<int64_t, 4> preferredFormats { {
+        VK_FORMAT_R8G8B8A8_UNORM,
+        VK_FORMAT_B8G8R8A8_UNORM,
+        VK_FORMAT_R8G8B8A8_SRGB,
+        VK_FORMAT_B8G8R8A8_SRGB,
+    } };
+    for (auto format : preferredFormats) {
+        if (supportedFormats.contains(format))
+            return format;
+    }
+    return supportedFormats.first();
+}
+
+Vector<uint64_t> OpenXRGraphicsBindingVulkan::enumerateSwapchainImages(XrSwapchain swapchain) const
+{
+    uint32_t imageCount = 0;
+    CHECK_XRCMD(xrEnumerateSwapchainImages(swapchain, 0, &imageCount, nullptr));
+    if (!imageCount) {
+        LOG(XR, "xrEnumerateSwapchainImages(): no images\n");
+        return { };
+    }
+
+    Vector<XrSwapchainImageVulkanKHR> imageBuffers(FillWith { }, imageCount, [] {
+        return createOpenXRStruct<XrSwapchainImageVulkanKHR, XR_TYPE_SWAPCHAIN_IMAGE_VULKAN2_KHR>();
+    }());
+
+    Vector<XrSwapchainImageBaseHeader*> imageHeaders = imageBuffers.map([](auto& image) {
+        return (XrSwapchainImageBaseHeader*) &image;
+    });
+
+    CHECK_XRCMD(xrEnumerateSwapchainImages(swapchain, imageCount, &imageCount, imageHeaders[0]));
+
+    return imageBuffers.map([](auto& image) -> uint64_t {
+        return toHandle(image.image);
+    });
+}
+
+void OpenXRGraphicsBindingVulkan::releaseSessionGraphics()
+{
+    if (m_vkDevice == VK_NULL_HANDLE)
+        return;
+
+    m_deviceTable.vkDeviceWaitIdle(m_vkDevice);
+
+    for (auto& exportedImage : m_exportedImages.values())
+        destroyExportedImage(exportedImage);
+    m_exportedImages.clear();
+
+    if (m_acquireSemaphore != VK_NULL_HANDLE) {
+        m_deviceTable.vkDestroySemaphore(m_vkDevice, m_acquireSemaphore, nullptr);
+        m_acquireSemaphore = VK_NULL_HANDLE;
+    }
+    m_acquireSemaphorePending = false;
+
+    if (m_commandPool != VK_NULL_HANDLE) {
+        m_deviceTable.vkDestroyCommandPool(m_vkDevice, m_commandPool, nullptr);
+        m_commandPool = VK_NULL_HANDLE;
+    }
+
+    m_deviceTable.vkDestroyDevice(m_vkDevice, nullptr);
+    m_vkDevice = VK_NULL_HANDLE;
+    m_vkQueue = VK_NULL_HANDLE;
+    m_vkPhysicalDevice = VK_NULL_HANDLE;
+
+    if (m_vkInstance != VK_NULL_HANDLE) {
+        m_instanceTable.vkDestroyInstance(m_vkInstance, nullptr);
+        m_vkInstance = VK_NULL_HANDLE;
+        m_instanceTable = { };
+    }
+
+    m_graphicsBinding = { };
+}
+
+void OpenXRGraphicsBindingVulkan::destroyExportedImage(ExportedImage& exportedImage)
+{
+    ASSERT(m_vkDevice != VK_NULL_HANDLE);
+    if (exportedImage.image != VK_NULL_HANDLE)
+        m_deviceTable.vkDestroyImage(m_vkDevice, exportedImage.image, nullptr);
+    if (exportedImage.memory != VK_NULL_HANDLE)
+        m_deviceTable.vkFreeMemory(m_vkDevice, exportedImage.memory, nullptr);
+    exportedImage = { };
+}
+
+static std::optional<uint32_t> findMemoryType(const VolkInstanceTable& instanceTable, VkPhysicalDevice physicalDevice, uint32_t memoryTypeBits, VkMemoryPropertyFlags properties)
+{
+    VkPhysicalDeviceMemoryProperties memoryProperties;
+    instanceTable.vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memoryProperties);
+    auto memoryTypes = unsafeMakeSpan(memoryProperties.memoryTypes, memoryProperties.memoryTypeCount);
+    uint32_t index = 0;
+    for (const auto& memoryType : memoryTypes) {
+        if ((memoryTypeBits & (1u << index)) && (memoryType.propertyFlags & properties) == properties)
+            return index;
+        ++index;
+    }
+    return std::nullopt;
+}
+
+static uint32_t drmFourCCForVkFormat(VkFormat format)
+{
+    switch (format) {
+    case VK_FORMAT_R8G8B8A8_UNORM:
+    case VK_FORMAT_R8G8B8A8_SRGB:
+        return DRM_FORMAT_ABGR8888;
+    case VK_FORMAT_B8G8R8A8_UNORM:
+    case VK_FORMAT_B8G8R8A8_SRGB:
+        return DRM_FORMAT_ARGB8888;
+    default:
+        return DRM_FORMAT_INVALID;
+    }
+}
+
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulkan::exportTexture(uint64_t image, const OpenXRSwapchain& swapchain, TextureType type, uint32_t width, uint32_t height)
+{
+    ASSERT(m_vkDevice != VK_NULL_HANDLE);
+
+    switch (type) {
+    case TextureType::Texture2D:
+        return exportTexture2D(image, swapchain, width, height);
+    case TextureType::Cubemap:
+        // FIXME: cube layers are not implemented yet for the Vulkan binding.
+        break;
+    }
+    return std::nullopt;
+}
+
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulkan::exportTexture2D(uint64_t swapchainImage, const OpenXRSwapchain& swapchain, uint32_t width, uint32_t height)
+{
+    auto format = static_cast<VkFormat>(swapchain.format());
+    auto fourcc = drmFourCCForVkFormat(format);
+    if (fourcc == DRM_FORMAT_INVALID) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: unsupported swapchain format %d for dma-buf export", format);
+        return std::nullopt;
+    }
+
+    VkExternalMemoryImageCreateInfo externalMemoryImageInfo { };
+    externalMemoryImageInfo.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+    externalMemoryImageInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+
+    // Linear tiling, exported as a DRM_FORMAT_MOD_LINEAR dma-buf. This avoids depending on VK_EXT_image_drm_format_modifier,
+    // which not every driver advertises, and is the most widely importable layout on the web process side. We only ever read
+    // this image as a transfer source (the web process renders into it via the dma-buf), so TRANSFER_SRC is enough.
+    //
+    // FIXME: prefer VK_EXT_image_drm_format_modifier when it is available, falling back to linear otherwise. This image is a
+    // render target the web process draws into every frame (per swapchain image, at the headset's refresh rate), so a tiled
+    // or otherwise optimal layout is worth the added complexity:
+    //   a) Performance: linear is the slowest layout for the GPU to render into and sample/copy from; a vendor-tiled modifier
+    //      has far better cache locality for those per-frame operations.
+    //   b) Bandwidth: some modifiers enable framebuffer compression (e.g. AMD DCC), cutting the memory traffic of both the
+    //      web process' rendering and our commitFrame copy.
+    //   c) Explicit layout negotiation: producer and consumer agree on the exact memory layout instead of relying on linear
+    //      being universally importable.
+    // Doing this correctly means creating the image with the intersection of the modifiers our device supports and the ones
+    // the consumer (the web process' dma-buf import) can handle, which requires plumbing the consumer's supported-modifier
+    // list here; linear stays as the fallback.
+    VkImageCreateInfo imageCreateInfo { };
+    imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageCreateInfo.pNext = &externalMemoryImageInfo;
+    imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageCreateInfo.format = format;
+    imageCreateInfo.extent = { width, height, 1 };
+    imageCreateInfo.mipLevels = 1;
+    imageCreateInfo.arrayLayers = 1;
+    imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageCreateInfo.tiling = VK_IMAGE_TILING_LINEAR;
+    imageCreateInfo.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    ExportedImage exportedImage;
+    exportedImage.width = width;
+    exportedImage.height = height;
+    exportedImage.format = format;
+
+    if (m_deviceTable.vkCreateImage(m_vkDevice, &imageCreateInfo, nullptr, &exportedImage.image) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateImage failed for exported texture");
+        return std::nullopt;
+    }
+
+    auto cleanupOnError = makeScopeExit([&] {
+        destroyExportedImage(exportedImage);
+    });
+
+    VkMemoryRequirements memoryRequirements;
+    m_deviceTable.vkGetImageMemoryRequirements(m_vkDevice, exportedImage.image, &memoryRequirements);
+
+    auto memoryTypeIndex = findMemoryType(m_instanceTable, m_vkPhysicalDevice, memoryRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    if (!memoryTypeIndex) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: no suitable memory type for exported texture");
+        return std::nullopt;
+    }
+
+    VkMemoryDedicatedAllocateInfo dedicatedAllocateInfo { };
+    dedicatedAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+    dedicatedAllocateInfo.image = exportedImage.image;
+
+    VkExportMemoryAllocateInfo exportAllocateInfo { };
+    exportAllocateInfo.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO;
+    exportAllocateInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+    exportAllocateInfo.pNext = &dedicatedAllocateInfo;
+
+    VkMemoryAllocateInfo memoryAllocateInfo { };
+    memoryAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    memoryAllocateInfo.pNext = &exportAllocateInfo;
+    memoryAllocateInfo.allocationSize = memoryRequirements.size;
+    memoryAllocateInfo.memoryTypeIndex = *memoryTypeIndex;
+
+    if (m_deviceTable.vkAllocateMemory(m_vkDevice, &memoryAllocateInfo, nullptr, &exportedImage.memory) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkAllocateMemory failed for exported texture");
+        return std::nullopt;
+    }
+    if (m_deviceTable.vkBindImageMemory(m_vkDevice, exportedImage.image, exportedImage.memory, 0) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkBindImageMemory failed for exported texture");
+        return std::nullopt;
+    }
+
+    // Single-plane linear layout: the row pitch and offset of the colour plane fully describe it.
+    VkImageSubresource subresource { };
+    subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    VkSubresourceLayout layout { };
+    m_deviceTable.vkGetImageSubresourceLayout(m_vkDevice, exportedImage.image, &subresource, &layout);
+
+    VkMemoryGetFdInfoKHR getFdInfo { };
+    getFdInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
+    getFdInfo.memory = exportedImage.memory;
+    getFdInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+
+    int dmaBufFd = -1;
+    if (m_deviceTable.vkGetMemoryFdKHR(m_vkDevice, &getFdInfo, &dmaBufFd) != VK_SUCCESS || dmaBufFd < 0) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkGetMemoryFdKHR failed for exported texture");
+        return std::nullopt;
+    }
+
+    cleanupOnError.release();
+    m_exportedImages.set(swapchainImage, WTF::move(exportedImage));
+
+    Vector<WTF::UnixFileDescriptor> fds;
+    fds.append(WTF::UnixFileDescriptor { dmaBufFd, WTF::UnixFileDescriptor::Adopt });
+    return PlatformXR::FrameData::ExternalTexture {
+        .fds = WTF::move(fds),
+        .strides = { static_cast<uint32_t>(layout.rowPitch) },
+        .offsets = { static_cast<uint32_t>(layout.offset) },
+        .fourcc = fourcc,
+        .modifier = DRM_FORMAT_MOD_LINEAR,
+    };
+}
+
+void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwapchain& swapchain, TextureType type, const Vector<uint64_t>&)
+{
+    // Consume any fence imported by waitFrameFence() for this commit. Snapshot it up front so the
+    // early returns below don't leave a stale payload waiting on the next layer's commit.
+    bool waitOnAcquireFence = std::exchange(m_acquireSemaphorePending, false);
+
+    if (type != TextureType::Texture2D)
+        return;
+
+    ASSERT(m_vkDevice != VK_NULL_HANDLE);
+
+    auto exportedImageIterator = m_exportedImages.find(keyImage);
+    if (exportedImageIterator == m_exportedImages.end())
+        return;
+    const auto& exportedImage = exportedImageIterator->value;
+
+    VkImage swapchainImage = toVkImage(swapchain.acquiredTexture());
+    ASSERT(swapchainImage != VK_NULL_HANDLE);
+
+    VkCommandBufferAllocateInfo commandBufferAllocateInfo { };
+    commandBufferAllocateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    commandBufferAllocateInfo.commandPool = m_commandPool;
+    commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    commandBufferAllocateInfo.commandBufferCount = 1;
+
+    VkCommandBuffer commandBuffer = VK_NULL_HANDLE;
+    if (m_deviceTable.vkAllocateCommandBuffers(m_vkDevice, &commandBufferAllocateInfo, &commandBuffer) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: failed to allocate command buffer for commit");
+        return;
+    }
+    auto freeCommandBuffer = makeScopeExit([&] {
+        m_deviceTable.vkFreeCommandBuffers(m_vkDevice, m_commandPool, 1, &commandBuffer);
+    });
+
+    VkCommandBufferBeginInfo beginInfo { };
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    m_deviceTable.vkBeginCommandBuffer(commandBuffer, &beginInfo);
+
+    auto makeBarrier = [](VkImage image, VkImageLayout oldLayout, VkImageLayout newLayout, VkAccessFlags srcAccess, VkAccessFlags dstAccess, uint32_t srcQueueFamily = VK_QUEUE_FAMILY_IGNORED, uint32_t dstQueueFamily = VK_QUEUE_FAMILY_IGNORED) {
+        VkImageMemoryBarrier barrier { };
+        barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        barrier.oldLayout = oldLayout;
+        barrier.newLayout = newLayout;
+        barrier.srcQueueFamilyIndex = srcQueueFamily;
+        barrier.dstQueueFamilyIndex = dstQueueFamily;
+        barrier.image = image;
+        barrier.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+        barrier.srcAccessMask = srcAccess;
+        barrier.dstAccessMask = dstAccess;
+        return barrier;
+    };
+
+    // The exported image was written by the WebProcess through an external (OpenGL) DMABuf import, so acquire queue family
+    // ownership of it from VK_QUEUE_FAMILY_FOREIGN_EXT before reading. We keep it in VK_IMAGE_LAYOUT_GENERAL throughout: GENERAL
+    // preserves the foreign contents (UNDEFINED would let the driver discard them) and imposes no Vulkan-specific tiling, which
+    // matches the externally-written linear DMABuf. The swapchain image is owned by our own device and fully overwritten by the
+    // blit, so it can start from UNDEFINED with no ownership transfer.
+    std::array<VkImageMemoryBarrier, 2> preBlitBarriers { {
+        makeBarrier(exportedImage.image, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL, 0, VK_ACCESS_TRANSFER_READ_BIT, VK_QUEUE_FAMILY_FOREIGN_EXT, m_queueFamilyIndex),
+        makeBarrier(swapchainImage, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 0, VK_ACCESS_TRANSFER_WRITE_BIT),
+    } };
+    m_deviceTable.vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, preBlitBarriers.size(), preBlitBarriers.data());
+
+    // The WebProcess renders into the exported image with OpenGL, whose framebuffer origin is the bottom left, whereas
+    // Vulkan (and therefore the runtime's swapchain image) uses the top left. We blit rather than copy so the destination's
+    // Y offsets can be inverted, correcting the flip in the same pass (vkCmdCopyImage cannot flip). The transfer is 1:1 in
+    // size and format so NEAREST adds no filtering, and the Y inversion itself costs nothing beyond the blit.
+    VkImageBlit blitRegion { };
+    blitRegion.srcSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
+    blitRegion.srcOffsets[0] = { 0, 0, 0 };
+    blitRegion.srcOffsets[1] = { static_cast<int32_t>(exportedImage.width), static_cast<int32_t>(exportedImage.height), 1 };
+    blitRegion.dstSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
+    blitRegion.dstOffsets[0] = { 0, static_cast<int32_t>(exportedImage.height), 0 };
+    blitRegion.dstOffsets[1] = { static_cast<int32_t>(exportedImage.width), 0, 1 };
+    m_deviceTable.vkCmdBlitImage(commandBuffer, exportedImage.image, VK_IMAGE_LAYOUT_GENERAL, swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blitRegion, VK_FILTER_NEAREST);
+
+    // Transition the swapchain image to COLOR_ATTACHMENT_OPTIMAL, which the runtime expects when it is released, and release
+    // ownership of the exported image back to the foreign (OpenGL) producer so it can render into it again next frame.
+    std::array<VkImageMemoryBarrier, 2> postBlitBarriers { {
+        makeBarrier(swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT),
+        makeBarrier(exportedImage.image, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL, VK_ACCESS_TRANSFER_READ_BIT, 0, m_queueFamilyIndex, VK_QUEUE_FAMILY_FOREIGN_EXT),
+    } };
+    m_deviceTable.vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, postBlitBarriers.size(), postBlitBarriers.data());
+
+    m_deviceTable.vkEndCommandBuffer(commandBuffer);
+
+    // Make the blit wait, on the GPU, for the web process to finish rendering into the exported image
+    // (the fence imported by waitFrameFence()). TRANSFER stage because the blit reads at transfer time.
+    VkPipelineStageFlags acquireWaitStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    VkSubmitInfo submitInfo { };
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    if (waitOnAcquireFence) {
+        submitInfo.waitSemaphoreCount = 1;
+        submitInfo.pWaitSemaphores = &m_acquireSemaphore;
+        submitInfo.pWaitDstStageMask = &acquireWaitStage;
+    }
+    submitInfo.commandBufferCount = 1;
+    submitInfo.pCommandBuffers = &commandBuffer;
+    m_deviceTable.vkQueueSubmit(m_vkQueue, 1, &submitInfo, VK_NULL_HANDLE);
+
+    // FIXME: perf — a per-frame queue wait serializes CPU and GPU. The eventual path should let the runtime synchronize on
+    // the queue instead of blocking here. Note this idle also currently guarantees m_acquireSemaphore's temporary payload is
+    // consumed before the next frame re-imports into it, so removing it needs per-frame semaphores or a tracking fence.
+    m_deviceTable.vkQueueWaitIdle(m_vkQueue);
+}
+
+void OpenXRGraphicsBindingVulkan::waitFrameFence(WTF::UnixFileDescriptor&& fenceFD)
+{
+    // The fence is the web process' render-completion sync_file. Import it into m_acquireSemaphore as a temporary SYNC_FD
+    // payload; commitFrame() then makes its blit submission wait on that semaphore so the copy observes the finished writes
+    // on the GPU without stalling the CPU. This mirrors the OpenGLES GLFence::importFD()/serverWait() path. SYNC_FD payloads
+    // are always temporary and are consumed by the wait, so the semaphore is reusable across frames.
+    if (!fenceFD)
+        return;
+
+    ASSERT(m_acquireSemaphore != VK_NULL_HANDLE);
+
+    VkImportSemaphoreFdInfoKHR importInfo { };
+    importInfo.sType = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
+    importInfo.semaphore = m_acquireSemaphore;
+    importInfo.flags = VK_SEMAPHORE_IMPORT_TEMPORARY_BIT;
+    importInfo.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
+    importInfo.fd = fenceFD.value();
+
+    if (m_deviceTable.vkImportSemaphoreFdKHR(m_vkDevice, &importInfo) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkImportSemaphoreFdKHR failed; frame fence ignored");
+        return;
+    }
+
+    // On a successful SYNC_FD import Vulkan takes ownership of the fd, so disown it from the descriptor (discarding the
+    // returned value) to avoid a double close.
+    (void)fenceFD.release();
+    m_acquireSemaphorePending = true;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR) && defined(XR_USE_GRAPHICS_API_VULKAN)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
@@ -32,11 +32,14 @@
 #include "OpenXRSwapchain.h"
 #include <array>
 #include <bit>
+#include <cstdlib>
 #include <cstring>
+#include <span>
 #include <utility>
 #include <wtf/RunLoop.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/StringView.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
 #if USE(GBM)
@@ -61,6 +64,36 @@ static inline uint64_t toHandle(VkImage image)
 static inline VkImage toVkImage(uint64_t handle)
 {
     return std::bit_cast<VkImage>(handle);
+}
+
+template<typename Handle> static inline uint64_t toDebugHandle(Handle handle)
+{
+    static_assert(sizeof(Handle) == sizeof(uint64_t), "Vulkan non-dispatchable handles are expected to be 64-bit");
+    return std::bit_cast<uint64_t>(handle);
+}
+
+static VKAPI_ATTR VkBool32 VKAPI_CALL vulkanDebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity, VkDebugUtilsMessageTypeFlagsEXT messageTypes, const VkDebugUtilsMessengerCallbackDataEXT* callbackData, void*)
+{
+    if (!callbackData || !callbackData->pMessage)
+        return VK_FALSE;
+
+    [[maybe_unused]] const char* severityLabel = "info";
+    if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
+        severityLabel = "error";
+    else if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
+        severityLabel = "warning";
+
+    [[maybe_unused]] const char* typeLabel = "general";
+    if (messageTypes & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)
+        typeLabel = "validation";
+    else if (messageTypes & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)
+        typeLabel = "performance";
+
+    // Registering a messenger makes the layer report through it instead of its own default output.
+    LOG(XR, "OpenXR Vulkan [%s/%s] %s", severityLabel, typeLabel, callbackData->pMessage);
+
+    // Always VK_FALSE: returning VK_TRUE aborts the offending call, which would turn a diagnostic into a behaviour change.
+    return VK_FALSE;
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRGraphicsBindingVulkan);
@@ -137,9 +170,20 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
     applicationInfo.pApplicationName = "WebKitWebXR";
     applicationInfo.apiVersion = apiVersion;
 
+    Vector<const char*> instanceLayers;
+    Vector<const char*> instanceExtensions;
+    VkValidationFeaturesEXT validationFeatures { };
+    bool validationEnabled = configureValidation(instanceLayers, instanceExtensions, validationFeatures);
+
     VkInstanceCreateInfo vkInstanceCreateInfo { };
     vkInstanceCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     vkInstanceCreateInfo.pApplicationInfo = &applicationInfo;
+    if (validationFeatures.sType)
+        vkInstanceCreateInfo.pNext = &validationFeatures;
+    vkInstanceCreateInfo.enabledLayerCount = static_cast<uint32_t>(instanceLayers.size());
+    vkInstanceCreateInfo.ppEnabledLayerNames = instanceLayers.span().data();
+    vkInstanceCreateInfo.enabledExtensionCount = static_cast<uint32_t>(instanceExtensions.size());
+    vkInstanceCreateInfo.ppEnabledExtensionNames = instanceExtensions.span().data();
 
     auto xrInstanceCreateInfo = createOpenXRStruct<XrVulkanInstanceCreateInfoKHR, XR_TYPE_VULKAN_INSTANCE_CREATE_INFO_KHR>();
     xrInstanceCreateInfo.systemId = systemId;
@@ -153,6 +197,11 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
         return false;
     }
     volkLoadInstanceTable(&m_instanceTable, m_vkInstance);
+
+    // After volkLoadInstanceTable, which resolves vkCreateDebugUtilsMessengerEXT. Messages from instance creation itself are
+    // reported by the layer directly rather than through the messenger.
+    if (validationEnabled)
+        createDebugMessenger();
 
     auto deviceGetInfo = createOpenXRStruct<XrVulkanGraphicsDeviceGetInfoKHR, XR_TYPE_VULKAN_GRAPHICS_DEVICE_GET_INFO_KHR>();
     deviceGetInfo.systemId = systemId;
@@ -204,6 +253,7 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
     VkPhysicalDeviceProperties physicalDeviceProperties;
     m_instanceTable.vkGetPhysicalDeviceProperties(m_vkPhysicalDevice, &physicalDeviceProperties);
     LOG(XR, "OpenXR Vulkan: runtime selected device '%s'", physicalDeviceProperties.deviceName);
+    logDeviceAndDriverUUIDs(physicalDeviceProperties.deviceName);
     uint32_t availableExtensionCount = 0;
     m_instanceTable.vkEnumerateDeviceExtensionProperties(m_vkPhysicalDevice, nullptr, &availableExtensionCount, nullptr);
     Vector<VkExtensionProperties> availableExtensions(availableExtensionCount);
@@ -282,6 +332,121 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
     return true;
 }
 
+void OpenXRGraphicsBindingVulkan::logDeviceAndDriverUUIDs(const char* deviceName) const
+{
+    // The device the runtime dictates has to be the one the web process' consumer imports on, and for handle types that are
+    // driver-private (opaque fd) the driver must match too, not just the device. A full check needs the consumer's UUIDs
+    // carried over IPC, which is the same missing plumbing as the modifier intersection; until then, report ours so the two
+    // sides can be compared from a single log.
+    VkPhysicalDeviceIDProperties idProperties { };
+    idProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
+    VkPhysicalDeviceProperties2 properties2 { };
+    properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+    properties2.pNext = &idProperties;
+    m_instanceTable.vkGetPhysicalDeviceProperties2(m_vkPhysicalDevice, &properties2);
+
+    [[maybe_unused]] auto toHex = [](std::span<const uint8_t, VK_UUID_SIZE> uuid) {
+        static constexpr std::array<char, 16> hexDigits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+        std::array<char, VK_UUID_SIZE * 2 + 1> text { };
+        for (size_t i = 0; i < VK_UUID_SIZE; ++i) {
+            text[i * 2] = hexDigits[(uuid[i] >> 4) & 0xf];
+            text[i * 2 + 1] = hexDigits[uuid[i] & 0xf];
+        }
+        return text;
+    };
+
+    LOG(XR, "OpenXR Vulkan: device '%s' deviceUUID %s driverUUID %s", deviceName,
+        toHex(std::span<const uint8_t, VK_UUID_SIZE> { idProperties.deviceUUID }).data(),
+        toHex(std::span<const uint8_t, VK_UUID_SIZE> { idProperties.driverUUID }).data());
+}
+
+// Optional diagnostics, opt-in via WEBKIT_WEBXR_VULKAN_VALIDATION. Requires the validation layer and VK_EXT_debug_utils
+// to be enabled at instance creation.
+bool OpenXRGraphicsBindingVulkan::configureValidation(Vector<const char*>& layers, Vector<const char*>& extensions, VkValidationFeaturesEXT& features)
+{
+    auto value = StringView::fromLatin1(getenv("WEBKIT_WEBXR_VULKAN_VALIDATION"));
+    const bool shouldEnableVulkanValidation = !value.isEmpty() && value != "0"_s;
+    if (!shouldEnableVulkanValidation)
+        return false;
+
+    uint32_t layerCount = 0;
+    vkEnumerateInstanceLayerProperties(&layerCount, nullptr);
+    Vector<VkLayerProperties> availableLayers(layerCount);
+    vkEnumerateInstanceLayerProperties(&layerCount, availableLayers.mutableSpan().data());
+    bool hasValidationLayer = availableLayers.containsIf([](const auto& layer) {
+        return StringView::fromLatin1(layer.layerName) == "VK_LAYER_KHRONOS_validation"_s;
+    });
+
+    uint32_t instanceExtensionCount = 0;
+    vkEnumerateInstanceExtensionProperties(nullptr, &instanceExtensionCount, nullptr);
+    Vector<VkExtensionProperties> availableInstanceExtensions(instanceExtensionCount);
+    vkEnumerateInstanceExtensionProperties(nullptr, &instanceExtensionCount, availableInstanceExtensions.mutableSpan().data());
+    bool hasDebugUtils = availableInstanceExtensions.containsIf([](const auto& extension) {
+        return StringView::fromLatin1(extension.extensionName) == VK_EXT_DEBUG_UTILS_EXTENSION_NAME ""_s;
+    });
+
+    if (!hasValidationLayer || !hasDebugUtils) {
+        LOG(XR, "OpenXR Vulkan: WEBKIT_WEBXR_VULKAN_VALIDATION is set but %s is unavailable; continuing without validation",
+            hasValidationLayer ? VK_EXT_DEBUG_UTILS_EXTENSION_NAME : "VK_LAYER_KHRONOS_validation");
+        return false;
+    }
+
+    layers.append("VK_LAYER_KHRONOS_validation");
+    extensions.append(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+    // VK_EXT_validation_features is provided by the layer, not the driver, so it is absent from the unfiltered instance
+    // extension list and must be queried against the layer. Enabling it when absent fails instance creation, and chaining
+    // VkValidationFeaturesEXT without enabling it is invalid, so require it first.
+    uint32_t layerExtensionCount = 0;
+    vkEnumerateInstanceExtensionProperties("VK_LAYER_KHRONOS_validation", &layerExtensionCount, nullptr);
+    Vector<VkExtensionProperties> layerExtensions(layerExtensionCount);
+    vkEnumerateInstanceExtensionProperties("VK_LAYER_KHRONOS_validation", &layerExtensionCount, layerExtensions.mutableSpan().data());
+    if (!layerExtensions.containsIf([](const auto& extension) { return StringView::fromLatin1(extension.extensionName) == VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME ""_s; })) {
+        LOG(XR, "OpenXR Vulkan: %s unavailable; core validation is enabled, synchronization validation is not", VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+        return true;
+    }
+
+    static constexpr std::array<VkValidationFeatureEnableEXT, 1> featureEnables { {
+        VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT,
+    } };
+    extensions.append(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+    features.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
+    features.enabledValidationFeatureCount = static_cast<uint32_t>(featureEnables.size());
+    features.pEnabledValidationFeatures = featureEnables.data();
+    return true;
+}
+
+void OpenXRGraphicsBindingVulkan::createDebugMessenger()
+{
+    if (!m_instanceTable.vkCreateDebugUtilsMessengerEXT) {
+        LOG(XR, "OpenXR Vulkan: vkCreateDebugUtilsMessengerEXT unavailable; validation messages will not be routed and objects will not be named");
+        return;
+    }
+
+    VkDebugUtilsMessengerCreateInfoEXT messengerCreateInfo { };
+    messengerCreateInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+    messengerCreateInfo.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+    messengerCreateInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+    messengerCreateInfo.pfnUserCallback = vulkanDebugUtilsCallback;
+    if (m_instanceTable.vkCreateDebugUtilsMessengerEXT(m_vkInstance, &messengerCreateInfo, nullptr, &m_debugMessenger) == VK_SUCCESS)
+        LOG(XR, "OpenXR Vulkan: validation enabled, debug messenger active");
+    else
+        LOG(XR, "OpenXR Vulkan: vkCreateDebugUtilsMessengerEXT failed; validation messages will not be routed and objects will not be named");
+}
+
+void OpenXRGraphicsBindingVulkan::setDebugName(VkObjectType objectType, uint64_t objectHandle, const char* name)
+{
+    if (!objectHandle || m_debugMessenger == VK_NULL_HANDLE || !m_instanceTable.vkSetDebugUtilsObjectNameEXT)
+        return;
+
+    VkDebugUtilsObjectNameInfoEXT nameInfo { };
+    nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+    nameInfo.objectType = objectType;
+    nameInfo.objectHandle = objectHandle;
+    nameInfo.pObjectName = name;
+    m_instanceTable.vkSetDebugUtilsObjectNameEXT(m_vkDevice, &nameInfo);
+}
+
 const void* OpenXRGraphicsBindingVulkan::sessionGraphicsBinding() const
 {
     return &m_graphicsBinding;
@@ -335,26 +500,35 @@ Vector<uint64_t> OpenXRGraphicsBindingVulkan::enumerateSwapchainImages(XrSwapcha
 
 void OpenXRGraphicsBindingVulkan::releaseSessionGraphics()
 {
-    if (m_vkDevice == VK_NULL_HANDLE)
+    if (m_vkDevice == VK_NULL_HANDLE && m_vkInstance == VK_NULL_HANDLE)
         return;
-
-    m_deviceTable.vkDeviceWaitIdle(m_vkDevice);
-
-    for (auto& exportedImage : m_exportedImages.values())
-        destroyExportedImage(exportedImage);
-    m_exportedImages.clear();
 
     m_pendingFenceFD = { };
 
-    if (m_commandPool != VK_NULL_HANDLE) {
-        m_deviceTable.vkDestroyCommandPool(m_vkDevice, m_commandPool, nullptr);
-        m_commandPool = VK_NULL_HANDLE;
-    }
+    if (m_vkDevice != VK_NULL_HANDLE) {
+        m_deviceTable.vkDeviceWaitIdle(m_vkDevice);
 
-    m_deviceTable.vkDestroyDevice(m_vkDevice, nullptr);
-    m_vkDevice = VK_NULL_HANDLE;
+        for (auto& exportedImage : m_exportedImages.values())
+            destroyExportedImage(exportedImage);
+        m_exportedImages.clear();
+
+        if (m_commandPool != VK_NULL_HANDLE) {
+            m_deviceTable.vkDestroyCommandPool(m_vkDevice, m_commandPool, nullptr);
+            m_commandPool = VK_NULL_HANDLE;
+        }
+
+        m_deviceTable.vkDestroyDevice(m_vkDevice, nullptr);
+        m_vkDevice = VK_NULL_HANDLE;
+        m_deviceTable = { };
+    }
     m_vkQueue = VK_NULL_HANDLE;
     m_vkPhysicalDevice = VK_NULL_HANDLE;
+
+    if (m_debugMessenger != VK_NULL_HANDLE) {
+        if (m_instanceTable.vkDestroyDebugUtilsMessengerEXT)
+            m_instanceTable.vkDestroyDebugUtilsMessengerEXT(m_vkInstance, m_debugMessenger, nullptr);
+        m_debugMessenger = VK_NULL_HANDLE;
+    }
 
     if (m_vkInstance != VK_NULL_HANDLE) {
         m_instanceTable.vkDestroyInstance(m_vkInstance, nullptr);
@@ -429,6 +603,9 @@ bool OpenXRGraphicsBindingVulkan::createExportedImageSyncObjects(ExportedImage& 
         RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateSemaphore failed for exported texture");
         return false;
     }
+
+    setDebugName(VK_OBJECT_TYPE_FENCE, toDebugHandle(exportedImage.inFlightFence), "WebXR exported image in-flight fence");
+    setDebugName(VK_OBJECT_TYPE_SEMAPHORE, toDebugHandle(exportedImage.acquireSemaphore), "WebXR exported image acquire semaphore");
     return true;
 }
 
@@ -525,10 +702,10 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulka
         return std::nullopt;
     }
 
-    // Only TRANSFER_SRC, not COLOR_ATTACHMENT: Vulkan merely transfer-reads this image for the commit blit, while the web
-    // process renders into the exported DMABuf via GL/EGL, and linear-tiled images generally do not support COLOR_ATTACHMENT.
-    // The tiled DRM-modifier path is the validation-clean way to export a DMABuf; the linear fallback is tolerated but not
-    // advertised where the modifier extension is missing, so it renders but emits VUID-VkImageCreateInfo-pNext-00990.
+    // Only TRANSFER_SRC as Vulkan merely transfer reads this image for the commit blit, while the WebProcess
+    // renders into the exported image via OpenGL/EGL, independently of the Vulkan usage. The tiled DRM-modifier path is
+    // the validation-clean way to export a DMABuf. The linear fallback is tolerated but not advertised where the modifier
+    // extension is missing, so it renders but emits VUID-VkImageCreateInfo-pNext-00990.
     // FIXME: the chosen modifier is one our device supports; it is not yet intersected with the modifiers the web process' EGL
     // import can consume (that needs the consumer's list plumbed across IPC). On a single GPU the sets overlap in practice.
     static constexpr VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
@@ -571,6 +748,7 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulka
         RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateImage failed for exported texture (useModifiers=%d)", useModifiers);
         return std::nullopt;
     }
+    setDebugName(VK_OBJECT_TYPE_IMAGE, toHandle(exportedImage.image), "WebXR exported image");
 
     auto cleanupOnError = makeScopeExit([&] {
         destroyExportedImage(exportedImage);
@@ -604,6 +782,7 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulka
         RELEASE_LOG(XR, "OpenXR Vulkan: vkAllocateMemory failed for exported texture");
         return std::nullopt;
     }
+    setDebugName(VK_OBJECT_TYPE_DEVICE_MEMORY, toDebugHandle(exportedImage.memory), "WebXR exported image memory");
     if (m_deviceTable.vkBindImageMemory(m_vkDevice, exportedImage.image, exportedImage.memory, 0) != VK_SUCCESS) {
         RELEASE_LOG(XR, "OpenXR Vulkan: vkBindImageMemory failed for exported texture");
         return std::nullopt;

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.cpp
@@ -246,13 +246,6 @@ bool OpenXRGraphicsBindingVulkan::initializeForSession(XrInstance instance, XrSy
         return false;
     }
 
-    VkSemaphoreCreateInfo semaphoreCreateInfo { };
-    semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-    if (m_deviceTable.vkCreateSemaphore(m_vkDevice, &semaphoreCreateInfo, nullptr, &m_acquireSemaphore) != VK_SUCCESS) {
-        LOG(XR, "Failed to create the Vulkan frame-fence semaphore.");
-        return false;
-    }
-
     m_graphicsBinding = createOpenXRStruct<XrGraphicsBindingVulkanKHR, XR_TYPE_GRAPHICS_BINDING_VULKAN2_KHR>();
     m_graphicsBinding.instance = m_vkInstance;
     m_graphicsBinding.physicalDevice = m_vkPhysicalDevice;
@@ -325,11 +318,7 @@ void OpenXRGraphicsBindingVulkan::releaseSessionGraphics()
         destroyExportedImage(exportedImage);
     m_exportedImages.clear();
 
-    if (m_acquireSemaphore != VK_NULL_HANDLE) {
-        m_deviceTable.vkDestroySemaphore(m_vkDevice, m_acquireSemaphore, nullptr);
-        m_acquireSemaphore = VK_NULL_HANDLE;
-    }
-    m_acquireSemaphorePending = false;
+    m_pendingFenceFD = { };
 
     if (m_commandPool != VK_NULL_HANDLE) {
         m_deviceTable.vkDestroyCommandPool(m_vkDevice, m_commandPool, nullptr);
@@ -353,10 +342,15 @@ void OpenXRGraphicsBindingVulkan::releaseSessionGraphics()
 void OpenXRGraphicsBindingVulkan::destroyExportedImage(ExportedImage& exportedImage)
 {
     ASSERT(m_vkDevice != VK_NULL_HANDLE);
+    if (exportedImage.acquireSemaphore != VK_NULL_HANDLE)
+        m_deviceTable.vkDestroySemaphore(m_vkDevice, exportedImage.acquireSemaphore, nullptr);
+    if (exportedImage.inFlightFence != VK_NULL_HANDLE)
+        m_deviceTable.vkDestroyFence(m_vkDevice, exportedImage.inFlightFence, nullptr);
     if (exportedImage.image != VK_NULL_HANDLE)
         m_deviceTable.vkDestroyImage(m_vkDevice, exportedImage.image, nullptr);
     if (exportedImage.memory != VK_NULL_HANDLE)
         m_deviceTable.vkFreeMemory(m_vkDevice, exportedImage.memory, nullptr);
+    // The command buffer is owned by m_commandPool and freed when the pool is destroyed.
     exportedImage = { };
 }
 
@@ -509,6 +503,23 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingVulka
         return std::nullopt;
     }
 
+    // Per-image synchronization objects. The fence starts signaled so the first commitFrame() that reuses this image waits on
+    // it without a special case. (On failure cleanupOnError destroys whatever was created.)
+    VkFenceCreateInfo fenceCreateInfo { };
+    fenceCreateInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    fenceCreateInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+    if (m_deviceTable.vkCreateFence(m_vkDevice, &fenceCreateInfo, nullptr, &exportedImage.inFlightFence) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateFence failed for exported texture");
+        return std::nullopt;
+    }
+
+    VkSemaphoreCreateInfo semaphoreCreateInfo { };
+    semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+    if (m_deviceTable.vkCreateSemaphore(m_vkDevice, &semaphoreCreateInfo, nullptr, &exportedImage.acquireSemaphore) != VK_SUCCESS) {
+        RELEASE_LOG(XR, "OpenXR Vulkan: vkCreateSemaphore failed for exported texture");
+        return std::nullopt;
+    }
+
     cleanupOnError.release();
     m_exportedImages.set(swapchainImage, WTF::move(exportedImage));
 
@@ -596,9 +607,9 @@ bool OpenXRGraphicsBindingVulkan::recordBlitCommandBuffer(ExportedImage& exporte
 
 void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwapchain& swapchain, TextureType type, const Vector<uint64_t>&)
 {
-    // Consume any fence imported by waitFrameFence() for this commit. Snapshot it up front so the
-    // early returns below don't leave a stale payload waiting on the next layer's commit.
-    bool waitOnAcquireFence = std::exchange(m_acquireSemaphorePending, false);
+    // Take the fence stashed by waitFrameFence() for this commit. Snapshot it up front so the early returns below don't leave a
+    // stale fd waiting on the next layer's commit (the UnixFileDescriptor closes it if we bail out).
+    auto pendingFenceFD = std::exchange(m_pendingFenceFD, WTF::UnixFileDescriptor { });
 
     if (type != TextureType::Texture2D)
         return;
@@ -613,59 +624,61 @@ void OpenXRGraphicsBindingVulkan::commitFrame(uint64_t keyImage, const OpenXRSwa
     VkImage swapchainImage = toVkImage(swapchain.acquiredTexture());
     ASSERT(swapchainImage != VK_NULL_HANDLE);
 
-    // The blit is identical every time this swapchain image is acquired (fixed source/destination images and region), so its
-    // command buffer is recorded once and resubmitted on every commit. Reuse is safe because the per-frame vkQueueWaitIdle below
-    // guarantees the previous submission completed before this one is resubmitted.
+    // The blit is identical every time this swapchain image is acquired so its command buffer is recorded once and resubmitted on every commit.
     if (exportedImage.commandBuffer == VK_NULL_HANDLE && !recordBlitCommandBuffer(exportedImage, swapchainImage))
         return;
 
-    // Make the blit wait, on the GPU, for the web process to finish rendering into the exported image
-    // (the fence imported by waitFrameFence()). TRANSFER stage because the blit reads at transfer time.
+    // Wait for this image's previous submission to retire before reusing its command buffer and acquire semaphore, then reset
+    // the fence for this frame's submission. The fence was created signaled and the image was last used a full swapchain cycle
+    // ago, so this almost always returns immediately; it only blocks if the GPU has fallen behind by the swapchain depth. This
+    // is what lets us drop the per-frame vkQueueWaitIdle and overlap CPU and GPU work.
+    m_deviceTable.vkWaitForFences(m_vkDevice, 1, &exportedImage.inFlightFence, VK_TRUE, UINT64_MAX);
+    m_deviceTable.vkResetFences(m_vkDevice, 1, &exportedImage.inFlightFence);
+
+    // Import the web process' render-completion fence (stashed by waitFrameFence()) into this image's semaphore so the blit can
+    // wait on it on the GPU. SYNC_FD payloads are temporary and consumed by the wait, and the fence wait above guarantees the
+    // previous wait on this semaphore has already executed, so re-importing here is safe.
+    bool waitOnAcquireFence = false;
+    if (pendingFenceFD) {
+        VkImportSemaphoreFdInfoKHR importInfo { };
+        importInfo.sType = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
+        importInfo.semaphore = exportedImage.acquireSemaphore;
+        importInfo.flags = VK_SEMAPHORE_IMPORT_TEMPORARY_BIT;
+        importInfo.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
+        importInfo.fd = pendingFenceFD.value();
+        if (m_deviceTable.vkImportSemaphoreFdKHR(m_vkDevice, &importInfo) == VK_SUCCESS) {
+            // Vulkan owns the fd on a successful SYNC_FD import, disown it (discarding the result) to avoid a double close.
+            (void)pendingFenceFD.release();
+            waitOnAcquireFence = true;
+        } else
+            RELEASE_LOG(XR, "OpenXR Vulkan: vkImportSemaphoreFdKHR failed; frame fence ignored");
+    }
+
+    // The blit waits on the GPU for the WebProcess to finish rendering into the exported image (TRANSFER stage, where the
+    // blit reads), and signals inFlightFence on completion so the next reuse of this image can wait on it.
     VkPipelineStageFlags acquireWaitStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
     VkSubmitInfo submitInfo { };
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     if (waitOnAcquireFence) {
         submitInfo.waitSemaphoreCount = 1;
-        submitInfo.pWaitSemaphores = &m_acquireSemaphore;
+        submitInfo.pWaitSemaphores = &exportedImage.acquireSemaphore;
         submitInfo.pWaitDstStageMask = &acquireWaitStage;
     }
     submitInfo.commandBufferCount = 1;
     submitInfo.pCommandBuffers = &exportedImage.commandBuffer;
-    m_deviceTable.vkQueueSubmit(m_vkQueue, 1, &submitInfo, VK_NULL_HANDLE);
-
-    // FIXME: perf — a per-frame queue wait serializes CPU and GPU. The eventual path should let the runtime synchronize on
-    // the queue instead of blocking here. Note this idle also currently guarantees m_acquireSemaphore's temporary payload is
-    // consumed before the next frame re-imports into it, so removing it needs per-frame semaphores or a tracking fence.
-    m_deviceTable.vkQueueWaitIdle(m_vkQueue);
+    m_deviceTable.vkQueueSubmit(m_vkQueue, 1, &submitInfo, exportedImage.inFlightFence);
 }
 
 void OpenXRGraphicsBindingVulkan::waitFrameFence(WTF::UnixFileDescriptor&& fenceFD)
 {
-    // The fence is the web process' render-completion sync_file. Import it into m_acquireSemaphore as a temporary SYNC_FD
-    // payload; commitFrame() then makes its blit submission wait on that semaphore so the copy observes the finished writes
-    // on the GPU without stalling the CPU. This mirrors the OpenGLES GLFence::importFD()/serverWait() path. SYNC_FD payloads
-    // are always temporary and are consumed by the wait, so the semaphore is reusable across frames.
-    if (!fenceFD)
-        return;
-
-    ASSERT(m_acquireSemaphore != VK_NULL_HANDLE);
-
-    VkImportSemaphoreFdInfoKHR importInfo { };
-    importInfo.sType = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
-    importInfo.semaphore = m_acquireSemaphore;
-    importInfo.flags = VK_SEMAPHORE_IMPORT_TEMPORARY_BIT;
-    importInfo.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
-    importInfo.fd = fenceFD.value();
-
-    if (m_deviceTable.vkImportSemaphoreFdKHR(m_vkDevice, &importInfo) != VK_SUCCESS) {
-        RELEASE_LOG(XR, "OpenXR Vulkan: vkImportSemaphoreFdKHR failed; frame fence ignored");
-        return;
-    }
-
-    // On a successful SYNC_FD import Vulkan takes ownership of the fd, so disown it from the descriptor (discarding the
-    // returned value) to avoid a double close.
-    (void)fenceFD.release();
-    m_acquireSemaphorePending = true;
+    // The fence is the WebProcess render completion sync_file. waitFrameFence() does not know which swapchain image the
+    // following endFrame()/commitFrame() will target, so just stash the fd here. Then commitFrame() imports it into that image's
+    // acquireSemaphore and the blit submission waits on it, mirroring the OpenGLES GLFence::importFD()/serverWait() path.
+    // The caller (OpenXRCoordinator::endFrame) always pairs a waitFrameFence() with the following layer's commitFrame(), which
+    // consumes and clears m_pendingFenceFD up front, so there must be no unconsumed fd here. (The move assignment would still close
+    // a previous fd rather than leak it, but a stash without an intervening consume means the pairing contract was broken.)
+    ASSERT(!m_pendingFenceFD);
+    m_pendingFenceFD = WTF::move(fenceFD);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.h
@@ -105,6 +105,10 @@ private:
     std::optional<PlatformXR::FrameData::ExternalTexture> exportImageAsAHardwareBuffer(uint64_t image, const OpenXRSwapchain&, uint32_t width, uint32_t height);
 #endif
     bool createExportedImageSyncObjects(ExportedImage&);
+    static bool configureValidation(Vector<const char*>& layers, Vector<const char*>& extensions, VkValidationFeaturesEXT&);
+    void logDeviceAndDriverUUIDs(const char* deviceName) const;
+    void createDebugMessenger();
+    void setDebugName(VkObjectType, uint64_t objectHandle, const char* name);
     bool recordBlitCommandBuffer(ExportedImage&, VkImage swapchainImage);
     void destroyExportedImage(ExportedImage&);
 
@@ -128,6 +132,8 @@ private:
     uint32_t m_queueFamilyIndex { 0 };
     VkQueue m_vkQueue { VK_NULL_HANDLE };
     VkCommandPool m_commandPool { VK_NULL_HANDLE };
+
+    VkDebugUtilsMessengerEXT m_debugMessenger { VK_NULL_HANDLE };
 
 #if USE(GBM)
     bool m_supportsDRMModifiers { false };

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR) && USE(OPENXR) && defined(XR_USE_GRAPHICS_API_VULKAN)
+
+#include "OpenXRGraphicsBinding.h"
+
+// openxr_platform.h declares the EGL graphics binding when XR_USE_PLATFORM_EGL is set (which it is
+// regardless of the selected graphics API), so the EGL types it references must exist beforehand.
+typedef void* EGLDisplay;
+typedef void* EGLContext;
+typedef void* EGLConfig;
+typedef unsigned EGLenum;
+#if defined(XR_USE_PLATFORM_EGL)
+typedef void (*(*PFNEGLGETPROCADDRESSPROC)(const char *))(void);
+#endif
+
+#if OS(ANDROID)
+#include <jni.h>
+#endif
+
+#if defined(XR_USE_GRAPHICS_API_VULKAN)
+#include <volk.h>
+#endif
+#include <openxr/openxr_platform.h>
+#include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebKit {
+
+class OpenXRSwapchain;
+
+class OpenXRGraphicsBindingVulkan final : public OpenXRGraphicsBinding {
+    WTF_MAKE_TZONE_ALLOCATED(OpenXRGraphicsBindingVulkan);
+public:
+    static std::unique_ptr<OpenXRGraphicsBindingVulkan> create();
+
+    ~OpenXRGraphicsBindingVulkan();
+
+    Vector<ASCIILiteral> requiredInstanceExtensions() const final;
+    bool initializeDisplay(bool isForTesting) final;
+    bool initializeForSession(XrInstance, XrSystemId) final;
+    const void* sessionGraphicsBinding() const final;
+    int64_t selectColorFormat(const Vector<int64_t>& supportedFormats, bool alpha) const final;
+    Vector<uint64_t> enumerateSwapchainImages(XrSwapchain) const final;
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportTexture(uint64_t image, const OpenXRSwapchain&, TextureType, uint32_t width, uint32_t height) final;
+    void commitFrame(uint64_t keyImage, const OpenXRSwapchain&, TextureType, const Vector<uint64_t>& images) final;
+    void waitFrameFence(WTF::UnixFileDescriptor&&) final;
+    void releaseSessionGraphics() final;
+
+private:
+    OpenXRGraphicsBindingVulkan();
+
+    // The runtime's own swapchain images cannot be directly exported as DMABufs (we do not control their allocation), so this
+    // mirrors the GBM fallback path, the WebProcess renders into our own buffer, then we copy it into the swapchain image.
+    struct ExportedImage {
+        VkImage image { VK_NULL_HANDLE };
+        VkDeviceMemory memory { VK_NULL_HANDLE };
+        uint32_t width { 0 };
+        uint32_t height { 0 };
+        VkFormat format { VK_FORMAT_UNDEFINED };
+    };
+
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportTexture2D(uint64_t swapchainImage, const OpenXRSwapchain&, uint32_t width, uint32_t height);
+    void destroyExportedImage(ExportedImage&);
+
+    // All dispatch below loader level goes through these tables instead of volk's globals, so this binding does not clobber the
+    // dispatch of any other volk user in the process. volkLoadDevice() is the one that really bites: it replaces the globals
+    // with pointers that bypass the loader trampoline and are only valid for the VkDevice they came from, so a second user
+    // would be misdirected to our device rather than merely sharing our dispatch. The loader-level entry points
+    // (vkGetInstanceProcAddr, vkEnumerateInstance*) are still globals, but those are instance-independent and set by the
+    // idempotent volkInitialize(), so sharing them is what volk intends.
+    // One global does remain unavoidably shared: volkLoadInstanceTable() also assigns the global vkGetDeviceProcAddr, because
+    // that is where volkLoadDeviceTable() reads it from. So the two must be called in that order, and a concurrent volk user
+    // could leave us resolving device functions through their instance's copy. volk has no API that avoids this.
+    // volkLoadInstanceTable() requires volk 341, which OptionsGTK/OptionsWPE enforce for WEBXR_GRAPHICS_API=VULKAN.
+    VolkInstanceTable m_instanceTable { };
+    VolkDeviceTable m_deviceTable { };
+
+    XrGraphicsBindingVulkanKHR m_graphicsBinding { };
+    VkInstance m_vkInstance { VK_NULL_HANDLE };
+    VkPhysicalDevice m_vkPhysicalDevice { VK_NULL_HANDLE };
+    VkDevice m_vkDevice { VK_NULL_HANDLE };
+    uint32_t m_queueFamilyIndex { 0 };
+    VkQueue m_vkQueue { VK_NULL_HANDLE };
+    VkCommandPool m_commandPool { VK_NULL_HANDLE };
+
+    // Binary semaphore used to GPU-wait on the web process' render-completion fence: waitFrameFence()
+    // imports the sync-file fd into it as a temporary payload, and commitFrame()'s blit submission
+    // waits on it so the copy observes the finished writes without stalling the CPU. Mirrors the
+    // OpenGLES GLFence::importFD()/serverWait() path. m_acquireSemaphorePending tracks whether a
+    // payload was imported for the current commit.
+    VkSemaphore m_acquireSemaphore { VK_NULL_HANDLE };
+    bool m_acquireSemaphorePending { false };
+
+    HashMap<uint64_t, ExportedImage> m_exportedImages;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR) && defined(XR_USE_GRAPHICS_API_VULKAN)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.h
@@ -49,6 +49,7 @@ typedef void (*(*PFNEGLGETPROCADDRESSPROC)(const char *))(void);
 #include <openxr/openxr_platform.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/unix/UnixFileDescriptor.h>
 
 namespace WebKit {
 
@@ -85,6 +86,12 @@ private:
         VkFormat format { VK_FORMAT_UNDEFINED };
         // Command buffer that blits this image into its paired swapchain image, recorded once and resubmitted on every commit.
         VkCommandBuffer commandBuffer { VK_NULL_HANDLE };
+        // Per-image synchronization so frames overlap without a per-frame queue wait. inFlightFence signals when this image's
+        // submission completes (lazy wait before reusing the command buffer), and acquireSemaphore receives the WebProcess
+        // render completion fence each frame (waited on by the blit). Both are sized to the swapchain so reusing one
+        // image's objects never collides with another's in flight work.
+        VkFence inFlightFence { VK_NULL_HANDLE };
+        VkSemaphore acquireSemaphore { VK_NULL_HANDLE };
     };
 
     std::optional<PlatformXR::FrameData::ExternalTexture> exportTexture2D(uint64_t swapchainImage, const OpenXRSwapchain&, uint32_t width, uint32_t height);
@@ -112,13 +119,10 @@ private:
     VkQueue m_vkQueue { VK_NULL_HANDLE };
     VkCommandPool m_commandPool { VK_NULL_HANDLE };
 
-    // Binary semaphore used to GPU-wait on the web process' render-completion fence: waitFrameFence()
-    // imports the sync-file fd into it as a temporary payload, and commitFrame()'s blit submission
-    // waits on it so the copy observes the finished writes without stalling the CPU. Mirrors the
-    // OpenGLES GLFence::importFD()/serverWait() path. m_acquireSemaphorePending tracks whether a
-    // payload was imported for the current commit.
-    VkSemaphore m_acquireSemaphore { VK_NULL_HANDLE };
-    bool m_acquireSemaphorePending { false };
+    // The WebProcess render completion fence, stashed by waitFrameFence() and consumed by the next
+    // commitFrame(), which imports it into the just acquired image's acquireSemaphore. waitFrameFence() does not know which
+    // image the commit will target, so the fd is held here in between.
+    WTF::UnixFileDescriptor m_pendingFenceFD;
 
     HashMap<uint64_t, ExportedImage> m_exportedImages;
 };

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.h
@@ -95,18 +95,15 @@ private:
         // image's objects never collides with another's in flight work.
         VkFence inFlightFence { VK_NULL_HANDLE };
         VkSemaphore acquireSemaphore { VK_NULL_HANDLE };
+        VkSemaphore renderFinishedSemaphore { VK_NULL_HANDLE };
     };
 
-#if USE(GBM)
-    std::optional<PlatformXR::FrameData::ExternalTexture> exportImageAsDMABuf(uint64_t image, const OpenXRSwapchain&, uint32_t width, uint32_t height);
-    Vector<VkDrmFormatModifierPropertiesEXT> supportedExportDRMModifiers(VkFormat, VkImageUsageFlags) const;
-#endif
-#if OS(ANDROID)
-    std::optional<PlatformXR::FrameData::ExternalTexture> exportImageAsAHardwareBuffer(uint64_t image, const OpenXRSwapchain&, uint32_t width, uint32_t height);
-#endif
+    VkImageUsageFlags maximalImageUsageFlags(VkFormat) const;
+    bool supportsOpaqueFDSharing(VkFormat, VkImageUsageFlags) const;
     bool createExportedImageSyncObjects(ExportedImage&);
+    bool createExportedImageSharingSemaphores(ExportedImage&);
     static bool configureValidation(Vector<const char*>& layers, Vector<const char*>& extensions, VkValidationFeaturesEXT&);
-    void logDeviceAndDriverUUIDs(const char* deviceName) const;
+    void readDeviceAndDriverUUIDs(const char* deviceName);
     void createDebugMessenger();
     void setDebugName(VkObjectType, uint64_t objectHandle, const char* name);
     bool recordBlitCommandBuffer(ExportedImage&, VkImage swapchainImage);
@@ -135,9 +132,9 @@ private:
 
     VkDebugUtilsMessengerEXT m_debugMessenger { VK_NULL_HANDLE };
 
-#if USE(GBM)
-    bool m_supportsDRMModifiers { false };
-#endif
+    std::array<uint64_t, 2> m_deviceUUID { };
+    std::array<uint64_t, 2> m_driverUUID { };
+
 
     // The WebProcess render completion fence, stashed by waitFrameFence() and consumed by the next
     // commitFrame(), which imports it into the just acquired image's acquireSemaphore. waitFrameFence() does not know which

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.h
@@ -83,9 +83,12 @@ private:
         uint32_t width { 0 };
         uint32_t height { 0 };
         VkFormat format { VK_FORMAT_UNDEFINED };
+        // Command buffer that blits this image into its paired swapchain image, recorded once and resubmitted on every commit.
+        VkCommandBuffer commandBuffer { VK_NULL_HANDLE };
     };
 
     std::optional<PlatformXR::FrameData::ExternalTexture> exportTexture2D(uint64_t swapchainImage, const OpenXRSwapchain&, uint32_t width, uint32_t height);
+    bool recordBlitCommandBuffer(ExportedImage&, VkImage swapchainImage);
     void destroyExportedImage(ExportedImage&);
 
     // All dispatch below loader level goes through these tables instead of volk's globals, so this binding does not clobber the

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingVulkan.h
@@ -41,6 +41,9 @@ typedef void (*(*PFNEGLGETPROCADDRESSPROC)(const char *))(void);
 
 #if OS(ANDROID)
 #include <jni.h>
+#ifndef VK_USE_PLATFORM_ANDROID_KHR
+#define VK_USE_PLATFORM_ANDROID_KHR 1
+#endif
 #endif
 
 #if defined(XR_USE_GRAPHICS_API_VULKAN)
@@ -94,7 +97,14 @@ private:
         VkSemaphore acquireSemaphore { VK_NULL_HANDLE };
     };
 
-    std::optional<PlatformXR::FrameData::ExternalTexture> exportTexture2D(uint64_t swapchainImage, const OpenXRSwapchain&, uint32_t width, uint32_t height);
+#if USE(GBM)
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportImageAsDMABuf(uint64_t image, const OpenXRSwapchain&, uint32_t width, uint32_t height);
+    Vector<VkDrmFormatModifierPropertiesEXT> supportedExportDRMModifiers(VkFormat, VkImageUsageFlags) const;
+#endif
+#if OS(ANDROID)
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportImageAsAHardwareBuffer(uint64_t image, const OpenXRSwapchain&, uint32_t width, uint32_t height);
+#endif
+    bool createExportedImageSyncObjects(ExportedImage&);
     bool recordBlitCommandBuffer(ExportedImage&, VkImage swapchainImage);
     void destroyExportedImage(ExportedImage&);
 
@@ -118,6 +128,10 @@ private:
     uint32_t m_queueFamilyIndex { 0 };
     VkQueue m_vkQueue { VK_NULL_HANDLE };
     VkCommandPool m_commandPool { VK_NULL_HANDLE };
+
+#if USE(GBM)
+    bool m_supportsDRMModifiers { false };
+#endif
 
     // The WebProcess render completion fence, stashed by waitFrameFence() and consumed by the next
     // commitFrame(), which imports it into the just acquired image's acquireSemaphore. waitFrameFence() does not know which

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -199,7 +199,9 @@ std::unique_ptr<OpenXRSwapchain> OpenXRCoordinator::createSwapchain(uint32_t wid
     // Single-sampled, deliberately ignoring the view configuration's recommendedSwapchainSampleCount. Antialiasing is applied and
     // resolved in the web process before the content reaches us.
     info.sampleCount = 1;
-    info.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
+    // Both bindings copy the web process' content into the swapchain image at commit time (vkCmdBlitImage for Vulkan,
+    // an FBO blit for OpenGLES), which requires TRANSFER_DST; without it the copy is invalid usage.
+    info.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_TRANSFER_DST_BIT;
 
     return OpenXRSwapchain::create(m_session, info, alpha ? OpenXRSwapchain::HasAlpha::Yes : OpenXRSwapchain::HasAlpha::No, *m_graphicsBinding);
 }

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -33,6 +33,8 @@
 #include "OpenXRGraphicsBinding.h"
 #if defined(XR_USE_GRAPHICS_API_OPENGL_ES)
 #include "OpenXRGraphicsBindingOpenGLES.h"
+#elif defined(XR_USE_GRAPHICS_API_VULKAN)
+#include "OpenXRGraphicsBindingVulkan.h"
 #endif
 #include "OpenXRHitTestManager.h"
 #include "OpenXRInput.h"
@@ -767,6 +769,8 @@ void OpenXRCoordinator::initializeDevice(bool isForTesting)
     std::unique_ptr<OpenXRGraphicsBinding> graphicsBinding;
 #if defined(XR_USE_GRAPHICS_API_OPENGL_ES)
     graphicsBinding = OpenXRGraphicsBindingOpenGLES::create();
+#elif defined(XR_USE_GRAPHICS_API_VULKAN)
+    graphicsBinding = OpenXRGraphicsBindingVulkan::create();
 #endif
     if (!graphicsBinding || !graphicsBinding->initializeDisplay(isForTesting)) {
         LOG(XR, "Failed to create a display for OpenXR.");

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -413,8 +413,25 @@ if (ENABLE_WEBXR)
     find_package(OpenXR REQUIRED CONFIG)
     SET_AND_EXPOSE_TO_BUILD(USE_OPENXR ${OpenXR_FOUND})
     set(OPENXR_VERSION "${OpenXR_VERSION}" CACHE INTERNAL "OpenXR SDK version")
+
+    # Graphics API used by the OpenXR backend. OpenGLES is the default; Vulkan can
+    # be selected at build time with -DWEBXR_GRAPHICS_API=VULKAN.
+    set(WEBXR_GRAPHICS_API "OPENGL_ES" CACHE STRING "Graphics API for the OpenXR WebXR backend (OPENGL_ES or VULKAN)")
+    set_property(CACHE WEBXR_GRAPHICS_API PROPERTY STRINGS "OPENGL_ES" "VULKAN")
+
+    if (WEBXR_GRAPHICS_API STREQUAL "VULKAN")
+        # 341 for volkLoadInstanceTable(), which the binding uses so its Vulkan dispatch stays out of volk's process-wide
+        # globals and cannot collide with any other volk user in the same process.
+        find_package(volk 341 CONFIG)
+        if (NOT TARGET volk::volk OR NOT TARGET volk::volk_headers)
+            message(FATAL_ERROR "Volk 341 or newer is required for WEBXR_GRAPHICS_API=VULKAN")
+        endif ()
+        SET_AND_EXPOSE_TO_BUILD(XR_USE_GRAPHICS_API_VULKAN TRUE)
+    else ()
+        SET_AND_EXPOSE_TO_BUILD(XR_USE_GRAPHICS_API_OPENGL_ES TRUE)
+    endif ()
+
     SET_AND_EXPOSE_TO_BUILD(XR_USE_PLATFORM_EGL TRUE)
-    SET_AND_EXPOSE_TO_BUILD(XR_USE_GRAPHICS_API_OPENGL_ES TRUE)
     SET_AND_EXPOSE_TO_BUILD(ENABLE_WEBXR_AR TRUE)
     SET_AND_EXPOSE_TO_BUILD(ENABLE_WEBXR_HANDS TRUE)
 endif ()

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -427,6 +427,8 @@ if (ENABLE_WEBXR)
             message(FATAL_ERROR "Volk 341 or newer is required for WEBXR_GRAPHICS_API=VULKAN")
         endif ()
         SET_AND_EXPOSE_TO_BUILD(XR_USE_GRAPHICS_API_VULKAN TRUE)
+        # The same condition spelled so USE() can consume it: XR_USE_GRAPHICS_API_VULKAN follows the OpenXR SDK style and has to be tested with defined(), which the serialization and message generators do not accept.
+        SET_AND_EXPOSE_TO_BUILD(USE_OPENXR_VULKAN TRUE)
     else ()
         SET_AND_EXPOSE_TO_BUILD(XR_USE_GRAPHICS_API_OPENGL_ES TRUE)
     endif ()

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -371,8 +371,25 @@ if (ENABLE_WEBXR)
     find_package(OpenXR REQUIRED CONFIG)
     SET_AND_EXPOSE_TO_BUILD(USE_OPENXR ${OpenXR_FOUND})
     set(OPENXR_VERSION "${OpenXR_VERSION}" CACHE INTERNAL "OpenXR SDK version")
+
+    # Graphics API used by the OpenXR backend. OpenGLES is the default; Vulkan can
+    # be selected at build time with -DWEBXR_GRAPHICS_API=VULKAN.
+    set(WEBXR_GRAPHICS_API "OPENGL_ES" CACHE STRING "Graphics API for the OpenXR WebXR backend (OPENGL_ES or VULKAN)")
+    set_property(CACHE WEBXR_GRAPHICS_API PROPERTY STRINGS "OPENGL_ES" "VULKAN")
+
+    if (WEBXR_GRAPHICS_API STREQUAL "VULKAN")
+        # 341 for volkLoadInstanceTable(), which the binding uses so its Vulkan dispatch stays out of volk's process-wide
+        # globals and cannot collide with any other volk user in the same process.
+        find_package(volk 341 CONFIG)
+        if (NOT TARGET volk::volk OR NOT TARGET volk::volk_headers)
+            message(FATAL_ERROR "Volk 341 or newer is required for WEBXR_GRAPHICS_API=VULKAN")
+        endif ()
+        SET_AND_EXPOSE_TO_BUILD(XR_USE_GRAPHICS_API_VULKAN TRUE)
+    else ()
+        SET_AND_EXPOSE_TO_BUILD(XR_USE_GRAPHICS_API_OPENGL_ES TRUE)
+    endif ()
+
     SET_AND_EXPOSE_TO_BUILD(XR_USE_PLATFORM_EGL TRUE)
-    SET_AND_EXPOSE_TO_BUILD(XR_USE_GRAPHICS_API_OPENGL_ES TRUE)
     SET_AND_EXPOSE_TO_BUILD(ENABLE_WEBXR_AR TRUE)
     SET_AND_EXPOSE_TO_BUILD(ENABLE_WEBXR_HANDS TRUE)
     if (ANDROID)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -385,6 +385,8 @@ if (ENABLE_WEBXR)
             message(FATAL_ERROR "Volk 341 or newer is required for WEBXR_GRAPHICS_API=VULKAN")
         endif ()
         SET_AND_EXPOSE_TO_BUILD(XR_USE_GRAPHICS_API_VULKAN TRUE)
+        # The same condition spelled so USE() can consume it: XR_USE_GRAPHICS_API_VULKAN follows the OpenXR SDK style and has to be tested with defined(), which the serialization and message generators do not accept.
+        SET_AND_EXPOSE_TO_BUILD(USE_OPENXR_VULKAN TRUE)
     else ()
         SET_AND_EXPOSE_TO_BUILD(XR_USE_GRAPHICS_API_OPENGL_ES TRUE)
     endif ()


### PR DESCRIPTION
#### 29b4b4faad986cb34528911a761dab6473b8fc4a
<pre>
[WebXR][OpenXR] Add opt-in Vulkan validation to the Vulkan binding

Vulkan offers multiple ways to validate that the API is used properly.
We&apos;re adding a validation layer + VK_EXT_debug_utils behind
WEBKIT_WEBXR_VULKAN_VALIDATION, which is set to be off by default.

Sync validation comes from VK_EXT_validation_features, which
the layer provides rather than the driver, so it is queried against the layer
and skipped when absent.

Messages go through a debug messenger so the callback logs
unconditionally and always returns VK_FALSE (VK_TRUE would abort the
call being validated). The used images, memory, fences and semaphores
get debug names so complaints point at something identifiable.

releaseSessionGraphics() no longer bails out when only the device is missing as
instance creation can succeed with device creation failing, and the messenger
still needs releasing.
</pre>
----------------------------------------------------------------------
#### 7e8933d3813018c98eae24ac2fee9d8d8c620d1f
<pre>
[WebXR][OpenXR] Export images with a validated DRM format modifier

We exported DMABuf backed images as plain linear ones without ever asking the
driver whether that combination works, triggering VUID-VkImageCreateInfo-pNext-00990
and VUID-VkExportMemoryAllocateInfo-handleTypes-00656 validation errors.

The right thing to do would be a driver chosen tiled DRM modifier layout where
VK_EXT_image_drm_format_modifier exists, validating each candidate with
vkGetPhysicalDeviceImageFormatProperties2 so we only create combinations the
driver reports as creatable and DMABuf exportable. Candidates are filtered on
format features derived from the image&apos;s actual usage rather than a hardcoded
set, which would otherwise drop valid modifiers and force the linear fallback.
The memory goes out as one fd with per-plane strides/offsets. The WebProcess
already handles the modifier and multi-plane layout on import.

Without the extension we still fall back to linear. Nothing advertises that as
DMABuf exportable, so it leans on the export being accepted anyway, but there is
no alternative on such a device.

Co-Authored-By: Claude Opus 4.8 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### ab78f444c03b246c6853e2af28966ffbb53fa526
<pre>
[WebXR][OpenXR] Request TRANSFER_DST usage for swapchain images

This is not exclusive to the Vulkan case, really both graphics bindings
copy the WebProcess content into the runtime&apos;s swapchain image at commit
time (except on the case of using the DMABuf extensions). That needs
VK_IMAGE_USAGE_TRANSFER_DST_BIT on the destination.
</pre>
----------------------------------------------------------------------
#### 957f58e98ccdbcf1f8934424564e6cc675c36f03
<pre>
[WebXR][OpenXR] Replace the perframe queue wait with perimage fences

commitFrame() ended with a vkQueueWaitIdle(), which stalls the CPU until the GPU
is completely idle every frame. It was not there really for compositing correctness
(the runtime synchronises its own reads, same as the OpenGLES path) but only to
guard reuse of our command buffer and of the single shared acquire semaphore.

Give each ExportedImage its own fence (created signaled, waited on and reset
before the buffer is reused) and its own acquire semaphore, so both hazards are
covered per image and the wait can go. An image is only reacquired a full
swapchain cycle later, so that fence wait almost always returns immediately.
waitFrameFence() now stashes the WebProcess fence and commitFrame() imports it
into the target image&apos;s semaphore.

The pool no longer needs reset flags, and teardown frees the new fences and
semaphores (command buffers still go with the pool).
</pre>
----------------------------------------------------------------------
#### e6c072d54680ec8344b898276a0788533ba59a45
<pre>
[WebXR][OpenXR] Record the Vulkan commit command buffer once per swapchain image

The blit required to pass the WebGL rendering into the OpenXR swapchain
(as we cannot export directly the vkImage from the runtime yet) never changes.
So we can record it once (kept in ExportedImage, owned by the pool) and just
resubmit, instead of allocating and recording one every frame.
The acquire semaphore wait stays in VkSubmitInfo, so that still
varies per submit.

Replaying is safe because the per frame vkQueueWaitIdle guarantees the
previous submit is finished. When that goes away these will need a fence.
</pre>
----------------------------------------------------------------------
#### e2fcdba5c2ae2d36eae5fcb707aeeded67e8ebb5
<pre>
[WebXR][OpenXR] Add a Vulkan graphics binding selectable at build time

Adds OpenXRGraphicsBindingVulkan on top of KHR_vulkan_enable2, so the runtime
creates the VkInstance/VkDevice for us. Build it with
-DWEBXR_GRAPHICS_API=VULKAN (OpenGLES stays the default).

It isn&apos;t very useful at the moment because it only uses vulkan to
retrieve images from the runtime. It does not even use Vulkan (via
opaque FDs) to share images between processes, we still export them
using DMABuf/GBM/AndroidHardwareBuffer.

This means that OpenGL is still used in ANGLE to render WebGL content.
The problem is that both graphics libraries have different origins so we
need to flip the Y for the GL-&gt;Vulkan differences. We do that flip in
the very same blit that we use to copy the contents from the buffer used
for sharing into the vkImage provided by the OpenXR runtime. In order to
sync the rendering the WebProcess render fence arrives as a SYNC_FD
semaphore so the blit would wait on the GPU not the CPU as required.

In order to use Vulkan as transport mechanism we would have to use the
Vulkan ANGLE backend which is out of the scope of this experiement.

Co-Authored-By: Claude Opus 5 &lt;noreply@anthropic.com&gt;
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1540ac236ffeee943e84ea21f5fad560ccf51a98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191760 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145863 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183398 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141692 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98345 "1 flakes 12 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122129 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44058 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42331 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4097 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10915 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41972 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2920 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42815 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193687 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55153 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151099 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55842 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38595 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150802 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45381 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128125 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123800 "Hash 1540ac23 for PR 71057 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54355 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16966 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53737 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53976 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->