### PR TITLE
[WebDriver][Tools] Fix pytest_collection_modifyitems to support proper flaky expectations

### DIFF
--- a/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
@@ -110,7 +110,10 @@ class SubtestResultRecorder(object):
         return hasattr(report.longrepr, 'reprcrash') and report.longrepr.reprcrash.message.startswith('Failed: Timeout >')
 
     def record_pass(self, report):
-        if hasattr(report, 'wasxfail'):
+        expected = dict(report.user_properties).get("expectations", [])
+        # Avoid expected flaky passes from being reported as XPASS, distracting from
+        # true XPASS tests.
+        if hasattr(report, 'wasxfail') and 'PASS' not in expected:
             if report.wasxfail == 'Timeout':
                 self.record(report.nodeid, 'XPASS_TIMEOUT')
             else:
@@ -131,8 +134,11 @@ class SubtestResultRecorder(object):
         self.record(report.nodeid, 'ERROR', message, report.longrepr)
 
     def record_skip(self, report):
+        expected = dict(report.user_properties).get("expectations", [])
         if hasattr(report, 'wasxfail'):
-            if self._was_timeout(report) and report.wasxfail != 'Timeout':
+            # Avoid expected flaky fail/timeouts from being reported as unexpected TIMEOUT,
+            # distracting from true TIMEOUT regressions.
+            if self._was_timeout(report) and report.wasxfail != 'Timeout' and 'TIMEOUT' not in expected:
                 self.record(report.nodeid, 'TIMEOUT', stack=report.longrepr)
             else:
                 self.record(report.nodeid, 'XFAIL')
@@ -160,13 +166,17 @@ class TestExpectationsMarker(object):
             item_name = get_item_name(item, self._ignore_param)
             if self._expectations.is_slow(test, item_name):
                 item.add_marker(pytest.mark.timeout(self._timeout * 5))
-            expected = self._expectations.get_expectation(test, item_name)[0]
-            if expected == 'FAIL':
+            expected = self._expectations.get_expectation(test, item_name)
+            if 'FAIL' in expected:
+                # Adding a "flaky" reason would overwrite the actual reason the test failed,
+                # making it harder to identify the actual reason
                 item.add_marker(pytest.mark.xfail)
-            elif expected == 'TIMEOUT':
+            elif 'TIMEOUT' in expected:
                 item.add_marker(pytest.mark.xfail(reason="Timeout"))
-            elif expected == 'SKIP':
+            elif 'SKIP' in expected:
                 item.add_marker(pytest.mark.skip)
+
+            item.user_properties.append(("expectations", expected))
 
 
 def collect(directory, args, ignore_param=None):


### PR DESCRIPTION
#### 906e60b3d82986684b7907e52b909c4a1e6982d8
<pre>
[WebDriver][Tools] Fix pytest_collection_modifyitems to support proper flaky expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=321175">https://bugs.webkit.org/show_bug.cgi?id=321175</a>

Reviewed by Carlos Alberto Lopez Perez.

Ensure we check the whole expectation list when installing the pytest
markers. Previously, only the first item was checked, effectively
ignoring flaky expectations, which have multiple expected outcomes.

As pytest has no natural flaky test marker, flakies are marked as xfail,
which, in the case of a pass, currently are reported as XPASS. To avoid
polluting the final report and hiding true XPASS cases, we also report
the flaky passes as regular PASS in the outer harness and resulting
json. The same approach is used for FAIL/TIMEOUT, to avoid the empty
xfail to mark an expected flaky timeout as a true timeout.

* Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py:
(SubtestResultRecorder.record_pass):
(TestExpectationsMarker.pytest_collection_modifyitems):

Canonical link: <a href="https://commits.webkit.org/318761@main">https://commits.webkit.org/318761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da97a96d7c054d3a20aca4f30e631b72d999d160

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189114 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139804 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120256 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178607 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40063 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/421 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191331 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52891 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149053 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39984 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53571 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148798 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43470 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120702 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52089 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15047 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51474 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51715 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->