### PR TITLE
Unreviewed, build fix for JSCOnly

### DIFF
--- a/Source/WTF/wtf/linux/HighPriorityThreads.cpp
+++ b/Source/WTF/wtf/linux/HighPriorityThreads.cpp
@@ -41,8 +41,10 @@
 
 namespace WTF {
 
+#if USE(GLIB)
 // Requested nice value. rtkit clamps this to its own MinNiceLevel.
 static constexpr int s_highPriorityNiceLevel = -20;
+#endif
 
 HighPriorityThreads& HighPriorityThreads::singleton()
 {


### PR DESCRIPTION
#### 44bab332e0f195ddbce08360d52ad0d25540bb2f
<pre>
Unreviewed, build fix for JSCOnly
<a href="https://bugs.webkit.org/show_bug.cgi?id=321183">https://bugs.webkit.org/show_bug.cgi?id=321183</a>
<a href="https://rdar.apple.com/184242684">rdar://184242684</a>

Having an erro.

```
FAILED: [code=1] Source/WTF/wtf/CMakeFiles/WTF.dir/linux/HighPriorityThreads.cpp.o
/usr/local/bin/clang++ -DBUILDING_JSCONLY__ -DBUILDING_WEBKIT=1 -DBUILDING_WITH_CMAKE=1 -DBUILDING_WTF -DHAVE_CONFIG_H=1 -DPAS_BMALLOC=1 -DSTATICALLY_LINKED_WITH_bmalloc -D_GLIBCXX_ASSERTIONS=1 -I/OpenSource/WebKitBuild/JSCOnly/Debug/Source/WTF/wtf/WTF-framework-headers.hmap -I/OpenSource/WebKitBuild/JSCOnly/Debug/Source/WTF/wtf/WTF-project-headers.hmap -I/OpenSource/WebKitBuild/JSCOnly/Debug -I/OpenSource/WebKitBuild/JSCOnly/Debug/WTF/DerivedSources -I/OpenSource/Source/WTF -I/OpenSource/Source/WTF/wtf -I/OpenSource/Source/WTF/wtf/dtoa -I/OpenSource/Source/WTF/wtf/fast_float -I/OpenSource/Source/WTF/wtf/persistence -I/OpenSource/Source/WTF/wtf/simdutf -I/OpenSource/Source/WTF/wtf/text -I/OpenSource/Source/WTF/wtf/text/icu -I/OpenSource/Source/WTF/wtf/threads -I/OpenSource/Source/WTF/wtf/unicode -I/OpenSource/WebKitBuild/JSCOnly/Debug/bmalloc/Headers -I/OpenSource/WebKitBuild/JSCOnly/Debug/bmalloc/PrivateHeaders -I/OpenSource/WebKitBuild/JSCOnly/Debug/Source/bmalloc/bmalloc-framework-headers.hmap -fdiagnostics-color=always -fcolor-diagnostics -Wextra -Wall -Wno-character-conversion -Werror=undefined-internal -Werror=undefined-inline -pipe -Wno-noexcept-type -Wno-nullability-completeness -Wno-psabi -Wno-misleading-indentation -Wno-parentheses-equality -Qunused-arguments -Wundef -Wpointer-arith -Wmissing-format-attribute -Wformat-security -Wcast-align -Wno-tautological-compare -fasynchronous-unwind-tables -mllvm -dwarf-linkage-names=Abstract -gsimple-template-names -fdebug-types-section -fno-omit-frame-pointer -fno-strict-aliasing -fno-exceptions -fno-rtti -fcoroutines -ffunction-sections -fdata-sections -O3 -g -std=c++23 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Werror -MD -MT Source/WTF/wtf/CMakeFiles/WTF.dir/linux/HighPriorityThreads.cpp.o -MF Source/WTF/wtf/CMakeFiles/WTF.dir/linux/HighPriorityThreads.cpp.o.d -o Source/WTF/wtf/CMakeFiles/WTF.dir/linux/HighPriorityThreads.cpp.o -c /OpenSource/Source/WTF/wtf/linux/HighPriorityThreads.cpp
../../../Source/WTF/wtf/linux/HighPriorityThreads.cpp:45:22: error: unused variable &apos;s_highPriorityNiceLevel&apos; [-Werror,-Wunused-const-variable]
   45 | static constexpr int s_highPriorityNiceLevel = -20;
      |                      ^~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

* Source/WTF/wtf/linux/HighPriorityThreads.cpp:

Canonical link: <a href="https://commits.webkit.org/318719@main">https://commits.webkit.org/318719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/299616d04cf29057cfef39a66fd480b368784c96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53118 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/46913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52828 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/189010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182136 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/8966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/39985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/316 "Failed to checkout and rebase branch from PR 71059") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40453 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45724 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191228 "Failed to checkout and rebase branch from PR 71059") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52788 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/159998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/191228 "Failed to checkout and rebase branch from PR 71059") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53468 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/191228 "Failed to checkout and rebase branch from PR 71059") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27189 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/43392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125740 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120590 "Failed to checkout and rebase branch from PR 71059") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51986 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/14965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51371 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51432 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->