### PR TITLE
MediaRecorder drops a frame whenever the writer input reports not ready

### DIFF
--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.cpp
@@ -83,12 +83,14 @@ Ref<MediaRecorderPrivateWriter::WriterPromise> MediaRecorderPrivateWriter::write
     static const MediaTime maxSegmentDuration = MediaTime::createWithDouble(10);
 
     auto result = Result::Success;
-    while (!m_pendingFrames.isEmpty() && result == Result::Success) {
-        auto sample = m_pendingFrames.takeFirst();
-        result = writeFrame(sample.get());
+    while (!m_pendingFrames.isEmpty()) {
+        result = writeFrame(m_pendingFrames.first().get());
+        if (result != Result::Success)
+            break;
+        m_pendingFrames.removeFirst();
         // End the segment if we succeded in writing all frames, otherwise we will retry them on the next call.
         MediaTime endSampleTime = m_pendingFrames.isEmpty() ? endTime : m_pendingFrames.first()->presentationTime();
-        if (!segmentsMustStartWithKeyframe() && result == Result::Success && endSampleTime - m_lastSegmentEndTime >= maxSegmentDuration) {
+        if (!segmentsMustStartWithKeyframe() && endSampleTime - m_lastSegmentEndTime >= maxSegmentDuration) {
             LOG(MediaStream, "MediaRecorderPrivateWriter::writeFrames forceNewSegment at time:%f", endTime.toDouble());
             forceNewSegment(endSampleTime);
             m_lastSegmentEndTime = endSampleTime;


### PR DESCRIPTION
#### 2c529b89097add1b320d3db123d7fa9ef8456329
<pre>
MediaRecorder drops a frame whenever the writer input reports not ready
<a href="https://bugs.webkit.org/show_bug.cgi?id=321218">https://bugs.webkit.org/show_bug.cgi?id=321218</a>
<a href="https://rdar.apple.com/184271782">rdar://184271782</a>

Reviewed by Darin Adler.

Previously, MediaRecorderPrivateWriter::writeFrames() removed the sample
from m_pendingFrames before calling writeFrame(). That caused the sample
to be destroyed instead of retried when writeFrame() returned NotReady,
contradicting the adjacent comment and discarding one frame. This removes
the sample from the deque if and only if writeFrame() returned Success,
which is the intended behavior.

* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.cpp:
(WebCore::MediaRecorderPrivateWriter::writeFrames):

Canonical link: <a href="https://commits.webkit.org/318778@main">https://commits.webkit.org/318778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/330bb8bffdc1570510c5f03f161841df991f8c8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189095 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181126 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139791 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120243 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42055 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40400 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40051 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/401 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52872 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149037 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39995 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53552 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148782 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43455 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125824 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120683 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52070 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15031 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51455 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51696 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->