### PR TITLE
[JSC] Retire Lexer::lexExpectIdentifier()

### DIFF
--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -125,8 +125,6 @@ public:
         m_hasLineTerminatorBeforeToken = terminator;
     }
 
-    JSTokenType lexExpectIdentifier(JSToken*, OptionSet<LexerFlags>, bool strictMode);
-
     ALWAYS_INLINE StringView getToken(const JSToken& token)
     {
         SourceProvider* sourceProvider = m_source->provider();
@@ -354,64 +352,6 @@ bool isSafeBuiltinIdentifier(VM&, const Identifier*);
 #else
 ALWAYS_INLINE bool isSafeBuiltinIdentifier(VM&, const Identifier*) { return true; }
 #endif // ASSERT_ENABLED
-
-template <typename T>
-ALWAYS_INLINE JSTokenType Lexer<T>::lexExpectIdentifier(JSToken* tokenRecord, OptionSet<LexerFlags> lexerFlags, bool strictMode)
-{
-    JSTokenData* tokenData = &tokenRecord->m_data;
-    ASSERT(lexerFlags.contains(LexerFlags::IgnoreReservedWords));
-    const T* start = m_code;
-    const T* ptr = start;
-    const T* end = m_codeEnd;
-    JSTextPosition startPosition = currentPosition();
-    if (ptr >= end) {
-        ASSERT(ptr == end);
-        goto slowCase;
-    }
-    if (!WTF::isASCIIAlpha(*ptr))
-        goto slowCase;
-    ++ptr;
-    while (ptr < end) {
-        if (!WTF::isASCIIAlphanumeric(*ptr))
-            break;
-        ++ptr;
-    }
-
-    // Here's the shift
-    if (ptr < end) {
-        if ((!WTF::isASCII(*ptr)) || (*ptr == '\\') || (*ptr == '_') || (*ptr == '$'))
-            goto slowCase;
-        m_current = *ptr;
-    } else
-        m_current = 0;
-
-    m_code = ptr;
-    ASSERT(currentOffset() >= currentLineStartOffset());
-
-    // Create the identifier if needed
-    if (lexerFlags.contains(LexerFlags::DontBuildKeywords)
-#if ASSERT_ENABLED
-        && !m_parsingBuiltinFunction
-#endif
-        )
-        tokenData->ident = nullptr;
-    else
-        tokenData->ident = makeLatin1Identifier({ start, ptr });
-
-    tokenRecord->m_startPosition = startPosition;
-    tokenRecord->m_endPosition = currentPosition();
-#if ASSERT_ENABLED
-    if (m_parsingBuiltinFunction) {
-        if (!isSafeBuiltinIdentifier(m_vm, tokenData->ident))
-            return ERRORTOK;
-    }
-#endif
-
-    return IDENT;
-    
-slowCase:
-    return lex(tokenRecord, lexerFlags, strictMode);
-}
 
 template <typename T>
 ALWAYS_INLINE JSTokenType Lexer<T>::lex(JSToken* tokenRecord, OptionSet<LexerFlags> lexerFlags, bool strictMode)

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -4699,9 +4699,9 @@ namedProperty:
         JSToken identToken = m_token;
 
         if (wasUnescapedIdent && !isGeneratorMethodParseMode(parseMode) && (*ident == m_vm.propertyNames->get || *ident == m_vm.propertyNames->set))
-            nextExpectIdentifier(LexerFlags::IgnoreReservedWords);
+            next(LexerFlags::IgnoreReservedWords);
         else
-            nextExpectIdentifier(TreeBuilder::DontBuildKeywords | LexerFlags::IgnoreReservedWords);
+            next(TreeBuilder::DontBuildKeywords | LexerFlags::IgnoreReservedWords);
 
         if (!isGeneratorMethodParseMode(parseMode) && !isAsyncMethodParseMode(parseMode) && match(COLON)) {
             next();
@@ -5628,7 +5628,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
             case DOT: {
                 m_parserState.nonTrivialExpressionCount++;
                 JSTextPosition expressionDivot = tokenStartPosition();
-                nextExpectIdentifier(TreeBuilder::DontBuildKeywords | LexerFlags::IgnoreReservedWords);
+                next(TreeBuilder::DontBuildKeywords | LexerFlags::IgnoreReservedWords);
                 const Identifier* ident = m_token.m_data.ident;
                 auto type = DotType::Name;
                 if (match(PRIVATENAME)) {

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1554,13 +1554,6 @@ private:
         m_token.m_type = m_lexer->lexWithoutClearingLineTerminator(&m_token, lexerFlags, strictMode());
     }
 
-    ALWAYS_INLINE void nextExpectIdentifier(OptionSet<LexerFlags> lexerFlags = { })
-    {
-        m_lastTokenLocation = m_token.location();
-        m_lastTokenType = m_token.m_type;
-        m_token.m_type = m_lexer->lexExpectIdentifier(&m_token, lexerFlags, strictMode());
-    }
-
     template <class TreeBuilder>
     ALWAYS_INLINE void lexCurrentTokenAgainUnderCurrentContext(TreeBuilder& context)
     {


### PR DESCRIPTION
#### 71c68f4b3b35d98548525c85b7d740a8c83613db
<pre>
[JSC] Retire Lexer::lexExpectIdentifier()
<a href="https://bugs.webkit.org/show_bug.cgi?id=321188">https://bugs.webkit.org/show_bug.cgi?id=321188</a>
<a href="https://rdar.apple.com/184247644">rdar://184247644</a>

Reviewed by Yusuke Suzuki.

Lexer::lexExpectIdentifier() is intended as the fast path for quickly parsing an
identifier. It was introduced a long time ago. In the meantime, the baseline
Lexer::parseIdentifier() has been vectorized and now performs better than
lexExpectIdentifier() with its character-by-character scanning and 4 conditionals.
Removing lexExpectIdentifier() simplifies and shrinks hot code and improves performance.

Covered by existing tests.

* Source/JavaScriptCore/parser/Lexer.h:
(JSC::Lexer&lt;T&gt;::lexExpectIdentifier): Deleted.
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseProperty):
(JSC::Parser&lt;LexerType&gt;::parseMemberExpression):
* Source/JavaScriptCore/parser/Parser.h:

Canonical link: <a href="https://commits.webkit.org/318793@main">https://commits.webkit.org/318793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dbb93378bfbe264a1e54548901ed0b1c3a73526

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189021 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143499 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c39f6507-cce4-4773-aea4-984ba8282104) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139739 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f659d2e8-515c-41ca-89a7-ae06f037c1db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160490 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120191 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d73c597b-89d0-4f4b-8ce6-4a9d1faa1afb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41998 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40342 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2161 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8975 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39994 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/327 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40464 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191239 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52799 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148977 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40004 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53479 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148723 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43400 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125751 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120606 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51997 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14974 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51382 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51443 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->