### PR TITLE
[macOS] Support gesture event handling without a backing NSEvent

### DIFF
--- a/Source/WebKit/Shared/NativeWebGestureEvent.h
+++ b/Source/WebKit/Shared/NativeWebGestureEvent.h
@@ -36,12 +36,29 @@ namespace WebKit {
 
 class NativeWebGestureEvent final : public WebGestureEvent {
 public:
-    static std::optional<NativeWebGestureEvent> create(NSEvent *, NSView *);
+    // Distinguishes magnify from rotate without needing a backing NSEvent.
+    enum class Kind : uint8_t { Magnification, Rotation };
 
+    struct Init {
+        Kind kind;
+        Phase phase;
+        WebCore::FloatPoint locationInWindow;
+        float gestureScale { 0 };
+        float gestureRotation { 0 };
+        MonotonicTime timestamp;
+    };
+
+    static std::optional<NativeWebGestureEvent> create(NSEvent *, NSView *);
+    static std::optional<NativeWebGestureEvent> create(const Init&, NSView *);
+
+    Kind kind() const { return m_kind; }
     NSEvent *nativeEvent() const { return m_nativeEvent.get(); }
 
 private:
-    explicit NativeWebGestureEvent(WebEventType, NSEvent *, NSView *);
+    static std::optional<NativeWebGestureEvent> create(const Init&, NSView *, NSEvent *);
+    explicit NativeWebGestureEvent(WebEventType, const Init&, NSView *, NSEvent *);
+
+    Kind m_kind;
     RetainPtr<NSEvent> m_nativeEvent;
 };
 

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -217,6 +217,7 @@ class WebKit::WebGestureEvent : WebKit::WebEvent {
     WebCore::IntPoint position();
     float gestureScale();
     float gestureRotation();
+    WebKit::WebEventPhase phase();
 };
 #endif
 

--- a/Source/WebKit/Shared/mac/NativeWebGestureEventMac.mm
+++ b/Source/WebKit/Shared/mac/NativeWebGestureEventMac.mm
@@ -28,21 +28,22 @@
 
 #if ENABLE(MAC_GESTURE_EVENTS)
 
+#import "WebEventFactory.h"
 #import "WebGestureEvent.h"
 #import <WebCore/IntPoint.h>
 #import <WebCore/PlatformEventFactoryMac.h>
 
 namespace WebKit {
 
-static inline std::optional<WebEventType> webEventTypeForNSEvent(NSEvent *event)
+static inline std::optional<WebEventType> webEventTypeForPhase(WebEventPhase phase)
 {
-    switch (event.phase) {
-    case NSEventPhaseBegan:
+    switch (phase) {
+    case WebEventPhase::Began:
         return WebEventType::GestureStart;
-    case NSEventPhaseChanged:
+    case WebEventPhase::Changed:
         return WebEventType::GestureChange;
-    case NSEventPhaseEnded:
-    case NSEventPhaseCancelled:
+    case WebEventPhase::Ended:
+    case WebEventPhase::Cancelled:
         return WebEventType::GestureEnd;
     default:
         break;
@@ -50,28 +51,54 @@ static inline std::optional<WebEventType> webEventTypeForNSEvent(NSEvent *event)
     return std::nullopt;
 }
 
-static NSPoint pointForEvent(NSEvent *event, NSView *windowView)
+static WebCore::IntPoint positionInView(WebCore::FloatPoint locationInWindow, NSView *view)
 {
-    NSPoint location = [event locationInWindow];
-    if (windowView)
-        location = [windowView convertPoint:location fromView:nil];
-    return location;
+    return WebCore::IntPoint { view ? WebCore::FloatPoint { [view convertPoint:locationInWindow fromView:nil] } : locationInWindow };
+}
+
+static NativeWebGestureEvent::Init initForEvent(NSEvent *event)
+{
+    using Kind = NativeWebGestureEvent::Kind;
+
+    ASSERT(event.type == NSEventTypeMagnify || event.type == NSEventTypeRotate);
+    bool isRotation = event.type == NSEventTypeRotate;
+
+    return {
+        isRotation ? Kind::Rotation : Kind::Magnification,
+        WebEventFactory::phaseForEvent(event),
+        WebCore::FloatPoint { event.locationInWindow },
+        isRotation ? 0 : static_cast<float>(event.magnification),
+        isRotation ? static_cast<float>(event.rotation) : 0,
+        MonotonicTime::fromRawSeconds(event.timestamp)
+    };
 }
 
 std::optional<NativeWebGestureEvent> NativeWebGestureEvent::create(NSEvent *event, NSView *view)
 {
-    auto type = webEventTypeForNSEvent(event);
-    if (!type)
-        return std::nullopt;
-    return { NativeWebGestureEvent { *type, event, view } };
+    return create(initForEvent(event), view, event);
 }
 
-NativeWebGestureEvent::NativeWebGestureEvent(WebEventType type, NSEvent *event, NSView *view)
-    : WebGestureEvent(
-        { type, OptionSet<WebEventModifier> { }, MonotonicTime::fromRawSeconds(event.timestamp) },
-        WebCore::IntPoint(pointForEvent(event, view)),
-        event.type == NSEventTypeMagnify ? event.magnification : 0,
-        event.type == NSEventTypeRotate ? event.rotation : 0)
+std::optional<NativeWebGestureEvent> NativeWebGestureEvent::create(const Init& init, NSView *view)
+{
+    return create(init, view, nil);
+}
+
+std::optional<NativeWebGestureEvent> NativeWebGestureEvent::create(const Init& init, NSView *view, NSEvent *event)
+{
+    return webEventTypeForPhase(init.phase).
+        and_then([&init, view = RetainPtr { view }, event = RetainPtr { event }](auto type) {
+            return std::optional { NativeWebGestureEvent { type, init, view, event } };
+        });
+}
+
+NativeWebGestureEvent::NativeWebGestureEvent(WebEventType type, const Init& init, NSView *view, NSEvent *event)
+    : WebGestureEvent {
+        { type, { }, init.timestamp },
+        positionInView(init.locationInWindow, view),
+        init.gestureScale,
+        init.gestureRotation,
+        init.phase }
+    , m_kind(init.kind)
     , m_nativeEvent(event)
 {
 }

--- a/Source/WebKit/Shared/mac/WebGestureEvent.h
+++ b/Source/WebKit/Shared/mac/WebGestureEvent.h
@@ -46,11 +46,12 @@ class WebGestureEvent : public WebEvent {
 public:
     using Phase = WebEventPhase;
 
-    WebGestureEvent(WebEvent&& event, WebCore::IntPoint position, float gestureScale, float gestureRotation)
+    WebGestureEvent(WebEvent&& event, WebCore::IntPoint position, float gestureScale, float gestureRotation, Phase phase)
         : WebEvent(WTF::move(event))
         , m_position(position)
         , m_gestureScale(gestureScale)
         , m_gestureRotation(gestureRotation)
+        , m_phase(phase)
     {
         ASSERT(isGestureEventType(type()));
     }
@@ -59,6 +60,7 @@ public:
 
     float gestureScale() const { return m_gestureScale; }
     float gestureRotation() const { return m_gestureRotation; }
+    Phase phase() const { return m_phase; }
 
 private:
     bool isGestureEventType(WebEventType) const;
@@ -66,6 +68,7 @@ private:
     WebCore::IntPoint m_position;
     float m_gestureScale;
     float m_gestureRotation;
+    Phase m_phase;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -83,7 +83,6 @@ class Navigation;
 
 #if PLATFORM(MAC)
 typedef WebKit::NativeWebWheelEvent PlatformScrollEvent;
-typedef NSEvent *PlatformMagnificationEvent;
 #elif PLATFORM(GTK)
 typedef struct {
     WebCore::FloatSize delta;
@@ -166,10 +165,8 @@ public:
 #endif
 
 #if PLATFORM(MAC)
-    void handleMagnificationGesture(double scale, WebEventPhase, WebCore::FloatPoint origin);
+    void handleMagnificationGesture(double scale, WebEventPhase, WebCore::FloatPoint originInViewCoordinates);
     void handleSmartMagnificationGesture(WebCore::FloatPoint gestureLocationInViewCoordinates);
-
-    void gestureEventWasNotHandledByWebCore(PlatformMagnificationEvent, WebCore::FloatPoint origin);
 
     void setCustomSwipeViews(Vector<RetainPtr<NSView>> views) { m_customSwipeViews = WTF::move(views); }
     bool hasCustomSwipeViews() const { return !m_customSwipeViews.isEmpty(); }

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -734,7 +734,7 @@ void PageClientImpl::wheelEventWasNotHandledByWebCore(const NativeWebWheelEvent&
 #if ENABLE(MAC_GESTURE_EVENTS)
 void PageClientImpl::gestureEventWasNotHandledByWebCore(const NativeWebGestureEvent& event)
 {
-    m_impl->gestureEventWasNotHandledByWebCore(event.nativeEvent());
+    m_impl->gestureEventWasNotHandledByWebCore(event);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -128,12 +128,6 @@ double ViewGestureController::resistanceForDelta(double deltaScale, double curre
     return resistance;
 }
 
-void ViewGestureController::gestureEventWasNotHandledByWebCore(NSEvent *event, FloatPoint origin)
-{
-    if (event.type == NSEventTypeMagnify)
-        handleMagnificationGesture(event.magnification, WebEventFactory::phaseForEvent(event), origin);
-}
-
 void ViewGestureController::handleMagnificationGesture(double scale, WebEventPhase phase, FloatPoint origin)
 {
     RefPtr page = m_webPageProxy.get();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -233,6 +233,9 @@ class PageClient;
 class PageClientImpl;
 class DrawingAreaProxy;
 class MediaSessionCoordinatorProxyPrivate;
+#if ENABLE(MAC_GESTURE_EVENTS)
+class NativeWebGestureEvent;
+#endif
 class BrowsingWarning;
 class ViewGestureController;
 class ViewSnapshot;
@@ -249,6 +252,7 @@ struct WebHitTestResultData;
 enum class ContinueUnsafeLoad : bool;
 enum class ForceSoftwareCapturingViewportSnapshot : bool;
 enum class UndoOrRedo : bool;
+enum class WebEventPhase : uint8_t;
 
 typedef id <NSValidatedUserInterfaceItem> ValidationItem;
 typedef Vector<RetainPtr<ValidationItem>> ValidationVector;
@@ -678,7 +682,9 @@ public:
 
     RetainPtr<NSEvent> setLastMouseDownEvent(NSEvent *);
 
-    void gestureEventWasNotHandledByWebCore(NSEvent *);
+#if ENABLE(MAC_GESTURE_EVENTS)
+    void gestureEventWasNotHandledByWebCore(const NativeWebGestureEvent&);
+#endif
     void gestureEventWasNotHandledByWebCoreFromViewOnly(NSEvent *);
 
     void didRestoreScrollPosition();
@@ -1026,6 +1032,8 @@ private:
 
     std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();
     bool inputMethodUsesCorrectKeyEventOrder();
+
+    void magnificationGestureWasNotHandledByWebCoreFromViewOnly(float magnification, WebEventPhase, WebCore::FloatPoint originInViewCoordinates);
 
     WeakObjCPtr<WKWebView> m_view;
     const UniqueRef<PageClient> m_pageClient;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5782,16 +5782,37 @@ void WebViewImpl::rotateWithEvent(NSEvent *event)
 }
 #endif
 
-void WebViewImpl::gestureEventWasNotHandledByWebCore(NSEvent *event)
+#if ENABLE(MAC_GESTURE_EVENTS)
+
+void WebViewImpl::gestureEventWasNotHandledByWebCore(const NativeWebGestureEvent& event)
 {
-    [m_view.get() _web_gestureEventWasNotHandledByWebCore:event];
+    // FIXME: We need to drive the -_gestureEventWasNotHandledByWebCore: SPI even when there is no backing NSEvent.
+    if (RetainPtr nativeEvent = event.nativeEvent()) {
+        [m_view.get() _web_gestureEventWasNotHandledByWebCore:nativeEvent];
+        return;
+    }
+
+    if (event.kind() != NativeWebGestureEvent::Kind::Magnification)
+        return;
+
+    magnificationGestureWasNotHandledByWebCoreFromViewOnly(event.gestureScale(), event.phase(), event.position());
 }
+
+#endif
 
 void WebViewImpl::gestureEventWasNotHandledByWebCoreFromViewOnly(NSEvent *event)
 {
+    if (event.type != NSEventTypeMagnify)
+        return;
+
+    magnificationGestureWasNotHandledByWebCoreFromViewOnly(event.magnification, WebEventFactory::phaseForEvent(event), [m_view.get() convertPoint:event.locationInWindow fromView:nil]);
+}
+
+void WebViewImpl::magnificationGestureWasNotHandledByWebCoreFromViewOnly(float magnification, WebEventPhase phase, FloatPoint originInViewCoordinates)
+{
 #if ENABLE(MAC_GESTURE_EVENTS)
     if (m_allowsMagnification && m_gestureController)
-        m_gestureController->gestureEventWasNotHandledByWebCore(event, [m_view.get() convertPoint:event.locationInWindow fromView:nil]);
+        m_gestureController->handleMagnificationGesture(magnification, phase, originInViewCoordinates);
 #endif
 }
 


### PR DESCRIPTION
#### 1eb4c74604e953e73ab237cf0fca967e2cf9b188
<pre>
[macOS] Support gesture event handling without a backing NSEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=321223">https://bugs.webkit.org/show_bug.cgi?id=321223</a>
<a href="https://rdar.apple.com/184273141">rdar://184273141</a>

Reviewed by Richard Robinson.

Forthcoming changes will make it possible to synthesize work for
ViewGestureController without going through the NSResponder/NSEvent
machinery that drives it today. Since these paths will not have a
backing NSEvent, we introduce this refactor that undoes a couple of
assumptions.

1. We teach WebGestureEvent about the gesture phase. This field is
   either populated by reading the `NSEvent.phase` property, or through
   other means.
2. We add a `Kind` enum to NativeWebGestureEvent, recording whether the
   gesture is a magnification or a rotation.
3. We make it possible to create a NativeWebGestureEvent instance from
   either an NSEvent, or from an explicit initialization structure that
   describes the gesture. In the latter case, we will store a null
   native event field, inspired by precedent established in 303084@main.
4. We pass around the entire NativeWebGestureEvent instance, rather than
   its native event, in the gestureEventWasNotHandledByWebCore path.
   This allows us to drive the namesake SPI when there is a backing
   event, and go straight to ViewGestureController magnification if not.

The new initialization method has no callers yet, and as such this patch
does not introduce a behavior change.

* Source/WebKit/Shared/NativeWebGestureEvent.h:
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/mac/NativeWebGestureEventMac.mm:
(WebKit::webEventTypeForPhase):
(WebKit::positionInView):
(WebKit::initForEvent):
(WebKit::NativeWebGestureEvent::create):
(WebKit::NativeWebGestureEvent::NativeWebGestureEvent):
(WebKit::webEventTypeForNSEvent): Deleted.
(WebKit::pointForEvent): Deleted.
* Source/WebKit/Shared/mac/WebGestureEvent.h:
(WebKit::WebGestureEvent::WebGestureEvent):
(WebKit::WebGestureEvent::phase const):
* Source/WebKit/UIProcess/ViewGestureController.h:

Also drop PlatformMagnificationEvent, which has no remaining users now
that nothing in ViewGestureController takes an NSEvent directly.

* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::gestureEventWasNotHandledByWebCore):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::gestureEventWasNotHandledByWebCore): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::gestureEventWasNotHandledByWebCore):
(WebKit::WebViewImpl::gestureEventWasNotHandledByWebCoreFromViewOnly):
(WebKit::WebViewImpl::magnificationGestureWasNotHandledByWebCoreFromViewOnly):

Canonical link: <a href="https://commits.webkit.org/318771@main">https://commits.webkit.org/318771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e88aa635dea4b8ddd7e44ea8f97a1eed4deeadf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179302 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189134 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139818 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120270 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40424 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40074 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/582 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40577 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191352 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52911 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149069 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53591 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148814 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27216 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43486 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125863 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120722 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52109 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15060 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51494 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51735 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51555 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->