### PR TITLE
Add unprefixed user-select (and feature flag)

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1829,6 +1829,21 @@ CSSUnprefixedBackdropFilterEnabled:
       "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
       default: false
 
+CSSUnprefixedUserSelectEnabled:
+  type: bool
+  status: internal
+  category: css
+  webcoreOnChange: setNeedsRecalcStyleInAllFrames
+  humanReadableName: "CSS Unprefixed User Select"
+  humanReadableDescription: "Enable the unprefixed user-select CSS property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSWhiteSpaceTrimEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12481,11 +12481,33 @@
             "status": "non-standard"
         },
         "-webkit-user-select": {
-            "animation-type": "not animatable (needs triage)",
-            "animation-type-comment": "Current spec for standard 'user-select' animation type is 'discrete'",
+            "animation-type": "not animatable (legacy)",
             "inherited": true,
             "initial": "text",
-            "initial-comment": "Current spec for standard 'user-select' initial is 'auto'",
+            "initial-comment": "Legacy behavior - 'auto' is folded into 'text'",
+            "values": [
+                "auto",
+                "text",
+                "none",
+                "all"
+            ],
+            "codegen-properties": {
+                "computed-style-has-explicitly-set-policy": "value-only",
+                "computed-style-has-explicitly-set-storage-path": ["m_inheritedRareData"],
+                "computed-style-name-for-methods": "WebkitUserSelect",
+                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-kind": "enum",
+                "computed-style-type": "UserSelect",
+                "parser-grammar": "<<values>>",
+                "comment": "Not an alias of 'user-select': this property is inherited, it overrides 'user-select' whenever it has been specified (hence the has-explicitly-set flag)."
+            },
+            "status": "non-standard"
+        },
+        "user-select": {
+            "animation-type": "not animatable (needs triage)",
+            "animation-type-comment": "Current spec animation type is 'discrete'",
+            "inherited": false,
+            "initial": "auto",
             "values": [
                 "auto",
                 "text",
@@ -12497,10 +12519,11 @@
                 "all"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_nonInheritedData", "miscData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "UserSelect",
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "settings-flag": "cssUnprefixedUserSelectEnabled"
             },
             "status": {
                 "status": "experimental"

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1286,6 +1286,7 @@ TextStream& operator<<(TextStream& ts, UserModify userModify)
 TextStream& operator<<(TextStream& ts, UserSelect userSelect)
 {
     switch (userSelect) {
+    case UserSelect::Auto: ts << "auto"_s; break;
     case UserSelect::None: ts << "none"_s; break;
     case UserSelect::Text: ts << "text"_s; break;
     case UserSelect::All: ts << "all"_s; break;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -494,7 +494,8 @@ enum class UserDrag : uint8_t {
 enum class UserSelect : uint8_t {
     None,
     Text,
-    All
+    All,
+    Auto
 };
 
 // CSS3 Image Values

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -638,12 +638,13 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
 #if ENABLE(IMAGE_ANALYSIS)
         // Don't allow selecting individual glyphs on text recognized inside an image:
         if (m_element->isInUserAgentShadowTree() && m_element->userAgentPart() == UserAgentParts::internalImageOverlayText()) {
-            switch (style.userSelect()) {
+            switch (style.webkitUserSelect()) {
             case UserSelect::All:
             case UserSelect::None:
                 break;
+            case UserSelect::Auto:
             case UserSelect::Text:
-                style.setUserSelect(UserSelect::All);
+                style.setWebkitUserSelect(UserSelect::All);
                 break;
             }
         }
@@ -1089,7 +1090,7 @@ void Adjuster::adjustForSiteSpecificQuirks(Style::ComputedStyle& style) const
     if (documentQuirks.needsPrimeVideoUserSelectNoneQuirk()) {
         static MainThreadNeverDestroyed<const AtomString> className("webPlayerSDKUiContainer"_s);
         if (m_element->hasClassName(className))
-            style.setUserSelect(UserSelect::None);
+            style.setWebkitUserSelect(UserSelect::None);
     }
 
     if (auto tikTokOverflowingContentQuery = documentQuirks.needsTikTokOverflowingContentQuirk(protect(*m_element), m_parentStyle)) {

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -800,7 +800,7 @@ public:
     {
         return a.effectiveInert != b.effectiveInert
             || a.userModify != b.userModify
-            || a.userSelect != b.userSelect
+            || a.webkitUserSelect != b.webkitUserSelect
             || a.appleColorFilter != b.appleColorFilter
             || a.imageRendering != b.imageRendering
             || a.accentColor != b.accentColor

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -528,7 +528,7 @@ UserSelect ComputedStyle::usedUserSelect() const
     if (effectiveInert())
         return UserSelect::None;
 
-    auto value = userSelect();
+    auto value = webkitUserSelect();
     if (userModify() != UserModify::ReadOnly && userDrag() != UserDrag::Element)
         return value == UserSelect::None ? UserSelect::Text : value;
 

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
@@ -91,7 +91,7 @@ InheritedRareData::InheritedRareData()
     , overflowWrap(static_cast<unsigned>(ComputedStyle::initialOverflowWrap()))
     , nbspMode(static_cast<unsigned>(NBSPMode::Normal))
     , lineBreak(static_cast<unsigned>(LineBreak::Auto))
-    , userSelect(static_cast<unsigned>(ComputedStyle::initialUserSelect()))
+    , webkitUserSelect(static_cast<unsigned>(ComputedStyle::initialWebkitUserSelect()))
     , speakAs(ComputedStyle::initialSpeakAs().toRaw())
     , hyphens(static_cast<unsigned>(Hyphens::Manual))
     , textCombine(static_cast<unsigned>(ComputedStyle::initialTextCombine()))
@@ -123,6 +123,7 @@ InheritedRareData::InheritedRareData()
     , joinStyle(static_cast<unsigned>(ComputedStyle::initialJoinStyle()))
     , hasExplicitlySetStrokeWidth(false)
     , hasExplicitlySetStrokeColor(false)
+    , hasExplicitlySetWebkitUserSelect(false)
     , effectiveInert(false)
     , effectivelyTransparent(false)
     , effectiveWrapInsideAvoid(false)
@@ -197,7 +198,7 @@ inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     , overflowWrap(o.overflowWrap)
     , nbspMode(o.nbspMode)
     , lineBreak(o.lineBreak)
-    , userSelect(o.userSelect)
+    , webkitUserSelect(o.webkitUserSelect)
     , speakAs(o.speakAs)
     , hyphens(o.hyphens)
     , textCombine(o.textCombine)
@@ -229,6 +230,7 @@ inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     , joinStyle(o.joinStyle)
     , hasExplicitlySetStrokeWidth(o.hasExplicitlySetStrokeWidth)
     , hasExplicitlySetStrokeColor(o.hasExplicitlySetStrokeColor)
+    , hasExplicitlySetWebkitUserSelect(o.hasExplicitlySetWebkitUserSelect)
     , effectiveInert(o.effectiveInert)
     , effectivelyTransparent(o.effectivelyTransparent)
     , effectiveWrapInsideAvoid(o.effectiveWrapInsideAvoid)
@@ -293,7 +295,7 @@ bool InheritedRareData::operator==(const InheritedRareData& o) const
 #if ENABLE(TEXT_AUTOSIZING)
         && textSizeAdjust == o.textSizeAdjust
 #endif
-        && userSelect == o.userSelect
+        && webkitUserSelect == o.webkitUserSelect
         && speakAs == o.speakAs
         && hyphens == o.hyphens
         && hyphenateLimitBefore == o.hyphenateLimitBefore
@@ -331,6 +333,7 @@ bool InheritedRareData::operator==(const InheritedRareData& o) const
         && joinStyle == o.joinStyle
         && hasExplicitlySetStrokeWidth == o.hasExplicitlySetStrokeWidth
         && hasExplicitlySetStrokeColor == o.hasExplicitlySetStrokeColor
+        && hasExplicitlySetWebkitUserSelect == o.hasExplicitlySetWebkitUserSelect
         && mathShift == o.mathShift
         && mathStyle == o.mathStyle
         && isInSubtreeWithBlendMode == o.isInSubtreeWithBlendMode
@@ -409,7 +412,7 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
     LOG_IF_DIFFERENT_WITH_CAST(OverflowWrap, overflowWrap);
     LOG_IF_DIFFERENT_WITH_CAST(NBSPMode, nbspMode);
     LOG_IF_DIFFERENT_WITH_CAST(LineBreak, lineBreak);
-    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, userSelect);
+    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, webkitUserSelect);
 
     LOG_IF_DIFFERENT_WITH_FROM_RAW(SpeakAs, speakAs);
 
@@ -451,6 +454,7 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetStrokeWidth);
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetStrokeColor);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetWebkitUserSelect);
 
     LOG_IF_DIFFERENT_WITH_CAST(MathShift, mathShift);
     LOG_IF_DIFFERENT_WITH_CAST(MathStyle, mathStyle);

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.h
@@ -183,7 +183,7 @@ public:
     PREFERRED_TYPE(OverflowWrap) unsigned overflowWrap : 2;
     PREFERRED_TYPE(NBSPMode) unsigned nbspMode : 1;
     PREFERRED_TYPE(LineBreak) unsigned lineBreak : 3;
-    PREFERRED_TYPE(UserSelect) unsigned userSelect : 2;
+    PREFERRED_TYPE(UserSelect) unsigned webkitUserSelect : 2;
     PREFERRED_TYPE(SpeakAs) unsigned speakAs : 4;
     PREFERRED_TYPE(Hyphens) unsigned hyphens : 2;
     PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;
@@ -215,6 +215,7 @@ public:
     PREFERRED_TYPE(LineJoin) unsigned joinStyle : 2;
     PREFERRED_TYPE(bool) unsigned hasExplicitlySetStrokeWidth : 1;
     PREFERRED_TYPE(bool) unsigned hasExplicitlySetStrokeColor : 1;
+    PREFERRED_TYPE(bool) unsigned hasExplicitlySetWebkitUserSelect : 1;
     PREFERRED_TYPE(bool) unsigned effectiveInert : 1;
     PREFERRED_TYPE(bool) unsigned effectivelyTransparent : 1;
     PREFERRED_TYPE(bool) unsigned effectiveWrapInsideAvoid : 1; // This box or an ancestor has wrap-inside: avoid.

--- a/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.cpp
@@ -63,6 +63,7 @@ NonInheritedMiscData::NonInheritedMiscData()
     , tableLayout(static_cast<unsigned>(ComputedStyle::initialTableLayout()))
     , appearance(static_cast<unsigned>(ComputedStyle::initialAppearance()))
     , usedAppearance(static_cast<unsigned>(ComputedStyle::initialAppearance()))
+    , userSelect(static_cast<unsigned>(ComputedStyle::initialUserSelect()))
     , textOverflow(static_cast<unsigned>(ComputedStyle::initialTextOverflow()))
     , userDrag(static_cast<unsigned>(ComputedStyle::initialUserDrag()))
     , objectFit(static_cast<unsigned>(ComputedStyle::initialObjectFit()))
@@ -104,6 +105,7 @@ NonInheritedMiscData::NonInheritedMiscData(const NonInheritedMiscData& o)
     , tableLayout(o.tableLayout)
     , appearance(o.appearance)
     , usedAppearance(o.usedAppearance)
+    , userSelect(o.userSelect)
     , textOverflow(o.textOverflow)
     , userDrag(o.userDrag)
     , objectFit(o.objectFit)
@@ -152,6 +154,7 @@ bool NonInheritedMiscData::operator==(const NonInheritedMiscData& o) const
         && tableLayout == o.tableLayout
         && appearance == o.appearance
         && usedAppearance == o.usedAppearance
+        && userSelect == o.userSelect
         && textOverflow == o.textOverflow
         && userDrag == o.userDrag
         && objectFit == o.objectFit
@@ -209,6 +212,8 @@ void NonInheritedMiscData::dumpDifferences(TextStream& ts, const NonInheritedMis
     LOG_IF_DIFFERENT_WITH_CAST(TableLayoutType, tableLayout);
     LOG_IF_DIFFERENT_WITH_CAST(StyleAppearance, appearance);
     LOG_IF_DIFFERENT_WITH_CAST(StyleAppearance, usedAppearance);
+
+    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, userSelect);
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, textOverflow);
 

--- a/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.h
@@ -112,6 +112,7 @@ public:
     PREFERRED_TYPE(TableLayoutType) unsigned tableLayout : 1;
     PREFERRED_TYPE(StyleAppearance) unsigned appearance : appearanceBitWidth;
     PREFERRED_TYPE(StyleAppearance) unsigned usedAppearance : appearanceBitWidth;
+    PREFERRED_TYPE(UserSelect) unsigned userSelect : 2;
     PREFERRED_TYPE(bool) unsigned textOverflow : 1; // Whether or not lines that spill out should be truncated with "..."
     PREFERRED_TYPE(UserDrag) unsigned userDrag : 2;
     PREFERRED_TYPE(ObjectFit) unsigned objectFit : 3;

--- a/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
+++ b/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
@@ -1228,6 +1228,8 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 constexpr CSSValueID toCSSValueID(UserSelect e)
 {
     switch (e) {
+    case UserSelect::Auto:
+        return CSSValueAuto;
     case UserSelect::None:
         return CSSValueNone;
     case UserSelect::Text:
@@ -1243,7 +1245,7 @@ template<> constexpr UserSelect fromCSSValueID(CSSValueID valueID)
 {
     switch (valueID) {
     case CSSValueAuto:
-        return UserSelect::Text;
+        return UserSelect::Auto;
     case CSSValueNone:
         return UserSelect::None;
     case CSSValueText:


### PR DESCRIPTION
#### 67dd9aaddcb13db8d38b010ba4fe700f385ac8a1
<pre>
Add unprefixed user-select (and feature flag)
<a href="https://bugs.webkit.org/show_bug.cgi?id=321119">https://bugs.webkit.org/show_bug.cgi?id=321119</a>
<a href="https://rdar.apple.com/184152184">rdar://184152184</a>

Reviewed by NOBODY (OOPS!).

Adds the (unprefixed) user-select property, gated by a new feature
flag (CSSUnprefixedUserSelectEnabled). The property is completely
inert - this only adds the plumbing, not any behavior. The
prefixed `-webkit-user-select` is still the source of truth.

No changes in behavior expected.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67dd9aaddcb13db8d38b010ba4fe700f385ac8a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53230 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189123 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/95eab93c-34c3-4761-a8b0-d644a4489de7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54523 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52940 "Build is in progress. Recent messages:") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182248 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/120279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b69f43b-ad5f-4d94-8691-44468e99d2e8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/52940 "Build is in progress. Recent messages:") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/2249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/430 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/40566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/52940 "Build is in progress. Recent messages:") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191341 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53580 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/148810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/43481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52098 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51544 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->