### PR TITLE
Improve Find in Page on very large pages

### DIFF
--- a/Source/WebCore/editing/CachedMatchFinder.cpp
+++ b/Source/WebCore/editing/CachedMatchFinder.cpp
@@ -305,17 +305,40 @@ Expected<unsigned, CachedMatchFinder::CacheUnusable> CachedMatchFinder::countMat
     return count;
 }
 
+void CachedMatchFinder::TextRun::resolveOffsets() const
+{
+    if (!textIteratorPosition.offsetBaseNode)
+        return;
+    unsigned index = textIteratorPosition.offsetBaseNode->computeNodeIndex();
+    textIteratorPosition.startOffset += index;
+    textIteratorPosition.endOffset += index;
+    textIteratorPosition.offsetBaseNode = nullptr;
+}
+
+BoundaryPoint CachedMatchFinder::TextRun::start() const
+{
+    resolveOffsets();
+    return { textIteratorPosition.container.copyRef(), textIteratorPosition.startOffset };
+}
+
+SimpleRange CachedMatchFinder::TextRun::range() const
+{
+    resolveOffsets();
+    return { { textIteratorPosition.container.copyRef(), textIteratorPosition.startOffset }, { textIteratorPosition.container.copyRef(), textIteratorPosition.endOffset } };
+}
+
 unsigned CachedMatchFinder::bufferOffsetForBoundaryPoint(StringView buffer, const Vector<TextRun>& runs, const BoundaryPoint& point, FindOptions options)
 {
     std::optional<unsigned> lastChunkEnd;
     for (auto [i, run] : indexedRange(runs)) {
-        if (&run.range.start.container.get() != &point.container.get())
+        if (run.textIteratorPosition.container.ptr() != point.container.ptr())
             continue;
-        if (point.offset < run.range.start.offset)
+        run.resolveOffsets();
+        if (point.offset < run.textIteratorPosition.startOffset)
             continue;
 
-        if (point.offset <= run.range.end.offset)
-            return run.offset + (point.offset - run.range.start.offset);
+        if (point.offset <= run.textIteratorPosition.endOffset)
+            return run.offset + (point.offset - run.textIteratorPosition.startOffset);
 
         lastChunkEnd = i + 1 < runs.size() ? runs[i + 1].offset : buffer.length();
     }
@@ -325,8 +348,8 @@ unsigned CachedMatchFinder::bufferOffsetForBoundaryPoint(StringView buffer, cons
 
     for (const auto& run : runs) {
         auto order = options.contains(FindOption::DoNotTraverseFlatTree)
-            ? treeOrder<ShadowIncludingTree>(run.range.start, point)
-            : treeOrder<ComposedTree>(run.range.start, point);
+            ? treeOrder<ShadowIncludingTree>(run.start(), point)
+            : treeOrder<ComposedTree>(run.start(), point);
         if (std::is_gteq(order))
             return run.offset;
     }
@@ -409,8 +432,8 @@ auto CachedMatchFinder::textForScope(ContainerNode& scope, FindOptions options) 
     for (; !it.atEnd(); it.advance()) {
         if (auto limit = maximumRunCountForTesting(); limit && runs.size() >= *limit)
             return std::nullopt;
-        auto textRunRange = it.range();
-        if (!runs.tryAppend(TextRun { static_cast<unsigned>(builder.length()), textRunRange }))
+        auto position = it.position();
+        if (!runs.tryAppend(TextRun { static_cast<unsigned>(builder.length()), TextIteratorPosition { WTF::move(position.container), WTF::move(position.offsetBaseNode), position.startOffset, position.endOffset } }))
             return std::nullopt;
         auto text = it.text();
         if (text.is8Bit()) {
@@ -439,9 +462,10 @@ BoundaryPoint CachedMatchFinder::boundaryForOffset(const Vector<CachedMatchFinde
 
     auto& run = runs[index];
     RELEASE_ASSERT(run.offset <= position);
+    run.resolveOffsets();
     unsigned offsetWithinChunk = static_cast<unsigned>(position - run.offset);
-    unsigned domOffset = std::min(run.range.start.offset + offsetWithinChunk, run.range.end.offset);
-    return { run.range.start.container.copyRef(), domOffset };
+    unsigned domOffset = std::min(run.textIteratorPosition.startOffset + offsetWithinChunk, run.textIteratorPosition.endOffset);
+    return { run.textIteratorPosition.container.copyRef(), domOffset };
 }
 
 SimpleRange CachedMatchFinder::bufferRangeToSimpleRange(const Vector<TextRun>& runs, size_t start, size_t end)

--- a/Source/WebCore/editing/CachedMatchFinder.h
+++ b/Source/WebCore/editing/CachedMatchFinder.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/FindOptions.h>
 #include <WebCore/SimpleRange.h>
+#include <WebCore/TextIterator.h>
 #include <wtf/Expected.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
@@ -58,8 +59,12 @@ public:
 
 private:
     struct TextRun {
-        unsigned offset;
-        SimpleRange range;
+        unsigned offset { 0 };
+        mutable TextIteratorPosition textIteratorPosition;
+
+        void resolveOffsets() const;
+        BoundaryPoint start() const;
+        SimpleRange range() const;
     };
 
     struct TextRunCache {

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1370,6 +1370,12 @@ void TextIterator::emitText(Text& textNode, RenderText& renderer, int textStartO
     m_hasEmitted = true;
 }
 
+TextIteratorPosition TextIterator::position() const
+{
+    ASSERT(!atEnd());
+    return { *m_positionNode, m_positionOffsetBaseNode, static_cast<unsigned>(m_positionStartOffset), static_cast<unsigned>(m_positionEndOffset) };
+}
+
 SimpleRange TextIterator::range() const
 {
     ASSERT(!atEnd());

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -92,6 +92,13 @@ private:
     unsigned m_length { 0 };
 };
 
+struct TextIteratorPosition {
+    Ref<Node> container;
+    RefPtr<Node> offsetBaseNode;
+    unsigned startOffset { 0 };
+    unsigned endOffset { 0 };
+};
+
 // Iterates through the DOM range, returning all the text, and 0-length boundaries
 // at points where replaced elements break up the text flow. The text is delivered in
 // the chunks it's already stored in, to avoid copying any text.
@@ -109,6 +116,7 @@ public:
 
     StringView text() const LIFETIME_BOUND { ASSERT(!atEnd()); return m_text; }
     WEBCORE_EXPORT SimpleRange range() const;
+    WEBCORE_EXPORT TextIteratorPosition position() const;
     WEBCORE_EXPORT Node* node() const;
 
     // Returns true when the current output is a newline emitted from exiting


### PR DESCRIPTION
#### c2f2ad1536f484aba4af75fe0a9a31a4dd08808f
<pre>
Improve Find in Page on very large pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=321235">https://bugs.webkit.org/show_bug.cgi?id=321235</a>
<a href="https://rdar.apple.com/181159812">rdar://181159812</a>

Reviewed by Ryosuke Niwa.

When the CachedMatchFinder has a cache miss, it has to rebuild it&apos;s
buffer using the TextIterator. It creates a vector of text runs that
is later used to to map the start and end in the buffer to a
SimpleRange in the DOM.

During buffer construction, the collected text runs store the
SimpleRanges of the current text it&apos;s adding to the buffer. This requires
calling TextIterator::range().

After taking some traces of find in page on very large pages, I found
that a majority of the time was spent in Node::computeNodeIndex(), which
is called from TextIterator::range(). This never had to be called before
the introduction of the CachedMatchFinder because we did not cache a
flattened buffer of the DOM text before.

To combat this problem, I instead store a new TextIteratorPosition, which
allows us to lazily evaluate to a SimpleRange only when we need it.
This dramatically speeds up initial buffer construction as well as other
cache misses on pages where misses are noticeable.

* Source/WebCore/editing/CachedMatchFinder.cpp:
(WebCore::CachedMatchFinder::TextRun::resolveOffsets const):
(WebCore::CachedMatchFinder::TextRun::start const):
(WebCore::CachedMatchFinder::TextRun::range const):
(WebCore::CachedMatchFinder::bufferOffsetForBoundaryPoint):
(WebCore::CachedMatchFinder::textForScope):
(WebCore::CachedMatchFinder::boundaryForOffset):
* Source/WebCore/editing/CachedMatchFinder.h:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::position const):
* Source/WebCore/editing/TextIterator.h:

Canonical link: <a href="https://commits.webkit.org/319046@main">https://commits.webkit.org/319046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccd878dfebc087437429f353da1c899f4f6ef6a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144369 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70cce01e-4254-4aa1-b9f0-a1dba1f2e335) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140408 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98141683-4003-4852-9a00-3d42f749fd0a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120859 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42742 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41054 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153146 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40721 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1419 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192194 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53662 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149753 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40157 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54349 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149484 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44129 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126612 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121719 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52866 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15709 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52249 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52486 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52312 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->