### PR TITLE
AX: Translate accessibility announcements (ARIA Notify, live regions) when the page is presented as a machine translation

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/aria-notify-translated-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/aria-notify-translated-expected.txt
@@ -1,0 +1,17 @@
+This test verifies that translated aria-notify announcements carry the target language on iOS.
+
+Announcement received, notification: AXAnnouncementRequested, attributed string: Hello_translated_to_fr{
+    UIAccessibilityARIAInterruptBehavior = None;
+    UIAccessibilityARIAPriority = Normal;
+    UIAccessibilitySpeechAttributeLanguage = fr;
+}
+Announcement received, notification: AXAnnouncementRequested, attributed string: World_translated_to_fr{
+    UIAccessibilityARIAInterruptBehavior = Pending;
+    UIAccessibilityARIAPriority = High;
+    UIAccessibilitySpeechAttributeLanguage = fr;
+}
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/ios-simulator/aria-notify-translated.html
+++ b/LayoutTests/accessibility/ios-simulator/aria-notify-translated.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsARIANotifyEnabled=true displayedTranslationLocale=fr announcementTranslationMode=immediate ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<script>
+var output = "This test verifies that translated aria-notify announcements carry the target language on iOS.\n\n";
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Announcement received, notification: ${notification}, attributed string: ${userInfo["AXAnnouncementRequested"]}\n`;
+        notificationCount++;
+
+        if (notificationCount == 1)
+            document.ariaNotify("World", { priority: "high", interrupt: "pending" });
+        else if (notificationCount == 2)
+            testFinished = true;
+    }
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    accessibilityController.addNotificationListener(notificationCallback);
+    document.ariaNotify("Hello");
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+ }
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/aria-notify-translated-expected.txt
+++ b/LayoutTests/accessibility/mac/aria-notify-translated-expected.txt
@@ -1,0 +1,19 @@
+Tests that ariaNotify announcements are translated, and reported in the target language, when the page is presented as a machine translation (Core-AAM).
+
+Received announcement request:
+AnnouncementKey: San Francisco_translated_to_fr
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: fr
+
+Received announcement request:
+AnnouncementKey: Hej_translated_to_fr
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: High
+AXAnnouncementLanguageKey: fr
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hej

--- a/LayoutTests/accessibility/mac/aria-notify-translated.html
+++ b/LayoutTests/accessibility/mac/aria-notify-translated.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsARIANotifyEnabled=true displayedTranslationLocale=fr announcementTranslationMode=immediate ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<button id="button" lang="da">Hej</button>
+
+<script>
+var output = "Tests that ariaNotify announcements are translated, and reported in the target language, when the page is presented as a machine translation (Core-AAM).\n\n";
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAriaNotifyUserInfo(userInfo);
+        notificationCount++;
+
+        // The source language here is the button's lang="da", not the document's "en", so this also
+        // covers passing the element's own language to the client as the translation source.
+        if (notificationCount == 1)
+            document.getElementById("button").ariaNotify("Hej", { priority: "high" });
+
+        if (notificationCount == 2)
+            testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    accessibilityController.addNotificationListener(notificationCallback);
+
+    document.ariaNotify("San Francisco");
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/aria-notify-translation-dropped-handler-expected.txt
+++ b/LayoutTests/accessibility/mac/aria-notify-translation-dropped-handler-expected.txt
@@ -1,0 +1,19 @@
+Tests that a translation client which drops the completion handler without calling it neither terminates the process nor loses the announcement, and does not block the ones behind it.
+
+Received announcement request:
+AnnouncementKey: First
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: en
+
+Received announcement request:
+AnnouncementKey: Second
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: en
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/aria-notify-translation-dropped-handler.html
+++ b/LayoutTests/accessibility/mac/aria-notify-translation-dropped-handler.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsARIANotifyEnabled=true displayedTranslationLocale=fr announcementTranslationMode=drop ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<script>
+var output = "Tests that a translation client which drops the completion handler without calling it neither terminates the process nor loses the announcement, and does not block the ones behind it.\n\n";
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAriaNotifyUserInfo(userInfo);
+        notificationCount++;
+
+        if (notificationCount == 1)
+            document.ariaNotify("Second");
+
+        if (notificationCount == 2)
+            testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    accessibilityController.addNotificationListener(notificationCallback);
+
+    document.ariaNotify("First");
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/aria-notify-translation-failure-expected.txt
+++ b/LayoutTests/accessibility/mac/aria-notify-translation-failure-expected.txt
@@ -1,0 +1,13 @@
+Tests that when the translation client declines to translate, the original announcement is used with its original language.
+
+Received announcement request:
+AnnouncementKey: San Francisco
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: en
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/aria-notify-translation-failure.html
+++ b/LayoutTests/accessibility/mac/aria-notify-translation-failure.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsARIANotifyEnabled=true displayedTranslationLocale=fr announcementTranslationMode=fail ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<script>
+var output = "Tests that when the translation client declines to translate, the original announcement is used with its original language.\n\n";
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAriaNotifyUserInfo(userInfo);
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    accessibilityController.addNotificationListener(notificationCallback);
+
+    document.ariaNotify("San Francisco");
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/aria-notify-translation-late-reply-expected.txt
+++ b/LayoutTests/accessibility/mac/aria-notify-translation-late-reply-expected.txt
@@ -1,0 +1,14 @@
+Tests that a translation arriving after its announcement already timed out is discarded rather than announced a second time.
+
+Received announcement request:
+AnnouncementKey: San Francisco
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: en
+
+Total announcements: 1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/aria-notify-translation-late-reply.html
+++ b/LayoutTests/accessibility/mac/aria-notify-translation-late-reply.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsARIANotifyEnabled=true displayedTranslationLocale=fr announcementTranslationMode=delayed ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<script>
+var output = "Tests that a translation arriving after its announcement already timed out is discarded rather than announced a second time.\n\n";
+var notificationCount = 0;
+var timedOutAnnouncementReceived = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAriaNotifyUserInfo(userInfo);
+        notificationCount++;
+        timedOutAnnouncementReceived = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // The client replies well after this deadline, so the announcement goes out untranslated first.
+    internals.setAccessibilityAnnouncementTranslationTimeout(0.05);
+    accessibilityController.addNotificationListener(notificationCallback);
+
+    document.ariaNotify("San Francisco");
+
+    setTimeout(async function() {
+        await waitFor(() => timedOutAnnouncementReceived);
+        // Outlive the client's reply, so a late translation reaching the platform would appear below
+        // as a second entry instead of going unnoticed.
+        await new Promise(resolve => setTimeout(resolve, 500));
+        output += `Total announcements: ${notificationCount}\n`;
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/aria-notify-translation-not-active-expected.txt
+++ b/LayoutTests/accessibility/mac/aria-notify-translation-not-active-expected.txt
@@ -1,0 +1,13 @@
+Tests that announcements are left alone when the page is not being presented as a machine translation, even with a translation client available.
+
+Received announcement request:
+AnnouncementKey: San Francisco
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: en
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/aria-notify-translation-not-active.html
+++ b/LayoutTests/accessibility/mac/aria-notify-translation-not-active.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsARIANotifyEnabled=true announcementTranslationMode=immediate ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<script>
+var output = "Tests that announcements are left alone when the page is not being presented as a machine translation, even with a translation client available.\n\n";
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAriaNotifyUserInfo(userInfo);
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    accessibilityController.addNotificationListener(notificationCallback);
+
+    // No displayedTranslationLocale is set for this test, so the client must not be consulted.
+    document.ariaNotify("San Francisco");
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/aria-notify-translation-ordering-expected.txt
+++ b/LayoutTests/accessibility/mac/aria-notify-translation-ordering-expected.txt
@@ -1,0 +1,25 @@
+Tests that announcements are released to the platform in the order they were produced, even when translations come back out of order.
+
+Received announcement request:
+AnnouncementKey: First_translated_to_fr
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: fr
+
+Received announcement request:
+AnnouncementKey: Second_translated_to_fr
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: fr
+
+Received announcement request:
+AnnouncementKey: Third_translated_to_fr
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: fr
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/aria-notify-translation-ordering.html
+++ b/LayoutTests/accessibility/mac/aria-notify-translation-ordering.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsARIANotifyEnabled=true displayedTranslationLocale=fr announcementTranslationMode=reverse ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<script>
+var output = "Tests that announcements are released to the platform in the order they were produced, even when translations come back out of order.\n\n";
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAriaNotifyUserInfo(userInfo);
+
+        if (++notificationCount == 3)
+            testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    accessibilityController.addNotificationListener(notificationCallback);
+
+    // The test delegate buffers these three translation requests and replies to them in reverse
+    // order, so the expected output below is the proof that ordering is restored before posting.
+    document.ariaNotify("First");
+    document.ariaNotify("Second");
+    document.ariaNotify("Third");
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/aria-notify-translation-timeout-expected.txt
+++ b/LayoutTests/accessibility/mac/aria-notify-translation-timeout-expected.txt
@@ -1,0 +1,19 @@
+Tests that a translation client which never replies cannot swallow an announcement. Instead, the original text is announced in its original language once the deadline passes, and a later announcement is not left stuck behind the stalled one.
+
+Received announcement request:
+AnnouncementKey: First
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: en
+
+Received announcement request:
+AnnouncementKey: Second
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: en
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/aria-notify-translation-timeout.html
+++ b/LayoutTests/accessibility/mac/aria-notify-translation-timeout.html
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsARIANotifyEnabled=true displayedTranslationLocale=fr announcementTranslationMode=hang ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<script>
+var output = "Tests that a translation client which never replies cannot swallow an announcement. Instead, the original text is announced in its original language once the deadline passes, and a later announcement is not left stuck behind the stalled one.\n\n";
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAriaNotifyUserInfo(userInfo);
+        notificationCount++;
+
+        // Announcing again after the first one timed out proves the queue drained rather than
+        // wedging behind the request that never came back.
+        if (notificationCount == 1)
+            document.ariaNotify("Second");
+
+        if (notificationCount == 2)
+            testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    internals.setAccessibilityAnnouncementTranslationTimeout(0.05);
+    accessibilityController.addNotificationListener(notificationCallback);
+
+    document.ariaNotify("First");
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-translated-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-translated-expected.txt
@@ -1,0 +1,14 @@
+This tests that live region announcements are translated, and carry the target language, when the page is presented as a machine translation (Core-AAM).
+
+Received announcement request:
+AnnouncementKey: Manzana_translated_to_fr{
+    AXLanguage = fr;
+}
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Apple: Manzana

--- a/LayoutTests/accessibility/mac/live-regions/live-region-translated.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-translated.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true displayedTranslationLocale=fr announcementTranslationMode=immediate ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<div id="region" aria-live="polite">
+<span lang="en">Apple:</span>
+<span lang="es" id="spanish-region"></span>
+</div>
+
+<script>
+var output = "This tests that live region announcements are translated, and carry the target language, when the page is presented as a machine translation (Core-AAM).\n\n";
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n${formatAnnouncementUserInfo(userInfo)}\n`;
+
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("region");
+
+    // The announcement is assembled after translation, so the per-range AXLanguage attribute must
+    // report the target locale rather than the "es" this element was authored in.
+    document.getElementById("spanish-region").textContent = "Manzana";
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXLiveRegionManager.cpp
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.cpp
@@ -403,12 +403,46 @@ void AXLiveRegionManager::postAnnouncementForChange(AccessibilityObject& object,
     if (diff.added.isEmpty() && diff.removed.isEmpty() && diff.changed.isEmpty())
         return;
 
-    AttributedString announcement = computeAnnouncement(newSnapshot, diff);
-    if (announcement.isNull() || announcement.string.isEmpty())
-        return;
+    // Collect the text of every object that could contribute to the announcement, in the order
+    // computeAnnouncement() will consider them, so translated text can be written back positionally.
+    Vector<String> segments;
+    auto collect = [&](const Vector<LiveRegionObject>& objects) {
+        for (auto& liveRegionObject : objects)
+            segments.append(liveRegionObject.text);
+    };
+    collect(diff.added);
+    collect(diff.removed);
+    collect(diff.changed);
 
-    if (CheckedPtr cache = m_cache)
-        cache->postLiveRegionNotification(object, newSnapshot.liveRegionStatus, announcement);
+    // Translation has to happen before computeAnnouncement(), not after, because it concatenates these
+    // objects into one AttributedString with per-range language and removal attributes, and word
+    // order changes across languages would make those ranges unrecoverable. Assembling afterwards
+    // also applies maximumAnnouncementLength to the translated text, which matters because
+    // translations commonly run longer than their source.
+    auto expectedSegmentCount = segments.size();
+    auto assemble = [this, object = Ref { object }, diff, newSnapshot, expectedSegmentCount](Vector<String>&& translatedSegments, const String& language) mutable {
+        if (translatedSegments.size() == expectedSegmentCount) {
+            size_t index = 0;
+            auto applyTranslation = [&](Vector<LiveRegionObject>& objects) {
+                for (auto& liveRegionObject : objects) {
+                    liveRegionObject.text = WTF::move(translatedSegments[index++]);
+                    if (!language.isEmpty())
+                        liveRegionObject.language = language;
+                }
+            };
+            applyTranslation(diff.added);
+            applyTranslation(diff.removed);
+            applyTranslation(diff.changed);
+        }
+
+        AttributedString announcement = computeAnnouncement(newSnapshot, diff);
+        if (announcement.isNull() || announcement.string.isEmpty())
+            return;
+
+        CheckedRef { m_cache }->postLiveRegionNotification(object, newSnapshot.liveRegionStatus, announcement);
+    };
+
+    CheckedRef { m_cache }->translateAnnouncementThenAssemble(Ref { object }, WTF::move(segments), WTF::move(assemble));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -410,6 +410,7 @@ AXObjectCache::AXObjectCache(LocalFrame& localFrame, Document* document)
     : m_document(document)
     , m_frameID(localFrame.frameID())
     , m_notificationPostTimer(*this, &AXObjectCache::notificationPostTimerFired)
+    , m_pendingAnnouncementTimeoutTimer(*this, &AXObjectCache::pendingAnnouncementTimeoutTimerFired)
 #if PLATFORM(COCOA)
     , m_passwordNotificationTimer(*this, &AXObjectCache::passwordNotificationTimerFired)
 #endif
@@ -486,6 +487,7 @@ AXObjectCache::~AXObjectCache()
     m_notificationPostTimer.stop();
     m_liveRegionChangedPostTimer.stop();
     m_performCacheUpdateTimer.stop();
+    m_pendingAnnouncementTimeoutTimer.stop();
 
     for (const auto& object : m_objects.values())
         object->detach(AccessibilityDetachmentType::CacheDestroyed);
@@ -1739,6 +1741,11 @@ void AXObjectCache::handleAllDeferredChildrenChanged()
             postPlatformNotification(object, AXNotification::ChildrenChanged);
 #endif
     }
+
+    // These entries only suppress the children-changed raised by the re-render that recorded them, so
+    // they must not survive into subsequent, genuine mutations of the same live region.
+    m_deferredReRenderedContent.clear();
+    m_reRenderedContentAndAncestors = std::nullopt;
 }
 
 void AXObjectCache::handleChildrenChanged(AccessibilityObject& object)
@@ -1814,7 +1821,7 @@ void AXObjectCache::handleChildrenChanged(AccessibilityObject& object)
         // This notification needs to be sent even when the screen reader has not accessed this live region since the last update.
         // Sometimes this function can be called many times within a short period of time, leading to posting too many AXLiveRegionChanged notifications.
         // To fix this, we use a timer to make sure we only post one notification for the children changes within a pre-defined time interval.
-        if (parent->supportsLiveRegion())
+        if (parent->supportsLiveRegion() && !isReRenderedContent(*parent))
             postLiveRegionChangeNotification(*parent);
 
         // If this object is an ARIA text control, notify that its value changed.
@@ -2165,6 +2172,200 @@ void AXObjectCache::enqueueNotificationToPost(Ref<AccessibilityObject>&& object,
         m_notificationPostTimer.startOneShot(0_s);
 }
 
+static std::optional<Seconds>& announcementTranslationTimeoutOverrideForTesting()
+{
+    static NeverDestroyed<std::optional<Seconds>> override;
+    return override;
+}
+
+void AXObjectCache::setAnnouncementTranslationTimeoutForTesting(std::optional<Seconds> timeout)
+{
+    announcementTranslationTimeoutOverrideForTesting() = timeout;
+}
+
+Seconds AXObjectCache::announcementTranslationTimeout()
+{
+    // Long enough for an on-device translation of a short string, short enough that a stalled
+    // translation service does not leave the user waiting on an announcement.
+    static constexpr Seconds defaultAnnouncementTranslationTimeout = 250_ms;
+    return announcementTranslationTimeoutOverrideForTesting().value_or(defaultAnnouncementTranslationTimeout);
+}
+
+void AXObjectCache::translateAnnouncementThenAssemble(Ref<AccessibilityObject>&& object, Vector<String>&& segments, Function<void(Vector<String>&&, const String&)>&& assemble)
+{
+    RefPtr document = m_document.get();
+    RefPtr page = document ? document->page() : nullptr;
+
+    bool needsTranslation = false;
+    String targetLocale;
+    if (page) {
+        // Every announcement in a translated rendering needs translating.
+        targetLocale = page->displayedTranslationLocaleIdentifier();
+        needsTranslation = !targetLocale.isEmpty();
+    }
+
+    if (!needsTranslation && m_pendingAnnouncements.isEmpty()) {
+        assemble(WTF::move(segments), { });
+        return;
+    }
+
+    static constexpr size_t maxPendingAnnouncements = 64;
+    if (m_pendingAnnouncements.size() >= maxPendingAnnouncements) [[unlikely]] {
+        // If we hit the pending announcements cap (e.g. translation is running slowly, and / or
+        // there is a high volume of announcements), release the oldest one untranslated rather
+        // than dropping it. Losing an announcement is worse than announcing it in the original language.
+        AX_ASSERT_NOT_REACHED();
+        auto oldest = m_pendingAnnouncements.takeFirst();
+        if (!oldest.object->isDetached() && oldest.object->axObjectCache())
+            oldest.assembleAndEnqueue(WTF::move(oldest.segments), { });
+    }
+
+    uint64_t requestID = needsTranslation ? ++m_nextAnnouncementTranslationRequestID : 0;
+    m_pendingAnnouncements.append(PendingAnnouncement {
+        WTF::move(object),
+        segments,
+        needsTranslation ? targetLocale : String { },
+        requestID,
+        MonotonicTime::now() + announcementTranslationTimeout(),
+        WTF::move(assemble)
+    });
+
+    if (needsTranslation) {
+        page->chrome().client().translateAccessibilityAnnouncementStrings(segments, targetLocale,
+            [weakCache = WeakPtr { *this }, requestID](Vector<String>&& translatedSegments) mutable {
+                if (CheckedPtr cache = weakCache.get())
+                    cache->announcementTranslationDidComplete(requestID, WTF::move(translatedSegments));
+            });
+    }
+
+    scheduleAnnouncementTimeoutTimerIfNeeded();
+}
+
+void AXObjectCache::deferReRenderedContent(Node& node)
+{
+    RefPtr document = m_document.get();
+    RefPtr page = document ? document->page() : nullptr;
+    if (!page || !page->isPresentingMachineTranslation()) {
+        // Re-rendered content is only relevant when page-level translation
+        // is active (the "re-rendering" is the replacement of the original
+        // DOM text with the translated version).
+        return;
+    }
+
+    m_deferredReRenderedContent.add(node);
+    // The ancestor closure was built from a smaller set, so it no longer answers correctly.
+    m_reRenderedContentAndAncestors = std::nullopt;
+}
+
+
+bool AXObjectCache::isReRenderedContent(const AccessibilityObject& object) const
+{
+    if (m_deferredReRenderedContent.isEmptyIgnoringNullReferences())
+        return false;
+
+    RefPtr document = m_document.get();
+    RefPtr page = document ? document->page() : nullptr;
+    if (!page || !page->isPresentingMachineTranslation()) {
+        // Only relevant when page-level translation is happening -- see similar comment
+        // in AXObjectCache::deferReRenderedContent.
+        return false;
+    }
+
+    // m_deferredReRenderedContent holds the containers whose text was swapped out, recorded by
+    // deferReRenderedContent(). The children-changed notification is raised either on such a
+    // container or on a live region ancestor of one, so both directions have to match.
+    RefPtr candidateNode = object.node();
+    if (!candidateNode)
+        return false;
+
+    if (!m_reRenderedContentAndAncestors) {
+        // Build a one-time cache (m_reRenderedContentAndAncestors) capturing whether any re-rendered
+        // node or any ancestor of one is a given node, so each query is a set lookup rather than an
+        // ancestor walk per m_deferredReRenderedContent member.
+        m_reRenderedContentAndAncestors.emplace();
+        for (Ref reRenderedNode : m_deferredReRenderedContent) {
+            for (RefPtr node = reRenderedNode.get(); node; node = node->parentNode()) {
+                if (!m_reRenderedContentAndAncestors->add(*node).isNewEntry) {
+                    // Stop when we found an ancestor that was already present, since everything above it
+                    // was already added by an earlier m_deferredReRenderedContent member.
+                    break;
+                }
+            }
+        }
+    }
+
+    return m_reRenderedContentAndAncestors->contains(*candidateNode);
+}
+
+void AXObjectCache::announcementTranslationDidComplete(uint64_t requestID, Vector<String>&& translatedSegments)
+{
+    AX_ASSERT(isMainThread());
+
+    auto iterator = m_pendingAnnouncements.findIf([&](auto& entry) {
+        return entry.translationRequestID == requestID;
+    });
+    // Already force-completed by a timeout or an overflow.
+    if (iterator == m_pendingAnnouncements.end())
+        return;
+
+    auto& entry = *iterator;
+    entry.translationRequestID = 0;
+
+    // A short or oversized reply means the client could not translate these strings,
+    // so keep the originals, and with them the original language.
+    if (translatedSegments.size() == entry.segments.size())
+        entry.segments = WTF::move(translatedSegments);
+    else
+        entry.targetLocale = { };
+
+    flushPendingAnnouncements();
+}
+
+void AXObjectCache::flushPendingAnnouncements()
+{
+    // Releasing an entry only enqueues a notification to post on a zero-delay timer, so nothing here
+    // re-enters this function. That matters: an inner flush would release later entries while an
+    // outer one was still draining, which is exactly the ordering this queue exists to preserve.
+    while (!m_pendingAnnouncements.isEmpty() && !m_pendingAnnouncements.first().translationRequestID) {
+        auto entry = m_pendingAnnouncements.takeFirst();
+        if (entry.object->isDetached() || !entry.object->axObjectCache())
+            continue;
+        entry.assembleAndEnqueue(WTF::move(entry.segments), entry.targetLocale);
+    }
+
+    scheduleAnnouncementTimeoutTimerIfNeeded();
+}
+
+void AXObjectCache::scheduleAnnouncementTimeoutTimerIfNeeded()
+{
+    if (m_pendingAnnouncements.isEmpty()) {
+        m_pendingAnnouncementTimeoutTimer.stop();
+        return;
+    }
+
+    if (m_pendingAnnouncementTimeoutTimer.isActive())
+        return;
+
+    // We only need to arm the timer based on the first entries deadline, since
+    // we re-arm the timer as subsequent entries (with their own deadline) are drained.
+    auto delay = std::max(0_s, m_pendingAnnouncements.first().deadline - MonotonicTime::now());
+    m_pendingAnnouncementTimeoutTimer.startOneShot(delay);
+}
+
+void AXObjectCache::pendingAnnouncementTimeoutTimerFired()
+{
+    auto now = MonotonicTime::now();
+    for (auto& entry : m_pendingAnnouncements) {
+        if (entry.deadline > now)
+            break;
+        // Give up waiting and announce the original text in the original language.
+        entry.translationRequestID = 0;
+        entry.targetLocale = { };
+    }
+
+    flushPendingAnnouncements();
+}
+
 void AXObjectCache::postNotification(RenderObject* renderer, AXNotification notification, PostTarget postTarget)
 {
     if (!renderer)
@@ -2293,7 +2494,24 @@ void AXObjectCache::postARIANotifyNotification(Node& node, const String& announc
         }
     }
 
-    enqueueNotificationToPost(Ref { *object }, AXNotificationWithData(AXNotification::ARIANotify, AriaNotifyData { announcement, priority, interruptBehavior, object->languageIncludingAncestors() }));
+    auto sourceLanguage = object->languageIncludingAncestors();
+
+    // Assembles and enqueues the notification once the announcement text is final, which is true when either:
+    //   1. No translation is needed, and thus can be announced immediately.
+    //   2. The translation request returns the new text.
+    //   3. The translation request times out, and the original text is used.
+    auto assemble = [weakCache = WeakPtr { *this }, object, priority, interruptBehavior, sourceLanguage](Vector<String>&& segments, const String& language) mutable {
+        if (segments.isEmpty())
+            return;
+        CheckedPtr cache = weakCache.get();
+        if (!cache)
+            return;
+
+        cache->enqueueNotificationToPost(Ref { *object }, AXNotificationWithData(AXNotification::ARIANotify,
+            AriaNotifyData { WTF::move(segments[0]), priority, interruptBehavior, language.isEmpty() ? sourceLanguage : language }));
+    };
+
+    translateAnnouncementThenAssemble(Ref { *object }, { announcement }, WTF::move(assemble));
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -684,6 +684,21 @@ public:
     // Requests clients to announce to the user the given message in the way they deem appropriate.
     WEBCORE_EXPORT void announce(const String&);
 
+    // Invokes `assemble` exactly once, either synchronously if the page is not translated and no
+    // other announcements are queued ahead, or when the translated text arrives (or times out).
+    // The `language` argument is the target language when the text was translated and empty otherwise.
+    void translateAnnouncementThenAssemble(Ref<AccessibilityObject>&&, Vector<String>&& segments, Function<void(Vector<String>&&, const String& language)>&& assemble);
+
+    // Records a node whose descendant text is about to be swapped out for a re-rendering of the same
+    // content, e.g. when page-level translation replaces text.
+    //
+    // The resulting children-changed is not a content change the user should hear about again, so the
+    // live region announcement for it is skipped. Forgotten once that change has been processed, so
+    // it never suppresses a later, genuine mutation of the same node.
+    WEBCORE_EXPORT void deferReRenderedContent(Node&);
+
+    WEBCORE_EXPORT static void setAnnouncementTranslationTimeoutForTesting(std::optional<Seconds>);
+
     void NODELETE setTextSelectionIntent(const AXTextStateChangeIntent&);
     void NODELETE setIsSynchronizingSelection(bool);
 
@@ -905,6 +920,13 @@ private:
     void notificationPostTimerFired();
     void enqueueNotificationToPost(Ref<AccessibilityObject>&&, AXNotificationWithData&&);
 
+    void announcementTranslationDidComplete(uint64_t requestID, Vector<String>&& translatedSegments);
+    bool isReRenderedContent(const AccessibilityObject&) const;
+    void flushPendingAnnouncements();
+    void pendingAnnouncementTimeoutTimerFired();
+    void scheduleAnnouncementTimeoutTimerIfNeeded();
+    static Seconds announcementTranslationTimeout();
+
     void liveRegionChangedNotificationPostTimerFired();
 
     void performCacheUpdateTimerFired() { performDeferredCacheUpdate(ForceLayout::No); }
@@ -1061,6 +1083,29 @@ private:
     Timer m_notificationPostTimer;
     Vector<std::pair<Ref<AccessibilityObject>, AXNotificationWithData>> m_notificationsToPost;
     HashSet<AXID> m_pendingLayoutCompleteObjectIDs;
+
+    // Core-AAM requires announcements to be translated before they reach the platform when the page
+    // is presented as a machine translation.
+    struct PendingAnnouncement {
+        Ref<AccessibilityObject> object;
+        Vector<String> segments;
+        String targetLocale;
+        // Zero once this entry is no longer awaiting a reply, whether it succeeded, failed, or timed out.
+        uint64_t translationRequestID { 0 };
+        MonotonicTime deadline;
+        // Rebuilds the payload from the (possibly translated) segments and enqueues it to post. The
+        // language argument is empty when the segments were left untranslated.
+        Function<void(Vector<String>&&, const String& language)> assembleAndEnqueue;
+    };
+
+    Deque<PendingAnnouncement> m_pendingAnnouncements;
+    Timer m_pendingAnnouncementTimeoutTimer;
+    uint64_t m_nextAnnouncementTranslationRequestID { 0 };
+    // Nodes whose pending children-changed is a re-rendering of content already announced.
+    WeakListHashSet<Node, WeakPtrImplWithEventTargetData> m_deferredReRenderedContent;
+    // The nodes above plus all their ancestors, so isReRenderedContent() is a lookup instead of a
+    // walk. Built on first query and discarded whenever m_deferredReRenderedContent changes.
+    mutable std::optional<WeakHashSet<Node, WeakPtrImplWithEventTargetData>> m_reRenderedContentAndAncestors;
 
 #if PLATFORM(COCOA)
     Timer m_passwordNotificationTimer;

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "TextManipulationController.h"
 
+#include "AXObjectCacheInlines.h"
 #include "AccessibilityObject.h"
 #include "CharacterData.h"
 #include "ContainerNodeInlines.h"
@@ -996,6 +997,9 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
     }
 
     RefPtr<Node> insertionPointNode = lastChildOfCommonAncestorInRange->nextSibling();
+
+    if (CheckedPtr cache = commonAncestor->document().existingAXObjectCache())
+        cache->deferReRenderedContent(*commonAncestor);
 
     for (auto& node : nodesToRemove)
         node->remove();

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -303,6 +303,8 @@ public:
     virtual void relayLiveRegionNotification(LiveRegionAnnouncementData&&) const = 0;
 #endif
 
+    virtual void translateAccessibilityAnnouncementStrings(const Vector<String>& strings, const String& targetLocaleIdentifier, CompletionHandler<void(Vector<String>&&)>&& completion) { UNUSED_PARAM(strings); UNUSED_PARAM(targetLocaleIdentifier); completion({ }); }
+
     virtual void mainFrameDidChange() { };
 
     virtual void didFinishLoadingImageForElement(HTMLImageElement&) = 0;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -556,6 +556,8 @@ Page::Page(PageConfiguration&& pageConfiguration)
     if (pageConfiguration.imageTranslationLanguageIdentifiers)
         protect(imageAnalysisQueue())->setTranslationLanguageIdentifiers(WTF::move(*pageConfiguration.imageTranslationLanguageIdentifiers));
 #endif
+
+    m_displayedTranslationLocaleIdentifier = WTF::move(pageConfiguration.displayedTranslationLocaleIdentifier);
 }
 
 Page::~Page()
@@ -5651,6 +5653,11 @@ void Page::setDefaultSpatialTrackingLabel(const String& label)
     });
 }
 #endif
+
+void Page::setDisplayedTranslationLocaleIdentifier(String&& localeIdentifier)
+{
+    m_displayedTranslationLocaleIdentifier = WTF::move(localeIdentifier);
+}
 
 #if ENABLE(GAMEPAD)
 void Page::gamepadsRecentlyAccessed()

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -765,6 +765,12 @@ public:
     ImageAnalysisQueue* imageAnalysisQueueIfExists() { return m_imageAnalysisQueue.get(); }
 #endif
 
+    // Non-empty while the user agent is presenting this page as a machine translation (e.g. a
+    // built-in "Translate this page" feature).
+    const String& displayedTranslationLocaleIdentifier() const LIFETIME_BOUND { return m_displayedTranslationLocaleIdentifier; }
+    bool isPresentingMachineTranslation() const { return !m_displayedTranslationLocaleIdentifier.isEmpty(); }
+    WEBCORE_EXPORT void setDisplayedTranslationLocaleIdentifier(String&&);
+
 #if ENABLE(WHEEL_EVENT_LATCHING)
     ScrollLatchingController& scrollLatchingController() LIFETIME_BOUND;
     ScrollLatchingController* scrollLatchingControllerIfExists() LIFETIME_BOUND { return m_scrollLatchingController.get(); }
@@ -1841,6 +1847,8 @@ private:
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_defaultSpatialTrackingLabel;
 #endif
+
+    String m_displayedTranslationLocaleIdentifier;
 
 #if ENABLE(GAMEPAD)
     MonotonicTime m_lastAccessNotificationTime;

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -257,6 +257,9 @@ public:
     std::optional<ImageTranslationLanguageIdentifiers> imageTranslationLanguageIdentifiers;
 #endif
 
+    // Non-empty if this page is being created while the user agent is presenting a machine translation.
+    String displayedTranslationLocaleIdentifier;
+
 #if ENABLE(WEB_AUTHN)
     Ref<CredentialRequestCoordinatorClient> credentialRequestCoordinatorClient;
 #endif

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -690,6 +690,7 @@ void Internals::resetToConsistentState(Page& page)
 #endif
     AXObjectCache::setEnhancedUserInterfaceAccessibility(false);
     AXObjectCache::disableAccessibilityForTesting();
+    AXObjectCache::setAnnouncementTranslationTimeoutForTesting(std::nullopt);
     WebCore::setShouldMockParentSearchResultsForTesting(false);
     WebCore::setShouldMockChildFrameSearchResultsForTesting(false);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -4789,6 +4790,11 @@ void Internals::forceAXObjectCacheUpdate() const
         if (CheckedPtr cache = document->axObjectCache())
             cache->performDeferredCacheUpdate(ForceLayout::Yes);
     }
+}
+
+void Internals::setAccessibilityAnnouncementTranslationTimeout(double seconds)
+{
+    AXObjectCache::setAnnouncementTranslationTimeoutForTesting(Seconds { seconds });
 }
 
 unsigned Internals::liveRegionSnapshotBuildCount() const

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -793,6 +793,7 @@ public:
     String toolTipFromElement(Element&) const;
 
     void forceAXObjectCacheUpdate() const;
+    void setAccessibilityAnnouncementTranslationTimeout(double seconds);
     unsigned liveRegionSnapshotBuildCount() const;
     void resetLiveRegionSnapshotBuildCount() const;
     void setShouldMockParentSearchResultsForTesting(bool);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1016,6 +1016,7 @@ enum ContentsFormat {
     undefined setUsesOverlayScrollbars(boolean enabled);
 
     undefined forceAXObjectCacheUpdate();
+    undefined setAccessibilityAnnouncementTranslationTimeout(unrestricted double seconds);
     unsigned long liveRegionSnapshotBuildCount();
     undefined resetLiveRegionSnapshotBuildCount();
     undefined setShouldMockParentSearchResultsForTesting(boolean enabled);

--- a/Source/WebKit/Headers.cmake
+++ b/Source/WebKit/Headers.cmake
@@ -441,6 +441,7 @@ list(APPEND WebKit_PRIVATE_FRAMEWORK_HEADERS
     UIProcess/API/Cocoa/_WKTextRun.h
     UIProcess/API/Cocoa/_WKThumbnailView.h
     UIProcess/API/Cocoa/_WKTouchEventGenerator.h
+    UIProcess/API/Cocoa/_WKTranslationDelegate.h
     UIProcess/API/Cocoa/_WKUserContentExtensionStore.h
     UIProcess/API/Cocoa/_WKUserContentExtensionStorePrivate.h
     UIProcess/API/Cocoa/_WKUserContentFilter.h

--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2044,6 +2044,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKTranslationDelegate {
+    header "_WKTranslationDelegate.h"
+    export *
+  }
+
   explicit module _WKUserContentExtensionStore {
     header "_WKUserContentExtensionStore.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -2950,6 +2950,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKTranslationDelegate {
+    header "_WKTranslationDelegate.h"
+    export *
+  }
+
   explicit module _WKUserContentExtensionStore {
     header "_WKUserContentExtensionStore.h"
     export *

--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -1380,6 +1380,7 @@ list(APPEND WebKit_PRIVATE_FRAMEWORK_HEADERS
     UIProcess/API/Cocoa/_WKTextManipulationItem.h
     UIProcess/API/Cocoa/_WKTextManipulationToken.h
     UIProcess/API/Cocoa/_WKThumbnailView.h
+    UIProcess/API/Cocoa/_WKTranslationDelegate.h
     UIProcess/API/Cocoa/_WKUserContentWorld.h
     UIProcess/API/Cocoa/_WKUserInitiatedAction.h
     UIProcess/API/Cocoa/_WKUserStyleSheet.h

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -390,6 +390,8 @@ struct WebPageCreationParameters {
     std::optional<WebCore::ImageTranslationLanguageIdentifiers> imageTranslationLanguageIdentifiers { std::nullopt };
 #endif
 
+    String displayedTranslationLocaleIdentifier { };
+
     std::optional<TextManipulationParameters> textManipulationParameters { std::nullopt };
 
     bool isPopup { false };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -303,6 +303,8 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     std::optional<WebCore::ImageTranslationLanguageIdentifiers> imageTranslationLanguageIdentifiers;
 #endif
 
+    String displayedTranslationLocaleIdentifier;
+
     std::optional<WebKit::TextManipulationParameters> textManipulationParameters;
 
     bool isPopup;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -160,6 +160,7 @@
 #import "_WKTextManipulationToken.h"
 #import "_WKTextPreview.h"
 #import "_WKTextRunInternal.h"
+#import "_WKTranslationDelegate.h"
 #import "_WKVisitedLinkStoreInternal.h"
 #import "_WKWarningView.h"
 #import <WebCore/AppHighlight.h>
@@ -1954,6 +1955,29 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 - (NSString *)_nameForVisualIdentificationOverlay
 {
     return @"WKWebView";
+}
+
+- (void)_translateAccessibilityAnnouncementStrings:(NSArray<NSString *> *)strings targetLocaleIdentifier:(NSString *)targetLocaleIdentifier completionHandler:(CompletionHandler<void(Vector<String>&&)>&&)completionHandler
+{
+    RetainPtr delegate = [self _translationDelegate];
+    if (![delegate respondsToSelector:@selector(_webView:translateAccessibilityAnnouncementStrings:targetLocaleIdentifier:completionHandler:)])
+        return completionHandler({ });
+
+    auto checker = WebKit::CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:translateAccessibilityAnnouncementStrings:targetLocaleIdentifier:completionHandler:));
+
+    // A client that releases the handler without calling it must not be fatal here. If that happens,
+    // rather than crashing, use a finalizer to reply as if no translation were available.
+    auto handler = CompletionHandlerWithFinalizer<void(Vector<String>&&)>(WTF::move(completionHandler), [checker = checker.copyRef()](Function<void(Vector<String>&&)>& function) mutable {
+        checker->didCallCompletionHandler();
+        function({ });
+    });
+
+    [delegate _webView:self translateAccessibilityAnnouncementStrings:strings targetLocaleIdentifier:targetLocaleIdentifier completionHandler:makeBlockPtr([handler = WTF::move(handler), checker = WTF::move(checker)](NSArray<NSString *> *translatedStrings) mutable {
+        if (checker->completionHandlerHasBeenCalled())
+            return;
+        checker->didCallCompletionHandler();
+        handler(makeVector<String>(translatedStrings));
+    }).get()];
 }
 
 - (void)_showWarningView:(const WebKit::BrowsingWarning&)warning completionHandler:(CompletionHandler<void(Variant<WebKit::ContinueUnsafeLoad, URL>&&)>&&)completionHandler
@@ -4525,6 +4549,33 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
 - (void)_setTextManipulationDelegate:(id <_WKTextManipulationDelegate>)delegate
 {
     _textManipulationDelegate = delegate;
+}
+
+- (id<_WKTranslationDelegate>)_translationDelegate
+{
+    return _translationDelegate.getAutoreleased();
+}
+
+- (void)_setTranslationDelegate:(id<_WKTranslationDelegate>)delegate
+{
+    _translationDelegate = delegate;
+}
+
+- (NSString *)_displayedTranslationLocaleIdentifier
+{
+    THROW_IF_SUSPENDED;
+    if (!_page)
+        return nil;
+
+    auto& localeIdentifier = _page->displayedTranslationLocaleIdentifier();
+    return localeIdentifier.isEmpty() ? nil : localeIdentifier.createNSString().autorelease();
+}
+
+- (void)_setDisplayedTranslationLocaleIdentifier:(NSString *)localeIdentifier
+{
+    THROW_IF_SUSPENDED;
+    if (_page)
+        _page->setDisplayedTranslationLocaleIdentifier(localeIdentifier);
 }
 
 static RetainPtr<NSDictionary<NSString *, id>> createUserInfo(const std::optional<WebCore::TextManipulationTokenInfo>& info)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -236,6 +236,7 @@ std::optional<WebCore::JSHandleIdentifier> jsHandleIdentifierInFrame(const WebFr
 #endif
 
 @protocol _WKTextManipulationDelegate;
+@protocol _WKTranslationDelegate;
 @protocol _WKInputDelegate;
 @protocol _WKAppHighlightDelegate;
 
@@ -354,6 +355,7 @@ struct LiveResizeSnapshotState {
     const std::unique_ptr<WebKit::ResourceLoadDelegate> _resourceLoadDelegate;
 
     WeakObjCPtr<id <_WKTextManipulationDelegate>> _textManipulationDelegate;
+    WeakObjCPtr<id<_WKTranslationDelegate>> _translationDelegate;
     WeakObjCPtr<id <_WKInputDelegate>> _inputDelegate;
     WeakObjCPtr<id <_WKAppHighlightDelegate>> _appHighlightDelegate;
 
@@ -663,6 +665,10 @@ struct LiveResizeSnapshotState {
 - (void)_doAfterNextVisibleContentRectAndPresentationUpdate:(void (^)(void))updateBlock;
 
 - (void)_recalculateViewportSizesWithMinimumViewportInset:(CocoaEdgeInsets)minimumViewportInset maximumViewportInset:(CocoaEdgeInsets)maximumViewportInset throwOnInvalidInput:(BOOL)throwOnInvalidInput;
+
+// Asks the _WKTranslationDelegate to translate accessibility announcements. Replies with an empty
+// Vector if there is no delegate or the delegate does not implement the method.
+- (void)_translateAccessibilityAnnouncementStrings:(NSArray<NSString *> *)strings targetLocaleIdentifier:(NSString *)targetLocaleIdentifier completionHandler:(CompletionHandler<void(Vector<String>&&)>&&)completionHandler;
 
 - (void)_showWarningView:(const WebKit::BrowsingWarning&)warning completionHandler:(CompletionHandler<void(Variant<WebKit::ContinueUnsafeLoad, URL>&&)>&&)completionHandler;
 - (void)_showBrowsingWarning:(const WebKit::BrowsingWarning&)warning completionHandler:(CompletionHandler<void(Variant<WebKit::ContinueUnsafeLoad, URL>&&)>&&)completionHandler;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -170,6 +170,7 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 @protocol _WKInputDelegate;
 @protocol _WKResourceLoadDelegate;
 @protocol _WKTextManipulationDelegate;
+@protocol _WKTranslationDelegate;
 
 @interface WKWebView (WKPrivate)
 
@@ -262,6 +263,15 @@ for this property.
 - (void)_startTextManipulationsWithConfiguration:(_WKTextManipulationConfiguration *)configuration completion:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 - (void)_completeTextManipulation:(_WKTextManipulationItem *)item completion:(void(^)(BOOL success))completionHandler WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 - (void)_completeTextManipulationForItems:(NSArray<_WKTextManipulationItem *> *)items completion:(void(^)(NSArray<NSError *> *errors))completionHandler WK_API_AVAILABLE(macos(11.0), ios(14.0));
+
+@property (nonatomic, weak, setter=_setTranslationDelegate:) id<_WKTranslationDelegate> _translationDelegate WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+/*! @abstract Non-nil while this web view is presenting the document as a machine translation.
+ @discussion Set this to the target locale when entering a translated rendering, and to nil when
+ returning to the original content. WebKit uses it to decide whether accessibility announcements
+ need translating, and reports it as the language of announcements it has translated.
+ */
+@property (nonatomic, copy, setter=_setDisplayedTranslationLocaleIdentifier:) NSString *_displayedTranslationLocaleIdentifier WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @property (nonatomic, setter=_setAddsVisitedLinks:) BOOL _addsVisitedLinks;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTranslationDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTranslationDelegate.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <WebKit/WKFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol _WKTranslationDelegate <NSObject>
+
+@optional
+
+/*! @abstract Translates strings that WebKit is about to hand to assistive technologies.
+ @param strings The strings to translate, in the order they will be announced.
+ @param targetLocaleIdentifier The BCP 47 tag of the language the page is being presented in.
+ @param completionHandler Must be called exactly once, on the main thread, with an array parallel to
+ @c strings. Pass nil, or an array whose count differs from @c strings, to indicate that no
+ translation is available; the original strings are then used.
+ @discussion Called only while -_displayedTranslationLocaleIdentifier is non-nil. Core-AAM requires
+ that announcements be conveyed in the language the user is seeing rather than the language of the
+ original content, so WebKit withholds the announcement -- and every announcement queued behind it --
+ until @c completionHandler runs. That wait is bounded. If the handler is not called within an
+ internal timeout, the original strings are announced instead so that a slow or unavailable
+ translation service can never silently drop an accessibility announcement.
+ */
+- (void)_webView:(WKWebView *)webView translateAccessibilityAnnouncementStrings:(NSArray<NSString *> *)strings targetLocaleIdentifier:(NSString *)targetLocaleIdentifier completionHandler:(void (^)(NSArray<NSString *> * _Nullable translatedStrings))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -185,6 +185,8 @@ public:
 
     void processDidUpdateThrottleState() final;
 
+    void translateAccessibilityAnnouncementStrings(Vector<String>&&, String&&, CompletionHandler<void(Vector<String>&&)>&&) final;
+
 private:
 #if ENABLE(FULLSCREEN_API)
     void setFullScreenClientForTesting(std::unique_ptr<WebFullScreenManagerProxyClient>&&) final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -534,4 +534,13 @@ void PageClientImplCocoa::handleSmartMagnificationInformationForPotentialTap(Web
 
 #endif // ENABLE(TWO_PHASE_CLICKS)
 
+void PageClientImplCocoa::translateAccessibilityAnnouncementStrings(Vector<String>&& strings, String&& targetLocaleIdentifier, CompletionHandler<void(Vector<String>&&)>&& completion)
+{
+    RetainPtr webView = this->webView();
+    if (!webView)
+        return completion({ });
+
+    [webView _translateAccessibilityAnnouncementStrings:createNSArray(strings).get() targetLocaleIdentifier:targetLocaleIdentifier.createNSString().get() completionHandler:WTF::move(completion)];
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -719,6 +719,8 @@ public:
     virtual void computeHasVisualSearchResults(const URL&, WebCore::ShareableBitmap&, CompletionHandler<void(bool)>&& completion) { completion(false); }
 #endif
 
+    virtual void translateAccessibilityAnnouncementStrings(Vector<String>&&, String&&, CompletionHandler<void(Vector<String>&&)>&& completion) { completion({ }); }
+
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
     virtual void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, const FrameInfoData&, WebCore::HTMLMediaElementIdentifier, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&& completionHandler) { completionHandler(WebCore::MediaControlsContextMenuItem::invalidID); }
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8844,6 +8844,10 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
 
     if (frame->isMainFrame())
         m_internals->textManipulationParameters = std::nullopt;
+
+    // The client re-establishes this if it continues translating the newly committed document.
+    if (frame->isMainFrame())
+        m_internals->displayedTranslationLocaleIdentifier = { };
 }
 
 void WebPageProxy::didFinishDocumentLoadForFrame(IPC::Connection& connection, FrameIdentifier frameID, std::optional<WebCore::NavigationIdentifier> navigationID, const UserData& userData, WallTime timestamp)
@@ -14427,6 +14431,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 
     parameters.textManipulationParameters = m_internals->textManipulationParameters;
 
+    parameters.displayedTranslationLocaleIdentifier = m_internals->displayedTranslationLocaleIdentifier;
+
     parameters.accessibilityMode = m_accessibilityMode;
     parameters.shouldForceSiteIsolationAlwaysOnForTesting = WebPreferences::forcedSiteIsolationAlwaysOnForTesting();
     parameters.shouldEnableNetworkInstrumentation = inspectorController().isNetworkInstrumentationEnabled();
@@ -15235,6 +15241,35 @@ void WebPageProxy::startVisualTranslation(const String& sourceLanguageIdentifier
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)
+
+const String& WebPageProxy::displayedTranslationLocaleIdentifier() const
+{
+    return m_internals->displayedTranslationLocaleIdentifier;
+}
+
+void WebPageProxy::setDisplayedTranslationLocaleIdentifier(const String& localeIdentifier)
+{
+    if (m_internals->displayedTranslationLocaleIdentifier == localeIdentifier)
+        return;
+
+    m_internals->displayedTranslationLocaleIdentifier = localeIdentifier;
+
+    // Under site isolation a cross-origin iframe's Document lives in a different process with its
+    // own Page, so every web content process backing this page needs the new value.
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        if (hasRunningProcess())
+            webProcess.send(Messages::WebPage::SetDisplayedTranslationLocaleIdentifier(localeIdentifier), pageID);
+    });
+}
+
+void WebPageProxy::translateAccessibilityAnnouncementStrings(Vector<String>&& strings, String&& targetLocaleIdentifier, CompletionHandler<void(Vector<String>&&)>&& completionHandler)
+{
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient)
+        return completionHandler({ });
+
+    pageClient->translateAccessibilityAnnouncementStrings(WTF::move(strings), WTF::move(targetLocaleIdentifier), WTF::move(completionHandler));
+}
 
 void WebPageProxy::requestImageBitmap(const ElementContext& elementContext, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&, const String&)>&& completion)
 {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2315,6 +2315,12 @@ public:
     void startVisualTranslation(const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier);
 #endif
 
+    // Non-empty while the client has told us it is presenting this page as a machine translation.
+    const String& displayedTranslationLocaleIdentifier() const;
+    void setDisplayedTranslationLocaleIdentifier(const String&);
+
+    void translateAccessibilityAnnouncementStrings(Vector<String>&&, String&&, CompletionHandler<void(Vector<String>&&)>&&);
+
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
     void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, const FrameInfoData&,  WebCore::HTMLMediaElementIdentifier, CompletionHandler<void(WebCore::MediaControlsContextMenuItemID)>&&);
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -63,6 +63,8 @@ messages -> WebPageProxy {
 #endif
     SetAccessibilityMode(enum:uint8_t WebCore::AccessibilityMode mode)
 
+    TranslateAccessibilityAnnouncementStrings(Vector<String> strings, String targetLocaleIdentifier) -> (Vector<String> translatedStrings)
+
 #if PLATFORM(COCOA) || PLATFORM(GTK)
     ShowValidationMessage(WebCore::IntRect anchorRect, String message, std::optional<WebCore::FrameIdentifier> rootFrameID)
     HideValidationMessage()

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -419,6 +419,9 @@ public:
 
     std::optional<TextManipulationParameters> textManipulationParameters;
 
+    // Non-empty while the client has told us it is presenting this page as a machine translation.
+    String displayedTranslationLocaleIdentifier;
+
     EnhancedSecurityTracking enhancedSecurityTracker;
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1992,6 +1992,7 @@
 		9ACC07B725C81D3400DC6386 /* WebMediaKeySystemClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 9ACC07B625C81D3300DC6386 /* WebMediaKeySystemClient.h */; };
 		9ACC07B925C8218400DC6386 /* WKMediaKeySystemPermissionCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 9ACC07B825C8218300DC6386 /* WKMediaKeySystemPermissionCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9B02E0CB235EB953004044B2 /* _WKTextManipulationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B02E0C9235EB62D004044B2 /* _WKTextManipulationDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9B02E0D1235EB953004044B2 /* _WKTranslationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B02E0D0235EB62D004044B2 /* _WKTranslationDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9B02E0CC235EB957004044B2 /* _WKTextManipulationItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B02E0CA235EB884004044B2 /* _WKTextManipulationItem.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9B02E0D7235FC94F004044B2 /* _WKTextManipulationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B02E0CD235EB967004044B2 /* _WKTextManipulationToken.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9B1229CD23FF25F2008CA751 /* RemoteAudioDestinationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B1229CB23FF25F2008CA751 /* RemoteAudioDestinationManager.h */; };
@@ -7705,6 +7706,7 @@
 		9ACC07B625C81D3300DC6386 /* WebMediaKeySystemClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebMediaKeySystemClient.h; sourceTree = "<group>"; };
 		9ACC07B825C8218300DC6386 /* WKMediaKeySystemPermissionCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKMediaKeySystemPermissionCallback.h; sourceTree = "<group>"; };
 		9B02E0C9235EB62D004044B2 /* _WKTextManipulationDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTextManipulationDelegate.h; sourceTree = "<group>"; };
+		9B02E0D0235EB62D004044B2 /* _WKTranslationDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTranslationDelegate.h; sourceTree = "<group>"; };
 		9B02E0CA235EB884004044B2 /* _WKTextManipulationItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTextManipulationItem.h; sourceTree = "<group>"; };
 		9B02E0CD235EB967004044B2 /* _WKTextManipulationToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTextManipulationToken.h; sourceTree = "<group>"; };
 		9B02E0CE235EBB14004044B2 /* _WKTextManipulationToken.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKTextManipulationToken.mm; sourceTree = "<group>"; };
@@ -13010,6 +13012,7 @@
 				F41145652CD939E0004CDBD1 /* _WKTouchEventGenerator.h */,
 				F41145662CD939E0004CDBD1 /* _WKTouchEventGenerator.mm */,
 				F411457C2CD94161004CDBD1 /* _WKTouchEventGeneratorInternal.h */,
+				9B02E0D0235EB62D004044B2 /* _WKTranslationDelegate.h */,
 				7C2413011AACFA7500A58C15 /* _WKUserContentExtensionStore.h */,
 				7C2413001AACFA7500A58C15 /* _WKUserContentExtensionStore.mm */,
 				7C2413041AACFA9C00A58C15 /* _WKUserContentExtensionStoreInternal.h */,
@@ -18059,6 +18062,7 @@
 				2DACE64E18ADBFF000E4CA76 /* _WKThumbnailViewInternal.h in Headers */,
 				F41145682CD939E0004CDBD1 /* _WKTouchEventGenerator.h in Headers */,
 				F411457D2CD94161004CDBD1 /* _WKTouchEventGeneratorInternal.h in Headers */,
+				9B02E0D1235EB953004044B2 /* _WKTranslationDelegate.h in Headers */,
 				7C2413031AACFA7500A58C15 /* _WKUserContentExtensionStore.h in Headers */,
 				7C2413051AACFA9C00A58C15 /* _WKUserContentExtensionStoreInternal.h in Headers */,
 				7CA3793E1AC378B30079DC37 /* _WKUserContentExtensionStorePrivate.h in Headers */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -838,6 +838,15 @@ IntRect WebChromeClient::rootViewToAccessibilityScreen(const IntRect& rect) cons
     return page ? page->rootViewToAccessibilityScreen(rect) : IntRect();
 }
 
+void WebChromeClient::translateAccessibilityAnnouncementStrings(const Vector<String>& strings, const String& targetLocaleIdentifier, CompletionHandler<void(Vector<String>&&)>&& completion)
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return completion({ });
+
+    page->sendWithAsyncReply(Messages::WebPageProxy::TranslateAccessibilityAnnouncementStrings(strings, targetLocaleIdentifier), WTF::move(completion));
+}
+
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 void WebChromeClient::requestFrameScreenPosition(FrameIdentifier frameID) const
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -139,6 +139,8 @@ private:
 
     WebCore::IntPoint accessibilityScreenToRootView(const WebCore::IntPoint&) const final;
     WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&) const final;
+
+    void translateAccessibilityAnnouncementStrings(const Vector<String>&, const String&, CompletionHandler<void(Vector<String>&&)>&&) final;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void requestFrameScreenPosition(WebCore::FrameIdentifier) const final;
     void scheduleAccessibilityFrameGeometryUpdate() const final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -929,6 +929,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     pageConfiguration.imageTranslationLanguageIdentifiers = WTF::move(parameters.imageTranslationLanguageIdentifiers);
 #endif
 
+    pageConfiguration.displayedTranslationLocaleIdentifier = WTF::move(parameters.displayedTranslationLocaleIdentifier);
+
     if (parameters.textManipulationParameters) {
         m_textManipulationIncludesSubframes = parameters.textManipulationParameters->includeSubframes;
         m_internals->textManipulationExclusionRules = WTF::move(parameters.textManipulationParameters->exclusionRules);
@@ -9939,6 +9941,12 @@ void WebPage::startVisualTranslation(const String& sourceLanguageIdentifier, con
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)
+
+void WebPage::setDisplayedTranslationLocaleIdentifier(String&& localeIdentifier)
+{
+    if (RefPtr page = m_page)
+        page->setDisplayedTranslationLocaleIdentifier(WTF::move(localeIdentifier));
+}
 
 void WebPage::requestImageBitmap(const ElementContext& context, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&, const String& sourceMIMEType)>&& completion)
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1983,6 +1983,8 @@ public:
     void startVisualTranslation(const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier);
 #endif
 
+    void setDisplayedTranslationLocaleIdentifier(String&&);
+
     void requestImageBitmap(const WebCore::ElementContext&, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&, const String& sourceMIMEType)>&&);
 
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -842,6 +842,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
     StartVisualTranslation(String sourceLanguageIdentifier, String targetLanguageIdentifier)
 #endif
 
+    SetDisplayedTranslationLocaleIdentifier(String localeIdentifier)
+
     ScrollToRect(WebCore::FloatRect targetRect, WebCore::FloatPoint origin)
     SetContentOffset(std::optional<int> x, std::optional<int> y, enum:bool WebCore::ScrollIsAnimated animated)
     ScrollToEdge(WebCore::RectEdges<bool> edges, enum:bool WebCore::ScrollIsAnimated animated)

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -70,6 +70,7 @@ Tests/WTF/cocoa/URLExtras.mm @nonARC
 Tests/WebCore/cocoa/WebAVPlayerControllerLeakTests.mm @nonARC
 
 Tests/WebKit/WKWebView/AVFoundationPreference.mm @nonARC
+Tests/WebKit/WKWebView/AccessibilityAnnouncementTranslation.mm @nonARC
 Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm @nonARC
 Tests/WebKit/WKWebView/AdditionalReadAccessAllowedURLs.mm @nonARC
 Tests/WebKit/WKWebView/AdditionalSupportedImageTypes.mm @nonARC

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AccessibilityAnnouncementTranslation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AccessibilityAnnouncementTranslation.mm
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+TEST(AccessibilityAnnouncementTranslation, DisplayedTranslationLocaleRoundTripsAndResetsOnNavigation)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 300)]);
+
+    EXPECT_NULL([webView _displayedTranslationLocaleIdentifier]);
+
+    [webView _setDisplayedTranslationLocaleIdentifier:@"fr"];
+    EXPECT_WK_STREQ("fr", [webView _displayedTranslationLocaleIdentifier]);
+
+    [webView synchronouslyLoadHTMLString:@"<body>first</body>"];
+    [webView synchronouslyLoadHTMLString:@"<body>second</body>"];
+
+    // A cross-document navigation should drop the translated rendering.
+    EXPECT_NULL([webView _displayedTranslationLocaleIdentifier]);
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -239,10 +239,12 @@ const TestFeatures& TestOptions::defaults()
         };
         features.stringTestRunnerFeatures = {
             { "additionalSupportedImageTypes", { } },
+            { "announcementTranslationMode", { } },
             { "applicationBundleIdentifier", { } },
             { "applicationManifest", { } },
             { "contentMode", { } },
             { "contentSecurityPolicyExtensionMode", { } },
+            { "displayedTranslationLocale", { } },
             { "dragInteractionPolicy", { } },
             { "focusStartsInputSessionPolicy", { } },
             { "jscOptions", { } },
@@ -322,10 +324,12 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "secureUpgradePort", TestHeaderKeyType::UInt16TestRunner },
 
         { "additionalSupportedImageTypes", TestHeaderKeyType::StringTestRunner },
+        { "announcementTranslationMode", TestHeaderKeyType::StringTestRunner },
         { "applicationBundleIdentifier", TestHeaderKeyType::StringTestRunner },
         { "applicationManifest", TestHeaderKeyType::StringRelativePathTestRunner },
         { "contentMode", TestHeaderKeyType::StringTestRunner },
         { "contentSecurityPolicyExtensionMode", TestHeaderKeyType::StringTestRunner },
+        { "displayedTranslationLocale", TestHeaderKeyType::StringTestRunner },
         { "dragInteractionPolicy", TestHeaderKeyType::StringTestRunner },
         { "focusStartsInputSessionPolicy", TestHeaderKeyType::StringTestRunner },
         { "jscOptions", TestHeaderKeyType::StringTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -112,10 +112,13 @@ public:
     uint16_t insecureUpgradePort() const { return uint16TestRunnerFeatureValue("insecureUpgradePort"); };
     uint16_t secureUpgradePort() const { return uint16TestRunnerFeatureValue("secureUpgradePort"); };
     std::string additionalSupportedImageTypes() const { return stringTestRunnerFeatureValue("additionalSupportedImageTypes"); }
+    // Drives the fake _WKTranslationDelegate in TestRunnerWKWebView. See its announcementTranslationMode.
+    std::string announcementTranslationMode() const { return stringTestRunnerFeatureValue("announcementTranslationMode"); }
     std::string applicationBundleIdentifier() const { return stringTestRunnerFeatureValue("applicationBundleIdentifier"); }
     std::string applicationManifest() const { return stringTestRunnerFeatureValue("applicationManifest"); }
     std::string contentMode() const { return stringTestRunnerFeatureValue("contentMode"); }
     std::string contentSecurityPolicyExtensionMode() const { return stringTestRunnerFeatureValue("contentSecurityPolicyExtensionMode"); }
+    std::string displayedTranslationLocale() const { return stringTestRunnerFeatureValue("displayedTranslationLocale"); }
     std::string dragInteractionPolicy() const { return stringTestRunnerFeatureValue("dragInteractionPolicy"); }
     std::string focusStartsInputSessionPolicy() const { return stringTestRunnerFeatureValue("focusStartsInputSessionPolicy"); }
     std::string jscOptions() const { return stringTestRunnerFeatureValue("jscOptions"); }

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -385,6 +385,13 @@ UniqueRef<PlatformWebView> TestController::platformCreateOtherPage(PlatformWebVi
 // Code that needs to run after TestController::m_mainWebView is initialized goes into this function.
 void TestController::finishCreatingPlatformWebView(PlatformWebView* view, const TestOptions& options)
 {
+    TestRunnerWKWebView *webView = view->platformView();
+    webView.announcementTranslationMode = [NSString stringWithUTF8String:options.announcementTranslationMode().c_str()];
+
+    auto displayedTranslationLocale = options.displayedTranslationLocale();
+    if (!displayedTranslationLocale.empty())
+        webView._displayedTranslationLocaleIdentifier = [NSString stringWithUTF8String:displayedTranslationLocale.c_str()];
+
 #if PLATFORM(MAC)
     if (options.shouldShowWindow())
         [view->platformWindow() orderFront:nil];

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
@@ -102,6 +102,10 @@
 @property (nonatomic, assign) BOOL shouldAcceptImmersiveEnvironmentRequests;
 #endif
 
+// Drives this view's fake _WKTranslationDelegate. One of "immediate", "async", "reverse", "fail",
+// "delayed", "hang", or "drop". Anything else, including the default, translates immediately.
+@property (nonatomic, copy) NSString *announcementTranslationMode;
+
 - (void)dismissActiveMenu;
 - (void)resetInteractionCallbacks;
 - (void)_didLoadAppInitiatedRequest:(void (^)(BOOL result))completionHandler;

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -31,12 +31,15 @@
 #import <WebKit/WKUIDelegatePrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/_WKFormInputSession.h>
+#import <WebKit/_WKTranslationDelegate.h>
 #import <wtf/Assertions.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/NeverDestroyed.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/Seconds.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/Vector.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
 
@@ -75,7 +78,7 @@ struct CustomMenuActionInfo {
     BlockPtr<void()> callback;
 };
 
-@interface TestRunnerWKWebView () <WKUIDelegatePrivate, _WKInputDelegate
+@interface TestRunnerWKWebView () <WKUIDelegatePrivate, _WKInputDelegate, _WKTranslationDelegate
 #if PLATFORM(IOS_FAMILY)
     , UIGestureRecognizerDelegate
 #endif
@@ -87,6 +90,9 @@ struct CustomMenuActionInfo {
     BOOL _isInteractingWithFormControl;
     BOOL _scrollingUpdatesDisabled;
     RetainPtr<NSArray<NSString *>> _allowedMenuActions;
+    // This is relevant for "reverse" mode, where replies are buffered here and returned in reverse
+    // order, ensuring the implementation can handle announcing in the correct order regardless.
+    Vector<BlockPtr<void()>> _bufferedAnnouncementTranslationReplies;
 #if PLATFORM(MAC)
     int _draggingSequenceNumber;
     RetainPtr<WebKitTestRunnerDraggingInfo> _currentDraggingInfo;
@@ -234,6 +240,7 @@ IGNORE_WARNINGS_END
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
         self.immersiveEnvironmentDelegate = self;
 #endif
+        self._translationDelegate = self;
     }
     return self;
 }
@@ -308,6 +315,72 @@ IGNORE_WARNINGS_END
     [menu update];
     [menu cancelTracking];
 #endif
+}
+
+// Fake translation client for tests.
+- (void)_webView:(WKWebView *)webView translateAccessibilityAnnouncementStrings:(NSArray<NSString *> *)strings targetLocaleIdentifier:(NSString *)targetLocaleIdentifier completionHandler:(void (^)(NSArray<NSString *> *))completionHandler
+{
+    NSString *mode = self.announcementTranslationMode;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcompletion-handler"
+    // Releases the handler without invoking it. WebKit must treat this as "no translation available".
+    if ([mode isEqualToString:@"drop"])
+        return;
+
+    // Holds the handler indefinitely without invoking it, the way a client waiting on a translation
+    // service that never answers would. Note the handler must be retained here, unlike "drop" above.
+    // Releasing it uncalled takes the finalizer path and replies immediately, which would never reach
+    // the timeout. NeverDestroyed keeps these alive for the process lifetime, which is deliberate.
+    if ([mode isEqualToString:@"hang"]) {
+        static NeverDestroyed<Vector<BlockPtr<void(NSArray<NSString *> *)>>> neverInvokedHandlers;
+        neverInvokedHandlers->append(makeBlockPtr(completionHandler));
+        return;
+    }
+#pragma clang diagnostic pop
+
+    // Declines to translate.
+    if ([mode isEqualToString:@"fail"])
+        return completionHandler(nil);
+
+    RetainPtr<NSMutableArray<NSString *>> translated = adoptNS([[NSMutableArray alloc] initWithCapacity:strings.count]);
+    for (NSString *string in strings)
+        [translated addObject:[NSString stringWithFormat:@"%@_translated_to_%@", string, targetLocaleIdentifier]];
+
+    auto reply = makeBlockPtr([completionHandler = makeBlockPtr(completionHandler), translated] {
+        completionHandler(translated.get());
+    });
+
+    // Replies well after WebKit's deadline, so the announcement goes out untranslated and the late
+    // translation must then be discarded rather than announced a second time.
+    if ([mode isEqualToString:@"delayed"]) {
+        RunLoop::mainSingleton().dispatchAfter(300_ms, [reply] {
+            reply();
+        });
+        return;
+    }
+
+    // Buffers replies and flushes them in reverse arrival order once the run loop drains, so tests
+    // can prove announcements are still released in the order they were produced.
+    if ([mode isEqualToString:@"reverse"]) {
+        _bufferedAnnouncementTranslationReplies.append(reply);
+        RunLoop::mainSingleton().dispatch([self, protectedSelf = retainPtr(self)] {
+            auto replies = std::exchange(_bufferedAnnouncementTranslationReplies, { });
+            for (auto it = replies.rbegin(); it != replies.rend(); ++it)
+                (*it)();
+        });
+        return;
+    }
+
+    if ([mode isEqualToString:@"async"]) {
+        RunLoop::mainSingleton().dispatch([reply] {
+            reply();
+        });
+        return;
+    }
+
+    // For "immediate" and any unrecognized mode, reply synchronously.
+    reply();
 }
 
 - (void)resetInteractionCallbacks


### PR DESCRIPTION
#### 2b96b320a28ffc4afb62c90b2e989f1049623194
<pre>
AX: Translate accessibility announcements (ARIA Notify, live regions) when the page is presented as a machine translation
<a href="https://bugs.webkit.org/show_bug.cgi?id=321206">https://bugs.webkit.org/show_bug.cgi?id=321206</a>
<a href="https://rdar.apple.com/184264303">rdar://184264303</a>

Reviewed by Dominic Mazzoni.

Core-AAM adds a normative requirement that when a user agent presents a document as a machine
translation, it must translate ariaNotify() and live region announcements before handing it to
the platform, so that assistive technology conveys it in the language that is visually presented.

WebKit did not do this. Safari translates a page by rewriting the DOM through the text manipulation
SPI, which cannot reach either case. ariaNotify() strings come from script and never enter the DOM,
and a live region announcement is computed from the DOM and posted on a zero-delay timer, before the
translation round trip replaces the text. The result was announcements spoken in the original
language, and live regions spoken twice.

Announcements are now held in a FIFO queue in AXObjectCache while the embedder is asked to translate
them, through a new _WKTranslationDelegate. WebKit cannot translate text itself, instead relying on
TranslationUIServices, allowing the client to supply it. The client also tells WebKit it&apos;s presenting
a translation by setting -_displayedTranslationLocaleIdentifier. With no locale set, the behavior is
unchanged.

Ordering and failure handling are the substance of the change. Translation requests are issued immediately and
in parallel, but announcements are released strictly in the order they were produced, so a slow
translation cannot let a later announcement overtake an earlier one. Each entry has a 250ms deadline,
after which the original text is announced in its original language, preventing a stalled or unavailable
translation service from blocking announcements outright. A translation client that declines, replies late, or drops
the completion handler entirely degrades the same way.

Finally, TextManipulationController now records the container it rewrites, so the children-changed
that its own text swap produces does not announce a live region a second time.

* LayoutTests/accessibility/ios-simulator/aria-notify-translated-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/aria-notify-translated.html: Added.
* LayoutTests/accessibility/mac/aria-notify-translated-expected.txt: Added.
* LayoutTests/accessibility/mac/aria-notify-translated.html: Added.
* LayoutTests/accessibility/mac/aria-notify-translation-dropped-handler-expected.txt: Added.
* LayoutTests/accessibility/mac/aria-notify-translation-dropped-handler.html: Added.
* LayoutTests/accessibility/mac/aria-notify-translation-failure-expected.txt: Added.
* LayoutTests/accessibility/mac/aria-notify-translation-failure.html: Added.
* LayoutTests/accessibility/mac/aria-notify-translation-late-reply-expected.txt: Added.
* LayoutTests/accessibility/mac/aria-notify-translation-late-reply.html: Added.
* LayoutTests/accessibility/mac/aria-notify-translation-not-active-expected.txt: Added.
* LayoutTests/accessibility/mac/aria-notify-translation-not-active.html: Added.
* LayoutTests/accessibility/mac/aria-notify-translation-ordering-expected.txt: Added.
* LayoutTests/accessibility/mac/aria-notify-translation-ordering.html: Added.
* LayoutTests/accessibility/mac/aria-notify-translation-timeout-expected.txt: Added.
* LayoutTests/accessibility/mac/aria-notify-translation-timeout.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-translated-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-translated.html: Added.
* Source/WebCore/accessibility/AXLiveRegionManager.cpp:
(WebCore::AXLiveRegionManager::postAnnouncementForChange):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::AXObjectCache):
(WebCore::AXObjectCache::~AXObjectCache):
(WebCore::AXObjectCache::handleAllDeferredChildrenChanged):
(WebCore::AXObjectCache::handleChildrenChanged):
(WebCore::announcementTranslationTimeoutOverrideForTesting):
(WebCore::AXObjectCache::setAnnouncementTranslationTimeoutForTesting):
(WebCore::AXObjectCache::announcementTranslationTimeout):
(WebCore::AXObjectCache::translateAnnouncementThenAssemble):
(WebCore::AXObjectCache::deferReRenderedContent):
(WebCore::AXObjectCache::isReRenderedContent const):
(WebCore::AXObjectCache::announcementTranslationDidComplete):
(WebCore::AXObjectCache::flushPendingAnnouncements):
(WebCore::AXObjectCache::scheduleAnnouncementTimeoutTimerIfNeeded):
(WebCore::AXObjectCache::pendingAnnouncementTimeoutTimerFired):
(WebCore::AXObjectCache::postARIANotifyNotification):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::replace):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::translateAccessibilityAnnouncementStrings):
* Source/WebCore/page/Page.cpp:
(WebCore::m_mediaSessionManagerFactory):
(WebCore::Page::setDisplayedTranslationLocaleIdentifier):
* Source/WebCore/page/Page.h:
(WebCore::Page::isPresentingMachineTranslation const):
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
(WebCore::Internals::setAccessibilityAnnouncementTranslationTimeout):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Headers.cmake:
* Source/WebKit/PlatformCocoa.cmake:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _translateAccessibilityAnnouncementStrings:sourceLocaleIdentifiers:targetLocaleIdentifier:completionHandler:]):
(-[WKWebView _translationDelegate]):
(-[WKWebView _setTranslationDelegate:]):
(-[WKWebView _displayedTranslationLocaleIdentifier]):
(-[WKWebView _setDisplayedTranslationLocaleIdentifier:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTranslationDelegate.h: Added.
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::translateAccessibilityAnnouncementStrings):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::translateAccessibilityAnnouncementStrings):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::displayedTranslationLocaleIdentifier const):
(WebKit::WebPageProxy::setDisplayedTranslationLocaleIdentifier):
(WebKit::WebPageProxy::translateAccessibilityAnnouncementStrings):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::translateAccessibilityAnnouncementStrings):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_allowsImmersiveEnvironments):
(WebKit::WebPage::setDisplayedTranslationLocaleIdentifier):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AccessibilityAnnouncementTranslation.mm: Added.
(TestWebKitAPI::TEST(AccessibilityAnnouncementTranslation, DisplayedTranslationLocaleRoundTripsAndResetsOnNavigation)):
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::announcementTranslationMode const):
(WTR::TestOptions::displayedTranslationLocale const):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::finishCreatingPlatformWebView):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h:
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView initWithFrame:configuration:]):
(-[TestRunnerWKWebView _webView:translateAccessibilityAnnouncementStrings:sourceLocaleIdentifiers:targetLocaleIdentifier:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/318920@main">https://commits.webkit.org/318920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42186438806373468071869ceec30407a6e3219a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143635 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5eeb435e-136b-4274-a484-602cc371602f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139845 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96792 "2 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7b2cc86-4ac1-42ff-aa10-7592f19acd44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160589 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120297 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8db3521c-e6fc-4947-adf4-f31d1e3d7742) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42115 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40448 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40094 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/609 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191376 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149096 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40072 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53616 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148839 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43512 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125888 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120746 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52133 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15080 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Uploaded test results") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51518 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51759 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51579 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->