### PR TITLE
Extend setAccessLevel to local and sync storage areas

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
@@ -30,6 +30,7 @@
 #include "APIData.h"
 #include "WebExtensionContext.h"
 #include "WebExtensionContextIdentifier.h"
+#include "WebExtensionStorageAccessLevel.h"
 #include "WebExtensionTabIdentifier.h"
 #include "WebExtensionWindowIdentifier.h"
 #include <pal/SessionID.h>
@@ -51,7 +52,8 @@ struct WebExtensionContextParameters {
     RefPtr<API::Data> manifestJSON;
 
     double manifestVersion { 0 };
-    bool isSessionStorageAllowedInContentScripts { false };
+
+    WebExtensionStorageAccessLevelMap storageAccessLevels;
 
     PAL::SessionID defaultSessionID;
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
@@ -36,7 +36,8 @@ struct WebKit::WebExtensionContextParameters {
     RefPtr<API::Data> manifestJSON;
 
     double manifestVersion;
-    bool isSessionStorageAllowedInContentScripts;
+
+    HashMap<WebKit::WebExtensionDataType, WebKit::WebExtensionStorageAccessLevel> storageAccessLevels;
 
     PAL::SessionID defaultSessionID;
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionDataType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionDataType.h
@@ -39,6 +39,15 @@ enum class WebExtensionDataType : uint8_t {
     Sync    = 1 << 2,
 };
 
+static constexpr OptionSet<WebExtensionDataType> allWebExtensionDataTypes()
+{
+    return {
+        WebExtensionDataType::Local,
+        WebExtensionDataType::Session,
+        WebExtensionDataType::Sync
+    };
+}
+
 inline String toAPIString(WebExtensionDataType dataType)
 {
     switch (dataType) {
@@ -52,6 +61,19 @@ inline String toAPIString(WebExtensionDataType dataType)
 
     ASSERT_NOT_REACHED();
     return { };
+}
+
+inline WebExtensionDataType toWebExtensionDataType(const String& storageAreaName)
+{
+    if (storageAreaName == "local"_s)
+        return WebExtensionDataType::Local;
+    if (storageAreaName == "session"_s)
+        return WebExtensionDataType::Session;
+    if (storageAreaName == "sync"_s)
+        return WebExtensionDataType::Sync;
+
+    ASSERT_NOT_REACHED();
+    return WebExtensionDataType::Local;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionStorageAccessLevel.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionStorageAccessLevel.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "WebExtensionDataType.h"
+#include <wtf/HashMap.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -35,6 +37,59 @@ enum class WebExtensionStorageAccessLevel : uint8_t {
     TrustedContexts,
     TrustedAndUntrustedContexts,
 };
+
+using WebExtensionStorageAccessLevelMap = HashMap<WebExtensionDataType, WebExtensionStorageAccessLevel>;
+
+inline WebExtensionStorageAccessLevel defaultStorageAccessLevel(WebExtensionDataType dataType)
+{
+    switch (dataType) {
+    case WebExtensionDataType::Local:
+    case WebExtensionDataType::Sync:
+        return WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts;
+    case WebExtensionDataType::Session:
+        return WebExtensionStorageAccessLevel::TrustedContexts;
+    }
+
+    ASSERT_NOT_REACHED();
+    return WebExtensionStorageAccessLevel::TrustedContexts;
+}
+
+inline WebExtensionStorageAccessLevel storageAccessLevel(const WebExtensionStorageAccessLevelMap& accessLevels, WebExtensionDataType dataType)
+{
+    return accessLevels.getOptional(dataType).value_or(defaultStorageAccessLevel(dataType));
+}
+
+inline bool isStorageTypeAllowedInUntrustedContexts(const WebExtensionStorageAccessLevelMap& accessLevels, WebExtensionDataType dataType)
+{
+    return storageAccessLevel(accessLevels, dataType) == WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts;
+}
+
+inline String toAPIString(WebExtensionStorageAccessLevel accessLevel)
+{
+    switch (accessLevel) {
+    case WebExtensionStorageAccessLevel::TrustedContexts:
+        return "TRUSTED_CONTEXTS"_s;
+    case WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts:
+        return "TRUSTED_AND_UNTRUSTED_CONTEXTS"_s;
+    }
+
+    ASSERT_NOT_REACHED();
+    return emptyString();
+}
+
+inline std::optional<WebExtensionStorageAccessLevel> toWebExtensionStorageAccessLevel(const String& accessLevelString)
+{
+    if (accessLevelString == "TRUSTED_CONTEXTS"_s)
+        return WebExtensionStorageAccessLevel::TrustedContexts;
+    if (accessLevelString == "TRUSTED_AND_UNTRUSTED_CONTEXTS"_s)
+        return WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts;
+
+    // An empty string means no access level was saved for the data type, which is expected.
+    // In this case, we fallback to the default value. Anything else implies an invalid accessLevel.
+    ASSERT(accessLevelString.isEmpty());
+
+    return std::nullopt;
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp
+++ b/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp
@@ -209,7 +209,7 @@ void WebExtensionContext::storageClear(WebPageProxyIdentifier webPageProxyIdenti
 
 void WebExtensionContext::storageSetAccessLevel(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const WebExtensionStorageAccessLevel accessLevel, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
-    setSessionStorageAllowedInContentScripts(accessLevel == WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts);
+    setStorageAccessLevel(dataType, accessLevel);
 
     completionHandler({ });
 }
@@ -273,7 +273,8 @@ void WebExtensionContext::fireStorageChangedEventIfNeeded(HashMap<String, String
         WorkQueue::mainSingleton().dispatch([this, protectedThis = Ref { *this }, serializedJSONStrings = crossThreadCopy(WTF::move(serializedJSONStrings)), dataType]() mutable {
             // Unlike other extension events which are only dispatched to the web process that hosts all the extension-related web views (background page, popup, full page extension content),
             // content scripts are allowed to listen to storage.onChanged events.
-            sendToContentScriptProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchStorageChangedEvent(serializedJSONStrings, dataType, WebExtensionContentWorldType::ContentScript));
+            if (isStorageAllowedInUntrustedContexts(dataType))
+                sendToContentScriptProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchStorageChangedEvent(serializedJSONStrings, dataType, WebExtensionContentWorldType::ContentScript));
 
             wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, this, protectedThis = Ref { *this }] {
                 sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchStorageChangedEvent(serializedJSONStrings, dataType, WebExtensionContentWorldType::Main));

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -120,7 +120,9 @@ static NSString * const lastSeenVersionStateKey = @"LastSeenVersion";
 static NSString * const lastSeenDisplayNameStateKey = @"LastSeenDisplayName";
 static NSString * const lastLoadedDeclarativeNetRequestHashStateKey = @"LastLoadedDeclarativeNetRequestHash";
 
+// Read-only, legacy key. Use storageAccessLevelsKey instead.
 static NSString * const sessionStorageAllowedInContentScriptsKey = @"SessionStorageAllowedInContentScripts";
+static NSString * const storageAccessLevelsKey = @"StorageAccessLevels";
 
 // Update this value when any changes are made to the WebExtensionEventListenerType enum.
 static constexpr NSInteger currentBackgroundContentListenerStateVersion = 4;
@@ -293,7 +295,7 @@ Expected<bool, RefPtr<API::Error>> WebExtensionContext::load(WebExtensionControl
     if (RetainPtr displayName = protect(m_extension)->displayName().createNSString())
         [m_state setObject:displayName.get() forKey:lastSeenDisplayNameStateKey];
 
-    m_isSessionStorageAllowedInContentScripts = boolForKey(m_state.get(), sessionStorageAllowedInContentScriptsKey, false);
+    loadStorageAccessLevelsFromStorage();
 
     determineInstallReasonDuringLoad();
 
@@ -574,6 +576,7 @@ void WebExtensionContext::invalidateStorage()
     m_localStorageStore = nullptr;
     m_sessionStorageStore = nullptr;
     m_syncStorageStore = nullptr;
+    m_storageAccessLevels.clear();
 }
 
 void WebExtensionContext::setInspectable(bool inspectable)
@@ -3481,19 +3484,54 @@ void WebExtensionContext::loadDeclarativeNetRequestRules(CompletionHandler<void(
     });
 }
 
-void WebExtensionContext::setSessionStorageAllowedInContentScripts(bool allowed)
+void WebExtensionContext::loadStorageAccessLevelsFromStorage()
 {
-    m_isSessionStorageAllowedInContentScripts = allowed;
+    auto *savedLevels = objectForKey<NSDictionary>(m_state.get(), storageAccessLevelsKey);
+    bool legacySessionStorageAllowed = boolForKey(m_state.get(), sessionStorageAllowedInContentScriptsKey, false);
 
-    [m_state setObject:@(allowed) forKey:sessionStorageAllowedInContentScriptsKey];
+    // Remove the legacy key.
+    [m_state removeObjectForKey:sessionStorageAllowedInContentScriptsKey];
 
+    if (savedLevels) {
+        for (auto dataType : allWebExtensionDataTypes()) {
+            auto *accessLevelString = objectForKey<NSString>(savedLevels, toAPIString(dataType).createNSString().get());
+            if (auto accessLevel = toWebExtensionStorageAccessLevel(String { accessLevelString }))
+                m_storageAccessLevels.set(dataType, *accessLevel);
+        }
+
+        return;
+    }
+
+    // Migrate the existing value.
+    if (legacySessionStorageAllowed) {
+        m_storageAccessLevels.set(WebExtensionDataType::Session, WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts);
+
+        saveStorageAccessLevelsToStorage();
+    }
+}
+
+void WebExtensionContext::saveStorageAccessLevelsToStorage()
+{
+    auto *savedLevels = [NSMutableDictionary dictionaryWithCapacity:m_storageAccessLevels.size()];
+
+    for (auto [dataType, accessLevel] : m_storageAccessLevels)
+        [savedLevels setObject:toAPIString(accessLevel).createNSString().get() forKey:toAPIString(dataType).createNSString().get()];
+
+    [m_state setObject:savedLevels forKey:storageAccessLevelsKey];
     writeStateToStorage();
+}
+
+void WebExtensionContext::setStorageAccessLevel(WebExtensionDataType dataType, WebExtensionStorageAccessLevel accessLevel)
+{
+    m_storageAccessLevels.set(dataType, accessLevel);
+
+    saveStorageAccessLevelsToStorage();
 
     if (!isLoaded())
         return;
 
     if (RefPtr extensionController = this->extensionController())
-        extensionController->sendToAllProcesses(Messages::WebExtensionContextProxy::SetStorageAccessLevel(allowed), identifier());
+        extensionController->sendToAllProcesses(Messages::WebExtensionContextProxy::SetStorageAccessLevel(dataType, accessLevel), identifier());
 }
 
 void WebExtensionContext::sendTestMessage(const String& message, id argument)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -1685,7 +1685,7 @@ WebExtensionContextParameters WebExtensionContext::parameters(IncludePrivilegedI
         extension->serializeLocalization(),
         extension->serializeManifest(),
         extension->manifestVersion(),
-        isSessionStorageAllowedInContentScripts(),
+        m_storageAccessLevels,
         extensionController()->configuration().defaultWebsiteDataStore().sessionID(),
         backgroundPageIdentifier(),
 #if ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -705,6 +705,9 @@ private:
     NSDictionary *readStateFromStorage();
     void writeStateToStorage() const;
 
+    void loadStorageAccessLevelsFromStorage();
+    void saveStorageAccessLevelsToStorage();
+
     void determineInstallReasonDuringLoad();
     void moveLocalStorageIfNeeded(const URL& previousBaseURL, CompletionHandler<void()>&&);
     void removeStaleExtensionWebsiteData();
@@ -812,8 +815,9 @@ private:
     Ref<WebExtensionRegisteredScriptsSQLiteStore> registeredContentScriptsStore();
 
     // Storage
-    void setSessionStorageAllowedInContentScripts(bool);
-    bool isSessionStorageAllowedInContentScripts() const { return m_isSessionStorageAllowedInContentScripts; }
+    void setStorageAccessLevel(WebExtensionDataType, WebExtensionStorageAccessLevel);
+    WebExtensionStorageAccessLevel storageAccessLevel(WebExtensionDataType dataType) const { return WebKit::storageAccessLevel(m_storageAccessLevels, dataType); }
+    bool isStorageAllowedInUntrustedContexts(WebExtensionDataType dataType) const { return isStorageTypeAllowedInUntrustedContexts(m_storageAccessLevels, dataType); }
     size_t quotaForStorageType(WebExtensionDataType);
 
     Ref<WebExtensionStorageSQLiteStore> localStorageStore();
@@ -1189,7 +1193,7 @@ private:
     MenuItemMap m_menuItems;
     MenuItemVector m_mainMenuItems;
 
-    bool m_isSessionStorageAllowedInContentScripts { false };
+    WebExtensionStorageAccessLevelMap m_storageAccessLevels;
 
     RefPtr<WebExtensionStorageSQLiteStore> m_localStorageStore;
     RefPtr<WebExtensionStorageSQLiteStore> m_sessionStorageStore;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -59,7 +59,7 @@ bool WebExtensionAPIStorageArea::isPropertyAllowed(const ASCIILiteral& propertyN
         return m_type == WebExtensionDataType::Sync;
 
     if (propertyName == "setAccessLevel"_s)
-        return m_type == WebExtensionDataType::Session;
+        return isForTrustedContext();
 
     ASSERT_NOT_REACHED();
     return false;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
@@ -37,6 +37,7 @@
 #import "WebExtensionAPIStorageArea.h"
 #import "WebExtensionContextMessages.h"
 #import "WebExtensionContextProxy.h"
+#import "WebExtensionDataType.h"
 
 namespace WebKit {
 
@@ -45,11 +46,10 @@ bool WebExtensionAPIStorage::isPropertyAllowed(const ASCIILiteral& propertyName,
     if (protect(extensionContext())->isUnsupportedAPI(propertyPath(), propertyName)) [[unlikely]]
         return false;
 
-    if (propertyName == "session"_s)
-        return extensionContext().isSessionStorageAllowedInContentScripts() || isForMainWorld();
+    if (isForTrustedContext())
+        return true;
 
-    ASSERT_NOT_REACHED();
-    return false;
+    return extensionContext().isStorageAllowedInUntrustedContexts(toWebExtensionDataType(propertyName));
 }
 
 WebExtensionAPIStorageArea& WebExtensionAPIStorage::local()

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
@@ -72,6 +72,10 @@ public:
     virtual ~WebExtensionAPIObject() = default;
 
     bool isForMainWorld() const { return m_contentWorldType == WebExtensionContentWorldType::Main; }
+
+    // Returns true for devtools pages.
+    bool isForTrustedContext() const { return isEqual(m_contentWorldType, WebExtensionContentWorldType::Main); }
+
     WebExtensionContentWorldType contentWorldType() const { return m_contentWorldType; }
 
     virtual WebExtensionAPIRuntimeBase& runtime() const { return *m_runtime; }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
@@ -52,7 +52,7 @@ public:
 
     double NODELETE quotaBytes();
 
-    // Exposed only by storage.session.
+    // Only exposed to trusted contexts.
     void setAccessLevel(WebPageProxyIdentifier, NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     // Exposed only by storage.sync.

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -87,7 +87,7 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExt
         Ref manifestJSON = *parameters.manifestJSON;
         context.m_manifest = JSON::Value::parseJSON(String::fromUTF8(manifestJSON->span()));
         context.m_manifestVersion = parameters.manifestVersion;
-        context.m_isSessionStorageAllowedInContentScripts = parameters.isSessionStorageAllowedInContentScripts;
+        context.m_storageAccessLevels = parameters.storageAccessLevels;
         context.m_defaultSessionID = parameters.defaultSessionID;
 
         if (parameters.privilegedIdentifier)

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorage.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorage.idl
@@ -28,9 +28,9 @@
     ReturnsPromiseWhenCallbackIsOmitted,
 ] interface WebExtensionAPIStorage {
 
-    readonly attribute WebExtensionAPIStorageArea local;
+    [Dynamic] readonly attribute WebExtensionAPIStorageArea local;
     [Dynamic] readonly attribute WebExtensionAPIStorageArea session;
-    readonly attribute WebExtensionAPIStorageArea sync;
+    [Dynamic] readonly attribute WebExtensionAPIStorageArea sync;
 
     readonly attribute WebExtensionAPIEvent onChanged;
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl
@@ -36,7 +36,7 @@
     [RaisesException] void remove([NSObject] any keys, [Optional, CallbackHandler] function callback);
     void clear([Optional, CallbackHandler] function callback);
 
-    [RaisesException, Dynamic, MainWorldOnly] void setAccessLevel([NSDictionary] any accessOptions, [Optional, CallbackHandler] function callback);
+    [RaisesException, Dynamic] void setAccessLevel([NSDictionary] any accessOptions, [Optional, CallbackHandler] function callback);
 
     readonly attribute WebExtensionAPIEvent onChanged;
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -186,9 +186,9 @@ void WebExtensionContextProxy::addTabPageIdentifier(WebCore::PageIdentifier page
         addTabPage(*page, tabIdentifier, windowIdentifier);
 }
 
-void WebExtensionContextProxy::setStorageAccessLevel(bool allowedInContentScripts)
+void WebExtensionContextProxy::setStorageAccessLevel(WebExtensionDataType dataType, WebExtensionStorageAccessLevel accessLevel)
 {
-    m_isSessionStorageAllowedInContentScripts = allowedInContentScripts;
+    m_storageAccessLevels.set(dataType, accessLevel);
 }
 
 void WebExtensionContextProxy::setContentScriptWorld(WebCore::DOMWrapperWorld& world)

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -92,7 +92,7 @@ public:
     bool supportsManifestVersion(double version) const { return manifestVersion() >= version; }
     RefPtr<WebExtensionLocalization> localization() const { return m_localization; }
 
-    bool isSessionStorageAllowedInContentScripts() const { return m_isSessionStorageAllowedInContentScripts; }
+    bool isStorageAllowedInUntrustedContexts(WebExtensionDataType dataType) const { return isStorageTypeAllowedInUntrustedContexts(m_storageAccessLevels, dataType); }
 
     PAL::SessionID defaultSessionID() const { return m_defaultSessionID; }
 
@@ -204,7 +204,7 @@ private:
     void dispatchRuntimeStartupEvent();
 
     // Storage
-    void NODELETE setStorageAccessLevel(bool);
+    void setStorageAccessLevel(WebExtensionDataType, WebExtensionStorageAccessLevel);
     void dispatchStorageChangedEvent(const Vector<String>& onChangedJSON, WebExtensionDataType, WebExtensionContentWorldType);
 
     // Tabs
@@ -248,7 +248,7 @@ private:
     RefPtr<WebExtensionLocalization> m_localization;
     RefPtr<JSON::Value> m_manifest;
     double m_manifestVersion { 0 };
-    bool m_isSessionStorageAllowedInContentScripts { false };
+    WebExtensionStorageAccessLevelMap m_storageAccessLevels;
     PAL::SessionID m_defaultSessionID { PAL::SessionID::defaultSessionID() };
     mutable PermissionsMap m_grantedPermissions;
     mutable WallTime m_nextGrantedPermissionsExpirationDate { WallTime::nan() };

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -81,7 +81,7 @@ messages -> WebExtensionContextProxy {
     DispatchRuntimeStartupEvent()
 
     // Storage
-    SetStorageAccessLevel(bool allowedInContentScripts)
+    SetStorageAccessLevel(WebKit::WebExtensionDataType dataType, enum:uint8_t WebKit::WebExtensionStorageAccessLevel accessLevel)
     DispatchStorageChangedEvent(Vector<String> onChangedJSON, WebKit::WebExtensionDataType dataType, WebKit::WebExtensionContentWorldType contentWorldType)
 
     // Tabs Events

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDevTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDevTools.mm
@@ -41,6 +41,8 @@ static auto *devToolsManifest = @{
     @"description": @"Test DevTools",
     @"version": @"1.0",
 
+    @"permissions": @[ @"storage" ],
+
     @"background": @{
         @"scripts": @[ @"background.js" ],
         @"type": @"module",
@@ -73,6 +75,40 @@ TEST(WKWebExtensionAPIDevTools, Basics)
 
     auto *resources = @{
         @"background.js": backgroundScript,
+        @"devtools.html": @"<script type='module' src='devtools.js'></script>",
+        @"devtools.js": devToolsScript
+    };
+
+    auto manager = Util::loadExtension(devToolsManifest, resources);
+
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIDevTools, StorageAccessLevel)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *devToolsScript = Util::constructScript(@[
+        // A devtools page is a trusted extension context so all storage areas should be available.
+        @"browser.test.assertEq(typeof browser.storage.local, 'object', 'browser.storage.local should be available in a devtools page')",
+        @"browser.test.assertEq(typeof browser.storage.session, 'object', 'browser.storage.session should be available in a devtools page')",
+        @"browser.test.assertEq(typeof browser.storage.sync, 'object', 'browser.storage.sync should be available in a devtools page')",
+
+        @"browser.test.assertEq(typeof browser.storage.local.setAccessLevel, 'function', 'storage.local.setAccessLevel should be available in a devtools page')",
+        @"browser.test.assertEq(typeof browser.storage.session.setAccessLevel, 'function', 'storage.session.setAccessLevel should be available in a devtools page')",
+        @"browser.test.assertEq(typeof browser.storage.sync.setAccessLevel, 'function', 'storage.sync.setAccessLevel should be available in a devtools page')",
+
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *resources = @{
+        @"background.js": @"// This script is intentionally left blank.",
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
         @"devtools.js": devToolsScript
     };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIStorage.mm
@@ -103,9 +103,6 @@ TEST(WKWebExtensionAPIStorage, Errors)
 TEST(WKWebExtensionAPIStorage, UndefinedProperties)
 {
     auto *backgroundScript = Util::constructScript(@[
-        @"browser.test.assertEq(browser?.storage?.local?.setAccessLevel, undefined)",
-        @"browser.test.assertEq(browser?.storage?.sync?.setAccessLevel, undefined)",
-
         @"browser.test.assertEq(browser?.storage?.local?.QUOTA_BYTES_PER_ITEM, undefined)",
         @"browser.test.assertEq(browser?.storage?.session?.QUOTA_BYTES_PER_ITEM, undefined)",
 
@@ -138,9 +135,14 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)
         @"  const tabId = tabs[0].id",
 
         @"  await browser?.storage?.session?.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' })",
+        @"  await browser.storage.local.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' })",
+        @"  await browser.storage.sync.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' })",
 
         @"  const response = await browser.test.assertSafeResolve(() => browser?.tabs?.sendMessage(tabId, { content: 'Access level set' }))",
-        @"  browser.test.assertEq(response?.content, undefined)",
+        @"  browser.test.assertEq(response.session, undefined)",
+        @"  browser.test.assertEq(response.local, undefined)",
+        @"  browser.test.assertEq(response.sync, undefined)",
+
 
         @"  browser.test.notifyPass()",
         @"})",
@@ -152,7 +154,7 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message?.content, 'Access level set', 'Should receive the correct message content')",
 
-        @"  sendResponse({ content: browser?.storage?.session })",
+        @"  sendResponse({ session: browser.storage.session, local: browser.storage.local, sync: browser.storage.sync  })",
         @"})",
 
         @"browser.runtime.sendMessage('Ready')"
@@ -214,6 +216,104 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedAndUntrustedContexts)
     [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
+}
+
+TEST(WKWebExtensionAPIStorage, DefaultAccessLevels)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {",
+        @"  browser.test.assertEq(message, 'Ready')",
+
+        @"  const tabs = await browser.tabs.query({ active: true, currentWindow: true })",
+        @"  const tabId = tabs[0].id",
+
+        @"  const response = await browser.test.assertSafeResolve(() => browser.tabs.sendMessage(tabId, { content: 'Report access' }))",
+        @"  browser.test.assertEq(response.local, 'object', 'Local storage should be available to content scripts by default')",
+        @"  browser.test.assertEq(response.sync, 'object', 'Sync storage should be available to content scripts by default')",
+        @"  browser.test.assertEq(response.session, 'undefined', 'Session storage should not be available to content scripts by default')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
+    ]);
+
+    auto *contentScript = Util::constructScript(@[
+        @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
+        @"  browser.test.assertEq(message.content, 'Report access', 'Should receive the correct message content')",
+
+        @"  sendResponse({ local: typeof browser.storage.local, sync: typeof browser.storage?.sync, session: typeof browser.storage.session })",
+        @"})",
+
+        @"browser.runtime.sendMessage('Ready')"
+    ]);
+
+    auto manager = Util::loadExtension(storageManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIStorage, MigratesLegacySessionStorageAllowedInUntrusedContextsState)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
+        @"  browser.test.assertEq(message.session, 'object', 'The legacy session storage opt-in should have been migrated')",
+        @"  browser.test.sendMessage('Content script reported')",
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
+    ]);
+
+    auto *contentScript = Util::constructScript(@[
+        @"browser.runtime.sendMessage({ session: typeof browser.storage.session })"
+    ]);
+
+    auto manager = Util::parseExtension(storageManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript }, WKWebExtensionControllerConfiguration._temporaryConfiguration);
+
+    // Give the extension a unique identifier so it opts into saving state in the temporary configuration.
+    manager.get().context.uniqueIdentifier = @"org.webkit.test.extension (76C788B8)";
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    auto *storageDirectory = [manager.get().controller.configuration._storageDirectoryPath stringByAppendingPathComponent:manager.get().context.uniqueIdentifier];
+    EXPECT_TRUE([NSFileManager.defaultManager createDirectoryAtPath:storageDirectory withIntermediateDirectories:YES attributes:nil error:nullptr]);
+
+    auto *stateFileURL = [NSURL fileURLWithPath:[storageDirectory stringByAppendingPathComponent:@"State.plist"]];
+    EXPECT_TRUE([@{ @"SessionStorageAllowedInContentScripts": @YES } writeToURL:stateFileURL error:nullptr]);
+
+    [manager load];
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager runUntilTestMessage:@"Content script reported"];
+
+    // The migration should have rewritten the state with the new key.
+    auto *savedState = [NSDictionary dictionaryWithContentsOfURL:stateFileURL];
+    EXPECT_NULL(savedState[@"SessionStorageAllowedInContentScripts"]);
+    EXPECT_NS_EQUAL(savedState[@"StorageAccessLevels"], @{ @"session": @"TRUSTED_AND_UNTRUSTED_CONTEXTS" });
+
+    [manager unload];
+    [manager load];
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager runUntilTestMessage:@"Content script reported"];
 }
 
 TEST(WKWebExtensionAPIStorage, Set)


### PR DESCRIPTION
#### a5114a1ab6dbe06a1b6fe53b9ff7fd43b69dba05
<pre>
Extend setAccessLevel to local and sync storage areas
<a href="https://bugs.webkit.org/show_bug.cgi?id=320697">https://bugs.webkit.org/show_bug.cgi?id=320697</a>
<a href="https://rdar.apple.com/183680404">rdar://183680404</a>

Reviewed by Timothy Hatcher.

This patch extends setAccessLevel to sync and local storage areas as it&apos;s documented on MDN.
This behavior now matches Chrome. Firefox doesn&apos;t have an implementation for setAccessLevel for any
storage area.

By default, session storage availability remains defaulted to trusted contexts. Local and sync
storage remain defaulted to trusted and untrusted contexts, but can now be limited to trusted contexts.

This patch also introduces a new isForTrustedContext() boolean used to determine if the storage APIs
should be exposed to devtools extension pages.

With these changes, the current WPT tests for the browser.storage API pass.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDevTools.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIStorage.mm

* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionDataType.h:
(WebKit::allWebExtensionDataTypes):
(WebKit::toWebExtensionDataType):
* Source/WebKit/Shared/Extensions/WebExtensionStorageAccessLevel.h:
(WebKit::defaultStorageAccessLevel):
(WebKit::storageAccessLevel):
(WebKit::isStorageTypeAllowedInUntrustedContexts):
(WebKit::toAPIString):
(WebKit::toWebExtensionStorageAccessLevel):
* Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp:
Only fire storage onChanged events to content scripts if the storage area is available in untrusted
contexts.

(WebKit::WebExtensionContext::storageSetAccessLevel):
(WebKit::WebExtensionContext::fireStorageChangedEventIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load):
(WebKit::WebExtensionContext::invalidateStorage):
(WebKit::WebExtensionContext::loadStorageAccessLevelsFromStorage):
(WebKit::WebExtensionContext::saveStorageAccessLevelsToStorage):
(WebKit::WebExtensionContext::setStorageAccessLevel):
(WebKit::WebExtensionContext::setSessionStorageAllowedInContentScripts): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::storageAccessLevel const):
(WebKit::WebExtensionContext::isStorageAllowedInUntrustedContexts const):
(WebKit::WebExtensionContext::isSessionStorageAllowedInContentScripts const): Deleted.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm:
(WebKit::WebExtensionAPIStorage::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h:
(WebKit::WebExtensionAPIObject::isForTrustedContext const):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h:
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::getOrCreate):
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorage.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl:
Replace MainWorldOnly with an isForTrustedContext check so setAccessLevel is available for devtools
extension pages.

* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::setStorageAccessLevel):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDevTools.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, StorageAccessLevel)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIStorage.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, UndefinedProperties)):
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)):
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, DefaultAccessLevels)):
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, MigratesLegacySessionStorageAllowedInUntrusedContextsState)):

Canonical link: <a href="https://commits.webkit.org/318980@main">https://commits.webkit.org/318980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4bcfe9985ac35fdf09865d5007aefcd7e2cb6f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143723 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ab0bb8c-fe4b-41b4-9518-9b80622b8837) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139911 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96814 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a45252a-e759-4e32-b928-0480a50ba473) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120363 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c9e86dc6-aca5-403d-b99a-b164e5903af7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42187 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40520 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40169 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/698 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191464 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53023 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149169 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53704 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148912 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27337 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43580 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125976 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120871 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52221 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15158 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51606 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51847 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51667 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->