### PR TITLE
[JSC] LazyJSValue::emit leaks a StringImpl reference when finalization is skipped

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp
@@ -238,6 +238,20 @@ uintptr_t LazyJSValue::switchLookupValue(SwitchKind kind) const
     return 0;
 }
 
+// LazyJSValue borrows NewStringImpl storage from Graph::m_localStrings, which dies before the
+// deferred materialization runs, so an escaping copy must own it. KnownStringImpl needs no
+// reference: those belong to the unlinked code block, which outlives finalization.
+struct EscapedLazyJSValue {
+    explicit EscapedLazyJSValue(const LazyJSValue& value)
+        : value(value)
+        , ownedString(value.kind() == LazyJSValue::NewStringImpl ? value.stringImpl() : nullptr)
+    {
+    }
+
+    LazyJSValue value;
+    RefPtr<StringImpl> ownedString;
+};
+
 void LazyJSValue::emit(CCallHelpers& jit, JSValueRegs result, Plan& planRef) const
 {
     if (m_kind == KnownValue) {
@@ -250,27 +264,18 @@ void LazyJSValue::emit(CCallHelpers& jit, JSValueRegs result, Plan& planRef) con
         CCallHelpers::TrustedImmPtr(static_cast<size_t>(0xd1e7beeflu)),
         result.payloadGPR());
 
-    LazyJSValue thisValue = *this;
-
-    // Once we do this, we're committed. Otherwise we leak memory. Note that we call ref/deref
-    // manually to ensure that there is no concurrency shadiness. We are doing something here
-    // that might be rather brutal: transfering ownership of this string.
-    if (m_kind == NewStringImpl)
-        thisValue.u.stringImpl->ref();
+    EscapedLazyJSValue thisValue { *this };
 
     CodeBlock* codeBlock = jit.codeBlock();
-    
+
     auto* plan = &planRef;
     jit.addLinkTask([=] (LinkBuffer& linkBuffer) {
         auto patchLocation = linkBuffer.locationOf<JITCompilationPtrTag>(label);
         plan->addMainThreadFinalizationTask([=] {
-            JSValue realValue = thisValue.getValue(codeBlock->vm());
+            JSValue realValue = thisValue.value.getValue(codeBlock->vm());
             RELEASE_ASSERT(realValue.isCell());
 
             codeBlock->addConstant(ConcurrentJSLocker(codeBlock->m_lock), realValue);
-
-            if (thisValue.m_kind == NewStringImpl)
-                thisValue.u.stringImpl->deref();
 
             MacroAssembler::repatchPointer(patchLocation, realValue.asCell());
         });


### PR DESCRIPTION
#### bbab514b1010b4a0eddd2ed5c479747a0511108d
<pre>
[JSC] LazyJSValue::emit leaks a StringImpl reference when finalization is skipped
<a href="https://bugs.webkit.org/show_bug.cgi?id=321221">https://bugs.webkit.org/show_bug.cgi?id=321221</a>
<a href="https://rdar.apple.com/184272837">rdar://184272837</a>

Reviewed by Yusuke Suzuki.

emit() manually refs a NewStringImpl&apos;s StringImpl and relies on the main-thread
finalization task to deref it, but several paths skip that task. When JIT
executable memory runs out after code generation, both DFG and FTL bail on
LinkBuffer::didFailToAllocate(), so the link task never runs and the finalization
task it would have registered never exists. Separately,
runMainThreadFinalizationTasks() runs inside JITFinalizer::finalize(), which
Plan::finalize() only reaches past its isStillValidCodeBlock() check, so a
compilation that links successfully and is then invalidated leaks as well. A plan
cancelled after code generation would leak the same way, which today only the
placement of safepoints prevents.

Hold the reference in a RefPtr instead, so it is released whether the task runs
or not.

* Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp:
(JSC::DFG::EscapedLazyJSValue::EscapedLazyJSValue):
(JSC::DFG::LazyJSValue::emit const):

Canonical link: <a href="https://commits.webkit.org/318800@main">https://commits.webkit.org/318800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06038a19d274546091ea7b0f24f6c6c0513135e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179444 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b89cd30-5eda-4d3c-9ec0-58bc0691bb58) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54677 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/189276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1dae2dd-3331-4b5d-857f-8180b0acb316) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182401 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf5969ca-170a-4533-87e6-93bb3603baeb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40719 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191495 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/148940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27232 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52251 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->