### PR TITLE
[webkitscmpy] Issue prompt doesn't mention that a bug ID is accepted

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
@@ -125,10 +125,14 @@ class Branch(Command):
             args.issue = repository.config().get('branch.{}.bug'.format(repository.branch))
 
         if not args.issue:
-            if Tracker.instance() and getattr(args, 'update_issue', True):
-                prompt = '{}nter issue URL or title of new issue: '.format('{}, e'.format(why) if why else 'E')
+            prefix = f'{why}, e' if why else 'E'
+            target = 'title of new issue' if getattr(args, 'update_issue', True) else 'name of new branch'
+            if Tracker.instance() and not redact and not Tracker.instance().hide_title:
+                prompt = f'{prefix}nter issue URL, {Tracker.instance().NAME} ID, or {target}: '
+            elif Tracker.instance():
+                prompt = f'{prefix}nter issue URL or {target}: '
             else:
-                prompt = '{}nter name of new branch (or issue URL): '.format('{}, e'.format(why) if why else 'E')
+                prompt = f'{prefix}nter name of new branch: '
             args.issue = Terminal.input(prompt, alert_after=2 * Terminal.RING_INTERVAL)
 
         if string_utils.decode(args.issue).isnumeric() and Tracker.instance() and not redact and not Tracker.instance().hide_title:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
@@ -79,7 +79,7 @@ class TestBranch(testing.PathTestCase):
             self.assertEqual(local.Git(self.path).branch, 'eng/example')
 
         self.assertEqual(captured.root.log.getvalue(), "Creating the local development branch 'eng/example'...\n")
-        self.assertEqual(captured.stdout.getvalue(), "Enter name of new branch (or issue URL): \nCreated the local development branch 'eng/example'\n")
+        self.assertEqual(captured.stdout.getvalue(), "Enter name of new branch: \nCreated the local development branch 'eng/example'\n")
 
     def test_prompt_number(self):
         with MockTerminal.input('2'), OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
@@ -93,7 +93,7 @@ class TestBranch(testing.PathTestCase):
             self.assertEqual(0, program.main(args=('branch', '-v'), path=self.path))
             self.assertEqual(local.Git(self.path).branch, 'eng/Example-feature-1')
         self.assertEqual(captured.root.log.getvalue(), "Creating the local development branch 'eng/Example-feature-1'...\n")
-        self.assertEqual(captured.stdout.getvalue(), "Enter issue URL or title of new issue: \nCreated the local development branch 'eng/Example-feature-1'\n")
+        self.assertEqual(captured.stdout.getvalue(), "Enter issue URL, Bugzilla ID, or title of new issue: \nCreated the local development branch 'eng/Example-feature-1'\n")
 
     def test_prompt_url(self):
         with MockTerminal.input('<rdar://2>'), OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path), \
@@ -133,7 +133,7 @@ class TestBranch(testing.PathTestCase):
         )
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Enter issue URL or title of new issue: \n"
+            "Enter issue URL, Bugzilla ID, or title of new issue: \n"
             "Existing radar to CC (leave empty to create new radar): \n"
             "Created the local development branch 'eng/Example-feature-1'\n",
         )
@@ -167,7 +167,7 @@ class TestBranch(testing.PathTestCase):
         )
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Enter issue URL or title of new issue: \n"
+            "Enter issue URL, Bugzilla ID, or title of new issue: \n"
             "Existing radar to CC (leave empty to create new radar): \n"
             "Created the local development branch 'eng/Example-feature-1'\n",
         )
@@ -201,7 +201,7 @@ class TestBranch(testing.PathTestCase):
         )
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Enter issue URL or title of new issue: \n"
+            "Enter issue URL, Bugzilla ID, or title of new issue: \n"
             "Existing radar to CC (leave empty to create new radar): \n"
             "Created the local development branch 'eng/Example-feature-1'\n",
         )
@@ -235,7 +235,7 @@ class TestBranch(testing.PathTestCase):
         )
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Enter issue URL or title of new issue: \n"
+            "Enter issue URL, Bugzilla ID, or title of new issue: \n"
             "Existing radar to CC (leave empty to create new radar): \n"
             "Created the local development branch 'eng/Example-feature-1'\n",
         )
@@ -272,7 +272,7 @@ class TestBranch(testing.PathTestCase):
         )
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Enter issue URL or title of new issue: \n"
+            "Enter issue URL, Bugzilla ID, or title of new issue: \n"
             "Created the local development branch 'eng/Example-feature-1'\n",
         )
 
@@ -311,7 +311,7 @@ class TestBranch(testing.PathTestCase):
         )
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Enter issue URL or title of new issue: \n"
+            "Enter issue URL, Bugzilla ID, or title of new issue: \n"
             "Existing radar to CC (leave empty to create new radar): \n"
             "Created the local development branch 'eng/Example-feature-1'\n",
         )
@@ -342,7 +342,7 @@ class TestBranch(testing.PathTestCase):
         )
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Enter issue URL or title of new issue: \n"
+            "Enter issue URL, Bugzilla ID, or title of new issue: \n"
             "Created the local development branch 'eng/Example-feature-1'\n",
         )
 
@@ -399,9 +399,9 @@ class TestBranch(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            '''Enter issue URL or title of new issue: 
-Issue description: 
-What project should the bug be associated with?:
+            'Enter issue URL, Bugzilla ID, or title of new issue: \n'
+            'Issue description: \n'
+            '''What project should the bug be associated with?:
     1) CFNetwork
     2) WebKit
 : 
@@ -440,9 +440,9 @@ Created the local development branch 'eng/Area-New-Issue'
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            '''Enter issue URL or title of new issue: 
-Issue description: 
-What component in 'WebKit' should the bug be associated with?:
+            'Enter issue URL or title of new issue: \n'
+            'Issue description: \n'
+            '''What component in 'WebKit' should the bug be associated with?:
     1) SVG
     2) Scrolling
     3) Tables

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -1144,7 +1144,54 @@ No pre-PR checks to run""")
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Enter issue URL or title of new issue: \n"
+            "Enter issue URL, Bugzilla ID, or title of new issue: \n"
+            "Created 'PR 1 | Example issue 1'!\n"
+            "Posted pull request link to https://bugs.example.com/show_bug.cgi?id=1\n"
+            "https://github.example.com/WebKit/WebKit/pull/1\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_github_existing_branch_bugzilla_id(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(
+                projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(
+                self.BUGZILLA.split('://')[-1],
+                projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+                environment=Environment(
+                    BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                    BUGS_EXAMPLE_COM_PASSWORD='password',
+                )), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)],
+        ), mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn(), MockTerminal.input('1'):
+
+            repo.commits['eng/pr-branch'] = [
+                repo.commits[repo.default_branch][-1],
+                Commit(
+                    hash='06de5d56554e693db72313f4ca1fb969c30b8ccb',
+                    branch='eng/pr-branch',
+                    author=dict(name='Tim Contributor', emails=['tcontributor@example.com']),
+                    identifier="5.1@eng/pr-branch",
+                    timestamp=int(time.time()),
+                    message='[Testing] Existing commit'
+                )
+            ]
+            repo.head = repo.commits['eng/pr-branch'][-1]
+            repo.staged['added.txt'] = 'added'
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history', '--commit'),
+                path=self.path,
+            ))
+
+            self.assertEqual(
+                Tracker.instance().issue(1).comments[-1].content,
+                'Pull request: https://github.example.com/WebKit/WebKit/pull/1',
+            )
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Enter issue URL, Bugzilla ID, or title of new issue: \n"
             "Created 'PR 1 | Example issue 1'!\n"
             "Posted pull request link to https://bugs.example.com/show_bug.cgi?id=1\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",


### PR DESCRIPTION
#### a95eeddb2c1315627474b16b2b0576851d74b9fd
<pre>
[webkitscmpy] Issue prompt doesn&apos;t mention that a bug ID is accepted
<a href="https://bugs.webkit.org/show_bug.cgi?id=321199">https://bugs.webkit.org/show_bug.cgi?id=321199</a>
<a href="https://rdar.apple.com/184257084">rdar://184257084</a>

Reviewed by Sam Sneddon.

Branch.ensure_issue already resolves a bare bug ID, but the prompt only
offered &quot;issue URL or title of new issue&quot;, so nobody knew. It also offered
&quot;(or issue URL)&quot; when no tracker is configured, where a URL does not resolve
either.

Advertise a bug ID only when one can actually be resolved, which excludes
redacted changes and trackers that hide titles:

    Enter issue URL, bug ID, or title of new issue:
    Enter issue URL or title of new issue:
    Enter name of new branch:

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.ensure_issue):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py:
(TestBranch.test_prompt_git):
(TestBranch.test_prompt_number):
(TestBranch.test_prompt_url):
(TestBranch.test_automatic_radar_cc):
(TestBranch.test_manual_radar_cc):
(TestBranch.test_manual_radar_cc_integer):
(TestBranch.test_manual_radar_cc_http):
(TestBranch.test_radar_cc_disabled):
(TestBranch.test_radar_cc_disabled_override):
(TestBranch.test_no_cc_radar):
(TestBranch.test_redacted):
(TestBranch.test_create_bug):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/319736@main">https://commits.webkit.org/319736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc62e382392bb4d8229df017a4f5231fc01655cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143618 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139823 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96784 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120275 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178634 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42095 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40431 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152495 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40081 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/592 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191359 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/178712 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52918 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149076 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40706 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53598 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148819 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43491 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120729 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52116 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15067 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51501 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51742 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->