### PR TITLE
Network cache traversal decodes every record in full just to read its URL

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2030,11 +2030,17 @@ void NetworkProcess::deleteWebsiteDataForOrigin(PAL::SessionID sessionID, Option
             RegistrableDomain topDomain = RegistrableDomain::uncheckedCreateFromHost(origin.topOrigin.host());
             String cachePartition = origin.clientOrigin == origin.topOrigin ? emptyString() : (topDomain.isEmpty() ? emptyString() : topDomain.string());
             bool shouldClearAllEntriesInPartition = origin.clientOrigin == origin.topOrigin;
-            cache->traverse(cachePartition, [cache, clearTasksHandler, shouldClearAllEntriesInPartition, origin = origin.clientOrigin, cachePartition, cacheKeysToDelete = WTF::move(cacheKeysToDelete)](auto* traversalEntry) mutable {
-                if (traversalEntry) {
-                    ASSERT_UNUSED(cachePartition, equalIgnoringNullity(traversalEntry->entry.key().partition(), cachePartition));
-                    if (shouldClearAllEntriesInPartition || SecurityOriginData::fromURLWithoutStrictOpaqueness(traversalEntry->entry.response().url()) == origin)
-                        cacheKeysToDelete.append(traversalEntry->entry.key());
+            cache->traverseRecords(cachePartition, [cache, clearTasksHandler, shouldClearAllEntriesInPartition, origin = origin.clientOrigin, cachePartition, cacheKeysToDelete = WTF::move(cacheKeysToDelete)](auto* traversalRecord) mutable {
+                if (traversalRecord) {
+                    ASSERT_UNUSED(cachePartition, equalIgnoringNullity(traversalRecord->record.key.partition(), cachePartition));
+                    if (shouldClearAllEntriesInPartition) {
+                        cacheKeysToDelete.append(traversalRecord->record.key);
+                        return;
+                    }
+
+                    auto url = NetworkCache::Entry::decodeStorageRecordResponseURL(traversalRecord->record);
+                    if (url && SecurityOriginData::fromURLWithoutStrictOpaqueness(*url) == origin)
+                        cacheKeysToDelete.append(traversalRecord->record.key);
                     return;
                 }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -639,7 +639,7 @@ void Cache::remove(const Vector<Key>& keys, Function<void()>&& completionHandler
     m_storage->remove(keys, WTF::move(completionHandler));
 }
 
-void Cache::traverse(Function<void(const TraversalEntry*)>&& traverseHandler)
+void Cache::traverseRecords(Function<void(const TraversalRecord*)>&& traverseHandler)
 {
     // Protect against clients making excessive traversal requests.
     const unsigned maximumTraverseCount = 3;
@@ -661,16 +661,12 @@ void Cache::traverse(Function<void(const TraversalEntry*)>&& traverseHandler)
             return;
         }
 
-        auto entry = Entry::decodeStorageRecord(*record);
-        if (!entry)
-            return;
-
-        TraversalEntry traversalEntry { *entry, recordInfo };
-        traverseHandler(&traversalEntry);
+        TraversalRecord traversalRecord { *record, recordInfo };
+        traverseHandler(&traversalRecord);
     });
 }
 
-void Cache::traverse(const String& partition, Function<void(const TraversalEntry*)>&& traverseHandler)
+void Cache::traverseRecords(const String& partition, Function<void(const TraversalRecord*)>&& traverseHandler)
 {
     m_storage->traverse(resourceType(), partition, { }, [traverseHandler = WTF::move(traverseHandler)] (const Storage::Record* record, const Storage::RecordInfo& recordInfo) mutable {
         if (!record) {
@@ -678,12 +674,8 @@ void Cache::traverse(const String& partition, Function<void(const TraversalEntry
             return;
         }
 
-        auto entry = Entry::decodeStorageRecord(*record);
-        if (!entry)
-            return;
-
-        TraversalEntry traversalEntry { *entry, recordInfo };
-        traverseHandler(&traversalEntry);
+        TraversalRecord traversalRecord { *record, recordInfo };
+        traverseHandler(&traversalRecord);
     });
 }
 
@@ -769,12 +761,15 @@ String Cache::recordsPathIsolatedCopy() const
 void Cache::fetchData(bool shouldComputeSize, CompletionHandler<void(Vector<WebsiteData::Entry>&&)>&& completionHandler)
 {
     HashMap<WebCore::SecurityOriginData, uint64_t> originsAndSizes;
-    traverse([protectedThis = Ref { *this }, shouldComputeSize, completionHandler = WTF::move(completionHandler), originsAndSizes = WTF::move(originsAndSizes)](auto* traversalEntry) mutable {
-        if (traversalEntry) {
-            auto url = traversalEntry->entry.response().url();
-            auto result = originsAndSizes.add({ url.protocol().toString(), url.host().toString(), url.port() }, 0);
+    traverseRecords([shouldComputeSize, completionHandler = WTF::move(completionHandler), originsAndSizes = WTF::move(originsAndSizes)](auto* traversalRecord) mutable {
+        if (traversalRecord) {
+            auto url = Entry::decodeStorageRecordResponseURL(traversalRecord->record);
+            if (!url)
+                return;
+
+            auto result = originsAndSizes.add({ url->protocol().toString(), url->host().toString(), url->port() }, 0);
             if (shouldComputeSize)
-                result.iterator->value += traversalEntry->entry.sourceStorageRecord().header.size() + traversalEntry->recordInfo.bodySize;
+                result.iterator->value += traversalRecord->record.header.size() + traversalRecord->recordInfo.bodySize;
             return;
         }
 
@@ -810,11 +805,14 @@ void Cache::deleteData(const Vector<WebCore::SecurityOriginData>& origins, Compl
         originSet.add(origin);
 
     Vector<NetworkCache::Key> keysToDelete;
-    traverse([this, protectedThis = Ref { *this }, originSet = WTF::move(originSet), completionHandler = WTF::move(completionHandler), keysToDelete = WTF::move(keysToDelete)](auto* traversalEntry) mutable {
-        if (traversalEntry) {
-            auto origin = WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(traversalEntry->entry.response().url());
-            if (originSet.contains(origin))
-                keysToDelete.append(traversalEntry->entry.key());
+    traverseRecords([this, protectedThis = Ref { *this }, originSet = WTF::move(originSet), completionHandler = WTF::move(completionHandler), keysToDelete = WTF::move(keysToDelete)](auto* traversalRecord) mutable {
+        if (traversalRecord) {
+            auto url = Entry::decodeStorageRecordResponseURL(traversalRecord->record);
+            if (!url)
+                return;
+
+            if (originSet.contains(WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(*url)))
+                keysToDelete.append(traversalRecord->record.key);
             return;
         }
 
@@ -830,11 +828,15 @@ void Cache::deleteDataForRegistrableDomains(const Vector<WebCore::RegistrableDom
 
     Vector<NetworkCache::Key> keysToDelete;
     HashSet<WebCore::RegistrableDomain> domainsDeleted;
-    traverse([this, protectedThis = Ref { *this }, domainSet = WTF::move(domainSet), completionHandler = WTF::move(completionHandler), keysToDelete = WTF::move(keysToDelete), domainsDeleted = WTF::move(domainsDeleted)](auto* traversalEntry) mutable {
-        if (traversalEntry) {
-            auto domain = WebCore::RegistrableDomain { traversalEntry->entry.response().url() };
+    traverseRecords([this, protectedThis = Ref { *this }, domainSet = WTF::move(domainSet), completionHandler = WTF::move(completionHandler), keysToDelete = WTF::move(keysToDelete), domainsDeleted = WTF::move(domainsDeleted)](auto* traversalRecord) mutable {
+        if (traversalRecord) {
+            auto url = Entry::decodeStorageRecordResponseURL(traversalRecord->record);
+            if (!url)
+                return;
+
+            auto domain = WebCore::RegistrableDomain { *url };
             if (domainSet.contains(domain)) {
-                keysToDelete.append(traversalEntry->entry.key());
+                keysToDelete.append(traversalRecord->record.key);
                 domainsDeleted.add(domain);
             }
             return;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -204,12 +204,12 @@ public:
     std::unique_ptr<Entry> storeRedirect(const WebCore::ResourceRequest&, const WebCore::ResourceResponse&, const WebCore::ResourceRequest& redirectRequest, std::optional<Seconds> maxAgeCap);
     std::unique_ptr<Entry> update(const WebCore::ResourceRequest&, const Entry&, const WebCore::ResourceResponse& validatingResponse, PrivateRelayed);
 
-    struct TraversalEntry {
-        const Entry& entry;
+    struct TraversalRecord {
+        const Storage::Record& record;
         const Storage::RecordInfo& recordInfo;
     };
-    void traverse(Function<void(const TraversalEntry*)>&&);
-    void traverse(const String& partition, Function<void(const TraversalEntry*)>&&);
+    void traverseRecords(Function<void(const TraversalRecord*)>&&);
+    void traverseRecords(const String& partition, Function<void(const TraversalRecord*)>&&);
     void remove(const Key&);
     void remove(const WebCore::ResourceRequest&);
     void remove(const Vector<Key>&, Function<void()>&&);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
@@ -126,6 +126,7 @@ std::unique_ptr<Entry> Entry::decodeStorageRecord(const Storage::Record& storage
         return nullptr;
     entry->m_response = WTF::move(*response);
     entry->m_response.setSource(WebCore::ResourceResponse::Source::DiskCache);
+    ASSERT(entry->m_response.isNull() || decodeStorageRecordResponseURL(storageEntry) == entry->m_response.url());
 
     std::optional<bool> hasVaryingRequestHeaders;
     decoder >> hasVaryingRequestHeaders;
@@ -169,6 +170,20 @@ std::unique_ptr<Entry> Entry::decodeStorageRecord(const Storage::Record& storage
     }
 
     return entry;
+}
+
+std::optional<URL> Entry::decodeStorageRecordResponseURL(const Storage::Record& storageEntry)
+{
+    WTF::Persistence::Decoder decoder(storageEntry.header.span());
+
+    std::optional<bool> responseIsNull;
+    decoder >> responseIsNull;
+    if (!responseIsNull || *responseIsNull)
+        return std::nullopt;
+
+    std::optional<URL> url;
+    decoder >> url;
+    return url;
 }
 
 bool Entry::hasReachedPrevalentResourceAgeCap() const

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
@@ -51,6 +51,7 @@ public:
 
     Storage::Record encodeAsStorageRecord() const;
     static std::unique_ptr<Entry> decodeStorageRecord(const Storage::Record&);
+    static std::optional<URL> decodeStorageRecordResponseURL(const Storage::Record&);
 
     PrivateRelayed privateRelayed() const { return m_privateRelayed; }
     const Key& key() const LIFETIME_BOUND { return m_key; }
@@ -67,8 +68,6 @@ public:
 
     bool needsValidation() const;
     void NODELETE setNeedsValidation(bool);
-
-    const Storage::Record& sourceStorageRecord() const LIFETIME_BOUND { return m_sourceStorageRecord; }
 
     void asJSON(StringBuilder&, const Storage::RecordInfo&) const;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
@@ -32,6 +32,7 @@
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import <JavaScriptCore/JSCConfig.h>
+#import <Network/Network.h>
 #import <WebCore/SQLiteFileSystem.h>
 #import <WebCore/SecurityOriginData.h>
 #import <WebKit/WKHTTPCookieStorePrivate.h>
@@ -1531,6 +1532,74 @@ TEST(WKWebsiteDataStore, FetchDiskCacheDataFromDifferentStores)
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
+}
+
+TEST(WKWebsiteDataStore, RemoveDiskCacheDataForOrigin)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer server({
+        { "/example"_s, { { { "Cache-Control"_s, "max-age=1000000"_s } }, "example"_s } },
+        { "/webkit"_s, { { { "Cache-Control"_s, "max-age=1000000"_s } }, "webkit"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr endpoint = adoptNS(nw_endpoint_create_host("127.0.0.1", [NSString stringWithFormat:@"%d", server.port()].UTF8String));
+    RetainPtr proxyConfig = adoptNS(nw_proxy_config_create_http_connect(endpoint.get(), nullptr));
+
+    WKWebsiteDataStore *dataStore = [WKWebsiteDataStore defaultDataStore];
+    dataStore.proxyConfigurations = @[ proxyConfig.get() ];
+
+    NSSet *types = [NSSet setWithObject:WKWebsiteDataTypeDiskCache];
+
+    done = false;
+    [dataStore removeDataOfTypes:types modifiedSince:[NSDate distantPast] completionHandler:^{
+        done = true;
+    }];
+    Util::run(&done);
+
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration setWebsiteDataStore:dataStore];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadRequestIgnoringSSLErrors:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [webView synchronouslyLoadRequestIgnoringSSLErrors:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit"]]];
+
+    // The cache is written after the load finishes.
+    __block RetainPtr<NSArray<WKWebsiteDataRecord *>> records;
+    while ([records count] < 2) {
+        done = false;
+        [dataStore fetchDataRecordsOfTypes:types completionHandler:^(NSArray<WKWebsiteDataRecord *> *fetchedRecords) {
+            records = fetchedRecords;
+            done = true;
+        }];
+        Util::run(&done);
+    }
+    EXPECT_EQ([records count], 2u);
+
+    RetainPtr<WKWebsiteDataRecord> exampleRecord;
+    for (WKWebsiteDataRecord *record in records.get()) {
+        if ([record.displayName isEqualToString:@"example.com"])
+            exampleRecord = record;
+    }
+    EXPECT_TRUE(!!exampleRecord);
+
+    done = false;
+    [dataStore removeDataOfTypes:types forDataRecords:@[ exampleRecord.get() ] completionHandler:^{
+        [dataStore fetchDataRecordsOfTypes:types completionHandler:^(NSArray<WKWebsiteDataRecord *> *remainingRecords) {
+            EXPECT_EQ([remainingRecords count], 1u);
+            EXPECT_WK_STREQ([[remainingRecords firstObject] displayName], @"webkit.org");
+            done = true;
+        }];
+    }];
+    Util::run(&done);
+
+    // Clean up defaultDataStore after test. The proxy has to be unset too, or later tests using the
+    // default store are routed through this test's server.
+    done = false;
+    [dataStore removeDataOfTypes:types modifiedSince:[NSDate distantPast] completionHandler:^{
+        done = true;
+    }];
+    Util::run(&done);
+    dataStore.proxyConfigurations = nil;
 }
 
 TEST(WKWebsiteDataStoreConfiguration, InitWithIdentifier)


### PR DESCRIPTION
#### db5ab4766a6212b3b8da3fc4a491f50b1ef8095c
<pre>
Network cache traversal decodes every record in full just to read its URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=321234">https://bugs.webkit.org/show_bug.cgi?id=321234</a>
<a href="https://rdar.apple.com/184280149">rdar://184280149</a>

Reviewed by Chris Dumez.

Cache::traverse decoded every visited record into an Entry before handing it to its client, and every client that
traverses only needs the response URL, to match the record against an origin or a registrable domain. Decoding an
Entry deserializes the whole ResourceResponse, so each record costs a full HTTP header map rebuild plus a SecTrust
deserialization, which DER-decodes and hashes the response&apos;s certificate chain, and this could be costly.

To reduce the cost, this patch adds Entry::decodeStorageRecordResponseURL, which only decodes URL from response and
stops there -- the Entry::encodeAsStorageRecord writes the response first, and Coder&lt;WebCore::ResourceResponse&gt; writes
m_isNull followed by m_url, so the URL is at the start of the record header and is decoded early.

Also, this patch adds assertion in decodeStorageRecord to ensure the decode URL is the same as Entry::response().url(),
so that reordering the coder&apos;s fields cannot silently turn the fast path into reading some other field as a URL.

Cache::traverse is replaced with Cache::traverseRecords, which hands out the undecoded Storage::Record and lets the
client decide what it needs, and convert the four clients that only need an origin.

One behavior difference: a record that failed to decode was previously skipped inside Cache::traverse, whichever field
failed. Now only a record whose URL cannot be decoded is skipped, so a record with a readable URL but a corrupt later
field becomes deletable, which seems more useful than keeping it around forever.

The new test WKWebsiteDataStore.RemoveDiskCacheDataForOrigin covers both directions of Cache::deleteData, that the
requested origin&apos;s entries are gone, and that another origin&apos;s entries are left alone.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::deleteWebsiteDataForOrigin):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::traverseRecords):
(WebKit::NetworkCache::Cache::fetchData):
(WebKit::NetworkCache::Cache::deleteData):
(WebKit::NetworkCache::Cache::deleteDataForRegistrableDomains):
(WebKit::NetworkCache::Cache::traverse): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp:
(WebKit::NetworkCache::Entry::decodeStorageRecord):
(WebKit::NetworkCache::Entry::decodeStorageRecordResponseURL):
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm:
(TEST(WKWebsiteDataStore, RemoveDiskCacheDataForOrigin)):

Canonical link: <a href="https://commits.webkit.org/318781@main">https://commits.webkit.org/318781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e29343845aac644e7d215c68c6ffb7b39a7b8643

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189139 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139820 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120272 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42094 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40427 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40077 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/590 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191357 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52916 "Built successfully") | | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149075 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; 28 flakes 2 failures; Uploaded test results; 3 flakes; Passed layout tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39998 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53596 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148818 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43500 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125868 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120727 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52114 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15063 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51499 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51740 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51560 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->