### PR TITLE
[AppKit Gestures] Clicking on PDF does not show HUD when using the alternate PDF HUD

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView+Testing.swift
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView+Testing.swift
@@ -53,7 +53,7 @@ extension WKAlternatePDFHUDView {
 
     @objc(_hideForTesting)
     private func hideForTesting() {
-        // FIXME: Implement `WKAlternatePDFHUDView.hide`.
+        model.isAutoHidden = true
     }
 }
 

--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
@@ -27,6 +27,24 @@ import AppKit
 public import Foundation
 import WebKit_Internal
 @_weakLinked @_spi(Private) import SwiftUI
+private import Observation
+
+@Observable
+@MainActor
+final class PDFHUDControlsModel {
+    var isAutoHidden = false
+    var isHovered = false
+    private(set) var resetSeed: UInt32 = 0
+
+    var isVisible: Bool {
+        !isAutoHidden || isHovered
+    }
+
+    func show() {
+        isAutoHidden = false
+        resetSeed &+= 1
+    }
+}
 
 struct PDFHUDControls: View {
     static let hoverMargin: CGFloat = 24
@@ -35,15 +53,8 @@ struct PDFHUDControls: View {
     let showSystemActions: Bool
     let action: (WKPDFHUDViewControlAction) -> Void
 
-    @State
-    private var initialHideTimerFired = false
-
-    @State
-    private var isHovered = false
-
-    private var isVisible: Bool {
-        !initialHideTimerFired || isHovered
-    }
+    @Environment(PDFHUDControlsModel.self)
+    private var model
 
     var body: some View {
         ControlGroup {
@@ -72,20 +83,20 @@ struct PDFHUDControls: View {
             }
         }
         .labelStyle(.iconOnly)
-        .opacity(isVisible ? 1 : 0)
-        .animation(.easeInOut, value: isVisible)
+        .opacity(model.isVisible ? 1 : 0)
+        .animation(.easeInOut, value: model.isVisible)
         #if USE_APPLE_INTERNAL_SDK && HAVE_NSGLASSEFFECTVIEW_EFFECT_IS_INTERACTIVE
         .controlGroupStyle(.toolbar)
         #endif
         .padding(Self.hoverMargin)
         .contentShape(.rect)
         .onHover {
-            isHovered = $0
+            model.isHovered = $0
         }
-        .task {
+        .task(id: model.resetSeed) {
             try? await Task.sleep(for: Self.autoHideDelay)
             guard !Task.isCancelled else { return }
-            initialHideTimerFired = true
+            model.isAutoHidden = true
         }
     }
 }
@@ -96,6 +107,9 @@ extension WKAlternatePDFHUDView {
     private static let barVerticalOffset: CGFloat = 40
 
     let frameIdentifier: UInt64
+
+    @nonobjc
+    final let model = PDFHUDControlsModel()
 
     init(
         frame: NSRect,
@@ -108,6 +122,7 @@ extension WKAlternatePDFHUDView {
         super.init(frame: frame)
 
         let controls = PDFHUDControls(showSystemActions: !isInRecoveryOS(), action: actionHandler)
+            .environment(model)
 
         let hostingView = NSHostingView(rootView: controls)
         hostingView.translatesAutoresizingMaskIntoConstraints = false
@@ -130,7 +145,7 @@ extension WKAlternatePDFHUDView {
     }
 
     func show() {
-        // FIXME: Implement `WKAlternatePDFHUDView.show`.
+        model.show()
     }
 }
 

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -535,17 +535,19 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
         return;
     }
 
-    // Clicks aren't delivered to NSButton's built-in click gesture
-    // recognizer when a parent view's GR recognizes first, so we
-    // forward the click manually.
-    if (gesture.state == NSGestureRecognizerStateBegan) {
-        WebCore::FloatPoint location { [gesture locationInView:webView.get()] };
-        CheckedPtr impl = [webView _impl];
-        if (RetainPtr hitView = impl->hitTestPDFHUD(location); hitView && impl->isViewVisible(hitView.get())) {
-            if (RetainPtr hudButton = dynamic_objc_cast<NSButton>(hitView))
-                [hudButton performClick:nil];
-            gesture.state = NSGestureRecognizerStateCancelled;
-            return;
+    if (!protect([webView _protectedPage]->preferences())->useAlternatePDFHUD()) {
+        // Clicks aren't delivered to NSButton's built-in click gesture
+        // recognizer when a parent view's GR recognizes first, so we
+        // forward the click manually.
+        if (gesture.state == NSGestureRecognizerStateBegan) {
+            WebCore::FloatPoint location { [gesture locationInView:webView.get()] };
+            CheckedPtr impl = [webView _impl];
+            if (RetainPtr hitView = impl->hitTestPDFHUD(location); hitView && impl->isViewVisible(hitView.get())) {
+                if (RetainPtr hudButton = dynamic_objc_cast<NSButton>(hitView))
+                    [hudButton performClick:nil];
+                gesture.state = NSGestureRecognizerStateCancelled;
+                return;
+            }
         }
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -557,7 +557,7 @@ extension AppKitGesturesTests.Basic {
         #expect(scaleAfterZooming > scaleBeforeZooming)
     }
 
-    @Test(arguments: [false])
+    @Test(arguments: [true, false])
     func clickingOnPDFShowsHUD(useAlternatePDFHUD: Bool) async throws {
         page.setWebFeature("UseAlternatePDFHUD", enabled: useAlternatePDFHUD)
 


### PR DESCRIPTION
#### ebe9a17c92fb3e6430085cf3ce6b6fa5b5d8d508
<pre>
[AppKit Gestures] Clicking on PDF does not show HUD when using the alternate PDF HUD
<a href="https://bugs.webkit.org/show_bug.cgi?id=321196">https://bugs.webkit.org/show_bug.cgi?id=321196</a>
<a href="https://rdar.apple.com/184256037">rdar://184256037</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

Implement `show` for the alternate PDF HUD view.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift

* Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView+Testing.swift:
(WKAlternatePDFHUDView.hideForTesting):
* Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift:
(PDFHUDControlsModel.resetSeed):
(PDFHUDControlsModel.isVisible):
(PDFHUDControlsModel.show):
(PDFHUDControls.body):
(WKAlternatePDFHUDView.show):
(PDFHUDControls.isVisible): Deleted.

Extract the state into an observable model so that the state can be affected by the outside.

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController singleClickGestureRecognized:]):

Skip this workaround when using the alternate PDF HUD; it wouldn&apos;t do anything anyways, and it
seems to work fine as-is.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

Canonical link: <a href="https://commits.webkit.org/318740@main">https://commits.webkit.org/318740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5edfb7754231e8dde4354e8aa667f460213b4510

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189040 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/263657f8-92f7-4ca1-aa37-2418be71d0d2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139754 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3656a70-586d-4512-b771-a6502c735c58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120206 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42c6eaec-eb2c-4642-ba67-df31f6418c65) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40003 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/346 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45754 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191258 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52818 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148997 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/39967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53498 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148742 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27203 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43417 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125770 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120625 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52016 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14983 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51401 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51642 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51462 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->