### PR TITLE
[interactive-widget] Add more comprehensive keyboard related layout tests

### DIFF
--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-hardware-keyboard-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-hardware-keyboard-expected.txt
@@ -1,0 +1,14 @@
+
+After focusing the text field with a hardware keyboard attached:
+PASS internals.visualViewportRect().width == internals.layoutViewportRect().width is true
+PASS internals.visualViewportRect().height == internals.layoutViewportRect().height is true
+PASS internals.visualViewportRect().height == window.initialLayoutViewport.height is true
+
+After blurring the text field:
+PASS internals.visualViewportRect().width == internals.layoutViewportRect().width is true
+PASS internals.visualViewportRect().height == internals.layoutViewportRect().height is true
+PASS internals.visualViewportRect().height == window.initialLayoutViewport.height is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-hardware-keyboard.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-hardware-keyboard.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=overlays-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../../resources/js-test.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            await UIHelper.setHardwareKeyboardAttached(true);
+
+            window.initialLayoutViewport = internals.layoutViewportRect();
+
+            await UIHelper.activateElementAndWaitForInputSession(textField);
+            await UIHelper.ensureVisibleContentRectUpdate();
+            debug("\nAfter focusing the text field with a hardware keyboard attached:");
+
+            shouldBeTrue('internals.visualViewportRect().width == internals.layoutViewportRect().width');
+            shouldBeTrue('internals.visualViewportRect().height == internals.layoutViewportRect().height');
+            shouldBeTrue('internals.visualViewportRect().height == window.initialLayoutViewport.height');
+
+            textField.blur();
+            await UIHelper.ensureVisibleContentRectUpdate();
+            debug("\nAfter blurring the text field:");
+
+            shouldBeTrue('internals.visualViewportRect().width == internals.layoutViewportRect().width');
+            shouldBeTrue('internals.visualViewportRect().height == internals.layoutViewportRect().height');
+            shouldBeTrue('internals.visualViewportRect().height == window.initialLayoutViewport.height');
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-orientation-rotations-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-orientation-rotations-expected.txt
@@ -1,0 +1,23 @@
+
+Before rotation:
+PASS window.visualViewportBeforeRotations.width == window.initialVisualViewport.width is true
+PASS window.visualViewportBeforeRotations.height == window.initialVisualViewport.height is true
+
+After rotation to landscape:
+PASS window.visualViewportAfterLandscapeRotation.width == internals.layoutViewportRect().width is true
+PASS window.visualViewportAfterLandscapeRotation.height == internals.layoutViewportRect().height is true
+
+Visual viewport's height should be smaller than portrait mode's visual viewport height:
+PASS window.visualViewportAfterLandscapeRotation.height < window.visualViewportBeforeRotations.height is true
+
+After keyboard dismissal while still in landscape mode:
+PASS internals.visualViewportRect().height == internals.layoutViewportRect().height is true
+PASS internals.visualViewportRect().height == window.visualViewportAfterLandscapeRotation.height is true
+
+After rotation back to portrait:
+PASS window.visualViewportBeforeRotations.height == internals.layoutViewportRect().height is true
+PASS internals.visualViewportRect().height > window.visualViewportAfterLandscapeRotation.height is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-orientation-rotations.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-orientation-rotations.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=overlays-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../../resources/js-test.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+
+            window.initialVisualViewport = internals.visualViewportRect();
+
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+            await UIHelper.ensurePresentationUpdate();
+
+            window.layoutViewportBeforeRotations = internals.layoutViewportRect();
+            window.visualViewportBeforeRotations = internals.visualViewportRect();
+            debug("\nBefore rotation:");
+
+            shouldBeTrue('window.visualViewportBeforeRotations.width == window.initialVisualViewport.width');
+            shouldBeTrue('window.visualViewportBeforeRotations.height == window.initialVisualViewport.height');
+
+            await UIHelper.rotateDevice("landscape-right", true);
+            await UIHelper.ensurePresentationUpdate();
+            window.layoutViewportAfterLandscapeRotation = internals.layoutViewportRect();
+            window.visualViewportAfterLandscapeRotation = internals.visualViewportRect();
+            debug("\nAfter rotation to landscape:");
+
+            shouldBeTrue('window.visualViewportAfterLandscapeRotation.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewportAfterLandscapeRotation.height == internals.layoutViewportRect().height');
+
+            debug("\nVisual viewport's height should be smaller than portrait mode's visual viewport height:");
+
+            shouldBeTrue('window.visualViewportAfterLandscapeRotation.height < window.visualViewportBeforeRotations.height');
+
+            // Dismiss the keyboard.
+            textField.blur();
+            await UIHelper.waitForKeyboardToHide();
+            await UIHelper.ensurePresentationUpdate();
+            debug("\nAfter keyboard dismissal while still in landscape mode:");
+
+            shouldBeTrue('internals.visualViewportRect().height == internals.layoutViewportRect().height');
+            shouldBeTrue('internals.visualViewportRect().height == window.visualViewportAfterLandscapeRotation.height');
+
+            await UIHelper.rotateDevice("portrait", true);
+            await UIHelper.ensurePresentationUpdate();
+            debug("\nAfter rotation back to portrait:");
+
+            shouldBeTrue('window.visualViewportBeforeRotations.height == internals.layoutViewportRect().height');
+            shouldBeTrue('internals.visualViewportRect().height > window.visualViewportAfterLandscapeRotation.height');
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-zoom-disabled-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-zoom-disabled-expected.txt
@@ -3,6 +3,8 @@ PASS window.visualViewport.scale == 1 is true
 PASS window.visualViewport.width == internals.layoutViewportRect().width is true
 PASS window.visualViewport.height == internals.layoutViewportRect().height is true
 PASS window.initialLayoutViewportHeight == internals.layoutViewportRect().height is true
+PASS window.visualViewport.height == window.initialLayoutViewportHeight is true
+PASS internals.layoutViewportRect().height == window.initialLayoutViewportHeight is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-zoom-disabled.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-zoom-disabled.html
@@ -29,6 +29,13 @@
             shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
             shouldBeTrue('window.initialLayoutViewportHeight == internals.layoutViewportRect().height');
 
+            // Dismiss the keyboard: the content should remain the same.
+            textField.blur();
+            await UIHelper.waitForKeyboardToHide();
+            await UIHelper.ensurePresentationUpdate();
+
+            shouldBeTrue('window.visualViewport.height == window.initialLayoutViewportHeight');
+            shouldBeTrue('internals.layoutViewportRect().height == window.initialLayoutViewportHeight');
             finishJSTest();
         });
     </script>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-hardware-keyboard-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-hardware-keyboard-expected.txt
@@ -1,0 +1,14 @@
+
+After focusing the text field with a hardware keyboard attached:
+PASS internals.visualViewportRect().width == internals.layoutViewportRect().width is true
+PASS Math.abs(internals.visualViewportRect().height - internals.layoutViewportRect().height) <= 1 is true
+PASS Math.abs(internals.layoutViewportRect().height - window.inputViewBoundsTopInView) <= 1 is true
+
+After blurring the text field:
+PASS internals.visualViewportRect().width == internals.layoutViewportRect().width is true
+PASS internals.visualViewportRect().height == internals.layoutViewportRect().height is true
+PASS internals.visualViewportRect().height == window.initialLayoutViewport.height is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-hardware-keyboard.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-hardware-keyboard.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=resizes-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../../resources/js-test.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            await UIHelper.setHardwareKeyboardAttached(true);
+
+            window.initialLayoutViewport = internals.layoutViewportRect();
+
+            await UIHelper.activateElementAndWaitForInputSession(textField);
+            await UIHelper.ensureVisibleContentRectUpdate();
+            window.inputViewBoundsTopInView = (await UIHelper.inputViewBoundsInWebView()).top;
+            debug("\nAfter focusing the text field with a hardware keyboard attached:");
+
+            shouldBeTrue('internals.visualViewportRect().width == internals.layoutViewportRect().width');
+            shouldBeTrue('Math.abs(internals.visualViewportRect().height - internals.layoutViewportRect().height) <= 1');
+            shouldBeTrue('Math.abs(internals.layoutViewportRect().height - window.inputViewBoundsTopInView) <= 1');
+
+            textField.blur();
+            await UIHelper.ensureVisibleContentRectUpdate();
+            debug("\nAfter blurring the text field:");
+
+            shouldBeTrue('internals.visualViewportRect().width == internals.layoutViewportRect().width');
+            shouldBeTrue('internals.visualViewportRect().height == internals.layoutViewportRect().height');
+            shouldBeTrue('internals.visualViewportRect().height == window.initialLayoutViewport.height');
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-orientation-rotations-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-orientation-rotations-expected.txt
@@ -1,0 +1,26 @@
+
+Before rotation:
+PASS window.visualViewportBeforeRotations.width == internals.layoutViewportRect().width is true
+PASS window.visualViewportBeforeRotations.height == internals.layoutViewportRect().height is true
+
+Layout viewport's height should be smaller than before:
+PASS window.layoutViewportBeforeRotations.height < window.initialLayoutViewport.height is true
+
+After rotation to landscape:
+PASS window.visualViewportAfterLandscapeRotation.width == internals.layoutViewportRect().width is true
+PASS window.visualViewportAfterLandscapeRotation.height == internals.layoutViewportRect().height is true
+
+Layout viewport's height should be smaller than portrait mode's layout viewport height:
+PASS window.layoutViewportAfterLandscapeRotation.height < window.layoutViewportBeforeRotations.height is true
+
+After keyboard dismissal while still in landscape mode:
+PASS internals.visualViewportRect().height == internals.layoutViewportRect().height is true
+PASS internals.visualViewportRect().height > window.visualViewportAfterLandscapeRotation.height is true
+
+After rotation back to portrait:
+PASS window.initialLayoutViewport.height == internals.layoutViewportRect().height is true
+PASS internals.layoutViewportRect().height > window.layoutViewportAfterLandscapeRotation.height is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-orientation-rotations.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-orientation-rotations.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=resizes-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../../resources/js-test.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+
+            window.initialLayoutViewport = internals.layoutViewportRect();
+
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+            await UIHelper.ensurePresentationUpdate();
+
+            window.layoutViewportBeforeRotations = internals.layoutViewportRect();
+            window.visualViewportBeforeRotations = internals.visualViewportRect();
+
+            debug("\nBefore rotation:");
+            shouldBeTrue('window.visualViewportBeforeRotations.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewportBeforeRotations.height == internals.layoutViewportRect().height');
+
+            debug("\nLayout viewport's height should be smaller than before:");
+            shouldBeTrue('window.layoutViewportBeforeRotations.height < window.initialLayoutViewport.height');
+
+            await UIHelper.rotateDevice("landscape-right", true);
+            await UIHelper.ensureVisibleContentRectAndStablePresentationUpdate();
+
+            window.layoutViewportAfterLandscapeRotation = internals.layoutViewportRect();
+            window.visualViewportAfterLandscapeRotation = internals.visualViewportRect();
+
+            debug("\nAfter rotation to landscape:");
+            shouldBeTrue('window.visualViewportAfterLandscapeRotation.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewportAfterLandscapeRotation.height == internals.layoutViewportRect().height');
+
+            debug("\nLayout viewport's height should be smaller than portrait mode's layout viewport height:");
+            shouldBeTrue('window.layoutViewportAfterLandscapeRotation.height < window.layoutViewportBeforeRotations.height');
+
+            // Dismiss the keyboard.
+            textField.blur();
+            await UIHelper.waitForKeyboardToHide();
+            await UIHelper.ensureVisibleContentRectAndStablePresentationUpdate();
+
+            debug("\nAfter keyboard dismissal while still in landscape mode:");
+            shouldBeTrue('internals.visualViewportRect().height == internals.layoutViewportRect().height');
+            shouldBeTrue('internals.visualViewportRect().height > window.visualViewportAfterLandscapeRotation.height');
+
+            await UIHelper.rotateDevice("portrait", true);
+            await UIHelper.ensureVisibleContentRectAndStablePresentationUpdate();
+
+            debug("\nAfter rotation back to portrait:");
+            shouldBeTrue('window.initialLayoutViewport.height == internals.layoutViewportRect().height');
+            shouldBeTrue('internals.layoutViewportRect().height > window.layoutViewportAfterLandscapeRotation.height');
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -532,6 +532,19 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static ensureVisibleContentRectAndStablePresentationUpdate()
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return UIHelper.renderingUpdate();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`
+                uiController.doAfterNextVisibleContentRectAndStablePresentationUpdate(function() {
+                    uiController.uiScriptComplete();
+                });`, resolve);
+        });
+    }
+
     static ensurePositionInformationUpdateForElement(element)
     {
         const boundingRect = element.getBoundingClientRect();


### PR DESCRIPTION
#### dc4953ade17ba1ac0a9fa07717071ccbc1339271
<pre>
[interactive-widget] Add more comprehensive keyboard related layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=321028">https://bugs.webkit.org/show_bug.cgi?id=321028</a>
<a href="https://rdar.apple.com/184061866">rdar://184061866</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Add more comprehensive keyboard related test for overlays-content
and resizes-content. The following new tests include these cases:
- Hardware keyboard mode
- Orientation rotations from portrait, to landscape, then back to portrait
- Keyboard dismissal

Include a new `ensureVisibleContentRectAndStablePresentationUpdate`
helper that calls...
- _doAfterNextVisibleContentRectUpdate: This calls _scheduleVisibleContentRectUpdate
which makes the UI process rebuild the visible content rect update from the view&apos;s
present state (e.g. window size, obscured insets)
- _doAfterNextStablePresentationUpdate: This either adds to
_stableStatePresentationUpdateCallbacks, or creates the array,
which only gets emptied out if the page is stable in _didCommitLayerTree.
Wait for the rotations to be finished before reading the heights of the viewports.

* LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-hardware-keyboard-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-hardware-keyboard.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-orientation-rotations-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-orientation-rotations.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-zoom-disabled-expected.txt:
* LayoutTests/fast/visual-viewport/ios/interactive-widget/overlays-content-zoom-disabled.html:
* LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-hardware-keyboard-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-hardware-keyboard.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-orientation-rotations-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget/resizes-content-orientation-rotations.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.ensureVisibleContentRectAndStablePresentationUpdate.return.new.Promise):
(window.UIHelper.ensureVisibleContentRectAndStablePresentationUpdate):

Canonical link: <a href="https://commits.webkit.org/319203@main">https://commits.webkit.org/319203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5423f670b4ccb93feb31307af99ddd92a8ff27d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145030 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140952 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121404 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41577 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41249 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2080 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192856 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150334 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55007 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150051 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27443 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44661 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122509 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53524 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16242 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52906 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53143 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52971 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->