### PR TITLE
[JSC] `JSC_JIT_CAGE_PROBE{,_IMPL}` fallback macros in `JITOperationValidation.h` do not compile

### DIFF
--- a/Source/JavaScriptCore/assembler/JITOperationValidation.h
+++ b/Source/JavaScriptCore/assembler/JITOperationValidation.h
@@ -58,11 +58,11 @@ namespace JSC {
 #endif
 
 #ifndef JSC_JIT_CAGE_PROBE
-#define JSC_JIT_CAGE_PROBE(v) do { (void)x; } while (0)
+#define JSC_JIT_CAGE_PROBE(v) do { (void)(v); } while (0)
 #endif
 
 #ifndef JSC_JIT_CAGE_PROBE_IMPL
-#define JSC_JIT_CAGE_PROBE(v) do { (void)x; } while (0)
+#define JSC_JIT_CAGE_PROBE_IMPL(v) do { (void)(v); } while (0)
 #endif
 
 template<typename Functor>


### PR DESCRIPTION
#### 95ffc89f5eb494d6b3918b7f6e98cc85bad52892
<pre>
[JSC] `JSC_JIT_CAGE_PROBE{,_IMPL}` fallback macros in `JITOperationValidation.h` do not compile
<a href="https://bugs.webkit.org/show_bug.cgi?id=321214">https://bugs.webkit.org/show_bug.cgi?id=321214</a>

Reviewed by Keith Miller.

318675@main added no-op fallbacks for JSC_JIT_CAGE_PROBE and
JSC_JIT_CAGE_PROBE_IMPL for when &lt;WebKitAdditions/JITCageAdditions.h&gt; does not
provide them, but both had copy-paste mistakes:

1. Both bodies were `(void)x` while the parameter is `v`, so any expansion
   (LLIntData.cpp) fails with an undeclared identifier.
2. The `#ifndef JSC_JIT_CAGE_PROBE_IMPL` block defined JSC_JIT_CAGE_PROBE
   again instead of JSC_JIT_CAGE_PROBE_IMPL, leaving the latter with no
   fallback (LLIntThunks.cpp) and redefining the former if the SDK header
   only provides JSC_JIT_CAGE_PROBE.

Use `(void)(v)` in both and define JSC_JIT_CAGE_PROBE_IMPL in the second block.
No behavior change for open-source builds since ENABLE(JIT_CAGE) is off there.

* Source/JavaScriptCore/assembler/JITOperationValidation.h:

Canonical link: <a href="https://commits.webkit.org/318765@main">https://commits.webkit.org/318765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e78400c2069f02eaec98589741f77cff56d1fb6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189088 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52905 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139787 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120239 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42059 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40395 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2209 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9026 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152459 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40046 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/394 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40531 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45801 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191305 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52865 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149030 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39988 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53545 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148775 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43460 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125817 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120676 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52063 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15026 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51448 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51689 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51509 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->