### PR TITLE
Add missing writeBarrier to Array.unshift

### DIFF
--- a/JSTests/stress/array-unshift-moved-cell-barrier.js
+++ b/JSTests/stress/array-unshift-moved-cell-barrier.js
@@ -1,0 +1,71 @@
+//@ requireOptions("--useDollarVM=1", "--numberOfGCMarkers=4", "--minimumGCPauseMS=0", "--gcPauseScale=0", "--maximumMutatorUtilization=0.01", "--useSamplingProfiler=true", "--sampleInterval=1")
+
+// unshift on a Contiguous array moves the existing elements up to make room
+// before publicLength is updated, so a moved cell is briefly outside the range
+// a concurrent collector scans. Without a barrier on the array itself the
+// collector can miss that cell and reclaim it while it is still reachable
+// through the array. The inserted value is a double, so the store implies no
+// barrier of its own.
+//
+// A cleared WeakRef whose only strong reference is the moved element means the
+// collector lost track of a live cell.
+
+function unshiftOne(array) {
+    array.unshift(13.37);
+}
+noInline(unshiftOne);
+
+// Monomorphic Contiguous receivers with spare capacity for ArrayUnshift, so
+// the single-element fast path is what gets compiled.
+const warmObject = { warmup: 0 };
+for (let i = 0; i < testLoopCount; ++i) {
+    const array = [warmObject, 0];
+    array.pop();
+    unshiftOne(array);
+}
+
+// Winning the race takes many attempts, but the configurations that lower
+// testLoopCount are the ones where each attempt is most expensive, so scale
+// both the victim pool and the round count with it. The pool is rounded down
+// to a power of two so that the permutation below covers it exactly.
+const victimCount = 1 << (28 - Math.clz32(testLoopCount));
+const mask = victimCount - 1;
+const victims = new Array(victimCount);
+const weak = new Array(victimCount);
+
+const rounds = Math.max(1, testLoopCount >> 9);
+
+for (let round = 0; round < rounds; ++round) {
+    for (let i = 0; i < victimCount; ++i) {
+        // Reachable only through the victim's element, so nothing else keeps
+        // it alive if the collector loses track of it.
+        const cell = new Array(100).fill(i + 0.25);
+        // Capacity for two elements while publicLength stays at one, which is
+        // what the fast path requires.
+        const victim = [cell, 0];
+        victim.pop();
+        victims[i] = victim;
+        weak[i] = new WeakRef(cell);
+    }
+
+    // A deref'd WeakRef keeps its target alive until the next microtask
+    // checkpoint, so drop that protection before the collection.
+    releaseWeakRefs();
+    $vm.gc(); // Pre-age the victims and clear newlyAllocated protection.
+    $vm.gcSweepAsynchronously();
+
+    // A full permutation decorrelates the mutator from the parallel markers'
+    // LIFO worklists, and the 1us sampling interval supplies the frequent
+    // preemption that exposes the window.
+    for (let i = 0; i < victimCount; ++i)
+        unshiftOne(victims[Math.imul(i, 0x9e3779b1) & mask]);
+
+    // Let the collector finish this cycle.
+    for (let i = 0; i < 2000; ++i)
+        globalThis.safepointSink = { i };
+
+    for (let i = 0; i < victimCount; ++i) {
+        if (weak[i].deref() === undefined)
+            throw new Error('collector reclaimed a cell still referenced by victims[' + i + ']');
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -271,8 +271,7 @@ private:
                 break;
             }
 
-            case ArrayPush:
-            case ArrayUnshift: {
+            case ArrayPush: {
                 switch (m_node->arrayMode().type()) {
                 case Array::Contiguous:
                 case Array::ArrayStorage:
@@ -290,6 +289,19 @@ private:
                 default:
                     break;
                 }
+                break;
+            }
+
+            case ArrayUnshift: {
+                // Only a single-element Contiguous unshift is emitted inline; every other case
+                // calls an operation that runs its own barrier. Inline, unshift moves the
+                // existing element up to make room, which can conceal an already-live cell from
+                // a concurrent collector: it sits outside the scanned range until publicLength
+                // is updated. The moved element is what needs barriering, so this considers the
+                // array itself rather than any of the operands.
+                unsigned elementCount = m_node->numChildren() - 2;
+                if (elementCount == 1 && m_node->arrayMode().type() == Array::Contiguous)
+                    considerBarrier(m_graph.varArgChild(m_node, 1));
                 break;
             }
 


### PR DESCRIPTION
#### f641af0b8e472dd959f5e0763e18a68072bfca6e
<pre>
Add missing writeBarrier to Array.unshift
<a href="https://bugs.webkit.org/show_bug.cgi?id=321217">https://bugs.webkit.org/show_bug.cgi?id=321217</a>
<a href="https://rdar.apple.com/183142160">rdar://183142160</a>

Reviewed by Yusuke Suzuki.

In 313475@main we added support for Array.p.unshift in the DFG based on
Array.push. Unlike Array.push, when relocating elements they may become
invisible to the GC. Since we inline the case where there is exactly
one element being prepended to the array and we don&apos;t know what the
contents of the array are we always have to writeBarrier the array.

Test: JSTests/stress/array-unshift-moved-cell-barrier.js
Canonical link: <a href="https://commits.webkit.org/318780@main">https://commits.webkit.org/318780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4919c77b178162f48aa9655859f8d179f0ccd1b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189105 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139794 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ad23f13-a096-4d69-8eca-6d4ce2858304) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120246 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42077 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40406 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2216 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9035 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40055 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/412 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40548 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191322 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52882 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149041 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53562 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148786 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27221 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43465 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125834 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120693 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52080 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15036 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51465 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51706 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51526 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->