### PR TITLE
[GFC] Refactor track filtering and phased sizing functions for intrinsic sizing

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -57,6 +57,19 @@ struct FlexTrack {
 
 enum class ExtraSpaceDistributionTarget : bool { BaseSizes, GrowthLimits };
 
+// Content and flexible tracks are resolved in separete phases.
+enum class ResolveIntrinsicTrackSizesPhase : bool { ContentSizedTracks, FlexibleTracks };
+
+// The min track sizing functions a base-size pass of https://drafts.csswg.org/css-grid-1/#algo-spanning-items
+// distributes space to. Legacy names these passes ResolveIntrinsicMinimums, ResolveContentBasedMinimums
+// and ResolveMaxContentMinimums in TrackSizeComputationPhase, the last covering both halves of item 3.
+enum class MinTrackSizingFunctionType : uint8_t {
+    Intrinsic, // Item 1: "tracks with an intrinsic min track sizing function".
+    MinContentOrMaxContent, // Item 2: "a min track sizing function of min-content or max-content".
+    AutoOrMaxContent, // Item 3, under a max-content constraint: "a min track sizing function of auto or max-content".
+    MaxContent // Item 3, in all cases: "a min track sizing function of max-content".
+};
+
 struct UnsizedTrack {
     LayoutUnit baseSize;
     LayoutUnit growthLimit;
@@ -573,15 +586,40 @@ static void distributeExtraSpace(ExtraSpaceDistributionTarget spaceDistributionT
     }
 }
 
-template<typename MinTrackSizingFunctionPredicate>
-static TrackIndexes flexibleTracksMatching(const UnsizedTracks& unsizedTracks, MinTrackSizingFunctionPredicate&& minMatches)
+// Collects the flexible tracks whose min track sizing function the given base-size pass distributes
+// space to.
+static TrackIndexes affectedFlexibleTracksMatchingMinSizeFunction(const UnsizedTracks& unsizedTracks, MinTrackSizingFunctionType minTrackSizingFunctionType)
 {
+    auto minSizingFunctionForType = [&](const auto& minTrackSizingFunction) {
+        switch (minTrackSizingFunctionType) {
+        case MinTrackSizingFunctionType::Intrinsic:
+            return minTrackSizingFunction.isContentSized();
+        case MinTrackSizingFunctionType::MinContentOrMaxContent:
+            return minTrackSizingFunction.isLength() && (minTrackSizingFunction.length().isMinContent() || minTrackSizingFunction.length().isMaxContent());
+        case MinTrackSizingFunctionType::AutoOrMaxContent:
+            return minTrackSizingFunction.isAuto() || (minTrackSizingFunction.isLength() && minTrackSizingFunction.length().isMaxContent());
+        case MinTrackSizingFunctionType::MaxContent:
+            return minTrackSizingFunction.isLength() && minTrackSizingFunction.length().isMaxContent();
+        }
+        ASSERT_NOT_REACHED();
+        return false;
+    };
+
     TrackIndexes trackIndexes;
     for (auto [trackIndex, track] : WTF::indexedRange(unsizedTracks)) {
-        if (track.trackSizingFunction.max.isFlex() && minMatches(track.trackSizingFunction.min))
+        if (track.trackSizingFunction.max.isFlex() && minSizingFunctionForType(track.trackSizingFunction.min))
             trackIndexes.append(trackIndex);
     }
     return trackIndexes;
+}
+
+// https://drafts.csswg.org/css-grid-1/#algo-spanning-items
+static void increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks(const ResolveIntrinsicTrackSizesContext& resolveIntrinsicTrackSizesContext,
+    UnsizedTracks& unsizedTracks)
+{
+    UNUSED_PARAM(resolveIntrinsicTrackSizesContext);
+    UNUSED_PARAM(unsizedTracks);
+    notImplemented();
 }
 
 // https://drafts.csswg.org/css-grid-1/#algo-spanning-flex-items
@@ -611,42 +649,34 @@ static void increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks(const 
         });
     }
 
-    // For intrinsic minimums: distribute extra space to the base sizes of tracks with an intrinsic
+    // 1. For intrinsic minimums: distribute extra space to the base sizes of tracks with an intrinsic
     // min track sizing function, to accommodate these items' minimum contributions. If the grid
     // container is being sized under a min-/max-content constraint, use the items' limited min-content
     // contributions instead.
-    auto flexibleTracksWithIntrinsicMinimums = flexibleTracksMatching(unsizedTracks, [](const auto& trackSize) {
-        return trackSize.isContentSized();
-    });
+    auto flexibleTracksWithIntrinsicMinimums = affectedFlexibleTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::Intrinsic);
     auto minimumSizeContributions = isSizedUnderMinOrMaxContentConstraint(resolveIntrinsicTrackSizesContext.axisConstraint)
         ? limitedContentContributions(minContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions), fixedMaxTrackSizingFunctionSums, minimumContributionsList)
         : minimumContributionsList;
     distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, flexibleTracksWithIntrinsicMinimums, minimumSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
 
-    // For content-based minimums: continue to distribute extra space to the base sizes of tracks with
+    // 2. For content-based minimums: continue to distribute extra space to the base sizes of tracks with
     // a min track sizing function of min-content or max-content, to accommodate the items' min-content
     // contributions.
     auto minContentSizeContributions = minContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions);
-    auto flexibleTracksWithContentBasedMinimums = flexibleTracksMatching(unsizedTracks, [](const auto& trackSize) {
-        return trackSize.isLength() && (trackSize.length().isMinContent() || trackSize.length().isMaxContent());
-    });
+    auto flexibleTracksWithContentBasedMinimums = affectedFlexibleTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::MinContentOrMaxContent);
     distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, flexibleTracksWithContentBasedMinimums, minContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
 
-    // For max-content minimums: if the grid container is being sized under a max-content constraint
+    // 3. For max-content minimums: if the grid container is being sized under a max-content constraint
     if (scenario == AxisConstraint::FreeSpaceScenario::MaxContent) {
         // continue to distribute extra space to the base sizes of tracks with a min track sizing function
         // of auto or max-content, to accommodate the items' limited max-content contributions...
-        auto flexibleTracksWithAutoOrMaxContentMinimums = flexibleTracksMatching(unsizedTracks, [](const auto& trackSize) {
-            return trackSize.isAuto() || (trackSize.isLength() && trackSize.length().isMaxContent());
-        });
+        auto flexibleTracksWithAutoOrMaxContentMinimums = affectedFlexibleTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::AutoOrMaxContent);
         auto limitedMaxContentSizeContributions = limitedContentContributions(maxContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions), fixedMaxTrackSizingFunctionSums, minimumContributionsList);
         distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, flexibleTracksWithAutoOrMaxContentMinimums, limitedMaxContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
     }
     // ...In all cases, distribute to tracks with a max-content min track sizing function
     // to accommodate the items' max-content contributions.
-    auto flexibleTracksWithMaxContentMinimums = flexibleTracksMatching(unsizedTracks, [](const auto& trackSize) {
-        return trackSize.isLength() && trackSize.length().isMaxContent();
-    });
+    auto flexibleTracksWithMaxContentMinimums = affectedFlexibleTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::MaxContent);
     auto maxContentSizeContributions = maxContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions);
     distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, flexibleTracksWithMaxContentMinimums, maxContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
 
@@ -670,6 +700,14 @@ static void increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks(const 
     //    flexible track is affected.
 }
 
+static void resolveIntrinsicTrackSizesWithSpanningItems(const ResolveIntrinsicTrackSizesContext& resolveIntrinsicTrackSizesContext, UnsizedTracks& unsizedTracks, ResolveIntrinsicTrackSizesPhase phase)
+{
+    if (phase == ResolveIntrinsicTrackSizesPhase::ContentSizedTracks)
+        increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks(resolveIntrinsicTrackSizesContext, unsizedTracks);
+    else
+        increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks(resolveIntrinsicTrackSizesContext, unsizedTracks);
+}
+
 // https://drafts.csswg.org/css-grid-1/#algo-content
 static void resolveIntrinsicTrackSizes(const ResolveIntrinsicTrackSizesContext& resolveIntrinsicTrackSizesContext,
     UnsizedTracks& unsizedTracks)
@@ -687,13 +725,10 @@ static void resolveIntrinsicTrackSizes(const ResolveIntrinsicTrackSizesContext& 
     // 3. Increase sizes to accommodate spanning items crossing content-sized tracks:
     // Next, consider the items with a span of 2 that do not span a track with a flexible
     // sizing function.
-    auto increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks = [] {
-        notImplemented();
-    };
-    UNUSED_VARIABLE(increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks);
+    resolveIntrinsicTrackSizesWithSpanningItems(resolveIntrinsicTrackSizesContext, unsizedTracks, ResolveIntrinsicTrackSizesPhase::ContentSizedTracks);
 
     // 4. Increase sizes to accommodate spanning items crossing flexible tracks:
-    increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks(resolveIntrinsicTrackSizesContext, unsizedTracks);
+    resolveIntrinsicTrackSizesWithSpanningItems(resolveIntrinsicTrackSizesContext, unsizedTracks, ResolveIntrinsicTrackSizesPhase::FlexibleTracks);
 
     // 5. If any track still has an infinite growth limit, set its growth limit to its base size.
     for (auto& unsizedTrack : unsizedTracks) {


### PR DESCRIPTION
#### 20363a36ca9fa4ac58f6f962e8c576a1db3460c7
<pre>
[GFC] Refactor track filtering and phased sizing functions for intrinsic sizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=321207">https://bugs.webkit.org/show_bug.cgi?id=321207</a>
<a href="https://rdar.apple.com/184267254">rdar://184267254</a>

Reviewed by Sammy Gill.

This PR refactors various, inlined functions used to filter grid tracks
by their min track sizing function out into an enum class that is mapped
to the corresponding min track sizing function.

This improves readability for increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks()
by simplifying the calls to affectedFlexibleTracksMatchingMinSizeFunction().

Intrinsic track size resolution for spanning items is done in 2 steps per spec:

<a href="https://drafts.csswg.org/css-grid-1/#algo-content">https://drafts.csswg.org/css-grid-1/#algo-content</a>

First resolving content sized tracks, then resolving flexible tracks. This PR parameterizes this
to call a single function, resolveIntrinsicTrackSizesWithSpanningItems() with a phase argument to
distinguish what step the function is called for. A follow up refactor will extract the code that
can be shared between:

increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks

and the notImplemented:

increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::affectedFlexibleTracksMatchingMinSizeFunction):
(WebCore::Layout::increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks):
(WebCore::Layout::increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks):
(WebCore::Layout::resolveIntrinsicTrackSizesWithSpanningItems):
(WebCore::Layout::resolveIntrinsicTrackSizes):
(WebCore::Layout::flexibleTracksMatching): Deleted.

Canonical link: <a href="https://commits.webkit.org/318937@main">https://commits.webkit.org/318937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24ceddfd7accd8ca00af4fe9f031966d5ba75c32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47621 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144198 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53541 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161057 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d9f3e60-8058-4f41-ac0e-fd07a50e2f88) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40584 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1247 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192021 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53491 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149599 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40080 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54178 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149330 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43978 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121493 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52695 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15570 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52077 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52315 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52141 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->