### PR TITLE
Remove `using WTF::Task` since it conflicts with Swift's Task

### DIFF
--- a/Source/WTF/wtf/CoroutineUtilities.h
+++ b/Source/WTF/wtf/CoroutineUtilities.h
@@ -175,4 +175,3 @@ private:
 using WTF::Awaitable;
 using WTF::AwaitableFromCompletionHandler;
 using WTF::CoroutineHandle;
-using WTF::Task;

--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -199,7 +199,7 @@ void callMemberFunction(T* object, MF U::* function, CT connection, ArgsTuple&& 
 template<typename T, typename U, typename MF, typename ArgsTuple>
 void callMemberFunctionCoroutine(T* object, MF U::* function, ArgsTuple&& tuple)
 {
-    [&] -> Task {
+    [&] -> WTF::Task {
         Ref protectedObject { *object };
         co_await std::apply([&](auto&&... args) {
             // Use of object without protection is safe here since std::apply() runs synchronously.
@@ -211,7 +211,7 @@ void callMemberFunctionCoroutine(T* object, MF U::* function, ArgsTuple&& tuple)
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CT>
 void callMemberFunctionCoroutine(T* object, MF U::* function, CT connection, ArgsTuple&& tuple)
 {
-    [&] -> Task {
+    [&] -> WTF::Task {
         Ref protectedObject { *object };
         co_await std::apply([&](auto&&... args) {
             // Use of object without protection is safe here since std::apply() runs synchronously.
@@ -223,7 +223,7 @@ void callMemberFunctionCoroutine(T* object, MF U::* function, CT connection, Arg
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CH>
 void callMemberFunctionCoroutine(T* object, MF U::* function, ArgsTuple&& tuple, CompletionHandler<CH>&& completionHandler)
 {
-    [&] (auto completionHandler) -> Task {
+    [&] (auto completionHandler) -> WTF::Task {
         Ref protectedObject { *object };
         // Use of object without protection is safe here since std::apply() runs synchronously and object is protected for the lifetime of the Task.
         completionHandler(co_await std::apply([&](auto&&... args) {
@@ -235,7 +235,7 @@ void callMemberFunctionCoroutine(T* object, MF U::* function, ArgsTuple&& tuple,
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CH>
 void callMemberFunctionCoroutine(T* object, MF U::* function, ArgsTuple&& tuple, WTF::RefCountable<WTF::CompletionHandler<CH>>* completionHandler)
 {
-    [&] (auto completionHandler) -> Task {
+    [&] (auto completionHandler) -> WTF::Task {
         Ref protectedObject { *object };
         // Use of object without protection is safe here since std::apply() runs synchronously and object is protected for the lifetime of the Task.
         completionHandler(co_await std::apply([&](auto&&... args) {
@@ -247,7 +247,7 @@ void callMemberFunctionCoroutine(T* object, MF U::* function, ArgsTuple&& tuple,
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CH>
 void callMemberFunctionCoroutine(T* object, MF U::* function, Connection& connection, ArgsTuple&& tuple, CompletionHandler<CH>&& completionHandler)
 {
-    [&] (auto completionHandler) -> Task {
+    [&] (auto completionHandler) -> WTF::Task {
         Ref protectedObject { *object };
         // Use of object without protection is safe here since std::apply() runs synchronously and object is protected for the lifetime of the Task.
         completionHandler(co_await std::apply([&](auto&&... args) {
@@ -259,7 +259,7 @@ void callMemberFunctionCoroutine(T* object, MF U::* function, Connection& connec
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CH>
 void callMemberFunctionCoroutine(T* object, MF U::* function, Connection* connection, ArgsTuple&& tuple, WTF::RefCountable<WTF::CompletionHandler<CH>>* completionHandler)
 {
-    [&] (auto completionHandler) -> Task {
+    [&] (auto completionHandler) -> WTF::Task {
         Ref protectedObject { *object };
         // Use of object without protection is safe here since std::apply() runs synchronously and object is protected for the lifetime of the Task.
         completionHandler(co_await std::apply([&](auto&&... args) {
@@ -271,7 +271,7 @@ void callMemberFunctionCoroutine(T* object, MF U::* function, Connection* connec
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CH>
 void callMemberFunctionCoroutineVoid(T* object, MF U::* function, ArgsTuple&& tuple, CompletionHandler<CH>&& completionHandler)
 {
-    [&] (auto completionHandler) -> Task {
+    [&] (auto completionHandler) -> WTF::Task {
         Ref protectedObject { *object };
         // Use of object without protection is safe here since std::apply() runs synchronously and object is protected for the lifetime of the Task.
         co_await std::apply([&](auto&&... args) {
@@ -284,7 +284,7 @@ void callMemberFunctionCoroutineVoid(T* object, MF U::* function, ArgsTuple&& tu
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CH>
 void callMemberFunctionCoroutineVoid(T* object, MF U::* function, ArgsTuple&& tuple, WTF::RefCountable<WTF::CompletionHandler<CH>>* completionHandler)
 {
-    [&] (auto completionHandler) -> Task {
+    [&] (auto completionHandler) -> WTF::Task {
         Ref protectedObject { *object };
         // Use of object without protection is safe here since std::apply() runs synchronously and object is protected for the lifetime of the Task.
         co_await std::apply([&](auto&&... args) {
@@ -297,7 +297,7 @@ void callMemberFunctionCoroutineVoid(T* object, MF U::* function, ArgsTuple&& tu
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CH>
 void callMemberFunctionCoroutineVoid(T* object, MF U::* function, Connection& connection, ArgsTuple&& tuple, CompletionHandler<CH>&& completionHandler)
 {
-    [&] (auto completionHandler) -> Task {
+    [&] (auto completionHandler) -> WTF::Task {
         Ref protectedObject { *object };
         // Use of object without protection is safe here since std::apply() runs synchronously and object is protected for the lifetime of the Task.
         co_await std::apply([&](auto&&... args) {
@@ -310,7 +310,7 @@ void callMemberFunctionCoroutineVoid(T* object, MF U::* function, Connection& co
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CH>
 void callMemberFunctionCoroutineVoid(T* object, MF U::* function, Connection* connection, ArgsTuple&& tuple, WTF::RefCountable<WTF::CompletionHandler<CH>>* completionHandler)
 {
-    [&] (auto completionHandler) -> Task {
+    [&] (auto completionHandler) -> WTF::Task {
         Ref protectedObject { *object };
         // Use of object without protection is safe here since std::apply() runs synchronously and object is protected for the lifetime of the Task.
         co_await std::apply([&](auto&&... args) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift
@@ -28,7 +28,6 @@ import struct Foundation.URL
 @_spi(WebKitAdditions_Testing) @_spi(Testing) import WebKit
 import SwiftUI
 import struct Swift.String
-import struct _Concurrency.Task
 import struct TestWebKitAPILibrary.DOMRect
 import Testing
 import TestWebKitAPILibrary

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -28,7 +28,6 @@ import struct Foundation.URL
 @_spi(WebKitAdditions_Testing) @_spi(Testing) import WebKit
 import SwiftUI
 import struct Swift.String
-import struct _Concurrency.Task
 private import struct TestWebKitAPILibrary.DOMRect
 import Testing
 private import TestWebKitAPILibrary

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/DoubleClickGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/DoubleClickGesturesTests.swift
@@ -28,7 +28,6 @@ import struct Foundation.URL
 @_spi(WebKitAdditions_Testing) @_spi(Testing) import WebKit
 import SwiftUI
 import struct Swift.String
-import struct _Concurrency.Task
 private import struct TestWebKitAPILibrary.DOMRect
 import Testing
 private import TestWebKitAPILibrary

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift
@@ -29,7 +29,6 @@ import struct Foundation.URL
 @_spi(Testing) import _WebKit_SwiftUI
 import SwiftUI
 import struct Swift.String
-import struct _Concurrency.Task
 private import struct TestWebKitAPILibrary.DOMRect
 import Testing
 private import TestWebKitAPILibrary

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/SendInspectorMessage.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/SendInspectorMessage.swift
@@ -160,7 +160,7 @@ private func waitForCaptured(
 ) async {
     for _ in 0..<maxIterations {
         if await predicate() { return }
-        try? await _Concurrency.Task.sleep(for: .milliseconds(50))
+        try? await Task.sleep(for: .milliseconds(50))
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift
@@ -25,7 +25,6 @@
 
 import Testing
 import WebKit
-import struct _Concurrency.Task
 import struct Swift.String
 import struct Foundation.URL
 private import TestWebKitAPILibrary

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift
@@ -25,7 +25,6 @@
 
 import Testing
 @_spi(Testing) import WebKit
-import struct _Concurrency.Task
 private import TestWebKitAPILibrary
 
 private struct NeverLoadingSchemeHandler: URLSchemeHandler {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift
@@ -30,7 +30,6 @@ import Testing
 import WebKit_Private.WKWebViewPrivate
 @_spi(Experimental) import _WebKit_SwiftUI
 private import TestWebKitAPILibrary
-import struct _Concurrency.Task
 import struct Swift.String
 #if WTF_PLATFORM_MAC
 import AppKit


### PR DESCRIPTION
#### 9f82586af24ce000cbf76a2b2aa22ea58c34f414
<pre>
Remove `using WTF::Task` since it conflicts with Swift&apos;s Task
<a href="https://bugs.webkit.org/show_bug.cgi?id=321212">https://bugs.webkit.org/show_bug.cgi?id=321212</a>
<a href="https://rdar.apple.com/184270073">rdar://184270073</a>

Reviewed by Aditya Keerthi.

Use of `Task` in Swift is much more common than uses of `WTF::Task` which is only used in a single
file. Therefore, remove the `using` declaration and just use the namespaced name, since that&apos;s what
namespaces are for anyways.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/DoubleClickGesturesTests.swift
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/SendInspectorMessage.swift
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift

* Source/WTF/wtf/CoroutineUtilities.h:
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::callMemberFunctionCoroutine):
(IPC::callMemberFunctionCoroutineVoid):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/DoubleClickGesturesTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/SendInspectorMessage.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebViewTests.swift:

Canonical link: <a href="https://commits.webkit.org/318824@main">https://commits.webkit.org/318824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97cc5c2e6f46e415d12af455f3836bcaec59a11f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189086 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143563 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139786 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120238 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42049 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40394 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2208 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9024 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40044 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/392 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40529 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191303 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52863 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40016 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53543 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148774 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43452 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125815 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120674 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52061 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15024 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51446 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51687 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51507 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->