### PR TITLE
[ANGLE] Re-derive the read render target when its cached texture is null in Metal backend

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
@@ -383,7 +383,15 @@ angle::Result FramebufferMtl::readPixels(const gl::Context *context,
         params.reverseRowOrder = !params.reverseRowOrder;
     }
 
-    ANGLE_TRY(readPixelsImpl(context, flippedArea, params, getColorReadRenderTarget(context),
+    RenderTargetMtl *readRenderTarget = getColorReadRenderTarget(context);
+    // The cached render target holds only a weak reference to its texture, so getTexture() may be
+    // null. Re-derive it from the attachment to get the current texture, or null if none exists.
+    if (readRenderTarget && !readRenderTarget->getTexture())
+    {
+        readRenderTarget = getColorReadRenderTargetNoCache(context);
+    }
+
+    ANGLE_TRY(readPixelsImpl(context, flippedArea, params, readRenderTarget,
                              static_cast<uint8_t *>(pixels) + outputSkipBytes));
 
     return angle::Result::Continue;

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/ReadPixelsTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/ReadPixelsTest.cpp
@@ -786,6 +786,49 @@ TEST_P(ReadPixelsPBOTest, SmallRowLength)
     ASSERT_GL_NO_ERROR();
 }
 
+// Tests that reading into a PBO does not crash when the read attachment's texture was redefined
+// and reattached after rendering. (Regression test for a stale-render-target crash on Metal.)
+TEST_P(ReadPixelsPBOTest, ReadToPBOFromRedefinedColorAttachment)
+{
+    // RGBA4 storage so the RGBA/UNSIGNED_BYTE read below is a format-converting read.
+    GLTexture texture;
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA4, 2, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+    GLFramebuffer framebuffer;
+    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+
+    // Render into the texture so the framebuffer has been used before the redefine below.
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
+    glClearBufferfv(GL_COLOR, 0, GLColor::red.toNormalizedVector().data());
+
+    // Reattach the texture at a different attachment and read from there.
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, texture, 0);
+    glReadBuffer(GL_COLOR_ATTACHMENT1);
+
+    // Redefine the read attachment's texture storage (intentionally the same call as above).
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA4, 2, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    ASSERT_GL_NO_ERROR();
+
+    GLBuffer pbo;
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo);
+    glBufferData(GL_PIXEL_PACK_BUFFER, 2 * sizeof(GLColor), nullptr, GL_STREAM_READ);
+
+    // Used to crash; contents are undefined after the redefine, so the bytes are not checked.
+    glReadPixels(0, 0, 2, 1, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+    EXPECT_GL_NO_ERROR();
+
+    // Verify the context still works: clear a known color and read it back into client memory.
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glClearBufferfv(GL_COLOR, 0, GLColor::green.toNormalizedVector().data());
+    GLColor pixel;
+    glReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, &pixel);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_EQ(GLColor::green, pixel);
+}
+
 class ReadPixelsPBODrawTest : public ReadPixelsPBOTest
 {
   protected:


### PR DESCRIPTION
#### 03c6f6f12ec7aec197fbdd8ae0ed8d4e1c6ec1cd
<pre>
[ANGLE] Re-derive the read render target when its cached texture is null in Metal backend
<a href="https://bugs.webkit.org/show_bug.cgi?id=321209">https://bugs.webkit.org/show_bug.cgi?id=321209</a>
<a href="https://rdar.apple.com/183915520">rdar://183915520</a>

Reviewed by NOBODY (OOPS!).

RenderTargetMtl holds only a weak reference to its Metal texture, so a cached read
render target can return a null getTexture() while the read attachment still has a
valid image, such as when the read&apos;s own state sync tears down an earlier render pass
that was the texture&apos;s last owner. The direct readPixels path bails out on a null
texture, but the PBO pack path does not: its format-converting compute packer turns
the null texture into a -1 index into the mT2BComputeShaders array and crashes under
libc++ hardening.

Fix by re-deriving the read render target from the attachment when the cached texture
is null. getColorReadRenderTargetNoCache() ensures native storage and rebinds the
render target to the current live image, so the read sees a valid texture. If the
attachment has no image the re-derive returns null, which readPixelsImpl() already
handles.

Adds ReadPixelsPBOTest.ReadToPBOFromRedefinedColorAttachment, which reproduces the
crash by rendering into a texture, reattaching it at a different color attachment,
redefining its storage with glTexImage2D, and reading it into a PBO.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm:
(rx::FramebufferMtl::readPixels):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/ReadPixelsTest.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03c6f6f12ec7aec197fbdd8ae0ed8d4e1c6ec1cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143741 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139925 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96822 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc7b8530-d91c-4d17-a6c0-fc8a8b2f48b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120377 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bdb54e86-98a9-4aa0-8a16-f4b2be66f28d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42199 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40534 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40181 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/717 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191482 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53041 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149184 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53722 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148927 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43597 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120889 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52239 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15170 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51624 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51865 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->