### PR TITLE
Web Extensions load with significant delay on iOS 26.6 when Safari is cold launched

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1521,8 +1521,18 @@ void NetworkStorageManager::moveData(OptionSet<WebsiteDataType> types, WebCore::
             targetOriginStorageManager->deleteData(types, -WallTime::infinity());
 
             // Move data from source origin to target origin.
-            originStorageManager(sourceOrigin)->moveData(types, targetOriginStorageManager->resolvedPath(WebsiteDataType::LocalStorage), targetOriginStorageManager->resolvedPath(WebsiteDataType::IndexedDBDatabases));
+            CheckedRef sourceOriginStorageManager = originStorageManager(sourceOrigin);
+            sourceOriginStorageManager->moveData(types, targetOriginStorageManager->resolvedPath(WebsiteDataType::LocalStorage), targetOriginStorageManager->resolvedPath(WebsiteDataType::IndexedDBDatabases));
+
+            // The source origin does not exist after the rename, so nothing using it can be active.
+            // Delete the data that was not moved, including ServiceWorkerRegistrations, which deleteDataOnDisk
+            // has to leave to SWServer for origins that may still be in use. Otherwise the source origin
+            // directory is left behind and every origin traversal keeps paying for it.
+            sourceOriginStorageManager->deleteData(allManagedTypes(), -WallTime::infinity());
         }
+
+        if (auto persistedFile = persistedFilePath(sourceOrigin); !persistedFile.isEmpty())
+            FileSystem::deleteFile(persistedFile);
 
         removeOriginStorageManagerIfPossible(targetOrigin);
         removeOriginStorageManagerIfPossible(sourceOrigin);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -507,34 +507,12 @@ void WebExtensionContext::moveLocalStorageIfNeeded(const URL& previousBaseURL, C
     }
 
     static NSSet<NSString *> *dataTypes = [NSSet setWithObjects:WKWebsiteDataTypeIndexedDBDatabases, WKWebsiteDataTypeLocalStorage, nil];
-    [webViewConfiguration().websiteDataStore _renameOrigin:previousBaseURL.createNSURL().get() to:baseURL().createNSURL().get() forDataOfTypes:dataTypes completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, previousBaseURL, completionHandler = WTF::move(completionHandler)]() mutable {
-        removeWebsiteDataForOrigin(previousBaseURL, WTF::move(completionHandler));
-    }).get()];
+    [webViewConfiguration().websiteDataStore _renameOrigin:previousBaseURL.createNSURL().get() to:baseURL().createNSURL().get() forDataOfTypes:dataTypes completionHandler:makeBlockPtr(WTF::move(completionHandler)).get()];
 }
 
 static OptionSet<WebsiteDataType> allWebsiteDataTypes()
 {
     return toWebsiteDataTypes([WKWebsiteDataStore _allWebsiteDataTypesIncludingPrivate]);
-}
-
-void WebExtensionContext::removeWebsiteDataForOrigin(const URL& originURL, CompletionHandler<void()>&& completionHandler)
-{
-    if (!originURL.isValid())
-        return completionHandler();
-
-    RetainPtr<WKWebsiteDataStore> dataStore = webViewConfiguration().websiteDataStore;
-    RefPtr websiteDataStore = dataStore ? dataStore->_websiteDataStore.get() : nullptr;
-    if (!websiteDataStore)
-        return completionHandler();
-
-    auto origin = WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(originURL);
-    auto dataTypes = allWebsiteDataTypes();
-
-    WebsiteDataRecord record;
-    for (auto type : dataTypes)
-        record.add(type, origin);
-
-    websiteDataStore->removeData(dataTypes, { record }, WTF::move(completionHandler));
 }
 
 void WebExtensionContext::removeStaleExtensionWebsiteData()

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -691,7 +691,6 @@ private:
 
     void determineInstallReasonDuringLoad();
     void moveLocalStorageIfNeeded(const URL& previousBaseURL, CompletionHandler<void()>&&);
-    void removeWebsiteDataForOrigin(const URL&, CompletionHandler<void()>&&);
     void removeStaleExtensionWebsiteData();
 
     void permissionsDidChange(PermissionNotification, const PermissionsSet&);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
@@ -591,6 +591,55 @@ TEST(WebKit, WebsiteDataStoreRenameOrigin)
     TestWebKitAPI::Util::run(&done);
 }
 
+static RetainPtr<NSSet> displayNamesOfDataRecords(WKWebsiteDataStore *dataStore, NSSet *types)
+{
+    __block RetainPtr<NSMutableSet> displayNames = adoptNS([[NSMutableSet alloc] init]);
+    __block bool done = false;
+    [dataStore fetchDataRecordsOfTypes:types completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+        for (WKWebsiteDataRecord *record in records)
+            [displayNames addObject:record.displayName];
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    return displayNames;
+}
+
+TEST(WebKit, WebsiteDataStoreRenameOriginRemovesSourceOriginData)
+{
+    NSSet *allTypes = [WKWebsiteDataStore allWebsiteDataTypes];
+
+    __block bool done = false;
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:allTypes modifiedSince:[NSDate distantPast] completionHandler:^{
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    NSURL *exampleURL = [NSURL URLWithString:@"https://example.com/"];
+    NSURL *webKitURL = [NSURL URLWithString:@"https://webkit.org/"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
+    [webView synchronouslyLoadHTMLString:@"<script>localStorage.setItem('testkey', 'testvalue')</script>" baseURL:exampleURL];
+
+    // DOMCache is not one of the renamed types, so it is what verifies that data left behind gets deleted.
+    EXPECT_WK_STREQ("ok", [webView objectByCallingAsyncFunction:@"const cache = await caches.open('testcache'); await cache.put('https://example.com/resource', new Response('body')); return 'ok';" withArguments:@{ }]);
+
+    WKWebsiteDataStore *dataStore = [webView configuration].websiteDataStore;
+    EXPECT_TRUE([displayNamesOfDataRecords(dataStore, allTypes).get() containsObject:@"example.com"]);
+
+    RetainPtr renamedTypes = adoptNS([[NSSet alloc] initWithObjects:WKWebsiteDataTypeLocalStorage, WKWebsiteDataTypeIndexedDBDatabases, nil]);
+    done = false;
+    [dataStore _renameOrigin:exampleURL to:webKitURL forDataOfTypes:renamedTypes.get() completionHandler:^{
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    [webView synchronouslyLoadHTMLString:@"hello" baseURL:webKitURL];
+    EXPECT_WK_STREQ("testvalue", [webView stringByEvaluatingJavaScript:@"localStorage.getItem('testkey')"]);
+
+    EXPECT_FALSE([displayNamesOfDataRecords(dataStore, allTypes).get() containsObject:@"example.com"]);
+}
+
 TEST(WebKit, NetworkCacheDirectory)
 {
     using namespace TestWebKitAPI;


### PR DESCRIPTION
#### 7f8d70c0622228116a14f5100cf0e3e6fd333de7
<pre>
Web Extensions load with significant delay on iOS 26.6 when Safari is cold launched
<a href="https://bugs.webkit.org/show_bug.cgi?id=320812">https://bugs.webkit.org/show_bug.cgi?id=320812</a>
<a href="https://rdar.apple.com/183827503">rdar://183827503</a>

Reviewed by Timothy Hatcher.

312231@main made WebExtensionContext::moveLocalStorageIfNeeded remove all website data for the previous base URL after
renaming localStorage and IndexedDB to the new one. A web extension gets a new base URL on every launch, so this runs
once per extension on every cold launch, with every website data type included. WebsiteDataType::DiskCache alone makes
NetworkCache::Cache::deleteData traverse the entire network cache, decoding every record&apos;s ResourceResponse on the
network process main thread. Other types also add their own launch-time cost: ScreenTime creates an STWebHistory XPC
connection on the UI process main thread, and DOMCache forces NetworkSession::ensureSWServer. Extension content
injection waits for all of it, because load() sets m_safeToInjectContent and calls addInjectedContent from
moveLocalStorageIfNeeded&apos;s completion handler.

This patch ensures to delete what the rename leaves behind as part of the rename instead.
NetworkStorageManager::moveData already calls removeOriginStorageManagerIfPossible for the source origin, which removes
the origin directory once it is empty, but it never became empty because only localStorage and IndexedDB were moved out
of it. Deleting the remaining managed types there makes that existing cleanup effective and lets WebExtensionContext
drop its separate removal entirely.

Partitions where the previous base URL is only one side of the ClientOrigin, along with MediaKeys and DeviceIdHashSalt,
are left to a follow-up that periodically removes data for extension origins that no longer belong to a loaded
extension: finding them requires traversing all origins, which that pass can do once instead of once per extension per
launch.

Test: WebKit.WebsiteDataStoreRenameOriginRemovesSourceOriginData

* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::moveData):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::moveLocalStorageIfNeeded):
(WebKit::WebExtensionContext::removeWebsiteDataForOrigin): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm:
(displayNamesOfDataRecords):
(TEST(WebKit, WebsiteDataStoreRenameOriginRemovesSourceOriginData)):
(TEST(WebKit, NetworkCacheDirectory)):

Canonical link: <a href="https://commits.webkit.org/318756@main">https://commits.webkit.org/318756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7137623323d56ef0bd83321dce61953e63751a2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189062 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139771 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120223 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40377 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152431 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40023 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/368 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45776 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191280 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52840 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149012 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39981 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53520 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36650 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148757 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43435 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125792 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120651 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52038 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15004 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51423 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51664 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51484 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->