### PR TITLE
[JSC] `Array#join` on Int32 arrays should use `JSOnlyStringsAndInt32sJoiner` for any separator

### DIFF
--- a/JSTests/microbenchmarks/array-join-int32-separator.js
+++ b/JSTests/microbenchmarks/array-join-int32-separator.js
@@ -1,0 +1,24 @@
+var seed = 42;
+function next() {
+    seed = (seed + 0x9e3779b9) | 0;
+    var t = seed ^ (seed >>> 16);
+    t = Math.imul(t, 0x21f0aaad);
+    t = t ^ (t >>> 15);
+    t = Math.imul(t, 0x735a2d97);
+    return (t ^ (t >>> 15)) & 0x7fffffff;
+}
+
+var ids = [];
+for (var i = 0; i < 100; ++i)
+    ids.push(next() % 1000000);
+
+function test(array) {
+    return array.join(",");
+}
+noInline(test);
+
+var total = 0;
+for (var i = 0; i < 2e4; ++i)
+    total += test(ids).length;
+if (total !== test(ids).length * 2e4)
+    throw new Error("bad result: " + total);

--- a/JSTests/stress/array-join-int32-separator.js
+++ b/JSTests/stress/array-join-int32-separator.js
@@ -1,0 +1,35 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(array, separator) {
+    return array.join(separator);
+}
+noInline(test);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(test([], ","), ``);
+    shouldBe(test([42], ","), `42`);
+    shouldBe(test([-42], ", "), `-42`);
+    shouldBe(test([1, 2, 3], ","), `1,2,3`);
+    shouldBe(test([1, 2, 3], ", "), `1, 2, 3`);
+    shouldBe(test([1, 2, 3], ""), `123`);
+    shouldBe(test([1, 2, 3], undefined), `1,2,3`);
+    shouldBe(test([1, 2, 3], "、"), `1、2、3`);
+    shouldBe(test([0, -1, 2147483647, -2147483648], "&id="), `0&id=-1&id=2147483647&id=-2147483648`);
+    shouldBe([10, 200, 3000].toString(), `10,200,3000`);
+
+    var array = new Array(3);
+    array[0] = 1;
+    array[2] = 3;
+    shouldBe(test(array, "-"), `1--3`);
+    shouldBe(test([1, , 3], ", "), `1, , 3`);
+}
+
+Array.prototype[1] = "x";
+shouldBe(test([1, , 3], "-"), `1-x-3`);
+var array = new Array(3);
+array[0] = 1;
+array[2] = 3;
+shouldBe(test(array, ", "), `1, x, 3`);

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1738,7 +1738,7 @@ static ALWAYS_INLINE JSString* arrayJoinWithStringSeparator(JSGlobalObject* glob
     if (!separator->length() && (array->indexingType() == ArrayWithContiguous || array->indexingType() == ArrayWithInt32)) {
         auto* butterfly = array->butterfly();
         JSOnlyStringsAndInt32sJoiner joiner(StringView { });
-        auto* joined = joiner.tryJoin(globalObject, butterfly->contiguous().data(), length);
+        auto* joined = joiner.tryJoin<ContiguousShape>(globalObject, butterfly->contiguous().data(), length);
         RETURN_IF_EXCEPTION(scope, { });
         if (joined)
             return joined;

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -444,7 +444,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncJoin, (JSGlobalObject* globalObject, Call
                 auto* butterfly = array->butterfly();
                 unsigned length = butterfly->publicLength();
                 JSOnlyStringsAndInt32sJoiner joiner(StringView { });
-                auto* joined = joiner.tryJoin(globalObject, butterfly->contiguous().data(), length);
+                auto* joined = joiner.tryJoin<ContiguousShape>(globalObject, butterfly->contiguous().data(), length);
                 RETURN_IF_EXCEPTION(scope, { });
                 if (joined)
                     return JSValue::encode(joined);

--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -310,9 +310,15 @@ ALWAYS_INLINE JSString* fastArrayJoin(JSGlobalObject* globalObject, JSObject* th
         auto& butterfly = *thisObject->butterfly();
         if (length > butterfly.publicLength()) [[unlikely]]
             break;
+        auto data = butterfly.contiguous().data();
+
+        JSOnlyStringsAndInt32sJoiner onlyInt32sJoiner(separator);
+        if (auto joined = onlyInt32sJoiner.tryJoin<Int32Shape>(globalObject, data, length))
+            RELEASE_AND_RETURN(scope, joined);
+        RETURN_IF_EXCEPTION(scope, { });
+
         joiner.reserveCapacity(globalObject, length);
         RETURN_IF_EXCEPTION(scope, { });
-        auto data = butterfly.contiguous().data();
         bool holesKnownToBeOK = false;
         for (; i < length; ++i) {
             JSValue value = data[i].get();
@@ -339,7 +345,7 @@ ALWAYS_INLINE JSString* fastArrayJoin(JSGlobalObject* globalObject, JSObject* th
         bool holesKnownToBeOK = false;
 
         JSOnlyStringsAndInt32sJoiner onlyStringsJoiner(separator);
-        if (auto joined = onlyStringsJoiner.tryJoin(globalObject, data, length))
+        if (auto joined = onlyStringsJoiner.tryJoin<ContiguousShape>(globalObject, data, length))
             RELEASE_AND_RETURN(scope, joined);
         RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
@@ -180,7 +180,7 @@ static inline String joinStrings(const JSStringJoiner::Entries& strings, std::sp
     return result;
 }
 
-template<typename OutputCharacterType, typename SeparatorCharacterType>
+template<IndexingType indexingShape, typename OutputCharacterType, typename SeparatorCharacterType>
 static inline String joinStrings(JSGlobalObject* globalObject, const WriteBarrier<Unknown>* strings, unsigned size, std::span<const SeparatorCharacterType> separator, unsigned joinedLength)
 {
     VM& vm = globalObject->vm();
@@ -196,43 +196,31 @@ static inline String joinStrings(JSGlobalObject* globalObject, const WriteBarrie
         return { };
     }
 
-    auto appendString = [&](JSString* string) {
-        unsigned length = string->length();
-        string->resolveToBuffer(data.first(length));
-        data = data.subspan(length);
+    auto appendValue = [&](JSValue value) {
+        if constexpr (indexingShape == ContiguousShape) {
+            if (value.isString()) {
+                JSString* string = asString(value);
+                unsigned length = string->length();
+                string->resolveToBuffer(data.first(length));
+                data = data.subspan(length);
+                return;
+            }
+        }
+        ASSERT(value.isInt32());
+        appendStringToData(data, value.asInt32());
     };
 
     switch (separator.size()) {
     case 0: {
-        for (unsigned i = 0; i < size; ++i) {
-            JSValue value = strings[i].get();
-            if (value.isString())
-                appendString(asString(value));
-            else {
-                ASSERT(value.isInt32());
-                appendStringToData(data, value.asInt32());
-            }
-        }
+        for (unsigned i = 0; i < size; ++i)
+            appendValue(strings[i].get());
         break;
     }
     default: {
-        JSValue value = strings[0].get();
-        if (value.isString())
-            appendString(asString(value));
-        else {
-            ASSERT(value.isInt32());
-            appendStringToData(data, value.asInt32());
-        }
-
+        appendValue(strings[0].get());
         for (unsigned i = 1; i < size; ++i) {
-            JSValue value = strings[i].get();
             appendStringToData(data, separator);
-            if (value.isString())
-                appendString(asString(value));
-            else {
-                ASSERT(value.isInt32());
-                appendStringToData(data, value.asInt32());
-            }
+            appendValue(strings[i].get());
         }
         break;
     }
@@ -295,6 +283,7 @@ JSString* JSStringJoiner::joinImpl(JSGlobalObject* globalObject)
     return jsString(vm, WTF::move(result));
 }
 
+template<IndexingType indexingShape>
 JSString* JSOnlyStringsAndInt32sJoiner::joinImpl(JSGlobalObject* globalObject, const WriteBarrier<Unknown>* data, unsigned length)
 {
     VM& vm = globalObject->vm();
@@ -313,18 +302,21 @@ JSString* JSOnlyStringsAndInt32sJoiner::joinImpl(JSGlobalObject* globalObject, c
 
     String result;
     if (m_isAll8Bit)
-        result = joinStrings<Latin1Character>(globalObject, data, length, m_separator.span8(), totalLength);
+        result = joinStrings<indexingShape, Latin1Character>(globalObject, data, length, m_separator.span8(), totalLength);
     else {
         if (m_separator.is8Bit())
-            result = joinStrings<char16_t>(globalObject, data, length, m_separator.span8(), totalLength);
+            result = joinStrings<indexingShape, char16_t>(globalObject, data, length, m_separator.span8(), totalLength);
         else
-            result = joinStrings<char16_t>(globalObject, data, length, m_separator.span16(), totalLength);
+            result = joinStrings<indexingShape, char16_t>(globalObject, data, length, m_separator.span16(), totalLength);
     }
 
     RETURN_IF_EXCEPTION(scope, { });
 
     return jsString(vm, WTF::move(result));
 }
+
+template JSString* JSOnlyStringsAndInt32sJoiner::joinImpl<Int32Shape>(JSGlobalObject*, const WriteBarrier<Unknown>*, unsigned);
+template JSString* JSOnlyStringsAndInt32sJoiner::joinImpl<ContiguousShape>(JSGlobalObject*, const WriteBarrier<Unknown>*, unsigned);
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.h
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.h
@@ -234,19 +234,24 @@ public:
     {
     }
 
+    template<IndexingType indexingShape>
     JSString* tryJoin(JSGlobalObject* globalObject, const WriteBarrier<Unknown>* data, unsigned length)
     {
+        static_assert(indexingShape == Int32Shape || indexingShape == ContiguousShape);
+
         if (length == 1) {
             JSValue value = data[0].get();
             if (!value)
                 return nullptr;
-            if (value.isString())
-                return asString(value);
-            if (value.isInt32()) {
-                m_accumulatedStringsLength = WTF::StringTypeAdapter<int32_t> { value.asInt32() }.length();
-                return joinImpl(globalObject, data, length);
+            if constexpr (indexingShape == ContiguousShape) {
+                if (value.isString())
+                    return asString(value);
+                if (!value.isInt32())
+                    return nullptr;
             }
-            return nullptr;
+            ASSERT(value.isInt32());
+            m_accumulatedStringsLength = WTF::StringTypeAdapter<int32_t> { value.asInt32() }.length();
+            return joinImpl<indexingShape>(globalObject, data, length);
         }
 
         for (size_t i = 0; i < length; ++i) {
@@ -254,25 +259,25 @@ public:
             if (!value)
                 return nullptr;
 
-            if (value.isString()) {
-                JSString* string = asString(value);
-                m_accumulatedStringsLength += string->length();
-                m_isAll8Bit &= string->is8Bit();
-                continue;
+            if constexpr (indexingShape == ContiguousShape) {
+                if (value.isString()) {
+                    JSString* string = asString(value);
+                    m_accumulatedStringsLength += string->length();
+                    m_isAll8Bit &= string->is8Bit();
+                    continue;
+                }
+                if (!value.isInt32())
+                    return nullptr;
             }
-
-            if (value.isInt32()) {
-                m_accumulatedStringsLength += WTF::StringTypeAdapter<int32_t> { value.asInt32() }.length();
-                continue;
-            }
-
-            return nullptr;
+            ASSERT(value.isInt32());
+            m_accumulatedStringsLength += WTF::StringTypeAdapter<int32_t> { value.asInt32() }.length();
         }
 
-        return joinImpl(globalObject, data, length);
+        return joinImpl<indexingShape>(globalObject, data, length);
     }
 
 private:
+    template<IndexingType indexingShape>
     JSString* joinImpl(JSGlobalObject*, const WriteBarrier<Unknown>*, unsigned);
 
     StringView m_separator;


### PR DESCRIPTION
#### a4df93500a72428a2220aa1282f4801dced50471
<pre>
[JSC] `Array#join` on Int32 arrays should use `JSOnlyStringsAndInt32sJoiner` for any separator
<a href="https://bugs.webkit.org/show_bug.cgi?id=321228">https://bugs.webkit.org/show_bug.cgi?id=321228</a>

Reviewed by Yusuke Suzuki.

295918@main taught JSOnlyStringsAndInt32sJoiner to write Int32 elements
directly into the result buffer, but fastArrayJoin&apos;s ALL_INT32_INDEXING_TYPES
case was not updated and still went through the generic JSStringJoiner,
allocating a numeric string per element. Only the empty-separator case was
fast because arrayProtoFuncJoin has its own early path, so `ids.join(&quot;&quot;)`
was ~2x faster than `ids.join(&quot;,&quot;)` / `ids.toString()`.

This patch makes the ALL_INT32 case try JSOnlyStringsAndInt32sJoiner first,
mirroring the ALL_CONTIGUOUS case, and falls back to the generic loop only
when the array has holes.

tryJoin is now templatized on the indexing shape so that the Int32Shape
instantiation only checks for holes and skips the per-element isString() checks
that the ContiguousShape one needs.

                                      baseline                  patched

array-join-int32-separator        22.1538+-0.6142     ^     10.9635+-0.7135        ^ definitely 2.0207x faster

Tests: JSTests/microbenchmarks/array-join-int32-separator.js
       JSTests/stress/array-join-int32-separator.js

* JSTests/microbenchmarks/array-join-int32-separator.js: Added.
(next):
(test):
* JSTests/stress/array-join-int32-separator.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h:
(JSC::fastArrayJoin):

Canonical link: <a href="https://commits.webkit.org/319022@main">https://commits.webkit.org/319022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50b80d9fdc97bee23e6c3e5b566943e4c067b1ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47951 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190419 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144527 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53869 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121003 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2970 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9816 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40860 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1578 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41482 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46752 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45440 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192353 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53819 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149898 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40139 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54507 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149627 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44265 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126770 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121914 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53024 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15849 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52406 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52643 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->