### PR TITLE
[libpas] Demacroify pas_mte_config.h

### DIFF
--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -182,8 +182,8 @@ void Config::initialize()
 
     [[maybe_unused]] uint8_t* reservedConfigBytes = reinterpret_cast_ptr<uint8_t*>(WebConfig::g_config);
 
-#if USE(LIBPAS) && defined(PAS_MTE_INITIALIZE_IN_WTF_CONFIG)
-    PAS_MTE_INITIALIZE_IN_WTF_CONFIG;
+#if USE(LIBPAS)
+    pas_mte_ensure_initialized();
 #endif // USE(LIBPAS)
 }
 

--- a/Source/bmalloc/bmalloc/Gigacage.cpp
+++ b/Source/bmalloc/bmalloc/Gigacage.cpp
@@ -180,7 +180,7 @@ void ensureGigacage()
             BPROFILE_ALLOCATION(INITIAL_GIGACAGE, totalSize);
 #if BENABLE(MTE)
             pas_mte_ensure_initialized();
-            if (BMALLOC_USE_MTE) {
+            if (pas_use_mte()) {
                 for (Kind kind : shuffledKinds) {
                     void* base = g_gigacageConfig.allocBasePtr(kind);
                     size_t size = g_gigacageConfig.allocSize(kind);

--- a/Source/bmalloc/bmalloc/VMAllocate.cpp
+++ b/Source/bmalloc/bmalloc/VMAllocate.cpp
@@ -63,7 +63,7 @@ bool isMadvZeroSupported()
 #if BENABLE(MTE) && BOS(DARWIN)
 bool tryVmZeroAndPurgeMTECase(void* p, size_t vmSize, VMTag usage)
 {
-    if (!BMALLOC_USE_MTE)
+    if (!pas_use_mte())
         return false;
     const vm_inherit_t childProcessInheritance = VM_INHERIT_DEFAULT;
     const bool copy = false;

--- a/Source/bmalloc/libpas/src/libpas/pas_internal_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_internal_config.h
@@ -101,6 +101,14 @@
 #define PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE_SHIFT 15
 #define PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE ((size_t)1 << PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE_SHIFT)
 
+/* "Large Object Delegation" means that user objects above a certain size are
+   handed off to the standard-library malloc rather than allocated from libpas'
+   own pool of memory, for heap-configs with delegate_large_user_allocations set.
+   Currently, this is only enabled when MTE is on for a given process + heap.
+   But it's perfectly possible to enable it regardless, if we were to want to do so:
+   libpas runs in hosted C, so there's always a system malloc to call out to. */
+#define PAS_USE_LARGE_OBJECT_DELEGATION_WITHOUT_MTE 0
+
 #define PAS_INTRINSIC_SMALL_LOOKUP_SIZE_UPPER_BOUND 10000
 #define PAS_SMALL_LOOKUP_SIZE_UPPER_BOUND 500
 #define PAS_UTILITY_LOOKUP_SIZE_UPPER_BOUND 1400

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -190,11 +190,17 @@ static pas_allocation_result delegated_allocate_impl(size_t size,
 }
 
 PAS_IGNORE_WARNINGS_BEGIN("unreachable-code")
+static bool can_use_large_object_delegation(void)
+{
+    return PAS_USE_LARGE_OBJECT_DELEGATION_WITHOUT_MTE || pas_mte_use_feature(pas_mte_feature_large_object_delegation);
+}
+
+
 static bool should_delegate_user_allocation_to_system_malloc(size_t size,
                                                              pas_allocation_mode allocation_mode,
                                                              const pas_heap_config* heap_config)
 {
-    if (!PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
+    if (!can_use_large_object_delegation())
         return false;
     if (size < PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE)
         return false;
@@ -264,7 +270,7 @@ bool pas_large_heap_try_deallocate(uintptr_t begin,
     }
 
     PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
-    if (PAS_MTE_USE_LARGE_OBJECT_DELEGATION) {
+    if (can_use_large_object_delegation()) {
         if (map_entry.delegated_to_system_malloc) {
             pas_system_heap_free((void*)map_entry.begin);
             return true;

--- a/Source/bmalloc/libpas/src/libpas/pas_mte.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte.c
@@ -25,7 +25,6 @@
 
 #include "pas_mte.h"
 
-#if defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
 #if PAS_ENABLE_MTE
 void* pas_mte_system_heap_realloc_zero_tagged(malloc_zone_t* zone, void* ptr, size_t size)
 {
@@ -41,4 +40,3 @@ void* pas_mte_system_heap_realloc_zero_tagged(malloc_zone_t* zone, void* ptr, si
     return result;
 }
 #endif // PAS_ENABLE_MTE
-#endif // defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE

--- a/Source/bmalloc/libpas/src/libpas/pas_mte.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte.h
@@ -44,7 +44,6 @@
 #include "unistd.h"
 #endif
 
-#if defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
 #if PAS_ENABLE_MTE
 
 #include "pas_utils.h"
@@ -291,14 +290,14 @@ PAS_IGNORE_WARNINGS_BEGIN("implicit-fallthrough")
 inline __attribute__((always_inline)) void pas_mte_tag_st2g_loop(uint8_t* begin, size_t size)
 {
     uint8_t* end = begin + size;
-    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+    if (pas_mte_use_feature(pas_mte_feature_log_on_tag))
         printf("[MTE]\t    Tagging initial 16 bytes %p to %p\n", begin, begin + 16);
     PAS_MTE_SET_TAG(begin);
 
     // Ensure begin is a multiple of 32 bytes from the end.
     begin += size % 32;
 
-    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG) && begin < end)
+    if (pas_mte_use_feature(pas_mte_feature_log_on_tag) && begin < end)
         printf("[MTE]\t    Doing ST2G loop from %p to %p\n", begin, end);
     while (begin < end)
         PAS_MTE_SET_TAG_PAIR_POSTINDEX(begin);
@@ -307,20 +306,20 @@ inline __attribute__((always_inline)) void pas_mte_tag_st2g_loop(uint8_t* begin,
 inline __attribute__((always_inline)) void pas_mte_tag_st2g_switching(uint8_t* begin, size_t size)
 {
     uint8_t* end = begin + size;
-    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+    if (pas_mte_use_feature(pas_mte_feature_log_on_tag))
         printf("[MTE]\t    Tagging initial 16 bytes %p to %p\n", begin, begin + 16);
     PAS_MTE_SET_TAG(begin);
 
     // Ensure begin is a multiple of 32 bytes from the end.
     begin += size % 32;
 
-    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+    if (pas_mte_use_feature(pas_mte_feature_log_on_tag))
         printf("[MTE]\t    Doing ST2G loop from %p to %p\n", begin, end);
     while (begin < end) {
         uintptr_t num_granules_to_st2g = (uintptr_t)(end - begin) / (uintptr_t)32 & 15;
         if (!num_granules_to_st2g)
             num_granules_to_st2g = 16;
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG)) {
+        if (pas_mte_use_feature(pas_mte_feature_log_on_tag)) {
             size_t tagged_size = num_granules_to_st2g * 32;
             printf("[MTE]\t        Tagging %zu bytes from %p to %p\n", tagged_size, begin, begin + tagged_size);
         }
@@ -351,7 +350,7 @@ inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_loop(uint8_t* begi
 {
     /* Get the small-object case out of the way. */
     if (size <= 48) {
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+        if (pas_mte_use_feature(pas_mte_feature_log_on_tag))
             printf("[MTE]\t    Tagging small object with size %zu from %p to %p\n", size, begin, begin + size);
         PAS_MTE_SET_TAG(begin);
         if (size <= 16)
@@ -364,7 +363,7 @@ inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_loop(uint8_t* begi
 
     /* Now that we know the size is at least 64 bytes, we can use DC GVA. */
     /* First, we handle the first 64 bytes, which may not be aligned to 64 bytes. */
-    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+    if (pas_mte_use_feature(pas_mte_feature_log_on_tag))
         printf("[MTE]\t    Tagging initial 64 bytes from %p to %p\n", begin, begin + 64);
     PAS_MTE_SET_TAG_PAIR(begin);
     PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 32);
@@ -376,7 +375,7 @@ inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_loop(uint8_t* begi
         begin = (uint8_t*)((uintptr_t)begin + DC_GVA_GRANULE_SIZE - 1 & (uintptr_t)-DC_GVA_GRANULE_SIZE);
         uint8_t* end_aligned = (uint8_t*)((uintptr_t)end & (uintptr_t)-DC_GVA_GRANULE_SIZE);
 
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+        if (pas_mte_use_feature(pas_mte_feature_log_on_tag))
             printf("[MTE]\t    Doing aligned DC GVA loop from %p to %p\n", begin, end_aligned);
         while (begin < end_aligned) {
             PAS_MTE_SET_TAGS_USING_DC_GVA(begin);
@@ -386,7 +385,7 @@ inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_loop(uint8_t* begi
 
     /* Handle the last 64 bytes, covering the unaligned remainder we may have */
     /* missed in our DC GVA loop. */
-    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+    if (pas_mte_use_feature(pas_mte_feature_log_on_tag))
         printf("[MTE]\t    Tagging final 64 bytes from %p to %p\n", end - 64, end);
     PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(end, -64);
     PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(end, -32);
@@ -412,7 +411,7 @@ inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_switching(uint8_t*
 {
     /* Get the small-object case out of the way. */
     if (size <= 48) {
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+        if (pas_mte_use_feature(pas_mte_feature_log_on_tag))
             printf("[MTE]\t    Tagging small object with size %zu from %p to %p\n", size, begin, begin + size);
         PAS_MTE_SET_TAG(begin);
         if (size <= 16)
@@ -425,7 +424,7 @@ inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_switching(uint8_t*
 
     /* Now that we know the size is at least 64 bytes, we can use DC GVA. */
     /* First, we handle the first 64 bytes, which may not be aligned to 64 bytes. */
-    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+    if (pas_mte_use_feature(pas_mte_feature_log_on_tag))
         printf("[MTE]\t    Tagging initial 64 bytes from %p to %p\n", begin, begin + 64);
     PAS_MTE_SET_TAG_PAIR(begin);
     PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 32);
@@ -437,13 +436,13 @@ inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_switching(uint8_t*
         begin = (uint8_t*)((uintptr_t)begin + 63 & (uintptr_t)-64);
         uint8_t* end_aligned = (uint8_t*)((uintptr_t)end & (uintptr_t)-64);
 
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+        if (pas_mte_use_feature(pas_mte_feature_log_on_tag))
             printf("[MTE]\t    Doing aligned DC GVA loop from %p to %p\n", begin, end_aligned);
         while (begin < end_aligned) {
             uintptr_t num_granules_to_gva = (uintptr_t)(end_aligned - begin) / (uintptr_t)DC_GVA_GRANULE_SIZE % 16;
             if (!num_granules_to_gva)
                 num_granules_to_gva = 16;
-            if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG)) {
+            if (pas_mte_use_feature(pas_mte_feature_log_on_tag)) {
                 size_t tagged_size = num_granules_to_gva * DC_GVA_GRANULE_SIZE;
                 printf("[MTE]\t        Tagging %zu bytes from %p to %p\n", tagged_size, begin, begin + tagged_size);
             }
@@ -472,7 +471,7 @@ inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_switching(uint8_t*
 
     /* Handle the last 64 bytes, covering the unaligned remainder we may have */
     /* missed in our DC GVA loop. */
-    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+    if (pas_mte_use_feature(pas_mte_feature_log_on_tag))
         printf("[MTE]\t    Tagging final 64 bytes from %p to %p\n", end - 64, end);
     PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(end, -64);
     PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(end, -32);
@@ -503,7 +502,7 @@ pas_mte_tag_region_from_pointer(
     bool is_known_medium)
 {
     uint8_t* ptr = (uint8_t*)(begin);
-    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG)) {
+    if (pas_mte_use_feature(pas_mte_feature_log_on_tag)) {
         void* purified_ptr = ptr;
         PAS_MTE_GET_MTAG(purified_ptr);
         printf("[MTE]\tTagging %zu bytes from %p to %p (old tag is %p)\n", size, ptr, ptr + size, purified_ptr);
@@ -521,11 +520,11 @@ pas_mte_tag_region_from_pointer(
  * and need to modify memory at that new address, such as page headers.
  */
 #define PAS_MTE_PURIFY(a) do { \
-        if (PAS_USE_MTE) { \
-            if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_PURIFY)) \
+        if (pas_use_mte()) { \
+            if (pas_mte_use_feature(pas_mte_feature_log_on_purify)) \
                 printf("[MTE]\tPurified %p", (void*)(a)); \
             PAS_MTE_GET_MTAG(a); \
-            if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_PURIFY)) \
+            if (pas_mte_use_feature(pas_mte_feature_log_on_purify)) \
                 printf(" to %p\n", (void*)(a)); \
         } \
     } while (0)
@@ -561,7 +560,7 @@ pas_mte_generate_random_tag(
     uintptr_t begin,
     pas_mte_tag_constraint constraint)
 {
-    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ZERO_TAG_ALL))
+    if (pas_mte_use_feature(pas_mte_feature_zero_tag_all))
         return begin & ~PAS_MTE_TAG_MASK;
     __asm__ volatile( \
         ".arch_extension memtag\n\t"
@@ -594,11 +593,11 @@ pas_mte_generate_tag_and_tag_region(
         begin &= ~PAS_MTE_TAG_MASK;
     else {
         pas_mte_tag_constraint valid_tags;
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION))
+        if (pas_mte_use_feature(pas_mte_feature_adjacent_tag_exclusion))
             valid_tags = pas_mte_compute_valid_tags_under_adjacent_tag_exclusion(begin, size, homogeneity, is_known_medium);
         else
             valid_tags = pas_mte_any_nonzero_tag;
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_PREVIOUS_TAG_EXCLUSION)) {
+        if (pas_mte_use_feature(pas_mte_feature_previous_tag_exclusion)) {
             /*
              * The LDG this incurs tends to be expensive, and could be avoided
              * for initial allocations at the cost of an extra branch. If this
@@ -615,8 +614,8 @@ pas_mte_generate_tag_and_tag_region(
     }
     if (mode != pas_always_compact_allocation_mode) {
         pas_mte_tag_region_from_pointer(begin, size, is_known_medium);
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION)
-            && PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT)) {
+        if (pas_mte_use_feature(pas_mte_feature_adjacent_tag_exclusion)
+            && pas_mte_use_feature(pas_mte_feature_assert_adjacent_tags_are_disjoint)) {
             pas_mte_assert_prior_tag_is_disjoint(begin);
             pas_mte_assert_prior_tag_is_disjoint(begin + size);
         }
@@ -627,7 +626,7 @@ pas_mte_generate_tag_and_tag_region(
 static PAS_ALWAYS_INLINE void
 pas_mte_check_tag_for_deallocation(uintptr_t ptr)
 {
-    if (!PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_CHECK_TAG_ON_DEALLOC))
+    if (!pas_mte_use_feature(pas_mte_feature_check_tag_on_dealloc))
         return;
     // We want to execute this load purely for its side-effects,
     // i.e. the tag-check and, on mismatch, subsequent tag-check-fault.
@@ -710,10 +709,12 @@ pas_mte_retag_freed_region_if_tagged(
  * when set, will force tag-on-alloc, as in the 'Tag-on-Alloc/Free' policy
  * described above.
  *
- * N.b.: the current implementation (as the name RETAG_ON_SCAVENGE
- * implies) does not retag-on-free, but on scavenge. This somewhat weakens
- * the ability of this approach to catch use-after-frees, but otherwise does
- * not break the validity of the tag/no-tag orderings above.
+ * N.b.: despite the name pas_mte_feature_retag_on_free, the current
+ * implementation for segregated heaps does not retag on free, but on scavenge.
+ * This weakens the ability of this approach to catch use-after-frees, but
+ * otherwise does not break the validity of the tag/no-tag orderings above.
+ * In practice we avoid this issue by not allocating MTE objects from
+ * segregated heaps.
  *
  * the point of view of the orderings mentioned above, as scavenging always
  * happens at some point before a subsequent allocation.
@@ -727,16 +728,16 @@ pas_mte_maybe_tag_allocated_region(
     pas_allocation_initiality initiality,
     bool is_known_medium)
 {
-    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_RETAG_ON_SCAVENGE)
+    if (pas_mte_use_feature(pas_mte_feature_retag_on_free)
         && !PAS_WORKAROUND_RDAR_171662605_UNCONDITIONAL_TAG_ON_ALLOC
         && initiality == pas_non_initial_allocation
         && mode == pas_non_compact_allocation_mode) {
         /* can assume: size >= 16 && begin % 16 == 0 */
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+        if (pas_mte_use_feature(pas_mte_feature_log_on_tag))
             printf("[MTE]\tSkipping alloc-tagging %zu bytes from %p to %p\n", size, (uint8_t*)begin, (uint8_t*)begin + size);
         PAS_MTE_PURIFY(begin);
     } else {
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG) && initiality != pas_non_initial_allocation) {
+        if (pas_mte_use_feature(pas_mte_feature_log_on_tag) && initiality != pas_non_initial_allocation) {
             const char* qualifier = (initiality == pas_initial_allocation) ? "First" : "Maybe first";
             printf("[MTE]\t%s time tagging region: alloc-tagging %zu bytes from %p to %p\n", qualifier, size, (uint8_t*)begin, (uint8_t*)begin + size);
         }
@@ -752,7 +753,7 @@ pas_mte_retag_freed_region_if_tagged(
     pas_page_base_config page_config,
     pas_allocator_homogeneity homogeneity)
 {
-    if (!PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_RETAG_ON_SCAVENGE))
+    if (!pas_mte_use_feature(pas_mte_feature_retag_on_free))
         return begin;
     uintptr_t tag = begin;
     PAS_MTE_GET_MTAG(tag);
@@ -780,7 +781,7 @@ pas_mte_retag_freed_region_if_tagged(
 
 #define PAS_MTE_ZERO_FILL_PAGE(ptr, size, flags, tag) do { \
         (void)flags; \
-        if (PAS_USE_MTE) { \
+        if (pas_use_mte()) { \
             const vm_inherit_t childProcessInheritance = VM_INHERIT_DEFAULT; \
             const bool copy = false; \
             /* FIXME: use mach_vm_behavior_set instead rdar://160813532 */ \
@@ -827,10 +828,10 @@ pas_mte_retag_freed_region_if_tagged(
 
 // Used to restore the correct tag when reallocating something to a new address before copying it.
 #define PAS_MTE_HANDLE_TRY_REALLOCATE_AND_COPY(ptr, old_ptr, size) do { \
-        if (PAS_USE_MTE) { \
-            PAS_MTE_CHECK_TAG_AND_SET_TCO(ptr); \
+        if (pas_use_mte()) { \
+            pas_mte_check_tag_and_set_tco((const void*)ptr); \
             memcpy((void*)ptr, old_ptr, size); \
-            PAS_MTE_CLEAR_TCO; \
+            pas_mte_clear_tco(); \
             if (verbose) { \
                 pas_log("\t...done copying size %zu from %p to %p\n", size, old_ptr, (void*)ptr); \
             } \
@@ -924,7 +925,7 @@ extern struct __pas_heap bmalloc_common_primitive_heap;
 
 // Used to set up whether a local allocator should tag its allocations.
 #define PAS_MTE_HANDLE_SET_UP_LOCAL_ALLOCATOR(page_config, segregated_heap, allocator) do { \
-        if (PAS_USE_MTE && PAS_MTE_SHOULD_TAG_SEGREGATED_HEAP(segregated_heap)) { \
+        if (pas_use_mte() && PAS_MTE_SHOULD_TAG_SEGREGATED_HEAP(segregated_heap)) { \
             allocator->is_mte_tagged = PAS_MTE_SHOULD_TAG_PAGE(page_config); \
             allocator->is_small = (page_config).base.page_config_size_category == pas_page_config_size_category_small; \
         } else \
@@ -945,7 +946,7 @@ extern struct __pas_heap bmalloc_common_primitive_heap;
 
 // Used to tag bitfit allocations.
 #define PAS_MTE_HANDLE_BITFIT_ALLOCATION(page_config, ptr, size, mode) do { \
-        if (PAS_USE_MTE && PAS_MTE_SHOULD_TAG_PAGE(page_config)) \
+        if (pas_use_mte() && PAS_MTE_SHOULD_TAG_PAGE(page_config)) \
             ptr = pas_mte_maybe_tag_allocated_region(ptr, (size_t)size, mode, pas_mte_nonhomogeneous_allocator, pas_maybe_initial_allocation, PAS_MTE_IS_KNOWN_MEDIUM_PAGE(page_config.base)); \
     } while (false)
 
@@ -1004,7 +1005,7 @@ void* pas_mte_system_heap_realloc_zero_tagged(malloc_zone_t* zone, void* ptr, si
 // the inevitable overhead of enabling PAS_MTE, but we don't want to burden non-PAS_MTE hardware with
 // this cost, so we inject this early return.
 #define PAS_MTE_HANDLE_MEGAPAGES_ALLOCATION(heap, size, alignment, heap_config) do { \
-        if (!PAS_USE_MTE) { \
+        if (!pas_use_mte()) { \
             return pas_large_heap_try_allocate_and_forget( \
                 &heap->large_heap, size, alignment, pas_non_compact_allocation_mode, \
                 heap_config, transaction); \
@@ -1013,21 +1014,21 @@ void* pas_mte_system_heap_realloc_zero_tagged(malloc_zone_t* zone, void* ptr, si
 
 // Used to redirect small megapage allocations when PAS_MTE is not enabled to the respective untagged megapage cache.
 #define PAS_MTE_HANDLE_SMALL_EXCLUSIVE_SEGREGATED_PAGE_ALLOCATION(heap, megapage_cache) do { \
-        if (!PAS_USE_MTE || !heap->parent_heap->is_non_compact_heap) \
+        if (!pas_use_mte() || !heap->parent_heap->is_non_compact_heap) \
             megapage_cache = &page_caches->small_compact_exclusive_segregated_megapage_cache; \
     } while (false)
 #define PAS_MTE_HANDLE_SMALL_BITFIT_PAGE_ALLOCATION(heap, megapage_cache) do { \
-        if (!PAS_USE_MTE || !heap->parent_heap->is_non_compact_heap) \
+        if (!pas_use_mte() || !heap->parent_heap->is_non_compact_heap) \
             megapage_cache = &page_caches->small_compact_other_megapage_cache; \
     } while (false)
 
 // Used to redirect medium megapage allocations when medium object tagging is not enabled to the respective untagged megapage cache.
 #define PAS_MTE_HANDLE_MEDIUM_SEGREGATED_PAGE_ALLOCATION(heap, megapage_cache) do { \
-        if (!PAS_USE_MTE || !heap->parent_heap->is_non_compact_heap) \
+        if (!pas_use_mte() || !heap->parent_heap->is_non_compact_heap) \
             megapage_cache = &page_caches->medium_compact_megapage_cache; \
     } while (false)
 #define PAS_MTE_HANDLE_MEDIUM_BITFIT_PAGE_ALLOCATION(heap, megapage_cache) do { \
-        if (!PAS_USE_MTE || !heap->parent_heap->is_non_compact_heap) \
+        if (!pas_use_mte() || !heap->parent_heap->is_non_compact_heap) \
             megapage_cache = &page_caches->medium_compact_megapage_cache; \
     } while (false)
 
@@ -1041,7 +1042,7 @@ void* pas_mte_system_heap_realloc_zero_tagged(malloc_zone_t* zone, void* ptr, si
         (void)page_config; \
         (void)ptr; \
         (void)size; \
-        if (PAS_USE_MTE && PAS_MTE_SHOULD_TAG_PAGE(page_config)) { \
+        if (pas_use_mte() && PAS_MTE_SHOULD_TAG_PAGE(page_config)) { \
             pas_mte_check_tag_for_deallocation(ptr); \
             ptr = pas_mte_retag_freed_region_if_tagged((uintptr_t)ptr, (size_t)size, page_config.base, pas_mte_nonhomogeneous_allocator); \
         } \
@@ -1052,20 +1053,16 @@ void* pas_mte_system_heap_realloc_zero_tagged(malloc_zone_t* zone, void* ptr, si
         (void)page_config; \
         (void)ptr; \
         (void)size; \
-        if (PAS_USE_MTE && PAS_MTE_SHOULD_TAG_PAGE(page_config)) { \
+        if (pas_use_mte() && PAS_MTE_SHOULD_TAG_PAGE(page_config)) { \
             pas_mte_check_tag_for_deallocation(ptr); \
             ptr = pas_mte_retag_freed_region_if_tagged((uintptr_t)ptr, (size_t)size, page_config.base, pas_mte_homogeneous_allocator); \
         } \
     } while (false)
 
-#define PAS_MTE_HANDLE_SCAVENGER_THREAD_MAIN(data) do { \
-        pas_mte_ensure_initialized(); \
-    } while (false)
-
 #if PAS_OS(DARWIN)
 #define PAS_MTE_HANDLE_PAGE_ALLOCATION(size, may_contain_small_or_medium, tag) do { \
         pas_mte_ensure_initialized(); \
-        if (PAS_USE_MTE && (may_contain_small_or_medium)) { \
+        if (pas_use_mte() && (may_contain_small_or_medium)) { \
             const vm_inherit_t childProcessInheritance = VM_INHERIT_DEFAULT; \
             const bool copy = false; \
             const vm_prot_t protections = VM_PROT_WRITE | VM_PROT_READ; \
@@ -1074,11 +1071,11 @@ void* pas_mte_system_heap_realloc_zero_tagged(malloc_zone_t* zone, void* ptr, si
                 PAS_RECORD_STAT(page_alloc_counts, size, may_contain_small_or_medium, true); \
             else { \
                 errno = 0; \
-                if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_PAGE_ALLOC)) \
+                if (pas_mte_use_feature(pas_mte_feature_log_page_alloc)) \
                     printf("[MTE]\tFailed to map %zu bytes with VM_FLAGS_MTE.\n", (size_t)(size)); \
                 return NULL; \
             } \
-            if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_PAGE_ALLOC)) \
+            if (pas_mte_use_feature(pas_mte_feature_log_page_alloc)) \
                 printf("[MTE]\tMapped %zu bytes from %p to %p with VM_FLAGS_MTE.\n", (size_t)(size), (void*)(mmap_result), (uint8_t*)(mmap_result) + (size)); \
             return mmap_result; \
         } \
@@ -1098,7 +1095,5 @@ PAS_IGNORE_WARNINGS_END
 #else // !PAS_ENABLE_MTE
 #define PAS_MTE_HANDLE(kind, ...) PAS_UNUSED_V(__VA_ARGS__)
 #endif // PAS_ENABLE_MTE
-#else // defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
-#define PAS_MTE_HANDLE(kind, ...) PAS_UNUSED_V(__VA_ARGS__)
-#endif // PAS_ENABLE_MTE
+
 #endif // PAS_MTE_H

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
@@ -74,7 +74,6 @@ extern const pas_heap_config iso_heap_config;
 #endif // PAS_ENABLE_ISO
 extern const pas_heap_config pas_utility_heap_config;
 
-#if defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
 #if PAS_ENABLE_MTE
 
 static int is_env_false(const char* var)
@@ -136,14 +135,17 @@ static void pas_mte_do_initialization(void)
 
     unsigned mode = 0;
     if (get_value_if_available(&mode, "MTE_libpasConfig")) {
-        uint8_t mode_byte = (uint8_t)(mode & 0xFF);
-        config->mode_bits.retag_on_scavenge = (mode_byte >> PAS_MTE_FEATURE_RETAG_ON_SCAVENGE) & 1;
-        config->mode_bits.log_on_tag = (mode_byte >> PAS_MTE_FEATURE_LOG_ON_TAG) & 1;
-        config->mode_bits.log_on_purify = (mode_byte >> PAS_MTE_FEATURE_LOG_ON_PURIFY) & 1;
-        config->mode_bits.log_page_alloc = (mode_byte >> PAS_MTE_FEATURE_LOG_PAGE_ALLOC) & 1;
-        config->mode_bits.zero_tag_all = (mode_byte >> PAS_MTE_FEATURE_ZERO_TAG_ALL) & 1;
-        config->mode_bits.adjacent_tag_exclusion = (mode_byte >> PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION) & 1;
-        config->mode_bits.assert_adjacent_tags_are_disjoint = (mode_byte >> PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT) & 1;
+        uint16_t mode_value = (uint16_t)(mode & 0xFFFF);
+        config->mode_bits.retag_on_free = (mode_value >> pas_mte_feature_retag_on_free) & 1;
+        config->mode_bits.log_on_tag = (mode_value >> pas_mte_feature_log_on_tag) & 1;
+        config->mode_bits.log_on_purify = (mode_value >> pas_mte_feature_log_on_purify) & 1;
+        config->mode_bits.log_page_alloc = (mode_value >> pas_mte_feature_log_page_alloc) & 1;
+        config->mode_bits.zero_tag_all = (mode_value >> pas_mte_feature_zero_tag_all) & 1;
+        config->mode_bits.adjacent_tag_exclusion = (mode_value >> pas_mte_feature_adjacent_tag_exclusion) & 1;
+        config->mode_bits.previous_tag_exclusion = (mode_value >> pas_mte_feature_previous_tag_exclusion) & 1;
+        config->mode_bits.assert_adjacent_tags_are_disjoint = (mode_value >> pas_mte_feature_assert_adjacent_tags_are_disjoint) & 1;
+        config->mode_bits.check_tag_on_dealloc = (mode_value >> pas_mte_feature_check_tag_on_dealloc) & 1;
+        config->mode_bits.large_object_delegation = (mode_value >> pas_mte_feature_large_object_delegation) & 1;
     }
 
     const char* name = getprogname();
@@ -167,12 +169,8 @@ static void pas_mte_do_initialization(void)
             pas_mte_force_nontaggable_user_allocations_into_large_heap();
         } else {
             config->is_hardened = false;
-#if !PAS_USE_MTE_IN_WEBCONTENT
             // Disable tagging in libpas by default in WebContent process
             config->enabled = false;
-#else
-            config->enabled = true;
-#endif
         }
 
 #ifndef NDEBUG
@@ -191,13 +189,13 @@ static void pas_mte_do_initialization(void)
     }
 
     PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
-    // Retag-on-scavenge functionally supports both segregated and bitfit heaps.
-    // However, true to the name, for segregated heaps the retag operation only
+    // Retag-on-free functionally supports both segregated and bitfit heaps.
+    // However, despite the name, for segregated heaps the retag operation only
     // takes place on the scavenging path.
     // For bitfit heaps, there is no such path: as such, freed bitfit objects are
     // immediately retagged. This closes the window where attackers could in
     // theory exploit a UAF.
-    // As such, when retag-on-scavenge is enabled, we prefer to allocate from
+    // As such, when retag-on-free is enabled, we prefer to allocate from
     // bitfit heaps to exploit this property -- the exception of course being
     // isoheaps, due to the intrinsic type-unsafety of bitfit heaps.
     // In practice, for privileged processes this already takes place when WebCore
@@ -206,7 +204,7 @@ static void pas_mte_do_initialization(void)
     // mini-mode because a few stray allocations there won't hurt, but for a
     // security boundary those stray allocations are more of a problem. So we force
     // this here, prior to the creation of such segregated directories.
-    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_RETAG_ON_SCAVENGE))
+    if (pas_mte_use_feature(pas_mte_feature_retag_on_free))
         pas_bmalloc_force_allocations_into_bitfit_heaps_where_available();
     PAS_IGNORE_WARNINGS_END;
 }
@@ -274,7 +272,7 @@ static void pas_report_config(void)
         "%s(%d,0x%x) malloc: libpas config:"
         "\n\tDeallocation Log (Max Entries, Max Bytes): %zu, %zuB"
         "\n\tScavenger (Period, Deep-Sleep Timeout, Epoch-Delta): %.2fms, %.2fms, %llu"
-        "\n\tMTE (Enabled/Lockdown/Hardened/ATE/RoS/ZTA): (%u, %u, %u, %u, %u, %u)"
+        "\n\tMTE (Enabled/Lockdown/Hardened/ATE/PTE/RoF/ZTA/LOD): (%u, %u, %u, %u, %u, %u, %u, %u)"
 #if PAS_ENABLE_BMALLOC
         "\n\tForwarding to System Heap: %u"
         LOG_FMT_STR_FOR_HEAP_CONFIG(bmalloc)
@@ -300,7 +298,9 @@ static void pas_report_config(void)
         (size_t)PAS_DEALLOCATION_LOG_SIZE, (size_t)PAS_DEALLOCATION_LOG_MAX_BYTES,
         pas_scavenger_period_in_milliseconds, pas_scavenger_deep_sleep_timeout_in_milliseconds, pas_scavenger_max_epoch_delta,
         config->enabled, config->is_lockdown_mode, config->is_hardened,
-        config->mode_bits.adjacent_tag_exclusion, config->mode_bits.retag_on_scavenge, config->mode_bits.zero_tag_all,
+        config->mode_bits.adjacent_tag_exclusion, config->mode_bits.previous_tag_exclusion,
+        config->mode_bits.retag_on_free, config->mode_bits.zero_tag_all,
+        config->mode_bits.large_object_delegation,
 #if PAS_ENABLE_BMALLOC
         pas_system_heap_should_supplant_bmalloc(pas_heap_config_kind_bmalloc),
         LOG_FMT_VARS_FOR_HEAP_CONFIG(bmalloc_heap_config),
@@ -375,10 +375,8 @@ void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void)
     // So we take the object-delegation path to be a special case and make
     // sure to re-apply after performing the above expansion.
     PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
-#if defined(PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
-    if (PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
+    if (pas_mte_use_feature(pas_mte_feature_large_object_delegation))
         pas_mte_force_nontaggable_user_allocations_into_large_heap();
-#endif // defined(PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
     PAS_IGNORE_WARNINGS_END;
 }
 
@@ -402,5 +400,4 @@ void pas_mte_force_nontaggable_user_allocations_into_large_heap(void)
     }
 #endif
 }
-#endif // defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
 #endif // LIBPAS_ENABLED

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
@@ -46,6 +46,7 @@
 #endif // __has_include(<libproc.h>)
 #endif // defined(__has_include)
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -64,22 +65,117 @@
 #endif // PAS_USE_APPLE_INTERNAL_SDK
 #endif // PAS_OS(DARWIN)
 
-#if defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
-#if PAS_ENABLE_MTE
-
-#define PAS_USE_MTE (PAS_RUNTIME_CONFIG_PTR->enabled)
-#ifndef PAS_USE_MTE_IN_WEBCONTENT
-#define PAS_USE_MTE_IN_WEBCONTENT 1
+#ifdef __cplusplus
+extern "C" {
 #endif
-
-#define PAS_MTE_IS_LOCKDOWN_MODE (PAS_RUNTIME_CONFIG_PTR->is_lockdown_mode)
-#define PAS_MTE_IS_HARDENED (PAS_RUNTIME_CONFIG_PTR->is_hardened)
-#define PAS_MTE_USE_LARGE_OBJECT_DELEGATION (PAS_USE_MTE && PAS_MTE_IS_HARDENED)
 
 #define PAS_VM_MTE 0x2000
 #define PAS_MTE_PROC_FLAG_SEC_ENABLED 0x4000000
 
 #define PAS_MTE_SHOULD_STORE_TAG 1
+
+/*
+ * The values double as bit positions within the mode value parsed by
+ * pas_mte_config.c, so they must be explicit and must stay contiguous.
+ */
+typedef enum pas_mte_feature {
+    pas_mte_feature_retag_on_free = 0,
+    pas_mte_feature_log_on_tag,
+    pas_mte_feature_log_on_purify,
+    pas_mte_feature_log_page_alloc = 3,
+    pas_mte_feature_zero_tag_all = 4,
+    pas_mte_feature_adjacent_tag_exclusion = 5,
+    pas_mte_feature_assert_adjacent_tags_are_disjoint = 6,
+    pas_mte_feature_check_tag_on_dealloc = 7,
+    pas_mte_feature_large_object_delegation = 8,
+    pas_mte_feature_previous_tag_exclusion = 9
+} pas_mte_feature;
+
+/*
+ * Regardless of this condition, features also enabled via a debug-only runtime
+ * bit (see pas_runtime_config.h pas_runtime_config.mode_bits).
+ */
+typedef enum pas_mte_use_feature_condition {
+    pas_mte_use_feature_never,
+    pas_mte_use_feature_debug,
+    pas_mte_use_feature_hardened,
+    pas_mte_use_feature_always
+} pas_mte_use_feature_condition;
+
+/* Helper to access feature bits by index (for dynamic feature checking) */
+#define PAS_MTE_FEATURE_BIT(feature) ( \
+    (feature) == pas_mte_feature_retag_on_free ? PAS_RUNTIME_CONFIG_PTR->mode_bits.retag_on_free : \
+    (feature) == pas_mte_feature_log_on_tag ? PAS_RUNTIME_CONFIG_PTR->mode_bits.log_on_tag : \
+    (feature) == pas_mte_feature_log_on_purify ? PAS_RUNTIME_CONFIG_PTR->mode_bits.log_on_purify : \
+    (feature) == pas_mte_feature_log_page_alloc ? PAS_RUNTIME_CONFIG_PTR->mode_bits.log_page_alloc : \
+    (feature) == pas_mte_feature_zero_tag_all ? PAS_RUNTIME_CONFIG_PTR->mode_bits.zero_tag_all : \
+    (feature) == pas_mte_feature_adjacent_tag_exclusion ? PAS_RUNTIME_CONFIG_PTR->mode_bits.adjacent_tag_exclusion : \
+    (feature) == pas_mte_feature_previous_tag_exclusion ? PAS_RUNTIME_CONFIG_PTR->mode_bits.previous_tag_exclusion : \
+    (feature) == pas_mte_feature_assert_adjacent_tags_are_disjoint ? PAS_RUNTIME_CONFIG_PTR->mode_bits.assert_adjacent_tags_are_disjoint : \
+    (feature) == pas_mte_feature_check_tag_on_dealloc ? PAS_RUNTIME_CONFIG_PTR->mode_bits.check_tag_on_dealloc : \
+    (feature) == pas_mte_feature_large_object_delegation ? PAS_RUNTIME_CONFIG_PTR->mode_bits.large_object_delegation : \
+    0)
+
+inline __attribute__((always_inline)) bool
+pas_use_mte(void)
+{
+#if PAS_ENABLE_MTE
+    return (PAS_RUNTIME_CONFIG_PTR->enabled);
+#else
+    return false;
+#endif
+}
+
+inline __attribute__((always_inline)) bool
+pas_mte_is_hardened(void)
+{
+    return pas_use_mte() && PAS_RUNTIME_CONFIG_PTR->is_hardened;
+}
+
+inline __attribute__((always_inline)) pas_mte_use_feature_condition
+pas_mte_feature_use_condition(pas_mte_feature feature)
+{
+    switch (feature) {
+    case pas_mte_feature_adjacent_tag_exclusion:
+    case pas_mte_feature_previous_tag_exclusion:
+    case pas_mte_feature_retag_on_free:
+    case pas_mte_feature_large_object_delegation:
+        return pas_mte_use_feature_hardened;
+    case pas_mte_feature_assert_adjacent_tags_are_disjoint:
+        return pas_mte_use_feature_debug;
+    case pas_mte_feature_log_on_tag:
+    case pas_mte_feature_log_on_purify:
+    case pas_mte_feature_log_page_alloc:
+    case pas_mte_feature_zero_tag_all:
+    case pas_mte_feature_check_tag_on_dealloc:
+        return pas_mte_use_feature_never;
+    }
+    return pas_mte_use_feature_never;
+}
+
+inline __attribute__((always_inline)) bool
+pas_mte_use_feature(pas_mte_feature feature)
+{
+    if (!pas_use_mte())
+        return false;
+
+    pas_mte_use_feature_condition condition = pas_mte_feature_use_condition(feature);
+
+    if (condition >= pas_mte_use_feature_always)
+        return true;
+
+#ifndef NDEBUG
+    /* Debug builds honor the runtime mode bits in addition to the
+     * static use-conditions. */
+    if (PAS_MTE_FEATURE_BIT(feature) || condition == pas_mte_use_feature_debug)
+        return true;
+#endif
+
+    return condition == pas_mte_use_feature_hardened && pas_mte_is_hardened();
+}
+
+// FIXME: rdar://171662605
+#define PAS_WORKAROUND_RDAR_171662605_UNCONDITIONAL_TAG_ON_ALLOC (1)
 
 /*
  * This setting would force all non-compact TZone allocations into a single bucket.
@@ -93,7 +189,7 @@
  * OK to bypass TZone for objects we know will be MTE-tagged.
  * Presently, the main reason for doing so would be performance, but as MTE
  * is currently (c. 2026) only enabled in non-performant processes, there's no
- * reason to have it on. If it is re-enabled it should be set to PAS_USE_MTE
+ * reason to have it on. If it is re-enabled it should be set to pas_use_mte()
  * so as to preserve the security properties of non-MTE processes.
  *
  * Astute observers may notice that in bmalloc we do the converse, i.e. allocating
@@ -103,111 +199,69 @@
  */
 #define PAS_BYPASS_TZONE_FOR_NONCOMPACT_OBJECTS 0
 
-#define PAS_MTE_FEATURE_RETAG_ON_SCAVENGE 0
-#define PAS_MTE_FEATURE_LOG_ON_TAG 1
-#define PAS_MTE_FEATURE_LOG_ON_PURIFY 2
-#define PAS_MTE_FEATURE_LOG_PAGE_ALLOC 3
-#define PAS_MTE_FEATURE_ZERO_TAG_ALL 4
-// ATE and PTE are always enabled together
-#define PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION 5
-#define PAS_MTE_FEATURE_PREVIOUS_TAG_EXCLUSION PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION
-#define PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT 6
-#define PAS_MTE_FEATURE_CHECK_TAG_ON_DEALLOC 7
-
-// Helper to access feature bits by index (for dynamic feature checking)
-#define PAS_MTE_FEATURE_BIT(feature) ( \
-    (feature) == PAS_MTE_FEATURE_RETAG_ON_SCAVENGE ? PAS_RUNTIME_CONFIG_PTR->mode_bits.retag_on_scavenge : \
-    (feature) == PAS_MTE_FEATURE_LOG_ON_TAG ? PAS_RUNTIME_CONFIG_PTR->mode_bits.log_on_tag : \
-    (feature) == PAS_MTE_FEATURE_LOG_ON_PURIFY ? PAS_RUNTIME_CONFIG_PTR->mode_bits.log_on_purify : \
-    (feature) == PAS_MTE_FEATURE_LOG_PAGE_ALLOC ? PAS_RUNTIME_CONFIG_PTR->mode_bits.log_page_alloc : \
-    (feature) == PAS_MTE_FEATURE_ZERO_TAG_ALL ? PAS_RUNTIME_CONFIG_PTR->mode_bits.zero_tag_all : \
-    (feature) == PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION ? PAS_RUNTIME_CONFIG_PTR->mode_bits.adjacent_tag_exclusion : \
-    (feature) == PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT ? PAS_RUNTIME_CONFIG_PTR->mode_bits.assert_adjacent_tags_are_disjoint : \
-    (feature) == PAS_MTE_FEATURE_CHECK_TAG_ON_DEALLOC ? PAS_RUNTIME_CONFIG_PTR->mode_bits.check_tag_on_dealloc : \
-    0)
-
-#define PAS_MTE_FEATURE_FORCED(feature) (0)
-#define PAS_MTE_FEATURE_HARDENED_FORCED(feature) (feature == PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION || feature == PAS_MTE_FEATURE_RETAG_ON_SCAVENGE)
-#define PAS_MTE_FEATURE_DEBUG_FORCED(feature) (feature == PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT || feature == PAS_MTE_FEATURE_RETAG_ON_SCAVENGE)
-
-#define PAS_MTE_FEATURE_FORCED_IN_RELEASE_BUILD(feature) \
-    (PAS_MTE_FEATURE_FORCED(feature) || \
-     (PAS_MTE_FEATURE_HARDENED_FORCED(feature) && PAS_MTE_IS_HARDENED))
-
-#define PAS_MTE_FEATURE_FORCED_IN_DEBUG_BUILD(feature) \
-    (PAS_MTE_FEATURE_FORCED_IN_RELEASE_BUILD(feature) || \
-     PAS_MTE_FEATURE_DEBUG_FORCED(feature) || \
-     PAS_MTE_FEATURE_BIT(feature))
-
-#ifndef NDEBUG
-#define PAS_MTE_FEATURE_ENABLED(feature) (PAS_USE_MTE && PAS_MTE_FEATURE_FORCED_IN_DEBUG_BUILD(feature))
-#else
-#define PAS_MTE_FEATURE_ENABLED(feature) (PAS_USE_MTE && PAS_MTE_FEATURE_FORCED_IN_RELEASE_BUILD(feature))
-#endif
-
-// FIXME: rdar://171662605
-#define PAS_WORKAROUND_RDAR_171662605_UNCONDITIONAL_TAG_ON_ALLOC (1)
-
 /*
  * These are defined here rather than in pas_mte.h because they are needed by
  * pas_zero_memory.h, which is a transitive depencency of pas_mte.h
  */
-#define PAS_MTE_CHECK_TAG_AND_SET_TCO(ptr) do { \
-        /* We're only checking one tag-granule, so it's not perfect, \
-         * but it does mean that a potential attacker would at least \
-         * need to know the tag for some of their target range. */ \
-        __asm__ volatile( \
-            ".arch_extension memtag\n\t" \
-            "ldr xzr, [%0]\n\t" \
-            "msr tco, #1" \
-            : \
-            : "r"(ptr) \
-            : "memory" \
-        ); \
-    } while (0)
-#define PAS_MTE_SET_TCO_UNCHECKED do { \
-        __asm__ volatile( \
-            ".arch_extension memtag\n\t" \
-            "msr tco, #1" \
-            : \
-            : \
-            : "memory" \
-        ); \
-    } while (0)
-#define PAS_MTE_CLEAR_TCO do { \
-        __asm__ volatile( \
-            ".arch_extension memtag\n\t" \
-            "msr tco, #0" \
-            : \
-            : \
-            : "memory" \
-        ); \
-    } while (0)
 
+inline __attribute__((always_inline)) void
+pas_mte_check_tag_and_set_tco(const void* ptr)
+{
+#if PAS_ENABLE_MTE
+    /*
+     * We're only checking one tag-granule, so it's not perfect, but it does
+     * mean that a potential attacker would at least need to know the tag for
+     * some of their target range.
+     */
+    __asm__ volatile(
+        ".arch_extension memtag\n\t"
+        "ldr xzr, [%0]\n\t"
+        "msr tco, #1"
+        :
+        : "r"(ptr)
+        : "memory"
+    );
 #else // !PAS_ENABLE_MTE
-#define PAS_USE_MTE (0)
-#define PAS_USE_MTE_IN_WEBCONTENT (0)
-#define PAS_MTE_FEATURE_ENABLED(feature) (0)
-#define PAS_MTE_USE_LARGE_OBJECT_DELEGATION (0)
-#define PAS_MTE_CHECK_TAG_AND_SET_TCO(ptr) do { (void)ptr; } while (0)
-#define PAS_MTE_SET_TCO_UNCHECKED do { } while (0)
-#define PAS_MTE_CLEAR_TCO do { } while (0)
-#define PAS_BYPASS_TZONE_FOR_NONCOMPACT_OBJECTS 0
+    (void)ptr;
 #endif // PAS_ENABLE_MTE
+}
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+inline __attribute__((always_inline)) void
+pas_mte_set_tco_unchecked(void)
+{
+#if PAS_ENABLE_MTE
+    __asm__ volatile(
+        ".arch_extension memtag\n\t"
+        "msr tco, #1"
+        :
+        :
+        : "memory"
+    );
+#endif // PAS_ENABLE_MTE
+}
+
+inline __attribute__((always_inline)) void
+pas_mte_clear_tco(void)
+{
+#if PAS_ENABLE_MTE
+    __asm__ volatile(
+        ".arch_extension memtag\n\t"
+        "msr tco, #0"
+        :
+        :
+        : "memory"
+    );
+#endif // PAS_ENABLE_MTE
+}
+
 bool pas_mte_is_mte_enabled(void);
 void pas_mte_ensure_initialized(void);
 void pas_mte_force_nontaggable_user_allocations_into_large_heap(void);
 void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void);
+
 #ifdef __cplusplus
 }
 #endif
-
-#define PAS_MTE_INITIALIZE_IN_WTF_CONFIG \
-    pas_mte_ensure_initialized()
 
 #if defined(PAS_BMALLOC)
 #if BENABLE(LIBPAS)
@@ -217,8 +271,6 @@ void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void);
 #endif // defined(PAS_BMALLOC)
 
 #define BMALLOC_VM_MTE PAS_VM_MTE
-#define BMALLOC_USE_MTE PAS_USE_MTE
 
 #endif // defined(PAS_BMALLOC) && BENABLE(LIBPAS)
-#endif // defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
 #endif // PAS_MTE_CONFIG_H

--- a/Source/bmalloc/libpas/src/libpas/pas_platform.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_platform.h
@@ -222,13 +222,10 @@
 #define PAS_USE_APPLE_INTERNAL_SDK 0
 #endif // PAS_PLATFORM(COCOA)
 
-#ifndef PAS_USE_OPENSOURCE_MTE
-#define PAS_USE_OPENSOURCE_MTE 1
 // For legacy consumers of certain headers
 #ifndef MTE_ENABLED_IN_BUILD
 #define MTE_ENABLED_IN_BUILD 0
 #endif // MTE_ENABLED_IN_BUILD
-#endif // PAS_USE_OPENSOURCE_MTE
 
 /* PAS_ALLOW_UNSAFE_BUFFER_USAGE */
 

--- a/Source/bmalloc/libpas/src/libpas/pas_runtime_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_runtime_config.h
@@ -67,7 +67,7 @@ typedef struct {
     uint8_t enabled;
 
     struct {
-        uint8_t retag_on_scavenge : 1;
+        uint8_t retag_on_free : 1;
         uint8_t log_on_tag : 1;
         uint8_t log_on_purify : 1;
         uint8_t log_page_alloc : 1;
@@ -75,6 +75,8 @@ typedef struct {
         uint8_t adjacent_tag_exclusion : 1;
         uint8_t assert_adjacent_tags_are_disjoint : 1;
         uint8_t check_tag_on_dealloc : 1;
+        uint8_t large_object_delegation : 1;
+        uint8_t previous_tag_exclusion : 1;
     } mode_bits;
 
     bool is_lockdown_mode;

--- a/Source/bmalloc/libpas/src/libpas/pas_scavenger.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_scavenger.c
@@ -221,8 +221,7 @@ static void* scavenger_thread_main(void* arg)
     pthread_set_qos_class_self_np(configured_qos_class, 0);
 #endif
 
-    PAS_PROFILE(SCAVENGER_THREAD_MAIN, data);
-    PAS_MTE_HANDLE(SCAVENGER_THREAD_MAIN, data);
+    pas_mte_ensure_initialized();
 
     for (;;) {
         pas_page_sharing_pool_scavenge_result scavenge_result;

--- a/Source/bmalloc/libpas/src/libpas/pas_zero_memory.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_zero_memory.h
@@ -39,12 +39,12 @@ static PAS_ALWAYS_INLINE void pas_zero_memory(void* memory, size_t size)
      * MTE systems perform poorly when zeroing large chunks
      * of memory, so we set TCO when applicable to avoid that overhead.
      */
-    if (PAS_USE_MTE)
-        PAS_MTE_CHECK_TAG_AND_SET_TCO(memory);
+    if (pas_use_mte())
+        pas_mte_check_tag_and_set_tco(memory);
     PAS_PROFILE(ZERO_MEMORY, memory, size);
     memset(memory, 0, size);
-    if (PAS_USE_MTE)
-        PAS_MTE_CLEAR_TCO;
+    if (pas_use_mte())
+        pas_mte_clear_tco();
     PAS_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 


### PR DESCRIPTION
#### cd8493fb3611bab90e2a633c5b2a044f212d01d3
<pre>
[libpas] Demacroify pas_mte_config.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=321193">https://bugs.webkit.org/show_bug.cgi?id=321193</a>
<a href="https://rdar.apple.com/184254226">rdar://184254226</a>

Reviewed by NOBODY (OOPS!).

Most notably, this replaces PAS_USE_MTE with an always inline function,
pas_use_mte(); same idea for PAS_MTE_FEATURE_ENABLED,
PAS_MTE_CHECK_TAG_AND_SET_TCO, PAS_MTE_SET_TCO_UNCHECKED, and
PAS_MTE_CLEAR_TCO.

It also entirely removes PAS_USE_MTE_IN_WEBCONTENT (now always off by
default), PAS_USE_OPENSOURCE_MTE (always on), and one or two others.

The old feature flags have been replaced with an enum, and additional
flags have been added for previous-tag-exclusion and
large-object-delegation.

* Source/WTF/wtf/WTFConfig.cpp:
(WTF::Config::initialize):
* Source/bmalloc/bmalloc/Gigacage.cpp:
(Gigacage::ensureGigacage):
* Source/bmalloc/bmalloc/VMAllocate.cpp:
(bmalloc::tryVmZeroAndPurgeMTECase):
* Source/bmalloc/libpas/src/libpas/pas_internal_config.h:
* Source/bmalloc/libpas/src/libpas/pas_large_heap.c:
(can_use_large_object_delegation):
(should_delegate_user_allocation_to_system_malloc):
(pas_large_heap_try_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_mte.c:
* Source/bmalloc/libpas/src/libpas/pas_mte.h:
(pas_mte_tag_st2g_loop):
(pas_mte_tag_st2g_switching):
(pas_mte_tag_dc_gva_loop):
(pas_mte_tag_dc_gva_switching):
(pas_mte_tag_region_from_pointer):
(pas_mte_generate_random_tag):
(pas_mte_generate_tag_and_tag_region):
(pas_mte_check_tag_for_deallocation):
(pas_mte_maybe_tag_allocated_region):
(pas_mte_retag_freed_region_if_tagged):
* Source/bmalloc/libpas/src/libpas/pas_mte_config.c:
(pas_mte_do_initialization):
(pas_report_config):
(pas_bmalloc_force_allocations_into_bitfit_heaps_where_available):
(pas_mte_force_nontaggable_user_allocations_into_large_heap):
* Source/bmalloc/libpas/src/libpas/pas_mte_config.h:
* Source/bmalloc/libpas/src/libpas/pas_platform.h:
* Source/bmalloc/libpas/src/libpas/pas_runtime_config.h:
* Source/bmalloc/libpas/src/libpas/pas_scavenger.c:
(scavenger_thread_main):
* Source/bmalloc/libpas/src/libpas/pas_zero_memory.h:
(pas_zero_memory):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd8493fb3611bab90e2a633c5b2a044f212d01d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143517 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bac0d614-46bb-4c31-a477-8dca89efdc5c) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54440 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139753 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96769 "3 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f90678d2-91eb-4a98-af1c-3ddeef4855df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120205 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c496aa9a-a828-44e2-9c8a-422abfbd0224) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42017 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40361 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2175 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8995 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152417 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40014 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/345 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40483 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191257 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/178611 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52817 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148996 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53497 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148741 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43422 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125769 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120624 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52015 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14994 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51400 "Built successfully") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51641 "Hash cd8493fb for PR 71070 does not build (failure)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51461 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->