### PR TITLE
[JSC] Add "Padding" Air opcode

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -2094,7 +2094,7 @@ private:
     }
 
     // Phase 3: Replace member Tmps with representative in all instructions.
-    // Nop self-Moves and adjust useDefCost for removed moves.
+    // Delete self-Moves and adjust useDefCost for removed moves.
     template<Bank bank>
     void rewriteCoalescedTmps(const Vector<AffinityGroup<bank>>& groups, const TmpGroupMap<bank>& tmpToGroup)
     {
@@ -3175,11 +3175,12 @@ private:
                     // WTF::Liveness and Air::LivenessAdapter do not handle a late-def/use followed by early-def
                     // correctly. While this register allocator does handle it correctly (since it models distinct
                     // late and early points between instructions (i.e. intervalForSpill() won't overlap for different
-                    // scratch Tmps)), insert a Nop so that subsequent liveness analysis correctly compute lifetime interference
-                    // when there are back-to-back Move spill-spill-scratch instructions (scratch is early-def, late-use).
+                    // scratch Tmps)), insert a Padding inst so that subsequent liveness analysis correctly computes
+                    // lifetime interference when there are back-to-back Move spill-spill-scratch instructions
+                    // (scratch is early-def, late-use).
                     // See https://bugs.webkit.org/show_bug.cgi?id=163548#c2 for more info.
                     // FIXME: reconsider this, https://bugs.webkit.org/show_bug.cgi?id=288122
-                    m_insertionSets[block].insert(instIndex, SpillMoveFrom, Nop, inst.origin);
+                    m_insertionSets[block].insert(instIndex, SpillMoveFrom, Padding, inst.origin);
                     continue;
                 }
 

--- a/Source/JavaScriptCore/b3/air/AirGenerate.cpp
+++ b/Source/JavaScriptCore/b3/air/AirGenerate.cpp
@@ -135,16 +135,16 @@ void prepareForGeneration(Code& code)
     // phase.
     simplifyCFG(code);
 
-    // This is needed to satisfy a requirement of B3::StackmapValue. This also removes dead
-    // code. We can avoid running this when certain optimizations are disabled.
+    // Not worth a whole-graph liveness scan just for the dead assignments it also kills, so this runs
+    // only for the used-register set that B3::StackmapValue reports to a patchpoint's generator.
     bool cfgMayHaveChanged = false;
-    if (code.optLevel() >= 2 || code.needsUsedRegisters())
+    if (code.needsUsedRegisters())
         cfgMayHaveChanged |= reportUsedRegisters(code);
 
     // Attempt to remove false dependencies between instructions created by partial register changes.
     // This must be executed as late as possible as it depends on the instructions order and register
-    // use. We _must_ run this after reportUsedRegisters(), since that kills variable assignments
-    // that seem dead. Luckily, this phase does not change register liveness, so that's OK.
+    // use, and it must follow reportUsedRegisters() when that runs, since that kills variable
+    // assignments that seem dead. Luckily, this phase does not change register liveness, so that's OK.
     fixPartialRegisterStalls(code);
 
     // Actually create entrypoints.

--- a/Source/JavaScriptCore/b3/air/AirInst.h
+++ b/Source/JavaScriptCore/b3/air/AirInst.h
@@ -197,8 +197,7 @@ struct Inst {
     // Some summaries about all arguments. These are useful for needsPadding().
     bool hasEarlyDef();
     bool hasLateUseOrDef();
-    
-    // Check if there needs to be a padding Nop between these two instructions.
+
     static bool needsPadding(Inst* prevInst, Inst* nextInst);
     
     // Use this to report which registers are live. This should be done just before codegen. Note

--- a/Source/JavaScriptCore/b3/air/AirKind.h
+++ b/Source/JavaScriptCore/b3/air/AirKind.h
@@ -75,7 +75,7 @@ struct Kind {
         return kind;
     }
 
-    Opcode opcode : 14 { Nop };
+    Opcode opcode : 14 { Padding };
 
     // This is an opcode-agnostic flag that indicates that we expect that this instruction will do
     // any of the following:

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -100,6 +100,10 @@
 # Note that the opcodes here have a leading capital (Add32) but must correspond to MacroAssembler
 # API that has a leading lower-case (add32).
 
+# The default Kind, so a deleted Inst becomes Padding, and it is also what padInterference() inserts
+# where two instructions must not be adjacent for liveness analysis to be sound.
+Padding /nocode
+
 Nop
 
 Add32 U:G:32, U:G:32, ZD:G:32

--- a/Source/JavaScriptCore/b3/air/AirPadInterference.cpp
+++ b/Source/JavaScriptCore/b3/air/AirPadInterference.cpp
@@ -40,7 +40,7 @@ void padInterference(Code& code)
         for (unsigned instIndex = 1; instIndex < block->size(); ++instIndex) {
             Inst& inst = block->at(instIndex);
             if (Inst::needsPadding(&block->at(instIndex - 1), &inst))
-                insertionSet.insert(instIndex, Nop, inst.origin);
+                insertionSet.insert(instIndex, Padding, inst.origin);
         }
         insertionSet.execute(block);
     }

--- a/Source/JavaScriptCore/b3/air/AirReportUsedRegisters.cpp
+++ b/Source/JavaScriptCore/b3/air/AirReportUsedRegisters.cpp
@@ -42,6 +42,8 @@ bool reportUsedRegisters(Code& code)
 
     static constexpr bool verbose = false;
 
+    // The RegLiveness below reasons about interference at instruction boundaries, so it is only
+    // correct once padding separates a late use or def from a following early def.
     padInterference(code);
 
     if (verbose)

--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -427,10 +427,20 @@ class Parser
                     when "return"
                         opcode.attributes[:return] = true
                         opcode.attributes[:terminal] = true
+                    when "nocode"
+                        opcode.attributes[:nocode] = true
                     else
                         parseError("Bad / directive")
                     end
                     advance
+                end
+
+                # Attributes are shared by every overload of an opcode, so this has to reject an
+                # unsupported signature on any of them, not just the one carrying /nocode.
+                if opcode.attributes[:nocode]
+                    parseError("/nocode opcode cannot take arguments") unless signature.empty?
+                    parseError("/nocode opcode cannot be a terminal") if opcode.attributes[:terminal]
+                    parseError("/nocode opcode cannot be restricted to an architecture") if opcodeArchs
                 end
 
                 parseArchs
@@ -1335,6 +1345,8 @@ writeH("OpcodeGenerated") {
         | opcode, overload, form |
         if opcode.custom
             outp.puts "OPGEN_RETURN(#{opcode.name}Custom::generate(*this, jit, context));"
+        elsif opcode.attributes[:nocode]
+            outp.puts "OPGEN_RETURN(result);"
         else
             beginArchs(outp, form.archs)
             if form.altName

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -6715,10 +6715,8 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(Compilati
     if (ionGraphPasses) [[unlikely]]
         procedure.setIonGraphPasses(*ionGraphPasses);
 
-    // This means we cannot use either StackmapGenerationParams::usedRegisters() or
-    // StackmapGenerationParams::unavailableRegisters(). In exchange for this concession, we
-    // don't strictly need to run Air::reportUsedRegisters(), which saves a bit of CPU time at
-    // optLevel=1.
+    // Skipping Air::reportUsedRegisters() costs us StackmapGenerationParams::usedRegisters() and
+    // StackmapGenerationParams::unavailableRegisters(), which OMG does not use.
     procedure.setNeedsUsedRegisters(false);
     
     procedure.setOptLevel(Options::wasmOMGOptimizationLevel());


### PR DESCRIPTION
#### 74091f918bfc6bda006375c335998783b9841418
<pre>
[JSC] Add &quot;Padding&quot; Air opcode
<a href="https://bugs.webkit.org/show_bug.cgi?id=321187">https://bugs.webkit.org/show_bug.cgi?id=321187</a>
<a href="https://rdar.apple.com/184246441">rdar://184246441</a>

Reviewed by Dan Hecht.

We found that AirReportUsedRegisters phase is taking very long time
because of padInterference, RegLiveness, and entire graph scanning.
But this is necessary only for FTL since we do not need to report used
registers in Wasm OMG. But disabling this caused large performance
regression in JetStream3/richards-wasm because we didn&apos;t remove `Nop`
(this phase is also removing Nops) and causing large performance
regression because of emitted `nop` instructions.

But most of Nops are inserted just for Padding in the instruction stream
for liveness analysis and we do not want to actually emit `nop` instructions
except for a few cases. Thus we introduce Padding AirOpcode, which looks
like a Nop, but emits nothing at code generator phase, so purely for padding.

And then we disable reportUsedRegisters for Wasm OMG. We may still want
to have Padding removal scanning (since it encourages simplifyCFG etc., but
so far, we don&apos;t see performance improvements from that.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::emitSpillCodeAndEnqueueNewTmps):
* Source/JavaScriptCore/b3/air/AirGenerate.cpp:
(JSC::B3::Air::prepareForGeneration):
* Source/JavaScriptCore/b3/air/AirInst.h:
* Source/JavaScriptCore/b3/air/AirKind.h:
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/air/AirPadInterference.cpp:
(JSC::B3::Air::padInterference):
* Source/JavaScriptCore/b3/air/AirReportUsedRegisters.cpp:
(JSC::B3::Air::reportUsedRegisters):
* Source/JavaScriptCore/b3/air/opcode_generator.rb:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::parseAndCompileOMG):

Canonical link: <a href="https://commits.webkit.org/318738@main">https://commits.webkit.org/318738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9b555d01e187b245f29617ff9b94a9a8f6b79dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189020 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc8956a8-0950-40bf-a891-e24a31b6a5af) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181052 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139740 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e62063f-d3b8-420c-b63c-0e41b5b9af94) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120192 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e2cac6e-95a2-442c-902a-4c6832ca2dfb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40341 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2162 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8969 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39988 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/326 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40463 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45734 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191238 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52798 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148976 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53478 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36615 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/media/media-play-stream-chunked-icy.html, http/tests/navigation/post-frames-goback1-uncached.html, http/tests/resourceLoadStatistics/do-not-block-top-level-navigation-redirect.html, http/tests/security/cached-cross-origin-shared-css-stylesheet.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/iframe-srcdoc-external-script.html, http/tests/security/mixedContent/redirect-http-to-https-script-in-iframe-UpgradeMixedContent.html, http/tests/site-isolation/frame-index.html, http/tests/site-isolation/inspector/network/resource-timing-cross-origin-page-navigation.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148722 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27202 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43399 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125750 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120605 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51996 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14968 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51381 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51622 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51442 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->