### PR TITLE
corner-shape: non-round corner shapes are ignored for composited content (<video>, images, composited descendants)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6666,7 +6666,6 @@ webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/border-shape
 webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-backdrop-filter-overflow.html [ ImageOnlyFailure ]
 webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-backdrop-filter-video-overflow.html [ ImageOnlyFailure Pass ]
 webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-backdrop-filter.html [ ImageOnlyFailure ]
-webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-bevel-overflow-composite.html [ ImageOnlyFailure ]
 webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/border-shape/border-shape-clips-background.html [ ImageOnlyFailure ]
 webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/border-shape/border-shape-collapsed-shape-clips-background.html [ ImageOnlyFailure ]
 webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/border-shape/border-shape-geometry-box.html [ ImageOnlyFailure ]

--- a/LayoutTests/compositing/corner-shape-ancestor-clip-expected.html
+++ b/LayoutTests/compositing/corner-shape-ancestor-clip-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Borders and Box Decorations 4: 'corner-shape' on a non-composited ancestor clips a composited descendant — reference</title>
+
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        .clipper {
+            position: relative;
+            width: 320px;
+            height: 240px;
+            margin: 20px;
+            border-radius: 80px;
+            corner-shape: notch scoop bevel squircle;
+            overflow: hidden;
+        }
+
+        .contents {
+            position: absolute;
+            left: -40px;
+            top: -40px;
+            width: 400px;
+            height: 320px;
+            background-color: blue;
+        }
+    </style>
+</head>
+<body>
+    <div class="clipper">
+        <div class="contents"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/corner-shape-ancestor-clip-shape-mask-expected.txt
+++ b/LayoutTests/compositing/corner-shape-ancestor-clip-shape-mask-expected.txt
@@ -1,0 +1,6 @@
+round: mask layer absent, expected absent - PASS
+square: mask layer absent, expected absent - PASS
+scoop: mask layer present, expected present - PASS
+bevel: mask layer present, expected present - PASS
+notch: mask layer present, expected present - PASS
+superellipse(-2): mask layer present, expected present - PASS

--- a/LayoutTests/compositing/corner-shape-ancestor-clip-shape-mask.html
+++ b/LayoutTests/compositing/corner-shape-ancestor-clip-shape-mask.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>corner-shape: an ancestor clip needs a shape mask layer only when it is not a rounded rect</title>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        .clipper {
+            position: relative;
+            height: 150px;
+            border-radius: 40px;
+            overflow: hidden;
+        }
+
+        .clipper > div {
+            position: absolute;
+            left: -20px;
+            top: -20px;
+            width: 260px;
+            height: 190px;
+            background-color: green;
+            transform: translateZ(0);
+        }
+
+        #round { width: 200px; corner-shape: round; }
+        #square { width: 201px; corner-shape: square; }
+        #scoop { width: 202px; corner-shape: scoop; }
+        #bevel { width: 203px; corner-shape: bevel; }
+        #notch { width: 204px; corner-shape: notch; }
+        #superellipse { width: 205px; corner-shape: superellipse(-2); }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        const EXPECT_MASK = {
+            200: ['round', false],
+            201: ['square', false],
+            202: ['scoop', true],
+            203: ['bevel', true],
+            204: ['notch', true],
+            205: ['superellipse(-2)', true],
+        };
+
+        function runTest()
+        {
+            if (!window.internals) {
+                document.getElementById('results').textContent = 'This test requires window.internals.';
+                return;
+            }
+
+            const tree = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CLIPPING);
+            const masked = new Set();
+            const lines = tree.split('\n');
+            let currentWidth = null;
+            for (let index = 0; index < lines.length; index++) {
+                const bounds = lines[index].match(/\(bounds (\d+)\.\d+ 150\.\d+\)/);
+                if (bounds)
+                    currentWidth = bounds[1];
+                if (lines[index].includes('(mask layer') && currentWidth)
+                    masked.add(currentWidth);
+            }
+
+            const results = Object.keys(EXPECT_MASK).map(width => {
+                const [shape, expected] = EXPECT_MASK[width];
+                const hasMask = masked.has(width);
+                return `${shape}: mask layer ${hasMask ? 'present' : 'absent'}, expected `
+                    + `${expected ? 'present' : 'absent'} - ${hasMask === expected ? 'PASS' : 'FAIL'}`;
+            });
+            document.getElementById('results').textContent = results.join('\n');
+        }
+    </script>
+</head>
+<body onload="runTest()">
+    <div class="clipper" id="round"><div></div></div>
+    <div class="clipper" id="square"><div></div></div>
+    <div class="clipper" id="scoop"><div></div></div>
+    <div class="clipper" id="bevel"><div></div></div>
+    <div class="clipper" id="notch"><div></div></div>
+    <div class="clipper" id="superellipse"><div></div></div>
+    <pre id="results"></pre>
+</body>
+</html>

--- a/LayoutTests/compositing/corner-shape-ancestor-clip.html
+++ b/LayoutTests/compositing/corner-shape-ancestor-clip.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Borders and Box Decorations 4: 'corner-shape' on a non-composited ancestor clips a composited descendant</title>
+    <meta name="fuzzy" content="maxDifference=0-45; totalPixels=0-191">
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        .clipper {
+            position: relative;
+            width: 320px;
+            height: 240px;
+            margin: 20px;
+            border-radius: 80px;
+            corner-shape: notch scoop bevel squircle;
+            overflow: hidden;
+        }
+
+        .composited {
+            position: absolute;
+            left: -40px;
+            top: -40px;
+            width: 400px;
+            height: 320px;
+            background-color: blue;
+            transform: translateZ(0);
+        }
+    </style>
+</head>
+<body>
+    <div class="clipper">
+        <div class="composited"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/corner-shape-mask-layer-offset-expected.html
+++ b/LayoutTests/compositing/corner-shape-mask-layer-offset-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Borders and Box Decorations 4: 'corner-shape' mask is positioned by the mask layer's offset from the renderer — reference</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        .stage {
+            position: relative;
+            margin: 60px;
+            width: 320px;
+            height: 240px;
+            border-radius: 80px;
+            corner-shape: notch scoop bevel squircle;
+            overflow: hidden;
+            box-shadow: -50px -40px 0 0 rgba(0, 128, 0, 0.001);
+        }
+
+        .contents {
+            position: absolute;
+            left: -40px;
+            top: -40px;
+            width: 400px;
+            height: 320px;
+            background-color: blue;
+        }
+    </style>
+</head>
+<body>
+    <div class="stage">
+        <div class="contents"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/corner-shape-mask-layer-offset.html
+++ b/LayoutTests/compositing/corner-shape-mask-layer-offset.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Borders and Box Decorations 4: 'corner-shape' mask is positioned by the mask layer's offset from the renderer</title>
+    <meta name="fuzzy" content="maxDifference=0-89; totalPixels=0-316">
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        .stage {
+            position: relative;
+            margin: 60px;
+            width: 320px;
+            height: 240px;
+            border-radius: 80px;
+            corner-shape: notch scoop bevel squircle;
+            overflow: hidden;
+            transform: translateZ(0);
+            box-shadow: -50px -40px 0 0 rgba(0, 128, 0, 0.001);
+        }
+
+        .contents {
+            position: absolute;
+            left: -40px;
+            top: -40px;
+            width: 400px;
+            height: 320px;
+            background-color: blue;
+            transform: translateZ(0);
+        }
+    </style>
+</head>
+<body>
+    <div class="stage">
+        <div class="contents"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/video/corner-shape-video-expected.html
+++ b/LayoutTests/compositing/video/corner-shape-video-expected.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Borders and Box Decorations 4: 'corner-shape' on a composited video</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        .stage {
+            position: relative;
+            width: 320px;
+            height: 240px;
+            margin: 20px;
+            background-color: red;
+        }
+
+        .stage > * {
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 320px;
+            height: 240px;
+            border-radius: 80px;
+            corner-shape: notch scoop bevel squircle;
+        }
+
+        .cover {
+            background-color: blue;
+        }
+    </style>
+</head>
+<body>
+    <div class="stage">
+        <div class="cover"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/video/corner-shape-video-overflow-expected.html
+++ b/LayoutTests/compositing/video/corner-shape-video-overflow-expected.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Borders and Box Decorations 4: 'corner-shape' clipping a composited video with overflow</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        .clipper {
+            position: relative;
+            width: 320px;
+            height: 240px;
+            margin: 20px;
+            border-radius: 80px;
+            corner-shape: notch scoop bevel squircle;
+            overflow: hidden;
+            background-color: red;
+        }
+
+        .clipper > * {
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+        }
+
+        .cover {
+            background-color: blue;
+            border-radius: 80px;
+            corner-shape: notch scoop bevel squircle;
+        }
+    </style>
+</head>
+<body>
+    <div class="clipper">
+        <div class="cover"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/video/corner-shape-video-overflow.html
+++ b/LayoutTests/compositing/video/corner-shape-video-overflow.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Borders and Box Decorations 4: 'corner-shape' clipping a composited video with overflow</title>
+    <meta name="fuzzy" content="maxDifference=0-137; totalPixels=0-400">
+
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        .clipper {
+            position: relative;
+            width: 320px;
+            height: 240px;
+            margin: 20px;
+            border-radius: 80px;
+            corner-shape: notch scoop bevel squircle;
+            overflow: hidden;
+            background-color: red;
+        }
+
+        .clipper > * {
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+        }
+
+        .cover {
+            background-color: blue;
+            border-radius: 80px;
+            corner-shape: notch scoop bevel squircle;
+        }
+
+        video {
+            object-fit: fill;
+        }
+    </style>
+    <script src="../../media/media-file.js"></script>
+    <script src="../../media/utilities.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function init()
+        {
+            document.addEventListener("error", function (event) {
+                console.log("Video failed to load, error " + event.target.error.code);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }, true);
+
+            const video = document.querySelector("video");
+            const gotFrame = waitForVideoFrame(video);
+
+            setSrcByTagName("video", findMediaFile("video", "../../media/content/pure-color-green"));
+
+            await gotFrame;
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+    </script>
+</head>
+<body onload="init();">
+    <div class="clipper">
+        <video></video>
+        <div class="cover"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/video/corner-shape-video.html
+++ b/LayoutTests/compositing/video/corner-shape-video.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Borders and Box Decorations 4: 'corner-shape' on a composited video</title>
+    <meta name="fuzzy" content="maxDifference=0-113; totalPixels=0-385">
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        .stage {
+            position: relative;
+            width: 320px;
+            height: 240px;
+            margin: 20px;
+            background-color: red;
+        }
+
+        .stage > * {
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 320px;
+            height: 240px;
+            border-radius: 80px;
+            corner-shape: notch scoop bevel squircle;
+        }
+
+        .cover {
+            background-color: blue;
+        }
+
+        video {
+            object-fit: fill;
+        }
+    </style>
+    <script src="../../media/media-file.js"></script>
+    <script src="../../media/utilities.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function init()
+        {
+            document.addEventListener("error", function (event) {
+                console.log("Video failed to load, error " + event.target.error.code);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }, true);
+
+            const video = document.querySelector("video");
+            const gotFrame = waitForVideoFrame(video);
+
+            setSrcByTagName("video", findMediaFile("video", "../../media/content/pure-color-green"));
+
+            await gotFrame;
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+    </script>
+</head>
+<body onload="init();">
+    <div class="stage">
+        <video></video>
+        <div class="cover"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/corner-shape-nested-clips-overflow-scroll-expected.html
+++ b/LayoutTests/fast/scrolling/corner-shape-nested-clips-overflow-scroll-expected.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<head>
+    <meta charset="utf-8">
+    <title>CSS Borders and Box Decorations 4: 'corner-shape' on two nested clips, the inner one an overflow scroller — reference</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+        ::-webkit-scrollbar {
+            display: none;
+        }
+        .outer {
+            position: absolute;
+            top: 40px;
+            left: 40px;
+            width: 320px;
+            height: 260px;
+            overflow: hidden;
+            border-radius: 70px;
+            corner-shape: notch scoop bevel squircle;
+        }
+        .scroller {
+            position: absolute;
+            top: 30px;
+            left: 30px;
+            width: 300px;
+            height: 240px;
+            overflow: scroll;
+            border-radius: 60px;
+            corner-shape: scoop squircle notch bevel;
+        }
+        .contents {
+            width: 460px;
+            height: 420px;
+            background-color: blue;
+        }
+    </style>
+</head>
+<body>
+    <div class="outer">
+        <div class="scroller">
+            <div class="contents"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/corner-shape-nested-clips-overflow-scroll.html
+++ b/LayoutTests/fast/scrolling/corner-shape-nested-clips-overflow-scroll.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<head>
+    <meta charset="utf-8">
+    <title>CSS Borders and Box Decorations 4: 'corner-shape' on two nested clips, the inner one an overflow scroller</title>
+    <meta name="fuzzy" content="maxDifference=0-49; totalPixels=0-153">
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        ::-webkit-scrollbar {
+            display: none;
+        }
+
+        .outer {
+            position: absolute;
+            top: 40px;
+            left: 40px;
+            width: 320px;
+            height: 260px;
+            overflow: hidden;
+            border-radius: 70px;
+            corner-shape: notch scoop bevel squircle;
+        }
+
+        .scroller {
+            position: absolute;
+            top: 30px;
+            left: 30px;
+            width: 300px;
+            height: 240px;
+            overflow: scroll;
+            border-radius: 60px;
+            corner-shape: scoop squircle notch bevel;
+        }
+
+        .contents {
+            width: 460px;
+            height: 420px;
+            background-color: blue;
+            transform: translateZ(0);
+        }
+    </style>
+</head>
+<body>
+    <div class="outer">
+        <div class="scroller">
+            <div class="contents"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/corner-shape-overflow-scroll-uneven-radii-expected.html
+++ b/LayoutTests/fast/scrolling/corner-shape-overflow-scroll-uneven-radii-expected.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<head>
+    <meta charset="utf-8">
+    <title>CSS Borders and Box Decorations 4: 'corner-shape' with uneven radii on a bordered overflow scroller — reference</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+        ::-webkit-scrollbar {
+            display: none;
+        }
+        .scroller {
+            position: relative;
+            margin: 50px;
+            width: 400px;
+            height: 300px;
+            overflow: scroll;
+            border: 30px solid rgba(0, 0, 128, 0.5);
+            padding: 20px;
+            border-top-right-radius: 150px 100px;
+            border-bottom-left-radius: 150px 100px;
+            border-top-left-radius: 60px 40px;
+            border-bottom-right-radius: 60px 40px;
+            corner-shape: scoop bevel notch squircle;
+        }
+        .contents {
+            width: 520px;
+            height: 420px;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <div class="scroller">
+        <div class="contents"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/corner-shape-overflow-scroll-uneven-radii.html
+++ b/LayoutTests/fast/scrolling/corner-shape-overflow-scroll-uneven-radii.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<head>
+    <meta charset="utf-8">
+    <title>CSS Borders and Box Decorations 4: 'corner-shape' with uneven radii on a bordered overflow scroller</title>
+    <meta name="fuzzy" content="maxDifference=0-119; totalPixels=0-263">
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        ::-webkit-scrollbar {
+            display: none;
+        }
+
+        .scroller {
+            position: relative;
+            margin: 50px;
+            width: 400px;
+            height: 300px;
+            overflow: scroll;
+            border: 30px solid rgba(0, 0, 128, 0.5);
+            padding: 20px;
+            border-top-right-radius: 150px 100px;
+            border-bottom-left-radius: 150px 100px;
+            border-top-left-radius: 60px 40px;
+            border-bottom-right-radius: 60px 40px;
+            corner-shape: scoop bevel notch squircle;
+        }
+
+        .contents {
+            width: 520px;
+            height: 420px;
+            background-color: green;
+            transform: translateZ(0);
+        }
+    </style>
+</head>
+<body>
+    <div class="scroller">
+        <div class="contents"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -344,6 +344,9 @@ public:
     // Set a rounded rect that will be used to clip the layer contents.
     FloatRoundedRect contentsClippingRect() const { return m_contentsClippingRect; }
     virtual void setContentsClippingRect(const FloatRoundedRect& roundedRect) { m_contentsClippingRect = roundedRect; }
+
+    const Path& contentsClipShapePath() const { return m_contentsClipShapePath; }
+    virtual void setContentsClipShapePath(const Path& path) { m_contentsClipShapePath = path; }
     
     // If true, contentsClippingRect is used to clip child GraphicsLayers.
     bool contentsRectClipsDescendants() const { return m_contentsRectClipsDescendants; }
@@ -686,6 +689,7 @@ protected:
 
     FloatRect m_contentsRect;
     FloatRoundedRect m_contentsClippingRect;
+    Path m_contentsClipShapePath;
     FloatSize m_contentsTilePhase;
     FloatSize m_contentsTileSize;
     ScalingFilter m_contentsMinificationFilter = ScalingFilter::Linear;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1071,6 +1071,25 @@ void GraphicsLayerCA::setContentsClippingRect(const FloatRoundedRect& rect)
     noteLayerPropertyChanged(ContentsRectsChanged);
 }
 
+static bool contentsClipShapePathsAreEqual(const Path& a, const Path& b)
+{
+    if (a.isEmpty() || b.isEmpty())
+        return a.isEmpty() && b.isEmpty();
+
+    auto* aSegments = a.segmentsIfExists();
+    auto* bSegments = b.segmentsIfExists();
+    return aSegments && bSegments && *aSegments == *bSegments;
+}
+
+void GraphicsLayerCA::setContentsClipShapePath(const Path& path)
+{
+    if (contentsClipShapePathsAreEqual(contentsClipShapePath(), path))
+        return;
+
+    GraphicsLayer::setContentsClipShapePath(path);
+    noteLayerPropertyChanged(ContentsRectsChanged);
+}
+
 void GraphicsLayerCA::setContentsRectClipsDescendants(bool contentsRectClipsDescendants)
 {
     if (contentsRectClipsDescendants == m_contentsRectClipsDescendants)
@@ -1091,7 +1110,9 @@ void GraphicsLayerCA::setVideoGravity(MediaPlayerVideoGravity gravity)
 
 void GraphicsLayerCA::setShapeLayerPath(const Path& path)
 {
-    // FIXME: need to check for path equality. No bool Path::operator==(const Path&)!.
+    if (!path.isEmpty() && shapeLayerPath().definitelyEqual(path))
+        return;
+
     GraphicsLayer::setShapeLayerPath(path);
     noteLayerPropertyChanged(ShapeChanged);
 }
@@ -3238,15 +3259,17 @@ void GraphicsLayerCA::updateContentsColorLayer()
 // roundedRect is in the coordinate space of clippingLayer.
 void GraphicsLayerCA::updateClippingStrategy(PlatformCALayer& clippingLayer, RefPtr<PlatformCALayer>& shapeMaskLayer, const FloatRoundedRect& roundedRect)
 {
+    bool hasShapePath = !contentsClipShapePath().isEmpty();
+
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-    if (m_isSeparated && roundedRect.radii().hasEvenCorners() && clippingLayer.bounds() == roundedRect.rect()) {
+    if (!hasShapePath && m_isSeparated && roundedRect.radii().hasEvenCorners() && clippingLayer.bounds() == roundedRect.rect()) {
         m_layer->setCornerRadius(roundedRect.radii().topLeft().width());
         return;
     }
     m_layer->setCornerRadius(0);
 #endif
 
-    if (roundedRect.radii().isUniformCornerRadius() && clippingLayer.bounds() == roundedRect.rect()) {
+    if (!hasShapePath && roundedRect.radii().isUniformCornerRadius() && clippingLayer.bounds() == roundedRect.rect()) {
         clippingLayer.setMaskLayer(nullptr);
         if (shapeMaskLayer) {
             shapeMaskLayer->setOwner(nullptr);
@@ -3272,9 +3295,15 @@ void GraphicsLayerCA::updateClippingStrategy(PlatformCALayer& clippingLayer, Ref
     auto shapeBounds = FloatRect { { }, roundedRect.rect().size() };
     shapeMaskLayer->setBounds(shapeBounds);
     
-    auto localRoundedRect = roundedRect;
-    localRoundedRect.setLocation({ });
-    shapeMaskLayer->setShapeRoundedRect(localRoundedRect);
+    if (hasShapePath) {
+        auto localPath = contentsClipShapePath();
+        localPath.translate(-toFloatSize(rectLocation));
+        shapeMaskLayer->setShapePath(localPath);
+    } else {
+        auto localRoundedRect = roundedRect;
+        localRoundedRect.setLocation({ });
+        shapeMaskLayer->setShapeRoundedRect(localRoundedRect);
+    }
 
     clippingLayer.setCornerRadius(0);
     RefPtr maskLayer = shapeMaskLayer;
@@ -3289,7 +3318,8 @@ void GraphicsLayerCA::updateContentsRects()
     auto contentBounds = FloatRect { { }, m_contentsRect.size() };
     
     bool gainedOrLostClippingLayer = false;
-    if (m_contentsClippingRect.hasNonZeroRadii() || !m_contentsClippingRect.rect().contains(m_contentsRect)) {
+    if (m_contentsClippingRect.hasNonZeroRadii() || !contentsClipShapePath().isEmpty()
+        || !m_contentsClippingRect.rect().contains(m_contentsRect)) {
         if (!m_contentsClippingLayer) {
             Ref contentsClippingLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, this);
             m_contentsClippingLayer = contentsClippingLayer.copyRef();

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -149,6 +149,7 @@ public:
     
     WEBCORE_EXPORT void setContentsRect(const FloatRect&) override;
     WEBCORE_EXPORT void setContentsClippingRect(const FloatRoundedRect&) override;
+    WEBCORE_EXPORT void setContentsClipShapePath(const Path&) override;
     WEBCORE_EXPORT void setContentsRectClipsDescendants(bool) override;
 
     WEBCORE_EXPORT void setVideoGravity(MediaPlayerVideoGravity) override;

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -708,6 +708,9 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
         drawRectRestricted(canvas, context.damageRegionOrNull(), SkRect(m_contentsRect), paint);
     } else if (m_contentsBuffer || m_imageBackingStore) {
         bool shouldPaintNow = [&] {
+            if (m_contentsClipPath)
+                return true;
+
             if (m_contentsClippingRect.hasNonZeroRadii())
                 return true;
 
@@ -730,7 +733,11 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
         if (shouldPaintNow) {
             canvas.concat(transform);
 
-            if (m_contentsClippingRect.hasNonZeroRadii() || !m_contentsClippingRect.rect().contains(m_contentsRect))
+            // A corner shape the clipping rect cannot express arrives as a path instead; the rect has had
+            // its radii dropped in that case, so the path is the whole clip.
+            if (m_contentsClipPath)
+                canvas.clipPath(*m_contentsClipPath, true);
+            else if (m_contentsClippingRect.hasNonZeroRadii() || !m_contentsClippingRect.rect().contains(m_contentsRect))
                 clipRect(canvas, m_contentsClippingRect);
         }
 
@@ -963,7 +970,7 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
         return matrix.mapRect(SkRect(rect.rect())).contains(childMatrix.mapRect(SkRect(childBounds)));
     };
 
-    const bool contentsRectClipsDescendants = !m_preserves3D && m_contentsRectClipsDescendants && (m_contentsClippingRect.hasNonZeroRadii() || !m_contentsClippingRect.rect().contains(m_contentsRect));
+    const bool contentsRectClipsDescendants = !m_preserves3D && m_contentsRectClipsDescendants && (m_contentsClipPath || m_contentsClippingRect.hasNonZeroRadii() || !m_contentsClippingRect.rect().contains(m_contentsRect));
     const bool masksToBounds = !m_preserves3D && m_masksToBounds;
     TransformationMatrix clipTransform;
     FloatRoundedRect clippingRect;

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -82,6 +82,7 @@ public:
     void setContentsOpaque(bool opaque) { m_contentsOpaque = opaque; }
     void setMasksToBounds(bool masksToBounds) { m_masksToBounds = masksToBounds; }
     void setContentsClippingRect(const FloatRoundedRect& rect) { m_contentsClippingRect = rect; }
+    void setContentsClipPath(std::optional<SkPath>&& clipPath) { m_contentsClipPath = WTF::move(clipPath); }
     void setContentsRectClipsDescendants(bool clips) { m_contentsRectClipsDescendants = clips; }
     void setOpacity(float);
     void setBlendMode(BlendMode);
@@ -312,6 +313,7 @@ private:
     float m_opacity { 1 };
     std::optional<SkBlendMode> m_blendMode;
     std::optional<SkPath> m_clipPath;
+    std::optional<SkPath> m_contentsClipPath;
     sk_sp<SkImage> m_maskImage;
     RefPtr<SkiaCompositingLayer> m_mask;
     RefPtr<SkiaCompositingLayer> m_replica;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -470,6 +470,18 @@ void CoordinatedPlatformLayer::setContentsClippingRect(const FloatRoundedRect& c
     notifyCompositionRequired();
 }
 
+void CoordinatedPlatformLayer::setContentsClipShapePath(const Path& path)
+{
+    assertIsHeld(m_lock);
+    if (m_contentsClipShapePath.definitelyEqual(path))
+        return;
+
+    m_contentsClipShapePath = path;
+    m_pendingChanges.add(Change::ContentsClipShapePath);
+    damageWholeLayer();
+    notifyCompositionRequired();
+}
+
 void CoordinatedPlatformLayer::setContentsScale(float contentsScale)
 {
     assertIsMainThread();
@@ -1084,6 +1096,12 @@ void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<Com
             layer.setContentsClippingRect(m_contentsClippingRect);
             m_pendingChanges.remove(Change::ContentsClippingRect);
         }
+
+        // FIXME: clip the contents to the corner-shape contour here too. TextureMapper::beginClip()
+        // takes a ClipPath, a triangulated vertex buffer, so this needs a Path tessellation step that
+        // does not exist yet; until then a non-round corner shape on composited contents is clipped
+        // only by the rect above.
+        m_pendingChanges.remove(Change::ContentsClipShapePath);
     }
 
     if (reasons.contains(CompositionReason::RenderingUpdate)) {
@@ -1272,6 +1290,17 @@ void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet
         if (m_pendingChanges.contains(Change::ContentsClippingRect)) {
             layer.setContentsClippingRect(m_contentsClippingRect);
             m_pendingChanges.remove(Change::ContentsClippingRect);
+        }
+
+        if (m_pendingChanges.contains(Change::ContentsClipShapePath)) {
+            if (m_contentsClipShapePath.isEmpty())
+                layer.setContentsClipPath(std::nullopt);
+            else {
+                auto contentsClipPath = *m_contentsClipShapePath.platformPath();
+                contentsClipPath.setFillType(SkPathFillType::kWinding);
+                layer.setContentsClipPath(WTF::move(contentsClipPath));
+            }
+            m_pendingChanges.remove(Change::ContentsClipShapePath);
         }
 
         if (m_pendingChanges.contains(Change::ContentsImage)) {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -157,6 +157,7 @@ public:
     void setContentsRect(const FloatRect&) WTF_REQUIRES_LOCK(m_lock);
     void setContentsRectClipsDescendants(bool) WTF_REQUIRES_LOCK(m_lock);
     void setContentsClippingRect(const FloatRoundedRect&) WTF_REQUIRES_LOCK(m_lock);
+    void setContentsClipShapePath(const Path&) WTF_REQUIRES_LOCK(m_lock);
     void setContentsScale(float) WTF_REQUIRES_LOCK(m_lock);
     float contentsScale() const WTF_REQUIRES_LOCK(m_lock);
     enum class RequireComposition : bool { No, Yes };
@@ -248,6 +249,7 @@ private:
         ClipPath,
         ContentsBuffer,
         ContentsClippingRect,
+        ContentsClipShapePath,
         ContentsColor,
         ContentsImage,
         ContentsOpaque,
@@ -312,6 +314,7 @@ private:
     FloatRect m_contentsRect WTF_GUARDED_BY_LOCK(m_lock);
     bool m_contentsRectClipsDescendants WTF_GUARDED_BY_LOCK(m_lock) { false };
     FloatRoundedRect m_contentsClippingRect WTF_GUARDED_BY_LOCK(m_lock);
+    Path m_contentsClipShapePath WTF_GUARDED_BY_LOCK(m_lock);
     Color m_contentsColor WTF_GUARDED_BY_LOCK(m_lock);
     FloatSize m_contentsTileSize WTF_GUARDED_BY_LOCK(m_lock);
     FloatSize m_contentsTilePhase WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -356,6 +356,15 @@ void GraphicsLayerCoordinated::setContentsClippingRect(const FloatRoundedRect& c
     noteLayerPropertyChanged(Change::ContentsClippingRect, ScheduleFlush::Yes);
 }
 
+void GraphicsLayerCoordinated::setContentsClipShapePath(const Path& path)
+{
+    if (contentsClipShapePath().definitelyEqual(path))
+        return;
+
+    GraphicsLayer::setContentsClipShapePath(path);
+    noteLayerPropertyChanged(Change::ContentsClipShapePath, ScheduleFlush::Yes);
+}
+
 void GraphicsLayerCoordinated::setContentsNeedsDisplay()
 {
     if (m_contentsDisplayDelegate)
@@ -525,7 +534,9 @@ void GraphicsLayerCoordinated::setEventRegion(EventRegion&& eventRegion)
 
 void GraphicsLayerCoordinated::setShapeLayerPath(const Path& path)
 {
-    // FIXME: need to check for path equality. No bool Path::operator==(const Path&)!.
+    if (!path.isEmpty() && shapeLayerPath().definitelyEqual(path))
+        return;
+
     GraphicsLayer::setShapeLayerPath(path);
     noteLayerPropertyChanged(Change::Shape, ScheduleFlush::Yes);
 }
@@ -1132,6 +1143,9 @@ void GraphicsLayerCoordinated::commitLayerChanges(CommitState& commitState, floa
 
     if (m_pendingChanges.contains(Change::ContentsClippingRect))
         m_platformLayer->setContentsClippingRect(m_contentsClippingRect);
+
+    if (m_pendingChanges.contains(Change::ContentsClipShapePath))
+        m_platformLayer->setContentsClipShapePath(contentsClipShapePath());
 
     updateRootRelativeScale(); // Needs to happen before Change::ContentsScale.
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -80,6 +80,7 @@ private:
     void setContentsTileSize(const FloatSize&) override;
     void setContentsTilePhase(const FloatSize&) override;
     void setContentsClippingRect(const FloatRoundedRect&) override;
+    void setContentsClipShapePath(const Path&) override;
     void setContentsNeedsDisplay() override;
     void setContentsNeedsDisplayInRect(const FloatRect&) override;
     void setContentsToPlatformLayer(PlatformLayer*, ContentsLayerPurpose) override;
@@ -147,6 +148,7 @@ private:
         ContentsBuffer,
         ContentsBufferNeedsDisplay,
         ContentsClippingRect,
+        ContentsClipShapePath,
         ContentsColor,
         ContentsImage,
         ContentsOpaque,

--- a/Source/WebCore/rendering/LayerAncestorClippingStack.cpp
+++ b/Source/WebCore/rendering/LayerAncestorClippingStack.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LayerAncestorClippingStack);
 
 LayerAncestorClippingStack::LayerAncestorClippingStack(Vector<CompositedClipData>&& clipDataStack)
-    : m_stack(WTF::map(WTF::move(clipDataStack), [](CompositedClipData&& clipDataEntry) { return ClippingStackEntry { WTF::move(clipDataEntry), std::nullopt, nullptr, nullptr }; }))
+    : m_stack(WTF::map(WTF::move(clipDataStack), [](CompositedClipData&& clipDataEntry) { return ClippingStackEntry { WTF::move(clipDataEntry), std::nullopt, nullptr, nullptr, nullptr }; }))
 {
 }
 
@@ -129,7 +129,7 @@ bool LayerAncestorClippingStack::updateWithClipData(ScrollingCoordinator* scroll
         auto& clipDataEntry = clipDataStack[i];
         
         if (i >= stackEntryCount) {
-            m_stack.append({ WTF::move(clipDataEntry), { }, nullptr, nullptr });
+            m_stack.append({ WTF::move(clipDataEntry), { }, nullptr, nullptr, nullptr });
             stackChanged = true;
             continue;
         }
@@ -182,6 +182,8 @@ static TextStream& operator<<(TextStream& ts, const LayerAncestorClippingStack::
         ts.dumpProperty("overflowScrollProxyNodeID"_s, entry.overflowScrollProxyNodeID);
     if (entry.clippingLayer)
         ts.dumpProperty("clippingLayer"_s, entry.clippingLayer->primaryLayerID());
+    if (entry.shapeMaskLayer)
+        ts.dumpProperty("shapeMaskLayer"_s, entry.shapeMaskLayer->primaryLayerID());
     if (entry.scrollingLayer)
         ts.dumpProperty("scrollingLayer"_s, entry.scrollingLayer->primaryLayerID());
     return ts;

--- a/Source/WebCore/rendering/LayerAncestorClippingStack.h
+++ b/Source/WebCore/rendering/LayerAncestorClippingStack.h
@@ -87,6 +87,7 @@ public:
         Markable<ScrollingNodeID> overflowScrollProxyNodeID; // The node for repositioning the scrolling proxy layer.
         RefPtr<GraphicsLayer> clippingLayer;
         RefPtr<GraphicsLayer> scrollingLayer; // Only present for scrolling entries.
+        RefPtr<GraphicsLayer> shapeMaskLayer; // Only present when the clip is not a rounded rect.
 
         GraphicsLayer* parentForSublayers() const
         {

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -375,7 +375,7 @@ RenderLayerBacking::~RenderLayerBacking()
     updateForegroundLayer(false);
     clearSVGSegmentLayers();
     updateBackgroundLayer(false);
-    updateMaskingLayer(false, false);
+    updateMaskingLayer(false, false, false);
     updateScrollingLayers(false);
     
     ASSERT(!m_viewportConstrainedNodeID);
@@ -1192,7 +1192,7 @@ void RenderLayerBacking::updateReflectionLayer()
 // This can only update things that don't require up-to-date layout.
 void RenderLayerBacking::updateConfigurationAfterStyleChange()
 {
-    updateMaskingLayer(renderer().hasMask(), renderer().hasClipPath());
+    updateMaskingLayer(renderer().hasMask(), renderer().hasClipPath(), needsCornerShapeMask());
 
     updateReflectionLayer();
 
@@ -1294,7 +1294,7 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
         }
     }
 
-    if (updateMaskingLayer(renderer().hasMask(), renderer().hasClipPath()))
+    if (updateMaskingLayer(renderer().hasMask(), renderer().hasClipPath(), needsCornerShapeMask()))
         layerConfigChanged = true;
 
     updateReflectionLayer();
@@ -1576,6 +1576,26 @@ LayoutRect RenderLayerBacking::computeParentGraphicsLayerRect(const RenderLayer*
     return parentGraphicsLayerRect;
 }
 
+static FloatRoundedRect contentsClippingRectForCornerShape(const FloatRoundedRect& clippingRect, const Style::ComputedStyle& style)
+{
+    if (style.border().hasNonRoundCornerShape())
+        return FloatRoundedRect { clippingRect.rect() };
+    return clippingRect;
+}
+
+static void setContentsClipShapePath(GraphicsLayer& graphicsLayer, const Style::ComputedStyle& style, const BorderShape& borderShape, float deviceScaleFactor, const FloatSize& offset)
+{
+    if (!style.border().hasCornerShapeOutsideRoundedRect()) {
+        if (!graphicsLayer.contentsClipShapePath().isEmpty())
+            graphicsLayer.setContentsClipShapePath({ });
+        return;
+    }
+
+    auto shapePath = borderShape.pathForInnerShape(deviceScaleFactor);
+    shapePath.translate(offset);
+    graphicsLayer.setContentsClipShapePath(shapePath);
+}
+
 void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
 {
     ASSERT(!m_owningLayer.normalFlowListDirty());
@@ -1718,7 +1738,7 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
         auto computeMasksToBoundsRect = [&] {
             if ((renderer().hasClipPath() || renderer().style().border().hasBorderRadius())) {
                 auto borderShape = BorderShape::shapeForBorderRect(renderer().style(), m_owningLayer.rendererBorderBoxRect());
-                auto contentsClippingRect = borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor);
+                auto contentsClippingRect = contentsClippingRectForCornerShape(borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor), renderer().style());
                 contentsClippingRect.move(LayoutSize(-clipLayer->offsetFromRenderer()));
                 return contentsClippingRect;
             }
@@ -1972,6 +1992,19 @@ void RenderLayerBacking::updateMaskingLayerGeometry()
     m_maskLayer->setOffsetFromRenderer(m_graphicsLayer->offsetFromRenderer());
     
     if (!m_maskLayer->drawsContent()) {
+        if (!renderer().hasClipPath() && needsCornerShapeMask()) {
+            CheckedPtr box = dynamicDowncast<RenderBox>(renderer());
+            if (!box)
+                return;
+
+            auto borderShape = BorderShape::shapeForBorderRect(box->style(), box->borderBoxRect());
+            auto shapePath = borderShape.pathForOuterShape(deviceScaleFactor());
+            shapePath.translate(-m_maskLayer->offsetFromRenderer());
+            m_maskLayer->setShapeLayerPath(shapePath);
+            m_maskLayer->setShapeLayerWindRule(WindRule::NonZero);
+            return;
+        }
+
         if (renderer().hasClipPath()) {
             ASSERT(!WTF::holdsAlternative<Style::ReferencePath>(renderer().style().clipPath()));
 
@@ -2122,9 +2155,10 @@ void RenderLayerBacking::updateContentsRects()
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         if (RenderLayerCompositor::isSeparated(renderer())) {
             auto borderShape = BorderShape::shapeForBorderRect(renderVideo->style(), renderVideo->borderBoxRect());
-            auto contentsClippingRect = borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor());
+            auto contentsClippingRect = contentsClippingRectForCornerShape(borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor()), renderVideo->style());
             contentsClippingRect.move(contentOffsetInCompositingLayer());
             m_graphicsLayer->setContentsClippingRect(contentsClippingRect);
+            setContentsClipShapePath(*m_graphicsLayer, renderVideo->style(), borderShape, deviceScaleFactor(), contentOffsetInCompositingLayer());
             return;
         }
 #endif
@@ -2138,10 +2172,11 @@ void RenderLayerBacking::updateContentsRects()
             contentsClippingRect = FloatRoundedRect(m_graphicsLayer->contentsRect());
         } else {
             auto borderShape = renderVideo->borderShapeForContentClipping(renderVideo->borderBoxRect());
-            contentsClippingRect = borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor());
+            contentsClippingRect = contentsClippingRectForCornerShape(borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor()), renderVideo->style());
             // Intersect with the (small) destination rect so the oversized contents layer is clipped to what's actually visible.
             contentsClippingRect = FloatRoundedRect(intersection(contentsClippingRect.rect(), FloatRect(renderVideo->videoBox())), contentsClippingRect.radii());
             contentsClippingRect.move(contentOffsetInCompositingLayer());
+            setContentsClipShapePath(*m_graphicsLayer, renderVideo->style(), borderShape, deviceScaleFactor(), contentOffsetInCompositingLayer());
         }
         m_graphicsLayer->setContentsClippingRect(contentsClippingRect);
         return;
@@ -2164,9 +2199,10 @@ void RenderLayerBacking::updateContentsRects()
     if (needsContentsClippingRectUpdate) {
         if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer())) {
             auto borderShape = BorderShape::shapeForBorderRect(renderBox->style(), renderBox->borderBoxRect());
-            auto contentsClippingRect = borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor());
+            auto contentsClippingRect = contentsClippingRectForCornerShape(borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor()), renderBox->style());
             contentsClippingRect.move(contentOffsetInCompositingLayer());
             m_graphicsLayer->setContentsClippingRect(contentsClippingRect);
+            setContentsClipShapePath(*m_graphicsLayer, renderBox->style(), borderShape, deviceScaleFactor(), contentOffsetInCompositingLayer());
             return;
         }
     }
@@ -2178,9 +2214,10 @@ void RenderLayerBacking::updateContentsRects()
         else {
             // FIXME: Support visible overflow for replaced content.
             auto borderShape = renderReplaced->borderShapeForContentClipping(renderReplaced->borderBoxRect());
-            auto contentsClippingRect = borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor());
+            auto contentsClippingRect = contentsClippingRectForCornerShape(borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor()), renderReplaced->style());
             contentsClippingRect.move(contentOffsetInCompositingLayer());
             m_graphicsLayer->setContentsClippingRect(contentsClippingRect);
+            setContentsClipShapePath(*m_graphicsLayer, renderReplaced->style(), borderShape, deviceScaleFactor(), contentOffsetInCompositingLayer());
         }
     }
 }
@@ -2520,6 +2557,18 @@ void RenderLayerBacking::ensureOverflowControlsHostLayerAncestorClippingStack(co
     connectClippingStackLayers(*m_overflowControlsHostLayerAncestorClippingStack);
 }
 
+static const RenderBox* boxNeedingShapeMaskForClip(const CompositedClipData& clipData)
+{
+    CheckedPtr clippingLayer = clipData.clippingLayer.get();
+    if (!clippingLayer)
+        return nullptr;
+
+    auto* box = dynamicDowncast<RenderBox>(clippingLayer->renderer());
+    if (!box || !box->style().border().hasCornerShapeOutsideRoundedRect())
+        return nullptr;
+    return box;
+}
+
 void RenderLayerBacking::ensureClippingStackLayers(LayerAncestorClippingStack& clippingStack)
 {
     for (auto& entry : clippingStack.stack()) {
@@ -2527,6 +2576,16 @@ void RenderLayerBacking::ensureClippingStackLayers(LayerAncestorClippingStack& c
             entry.clippingLayer = createGraphicsLayer(entry.clipData.isOverflowScroll ? "clip for scroller"_s : "ancestor clipping"_s);
             entry.clippingLayer->setMasksToBounds(true);
             entry.clippingLayer->setPaintingPhase({ });
+        }
+
+        if (boxNeedingShapeMaskForClip(entry.clipData)) {
+            if (!entry.shapeMaskLayer) {
+                entry.shapeMaskLayer = createGraphicsLayer("ancestor clip shape mask"_s, GraphicsLayer::Type::Shape);
+                entry.clippingLayer->setMaskLayer(entry.shapeMaskLayer.copyRef());
+            }
+        } else if (entry.shapeMaskLayer) {
+            entry.clippingLayer->setMaskLayer(nullptr);
+            GraphicsLayer::unparentAndClear(entry.shapeMaskLayer);
         }
 
         if (entry.clipData.isOverflowScroll) {
@@ -2540,6 +2599,9 @@ void RenderLayerBacking::ensureClippingStackLayers(LayerAncestorClippingStack& c
 void RenderLayerBacking::removeClippingStackLayers(LayerAncestorClippingStack& clippingStack)
 {
     for (auto& entry : clippingStack.stack()) {
+        if (entry.clippingLayer && entry.shapeMaskLayer)
+            entry.clippingLayer->setMaskLayer(nullptr);
+        GraphicsLayer::unparentAndClear(entry.shapeMaskLayer);
         GraphicsLayer::unparentAndClear(entry.clippingLayer);
         GraphicsLayer::unparentAndClear(entry.scrollingLayer);
     }
@@ -2585,7 +2647,21 @@ void RenderLayerBacking::updateClippingStackLayerGeometry(LayerAncestorClippingS
 
         clipRect.setLocation({ });
         roundedClipRect.setRect(clipRect);
-        entry.clippingLayer->setContentsClippingRect(FloatRoundedRect(roundedClipRect));
+
+        if (CheckedPtr box = boxNeedingShapeMaskForClip(entry.clipData); box && entry.shapeMaskLayer) {
+            entry.clippingLayer->setContentsClippingRect(contentsClippingRectForCornerShape(FloatRoundedRect(roundedClipRect), box->style()));
+
+            auto borderShape = BorderShape::shapeForBorderRect(box->style(), box->borderBoxRect());
+            auto shapePath = borderShape.pathForInnerShape(deviceScaleFactor);
+            auto clipOffsetInBox = box->overflowClipRect(LayoutPoint { }).location();
+            shapePath.translate(FloatSize { -clipOffsetInBox.x().toFloat(), -clipOffsetInBox.y().toFloat() });
+
+            entry.shapeMaskLayer->setSize(snappedClippingLayerRect.size());
+            entry.shapeMaskLayer->setPosition(FloatPoint());
+            entry.shapeMaskLayer->setShapeLayerPath(shapePath);
+            entry.shapeMaskLayer->setShapeLayerWindRule(WindRule::NonZero);
+        } else
+            entry.clippingLayer->setContentsClippingRect(FloatRoundedRect(roundedClipRect));
         entry.clippingLayer->setContentsRectClipsDescendants(true);
 
         lastClipLayerRect = snappedClippingLayerRect;
@@ -3102,11 +3178,19 @@ void RenderLayerBacking::paintSystemPreviewBadgeLayer(GraphicsContext& context, 
 }
 #endif
 
-// Masking layer is used for masks or clip-path.
-bool RenderLayerBacking::updateMaskingLayer(bool hasMask, bool hasClipPath)
+bool RenderLayerBacking::needsCornerShapeMask() const
+{
+    if (!renderer().style().border().hasCornerShapeOutsideRoundedRect())
+        return false;
+
+    return m_graphicsLayer->contentsRectClipsDescendants() || m_childContainmentLayer || m_scrollContainerLayer;
+}
+
+// Masking layer is used for masks, clip-path, or corner-shape
+bool RenderLayerBacking::updateMaskingLayer(bool hasMask, bool hasClipPath, bool hasCornerShapeMask)
 {
     bool layerChanged = false;
-    if (hasMask || hasClipPath) {
+    if (hasMask || hasClipPath || hasCornerShapeMask) {
         OptionSet<GraphicsLayerPaintingPhase> maskPhases;
         if (hasMask)
             maskPhases = GraphicsLayerPaintingPhase::Mask;
@@ -3519,6 +3603,9 @@ static bool supportsDirectlyCompositedBoxDecorations(const RenderLayerModelObjec
     if (renderer.hasClip())
         return false;
 
+    if (style.border().hasNonRoundCornerShape())
+        return false;
+
     if (hasPaintedBoxDecorationsOrBackgroundImage(renderer))
         return false;
 
@@ -3766,6 +3853,9 @@ bool RenderLayerBacking::containsPaintedContent(PaintedContentsInfo& contentsInf
 bool RenderLayerBacking::isDirectlyCompositedImage() const
 {
     if (m_owningLayer.hasVisibleBoxDecorationsOrBackground() || m_owningLayer.shouldPaintWithFilters() || renderer().hasClip())
+        return false;
+
+    if (renderer().style().border().hasNonRoundCornerShape())
         return false;
 
     // Fixed layers that allow detaching won't have a backing store,

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -384,7 +384,8 @@ private:
 #if ENABLE(MODEL_PROCESS)
     bool updateContentsContainmentLayer();
 #endif
-    bool updateMaskingLayer(bool hasMask, bool hasClipPath);
+    bool updateMaskingLayer(bool hasMask, bool hasClipPath, bool hasCornerShapeMask);
+    bool needsCornerShapeMask() const;
     void updateReflectionLayer();
     bool updateTransformFlatteningLayer(const RenderLayer* compositingAncestor);
 #if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)

--- a/Source/WebCore/rendering/style/BorderData.cpp
+++ b/Source/WebCore/rendering/style/BorderData.cpp
@@ -54,6 +54,26 @@ bool BorderData::hasBorderRadius() const
     return radii.anyOf([](auto& corner) { return !Style::isKnownEmpty(corner); });
 }
 
+bool BorderData::hasNonRoundCornerShape() const
+{
+    if (!hasBorderRadius())
+        return false;
+
+    return cornerShapes.anyOf([](auto& shape) {
+        return shape != Style::CornerShapeValue { CSS::Keyword::Round { } };
+    });
+}
+
+bool BorderData::hasCornerShapeOutsideRoundedRect() const
+{
+    if (!hasNonRoundCornerShape())
+        return false;
+
+    return !cornerShapes.allOf([](auto& shape) {
+        return shape == Style::CornerShapeValue { CSS::Keyword::Square { } };
+    });
+}
+
 bool BorderData::containsCurrentColor() const
 {
     return edges.anyOf([](const auto& edge) {

--- a/Source/WebCore/rendering/style/BorderData.h
+++ b/Source/WebCore/rendering/style/BorderData.h
@@ -52,6 +52,10 @@ struct BorderData {
 
     bool hasBorderRadius() const;
 
+    bool hasNonRoundCornerShape() const;
+
+    bool hasCornerShapeOutsideRoundedRect() const;
+
     bool hasVisibleBorderDecoration() const
     {
         return hasVisibleBorder() || hasBorderImage();


### PR DESCRIPTION
#### e303a714c767cbc7d553c6297b1041713745ff82
<pre>
corner-shape: non-round corner shapes are ignored for composited content (&lt;video&gt;, images, composited descendants)
<a href="https://bugs.webkit.org/show_bug.cgi?id=321194">https://bugs.webkit.org/show_bug.cgi?id=321194</a>
<a href="https://rdar.apple.com/184258503">rdar://184258503</a>

Reviewed by Simon Fraser.

This adds a shape mask for the cases the layer can clip itself, and
refuses the directly-composited fast paths for the cases it can&apos;t

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/LayerAncestorClippingStack.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::~RenderLayerBacking):
(WebCore::RenderLayerBacking::updateBackdropFiltersGeometry):
(WebCore::RenderLayerBacking::updateAppleVisualEffect):
(WebCore::RenderLayerBacking::updateConfigurationAfterStyleChange):
(WebCore::RenderLayerBacking::updateConfiguration):
(WebCore::contentsClippingRectForCornerShape):
(WebCore::RenderLayerBacking::updateGeometry):
(WebCore::RenderLayerBacking::updateMaskingLayerGeometry):
(WebCore::RenderLayerBacking::updateContentsRects):
(WebCore::boxNeedingShapeMaskForClip):
(WebCore::RenderLayerBacking::ensureClippingStackLayers):
(WebCore::RenderLayerBacking::removeClippingStackLayers):
(WebCore::RenderLayerBacking::updateClippingStackLayerGeometry):
(WebCore::RenderLayerBacking::needsCornerShapeMask const):
(WebCore::RenderLayerBacking::updateMaskingLayer):
(WebCore::supportsDirectlyCompositedBoxDecorations):
(WebCore::RenderLayerBacking::isDirectlyCompositedImage const):
(WebCore::setContentsClipShapePath):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/style/BorderData.cpp:
(WebCore::BorderData::hasNonRoundCornerShape const):
(WebCore::BorderData::hasCornerShapeOutsideBorderRadius const):
(WebCore::BorderData::hasCornerShapeOutsideRoundedRect const):
* Source/WebCore/rendering/style/BorderData.h:
* LayoutTests/compositing/video/corner-shape-video-expected.html: Added.
* LayoutTests/compositing/video/corner-shape-video-overflow-expected.html: Added.
* LayoutTests/compositing/video/corner-shape-video-overflow.html: Added.
* LayoutTests/compositing/video/corner-shape-video.html: Added.
* Source/WebCore/rendering/LayerAncestorClippingStack.cpp:
(WebCore::LayerAncestorClippingStack::LayerAncestorClippingStack):
(WebCore::LayerAncestorClippingStack::updateWithClipData):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::contentsClipShapePath const):
(WebCore::GraphicsLayer::setContentsClipShapePath):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::contentsClipShapePathsAreEqual):
(WebCore::GraphicsLayerCA::setContentsClipShapePath):
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
(WebCore::GraphicsLayerCA::setShapeLayerPath):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* LayoutTests/compositing/corner-shape-ancestor-clip-expected.html: Added.
* LayoutTests/compositing/corner-shape-ancestor-clip.html: Added.
* LayoutTests/compositing/corner-shape-mask-layer-offset-expected.html: Added.
* LayoutTests/compositing/corner-shape-mask-layer-offset.html: Added.
* LayoutTests/compositing/corner-shape-ancestor-clip-shape-mask-expected.txt: Added.
* LayoutTests/compositing/corner-shape-ancestor-clip-shape-mask.html: Added.
* LayoutTests/fast/scrolling/corner-shape-nested-clips-overflow-scroll-expected.html: Added.
* LayoutTests/fast/scrolling/corner-shape-nested-clips-overflow-scroll.html: Added.
* LayoutTests/fast/scrolling/corner-shape-overflow-scroll-uneven-radii-expected.html: Added.
* LayoutTests/fast/scrolling/corner-shape-overflow-scroll-uneven-radii.html: Added.
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintContents):
(WebCore::SkiaCompositingLayer::paintSelfAndChildren):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setContentsClipShapePath):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnTarget):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::setContentsClipShapePath):
(WebCore::GraphicsLayerCoordinated::setShapeLayerPath):
(WebCore::GraphicsLayerCoordinated::commitLayerChanges):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:

Canonical link: <a href="https://commits.webkit.org/319257@main">https://commits.webkit.org/319257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7ab56487bc5c7fce6b115df6d6cb342033a3b2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191183 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145292 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141196 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121648 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43530 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41809 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41468 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2343 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193118 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54580 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150581 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40288 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55268 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150298 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44887 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127534 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123003 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53785 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16462 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53404 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->