### PR TITLE
[JSC] Overhaul ArrayBuffer & Wasm::Memory sizing with memory64

### DIFF
--- a/JSTests/stress/array-buffer-slice-larger-than-4gb.js
+++ b/JSTests/stress/array-buffer-slice-larger-than-4gb.js
@@ -1,0 +1,29 @@
+//@ memoryHog!
+//@ skip if $addressBits <= 32
+//@ runDefault
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+const gib = 1024 * 1024 * 1024;
+const size = 5 * gib;
+
+for (const ArrayBufferClass of [ArrayBuffer, SharedArrayBuffer]) {
+    const buffer = new ArrayBufferClass(size);
+    shouldBe(buffer.byteLength, size);
+
+    new Uint8Array(buffer).set([1, 2, 3, 4], size - 4);
+
+    // Slicing only a window at the end keeps the copy small while still forcing the byte length
+    // itself through the argument clamping.
+    shouldBe(buffer.slice(size - 4).byteLength, 4);
+    shouldBe([...new Uint8Array(buffer.slice(size - 4))].join(), "1,2,3,4");
+    shouldBe(buffer.slice(-4).byteLength, 4);
+    shouldBe(buffer.slice(size - 4, size).byteLength, 4);
+    shouldBe(buffer.slice(size - 4, -1).byteLength, 3);
+    shouldBe(buffer.slice(4 * gib, 4 * gib + 8).byteLength, 8);
+    shouldBe(buffer.slice(size, size).byteLength, 0);
+    shouldBe(buffer.slice(size + 1).byteLength, 0);
+}

--- a/JSTests/stress/shared-array-buffer-large-maxbytelength.js
+++ b/JSTests/stress/shared-array-buffer-large-maxbytelength.js
@@ -1,4 +1,5 @@
-const MAX64 = 4294967296 + 1;
+// One byte past MAX_ARRAY_BUFFER_SIZE, so neither constructor can satisfy it.
+const MAX64 = 2 ** 34 + 1;
 // Okay to throw, but should not crash.
 try {
     new SharedArrayBuffer(4, { maxByteLength: MAX64 });

--- a/JSTests/stress/typedarray-canonical-numeric-index-string-past-max-array-index.js
+++ b/JSTests/stress/typedarray-canonical-numeric-index-string-past-max-array-index.js
@@ -1,0 +1,74 @@
+// A canonical numeric index string on a typed array never reaches ordinary property lookup, whatever
+// number it denotes. https://tc39.es/ecma262/#sec-canonicalnumericindexstring
+//
+// Keys past MAX_ARRAY_INDEX are recognized as integer indices, so they must behave like any other
+// out-of-bounds index on a short array rather than becoming ordinary properties.
+
+function shouldBe(actual, expected, what) {
+    if (actual !== expected)
+        throw new Error(`bad value for ${what}: expected ${expected} but got ${actual}`);
+}
+
+function shouldThrowTypeError(f, what) {
+    try {
+        f();
+    } catch (e) {
+        if (e instanceof TypeError)
+            return;
+        throw new Error(`${what}: expected a TypeError but got ${e}`);
+    }
+    throw new Error(`${what}: expected a TypeError but nothing was thrown`);
+}
+
+const array = new Uint8Array(4);
+const prototype = Object.getPrototypeOf(array);
+
+// String(n) is by construction the canonical spelling of n, so each of these is a
+// CanonicalNumericIndexString. They span both sides of every internal cutoff: MAX_ARRAY_INDEX, 2^32,
+// 2^53, and 2^64, plus the values that are canonical but are not integer indices at all.
+const keys = [
+    2 ** 32 - 1,        // 0xFFFFFFFF, excluded by isIndex()
+    2 ** 32,
+    2 ** 53 - 1,        // the largest integer index the spec allows
+    2 ** 53,
+    2 ** 60,
+    2 ** 64,            // past uint64_t, so no index is recoverable
+    1e21,               // spelled in exponential form
+    -1,
+    1.5,
+    2 ** 32 + 0.5,      // canonical, past MAX_ARRAY_INDEX, and not an integer
+    NaN,
+    Infinity,
+    -Infinity,
+].map(String).concat(["-0"]); // String(-0) is "0", so -0 has to be spelled out.
+
+for (const key of keys) {
+    // An element that does not exist must not be found on the prototype either.
+    prototype[key] = "fromPrototype";
+
+    shouldBe(array[key], undefined, `array["${key}"]`);
+    shouldBe(key in array, false, `"${key}" in array`);
+    shouldBe(array.hasOwnProperty(key), false, `hasOwnProperty("${key}")`);
+    shouldBe(Object.getOwnPropertyDescriptor(array, key), undefined, `getOwnPropertyDescriptor("${key}")`);
+
+    // The store is ignored, but the right hand side is still coerced first.
+    let coerced = false;
+    array[key] = { valueOf() { coerced = true; return 1; } };
+    shouldBe(coerced, true, `array["${key}"] = ... coerces the right hand side`);
+    shouldBe(array.hasOwnProperty(key), false, `"${key}" was not added as a property`);
+
+    // Deleting an index that does not exist succeeds vacuously.
+    shouldBe(delete array[key], true, `delete array["${key}"]`);
+
+    shouldThrowTypeError(() => Object.defineProperty(array, key, { value: 1 }), `defineProperty("${key}")`);
+
+    delete prototype[key];
+}
+
+// Numeric-looking strings that are not canonical are ordinary properties, and stay that way.
+for (const key of ["042", "1e3", " 1", "0x10", "4294967296 ", "+4294967296"]) {
+    array[key] = "ordinary";
+    shouldBe(array.hasOwnProperty(key), true, `"${key}" is an ordinary property`);
+    shouldBe(array[key], "ordinary", `array["${key}"]`);
+    shouldBe(delete array[key], true, `delete array["${key}"]`);
+}

--- a/JSTests/stress/typedarray-index-past-max-array-index.js
+++ b/JSTests/stress/typedarray-index-past-max-array-index.js
@@ -1,0 +1,73 @@
+//@ memoryHog!
+//@ skip if $addressBits <= 32
+//@ runDefault
+
+// Indexed access on a typed array longer than MAX_ARRAY_INDEX elements.
+//
+// MAX_ARRAY_BUFFER_SIZE is 2^34, so a Uint8Array can be longer than MAX_ARRAY_INDEX (0xFFFFFFFE),
+// the ceiling on a property key expressed as an index. Every element below the view's length is a
+// valid integer index per IsValidIntegerIndex, so [] must reach it. Such a key arrives as a string,
+// where parseIndex() cannot hold it, so it is recognized by isCanonicalNumericIndexString() instead.
+
+function shouldBe(actual, expected, what) {
+    if (actual !== expected)
+        throw new Error(`bad value for ${what}: expected ${expected} but got ${actual}`);
+}
+
+// 4GiB + 2 bytes: the smallest view with indices on both sides of 0xFFFFFFFF and above 2^32, so one
+// allocation covers every case.
+let array;
+try {
+    array = new Uint8Array(4294967298);
+} catch (e) {
+    // A port that cannot spare 4GiB has nothing to test here.
+    if (!(e instanceof RangeError))
+        throw e;
+}
+
+if (array !== undefined) {
+    // fill() and subarray() take the size_t path, so they establish what a byte holds independently of [].
+    const trueValueAt = index => array.subarray(index, index + 1)[0];
+
+    for (const index of [
+        4294967294, // 0xFFFFFFFE, the last index a property key can express: the control.
+        4294967295, // 0xFFFFFFFF: fits a uint32 but is excluded by isIndex().
+        4294967296, // 2^32: does not fit a uint32 at all.
+        array.length - 1,
+    ]) {
+        array.fill(7, index, index + 1);
+        shouldBe(trueValueAt(index), 7, `fill() at ${index}`);
+
+        shouldBe(array[index], 7, `array[${index}]`);
+        shouldBe(array.at(index), 7, `array.at(${index})`);
+
+        array[index] = 99;
+        shouldBe(trueValueAt(index), 99, `array[${index}] = 99`);
+        shouldBe(array[index], 99, `array[${index}] after assignment`);
+
+        shouldBe(index in array, true, `${index} in array`);
+        shouldBe(array.hasOwnProperty(String(index)), true, `hasOwnProperty(${index})`);
+        shouldBe(Reflect.has(array, String(index)), true, `Reflect.has(array, "${index}")`);
+
+        const descriptor = Object.getOwnPropertyDescriptor(array, String(index));
+        shouldBe(descriptor !== undefined, true, `getOwnPropertyDescriptor(${index}) exists`);
+        shouldBe(descriptor.value, 99, `getOwnPropertyDescriptor(${index}).value`);
+        shouldBe(descriptor.writable, true, `getOwnPropertyDescriptor(${index}).writable`);
+        shouldBe(descriptor.enumerable, true, `getOwnPropertyDescriptor(${index}).enumerable`);
+        shouldBe(descriptor.configurable, true, `getOwnPropertyDescriptor(${index}).configurable`);
+
+        // An integer index that exists cannot be deleted.
+        shouldBe(delete array[index], false, `delete array[${index}]`);
+        shouldBe(trueValueAt(index), 99, `array[${index}] survives delete`);
+
+        Object.defineProperty(array, String(index), { value: 123 });
+        shouldBe(trueValueAt(index), 123, `defineProperty at ${index}`);
+
+        // Reading through the prototype must not shadow an element that exists.
+        Object.getPrototypeOf(array)[String(index)] = "fromProto";
+        shouldBe(array[index], 123, `array[${index}] is not shadowed by the prototype`);
+        delete Object.getPrototypeOf(array)[String(index)];
+
+        array.fill(0, index, index + 1);
+    }
+}

--- a/JSTests/wasm/js-api/memory-toResizableBuffer.js
+++ b/JSTests/wasm/js-api/memory-toResizableBuffer.js
@@ -67,21 +67,21 @@ function assertSharedGrowableBufferOfPageSize(pageCount, buffer, maxPageCount) {
     assertTrue(memory.buffer !== buffer);
 }
 
-// A resize whose page-aligned growth delta exceeds the maximum representable
-// PageCount must throw a catchable RangeError, not hit a release assertion.
+// A resize whose page-aligned growth delta exceeds what a memory32 may declare
+// must throw a catchable RangeError, not hit a release assertion.
 // https://bugs.webkit.org/show_bug.cgi?id=318524
 {
     let memory = new WebAssembly.Memory({ initial: 1, maximum: 65536 });
     let buffer = memory.toResizableBuffer();
     assertIsolatedResizableBufferOfPageSize(1, buffer, 65536);
 
-    // Growth delta of 65537 pages is not representable as a PageCount.
+    // 65538 pages is not a page count a memory32 may reach at all.
     assertThrows(() => buffer.resize(65538 * pageSize), RangeError, "");
     // The buffer is unchanged and remains usable after the failed resize.
     assertIsolatedResizableBufferOfPageSize(1, buffer, 65536);
 
-    // A representable delta that would still exceed the declared maximum must
-    // also throw catchably.
+    // A page count a memory32 may reach, but which still exceeds the declared
+    // maximum, must also throw catchably.
     assertThrows(() => buffer.resize(65537 * pageSize), RangeError, "");
     assertIsolatedResizableBufferOfPageSize(1, buffer, 65536);
 

--- a/JSTests/wasm/js-api/memory64-js-api-errors.js
+++ b/JSTests/wasm/js-api/memory64-js-api-errors.js
@@ -57,12 +57,12 @@ for (const address of ["i65", "", "I64", "u64", null, 1, {}]) {
     assert.throws(() => table.grow(-1n), TypeError, "Expect an integer argument in the range: [0, 2^64 - 1]");
 }
 
-// A memory64's declared maximum may exceed the memory32 page limit.
+// A memory64's declared maximum may exceed the memory32 page limit, up to 262144 pages (16 GiB).
 {
     const mem = new WebAssembly.Memory({ initial: 1n, maximum: 131072n, address: "i64" });
     assert.eq(mem.type().maximum, 131072n);
-    assert.eq(new WebAssembly.Memory({ initial: 0n, maximum: 137438953471n, address: "i64" }).type().maximum, 137438953471n);
-    assert.throws(() => new WebAssembly.Memory({ initial: 1n, maximum: 137438953472n, address: "i64" }), RangeError,
+    assert.eq(new WebAssembly.Memory({ initial: 0n, maximum: 262144n, address: "i64" }).type().maximum, 262144n);
+    assert.throws(() => new WebAssembly.Memory({ initial: 1n, maximum: 262145n, address: "i64" }), RangeError,
         "WebAssembly.Memory 'maximum' page count is too large");
     // An i32 memory keeps the memory32 limit.
     assert.throws(() => new WebAssembly.Memory({ initial: 1, maximum: 65537 }), RangeError,

--- a/JSTests/wasm/js-api/memory64-js-api.js
+++ b/JSTests/wasm/js-api/memory64-js-api.js
@@ -52,31 +52,27 @@ const pageSize = 64 * 1024;
 }
 
 // Constructor: initial page count too large throws. An initial page count is declarative in the same
-// way a maximum is, so the limit is the one a module may declare for an i64 memory; a count within
-// that limit which cannot be allocated is out of memory instead.
+// way a maximum is, so the limit is the largest count a module may declare for an i64 memory, which
+// is 262144 pages (16 GiB).
 {
     assert.throws(
-        () => new WebAssembly.Memory({ initial: 137438953472n, address: "i64" }),
+        () => new WebAssembly.Memory({ initial: 262145n, address: "i64" }),
         RangeError,
         "WebAssembly.Memory 'initial' page count is too large"
     );
-    assert.throws(
-        () => new WebAssembly.Memory({ initial: 65537n, address: "i64" }),
-        RangeError,
-        "Out of memory"
-    );
 }
 
-// Constructor: maximum page count too large throws. A maximum is declarative, so the limit is the
-// one a module may declare for an i64 memory, not the memory32 page limit.
+// Constructor: maximum page count too large throws. A maximum is bounded by that same i64 limit
+// rather than by the memory32 page limit.
 {
     assert.throws(
-        () => new WebAssembly.Memory({ initial: 1n, maximum: 137438953472n, address: "i64" }),
+        () => new WebAssembly.Memory({ initial: 1n, maximum: 262145n, address: "i64" }),
         RangeError,
         "WebAssembly.Memory 'maximum' page count is too large"
     );
     const memory = new WebAssembly.Memory({ initial: 1n, maximum: 65537n, address: "i64" });
     assert.eq(memory.type().maximum, 65537n);
+    assert.eq(new WebAssembly.Memory({ initial: 1n, maximum: 262144n, address: "i64" }).type().maximum, 262144n);
 }
 
 // Constructor: passing invalid address

--- a/JSTests/wasm/stress/memory64-grow-past-4gb.js
+++ b/JSTests/wasm/stress/memory64-grow-past-4gb.js
@@ -1,0 +1,88 @@
+//@ memoryHog!
+//@ skip if $addressBits <= 32
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// A memory64 exists to address more than the 4GiB a memory32 can, so both the wasm-level grow and
+// the resizable-buffer path must cross that boundary.
+
+const options = { memory64: true, threads: true };
+const pageSize = 65536;
+const maxMemory64Pages = 262144;
+const fourGiB = 4 * 1024 * 1024 * 1024;
+const pastFourGiB = fourGiB + pageSize;
+
+// A memory with no declared maximum reports the most this platform could grow it to, which is what
+// bounds every maxByteLength below.
+const ceilingBytes = new WebAssembly.Memory({ initial: 1n, address: "i64" }).toResizableBuffer().maxByteLength;
+
+// A memory whose initial size is already past 4GiB proves this port can host one at all. Where it
+// can, growing past 4GiB below must succeed; where it cannot, refusing cleanly is the only option.
+// Only the constructor belongs in the try: an assertion inside it would be swallowed by the catch.
+let probe;
+try {
+    probe = new WebAssembly.Memory({ initial: BigInt(pastFourGiB / pageSize), address: "i64" });
+} catch (e) {
+    assert.truthy(e instanceof RangeError && e.message === "Out of memory", `expected an out of memory RangeError, got ${e}`);
+}
+const canHostPastFourGiB = probe !== undefined;
+if (canHostPastFourGiB)
+    assert.eq(probe.buffer.byteLength, pastFourGiB);
+// Nothing below needs the probe, and holding 4GiB across the rest of the file would starve it.
+probe = undefined;
+
+for (const shared of [false, true]) {
+    let mem;
+    try {
+        mem = (await instantiate(`
+        (module
+            (memory (export "mem") i64 1 ${pastFourGiB / pageSize} ${shared ? "shared" : ""}))
+        `, {}, options)).exports.mem;
+    } catch (e) {
+        // A shared memory reserves its whole maximum up front, which this port may not be able to spare.
+        assert.truthy(e instanceof RangeError && e.message === "Out of memory", `expected an out of memory RangeError, got ${e}`);
+        continue;
+    }
+
+    const buffer = mem.toResizableBuffer();
+    assert.eq(buffer.maxByteLength, Math.min(pastFourGiB, ceilingBytes));
+
+    const grow = shared ? size => buffer.grow(size) : size => buffer.resize(size);
+    if (canHostPastFourGiB) {
+        // The non-shared path grows by copying, so it holds the old and new regions at once. Hosting one
+        // 4GiB memory does not imply room for both.
+        let grown = true;
+        try {
+            grow(pastFourGiB);
+        } catch (e) {
+            assert.truthy(e instanceof RangeError, `expected a RangeError, got ${e}`);
+            grown = false;
+        }
+        if (grown)
+            assert.eq(buffer.byteLength, pastFourGiB);
+    } else {
+        assert.throws(() => grow(pastFourGiB), RangeError, "failed with new byte length");
+        assert.eq(buffer.byteLength, pageSize);
+    }
+
+    // Past the declared maximum is a clean RangeError either way. The shared and non-shared paths
+    // word it differently ("grow failed ...", "ArrayBuffer resize failed ...") around a common core.
+    assert.throws(() => grow(pastFourGiB + pageSize), RangeError, "failed with new byte length");
+}
+
+// A shared memory's buffer reports the maximum it can actually reach, and growth within the mapping
+// succeeds.
+{
+    let memory;
+    try {
+        memory = new WebAssembly.Memory({ initial: 1n, maximum: BigInt(maxMemory64Pages), address: "i64", shared: true });
+    } catch (e) {
+        assert.truthy(e instanceof RangeError && e.message === "Out of memory", `expected an out of memory RangeError, got ${e}`);
+    }
+    if (memory !== undefined) {
+        const buffer = memory.toResizableBuffer();
+        assert.eq(buffer.maxByteLength, Math.min(maxMemory64Pages * pageSize, ceilingBytes));
+        buffer.grow(2 * pageSize);
+        assert.eq(buffer.byteLength, 2 * pageSize);
+    }
+}

--- a/JSTests/wasm/stress/memory64-maximum-limits.js
+++ b/JSTests/wasm/stress/memory64-maximum-limits.js
@@ -1,0 +1,50 @@
+//@ requireOptions("--useWasmJSTypes=1")
+//@ memoryHog!
+//@ skip if $addressBits <= 32
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// A memory64's declared maximum is bounded so that it is always representable as an ArrayBuffer byte
+// length. What its buffer reports is bounded further, by the address space one reservation may claim on
+// this platform, so that a resize within maxByteLength never fails deterministically.
+
+const options = { memory64: true, threads: true };
+const pageSize = 65536;
+const maxMemory64Pages = 262144;
+const maxMemory32Pages = 65536;
+
+// A memory with no declared maximum reports its own address type's ceiling, so it discovers what this
+// platform will reserve. A memory32's ceiling is reservable in full everywhere.
+const ceilingBytes = new WebAssembly.Memory({ initial: 1n, address: "i64" }).toResizableBuffer().maxByteLength;
+assert.truthy(ceilingBytes <= maxMemory64Pages * pageSize, `memory64 ceiling ${ceilingBytes} exceeds the declarable maximum`);
+assert.truthy(ceilingBytes >= maxMemory32Pages * pageSize, `memory64 ceiling ${ceilingBytes} is below the memory32 ceiling`);
+assert.eq(new WebAssembly.Memory({ initial: 1 }).toResizableBuffer().maxByteLength, maxMemory32Pages * pageSize);
+
+// A declared maximum at the limit is accepted, and the buffer reports it clamped to that ceiling. The
+// shared memory reserves the whole thing up front, so this arm is why the file is a memory hog, and a
+// port that cannot spare the address space must refuse cleanly rather than fail the test.
+for (const shared of [false, true]) {
+    let mem;
+    try {
+        mem = (await instantiate(`
+        (module
+            (memory (export "mem") i64 1 ${maxMemory64Pages} ${shared ? "shared" : ""}))
+        `, {}, options)).exports.mem;
+    } catch (e) {
+        assert.truthy(e instanceof RangeError && e.message === "Out of memory", `expected an out of memory RangeError, got ${e}`);
+        continue;
+    }
+
+    assert.eq(mem.type().maximum, BigInt(maxMemory64Pages));
+    assert.eq(mem.type().address, "i64");
+    assert.eq(mem.toResizableBuffer().maxByteLength, Math.min(maxMemory64Pages * pageSize, ceilingBytes));
+}
+
+// The JS constructor applies the same bound. Module decoding is covered by
+// memory64-oversized-limits.js.
+assert.throws(() => new WebAssembly.Memory({ initial: 1n, maximum: BigInt(maxMemory64Pages + 1), address: "i64" }),
+    RangeError, "WebAssembly.Memory 'maximum' page count is too large");
+
+// A memory32 is bounded by the memory32 page limit rather than the memory64 one.
+assert.throws(() => new WebAssembly.Memory({ initial: 1, maximum: maxMemory32Pages + 1 }),
+    RangeError, "WebAssembly.Memory 'maximum' page count is too large");

--- a/JSTests/wasm/stress/memory64-oversized-limits.js
+++ b/JSTests/wasm/stress/memory64-oversized-limits.js
@@ -1,3 +1,4 @@
+//@ memoryHog!
 //@ skip if $addressBits <= 32
 import * as assert from "../assert.js";
 
@@ -14,38 +15,59 @@ function leb128(value) {
     return bytes;
 }
 
-// A module whose only content is a memory with the given limits.
+// A module whose only content is a memory with the given limits, exported as "mem".
 function moduleBytesWithMemoryLimits({ initial, maximum, is64bit = true }) {
     const hasMaximum = maximum !== undefined;
     const limitsFlags = (is64bit ? 0x04 : 0x00) | (hasMaximum ? 0x01 : 0x00); // bit 2: 64-bit index type, bit 0: has a maximum
     const limits = [limitsFlags, ...leb128(initial), ...(hasMaximum ? leb128(maximum) : [])];
     const memorySectionBody = [0x01, ...limits]; // 1 memory
+    const exportSectionBody = [0x01, 0x03, 0x6d, 0x65, 0x6d, 0x02, 0x00]; // 1 export: "mem" names memory 0
     return new Uint8Array([
         0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
         0x05, ...leb128(memorySectionBody.length), ...memorySectionBody, // memory section
+        0x07, ...leb128(exportSectionBody.length), ...exportSectionBody, // export section
     ]);
 }
 
-// The JS API caps a memory64 memory's limits at 2**37 - 1 pages, far more than can be allocated.
-// https://www.w3.org/TR/wasm-js-api-2/#limits
-const maxMemory64Pages = (1n << 37n) - 1n;
-const formerInvalidPageCountSentinel = (1n << 32n) - 1n;
+// The JS API caps the limits a memory may declare at 262144 pages (16 GiB) for a 64-bit memory and
+// 65536 pages (4 GiB) for a 32-bit one. https://www.w3.org/TR/wasm-js-api-2/#limits
+const maxMemory64Pages = 262144n;
+const pageSize = 65536;
 
-// An initial page count that can be declared but not allocated compiles, and must be rejected at
-// instantiation rather than truncated to an allocatable size.
-for (const initial of [maxMemory64Pages, 1n << 32n, (1n << 32n) + 5n, formerInvalidPageCountSentinel]) {
+// An initial page count is checked against that cap and nothing else, so every count up to it
+// compiles, and instantiation must honor it verbatim rather than clamp it to a smaller size.
+for (const initial of [65537n, maxMemory64Pages]) {
     const module = new WebAssembly.Module(moduleBytesWithMemoryLimits({ initial }));
-    assert.throws(() => new WebAssembly.Instance(module), RangeError, "Out of memory");
+    let memory;
+    try {
+        memory = new WebAssembly.Instance(module).exports.mem;
+    } catch (e) {
+        // A port whose address space cannot host this much refuses cleanly instead.
+        assert.truthy(e instanceof RangeError && e.message === "Out of memory", `expected an out of memory RangeError, got ${e}`);
+        continue;
+    }
+    assert.eq(memory.buffer.byteLength, Number(initial) * pageSize);
 }
 
-// A maximum is only a declaration: an unallocatable one doesn't prevent instantiation.
-for (const maximum of [maxMemory64Pages, 1n << 32n, formerInvalidPageCountSentinel])
-    new WebAssembly.Instance(new WebAssembly.Module(moduleBytesWithMemoryLimits({ initial: 1n, maximum })));
+// A maximum is only a declaration, so even one at the cap costs nothing to instantiate: the memory
+// is created at its initial size.
+for (const maximum of [65537n, maxMemory64Pages]) {
+    const { mem } = new WebAssembly.Instance(new WebAssembly.Module(moduleBytesWithMemoryLimits({ initial: 1n, maximum }))).exports;
+    assert.eq(mem.buffer.byteLength, pageSize);
+}
 
-// Anything above the limit is invalid, and so is a memory32 above 2**16 pages.
+// Anything above the cap is invalid, including page counts that used to be declarable when the bound
+// was PageCount's own 2**37-1, and the UINT64_MAX that PageCount reserves to mean "no page count".
+// A memory32 above 2**16 pages is invalid too.
+const pageCountSentinel = (1n << 64n) - 1n;
 for (const [limits, message] of [
     [{ initial: maxMemory64Pages + 1n }, `Memory's initial page count of ${maxMemory64Pages + 1n} is invalid`],
     [{ initial: 0n, maximum: maxMemory64Pages + 1n }, `Memory's maximum page count of ${maxMemory64Pages + 1n} is invalid`],
+    [{ initial: 0n, maximum: (1n << 32n) - 1n }, `Memory's maximum page count of ${(1n << 32n) - 1n} is invalid`],
+    [{ initial: 0n, maximum: 1n << 32n }, `Memory's maximum page count of ${1n << 32n} is invalid`],
+    [{ initial: 0n, maximum: (1n << 37n) - 1n }, `Memory's maximum page count of ${(1n << 37n) - 1n} is invalid`],
+    [{ initial: pageCountSentinel }, `Memory's initial page count of ${pageCountSentinel} is invalid`],
+    [{ initial: 0n, maximum: pageCountSentinel }, `Memory's maximum page count of ${pageCountSentinel} is invalid`],
     [{ initial: 65537n, is64bit: false }, "Memory's initial page count of 65537 is invalid"],
 ])
     assert.throws(() => new WebAssembly.Module(moduleBytesWithMemoryLimits(limits)), WebAssembly.CompileError, message);

--- a/JSTests/wasm/v8/memory64.js
+++ b/JSTests/wasm/v8/memory64.js
@@ -1,3 +1,5 @@
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -42,19 +44,10 @@ function BasicMemory64Tests(num_pages) {
   let store = module.exports.store;
 
   assertEquals(num_bytes, memory.buffer.byteLength);
-  // TODO(v8:4153): Enable for all sizes once the TypedArray size limit is
-  // raised.
-  const kMaxTypedArraySize = Math.pow(2, 32);
-  if (num_bytes > kMaxTypedArraySize) {
-    // TODO(v8:4153): Fix the error message below, if we don't decide to bump
-    // the limit soon.
-    assertThrows(
-        () => new Int8Array(memory.buffer), RangeError,
-        'Invalid typed array length: undefined');
-  } else {
-    let array = new Int8Array(memory.buffer);
-    assertEquals(num_bytes, array.length);
-  }
+  // JSC's array buffer byte length limit is 2**34, which is also the largest memory64, so every size
+  // reachable here also fits a typed array. V8 caps buffers at 2**32 and skips the big sizes instead.
+  let array = new Int8Array(memory.buffer);
+  assertEquals(num_bytes, array.length);
 
   assertEquals(0, load(num_bytes - 4));
   assertThrows(() => load(num_bytes - 3));
@@ -121,7 +114,6 @@ function allowOOM(fn) {
   allowOOM(() => BasicMemory64Tests(max_num_pages));
 })();
 
-/*
 (function TestTooBigDeclaredInitial() {
   // print(arguments.callee.name);
   let builder = new WasmModuleBuilder();
@@ -130,12 +122,9 @@ function allowOOM(fn) {
   assertFalse(WebAssembly.validate(builder.toBuffer()));
   assertThrows(
       () => builder.toModule(), WebAssembly.CompileError,
-      'WebAssembly.Module(): initial memory size (262145 pages) is larger ' +
-          'than implementation limit (262144 pages) @+12');
+      /Memory's initial page count of 262145 is invalid/);
 })();
-*/
 
-/*
 (function TestTooBigDeclaredMaximum() {
   // print(arguments.callee.name);
   let builder = new WasmModuleBuilder();
@@ -144,10 +133,8 @@ function allowOOM(fn) {
   assertFalse(WebAssembly.validate(builder.toBuffer()));
   assertThrows(
       () => builder.toModule(), WebAssembly.CompileError,
-      'WebAssembly.Module(): maximum memory size (262145 pages) is larger ' +
-          'than implementation limit (262144 pages) @+13');
+      /Memory's maximum page count of 262145 is invalid/);
 })();
-*/
 
 (function TestGrow64() {
   // print(arguments.callee.name);

--- a/LayoutTests/fast/canvas/webgl/array-unit-tests.html
+++ b/LayoutTests/fast/canvas/webgl/array-unit-tests.html
@@ -650,9 +650,9 @@ function testConstructionOfHugeArray(type, name, sz) {
     if (sz == 1)
         return;
     try {
-        // Construction of huge arrays must fail because byteLength is
-        // an unsigned long
-        array = new type(3000000000);
+        // A length that is a valid array index but whose byte length no buffer
+        // can reach, so construction must fail for every element size.
+        array = new type(Number.MAX_SAFE_INTEGER);
         testFailed("Construction of huge " + name + " should throw exception");
     } catch (e) {
         testPassed("Construction of huge " + name + " threw exception");

--- a/LayoutTests/fast/canvas/webgl/webgl-array-invalid-ranges.html
+++ b/LayoutTests/fast/canvas/webgl/webgl-array-invalid-ranges.html
@@ -48,9 +48,9 @@ function testConstructionOfHugeArray(type, name, sz) {
     if (sz == 1)
         return;
     try {
-        // Construction of huge arrays must fail because byteLength is
-        // an unsigned long
-        array = new type(3000000000);
+        // A length that is a valid array index but whose byte length no buffer
+        // can reach, so construction must fail for every element size.
+        array = new type(Number.MAX_SAFE_INTEGER);
         testFailed("Construction of huge " + name + " should throw exception");
     } catch (e) {
         testPassed("Construction of huge " + name + " threw exception");

--- a/LayoutTests/fast/canvas/webgl/webgl2-array-buffer-view-offset-past-32-bits-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/webgl2-array-buffer-view-offset-past-32-bits-expected.txt
@@ -1,0 +1,48 @@
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: bufferData: srcOffset or length is out of bounds
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: bufferData: srcOffset or length is out of bounds
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: bufferData: srcOffset or length is out of bounds
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: bufferSubData: srcOffset or length is out of bounds
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: bufferSubData: srcOffset or length is out of bounds
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: bufferSubData: srcOffset or length is out of bounds
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: getBufferSubData: dstOffset is larger than the length of the destination buffer.
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: getBufferSubData: dstOffset is larger than the length of the destination buffer.
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: getBufferSubData: dstOffset is larger than the length of the destination buffer.
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: readPixels: srcOffset or length is out of bounds
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: readPixels: srcOffset or length is out of bounds
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: readPixels: srcOffset or length is out of bounds
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texImage2D: ArrayBufferView not big enough for request
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texImage2D: ArrayBufferView not big enough for request
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texImage2D: ArrayBufferView not big enough for request
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texSubImage2D: ArrayBufferView not big enough for request
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texSubImage2D: ArrayBufferView not big enough for request
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texSubImage2D: ArrayBufferView not big enough for request
+An ArrayBufferView offset past 2^32 must be rejected rather than truncated to 32 bits, which would silently transfer the bytes at the truncated offset instead.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS bufferData with srcOffset 4294967296 was rejected
+PASS bufferData with srcOffset 4294967304 was rejected
+PASS bufferData with srcOffset 8589934592 was rejected
+PASS bufferSubData with srcOffset 4294967296 was rejected
+PASS bufferSubData with srcOffset 4294967304 was rejected
+PASS bufferSubData with srcOffset 8589934592 was rejected
+PASS getBufferSubData with srcOffset 4294967296 was rejected
+PASS getBufferSubData with srcOffset 4294967304 was rejected
+PASS getBufferSubData with srcOffset 8589934592 was rejected
+PASS readPixels with srcOffset 4294967296 was rejected
+PASS readPixels with srcOffset 4294967304 was rejected
+PASS readPixels with srcOffset 8589934592 was rejected
+PASS texImage2D with srcOffset 4294967296 was rejected
+PASS texImage2D with srcOffset 4294967304 was rejected
+PASS texImage2D with srcOffset 8589934592 was rejected
+PASS texSubImage2D with srcOffset 4294967296 was rejected
+PASS texSubImage2D with srcOffset 4294967304 was rejected
+PASS texSubImage2D with srcOffset 8589934592 was rejected
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS [...readBack].join() is '1,2,3,4'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/webgl/webgl2-array-buffer-view-offset-past-32-bits.html
+++ b/LayoutTests/fast/canvas/webgl/webgl2-array-buffer-view-offset-past-32-bits.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="4" height="4"></canvas>
+<script>
+description("An ArrayBufferView offset past 2^32 must be rejected rather than truncated to 32 bits, which would silently transfer the bytes at the truncated offset instead.");
+
+var gl = document.getElementById("canvas").getContext("webgl2");
+
+// 2^32 truncates to 0 and 2^32 + 8 truncates to 8, both of which name real data
+// in a small view, so a truncating implementation reports no error and moves the
+// wrong bytes.
+var pastUint32 = 4294967296;
+var view = new Uint8Array(16);
+view.set([1, 2, 3, 4], 8);
+
+var buffer = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+gl.bufferData(gl.ARRAY_BUFFER, 16, gl.STATIC_DRAW);
+
+var texture = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, texture);
+
+function shouldRejectOffset(name, call) {
+    for (var offset of [pastUint32, pastUint32 + 8, 2 * pastUint32]) {
+        call(offset);
+        var error = gl.getError();
+        if (error === gl.INVALID_VALUE || error === gl.INVALID_OPERATION)
+            testPassed(name + " with srcOffset " + offset + " was rejected");
+        else
+            testFailed(name + " with srcOffset " + offset + " gave 0x" + error.toString(16) + ", expected INVALID_VALUE");
+    }
+}
+
+shouldRejectOffset("bufferData", (offset) => gl.bufferData(gl.ARRAY_BUFFER, view, gl.STATIC_DRAW, offset, 4));
+shouldRejectOffset("bufferSubData", (offset) => gl.bufferSubData(gl.ARRAY_BUFFER, 0, view, offset, 4));
+shouldRejectOffset("getBufferSubData", (offset) => gl.getBufferSubData(gl.ARRAY_BUFFER, 0, view, offset, 4));
+shouldRejectOffset("readPixels", (offset) => gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, view, offset));
+shouldRejectOffset("texImage2D", (offset) => gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, view, offset));
+shouldRejectOffset("texSubImage2D", (offset) => {
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.getError();
+    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, view, offset);
+});
+
+// An offset that really does name the data still works, so the rejection above is
+// about the magnitude and not about the argument being ignored.
+gl.bufferData(gl.ARRAY_BUFFER, view, gl.STATIC_DRAW, 8, 4);
+shouldBe("gl.getError()", "gl.NO_ERROR");
+var readBack = new Uint8Array(4);
+gl.getBufferSubData(gl.ARRAY_BUFFER, 0, readBack);
+shouldBe("gl.getError()", "gl.NO_ERROR");
+shouldBe("[...readBack].join()", "'1,2,3,4'");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/websocket/tests/hybi/bufferedAmount-past-32-bits-after-close-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/bufferedAmount-past-32-bits-after-close-expected.txt
@@ -1,0 +1,14 @@
+WebSocket: bufferedAmount past 32 bits after the socket is closed.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Connected
+Closed
+PASS ws.bufferedAmount is 0
+PASS expectedBufferedAmount > Math.pow(2, 32) is true
+PASS ws.bufferedAmount is expectedBufferedAmount
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/websocket/tests/hybi/bufferedAmount-past-32-bits-after-close.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/bufferedAmount-past-32-bits-after-close.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("WebSocket: bufferedAmount past 32 bits after the socket is closed.");
+
+jsTestIsAsync = true;
+
+// bufferedAmount is an unsigned long long, so once the socket is closed it must keep counting past
+// 2^32 rather than saturating. Sending after close only adds to the count, so no data is ever staged
+// and one buffer can be reused.
+
+const chunkSize = 0x100000;
+const framingOverhead = 2 + 4 + 8; // Base header, masking key, and the 64-bit extended payload length.
+const chunkCost = chunkSize + framingOverhead;
+const chunkCount = Math.ceil(Math.pow(2, 32) / chunkCost) + 1;
+const expectedBufferedAmount = chunkCount * chunkCost;
+
+const ws = new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/simple");
+
+ws.onopen = () => {
+    debug("Connected");
+    ws.close();
+};
+
+ws.onclose = () => {
+    debug("Closed");
+    shouldBe("ws.bufferedAmount", "0");
+
+    const chunk = new ArrayBuffer(chunkSize);
+    for (let i = 0; i < chunkCount; ++i)
+        ws.send(chunk);
+
+    shouldBeTrue("expectedBufferedAmount > Math.pow(2, 32)");
+    shouldBe("ws.bufferedAmount", "expectedBufferedAmount");
+
+    finishJSTest();
+};
+</script>

--- a/LayoutTests/webrtc/generate-certificate-public-exponent-expected.txt
+++ b/LayoutTests/webrtc/generate-certificate-public-exponent-expected.txt
@@ -1,0 +1,7 @@
+
+PASS The canonical public exponent 65537 is accepted
+PASS Leading zero padding is accepted
+PASS Padding longer than the value is accepted
+PASS A publicExponent with more significant bytes than an int is rejected
+PASS A publicExponent that does not fit an int is rejected
+

--- a/LayoutTests/webrtc/generate-certificate-public-exponent.html
+++ b/LayoutTests/webrtc/generate-certificate-public-exponent.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>RTCPeerConnection.generateCertificate publicExponent handling</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+function generate(publicExponent)
+{
+    return RTCPeerConnection.generateCertificate({ name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, hash: "SHA-256", publicExponent });
+}
+
+promise_test(async (test) => {
+    const certificate = await generate(new Uint8Array([1, 0, 1]));
+    assert_true(certificate instanceof RTCCertificate);
+}, "The canonical public exponent 65537 is accepted");
+
+promise_test(async (test) => {
+    const certificate = await generate(new Uint8Array([0, 0, 0, 0, 1, 0, 1]));
+    assert_true(certificate instanceof RTCCertificate);
+}, "Leading zero padding is accepted");
+
+promise_test(async (test) => {
+    // A WebCrypto BigInteger may carry arbitrarily much leading zero padding, so its length must not
+    // decide anything on its own. This is 65537 padded to the length of an RSA-2048 modulus.
+    const publicExponent = new Uint8Array(256);
+    publicExponent.set([1, 0, 1], 253);
+    const certificate = await generate(publicExponent);
+    assert_true(certificate instanceof RTCCertificate);
+}, "Padding longer than the value is accepted");
+
+promise_test((test) => {
+    // Five significant bytes cannot fit the int the certificate generator takes.
+    return promise_rejects_dom(test, "NotSupportedError", generate(new Uint8Array([1, 0, 0, 0, 0])));
+}, "A publicExponent with more significant bytes than an int is rejected");
+
+promise_test((test) => {
+    return promise_rejects_dom(test, "NotSupportedError", generate(new Uint8Array([0x80, 0, 0, 0])));
+}, "A publicExponent that does not fit an int is rejected");
+        </script>
+    </body>
+</html>

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -115,6 +115,11 @@ static RefPtr<BufferMemoryHandle> tryAllocateResizableMemory(VM* vm, size_t size
     if (!maximumBytes)
         maximumBytes = PageCount::pageSize;
 
+    // The whole maximum is reserved up front while only the initial size is charged against the
+    // physical budget, so without this a single buffer could claim all the address space there is.
+    if (static_cast<uint64_t>(maximumBytes) > maxGrowableBufferReservationBytes)
+        return nullptr;
+
     bool done = tryAllocate(vm,
         [&] () -> BufferMemoryResult::Kind {
             return BufferMemoryManager::singleton().tryAllocatePhysicalBytes(initialBytes);
@@ -549,75 +554,78 @@ Expected<int64_t, GrowFailReason> ArrayBuffer::resize(VM& vm, size_t newByteLeng
     if (!memoryHandle || m_contents.m_shared) [[unlikely]]
         return makeUnexpected(GrowFailReason::GrowSharedUnavailable);
 
-    int64_t deltaByteLength = 0;
-    {
-        Locker { memoryHandle->lock() };
+    // A non-shared buffer that is not a Wasm memory owns its handle outright and is reachable only
+    // from its own agent's thread, so the handle's lock has nothing to guard here.
 
-        // Keep in mind that newByteLength may not be page-size-aligned.
-        if (m_contents.m_maxByteLength < newByteLength)
-            return makeUnexpected(GrowFailReason::InvalidGrowSize);
+    // Keep in mind that newByteLength may not be page-size-aligned.
+    if (m_contents.m_maxByteLength < newByteLength)
+        return makeUnexpected(GrowFailReason::InvalidGrowSize);
 
-        deltaByteLength = static_cast<int64_t>(newByteLength) - static_cast<int64_t>(m_contents.m_sizeInBytes);
-        if (!deltaByteLength)
-            return 0;
+    int64_t deltaByteLength = static_cast<int64_t>(newByteLength) - static_cast<int64_t>(m_contents.m_sizeInBytes);
+    if (!deltaByteLength)
+        return 0;
 
-        auto newPageCount = PageCount::fromBytesWithRoundUp(newByteLength);
-        auto oldPageCount = PageCount::fromBytes(memoryHandle->size()); // MemoryHandle's size is always page-size aligned.
-        if (newPageCount.bytes() > MAX_ARRAY_BUFFER_SIZE)
-            return makeUnexpected(GrowFailReason::WouldExceedMaximum);
+    // A buffer's maxByteLength may exceed the region actually mapped for it, so growth is bounded by
+    // the mapping.
+    if (newByteLength > memoryHandle->mappedCapacity())
+        return makeUnexpected(GrowFailReason::WouldExceedMaximum);
 
-        if (newPageCount != oldPageCount) {
-            ASSERT(memoryHandle->maximum() >= newPageCount);
+    auto newPageCount = PageCount::fromBytesWithRoundUp(newByteLength);
+    auto oldPageCount = PageCount::fromBytes(memoryHandle->size()); // MemoryHandle's size is always page-size aligned.
+    if (newPageCount.bytes() > MAX_ARRAY_BUFFER_SIZE)
+        return makeUnexpected(GrowFailReason::WouldExceedMaximum);
 
-            size_t desiredSize = newPageCount.bytes();
-            RELEASE_ASSERT(desiredSize <= MAX_ARRAY_BUFFER_SIZE);
+    if (newPageCount != oldPageCount) {
+        ASSERT(memoryHandle->maximum() >= newPageCount);
 
-            if (desiredSize > memoryHandle->size()) {
-                size_t bytesToAdd = desiredSize - memoryHandle->size();
-                ASSERT(bytesToAdd);
-                ASSERT(roundUpToMultipleOf<PageCount::pageSize>(bytesToAdd) == bytesToAdd);
-                bool allocationSuccess = tryAllocate(&vm,
-                    [&] () -> BufferMemoryResult::Kind {
-                        return BufferMemoryManager::singleton().tryAllocatePhysicalBytes(bytesToAdd);
-                    });
-                if (!allocationSuccess)
-                    return makeUnexpected(GrowFailReason::OutOfMemory);
+        size_t desiredSize = newPageCount.bytes();
+        RELEASE_ASSERT(desiredSize <= MAX_ARRAY_BUFFER_SIZE);
 
-                void* memory = memoryHandle->memory();
-                RELEASE_ASSERT(memory);
+        if (desiredSize > memoryHandle->size()) {
+            size_t bytesToAdd = desiredSize - memoryHandle->size();
+            ASSERT(bytesToAdd);
+            ASSERT(roundUpToMultipleOf<PageCount::pageSize>(bytesToAdd) == bytesToAdd);
+            bool allocationSuccess = tryAllocate(&vm,
+                [&] () -> BufferMemoryResult::Kind {
+                    return BufferMemoryManager::singleton().tryAllocatePhysicalBytes(bytesToAdd);
+                });
+            if (!allocationSuccess)
+                return makeUnexpected(GrowFailReason::OutOfMemory);
 
-                // Signaling memory must have been pre-allocated virtually.
-                uint8_t* startAddress = static_cast<uint8_t*>(memory) + memoryHandle->size();
+            void* memory = memoryHandle->memory();
+            RELEASE_ASSERT(memory);
 
-                dataLogLnIf(ArrayBufferInternal::verbose, "Marking memory's ", RawPointer(memory), " as read+write in range [", RawPointer(startAddress), ", ", RawPointer(startAddress + bytesToAdd), ")");
-                constexpr bool readable = true;
-                constexpr bool writable = true;
-                OSAllocator::protect(startAddress, bytesToAdd, readable, writable);
-            } else {
-                size_t bytesToSubtract = memoryHandle->size() - desiredSize;
-                ASSERT(bytesToSubtract);
-                ASSERT(roundUpToMultipleOf<PageCount::pageSize>(bytesToSubtract) == bytesToSubtract);
-                BufferMemoryManager::singleton().freePhysicalBytes(bytesToSubtract);
+            // Signaling memory must have been pre-allocated virtually.
+            uint8_t* startAddress = static_cast<uint8_t*>(memory) + memoryHandle->size();
 
-                void* memory = memoryHandle->memory();
-                RELEASE_ASSERT(memory);
+            dataLogLnIf(ArrayBufferInternal::verbose, "Marking memory's ", RawPointer(memory), " as read+write in range [", RawPointer(startAddress), ", ", RawPointer(startAddress + bytesToAdd), ")");
+            constexpr bool readable = true;
+            constexpr bool writable = true;
+            OSAllocator::protect(startAddress, bytesToAdd, readable, writable);
+        } else {
+            size_t bytesToSubtract = memoryHandle->size() - desiredSize;
+            ASSERT(bytesToSubtract);
+            ASSERT(roundUpToMultipleOf<PageCount::pageSize>(bytesToSubtract) == bytesToSubtract);
+            BufferMemoryManager::singleton().freePhysicalBytes(bytesToSubtract);
 
-                // Signaling memory must have been pre-allocated virtually.
-                uint8_t* startAddress = static_cast<uint8_t*>(memory) + desiredSize;
+            void* memory = memoryHandle->memory();
+            RELEASE_ASSERT(memory);
 
-                dataLogLnIf(ArrayBufferInternal::verbose, "Marking memory's ", RawPointer(memory), " as none in range [", RawPointer(startAddress), ", ", RawPointer(startAddress + bytesToSubtract), ")");
-                constexpr bool readable = false;
-                constexpr bool writable = false;
-                OSAllocator::protect(startAddress, bytesToSubtract, readable, writable);
-            }
-            memoryHandle->updateSize(desiredSize);
+            // Signaling memory must have been pre-allocated virtually.
+            uint8_t* startAddress = static_cast<uint8_t*>(memory) + desiredSize;
+
+            dataLogLnIf(ArrayBufferInternal::verbose, "Marking memory's ", RawPointer(memory), " as none in range [", RawPointer(startAddress), ", ", RawPointer(startAddress + bytesToSubtract), ")");
+            constexpr bool readable = false;
+            constexpr bool writable = false;
+            OSAllocator::protect(startAddress, bytesToSubtract, readable, writable);
         }
-
-        if (m_contents.m_sizeInBytes < newByteLength)
-            zeroFill(std::bit_cast<uint8_t*>(data()) + m_contents.m_sizeInBytes, newByteLength - m_contents.m_sizeInBytes);
-
-        m_contents.m_sizeInBytes = newByteLength;
+        memoryHandle->updateSize(desiredSize);
     }
+
+    if (m_contents.m_sizeInBytes < newByteLength)
+        zeroFill(std::bit_cast<uint8_t*>(data()) + m_contents.m_sizeInBytes, newByteLength - m_contents.m_sizeInBytes);
+
+    m_contents.m_sizeInBytes = newByteLength;
 
     if (deltaByteLength > 0)
         vm.heap.reportExtraMemoryAllocated(static_cast<JSCell*>(nullptr), deltaByteLength);
@@ -647,10 +655,33 @@ Expected<int64_t, GrowFailReason> SharedArrayBufferContents::grow(VM& vm, size_t
     if (!m_hasMaxByteLength)
         return makeUnexpected(GrowFailReason::GrowSharedUnavailable);
     ASSERT(m_memoryHandle);
-    return grow(Locker { m_memoryHandle->lock() }, vm, newByteLength, requirePageMultiple);
+
+    // Collections happen with the lock released, because asking for one can run finalizers on this
+    // thread; a retry therefore starts over, since another agent may have grown this buffer meanwhile.
+    constexpr unsigned maximumAttempts = 2;
+    for (unsigned attempt = 1; ; ++attempt) {
+        auto collection = BufferMemoryResult::Kind::Success;
+        Expected<int64_t, GrowFailReason> result;
+        {
+            Locker locker { m_memoryHandle->lock() };
+            result = tryGrow(locker, newByteLength, requirePageMultiple, collection);
+        }
+        switch (collection) {
+        case BufferMemoryResult::Kind::Success:
+            return result;
+        case BufferMemoryResult::Kind::SuccessAndNotifyMemoryPressure:
+            vm.heap.collectAsync(CollectionScope::Full);
+            return result;
+        case BufferMemoryResult::Kind::SyncTryToReclaimMemory:
+            if (attempt == maximumAttempts)
+                return makeUnexpected(GrowFailReason::OutOfMemory);
+            vm.heap.collectSync(CollectionScope::Full);
+            break;
+        }
+    }
 }
 
-Expected<int64_t, GrowFailReason> SharedArrayBufferContents::grow(const AbstractLocker& locker, VM& vm, size_t newByteLength, bool requirePageMultiple)
+Expected<int64_t, GrowFailReason> SharedArrayBufferContents::tryGrow(const AbstractLocker& locker, size_t newByteLength, bool requirePageMultiple, BufferMemoryResult::Kind& collection)
 {
     // Keep in mind that newByteLength may not be page-size-aligned. If the buffer is a Wasm memory, that is an error.
     size_t sizeInBytes = m_sizeInBytes.load(std::memory_order_seq_cst);
@@ -671,6 +702,11 @@ Expected<int64_t, GrowFailReason> SharedArrayBufferContents::grow(const Abstract
     if (!deltaByteLength)
         return 0;
 
+    // A buffer's maxByteLength may exceed the region actually mapped for it, so growth is bounded by
+    // the mapping.
+    if (newByteLength > m_memoryHandle->mappedCapacity())
+        return makeUnexpected(GrowFailReason::WouldExceedMaximum);
+
     auto newPageCount = PageCount::fromBytesWithRoundUp(newByteLength);
     auto oldPageCount = PageCount::fromBytes(m_memoryHandle->size()); // MemoryHandle's size is always page-size aligned.
     if (newPageCount.bytes() > MAX_ARRAY_BUFFER_SIZE)
@@ -685,11 +721,8 @@ Expected<int64_t, GrowFailReason> SharedArrayBufferContents::grow(const Abstract
 
         size_t extraBytes = desiredSize - memoryHandle->size();
         RELEASE_ASSERT(extraBytes);
-        bool allocationSuccess = tryAllocate(&vm,
-            [&] () -> BufferMemoryResult::Kind {
-                return BufferMemoryManager::singleton().tryAllocatePhysicalBytes(extraBytes);
-            });
-        if (!allocationSuccess)
+        collection = BufferMemoryManager::singleton().tryAllocatePhysicalBytes(extraBytes);
+        if (collection == BufferMemoryResult::Kind::SyncTryToReclaimMemory)
             return makeUnexpected(GrowFailReason::OutOfMemory);
 
         void* memory = memoryHandle->memory();

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -86,7 +86,13 @@ public:
     Mode mode() const { return m_mode; }
 
     Expected<int64_t, GrowFailReason> grow(VM&, size_t newByteLength, bool requirePageMultiple);
-    Expected<int64_t, GrowFailReason> grow(const AbstractLocker&, VM&, size_t newByteLength, bool requirePageMultiple);
+
+    // One attempt, which cannot collect because it takes no VM. Reports what the caller owes the heap
+    // once it has released the memory handle's lock: asking for a collection of either kind can run
+    // finalizers on the calling thread, so neither may be asked for while that lock is held. On
+    // SyncTryToReclaimMemory the caller must recompute the whole attempt, since the size it was working
+    // from can move while unlocked.
+    Expected<int64_t, GrowFailReason> tryGrow(const AbstractLocker&, size_t newByteLength, bool requirePageMultiple, BufferMemoryResult::Kind&);
 
     void updateSize(size_t sizeInBytes, std::memory_order order = std::memory_order_seq_cst)
     {
@@ -107,6 +113,7 @@ private:
         , m_hasMaxByteLength(!!maxByteLength)
         , m_mode(mode)
     {
+        RELEASE_ASSERT(m_maxByteLength <= MAX_ARRAY_BUFFER_SIZE);
 #if ASSERT_ENABLED
         if (m_hasMaxByteLength)
             ASSERT(m_memoryHandle);

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
@@ -63,10 +63,15 @@ size_t BufferMemoryHandle::fastMappedRedzoneBytes()
 
 size_t BufferMemoryHandle::fastMappedBytes()
 {
-    // MAX_ARRAY_BUFFER_SIZE is 4GB on 64bit and 2GB on 32bit platforms.
-    // This code should never be called in 32bit platforms they don't
-    // support fast memory.
-    return MAX_ARRAY_BUFFER_SIZE + fastMappedRedzoneBytes();
+    // Signaling memory is memory32 only, and reserves memory32's whole address range up front. A
+    // 32-bit process cannot reserve its entire address space, so it never uses this mode, and the
+    // range does not fit its size_t either.
+#if CPU(ADDRESS32)
+    RELEASE_ASSERT_NOT_REACHED();
+    return 0;
+#else
+    return PageCount::maxMemory32Bytes + fastMappedRedzoneBytes();
+#endif
 }
 
 void BufferMemoryResult::dump(PrintStream& out) const

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -30,6 +30,7 @@
 
 #include <atomic>
 
+#include <bmalloc/Gigacage.h>
 #include <wtf/CagedPtr.h>
 #include <wtf/Lock.h>
 #include <wtf/RAMSize.h>
@@ -58,6 +59,14 @@ enum class GrowFailReason : uint8_t {
     OutOfMemory,
     GrowSharedUnavailable,
 };
+
+// The most address space one growable buffer may reserve. A growable buffer reserves its whole maximum
+// up front while only its initial size is charged against the physical budget, so without a bound one
+// buffer could claim every Primitive allocation the process will ever hand out.
+// FIXME: Nothing bounds the total across buffers; see https://bugs.webkit.org/show_bug.cgi?id=170825.
+constexpr uint64_t maxGrowableBufferReservationBytes = Gigacage::primitiveAddressSpaceBudget / 4;
+static_assert(maxGrowableBufferReservationBytes >= PageCount::maxMemory32Bytes,
+    "A memory32, and any buffer that can address one, must stay reservable in full on every platform");
 
 struct BufferMemoryResult {
     enum class Kind {

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
@@ -89,7 +89,7 @@ std::optional<JSValue> arrayBufferSpeciesConstructorSlow(JSGlobalObject* globalO
     return species.isUndefinedOrNull() ? std::nullopt : std::make_optional(species);
 }
 
-static ALWAYS_INLINE std::pair<SpeciesConstructResult, JSArrayBuffer*> speciesConstructArrayBuffer(JSGlobalObject* globalObject, JSArrayBuffer* thisObject, unsigned length, ArrayBufferSharingMode mode)
+static ALWAYS_INLINE std::pair<SpeciesConstructResult, JSArrayBuffer*> speciesConstructArrayBuffer(JSGlobalObject* globalObject, JSArrayBuffer* thisObject, size_t length, ArrayBufferSharingMode mode)
 {
     // This is optimized way of SpeciesConstruct invoked from {ArrayBuffer,SharedArrayBuffer}.prototype.slice.
     // https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice
@@ -175,31 +175,31 @@ static EncodedJSValue arrayBufferSlice(JSGlobalObject* globalObject, JSValue arr
 
     // 5. Let len be O.[[ArrayBufferByteLength]].
     // https://tc39.es/proposal-resizablearraybuffer/#sec-sharedarraybuffer.prototype.slice
-    unsigned byteLength = thisObject->impl()->byteLength();
+    size_t byteLength = thisObject->impl()->byteLength();
 
-    unsigned firstIndex = 0;
+    size_t firstIndex = 0;
     double relativeStart = startValue.toIntegerOrInfinity(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     if (relativeStart < 0)
-        firstIndex = static_cast<unsigned>(std::max<double>(byteLength + relativeStart, 0));
+        firstIndex = static_cast<size_t>(std::max<double>(byteLength + relativeStart, 0));
     else
-        firstIndex = static_cast<unsigned>(std::min<double>(relativeStart, byteLength));
+        firstIndex = static_cast<size_t>(std::min<double>(relativeStart, byteLength));
     ASSERT(firstIndex <= byteLength);
 
-    unsigned finalIndex = 0;
+    size_t finalIndex = 0;
     if (!endValue.isUndefined()) {
         double relativeEnd = endValue.toIntegerOrInfinity(globalObject);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
         if (relativeEnd < 0)
-            finalIndex = static_cast<unsigned>(std::max<double>(byteLength + relativeEnd, 0));
+            finalIndex = static_cast<size_t>(std::max<double>(byteLength + relativeEnd, 0));
         else
-            finalIndex = static_cast<unsigned>(std::min<double>(relativeEnd, byteLength));
+            finalIndex = static_cast<size_t>(std::min<double>(relativeEnd, byteLength));
     } else
         finalIndex = byteLength;
     ASSERT(finalIndex <= byteLength);
 
     // 14. Let newLen be max(final - first, 0).
-    unsigned newLength = (finalIndex >= firstIndex) ? finalIndex - firstIndex : 0;
+    size_t newLength = (finalIndex >= firstIndex) ? finalIndex - firstIndex : 0;
 
     // 15. Let ctor be ? SpeciesConstructor(O, %ArrayBuffer%).
     auto speciesResult = speciesConstructArrayBuffer(globalObject, thisObject, newLength, mode);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -529,8 +529,29 @@ bool JSGenericTypedArrayView<Adaptor>::getOwnPropertySlot(
     if (std::optional<uint32_t> index = parseIndex(propertyName))
         return getOwnPropertySlotByIndex(thisObject, globalObject, index.value(), slot);
 
-    if (isCanonicalNumericIndexString(propertyName.uid()))
-        return false;
+    // https://tc39.es/ecma262/#sec-typedarray-getownproperty: a canonical numeric index string never
+    // reaches the ordinary lookup, and yields an element exactly when it is a valid integer index.
+    std::optional<uint64_t> integerIndex;
+    if (isCanonicalNumericIndexString(propertyName.uid(), &integerIndex)) {
+        if (!integerIndex) [[likely]]
+            return false;
+        VM& vm = globalObject->vm();
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        if (thisObject->isDetached() || !thisObject->inBounds(integerIndex.value()))
+            return false;
+        size_t index = integerIndex.value(); // inBounds() has shown it is a length, so it fits.
+        JSValue value;
+        if constexpr (Adaptor::canConvertToJSQuickly) {
+            UNUSED_VARIABLE(scope);
+            value = thisObject->getIndexQuickly(index);
+        } else {
+            auto nativeValue = thisObject->getIndexQuicklyAsNativeValue(index);
+            value = Adaptor::toJSValue(globalObject, nativeValue);
+            RETURN_IF_EXCEPTION(scope, false);
+        }
+        slot.setValue(thisObject, static_cast<unsigned>(PropertyAttribute::None), value);
+        return true;
+    }
 
     return Base::getOwnPropertySlot(thisObject, globalObject, propertyName, slot);
 }
@@ -552,11 +573,19 @@ bool JSGenericTypedArrayView<Adaptor>::put(
         return putByIndex(thisObject, globalObject, index.value(), value, slot.isStrictMode());
     }
 
-    if (isCanonicalNumericIndexString(propertyName.uid())) {
-        if (isThisValueAltered(slot, thisObject)) [[unlikely]]
-            return true;
-        // Cases like '-0', '1.1', etc. are still obliged to give the RHS a chance to throw.
-        toNativeFromValue<Adaptor>(globalObject, value);
+    std::optional<uint64_t> integerIndex;
+    if (isCanonicalNumericIndexString(propertyName.uid(), &integerIndex)) {
+        if (isThisValueAltered(slot, thisObject)) [[unlikely]] {
+            if (!integerIndex || thisObject->isDetached() || !thisObject->inBounds(integerIndex.value()))
+                return true;
+            return ordinarySetSlow(globalObject, thisObject, propertyName, value, slot.thisValue(), slot.isStrictMode());
+        }
+        // TypedArraySetElement coerces the RHS before deciding whether the index is valid, so cases like
+        // '-0' and '1.1' are still obliged to give it a chance to throw. setIndex() does the same.
+        if (integerIndex) [[unlikely]]
+            thisObject->setIndex(globalObject, integerIndex.value(), value);
+        else
+            toNativeFromValue<Adaptor>(globalObject, value);
         return true;
     }
 
@@ -572,7 +601,17 @@ bool JSGenericTypedArrayView<Adaptor>::defineOwnProperty(
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSGenericTypedArrayView* thisObject = uncheckedDowncast<JSGenericTypedArrayView>(object);
 
-    if (std::optional<uint32_t> index = parseIndex(propertyName)) {
+    // https://tc39.es/ecma262/#sec-typedarray-defineownproperty. A key past MAX_ARRAY_INDEX arrives as a
+    // canonical numeric index string, so the index comes from there instead.
+    std::optional<uint64_t> index = parseIndex(propertyName);
+    bool isCanonicalNumeric = false;
+    if (!index) [[unlikely]] {
+        std::optional<uint64_t> integerIndex;
+        isCanonicalNumeric = isCanonicalNumericIndexString(propertyName.uid(), &integerIndex);
+        index = integerIndex;
+    }
+
+    if (index) {
         auto throwTypeErrorIfNeeded = [&] (ASCIILiteral errorMessage) -> bool {
             if (shouldThrow)
                 throwTypeError(globalObject, scope, makeString(errorMessage, *index));
@@ -599,12 +638,12 @@ bool JSGenericTypedArrayView<Adaptor>::defineOwnProperty(
 
         scope.release();
         if (descriptor.value())
-            thisObject->setIndex(globalObject, index.value(), descriptor.value());
+            thisObject->setIndex(globalObject, static_cast<size_t>(index.value()), descriptor.value());
 
         return true;
     }
 
-    if (isCanonicalNumericIndexString(propertyName.uid()))
+    if (isCanonicalNumeric)
         return typeError(globalObject, scope, shouldThrow, "Attempting to store canonical numeric string property on a typed array"_s);
 
     RELEASE_AND_RETURN(scope, Base::defineOwnProperty(thisObject, globalObject, propertyName, descriptor, shouldThrow));
@@ -619,8 +658,13 @@ bool JSGenericTypedArrayView<Adaptor>::deleteProperty(
     if (std::optional<uint32_t> index = parseIndex(propertyName))
         return deletePropertyByIndex(thisObject, globalObject, index.value());
 
-    if (isCanonicalNumericIndexString(propertyName.uid()))
+    std::optional<uint64_t> integerIndex;
+    if (isCanonicalNumericIndexString(propertyName.uid(), &integerIndex)) {
+        // Integer-indexed elements can't be deleted, so we must return false when the index is valid.
+        if (integerIndex) [[unlikely]]
+            return thisObject->isDetached() || !thisObject->inBounds(integerIndex.value());
         return true;
+    }
 
     return Base::deleteProperty(thisObject, globalObject, propertyName, slot);
 }

--- a/Source/JavaScriptCore/runtime/PageCount.h
+++ b/Source/JavaScriptCore/runtime/PageCount.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <limits>
 #include <wtf/MathExtras.h>
 
@@ -37,7 +36,7 @@ namespace JSC {
 
 #if USE(LARGE_TYPED_ARRAYS)
 static_assert(sizeof(size_t) == sizeof(uint64_t));
-#define MAX_ARRAY_BUFFER_SIZE (1ull << 32)
+#define MAX_ARRAY_BUFFER_SIZE (1ull << 34)
 #else
 static_assert(sizeof(size_t) == sizeof(uint32_t));
 // Because we are using a size_t to store the size in bytes of array buffers, we cannot support 4GB on 32-bit platforms.
@@ -111,15 +110,19 @@ public:
     }
 
     static constexpr uint32_t pageSize = 64 * KB;
+
+    // Page counts are declarative: a memory may declare a maximum this process cannot map, and must
+    // still parse and instantiate at its initial size. This is the largest count any memory may declare.
+    static constexpr uint32_t maxPageCount = 256 * 1024;
+
+    static constexpr uint32_t maxMemory32PageCount = 64 * 1024;
+    static constexpr uint64_t maxMemory32Bytes = static_cast<uint64_t>(maxMemory32PageCount) * pageSize;
+
 private:
-    // The spec requires we are able to instantiate a memory with a *maximum* size of 64K pages.
-    // This does not mean the memory can necessarily grow that big, and where the
-    // MAX_ARRAY_BUFFER_SIZE is smaller (e.g.: on 32-bit platforms), trying to grow the memory
-    // that large will fail, which is acceptable according to the spec. Nevertheless, we should
-    // be able to parse such a memory and instantiate it with a smaller initial size.
-    static constexpr uint32_t maxPageCount = std::max<uint32_t>(64*1024, MAX_ARRAY_BUFFER_SIZE / static_cast<uint64_t>(pageSize));
     static constexpr uint64_t invalidPageCount = std::numeric_limits<uint64_t>::max();
     static_assert(maxPageCount < invalidPageCount);
+    // fromBytes() must accept the byte length of any array buffer.
+    static_assert(MAX_ARRAY_BUFFER_SIZE <= static_cast<uint64_t>(maxPageCount) * pageSize);
 
     uint64_t m_pageCount;
 };

--- a/Source/JavaScriptCore/runtime/PropertyName.h
+++ b/Source/JavaScriptCore/runtime/PropertyName.h
@@ -153,8 +153,17 @@ ALWAYS_INLINE std::optional<bool> fastIsCanonicalNumericIndexString(std::span<co
 }
 
 // https://www.ecma-international.org/ecma-262/9.0/index.html#sec-canonicalnumericindexstring
-ALWAYS_INLINE bool isCanonicalNumericIndexString(UniquedStringImpl* propertyName)
+// An integer-indexed exotic object can be longer than MAX_ARRAY_INDEX, so a key denoting an index
+// parseIndex() cannot hold still has to reach an element. Such a key always arrives as a string, so
+// callers that must serve it pass integerIndex to have it reported. A canonical numeric index string
+// covers far more than that (negatives, fractions, NaN, values past uint64_t), so anything outside the
+// reportable range is still a canonical numeric index string with no index to report.
+// integerIndex is a pointer rather than a reference so that the callers who only classify the key,
+// which include a property lookup fast path, compile to exactly what they did before.
+ALWAYS_INLINE bool isCanonicalNumericIndexString(UniquedStringImpl* propertyName, std::optional<uint64_t>* integerIndex = nullptr)
 {
+    if (integerIndex)
+        *integerIndex = std::nullopt;
     if (!propertyName)
         return false;
     if (propertyName->isSymbol())
@@ -171,7 +180,22 @@ ALWAYS_INLINE bool isCanonicalNumericIndexString(UniquedStringImpl* propertyName
     double index = jsToNumber(propertyName);
     NumberToStringBuffer buffer;
     auto span = WTF::numberToStringAndSize(index, buffer);
-    return equal(propertyName, byteCast<Latin1Character>(span));
+    if (!equal(propertyName, byteCast<Latin1Character>(span)))
+        return false;
+
+    if (integerIndex) {
+        // Anything up to MAX_ARRAY_INDEX reached the caller through parseIndex() instead. The round trip
+        // through uint64_t rejects a fractional value, which is canonical too ("4294967296.5") but is not
+        // an integer index.
+        constexpr double smallestReportedIndex = static_cast<double>(MAX_ARRAY_INDEX) + 1;
+        constexpr double firstIndexPastUInt64 = static_cast<double>(std::numeric_limits<uint64_t>::max());
+        if (index >= smallestReportedIndex && index < firstIndexPastUInt64) {
+            uint64_t candidate = static_cast<uint64_t>(index);
+            if (static_cast<double>(candidate) == index)
+                *integerIndex = candidate;
+        }
+    }
+    return true;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/WasmAddressType.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.cpp
@@ -32,10 +32,6 @@
 
 namespace JSC { namespace Wasm {
 
-AddressType::AddressType(AddressType::Kind addressType) : m_type(addressType) { };
-
-AddressType::AddressType(bool is64Bit) : m_type(is64Bit ? AddressType::I64 : AddressType::I32) { };
-
 static constexpr const char* invalidAddressTypeConversion = "Invalid Wasm Type to AddressType conversion";
 
 AddressType::AddressType(TypeKind typeKind)

--- a/Source/JavaScriptCore/wasm/WasmAddressType.h
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.h
@@ -45,11 +45,15 @@ public:
     using enum Kind;
     AddressType() = default;
     AddressType(TypeKind);
-    AddressType(AddressType::Kind);
+    constexpr AddressType(AddressType::Kind addressType)
+        : m_type(addressType)
+    { }
 #if !PLATFORM(PLAYSTATION)
     AddressType(B3::Type);
 #endif
-    explicit AddressType(bool is64bit);
+    explicit constexpr AddressType(bool is64Bit)
+        : m_type(is64Bit ? AddressType::I64 : AddressType::I32)
+    { }
 
     AddressType::Kind type() const { return m_type; }
     TypeKind NODELETE asWasmTypeKind() const;
@@ -58,7 +62,7 @@ public:
 
     friend bool NODELETE operator==(const AddressType& lhs, const AddressType& rhs);
     friend bool operator!=(const AddressType& lhs, const AddressType& rhs);
-    bool is64Bit() const { return m_type == AddressType::I64; }
+    constexpr bool is64Bit() const { return m_type == AddressType::I64; }
 
 private:
 

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -29,6 +29,10 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include <JavaScriptCore/PageCount.h>
+#include <JavaScriptCore/WasmAddressType.h>
+
+#include <algorithm>
 #include <cstdint>
 
 namespace JSC {
@@ -65,8 +69,28 @@ constexpr size_t maxTableEntries = 10000000;
 constexpr size_t maxTableInitializationEntries = 10000000;
 constexpr unsigned maxTables = 100000;
 
-constexpr uint64_t maxMemoryPages = 1ULL << 16;
-constexpr uint64_t maxMemory64Pages = (1ULL << 37) - 1;
+constexpr uint64_t maxMemory32Pages = PageCount::maxMemory32PageCount;
+constexpr uint64_t maxMemory64Pages = PageCount::maxPageCount;
+
+constexpr uint64_t maxDeclarablePages(AddressType addressType)
+{
+    return addressType.is64Bit() ? maxMemory64Pages : maxMemory32Pages;
+}
+
+// MAX_ARRAY_BUFFER_SIZE is not a page multiple on 32-bit, and a memory's size always is.
+constexpr uint64_t maxPageAlignedArrayBufferBytes = (MAX_ARRAY_BUFFER_SIZE / PageCount::pageSize) * PageCount::pageSize;
+
+// The largest byte length the buffer of a memory of this address type may advertise. The clamp only
+// bites on 32-bit, where a declared maximum need not be representable; growth is bounded separately.
+constexpr uint64_t maxBufferByteLength(AddressType addressType)
+{
+    return std::min<uint64_t>(maxDeclarablePages(addressType) * PageCount::pageSize, maxPageAlignedArrayBufferBytes);
+}
+
+#if USE(LARGE_TYPED_ARRAYS)
+static_assert(maxBufferByteLength(AddressType { AddressType::I32 }) == maxMemory32Pages * PageCount::pageSize);
+static_assert(maxBufferByteLength(AddressType { AddressType::I64 }) == maxMemory64Pages * PageCount::pageSize);
+#endif
 
 // Limit of GC arrays in bytes. This is not included in the limits in the
 // JS API spec, but we set a limit to avoid complicated boundary conditions.

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -32,7 +32,9 @@
 #include "JSWebAssemblyInstance.h"
 #include "Options.h"
 #include "WasmFaultSignalHandler.h"
+#include "WasmLimits.h"
 #include "WeakGCSetInlines.h"
+#include <bmalloc/Gigacage.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/DataLog.h>
 #include <wtf/FastMalloc.h>
@@ -61,6 +63,13 @@ constexpr bool verbose = false;
 
 NEVER_INLINE NO_RETURN_DUE_TO_CRASH void webAssemblyCouldntGetFastMemory() { CRASH(); }
 
+// A grow's resulting page count must be one the memory's own address type can declare, which is
+// tighter than what PageCount can represent.
+static bool isDeclarablePageCount(PageCount pageCount, AddressType addressType)
+{
+    return pageCount && pageCount.isValid() && pageCount.pageCount() <= maxDeclarablePages(addressType);
+}
+
 template<typename Func>
 static bool tryAllocate(VM& vm, const Func& allocate)
 {
@@ -86,6 +95,11 @@ static bool tryAllocate(VM& vm, const Func& allocate)
 }
 
 } // anonymous namespace
+
+uint64_t maxAllocatableBytes(AddressType addressType)
+{
+    return std::min<uint64_t>(maxBufferByteLength(addressType), maxGrowableBufferReservationBytes);
+}
 
 Memory::Memory()
     : m_handle(adoptRef(*new BufferMemoryHandle(BufferMemoryHandle::nullBasePointer(), 0, 0, PageCount(0), PageCount(0), MemorySharingMode::Default, MemoryMode::BoundsChecking)))
@@ -148,24 +162,28 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
     RELEASE_ASSERT(!maximum || maximum >= initial); // This should be guaranteed by our caller.
 
     const uint64_t initialBytes = initial.bytes();
-    const uint64_t maximumBytes = maximum ? maximum.bytes() : 0;
+    const uint64_t allocatableBytes = maxAllocatableBytes(addressType);
+    const uint64_t declaredMaximumBytes = maximum ? maximum.bytes() : 0;
+    // A buffer must not advertise a length this platform could never grow the memory to, so what it
+    // reports is bounded by what can be allocated rather than by what the address type may declare.
+    const size_t reservedMaximumBytes = std::min(declaredMaximumBytes, allocatableBytes);
 
-    if (initialBytes > MAX_ARRAY_BUFFER_SIZE)
+    if (initialBytes > allocatableBytes)
         return nullptr; // Client will throw OOMError.
 
-    if (maximum && !maximumBytes) {
+    if (maximum && !declaredMaximumBytes) {
         // User specified a zero maximum, initial size must also be zero.
         RELEASE_ASSERT(!initialBytes);
         return createZeroSized(sharingMode, addressType, WTF::move(growSuccessCallback));
     }
-    
+
     bool done = tryAllocate(vm,
         [&] () -> BufferMemoryResult::Kind {
             return BufferMemoryManager::singleton().tryAllocatePhysicalBytes(initialBytes);
         });
     if (!done)
         return nullptr;
-        
+
     char* fastMemory = nullptr;
     if (Options::useWasmFastMemory() && desiredMemoryMode.value_or(MemoryMode::Signaling) == MemoryMode::Signaling && !addressType.is64Bit()) {
 #if CPU(ADDRESS32)
@@ -188,9 +206,9 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
             return Memory::create(adoptRef(*new BufferMemoryHandle(fastMemory, initialBytes, BufferMemoryHandle::fastMappedBytes(), initial, maximum, MemorySharingMode::Default, MemoryMode::Signaling)), addressType, WTF::move(growSuccessCallback));
         }
         case MemorySharingMode::Shared: {
-            auto handle = adoptRef(*new BufferMemoryHandle(fastMemory, initialBytes, BufferMemoryHandle::fastMappedBytes(), initial, maximum, MemorySharingMode::Shared, MemoryMode::Signaling));
+            Ref handle = adoptRef(*new BufferMemoryHandle(fastMemory, initialBytes, BufferMemoryHandle::fastMappedBytes(), initial, maximum, MemorySharingMode::Shared, MemoryMode::Signaling));
             auto span = handle->mutableSpan();
-            auto content = SharedArrayBufferContents::create(span, maximumBytes, WTF::move(handle), nullptr, SharedArrayBufferContents::Mode::WebAssembly);
+            auto content = SharedArrayBufferContents::create(span, reservedMaximumBytes, WTF::move(handle), nullptr, SharedArrayBufferContents::Mode::WebAssembly);
             return Memory::create(WTF::move(content), addressType, WTF::move(growSuccessCallback));
         }
         }
@@ -198,8 +216,10 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
         return nullptr;
     }
 
-    if (desiredMemoryMode == MemoryMode::Signaling)
+    if (desiredMemoryMode == MemoryMode::Signaling) {
+        BufferMemoryManager::singleton().freePhysicalBytes(initialBytes);
         return nullptr;
+    }
 
     if (Options::crashIfWasmCantFastMemory()) [[unlikely]]
         webAssemblyCouldntGetFastMemory();
@@ -220,7 +240,7 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
         char* slowMemory = nullptr;
         tryAllocate(vm,
             [&] () -> BufferMemoryResult::Kind {
-                auto result = BufferMemoryManager::singleton().tryAllocateGrowableBoundsCheckingMemory(maximumBytes);
+                auto result = BufferMemoryManager::singleton().tryAllocateGrowableBoundsCheckingMemory(reservedMaximumBytes);
                 slowMemory = std::bit_cast<char*>(result.basePtr);
                 return result.kind;
             });
@@ -231,11 +251,11 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
 
         constexpr bool readable = false;
         constexpr bool writable = false;
-        OSAllocator::protect(slowMemory + initialBytes, maximumBytes - initialBytes, readable, writable);
+        OSAllocator::protect(slowMemory + initialBytes, reservedMaximumBytes - initialBytes, readable, writable);
 
-        auto handle = adoptRef(*new BufferMemoryHandle(slowMemory, initialBytes, maximumBytes, initial, maximum, MemorySharingMode::Shared, MemoryMode::BoundsChecking));
+        Ref handle = adoptRef(*new BufferMemoryHandle(slowMemory, initialBytes, reservedMaximumBytes, initial, maximum, MemorySharingMode::Shared, MemoryMode::BoundsChecking));
         auto span = handle->mutableSpan();
-        auto content = SharedArrayBufferContents::create(span, maximumBytes, WTF::move(handle), nullptr, SharedArrayBufferContents::Mode::WebAssembly);
+        auto content = SharedArrayBufferContents::create(span, reservedMaximumBytes, WTF::move(handle), nullptr, SharedArrayBufferContents::Mode::WebAssembly);
         return Memory::create(WTF::move(content), addressType, WTF::move(growSuccessCallback));
     }
     }
@@ -252,43 +272,59 @@ bool Memory::addressIsInGrowableOrFastMemory(void* address)
 
 Expected<PageCount, GrowFailReason> Memory::growShared(VM& vm, PageCount delta)
 {
-    PageCount oldPageCount;
-    PageCount newPageCount;
-    Expected<int64_t, GrowFailReason> result;
-    {
-        std::optional<Locker<Lock>> locker;
-        // m_shared may not be exist, if this is zero byte memory with zero byte maximum size.
-        if (m_shared)
-            locker.emplace(m_shared->memoryHandle()->lock());
+    // Collections happen with the handle lock released, so a retry recomputes the target: another agent
+    // may have grown this memory while we were unlocked, and delta is relative to whatever the size is now.
+    constexpr unsigned maximumAttempts = 2;
+    for (unsigned attempt = 1; ; ++attempt) {
+        PageCount oldPageCount;
+        PageCount newPageCount;
+        Expected<int64_t, GrowFailReason> result;
+        auto collection = BufferMemoryResult::Kind::Success;
+        {
+            std::optional<Locker<Lock>> locker;
+            // m_shared may not be exist, if this is zero byte memory with zero byte maximum size.
+            if (m_shared)
+                locker.emplace(m_shared->memoryHandle()->lock());
 
-        oldPageCount = PageCount::fromBytes(size());
-        newPageCount = oldPageCount + delta;
-        if (!newPageCount || !newPageCount.isValid())
-            return makeUnexpected(GrowFailReason::InvalidGrowSize);
-        if (newPageCount.bytes() > MAX_ARRAY_BUFFER_SIZE)
-            return makeUnexpected(GrowFailReason::OutOfMemory);
+            oldPageCount = PageCount::fromBytes(size());
+            newPageCount = oldPageCount + delta;
+            if (!isDeclarablePageCount(newPageCount, addressType()))
+                return makeUnexpected(GrowFailReason::InvalidGrowSize);
+            const uint64_t allocatableBytes = maxAllocatableBytes(addressType());
+            if (newPageCount.bytes() > allocatableBytes)
+                return makeUnexpected(GrowFailReason::OutOfMemory);
 
-        if (!delta.pageCount())
-            return oldPageCount;
+            if (!delta.pageCount())
+                return oldPageCount;
 
-        dataLogLnIf(verbose, "Memory::grow(", delta, ") to ", newPageCount, " from ", *this);
-        RELEASE_ASSERT(newPageCount > PageCount::fromBytes(size()));
+            dataLogLnIf(verbose, "Memory::grow(", delta, ") to ", newPageCount, " from ", *this);
+            RELEASE_ASSERT(newPageCount > PageCount::fromBytes(size()));
 
-        if (maximum() && newPageCount > maximum())
-            return makeUnexpected(GrowFailReason::WouldExceedMaximum);
+            if (maximum() && newPageCount > maximum())
+                return makeUnexpected(GrowFailReason::WouldExceedMaximum);
 
-        size_t desiredSize = newPageCount.bytes();
-        RELEASE_ASSERT(m_shared);
-        RELEASE_ASSERT(desiredSize <= MAX_ARRAY_BUFFER_SIZE);
-        RELEASE_ASSERT(desiredSize > size());
-        constexpr bool sizeMustBePageMultiple = true;
-        result = m_shared->grow(locker.value(), vm, desiredSize, sizeMustBePageMultiple);
+            size_t desiredSize = newPageCount.bytes();
+            RELEASE_ASSERT(m_shared);
+            RELEASE_ASSERT(desiredSize <= allocatableBytes);
+            RELEASE_ASSERT(desiredSize > size());
+            constexpr bool sizeMustBePageMultiple = true;
+            result = m_shared->tryGrow(locker.value(), desiredSize, sizeMustBePageMultiple, collection);
+        }
+        if (collection == BufferMemoryResult::Kind::SyncTryToReclaimMemory) {
+            if (attempt == maximumAttempts)
+                return makeUnexpected(GrowFailReason::OutOfMemory);
+            vm.heap.collectSync(CollectionScope::Full);
+            continue;
+        }
+        if (!result)
+            return makeUnexpected(result.error());
+
+        // The instances' cached memories are brought up to date before anything can collect.
+        m_growSuccessCallback(GrowSuccessTag, oldPageCount, newPageCount);
+        if (collection == BufferMemoryResult::Kind::SuccessAndNotifyMemoryPressure)
+            vm.heap.collectAsync(CollectionScope::Full);
+        return oldPageCount;
     }
-    if (!result)
-        return makeUnexpected(result.error());
-
-    m_growSuccessCallback(GrowSuccessTag, oldPageCount, newPageCount);
-    return oldPageCount;
 }
 
 Expected<PageCount, GrowFailReason> Memory::grow(VM& vm, PageCount delta)
@@ -302,9 +338,10 @@ Expected<PageCount, GrowFailReason> Memory::grow(VM& vm, PageCount delta)
     ASSERT(!m_shared);
     const PageCount oldPageCount = PageCount::fromBytes(size());
     const PageCount newPageCount = oldPageCount + delta;
-    if (!newPageCount || !newPageCount.isValid())
+    if (!isDeclarablePageCount(newPageCount, addressType()))
         return makeUnexpected(GrowFailReason::InvalidGrowSize);
-    if (newPageCount.bytes() > MAX_ARRAY_BUFFER_SIZE)
+    const uint64_t allocatableBytes = maxAllocatableBytes(addressType());
+    if (newPageCount.bytes() > allocatableBytes)
         return makeUnexpected(GrowFailReason::OutOfMemory);
 
     auto success = [&] () {
@@ -331,7 +368,7 @@ Expected<PageCount, GrowFailReason> Memory::grow(VM& vm, PageCount delta)
         return makeUnexpected(GrowFailReason::WouldExceedMaximum);
 
     size_t desiredSize = newPageCount.bytes();
-    RELEASE_ASSERT(desiredSize <= MAX_ARRAY_BUFFER_SIZE);
+    RELEASE_ASSERT(desiredSize <= allocatableBytes);
     RELEASE_ASSERT(desiredSize > size());
     switch (mode()) {
     case MemoryMode::BoundsChecking: {
@@ -345,11 +382,13 @@ Expected<PageCount, GrowFailReason> Memory::grow(VM& vm, PageCount delta)
         RELEASE_ASSERT(maximum().bytes() != 0);
 
         void* newMemory = Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, desiredSize);
-        if (!newMemory)
+        if (!newMemory) {
+            BufferMemoryManager::singleton().freePhysicalBytes(desiredSize);
             return makeUnexpected(GrowFailReason::OutOfMemory);
+        }
 
-        memcpy(newMemory, basePointer(), size());
-        auto newHandle = adoptRef(*new BufferMemoryHandle(newMemory, desiredSize, desiredSize, initial(), maximum(), sharingMode(), MemoryMode::BoundsChecking));
+        memcpySpan(unsafeMakeSpan(static_cast<uint8_t*>(newMemory), desiredSize), m_handle->mutableSpan());
+        Ref newHandle = adoptRef(*new BufferMemoryHandle(newMemory, desiredSize, desiredSize, initial(), maximum(), sharingMode(), MemoryMode::BoundsChecking));
         m_handle->transferAnchors(newHandle.get());
         m_handle = WTF::move(newHandle);
 

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -52,6 +52,11 @@ namespace JSC {
 class LLIntOffsetsExtractor;
 
 namespace Wasm {
+
+// The most bytes a memory of this address type can actually be given, as opposed to declare. Bounded
+// both by the address type's own ceiling and by what a single growable reservation may claim.
+uint64_t maxAllocatableBytes(AddressType);
+
 class Memory final : public RefCounted<Memory> {
     WTF_MAKE_NONCOPYABLE(Memory);
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(Memory, JS_EXPORT_PRIVATE);

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -411,7 +411,7 @@ auto SectionParser::parseMemoryHelper(bool isImport) -> PartialResult
             return makeUnexpected(WTF::move(limits.error()));
         ASSERT(!maximum || *maximum >= initial);
 
-        const uint64_t maxDeclarablePageCount = isMemory64 ? maxMemory64Pages : maxMemoryPages;
+        const uint64_t maxDeclarablePageCount = maxDeclarablePages(AddressType { isMemory64 });
         WASM_PARSER_FAIL_IF(initial > maxDeclarablePageCount, "Memory's initial page count of "_s, initial, " is invalid"_s);
 
         // FIXME(wasm-memory64): for now IPInt checks m_cachedIsMemory64 (flag if memory 0 is 64-bit)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
@@ -82,23 +82,11 @@ void JSWebAssemblyMemory::associateArrayBuffer(JSGlobalObject* globalObject, boo
             auto destructor = createSharedTask<void(void*)>([protectedHandle = WTF::move(protectedHandle)] (void*) { });
             m_buffer = ArrayBuffer::createFromBytes({ static_cast<const uint8_t*>(data), size }, WTF::move(destructor));
         } else {
-            // The determination of maxByteLength of a resizable non-shared array buffer may change in
-            // https://webassembly.github.io/threads/js-api/index.html#create-a-resizable-memory-buffer
-            // Currently we are implementing the behavior expected by WPT tests,
-            // so that maxByteLength is 2^32 if the memory has no user-defined max size.
-#if USE(LARGE_TYPED_ARRAYS)
-            // If sizeof(size_t) == 8 we use the proper spec value because it's representable.
-            constexpr size_t defaultMaxByteLengthIfMemoryHasNoMax = 65536ULL * 65536ULL;
-#else
-            // If sizeof(size_t) == 4, compute the largest page-aligned size that fits within MAX_ARRAY_BUFFER_SIZE.
-            uint32_t maxPages = MAX_ARRAY_BUFFER_SIZE / PageCount::pageSize;
-            const size_t defaultMaxByteLengthIfMemoryHasNoMax = static_cast<size_t>(PageCount(maxPages).bytes());
-#endif
+            // The buffer must not advertise a length this platform could never grow the memory to, so the
+            // ceiling is what can be allocated rather than what the address type may declare.
+            size_t ceilingBytes = Wasm::maxAllocatableBytes(m_memory->addressType());
             PageCount memoryMax = m_memory->maximum();
-            // A memory64 may declare a maximum far above what an ArrayBuffer can address, while the
-            // memory itself can never grow past MAX_ARRAY_BUFFER_SIZE.
-            // FIXME: We should bump MAX_ARRAY_BUFFER_SIZE and reduce the maximum size of memory64.
-            size_t maxByteLength = memoryMax ? std::min<uint64_t>(memoryMax.bytes(), defaultMaxByteLengthIfMemoryHasNoMax) : defaultMaxByteLengthIfMemoryHasNoMax;
+            size_t maxByteLength = memoryMax ? std::min<uint64_t>(memoryMax.bytes(), ceilingBytes) : ceilingBytes;
             ArrayBufferContents contents(data, size, maxByteLength, WTF::move(protectedHandle));
             m_buffer = ArrayBuffer::create(WTF::move(contents));
         }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
@@ -77,8 +77,7 @@ JSWebAssemblyMemory* WebAssemblyMemoryConstructor::createMemoryFromDescriptor(JS
 
     // Page counts are declarative, so accept everything a module's own memory type may declare.
     // What can actually be allocated is bounded separately, and more tightly.
-    // FIXME: We should bump MAX_ARRAY_BUFFER_SIZE and reduce the maximum size of memory64.
-    uint64_t maxDeclarablePageCount = addressType.is64Bit() ? Wasm::maxMemory64Pages : Wasm::maxMemoryPages;
+    uint64_t maxDeclarablePageCount = Wasm::maxDeclarablePages(addressType);
 
     PageCount initialPageCount;
     {
@@ -100,10 +99,6 @@ JSWebAssemblyMemory* WebAssemblyMemoryConstructor::createMemoryFromDescriptor(JS
         RETURN_IF_EXCEPTION(throwScope, { });
         if (size > maxDeclarablePageCount) {
             throwException(globalObject, throwScope, createRangeError(globalObject, "WebAssembly.Memory 'initial' page count is too large"_s));
-            return { };
-        }
-        if (PageCount(size).bytes() > MAX_ARRAY_BUFFER_SIZE) {
-            throwException(globalObject, throwScope, createOutOfMemoryError(globalObject));
             return { };
         }
         initialPageCount = PageCount(size);

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -72,6 +72,7 @@
 #include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/Uint8Array.h>
 #include <algorithm>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
@@ -1082,14 +1083,24 @@ static inline ExceptionOr<PeerConnectionBackend::CertificateInformation> certifi
 
         auto result = PeerConnectionBackend::CertificateInformation::RSASSA_PKCS1_v1_5();
         if (parameters.modulusLength && parameters.publicExponent) {
-            int publicExponent = 0;
-            int value = 1;
-            for (unsigned counter = 0; counter < parameters.publicExponent->byteLength(); ++counter) {
-                publicExponent += parameters.publicExponent->typedSpan()[counter] * value;
-                value <<= 8;
-            }
+            // A WebCrypto BigInteger is big endian with arbitrary leading zero padding, so its length says
+            // nothing about its magnitude. Only what is left once the padding is skipped has to fit the
+            // int the certificate generator takes.
+            auto bigInteger = parameters.publicExponent->typedSpan();
+            size_t firstSignificantByte = 0;
+            while (firstSignificantByte < bigInteger.size() && !bigInteger[firstSignificantByte])
+                ++firstSignificantByte;
+            auto significantBytes = bigInteger.subspan(firstSignificantByte);
+            if (significantBytes.size() > sizeof(int32_t))
+                return Exception { ExceptionCode::NotSupportedError, "publicExponent is too large"_s };
 
-            result.rsaParameters = PeerConnectionBackend::CertificateInformation::RSA { *parameters.modulusLength, publicExponent };
+            CheckedInt32 publicExponent = 0;
+            for (uint8_t byte : significantBytes)
+                publicExponent = publicExponent * 256 + static_cast<int32_t>(byte);
+            if (publicExponent.hasOverflowed())
+                return Exception { ExceptionCode::NotSupportedError, "publicExponent is too large"_s };
+
+            result.rsaParameters = PeerConnectionBackend::CertificateInformation::RSA { *parameters.modulusLength, publicExponent.value() };
         }
         result.expires = parameters.expires;
         return result;

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.h
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.h
@@ -70,7 +70,7 @@ public:
     virtual String extensions() = 0; // Will be available after didConnect() callback is invoked.
 
     virtual void send(CString&&) = 0;
-    virtual void send(const JSC::ArrayBuffer&, unsigned byteOffset, unsigned byteLength) = 0;
+    virtual void send(const JSC::ArrayBuffer&, size_t byteOffset, size_t byteLength) = 0;
     virtual void send(Blob&) = 0;
 
     virtual void close(int code, const String& reason) = 0;

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.cpp
@@ -142,7 +142,7 @@ void ThreadableWebSocketChannelClientWrapper::didReceiveBinaryData(Vector<uint8_
         processPendingTasks();
 }
 
-void ThreadableWebSocketChannelClientWrapper::didUpdateBufferedAmount(unsigned bufferedAmount)
+void ThreadableWebSocketChannelClientWrapper::didUpdateBufferedAmount(uint64_t bufferedAmount)
 {
     m_pendingTasks.append(makeUnique<ScriptExecutionContext::Task>([this, protectedThis = Ref { *this }, bufferedAmount] (ScriptExecutionContext&) {
         if (RefPtr client = m_client.get())
@@ -164,7 +164,7 @@ void ThreadableWebSocketChannelClientWrapper::didStartClosingHandshake()
         processPendingTasks();
 }
 
-void ThreadableWebSocketChannelClientWrapper::didClose(unsigned unhandledBufferedAmount, WebSocketChannelClient::ClosingHandshakeCompletionStatus closingHandshakeCompletion, unsigned short code, const String& reason)
+void ThreadableWebSocketChannelClientWrapper::didClose(uint64_t unhandledBufferedAmount, WebSocketChannelClient::ClosingHandshakeCompletionStatus closingHandshakeCompletion, unsigned short code, const String& reason)
 {
     m_pendingTasks.append(makeUnique<ScriptExecutionContext::Task>([this, protectedThis = Ref { *this }, unhandledBufferedAmount, closingHandshakeCompletion, code, reason = reason.isolatedCopy()] (ScriptExecutionContext&) {
         if (RefPtr client = m_client.get())

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
@@ -67,9 +67,9 @@ public:
     void didConnect();
     void didReceiveMessage(String&& message);
     void didReceiveBinaryData(Vector<uint8_t>&&);
-    void didUpdateBufferedAmount(unsigned bufferedAmount);
+    void didUpdateBufferedAmount(uint64_t bufferedAmount);
     void didStartClosingHandshake();
-    void didClose(unsigned unhandledBufferedAmount, WebSocketChannelClient::ClosingHandshakeCompletionStatus, unsigned short code, const String& reason);
+    void didClose(uint64_t unhandledBufferedAmount, WebSocketChannelClient::ClosingHandshakeCompletionStatus, unsigned short code, const String& reason);
     void didReceiveMessageError(String&& reason);
     void didUpgradeURL();
 

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -134,12 +134,24 @@ static String joinStrings(const Vector<String>& strings, ASCIILiteral separator)
     return builder.toString();
 }
 
-static unsigned NODELETE saturateAdd(unsigned a, unsigned b)
+// bufferedAmount is only ever added to while the socket is closing or closed, so it accumulates without
+// anything draining it. No single payload comes close to overflowing, but repeated sends do, and the
+// attribute has no value to report past its own range, so it stops there.
+static uint64_t NODELETE saturateAdd(uint64_t a, uint64_t b)
 {
-    if (std::numeric_limits<unsigned>::max() - a < b)
-        return std::numeric_limits<unsigned>::max();
+    if (std::numeric_limits<uint64_t>::max() - a < b)
+        return std::numeric_limits<uint64_t>::max();
     return a + b;
 }
+
+// Every channel implementation stages a binary payload into a Vector or a SharedBuffer before it
+// reaches the network, so a payload longer than one of those can hold can never be framed at all.
+static bool isFramablePayloadSize(size_t payloadSize)
+{
+    return WTF::isValidCapacityForVector<uint8_t>(payloadSize);
+}
+
+static constexpr ASCIILiteral payloadTooLargeMessage = "Failed to send WebSocket frame: payload is too large"_s;
 
 ASCIILiteral WebSocket::subprotocolSeparator()
 {
@@ -377,9 +389,13 @@ ExceptionOr<void> WebSocket::send(ArrayBuffer& binaryData)
     if (m_state == CONNECTING)
         return Exception { ExceptionCode::InvalidStateError };
     if (m_state == CLOSING || m_state == CLOSED) {
-        unsigned payloadSize = binaryData.byteLength();
+        size_t payloadSize = binaryData.byteLength();
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
+        return { };
+    }
+    if (!isFramablePayloadSize(binaryData.byteLength())) {
+        channel()->fail(payloadTooLargeMessage);
         return { };
     }
     m_bufferedAmount = saturateAdd(m_bufferedAmount, binaryData.byteLength());
@@ -394,9 +410,13 @@ ExceptionOr<void> WebSocket::send(ArrayBufferView& arrayBufferView)
     if (m_state == CONNECTING)
         return Exception { ExceptionCode::InvalidStateError };
     if (m_state == CLOSING || m_state == CLOSED) {
-        unsigned payloadSize = arrayBufferView.byteLength();
+        size_t payloadSize = arrayBufferView.byteLength();
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
+        return { };
+    }
+    if (!isFramablePayloadSize(arrayBufferView.byteLength())) {
+        channel()->fail(payloadTooLargeMessage);
         return { };
     }
     m_bufferedAmount = saturateAdd(m_bufferedAmount, arrayBufferView.byteLength());
@@ -410,7 +430,7 @@ ExceptionOr<void> WebSocket::send(Blob& binaryData)
     if (m_state == CONNECTING)
         return Exception { ExceptionCode::InvalidStateError };
     if (m_state == CLOSING || m_state == CLOSED) {
-        unsigned payloadSize = static_cast<unsigned>(binaryData.size());
+        size_t payloadSize = binaryData.size();
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
         return { };
@@ -465,7 +485,7 @@ WebSocket::State WebSocket::readyState() const
     return m_state;
 }
 
-unsigned WebSocket::bufferedAmount() const
+uint64_t WebSocket::bufferedAmount() const
 {
     return saturateAdd(m_bufferedAmount, m_bufferedAmountAfterClose);
 }
@@ -613,9 +633,9 @@ void WebSocket::didReceiveMessageError(String&& reason)
     });
 }
 
-void WebSocket::didUpdateBufferedAmount(unsigned bufferedAmount)
+void WebSocket::didUpdateBufferedAmount(uint64_t bufferedAmount)
 {
-    LOG(Network, "WebSocket %p didUpdateBufferedAmount() New bufferedAmount is %u", this, bufferedAmount);
+    LOG(Network, "WebSocket %p didUpdateBufferedAmount() New bufferedAmount is %" PRIu64, this, bufferedAmount);
     if (m_state == CLOSED)
         return;
     m_bufferedAmount = bufferedAmount;
@@ -631,7 +651,7 @@ void WebSocket::didStartClosingHandshake()
     });
 }
 
-void WebSocket::didClose(unsigned unhandledBufferedAmount, ClosingHandshakeCompletionStatus closingHandshakeCompletion, unsigned short code, const String& reason)
+void WebSocket::didClose(uint64_t unhandledBufferedAmount, ClosingHandshakeCompletionStatus closingHandshakeCompletion, unsigned short code, const String& reason)
 {
     LOG(Network, "WebSocket %p didClose()", this);
     queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [unhandledBufferedAmount, closingHandshakeCompletion, code, reason](auto& socket) {

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -93,7 +93,7 @@ public:
 
     const URL& NODELETE url() const;
     State NODELETE readyState() const;
-    unsigned NODELETE bufferedAmount() const;
+    uint64_t NODELETE bufferedAmount() const;
 
     String NODELETE protocol() const;
     String NODELETE extensions() const;
@@ -125,9 +125,9 @@ private:
     void didReceiveMessage(String&& message) final;
     void didReceiveBinaryData(Vector<uint8_t>&&) final;
     void didReceiveMessageError(String&& reason) final;
-    void NODELETE didUpdateBufferedAmount(unsigned bufferedAmount) final;
+    void NODELETE didUpdateBufferedAmount(uint64_t bufferedAmount) final;
     void didStartClosingHandshake() final;
-    void didClose(unsigned unhandledBufferedAmount, ClosingHandshakeCompletionStatus, unsigned short code, const String& reason) final;
+    void didClose(uint64_t unhandledBufferedAmount, ClosingHandshakeCompletionStatus, unsigned short code, const String& reason) final;
     void didUpgradeURL() final;
 
     size_t NODELETE getFramingOverhead(size_t payloadSize);
@@ -140,8 +140,8 @@ private:
     State m_state { CONNECTING };
     URL m_url;
     const RefPtr<SecurityOrigin> m_origin;
-    unsigned m_bufferedAmount { 0 };
-    unsigned m_bufferedAmountAfterClose { 0 };
+    uint64_t m_bufferedAmount { 0 };
+    uint64_t m_bufferedAmountAfterClose { 0 };
     BinaryType m_binaryType { BinaryType::Blob };
     String m_subprotocol;
     String m_extensions;

--- a/Source/WebCore/Modules/websockets/WebSocket.idl
+++ b/Source/WebCore/Modules/websockets/WebSocket.idl
@@ -48,7 +48,7 @@ enum BinaryType { "blob", "arraybuffer" };
     const unsigned short CLOSING = 2;
     const unsigned short CLOSED = 3;
     readonly attribute unsigned short readyState;
-    readonly attribute unsigned long bufferedAmount;
+    readonly attribute unsigned long long bufferedAmount;
 
     // networking
     attribute EventHandler onopen;

--- a/Source/WebCore/Modules/websockets/WebSocketChannelClient.h
+++ b/Source/WebCore/Modules/websockets/WebSocketChannelClient.h
@@ -42,13 +42,13 @@ public:
     virtual void didReceiveMessage(String&&) = 0;
     virtual void didReceiveBinaryData(Vector<uint8_t>&&) = 0;
     virtual void didReceiveMessageError(String&&) = 0;
-    virtual void didUpdateBufferedAmount(unsigned bufferedAmount) = 0;
+    virtual void didUpdateBufferedAmount(uint64_t bufferedAmount) = 0;
     virtual void didStartClosingHandshake() = 0;
     enum ClosingHandshakeCompletionStatus {
         ClosingHandshakeIncomplete,
         ClosingHandshakeComplete
     };
-    virtual void didClose(unsigned unhandledBufferedAmount, ClosingHandshakeCompletionStatus, unsigned short code, const String& reason) = 0;
+    virtual void didClose(uint64_t unhandledBufferedAmount, ClosingHandshakeCompletionStatus, unsigned short code, const String& reason) = 0;
     virtual void didUpgradeURL() = 0;
 
 protected:

--- a/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
@@ -100,7 +100,7 @@ void WorkerThreadableWebSocketChannel::send(CString&& message)
         bridge->send(WTF::move(message));
 }
 
-void WorkerThreadableWebSocketChannel::send(const ArrayBuffer& binaryData, unsigned byteOffset, unsigned byteLength)
+void WorkerThreadableWebSocketChannel::send(const ArrayBuffer& binaryData, size_t byteOffset, size_t byteLength)
 {
     if (RefPtr bridge = m_bridge)
         bridge->send(binaryData, byteOffset, byteLength);
@@ -280,7 +280,7 @@ void WorkerThreadableWebSocketChannel::Peer::didReceiveBinaryData(Vector<uint8_t
     }, m_taskMode);
 }
 
-void WorkerThreadableWebSocketChannel::Peer::didUpdateBufferedAmount(unsigned bufferedAmount)
+void WorkerThreadableWebSocketChannel::Peer::didUpdateBufferedAmount(uint64_t bufferedAmount)
 {
     ASSERT(isMainThread());
 
@@ -308,7 +308,7 @@ void WorkerThreadableWebSocketChannel::Peer::didStartClosingHandshake()
     }, m_taskMode);
 }
 
-void WorkerThreadableWebSocketChannel::Peer::didClose(unsigned unhandledBufferedAmount, ClosingHandshakeCompletionStatus closingHandshakeCompletion, unsigned short code, const String& reason)
+void WorkerThreadableWebSocketChannel::Peer::didClose(uint64_t unhandledBufferedAmount, ClosingHandshakeCompletionStatus closingHandshakeCompletion, unsigned short code, const String& reason)
 {
     ASSERT(isMainThread());
     m_mainWebSocketChannel = nullptr;
@@ -436,14 +436,18 @@ void WorkerThreadableWebSocketChannel::Bridge::send(CString&& message)
     });
 }
 
-void WorkerThreadableWebSocketChannel::Bridge::send(const ArrayBuffer& binaryData, unsigned byteOffset, unsigned byteLength)
+void WorkerThreadableWebSocketChannel::Bridge::send(const ArrayBuffer& binaryData, size_t byteOffset, size_t byteLength)
 {
     RefPtr peer = m_peer.get();
     if (!peer)
         return;
 
-    // ArrayBuffer isn't thread-safe, hence the content of ArrayBuffer is copied into Vector<uint8_t>.
-    Vector<uint8_t> data(byteLength);
+    // ArrayBuffer isn't thread-safe, so its content is copied into a Vector to cross to the main thread.
+    Vector<uint8_t> data;
+    if (!data.tryGrow(byteLength)) {
+        fail("Failed to send WebSocket frame: payload is too large"_s);
+        return;
+    }
     if (binaryData.byteLength())
         memcpySpan(data.mutableSpan(), binaryData.span().subspan(byteOffset, byteLength));
 

--- a/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.h
+++ b/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.h
@@ -59,7 +59,7 @@ public:
     String subprotocol() final;
     String extensions() final;
     void send(CString&&) final;
-    void send(const JSC::ArrayBuffer&, unsigned byteOffset, unsigned byteLength) final;
+    void send(const JSC::ArrayBuffer&, size_t byteOffset, size_t byteLength) final;
     void send(Blob&) final;
     void close(int code, const String& reason) final;
     void fail(String&& reason) final;
@@ -93,9 +93,9 @@ public:
         void didConnect() final;
         void didReceiveMessage(String&& message) final;
         void didReceiveBinaryData(Vector<uint8_t>&&) final;
-        void didUpdateBufferedAmount(unsigned bufferedAmount) final;
+        void didUpdateBufferedAmount(uint64_t bufferedAmount) final;
         void didStartClosingHandshake() final;
-        void didClose(unsigned unhandledBufferedAmount, ClosingHandshakeCompletionStatus, unsigned short code, const String& reason) final;
+        void didClose(uint64_t unhandledBufferedAmount, ClosingHandshakeCompletionStatus, unsigned short code, const String& reason) final;
         void didReceiveMessageError(String&& reason) final;
         void didUpgradeURL() final;
 
@@ -123,7 +123,7 @@ private:
         void initialize(WorkerGlobalScope&);
         void connect(const URL&, const String& protocol);
         void send(CString&&);
-        void send(const JSC::ArrayBuffer&, unsigned byteOffset, unsigned byteLength);
+        void send(const JSC::ArrayBuffer&, size_t byteOffset, size_t byteLength);
         void send(Blob&);
         void close(int code, const String& reason);
         void fail(String&& reason);

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -97,8 +97,7 @@ Ref<FontFace> FontFace::create(ScriptExecutionContext& context, const AtomString
                 return { };
 
             result->m_sourceIsImmediateBuffer = true;
-            unsigned byteLength = arrayBuffer->byteLength();
-            auto arrayBufferView = JSC::Uint8Array::create(WTF::move(arrayBuffer), 0, byteLength);
+            auto arrayBufferView = JSC::Uint8Array::create(WTF::move(arrayBuffer));
             dataRequiresAsynchronousLoading = populateFontFaceWithArrayBuffer(protect(result->backing()), WTF::move(arrayBufferView));
             return { };
         }

--- a/Source/WebCore/fileapi/NetworkSendQueue.cpp
+++ b/Source/WebCore/fileapi/NetworkSendQueue.cpp
@@ -56,7 +56,7 @@ void NetworkSendQueue::enqueue(CString&& utf8)
     m_queue.append(WTF::move(utf8));
 }
 
-void NetworkSendQueue::enqueue(const JSC::ArrayBuffer& binaryData, unsigned byteOffset, unsigned byteLength)
+void NetworkSendQueue::enqueue(const JSC::ArrayBuffer& binaryData, size_t byteOffset, size_t byteLength)
 {
     if (m_queue.isEmpty()) {
         m_writeRawData(binaryData.span().subspan(byteOffset, byteLength));

--- a/Source/WebCore/fileapi/NetworkSendQueue.h
+++ b/Source/WebCore/fileapi/NetworkSendQueue.h
@@ -57,7 +57,7 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     void enqueue(CString&& utf8);
-    void enqueue(const JSC::ArrayBuffer&, unsigned byteOffset, unsigned byteLength);
+    void enqueue(const JSC::ArrayBuffer&, size_t byteOffset, size_t byteLength);
     void enqueue(Blob&);
 
     void clear();

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -439,7 +439,7 @@ GCGLint WebGL2RenderingContext::maxTextureLevelForTarget(GCGLenum target)
     return WebGLRenderingContextBase::maxTextureLevelForTarget(target);
 }
 
-RefPtr<ArrayBufferView> WebGL2RenderingContext::arrayBufferViewSliceFactory(ASCIILiteral functionName, const ArrayBufferView& data, unsigned startByte,  unsigned numElements)
+RefPtr<ArrayBufferView> WebGL2RenderingContext::arrayBufferViewSliceFactory(ASCIILiteral functionName, const ArrayBufferView& data, size_t startByte, size_t numElements)
 {
     RefPtr<ArrayBufferView> slice;
 
@@ -465,7 +465,7 @@ RefPtr<ArrayBufferView> WebGL2RenderingContext::arrayBufferViewSliceFactory(ASCI
     return slice;
 }
 
-RefPtr<ArrayBufferView> WebGL2RenderingContext::sliceArrayBufferView(ASCIILiteral functionName, const ArrayBufferView& data, GCGLuint srcOffset, GCGLuint length)
+RefPtr<ArrayBufferView> WebGL2RenderingContext::sliceArrayBufferView(ASCIILiteral functionName, const ArrayBufferView& data, uint64_t srcOffset, GCGLuint length)
 {
     if (data.getType() == JSC::NotTypedArray) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "Invalid type of Array Buffer View"_s);
@@ -473,18 +473,18 @@ RefPtr<ArrayBufferView> WebGL2RenderingContext::sliceArrayBufferView(ASCIILitera
     }
 
     auto elementSize = JSC::elementSize(data.getType());
-    Checked<GCGLuint, RecordOverflow> checkedElementSize(elementSize);
-
-    Checked<GCGLuint, RecordOverflow> checkedSrcOffset(srcOffset);
-    Checked<GCGLuint, RecordOverflow> checkedByteSrcOffset = checkedSrcOffset * checkedElementSize;
-    Checked<GCGLuint, RecordOverflow> checkedLength(length);
-    if (!checkedLength) {
-        // Default to the remainder of the buffer.
-        checkedLength = data.byteLength();
-        checkedLength /= elementSize;
-        checkedLength -= srcOffset;
+    // An offset a size_t cannot hold is past the end of any view. Narrowing it here also keeps the
+    // arithmetic below in one width: Checked's result type for mixed widths differs between platforms.
+    if (!isInBounds<size_t>(srcOffset)) {
+        synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "srcOffset or length is out of bounds"_s);
+        return nullptr;
     }
-    Checked<GCGLuint, RecordOverflow> checkedByteLength = checkedLength * checkedElementSize;
+    size_t offsetInElements = srcOffset;
+
+    CheckedSize checkedByteSrcOffset = CheckedSize { offsetInElements } * elementSize;
+    // A zero length means the remainder of the buffer.
+    CheckedSize checkedLength = length ? CheckedSize { length } : CheckedSize { data.byteLength() / elementSize } - offsetInElements;
+    CheckedSize checkedByteLength = checkedLength * elementSize;
 
     if (checkedLength.hasOverflowed() || checkedByteSrcOffset.hasOverflowed()
         || checkedByteLength.hasOverflowed()
@@ -537,13 +537,13 @@ void WebGL2RenderingContext::pixelStorei(GCGLenum pname, GCGLint param)
     protect(graphicsContextGL())->pixelStorei(pname, param);
 }
 
-void WebGL2RenderingContext::bufferData(GCGLenum target, const ArrayBufferView& data, GCGLenum usage, GCGLuint srcOffset, GCGLuint length)
+void WebGL2RenderingContext::bufferData(GCGLenum target, const ArrayBufferView& data, GCGLenum usage, uint64_t srcOffset, GCGLuint length)
 {
     if (auto slice = sliceArrayBufferView("bufferData"_s, data, srcOffset, length))
         WebGLRenderingContextBase::bufferData(target, BufferDataSource(slice.releaseNonNull()), usage);
 }
 
-void WebGL2RenderingContext::bufferSubData(GCGLenum target, long long offset, const ArrayBufferView& data, GCGLuint srcOffset, GCGLuint length)
+void WebGL2RenderingContext::bufferSubData(GCGLenum target, long long offset, const ArrayBufferView& data, uint64_t srcOffset, GCGLuint length)
 {
     if (auto slice = sliceArrayBufferView("bufferSubData"_s, data, srcOffset, length))
         WebGLRenderingContextBase::bufferSubData(target, offset, BufferDataSource(slice.releaseNonNull()));
@@ -584,7 +584,7 @@ void WebGL2RenderingContext::copyBufferSubData(GCGLenum readTarget, GCGLenum wri
     protect(graphicsContextGL())->copyBufferSubData(readTarget, writeTarget, checkedReadOffset, checkedWriteOffset, checkedSize);
 }
 
-void WebGL2RenderingContext::getBufferSubData(GCGLenum target, long long srcByteOffset, RefPtr<ArrayBufferView>&& dstData, GCGLuint dstOffset, GCGLuint length)
+void WebGL2RenderingContext::getBufferSubData(GCGLenum target, long long srcByteOffset, RefPtr<ArrayBufferView>&& dstData, uint64_t dstOffset, GCGLuint length)
 {
     if (isContextLost())
         return;
@@ -605,24 +605,24 @@ void WebGL2RenderingContext::getBufferSubData(GCGLenum target, long long srcByte
     }
 
     auto elementSize = JSC::elementSize(dstData->getType());
-    auto dstDataLength = dstData->byteLength() / elementSize;
+    size_t dstDataLength = dstData->byteLength() / elementSize;
 
     if (dstOffset > dstDataLength) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "getBufferSubData"_s, "dstOffset is larger than the length of the destination buffer."_s);
         return;
     }
+    size_t dstElementOffset = dstOffset;
 
-    GCGLuint copyLength = length ? length : dstDataLength - dstOffset;
+    // A zero length means the remainder of the destination.
+    size_t copyLength = length ? length : dstDataLength - dstElementOffset;
 
-    Checked<GCGLuint, RecordOverflow> checkedDstOffset(dstOffset);
-    Checked<GCGLuint, RecordOverflow> checkedCopyLength(copyLength);
-    auto checkedDestinationEnd = checkedDstOffset + checkedCopyLength;
+    CheckedSize checkedDestinationEnd = CheckedSize { dstElementOffset } + copyLength;
     if (checkedDestinationEnd.hasOverflowed()) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "getBufferSubData"_s, "dstOffset + copyLength is too high"_s);
         return;
     }
 
-    if (checkedDestinationEnd > dstDataLength) {
+    if (checkedDestinationEnd.value() > dstDataLength) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "getBufferSubData"_s, "end of written destination is past the end of the buffer"_s);
         return;
     }
@@ -636,7 +636,7 @@ void WebGL2RenderingContext::getBufferSubData(GCGLenum target, long long srcByte
         return;
 
     // FIXME: Coalesce multiple getBufferSubData() calls to use a single map() call
-    protect(graphicsContextGL())->getBufferSubData(target, srcByteOffset, dstData->mutableSpan().subspan(dstOffset * elementSize, copyLength * elementSize));
+    protect(graphicsContextGL())->getBufferSubData(target, srcByteOffset, dstData->mutableSpan().subspan(dstElementOffset * elementSize, copyLength * elementSize));
 }
 
 void WebGL2RenderingContext::bindFramebuffer(GCGLenum target, WebGLFramebuffer* buffer)
@@ -923,7 +923,7 @@ ExceptionOr<void> WebGL2RenderingContext::texImage2D(GCGLenum target, GCGLint le
     return WebGLRenderingContextBase::texImageSourceHelper(TexImageFunctionID::TexImage2D, target, level, internalformat, border, format, type, 0, 0, 0, getTextureSourceSubRectangle(width, height), 1, 0, WTF::move(source));
 }
 
-void WebGL2RenderingContext::texImage2D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, GCGLuint srcOffset)
+void WebGL2RenderingContext::texImage2D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, uint64_t srcOffset)
 {
     if (isContextLost())
         return;
@@ -983,7 +983,7 @@ void WebGL2RenderingContext::texImage3D(GCGLenum target, GCGLint level, GCGLint 
     texImageArrayBufferViewHelper(TexImageFunctionID::TexImage3D, target, level, internalformat, width, height, depth, border, format, type, 0, 0, 0, WTF::move(srcData), NullAllowed, 0);
 }
 
-void WebGL2RenderingContext::texImage3D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, GCGLuint srcOffset)
+void WebGL2RenderingContext::texImage3D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, uint64_t srcOffset)
 {
     if (isContextLost())
         return;
@@ -1053,7 +1053,7 @@ ExceptionOr<void> WebGL2RenderingContext::texSubImage2D(GCGLenum target, GCGLint
     return WebGLRenderingContextBase::texImageSourceHelper(TexImageFunctionID::TexSubImage2D, target, level, 0, 0, format, type, xoffset, yoffset, 0, getTextureSourceSubRectangle(width, height), 1, 0, WTF::move(source));
 }
 
-void WebGL2RenderingContext::texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, GCGLuint srcOffset)
+void WebGL2RenderingContext::texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, uint64_t srcOffset)
 {
     if (isContextLost())
         return;
@@ -1085,7 +1085,7 @@ void WebGL2RenderingContext::texSubImage3D(GCGLenum target, GCGLint level, GCGLi
     protect(graphicsContextGL())->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, offset);
 }
 
-void WebGL2RenderingContext::texSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, GCGLuint srcOffset)
+void WebGL2RenderingContext::texSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, uint64_t srcOffset)
 {
     if (isContextLost())
         return;
@@ -1153,7 +1153,7 @@ void WebGL2RenderingContext::compressedTexImage2D(GCGLenum target, GCGLint level
     protect(graphicsContextGL())->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, offset);
 }
 
-void WebGL2RenderingContext::compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, ArrayBufferView& srcData, GCGLuint srcOffset, GCGLuint srcLengthOverride)
+void WebGL2RenderingContext::compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, ArrayBufferView& srcData, uint64_t srcOffset, GCGLuint srcLengthOverride)
 {
     if (isContextLost())
         return;
@@ -1190,7 +1190,7 @@ void WebGL2RenderingContext::compressedTexImage3D(GCGLenum target, GCGLint level
     protect(graphicsContextGL())->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, offset);
 }
 
-void WebGL2RenderingContext::compressedTexImage3D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, ArrayBufferView& srcData, GCGLuint srcOffset, GCGLuint srcLengthOverride)
+void WebGL2RenderingContext::compressedTexImage3D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, ArrayBufferView& srcData, uint64_t srcOffset, GCGLuint srcLengthOverride)
 {
     if (isContextLost())
         return;
@@ -1240,7 +1240,7 @@ void WebGL2RenderingContext::compressedTexSubImage2D(GCGLenum target, GCGLint le
     protect(graphicsContextGL())->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, offset);
 }
 
-void WebGL2RenderingContext::compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, ArrayBufferView& srcData, GCGLuint srcOffset, GCGLuint srcLengthOverride)
+void WebGL2RenderingContext::compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, ArrayBufferView& srcData, uint64_t srcOffset, GCGLuint srcLengthOverride)
 {
     if (isContextLost())
         return;
@@ -1277,7 +1277,7 @@ void WebGL2RenderingContext::compressedTexSubImage3D(GCGLenum target, GCGLint le
     protect(graphicsContextGL())->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, offset);
 }
 
-void WebGL2RenderingContext::compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, ArrayBufferView& srcData, GCGLuint srcOffset, GCGLuint srcLengthOverride)
+void WebGL2RenderingContext::compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, ArrayBufferView& srcData, uint64_t srcOffset, GCGLuint srcLengthOverride)
 {
     if (isContextLost())
         return;
@@ -1334,7 +1334,7 @@ void WebGL2RenderingContext::uniform4ui(const WebGLUniformLocation* location, GC
     protect(graphicsContextGL())->uniform4ui(location->location(), v0, v1, v2, v3);
 }
 
-void WebGL2RenderingContext::uniform1uiv(const WebGLUniformLocation* location, Uint32List&& value, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniform1uiv(const WebGLUniformLocation* location, Uint32List&& value, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -1344,7 +1344,7 @@ void WebGL2RenderingContext::uniform1uiv(const WebGLUniformLocation* location, U
     protect(graphicsContextGL())->uniform1uiv(location->location(), data.value());
 }
 
-void WebGL2RenderingContext::uniform2uiv(const WebGLUniformLocation* location, Uint32List&& value, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniform2uiv(const WebGLUniformLocation* location, Uint32List&& value, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -1354,7 +1354,7 @@ void WebGL2RenderingContext::uniform2uiv(const WebGLUniformLocation* location, U
     protect(graphicsContextGL())->uniform2uiv(location->location(), data.value());
 }
 
-void WebGL2RenderingContext::uniform3uiv(const WebGLUniformLocation* location, Uint32List&& value, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniform3uiv(const WebGLUniformLocation* location, Uint32List&& value, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -1364,7 +1364,7 @@ void WebGL2RenderingContext::uniform3uiv(const WebGLUniformLocation* location, U
     protect(graphicsContextGL())->uniform3uiv(location->location(), data.value());
 }
 
-void WebGL2RenderingContext::uniform4uiv(const WebGLUniformLocation* location, Uint32List&& value, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniform4uiv(const WebGLUniformLocation* location, Uint32List&& value, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -1374,7 +1374,7 @@ void WebGL2RenderingContext::uniform4uiv(const WebGLUniformLocation* location, U
     protect(graphicsContextGL())->uniform4uiv(location->location(), data.value());
 }
 
-void WebGL2RenderingContext::uniformMatrix2x3fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniformMatrix2x3fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -1384,7 +1384,7 @@ void WebGL2RenderingContext::uniformMatrix2x3fv(const WebGLUniformLocation* loca
     protect(graphicsContextGL())->uniformMatrix2x3fv(location->location(), transpose, data.value());
 }
 
-void WebGL2RenderingContext::uniformMatrix3x2fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniformMatrix3x2fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -1394,7 +1394,7 @@ void WebGL2RenderingContext::uniformMatrix3x2fv(const WebGLUniformLocation* loca
     protect(graphicsContextGL())->uniformMatrix3x2fv(location->location(), transpose, data.value());
 }
 
-void WebGL2RenderingContext::uniformMatrix2x4fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniformMatrix2x4fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -1404,7 +1404,7 @@ void WebGL2RenderingContext::uniformMatrix2x4fv(const WebGLUniformLocation* loca
     protect(graphicsContextGL())->uniformMatrix2x4fv(location->location(), transpose, data.value());
 }
 
-void WebGL2RenderingContext::uniformMatrix4x2fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniformMatrix4x2fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -1414,7 +1414,7 @@ void WebGL2RenderingContext::uniformMatrix4x2fv(const WebGLUniformLocation* loca
     protect(graphicsContextGL())->uniformMatrix4x2fv(location->location(), transpose, data.value());
 }
 
-void WebGL2RenderingContext::uniformMatrix3x4fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniformMatrix3x4fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -1424,7 +1424,7 @@ void WebGL2RenderingContext::uniformMatrix3x4fv(const WebGLUniformLocation* loca
     protect(graphicsContextGL())->uniformMatrix3x4fv(location->location(), transpose, data.value());
 }
 
-void WebGL2RenderingContext::uniformMatrix4x3fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniformMatrix4x3fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -1458,8 +1458,7 @@ void WebGL2RenderingContext::vertexAttribI4iv(GCGLuint index, Int32List&& list)
         return;
     }
 
-    int size = list.length();
-    if (size < 4) {
+    if (data.size() < 4) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "vertexAttribI4iv"_s, "array too small"_s);
         return;
     }
@@ -1496,8 +1495,7 @@ void WebGL2RenderingContext::vertexAttribI4uiv(GCGLuint index, Uint32List&& list
         return;
     }
 
-    int size = list.length();
-    if (size < 4) {
+    if (data.size() < 4) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "vertexAttribI4uiv"_s, "array too small"_s);
         return;
     }
@@ -1660,7 +1658,7 @@ void WebGL2RenderingContext::drawBuffers(const Vector<GCGLenum>& buffers)
     }
 }
 
-void WebGL2RenderingContext::clearBufferiv(GCGLenum buffer, GCGLint drawbuffer, Int32List&& values, GCGLuint srcOffset)
+void WebGL2RenderingContext::clearBufferiv(GCGLenum buffer, GCGLint drawbuffer, Int32List&& values, uint64_t srcOffset)
 {
     if (isContextLost())
         return;
@@ -1675,7 +1673,7 @@ void WebGL2RenderingContext::clearBufferiv(GCGLenum buffer, GCGLint drawbuffer, 
     protect(graphicsContextGL())->clearBufferiv(buffer, drawbuffer, data.value());
 }
 
-void WebGL2RenderingContext::clearBufferuiv(GCGLenum buffer, GCGLint drawbuffer, Uint32List&& values, GCGLuint srcOffset)
+void WebGL2RenderingContext::clearBufferuiv(GCGLenum buffer, GCGLint drawbuffer, Uint32List&& values, uint64_t srcOffset)
 {
     if (isContextLost())
         return;
@@ -1689,7 +1687,7 @@ void WebGL2RenderingContext::clearBufferuiv(GCGLenum buffer, GCGLint drawbuffer,
     protect(graphicsContextGL())->clearBufferuiv(buffer, drawbuffer, data.value());
 }
 
-void WebGL2RenderingContext::clearBufferfv(GCGLenum buffer, GCGLint drawbuffer, Float32List&& values, GCGLuint srcOffset)
+void WebGL2RenderingContext::clearBufferfv(GCGLenum buffer, GCGLint drawbuffer, Float32List&& values, uint64_t srcOffset)
 {
     if (isContextLost())
         return;
@@ -3301,28 +3299,29 @@ bool WebGL2RenderingContext::validateCapability(ASCIILiteral functionName, GCGLe
 }
 
 template<typename T, typename TypedArrayType>
-std::optional<std::span<const T>> WebGL2RenderingContext::validateClearBuffer(ASCIILiteral functionName, GCGLenum buffer, TypedList<TypedArrayType, T>& values, GCGLuint srcOffset)
+std::optional<std::span<const T>> WebGL2RenderingContext::validateClearBuffer(ASCIILiteral functionName, GCGLenum buffer, TypedList<TypedArrayType, T>& values, uint64_t srcOffset)
 {
-    Checked<GCGLsizei, RecordOverflow> checkedSize(values.length());
-    checkedSize -= srcOffset;
-    if (checkedSize.hasOverflowed()) {
+    auto span = values.span();
+    if (srcOffset > span.size()) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "invalid array size / srcOffset"_s);
         return { };
     }
+    size_t offset = srcOffset;
+    size_t size = span.size() - offset;
     switch (buffer) {
     case GraphicsContextGL::COLOR:
-        if (checkedSize < 4) {
+        if (size < 4) {
             synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "invalid array size / srcOffset"_s);
             return { };
         }
-        return values.span().subspan(srcOffset, 4);
+        return span.subspan(offset, 4);
     case GraphicsContextGL::DEPTH:
     case GraphicsContextGL::STENCIL:
-        if (checkedSize < 1) {
+        if (size < 1) {
             synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "invalid array size / srcOffset"_s);
             return { };
         }
-        return values.span().subspan(srcOffset, 1);
+        return span.subspan(offset, 1);
 
     default:
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid buffer"_s);
@@ -3330,7 +3329,7 @@ std::optional<std::span<const T>> WebGL2RenderingContext::validateClearBuffer(AS
     }
 }
 
-void WebGL2RenderingContext::uniform1fv(const WebGLUniformLocation* location, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniform1fv(const WebGLUniformLocation* location, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -3340,7 +3339,7 @@ void WebGL2RenderingContext::uniform1fv(const WebGLUniformLocation* location, Fl
     protect(graphicsContextGL())->uniform1fv(location->location(), result.value());
 }
 
-void WebGL2RenderingContext::uniform2fv(const WebGLUniformLocation* location, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniform2fv(const WebGLUniformLocation* location, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -3350,7 +3349,7 @@ void WebGL2RenderingContext::uniform2fv(const WebGLUniformLocation* location, Fl
     protect(graphicsContextGL())->uniform2fv(location->location(), result.value());
 }
 
-void WebGL2RenderingContext::uniform3fv(const WebGLUniformLocation* location, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniform3fv(const WebGLUniformLocation* location, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -3360,7 +3359,7 @@ void WebGL2RenderingContext::uniform3fv(const WebGLUniformLocation* location, Fl
     protect(graphicsContextGL())->uniform3fv(location->location(), result.value());
 }
 
-void WebGL2RenderingContext::uniform4fv(const WebGLUniformLocation* location, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniform4fv(const WebGLUniformLocation* location, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -3370,7 +3369,7 @@ void WebGL2RenderingContext::uniform4fv(const WebGLUniformLocation* location, Fl
     protect(graphicsContextGL())->uniform4fv(location->location(), result.value());
 }
 
-void WebGL2RenderingContext::uniform1iv(const WebGLUniformLocation* location, Int32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniform1iv(const WebGLUniformLocation* location, Int32List&& data, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -3380,7 +3379,7 @@ void WebGL2RenderingContext::uniform1iv(const WebGLUniformLocation* location, In
     protect(graphicsContextGL())->uniform1iv(location->location(), result.value());
 }
 
-void WebGL2RenderingContext::uniform2iv(const WebGLUniformLocation* location, Int32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniform2iv(const WebGLUniformLocation* location, Int32List&& data, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -3390,7 +3389,7 @@ void WebGL2RenderingContext::uniform2iv(const WebGLUniformLocation* location, In
     protect(graphicsContextGL())->uniform2iv(location->location(), result.value());
 }
 
-void WebGL2RenderingContext::uniform3iv(const WebGLUniformLocation* location, Int32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniform3iv(const WebGLUniformLocation* location, Int32List&& data, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -3400,7 +3399,7 @@ void WebGL2RenderingContext::uniform3iv(const WebGLUniformLocation* location, In
     protect(graphicsContextGL())->uniform3iv(location->location(), result.value());
 }
 
-void WebGL2RenderingContext::uniform4iv(const WebGLUniformLocation* location, Int32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniform4iv(const WebGLUniformLocation* location, Int32List&& data, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -3410,7 +3409,7 @@ void WebGL2RenderingContext::uniform4iv(const WebGLUniformLocation* location, In
     protect(graphicsContextGL())->uniform4iv(location->location(), result.value());
 }
 
-void WebGL2RenderingContext::uniformMatrix2fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniformMatrix2fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -3420,7 +3419,7 @@ void WebGL2RenderingContext::uniformMatrix2fv(const WebGLUniformLocation* locati
     protect(graphicsContextGL())->uniformMatrix2fv(location->location(), transpose, result.value());
 }
 
-void WebGL2RenderingContext::uniformMatrix3fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniformMatrix3fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -3430,7 +3429,7 @@ void WebGL2RenderingContext::uniformMatrix3fv(const WebGLUniformLocation* locati
     protect(graphicsContextGL())->uniformMatrix3fv(location->location(), transpose, result.value());
 }
 
-void WebGL2RenderingContext::uniformMatrix4fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
+void WebGL2RenderingContext::uniformMatrix4fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (isContextLost())
         return;
@@ -3498,7 +3497,7 @@ void WebGL2RenderingContext::readPixels(GCGLint x, GCGLint y, GCGLsizei width, G
     protect(graphicsContextGL())->readPixelsBufferObject(rect, format, type, offsetAndSkip.value(), m_packParameters.alignment, m_packParameters.rowLength);
 }
 
-void WebGL2RenderingContext::readPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, ArrayBufferView& dstData, GCGLuint dstOffset)
+void WebGL2RenderingContext::readPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, ArrayBufferView& dstData, uint64_t dstOffset)
 {
     if (isContextLost())
         return;

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -55,10 +55,10 @@ public:
     // Buffer objects
     using WebGLRenderingContextBase::bufferData;
     using WebGLRenderingContextBase::bufferSubData;
-    void bufferData(GCGLenum target, const ArrayBufferView& data, GCGLenum usage, GCGLuint srcOffset, GCGLuint length);
-    void bufferSubData(GCGLenum target, long long offset, const ArrayBufferView& data, GCGLuint srcOffset, GCGLuint length);
+    void bufferData(GCGLenum target, const ArrayBufferView& data, GCGLenum usage, uint64_t srcOffset, GCGLuint length);
+    void bufferSubData(GCGLenum target, long long offset, const ArrayBufferView& data, uint64_t srcOffset, GCGLuint length);
     void copyBufferSubData(GCGLenum readTarget, GCGLenum writeTarget, GCGLint64 readOffset, GCGLint64 writeOffset, GCGLint64 size);
-    void getBufferSubData(GCGLenum target, long long srcByteOffset, RefPtr<ArrayBufferView>&& dstData, GCGLuint dstOffset = 0, GCGLuint length = 0);
+    void getBufferSubData(GCGLenum target, long long srcByteOffset, RefPtr<ArrayBufferView>&& dstData, uint64_t dstOffset = 0, GCGLuint length = 0);
     
     // Framebuffer objects
     WebGLAny getFramebufferAttachmentParameter(GCGLenum target, GCGLenum attachment, GCGLenum pname) final;
@@ -85,12 +85,12 @@ public:
     // WebGL 2.0 entry points:
     void texImage2D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, GCGLintptr offset);
     ExceptionOr<void> texImage2D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, TexImageSource&&);
-    void texImage2D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, GCGLuint srcOffset);
+    void texImage2D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, uint64_t srcOffset);
 
     void texImage3D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, GCGLint64 pboOffset);
     ExceptionOr<void> texImage3D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, TexImageSource&&);
     void texImage3D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& pixels);
-    void texImage3D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, GCGLuint srcOffset);
+    void texImage3D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, uint64_t srcOffset);
 
     // Must override the WebGL 1.0 signature to add extra validation.
     void texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&&) override;
@@ -98,10 +98,10 @@ public:
     // WebGL 2.0 entry points:
     void texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, GCGLintptr pboOffset);
     ExceptionOr<void> texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, TexImageSource&&);
-    void texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, GCGLuint srcOffset);
+    void texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, uint64_t srcOffset);
 
     void texSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, GCGLint64 pboOffset);
-    void texSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& pixels, GCGLuint srcOffset);
+    void texSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& pixels, uint64_t srcOffset);
     ExceptionOr<void> texSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, TexImageSource&&);
 
     void copyTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height);
@@ -110,18 +110,18 @@ public:
     void compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, ArrayBufferView& srcData);
     // WebGL 2.0 entry points:
     void compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLsizei imageSize, GCGLint64 offset);
-    void compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, ArrayBufferView& srcData, GCGLuint srcOffset, GCGLuint srcLengthOverride);
+    void compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, ArrayBufferView& srcData, uint64_t srcOffset, GCGLuint srcLengthOverride);
     void compressedTexImage3D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLsizei imageSize, GCGLint64 offset);
-    void compressedTexImage3D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, ArrayBufferView& srcData, GCGLuint srcOffset, GCGLuint srcLengthOverride);
+    void compressedTexImage3D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, ArrayBufferView& srcData, uint64_t srcOffset, GCGLuint srcLengthOverride);
 
     // Must override the WebGL 1.0 signature in order to add extra validation.
     void compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, ArrayBufferView& srcData);
     // WebGL 2.0 entry points:
     void compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLsizei imageSize, GCGLintptr offset);
-    void compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, ArrayBufferView& srcData, GCGLuint srcOffset, GCGLuint srcLengthOverride);
+    void compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, ArrayBufferView& srcData, uint64_t srcOffset, GCGLuint srcLengthOverride);
 
     void compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLsizei imageSize, GCGLint64 offset);
-    void compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, ArrayBufferView& srcData, GCGLuint srcOffset, GCGLuint srcLengthOverride);
+    void compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, ArrayBufferView& srcData, uint64_t srcOffset, GCGLuint srcLengthOverride);
 
     // Programs and shaders
     GCGLint getFragDataLocation(WebGLProgram&, const String& name);
@@ -133,16 +133,16 @@ public:
     void uniform2ui(const WebGLUniformLocation*, GCGLuint v0, GCGLuint v1);
     void uniform3ui(const WebGLUniformLocation*, GCGLuint v0, GCGLuint v1, GCGLuint v2);
     void uniform4ui(const WebGLUniformLocation*, GCGLuint v0, GCGLuint v1, GCGLuint v2, GCGLuint v3);
-    void uniform1uiv(const WebGLUniformLocation*, Uint32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniform2uiv(const WebGLUniformLocation*, Uint32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniform3uiv(const WebGLUniformLocation*, Uint32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniform4uiv(const WebGLUniformLocation*, Uint32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniformMatrix2x3fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& value, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniformMatrix3x2fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& value, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniformMatrix2x4fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& value, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniformMatrix4x2fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& value, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniformMatrix3x4fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& value, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniformMatrix4x3fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& value, GCGLuint srcOffset, GCGLuint srcLength);
+    void uniform1uiv(const WebGLUniformLocation*, Uint32List&& data, uint64_t srcOffset, GCGLuint srcLength);
+    void uniform2uiv(const WebGLUniformLocation*, Uint32List&& data, uint64_t srcOffset, GCGLuint srcLength);
+    void uniform3uiv(const WebGLUniformLocation*, Uint32List&& data, uint64_t srcOffset, GCGLuint srcLength);
+    void uniform4uiv(const WebGLUniformLocation*, Uint32List&& data, uint64_t srcOffset, GCGLuint srcLength);
+    void uniformMatrix2x3fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& value, uint64_t srcOffset, GCGLuint srcLength);
+    void uniformMatrix3x2fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& value, uint64_t srcOffset, GCGLuint srcLength);
+    void uniformMatrix2x4fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& value, uint64_t srcOffset, GCGLuint srcLength);
+    void uniformMatrix4x2fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& value, uint64_t srcOffset, GCGLuint srcLength);
+    void uniformMatrix3x4fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& value, uint64_t srcOffset, GCGLuint srcLength);
+    void uniformMatrix4x3fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& value, uint64_t srcOffset, GCGLuint srcLength);
     void vertexAttribI4i(GCGLuint index, GCGLint x, GCGLint y, GCGLint z, GCGLint w);
     void vertexAttribI4iv(GCGLuint index, Int32List&& v);
     void vertexAttribI4ui(GCGLuint index, GCGLuint x, GCGLuint y, GCGLuint z, GCGLuint w);
@@ -153,26 +153,26 @@ public:
     using WebGLRenderingContextBase::uniform2fv;
     using WebGLRenderingContextBase::uniform3fv;
     using WebGLRenderingContextBase::uniform4fv;
-    void uniform1fv(const WebGLUniformLocation*, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniform2fv(const WebGLUniformLocation*, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniform3fv(const WebGLUniformLocation*, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniform4fv(const WebGLUniformLocation*, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
+    void uniform1fv(const WebGLUniformLocation*, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength);
+    void uniform2fv(const WebGLUniformLocation*, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength);
+    void uniform3fv(const WebGLUniformLocation*, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength);
+    void uniform4fv(const WebGLUniformLocation*, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength);
 
     using WebGLRenderingContextBase::uniform1iv;
     using WebGLRenderingContextBase::uniform2iv;
     using WebGLRenderingContextBase::uniform3iv;
     using WebGLRenderingContextBase::uniform4iv;
-    void uniform1iv(const WebGLUniformLocation*, Int32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniform2iv(const WebGLUniformLocation*, Int32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniform3iv(const WebGLUniformLocation*, Int32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniform4iv(const WebGLUniformLocation*, Int32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
+    void uniform1iv(const WebGLUniformLocation*, Int32List&& data, uint64_t srcOffset, GCGLuint srcLength);
+    void uniform2iv(const WebGLUniformLocation*, Int32List&& data, uint64_t srcOffset, GCGLuint srcLength);
+    void uniform3iv(const WebGLUniformLocation*, Int32List&& data, uint64_t srcOffset, GCGLuint srcLength);
+    void uniform4iv(const WebGLUniformLocation*, Int32List&& data, uint64_t srcOffset, GCGLuint srcLength);
 
     using WebGLRenderingContextBase::uniformMatrix2fv;
     using WebGLRenderingContextBase::uniformMatrix3fv;
     using WebGLRenderingContextBase::uniformMatrix4fv;
-    void uniformMatrix2fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniformMatrix3fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
-    void uniformMatrix4fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength);
+    void uniformMatrix2fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength);
+    void uniformMatrix3fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength);
+    void uniformMatrix4fv(const WebGLUniformLocation*, GCGLboolean transpose, Float32List&& data, uint64_t srcOffset, GCGLuint srcLength);
 
     // Writing to the drawing buffer
     void vertexAttribDivisor(GCGLuint index, GCGLuint divisor);
@@ -182,9 +182,9 @@ public:
     
     // Multiple render targets
     void drawBuffers(const Vector<GCGLenum>& buffers);
-    void clearBufferiv(GCGLenum buffer, GCGLint drawbuffer, Int32List&& values, GCGLuint srcOffset);
-    void clearBufferuiv(GCGLenum buffer, GCGLint drawbuffer, Uint32List&& values, GCGLuint srcOffset);
-    void clearBufferfv(GCGLenum buffer, GCGLint drawbuffer, Float32List&& values, GCGLuint srcOffset);
+    void clearBufferiv(GCGLenum buffer, GCGLint drawbuffer, Int32List&& values, uint64_t srcOffset);
+    void clearBufferuiv(GCGLenum buffer, GCGLint drawbuffer, Uint32List&& values, uint64_t srcOffset);
+    void clearBufferfv(GCGLenum buffer, GCGLint drawbuffer, Float32List&& values, uint64_t srcOffset);
     void clearBufferfi(GCGLenum buffer, GCGLint drawbuffer, GCGLfloat depth, GCGLint stencil);
     
     // Query objects
@@ -249,7 +249,7 @@ public:
     // Must override the WebGL 1.0 signature in order to add extra validation.
     void readPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& pixels) override;
     void readPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, GCGLintptr offset);
-    void readPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, ArrayBufferView& dstData, GCGLuint dstOffset);
+    void readPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, ArrayBufferView& dstData, uint64_t dstOffset);
 
     GCGLuint NODELETE maxTransformFeedbackSeparateAttribs() const;
 
@@ -263,8 +263,8 @@ private:
     using WebGLRenderingContextBase::WebGLRenderingContextBase;
     void initializeContextState() WTF_REQUIRES_LOCK(objectGraphLock()) final;
 
-    RefPtr<ArrayBufferView> arrayBufferViewSliceFactory(ASCIILiteral functionName, const ArrayBufferView& data, unsigned startByte, unsigned bytelength);
-    RefPtr<ArrayBufferView> sliceArrayBufferView(ASCIILiteral functionName, const ArrayBufferView& data, GCGLuint srcOffset, GCGLuint length);
+    RefPtr<ArrayBufferView> arrayBufferViewSliceFactory(ASCIILiteral functionName, const ArrayBufferView& data, size_t startByte, size_t numElements);
+    RefPtr<ArrayBufferView> sliceArrayBufferView(ASCIILiteral functionName, const ArrayBufferView& data, uint64_t srcOffset, GCGLuint length);
 
     long long getInt64Parameter(GCGLenum) final;
     Vector<bool> getIndexedBooleanArrayParameter(GCGLenum pname, GCGLuint index);
@@ -280,7 +280,7 @@ private:
     GCGLint maxColorAttachments() final;
     bool validateCapability(ASCIILiteral functionName, GCGLenum cap) final;
     template<typename T, typename TypedArrayType>
-    std::optional<std::span<const T>> validateClearBuffer(ASCIILiteral functionName, GCGLenum buffer, TypedList<TypedArrayType, T>& values, GCGLuint srcOffset);
+    std::optional<std::span<const T>> validateClearBuffer(ASCIILiteral functionName, GCGLenum buffer, TypedList<TypedArrayType, T>& values, uint64_t srcOffset);
     bool validateFramebufferTarget(GCGLenum target) final;
     WebGLFramebuffer* getFramebufferBinding(GCGLenum target) final;
     bool validateNonDefaultFramebufferAttachment(ASCIILiteral functionName, GCGLenum attachment);

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
@@ -345,11 +345,11 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
     const GLenum MAX_CLIENT_WAIT_TIMEOUT_WEBGL                 = 0x9247;
 
     // Buffer objects.
-    undefined bufferData(GLenum target, [AllowShared] ArrayBufferView data, GLenum usage, GLuint srcOffset, optional GLuint length = 0);
-    undefined bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] ArrayBufferView srcData, GLuint srcOffset, optional GLuint length = 0);
+    undefined bufferData(GLenum target, [AllowShared] ArrayBufferView data, GLenum usage, unsigned long long srcOffset, optional GLuint length = 0);
+    undefined bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset, optional GLuint length = 0);
 
     undefined copyBufferSubData(GLenum readTarget, GLenum writeTarget, GLintptr readOffset, GLintptr writeOffset, GLsizeiptr size);
-    undefined getBufferSubData(GLenum target, GLintptr srcByteOffset, [AllowShared] ArrayBufferView dstData, optional GLuint dstOffset = 0, optional GLuint length = 0);
+    undefined getBufferSubData(GLenum target, GLintptr srcByteOffset, [AllowShared] ArrayBufferView dstData, optional unsigned long long dstOffset = 0, optional GLuint length = 0);
 
     // Framebuffer objects.
     undefined blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
@@ -369,18 +369,18 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
     undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, GLintptr pboOffset);
     undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, TexImageSource source);
     undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
-    undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, GLuint srcOffset);
+    undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset);
 
     undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, GLintptr pboOffset);
     undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, TexImageSource source);
-    undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, [AllowShared] ArrayBufferView? srcData, optional GLuint srcOffset = 0);
+    undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, [AllowShared] ArrayBufferView? srcData, optional unsigned long long srcOffset = 0);
 
     undefined copyTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLint x, GLint y, GLsizei width, GLsizei height);
 
     undefined compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, GLintptr offset);
-    undefined compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, [AllowShared] ArrayBufferView srcData, optional GLuint srcOffset = 0, optional GLuint srcLengthOverride = 0);
+    undefined compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, [AllowShared] ArrayBufferView srcData, optional unsigned long long srcOffset = 0, optional GLuint srcLengthOverride = 0);
     undefined compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLsizei imageSize, GLintptr offset);
-    undefined compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, [AllowShared] ArrayBufferView srcData, optional GLuint srcOffset = 0, optional GLuint srcLengthOverride = 0);
+    undefined compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, [AllowShared] ArrayBufferView srcData, optional unsigned long long srcOffset = 0, optional GLuint srcLengthOverride = 0);
 
     // Programs and shaders/
     GLint getFragDataLocation(WebGLProgram program, DOMString name);
@@ -390,16 +390,16 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
     undefined uniform2ui(WebGLUniformLocation? location, GLuint v0, GLuint v1);
     undefined uniform3ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2);
     undefined uniform4ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
-    undefined uniform1uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    undefined uniform2uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    undefined uniform3uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    undefined uniform4uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    undefined uniformMatrix2x3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    undefined uniformMatrix3x2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    undefined uniformMatrix2x4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    undefined uniformMatrix4x2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    undefined uniformMatrix3x4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    undefined uniformMatrix4x3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniform1uiv(WebGLUniformLocation? location, Uint32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniform2uiv(WebGLUniformLocation? location, Uint32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniform3uiv(WebGLUniformLocation? location, Uint32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniform4uiv(WebGLUniformLocation? location, Uint32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniformMatrix2x3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniformMatrix3x2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniformMatrix2x4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniformMatrix4x2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniformMatrix3x4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniformMatrix4x3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
     undefined vertexAttribI4i(GLuint index, GLint x, GLint y, GLint z, GLint w);
     undefined vertexAttribI4iv(GLuint index, Int32List values);
     undefined vertexAttribI4ui(GLuint index, GLuint x, GLuint y, GLuint z, GLuint w);
@@ -414,9 +414,9 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
 
     // Multiple Render Targets.
     undefined drawBuffers(sequence<GLenum> buffers);
-    undefined clearBufferiv(GLenum buffer, GLint drawbuffer, Int32List values, optional GLuint srcOffset = 0);
-    undefined clearBufferuiv(GLenum buffer, GLint drawbuffer, Uint32List values, optional GLuint srcOffset = 0);
-    undefined clearBufferfv(GLenum buffer, GLint drawbuffer, Float32List values, optional GLuint srcOffset = 0);
+    undefined clearBufferiv(GLenum buffer, GLint drawbuffer, Int32List values, optional unsigned long long srcOffset = 0);
+    undefined clearBufferuiv(GLenum buffer, GLint drawbuffer, Uint32List values, optional unsigned long long srcOffset = 0);
+    undefined clearBufferfv(GLenum buffer, GLint drawbuffer, Float32List values, optional unsigned long long srcOffset = 0);
     undefined clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
 
     // Query Objects.
@@ -478,34 +478,34 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
 
     undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, GLintptr pboOffset);
     undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, TexImageSource source);
-    undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, GLuint srcOffset);
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset);
 
     undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, GLintptr pboOffset);
     undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, TexImageSource source);
-    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, GLuint srcOffset);
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset);
 
     undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, GLintptr offset);
-    undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, [AllowShared] ArrayBufferView srcData, GLuint srcOffset, optional GLuint srcLengthOverride = 0);
+    undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset, optional GLuint srcLengthOverride = 0);
 
     undefined compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLsizei imageSize, GLintptr offset);
-    undefined compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, [AllowShared] ArrayBufferView srcData, GLuint srcOffset, optional GLuint srcLengthOverride = 0);
+    undefined compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset, optional GLuint srcLengthOverride = 0);
 
-    undefined uniform1fv(WebGLUniformLocation? location, Float32List data, GLuint srcOffset, optional GLuint srcLength = 0);
-    undefined uniform2fv(WebGLUniformLocation? location, Float32List data, GLuint srcOffset, optional GLuint srcLength = 0);
-    undefined uniform3fv(WebGLUniformLocation? location, Float32List data, GLuint srcOffset, optional GLuint srcLength = 0);
-    undefined uniform4fv(WebGLUniformLocation? location, Float32List data, GLuint srcOffset, optional GLuint srcLength = 0);
+    undefined uniform1fv(WebGLUniformLocation? location, Float32List data, unsigned long long srcOffset, optional GLuint srcLength = 0);
+    undefined uniform2fv(WebGLUniformLocation? location, Float32List data, unsigned long long srcOffset, optional GLuint srcLength = 0);
+    undefined uniform3fv(WebGLUniformLocation? location, Float32List data, unsigned long long srcOffset, optional GLuint srcLength = 0);
+    undefined uniform4fv(WebGLUniformLocation? location, Float32List data, unsigned long long srcOffset, optional GLuint srcLength = 0);
 
-    undefined uniform1iv(WebGLUniformLocation? location, Int32List data, GLuint srcOffset, optional GLuint srcLength = 0);
-    undefined uniform2iv(WebGLUniformLocation? location, Int32List data, GLuint srcOffset, optional GLuint srcLength = 0);
-    undefined uniform3iv(WebGLUniformLocation? location, Int32List data, GLuint srcOffset, optional GLuint srcLength = 0);
-    undefined uniform4iv(WebGLUniformLocation? location, Int32List data, GLuint srcOffset, optional GLuint srcLength = 0);
+    undefined uniform1iv(WebGLUniformLocation? location, Int32List data, unsigned long long srcOffset, optional GLuint srcLength = 0);
+    undefined uniform2iv(WebGLUniformLocation? location, Int32List data, unsigned long long srcOffset, optional GLuint srcLength = 0);
+    undefined uniform3iv(WebGLUniformLocation? location, Int32List data, unsigned long long srcOffset, optional GLuint srcLength = 0);
+    undefined uniform4iv(WebGLUniformLocation? location, Int32List data, unsigned long long srcOffset, optional GLuint srcLength = 0);
 
-    undefined uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, GLuint srcOffset, optional GLuint srcLength = 0);
-    undefined uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, GLuint srcOffset, optional GLuint srcLength = 0);
-    undefined uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, GLuint srcOffset, optional GLuint srcLength = 0);
+    undefined uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, unsigned long long srcOffset, optional GLuint srcLength = 0);
+    undefined uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, unsigned long long srcOffset, optional GLuint srcLength = 0);
+    undefined uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, unsigned long long srcOffset, optional GLuint srcLength = 0);
 
     undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLintptr offset);
-    undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView dstData, GLuint dstOffset);
+    undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView dstData, unsigned long long dstOffset);
 };
 
 WebGL2RenderingContext includes WebGLRenderingContextBase;

--- a/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
@@ -183,14 +183,14 @@ bool WebGLMultiDraw::validateDrawcount(WebGLRenderingContextBase& context, ASCII
     return true;
 }
 
-bool WebGLMultiDraw::validateOffset(WebGLRenderingContextBase& context, ASCIILiteral functionName, ASCIILiteral outOfBoundsDescription, GCGLsizei size, GCGLuint offset, GCGLsizei drawcount)
+bool WebGLMultiDraw::validateOffset(WebGLRenderingContextBase& context, ASCIILiteral functionName, ASCIILiteral outOfBoundsDescription, size_t size, GCGLuint offset, GCGLsizei drawcount)
 {
-    if (drawcount > size) {
+    if (static_cast<size_t>(drawcount) > size) {
         context.synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "drawcount out of bounds"_s);
         return false;
     }
 
-    if (offset > static_cast<GCGLuint>(size - drawcount)) {
+    if (offset > size - drawcount) {
         context.synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, outOfBoundsDescription);
         return false;
     }

--- a/Source/WebCore/html/canvas/WebGLMultiDraw.h
+++ b/Source/WebCore/html/canvas/WebGLMultiDraw.h
@@ -54,7 +54,7 @@ public:
 
 private:
     bool validateDrawcount(WebGLRenderingContextBase&, ASCIILiteral functionName, GCGLsizei drawcount);
-    bool validateOffset(WebGLRenderingContextBase&, ASCIILiteral functionName, ASCIILiteral outOfBoundsDescription, GCGLsizei, GCGLuint offset, GCGLsizei drawcount);
+    bool validateOffset(WebGLRenderingContextBase&, ASCIILiteral functionName, ASCIILiteral outOfBoundsDescription, size_t, GCGLuint offset, GCGLsizei drawcount);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
@@ -127,14 +127,14 @@ bool WebGLMultiDrawInstancedBaseVertexBaseInstance::validateDrawcount(WebGLRende
     return true;
 }
 
-bool WebGLMultiDrawInstancedBaseVertexBaseInstance::validateOffset(WebGLRenderingContextBase& context, ASCIILiteral functionName, ASCIILiteral outOfBoundsDescription, GCGLsizei size, GCGLuint offset, GCGLsizei drawcount)
+bool WebGLMultiDrawInstancedBaseVertexBaseInstance::validateOffset(WebGLRenderingContextBase& context, ASCIILiteral functionName, ASCIILiteral outOfBoundsDescription, size_t size, GCGLuint offset, GCGLsizei drawcount)
 {
-    if (drawcount > size) {
+    if (static_cast<size_t>(drawcount) > size) {
         context.synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "drawcount out of bounds"_s);
         return false;
     }
 
-    if (offset > static_cast<GCGLuint>(size - drawcount)) {
+    if (offset > size - drawcount) {
         context.synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, outOfBoundsDescription);
         return false;
     }

--- a/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.h
+++ b/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.h
@@ -51,7 +51,7 @@ public:
 
 private:
     bool validateDrawcount(WebGLRenderingContextBase&, ASCIILiteral functionName, GCGLsizei drawcount);
-    bool validateOffset(WebGLRenderingContextBase&, ASCIILiteral functionName, ASCIILiteral outOfBoundsDescription, GCGLsizei, GCGLuint offset, GCGLsizei drawcount);
+    bool validateOffset(WebGLRenderingContextBase&, ASCIILiteral functionName, ASCIILiteral outOfBoundsDescription, size_t, GCGLuint offset, GCGLsizei drawcount);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3485,7 +3485,7 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSource(TexImageFunctionID f
 }
 #endif
 
-void WebGLRenderingContextBase::texImageArrayBufferViewHelper(TexImageFunctionID functionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, RefPtr<ArrayBufferView>&& pixels, NullDisposition nullDisposition, GCGLuint srcOffset)
+void WebGLRenderingContextBase::texImageArrayBufferViewHelper(TexImageFunctionID functionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, RefPtr<ArrayBufferView>&& pixels, NullDisposition nullDisposition, uint64_t srcOffset)
 {
     if (isContextLost())
         return;
@@ -3879,7 +3879,7 @@ bool WebGLRenderingContextBase::validateImageFormatAndType(ASCIILiteral function
     return true;
 }
 
-std::optional<std::span<const uint8_t>> WebGLRenderingContextBase::validateTexFuncData(ASCIILiteral functionName, TexImageDimension texDimension, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, ArrayBufferView* pixels, NullDisposition disposition, GCGLuint srcOffset)
+std::optional<std::span<const uint8_t>> WebGLRenderingContextBase::validateTexFuncData(ASCIILiteral functionName, TexImageDimension texDimension, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, ArrayBufferView* pixels, NullDisposition disposition, uint64_t srcOffset)
 {
     // All calling functions check isContextLost, so a duplicate check is not
     // needed here.
@@ -3907,8 +3907,16 @@ std::optional<std::span<const uint8_t>> WebGLRenderingContextBase::validateTexFu
         return std::nullopt;
     }
 
+    // An offset a size_t cannot hold is past the end of any view. Narrowing it here also keeps the
+    // arithmetic below in one width: Checked's result type for mixed widths differs between platforms.
+    if (!isInBounds<size_t>(srcOffset)) {
+        synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "ArrayBufferView not big enough for request"_s);
+        return std::nullopt;
+    }
+    size_t offsetInElements = srcOffset;
+
     auto dataLength = CheckedSize { packSizes->imageBytes } + packSizes->initialSkipBytes;
-    auto offset = CheckedSize { pixels ? JSC::elementSize(pixels->getType()) : 0 } * srcOffset;
+    auto offset = CheckedSize { pixels ? JSC::elementSize(pixels->getType()) : 0 } * offsetInElements;
     auto total = offset + dataLength;
     if (total.hasOverflowed() || !isInBounds<GCGLsizei>(dataLength)) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "image too large"_s);
@@ -5055,11 +5063,12 @@ bool WebGLRenderingContextBase::validateCapability(ASCIILiteral functionName, GC
 }
 
 template<typename T, typename TypedListType>
-std::optional<std::span<const T>> WebGLRenderingContextBase::validateUniformMatrixParameters(ASCIILiteral functionName, const WebGLUniformLocation* location, GCGLboolean transpose, const TypedList<TypedListType, T>& values, GCGLsizei requiredMinSize, GCGLuint srcOffset, GCGLuint srcLength)
+std::optional<std::span<const T>> WebGLRenderingContextBase::validateUniformMatrixParameters(ASCIILiteral functionName, const WebGLUniformLocation* location, GCGLboolean transpose, const TypedList<TypedListType, T>& values, GCGLsizei requiredMinSize, uint64_t srcOffset, GCGLuint srcLength)
 {
     if (!validateUniformLocation(functionName, location))
         return { };
-    if (!values.data()) {
+    auto span = values.span();
+    if (!span.data()) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "no array"_s);
         return { };
     }
@@ -5067,33 +5076,35 @@ std::optional<std::span<const T>> WebGLRenderingContextBase::validateUniformMatr
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "transpose not FALSE"_s);
         return { };
     }
-    if (srcOffset >= static_cast<GCGLuint>(values.length())) {
+    if (srcOffset >= span.size()) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "invalid srcOffset"_s);
         return { };
     }
-    GCGLsizei actualSize = values.length() - srcOffset;
+    size_t offset = srcOffset;
+    size_t actualSize = span.size() - offset;
     if (srcLength > 0) {
-        if (srcLength > static_cast<GCGLuint>(actualSize)) {
+        if (srcLength > actualSize) {
             synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "invalid srcOffset + srcLength"_s);
             return { };
         }
         actualSize = srcLength;
     }
-    if (actualSize < requiredMinSize || (actualSize % requiredMinSize)) {
+    // The element count reaches GL as a GCGLsizei, so a longer run cannot be expressed.
+    if (actualSize < static_cast<size_t>(requiredMinSize) || (actualSize % requiredMinSize) || !isInBounds<GCGLsizei>(actualSize)) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "invalid size"_s);
         return { };
     }
-    return values.span().subspan(srcOffset, actualSize);
+    return span.subspan(offset, actualSize);
 }
 
 template
-std::optional<std::span<const GCGLuint>> WebGLRenderingContextBase::validateUniformMatrixParameters<GCGLuint, Uint32Array>(ASCIILiteral functionName, const WebGLUniformLocation*, GCGLboolean transpose, const TypedList<Uint32Array, uint32_t>& values, GCGLsizei requiredMinSize, GCGLuint srcOffset, GCGLuint srcLength);
+std::optional<std::span<const GCGLuint>> WebGLRenderingContextBase::validateUniformMatrixParameters<GCGLuint, Uint32Array>(ASCIILiteral functionName, const WebGLUniformLocation*, GCGLboolean transpose, const TypedList<Uint32Array, uint32_t>& values, GCGLsizei requiredMinSize, uint64_t srcOffset, GCGLuint srcLength);
 
 template
-std::optional<std::span<const GCGLint>> WebGLRenderingContextBase::validateUniformMatrixParameters<GCGLint, Int32Array>(ASCIILiteral functionName, const WebGLUniformLocation*, GCGLboolean transpose, const TypedList<Int32Array, int32_t>& values, GCGLsizei requiredMinSize, GCGLuint srcOffset, GCGLuint srcLength);
+std::optional<std::span<const GCGLint>> WebGLRenderingContextBase::validateUniformMatrixParameters<GCGLint, Int32Array>(ASCIILiteral functionName, const WebGLUniformLocation*, GCGLboolean transpose, const TypedList<Int32Array, int32_t>& values, GCGLsizei requiredMinSize, uint64_t srcOffset, GCGLuint srcLength);
 
 template
-std::optional<std::span<const GCGLfloat>> WebGLRenderingContextBase::validateUniformMatrixParameters<GCGLfloat, Float32Array>(ASCIILiteral functionName, const WebGLUniformLocation*, GCGLboolean transpose, const TypedList<Float32Array, float>& values, GCGLsizei requiredMinSize, GCGLuint srcOffset, GCGLuint srcLength);
+std::optional<std::span<const GCGLfloat>> WebGLRenderingContextBase::validateUniformMatrixParameters<GCGLfloat, Float32Array>(ASCIILiteral functionName, const WebGLUniformLocation*, GCGLboolean transpose, const TypedList<Float32Array, float>& values, GCGLsizei requiredMinSize, uint64_t srcOffset, GCGLuint srcLength);
 
 RefPtr<WebGLBuffer> WebGLRenderingContextBase::validateBufferDataParameters(ASCIILiteral functionName, GCGLenum target, GCGLenum usage)
 {
@@ -5215,8 +5226,7 @@ void WebGLRenderingContextBase::vertexAttribfvImpl(ASCIILiteral functionName, GC
         return;
     }
 
-    int size = list.length();
-    if (size < expectedSize) {
+    if (data.size() < static_cast<size_t>(expectedSize)) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "invalid size"_s);
         return;
     }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -361,11 +361,11 @@ public:
             );
         }
 
-        GCGLsizei length() const
+        size_t length() const
         {
             return WTF::switchOn(m_variant,
-                [](const Ref<TypedArray>& typedArray) -> GCGLsizei { return typedArray->length(); },
-                [](const Vector<DataType>& vector) -> GCGLsizei { return vector.size(); }
+                [](const Ref<TypedArray>& typedArray) -> size_t { return typedArray->length(); },
+                [](const Vector<DataType>& vector) -> size_t { return vector.size(); }
             );
         }
 
@@ -862,7 +862,7 @@ protected:
     IntRect NODELETE getImageDataSize(ImageData*);
 
     ExceptionOr<void> texImageSourceHelper(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, const IntRect& sourceImageRect, GCGLsizei depth, GCGLint unpackImageHeight, TexImageSource&&);
-    void texImageArrayBufferViewHelper(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, RefPtr<ArrayBufferView>&& pixels, NullDisposition, GCGLuint srcOffset);
+    void texImageArrayBufferViewHelper(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, RefPtr<ArrayBufferView>&& pixels, NullDisposition, uint64_t srcOffset);
     void texImageImpl(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLenum format, GCGLenum type, Image&, GraphicsContextGL::DOMSource, bool flipY, bool premultiplyAlpha, bool ignoreNativeImageAlphaPremultiplication, const IntRect&, GCGLsizei depth, GCGLint unpackImageHeight);
     void texImage2DBase(GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, std::span<const uint8_t> pixels);
     void texSubImage2DBase(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum internalFormat, GCGLenum format, GCGLenum type, std::span<const uint8_t> pixels);
@@ -944,7 +944,7 @@ protected:
         GCGLenum format, GCGLenum type,
         ArrayBufferView* pixels,
         NullDisposition,
-        GCGLuint srcOffset);
+        uint64_t srcOffset);
 
     // Helper function to validate a given texture format is settable as in
     // you can supply data to texImage2D, or call texImage2D, copyTexImage2D and
@@ -976,12 +976,12 @@ protected:
     // Helper function to validate input parameters for uniform functions.
     bool validateUniformLocation(ASCIILiteral functionName, const WebGLUniformLocation*);
     template<typename T, typename TypedListType>
-    std::optional<std::span<const T>> validateUniformParameters(ASCIILiteral functionName, const WebGLUniformLocation* location, const TypedList<TypedListType, T>& values, GCGLsizei requiredMinSize, GCGLuint srcOffset = 0, GCGLuint srcLength = 0)
+    std::optional<std::span<const T>> validateUniformParameters(ASCIILiteral functionName, const WebGLUniformLocation* location, const TypedList<TypedListType, T>& values, GCGLsizei requiredMinSize, uint64_t srcOffset = 0, GCGLuint srcLength = 0)
     {
         return validateUniformMatrixParameters(functionName, location, false, values, requiredMinSize, srcOffset, srcLength);
     }
     template<typename T, typename TypedListType>
-    std::optional<std::span<const T>> validateUniformMatrixParameters(ASCIILiteral functionName, const WebGLUniformLocation*, GCGLboolean transpose, const TypedList<TypedListType, T>&, GCGLsizei requiredMinSize, GCGLuint srcOffset = 0, GCGLuint srcLength = 0);
+    std::optional<std::span<const T>> validateUniformMatrixParameters(ASCIILiteral functionName, const WebGLUniformLocation*, GCGLboolean transpose, const TypedList<TypedListType, T>&, GCGLsizei requiredMinSize, uint64_t srcOffset = 0, GCGLuint srcLength = 0);
 
     // Helper function to validate parameters for bufferData.
     // Return the current bound buffer to target, or 0 if parameters are invalid.

--- a/Source/WebCore/platform/graphics/iso/ISOBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOBox.cpp
@@ -39,8 +39,18 @@ ISOBox::ISOBox() = default;
 ISOBox::~ISOBox() = default;
 ISOBox::ISOBox(const ISOBox&) = default;
 
+// A box's size field and the cursor these parsers walk it with are both 32-bit, so a larger view
+// cannot be walked at all: its remaining length would not even be representable.
+static bool isWalkableView(const DataView& view)
+{
+    return isInBounds<unsigned>(view.byteLength());
+}
+
 ISOBox::PeekResult ISOBox::peekBox(DataView& view, unsigned offset)
 {
+    if (!isWalkableView(view))
+        return std::nullopt;
+
     unsigned maximumPossibleSize = view.byteLength() - offset;
     uint64_t size = 0;
     if (!checkedRead<uint32_t>(size, view, offset, BigEndian))
@@ -79,6 +89,9 @@ bool ISOBox::read(DataView& view, unsigned& offset)
 
 bool ISOBox::parse(DataView& view, unsigned& offset)
 {
+    if (!isWalkableView(view))
+        return false;
+
     unsigned maximumPossibleSize = view.byteLength() - offset;
     if (!checkedRead<uint32_t>(m_size, view, offset, BigEndian))
         return false;

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -224,7 +224,7 @@ void WebSocketChannel::send(CString&& message)
     m_messageQueue->enqueue(WTF::move(message));
 }
 
-void WebSocketChannel::send(const JSC::ArrayBuffer& binaryData, unsigned byteOffset, unsigned byteLength)
+void WebSocketChannel::send(const JSC::ArrayBuffer& binaryData, size_t byteOffset, size_t byteLength)
 {
     if (!increaseBufferedAmount(byteLength))
         return;

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.h
@@ -70,7 +70,7 @@ private:
     String subprotocol() final;
     String extensions() final;
     void send(CString&&) final;
-    void send(const JSC::ArrayBuffer&, unsigned byteOffset, unsigned byteLength) final;
+    void send(const JSC::ArrayBuffer&, size_t byteOffset, size_t byteLength) final;
     void send(WebCore::Blob&) final;
     void close(int code, const String& reason) final;
     void fail(String&& reason) final;

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -159,12 +159,12 @@ void WebSocketChannel::send(CString&& message)
     processOutgoingFrameQueue();
 }
 
-void WebSocketChannel::send(const ArrayBuffer& binaryData, unsigned byteOffset, unsigned byteLength)
+void WebSocketChannel::send(const ArrayBuffer& binaryData, size_t byteOffset, size_t byteLength)
 {
     if (m_outgoingFrameQueueStatus != OutgoingFrameQueueOpen)
         return;
 
-    LOG(Network, "WebSocketChannel %p send() Sending ArrayBuffer %p byteOffset=%u byteLength=%u", this, &binaryData, byteOffset, byteLength);
+    LOG(Network, "WebSocketChannel %p send() Sending ArrayBuffer %p byteOffset=%zu byteLength=%zu", this, &binaryData, byteOffset, byteLength);
     enqueueRawFrame(WebSocketFrame::OpCodeBinary, binaryData.span().subspan(byteOffset, byteLength));
     processOutgoingFrameQueue();
 }

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
@@ -80,7 +80,7 @@ public:
     String subprotocol() final;
     String extensions() final;
     void send(CString&&) final;
-    void send(const JSC::ArrayBuffer&, unsigned byteOffset, unsigned byteLength) final;
+    void send(const JSC::ArrayBuffer&, size_t byteOffset, size_t byteLength) final;
     void send(Blob&) final;
     void close(int code, const String& reason) final; // Start closing handshake.
     void fail(String&& reason) final;
@@ -190,7 +190,7 @@ private:
     Timer m_closingTimer;
     bool m_closed { false };
     bool m_shouldDiscardReceivedData { false };
-    unsigned m_unhandledBufferedAmount { 0 };
+    uint64_t m_unhandledBufferedAmount { 0 };
 
     WebSocketChannelIdentifier m_progressIdentifier;
 

--- a/Source/bmalloc/bmalloc/Gigacage.h
+++ b/Source/bmalloc/bmalloc/Gigacage.h
@@ -60,9 +60,17 @@ constexpr bool hasCapacityToUseLargeGigacage = false;
 constexpr bool hasCapacityToUseLargeGigacage = true;
 #endif
 
+// How much address space this process will hand out for Primitive allocations in total. Where there
+// is a Gigacage this is the size of the cage; where there is not, the same figure still tracks what
+// the platform can spare, so clients that must bound a reservation can use it either way. It exceeds
+// what size_t can hold where size_t is 32 bits, hence uint64_t.
+constexpr uint64_t primitiveAddressSpaceBudget = (hasCapacityToUseLargeGigacage ? 64 : 16) * static_cast<uint64_t>(bmalloc::Sizes::GB);
+
 #if GIGACAGE_ENABLED
 
-constexpr size_t primitiveGigacageSize = (hasCapacityToUseLargeGigacage ? 64 : 16) * bmalloc::Sizes::GB;
+// A cage is a real mapping, so it only exists on a platform whose size_t can address the whole budget.
+static_assert(primitiveAddressSpaceBudget == static_cast<size_t>(primitiveAddressSpaceBudget));
+constexpr size_t primitiveGigacageSize = static_cast<size_t>(primitiveAddressSpaceBudget);
 constexpr size_t maximumCageSizeReductionForSlide = hasCapacityToUseLargeGigacage ? 4 * bmalloc::Sizes::GB : bmalloc::Sizes::GB / 4;
 
 


### PR DESCRIPTION
#### 2c2c1af3574308929fecb71bc1897b8f6b04dc2e
<pre>
[JSC] Overhaul ArrayBuffer &amp; Wasm::Memory sizing with memory64
<a href="https://bugs.webkit.org/show_bug.cgi?id=321182">https://bugs.webkit.org/show_bug.cgi?id=321182</a>
<a href="https://rdar.apple.com/184241045">rdar://184241045</a>

Reviewed by Yijia Huang.

Currently memory64 crashes when growing a shared buffer more than 4GB.
We have an inconsistency in our current implementation in terms of
size. ArrayBuffer&apos;s maximum size is right now 4GB, but Wasm::Memory&apos;s
maximum reserved size is 2^37-1 pages, which is way more than the
actually usable memory (8PB).

This patch overhauls the design and the limit of ArrayBuffer / Wasm::Memory
sizing.

1. Now ArrayBuffer max size is bumped from 4GB to 16GB, aligning to V8&apos;s
   number. Also this 16GB is aligned to the spec&apos;s limit size[1].
   &quot;The maximum size of a 64-bit memory is 262,144 pages (16 GiB).&quot;
   Because of our LARGE_TYPED_ARRAYS work, size of ArrayBuffer can be
   larger than 4GB already, so changing this is not hard. On 32bit
   environment, no threshold change is done.
2. We introduce a limit for memory32 and memory64 based on the spec[1].
   4GB for memory32 and 16GB for memory64.
3. We also found that some of WebCore side is truncating size of
   ArrayBuffer to `unsinged` (32bit) while it can be 64bit size before
   this change. They are semantically incorrect but it is fine (just
   only handling small sized part), but anyway, fixing them.
4. Also avoid calling GC while taking a lock of BufferMemoryHandle.
5. This also revealed many of WebGL issues too, where it is not using
   `unsinged long long` while spec requires so. This patch fixes them
   too as they started becoming failures after ArrayBuffer can get
   larger size than 32bit.

Three web-visible behavior changes fall out of this:

1. A memory64 may now declare a maximum of at most 262144 pages, down from
   PageCount&apos;s own 2^37-1. A module declaring more used to compile and
   instantiate at its initial size and now fails WebAssembly.Module(), which
   matches V8&apos;s kV8MaxWasmMemory64Pages. JSTests/wasm/v8/memory64.js&apos;s two
   tests for this are re-enabled.
2. A memory&apos;s buffer reports the maximum this platform could actually grow it
   to, rather than the one the address type permits declaring, so that a resize
   within maxByteLength never fails deterministically. The two differ wherever
   the Primitive address space budget is the tighter bound.
3. RTCPeerConnection.generateCertificate() reads publicExponent as the big
   endian WebCrypto BigInteger it is, rather than little endian, and accepts
   arbitrary leading zero padding. WebSocket.send() now fails the connection
   for a binary payload too large to frame instead of dropping it or crashing.

[1]: <a href="https://www.w3.org/TR/wasm-js-api-2/#limits">https://www.w3.org/TR/wasm-js-api-2/#limits</a>

Tests: JSTests/stress/array-buffer-slice-larger-than-4gb.js
       JSTests/wasm/stress/memory64-grow-past-4gb.js
       JSTests/wasm/stress/memory64-maximum-limits.js
       webrtc/generate-certificate-public-exponent.html

* JSTests/stress/array-buffer-slice-larger-than-4gb.js: Added.
(shouldBe):
* JSTests/stress/shared-array-buffer-large-maxbytelength.js:
(catch):
* JSTests/stress/typedarray-canonical-numeric-index-string-past-max-array-index.js: Added.
(shouldBe):
(const.key.of.keys.array.key.valueOf):
* JSTests/stress/typedarray-index-past-max-array-index.js: Added.
(shouldBe):
(catch):
(array.undefined.String):
* JSTests/wasm/js-api/memory-toResizableBuffer.js:
(assertTrue):
* JSTests/wasm/js-api/memory64-js-api-errors.js:
(assert.throws):
* JSTests/wasm/js-api/memory64-js-api.js:
(assert.throws):
* JSTests/wasm/stress/memory64-grow-past-4gb.js: Added.
(catch):
(true.try.mem.await.instantiate.module.memory):
(true.catch):
(true.canHostPastFourGiB.catch):
(assert.throws.grow):
* JSTests/wasm/stress/memory64-maximum-limits.js: Added.
(true.try.mem.await.instantiate.module.memory):
(true.catch):
* JSTests/wasm/stress/memory64-oversized-limits.js:
(moduleBytesWithMemoryLimits):
* JSTests/wasm/v8/memory64.js:
(BasicMemory64Tests):
(TestBulkMemoryOperations): Deleted.
* LayoutTests/fast/canvas/webgl/array-unit-tests.html:
* LayoutTests/fast/canvas/webgl/webgl-array-invalid-ranges.html:
* LayoutTests/fast/canvas/webgl/webgl2-array-buffer-view-offset-past-32-bits-expected.txt: Added.
* LayoutTests/fast/canvas/webgl/webgl2-array-buffer-view-offset-past-32-bits.html: Added.
* LayoutTests/http/tests/websocket/tests/hybi/bufferedAmount-past-32-bits-after-close-expected.txt: Added.
* LayoutTests/http/tests/websocket/tests/hybi/bufferedAmount-past-32-bits-after-close.html: Added.
* LayoutTests/webrtc/generate-certificate-public-exponent-expected.txt: Added.
* LayoutTests/webrtc/generate-certificate-public-exponent.html: Added.
* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::tryAllocateResizableMemory):
(JSC::ArrayBuffer::resize):
(JSC::SharedArrayBufferContents::grow):
(JSC::SharedArrayBufferContents::tryGrow):
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp:
(JSC::BufferMemoryHandle::fastMappedBytes):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.h:
* Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp:
(JSC::arrayBufferSlice):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::getOwnPropertySlot):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::put):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::defineOwnProperty):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::deleteProperty):
* Source/JavaScriptCore/runtime/PageCount.h:
* Source/JavaScriptCore/runtime/PropertyName.h:
(JSC::isCanonicalNumericIndexString):
* Source/JavaScriptCore/wasm/WasmAddressType.cpp:
* Source/JavaScriptCore/wasm/WasmAddressType.h:
(JSC::Wasm::AddressType::AddressType):
(JSC::Wasm::AddressType::is64Bit const):
* Source/JavaScriptCore/wasm/WasmLimits.h:
(JSC::Wasm::maxDeclarablePages):
(JSC::Wasm::maxBufferByteLength):
(JSC::Wasm::static_assert):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::maxAllocatableBytes):
(JSC::Wasm::Memory::tryCreate):
(JSC::Wasm::Memory::growShared):
(JSC::Wasm::Memory::grow):
* Source/JavaScriptCore/wasm/WasmMemory.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseMemoryHelper):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp:
(JSC::JSWebAssemblyMemory::associateArrayBuffer):
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp:
(JSC::WebAssemblyMemoryConstructor::createMemoryFromDescriptor):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::certificateTypeFromAlgorithmIdentifier):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.h:
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.cpp:
(WebCore::ThreadableWebSocketChannelClientWrapper::didUpdateBufferedAmount):
(WebCore::ThreadableWebSocketChannelClientWrapper::didClose):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h:
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::saturateAdd):
(WebCore::isFramablePayloadSize):
(WebCore::WebSocket::send):
(WebCore::WebSocket::bufferedAmount const):
(WebCore::WebSocket::didUpdateBufferedAmount):
(WebCore::WebSocket::didClose):
* Source/WebCore/Modules/websockets/WebSocket.h:
* Source/WebCore/Modules/websockets/WebSocket.idl:
* Source/WebCore/Modules/websockets/WebSocketChannelClient.h:
* Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp:
(WebCore::WorkerThreadableWebSocketChannel::send):
(WebCore::WorkerThreadableWebSocketChannel::Peer::didUpdateBufferedAmount):
(WebCore::WorkerThreadableWebSocketChannel::Peer::didClose):
(WebCore::WorkerThreadableWebSocketChannel::Bridge::send):
* Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.h:
* Source/WebCore/css/FontFace.cpp:
(WebCore::FontFace::create):
* Source/WebCore/fileapi/NetworkSendQueue.cpp:
(WebCore::NetworkSendQueue::enqueue):
* Source/WebCore/fileapi/NetworkSendQueue.h:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::arrayBufferViewSliceFactory):
(WebCore::WebGL2RenderingContext::sliceArrayBufferView):
(WebCore::WebGL2RenderingContext::bufferData):
(WebCore::WebGL2RenderingContext::bufferSubData):
(WebCore::WebGL2RenderingContext::getBufferSubData):
(WebCore::WebGL2RenderingContext::texImage2D):
(WebCore::WebGL2RenderingContext::texImage3D):
(WebCore::WebGL2RenderingContext::texSubImage2D):
(WebCore::WebGL2RenderingContext::texSubImage3D):
(WebCore::WebGL2RenderingContext::compressedTexImage2D):
(WebCore::WebGL2RenderingContext::compressedTexImage3D):
(WebCore::WebGL2RenderingContext::compressedTexSubImage2D):
(WebCore::WebGL2RenderingContext::compressedTexSubImage3D):
(WebCore::WebGL2RenderingContext::uniform1uiv):
(WebCore::WebGL2RenderingContext::uniform2uiv):
(WebCore::WebGL2RenderingContext::uniform3uiv):
(WebCore::WebGL2RenderingContext::uniform4uiv):
(WebCore::WebGL2RenderingContext::uniformMatrix2x3fv):
(WebCore::WebGL2RenderingContext::uniformMatrix3x2fv):
(WebCore::WebGL2RenderingContext::uniformMatrix2x4fv):
(WebCore::WebGL2RenderingContext::uniformMatrix4x2fv):
(WebCore::WebGL2RenderingContext::uniformMatrix3x4fv):
(WebCore::WebGL2RenderingContext::uniformMatrix4x3fv):
(WebCore::WebGL2RenderingContext::vertexAttribI4iv):
(WebCore::WebGL2RenderingContext::vertexAttribI4uiv):
(WebCore::WebGL2RenderingContext::clearBufferiv):
(WebCore::WebGL2RenderingContext::clearBufferuiv):
(WebCore::WebGL2RenderingContext::clearBufferfv):
(WebCore::WebGL2RenderingContext::validateClearBuffer):
(WebCore::WebGL2RenderingContext::uniform1fv):
(WebCore::WebGL2RenderingContext::uniform2fv):
(WebCore::WebGL2RenderingContext::uniform3fv):
(WebCore::WebGL2RenderingContext::uniform4fv):
(WebCore::WebGL2RenderingContext::uniform1iv):
(WebCore::WebGL2RenderingContext::uniform2iv):
(WebCore::WebGL2RenderingContext::uniform3iv):
(WebCore::WebGL2RenderingContext::uniform4iv):
(WebCore::WebGL2RenderingContext::uniformMatrix2fv):
(WebCore::WebGL2RenderingContext::uniformMatrix3fv):
(WebCore::WebGL2RenderingContext::uniformMatrix4fv):
(WebCore::WebGL2RenderingContext::readPixels):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGL2RenderingContext.idl:
* Source/WebCore/html/canvas/WebGLMultiDraw.cpp:
(WebCore::WebGLMultiDraw::validateOffset):
* Source/WebCore/html/canvas/WebGLMultiDraw.h:
* Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp:
(WebCore::WebGLMultiDrawInstancedBaseVertexBaseInstance::validateOffset):
* Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageArrayBufferViewHelper):
(WebCore::WebGLRenderingContextBase::validateTexFuncData):
(WebCore::WebGLRenderingContextBase::validateUniformMatrixParameters):
(WebCore::WebGLRenderingContextBase::vertexAttribfvImpl):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::TypedList::length const):
(WebCore::WebGLRenderingContextBase::validateUniformParameters):
* Source/WebCore/platform/graphics/iso/ISOBox.cpp:
(WebCore::isWalkableView):
(WebCore::ISOBox::peekBox):
(WebCore::ISOBox::parse):
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::send):
* Source/WebKit/WebProcess/Network/WebSocketChannel.h:
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::send):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h:
* Source/bmalloc/bmalloc/Gigacage.h:

Canonical link: <a href="https://commits.webkit.org/318784@main">https://commits.webkit.org/318784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/271956585f1a19f1477f6f672d61c0bea17dc4f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189179 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9cd1558b-b95d-4042-85cb-58021e9772f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139868 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2c3c399-b03a-45fd-89de-fe9d830b1102) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120320 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5f58720-604b-4c7e-afb5-ae1101ec2c5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42133 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40465 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2290 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9092 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152533 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40112 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/630 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40622 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45892 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44712 "Found 1 new test failure: imported/w3c/web-platform-tests/payment-request/rejects_if_not_active.https.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191397 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149113 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53637 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148856 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27222 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43531 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125909 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120771 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52154 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15098 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51539 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51780 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51600 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->