### PR TITLE
[Site Isolation] Web Inspector: searchInResources.html fails under Site Isolation

### DIFF
--- a/LayoutTests/inspector/page/searchInResources.html
+++ b/LayoutTests/inspector/page/searchInResources.html
@@ -24,6 +24,10 @@ function test()
         return url.replace(/^.*?LayoutTests\//, "");
     }
 
+    function pageAgent() {
+        return WI.networkManager.enabledPageForSiteIsolation && WI.backendTarget ? WI.backendTarget.PageAgent : window.PageAgent;
+    }
+
     let suite = InspectorTest.createAsyncSuite("Page.searchInResources and Page.searchInResource");
 
     const searchString = "SeArCh-StRiNg";
@@ -39,7 +43,7 @@ function test()
         name: "SearchAllResources",
         description: "Able to find text results in different resources.",
         test(resolve, reject) {
-            PageAgent.searchInResources(searchString, (error, results) => {
+            pageAgent().searchInResources(searchString, (error, results) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(results.length > 0, "Should find results in multiple resources.");
                 searchResults = results.sort((a, b) => a.url.localeCompare(b.url));
@@ -55,7 +59,7 @@ function test()
         description: "Able to find text results in different resources.",
         test(resolve, reject) {
             const caseSensitive = true;
-            PageAgent.searchInResources(searchStringCaseSensitive, caseSensitive, (error, results) => {
+            pageAgent().searchInResources(searchStringCaseSensitive, caseSensitive, (error, results) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(results.length > 0, "Should find results in multiple resources.");
                 searchResultsCaseSensitive = results.sort((a, b) => a.url.localeCompare(b.url));
@@ -72,7 +76,7 @@ function test()
         test(resolve, reject) {
             const caseSensitive = undefined;
             const isRegex = true;
-            PageAgent.searchInResources(searchStringRegex, caseSensitive, isRegex, (error, results) => {
+            pageAgent().searchInResources(searchStringRegex, caseSensitive, isRegex, (error, results) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(results.length > 0, "Should find results in multiple resources.");
                 searchResultsIsRegex = results.sort((a, b) => a.url.localeCompare(b.url));
@@ -89,7 +93,7 @@ function test()
         test(resolve, reject) {
             const caseSensitive = true;
             const isRegex = true;
-            PageAgent.searchInResources(searchStringRegex, caseSensitive, isRegex, (error, results) => {
+            pageAgent().searchInResources(searchStringRegex, caseSensitive, isRegex, (error, results) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(results.length > 0, "Should find results in multiple resources.");
                 searchResultsCaseSensitiveIsRegex = results.sort((a, b) => a.url.localeCompare(b.url));
@@ -108,7 +112,7 @@ function test()
             if (!result)
                 reject();
 
-            PageAgent.searchInResource(result.frameId, result.url, searchString, (error, matches) => {
+            pageAgent().searchInResource(result.frameId, result.url, searchString, (error, matches) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(matches.length === result.matchesCount, `Should find ${result.matchesCount} matches.`);
                 for (let match of matches)
@@ -127,7 +131,7 @@ function test()
                 reject();
 
             const caseSensitive = true;
-            PageAgent.searchInResource(result.frameId, result.url, searchStringCaseSensitive, caseSensitive, (error, matches) => {
+            pageAgent().searchInResource(result.frameId, result.url, searchStringCaseSensitive, caseSensitive, (error, matches) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(matches.length === result.matchesCount, `Should find ${result.matchesCount} matches.`);
                 for (let match of matches)
@@ -147,7 +151,7 @@ function test()
 
             const caseSensitive = undefined;
             const isRegex = true;
-            PageAgent.searchInResource(result.frameId, result.url, searchStringRegex, caseSensitive, isRegex, (error, matches) => {
+            pageAgent().searchInResource(result.frameId, result.url, searchStringRegex, caseSensitive, isRegex, (error, matches) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(matches.length === result.matchesCount, `Should find ${result.matchesCount} matches.`);
                 for (let match of matches)
@@ -167,7 +171,7 @@ function test()
 
             const caseSensitive = true;
             const isRegex = true;
-            PageAgent.searchInResource(result.frameId, result.url, searchStringRegex, caseSensitive, isRegex, (error, matches) => {
+            pageAgent().searchInResource(result.frameId, result.url, searchStringRegex, caseSensitive, isRegex, (error, matches) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(matches.length === result.matchesCount, `Should find ${result.matchesCount} matches.`);
                 for (let match of matches)
@@ -188,7 +192,7 @@ function test()
             const isRegex = undefined;
             const caseSensitive = undefined;
 
-            PageAgent.searchInResource(result.frameId, result.url, searchString, caseSensitive, isRegex, result.requestId, (error, matches) => {
+            pageAgent().searchInResource(result.frameId, result.url, searchString, caseSensitive, isRegex, result.requestId, (error, matches) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(matches.length === result.matchesCount, `Should find ${result.matchesCount} matches.`);
                 for (let match of matches)
@@ -209,7 +213,7 @@ function test()
             const isRegex = undefined;
             const caseSensitive = true;
 
-            PageAgent.searchInResource(result.frameId, result.url, searchStringCaseSensitive, caseSensitive, isRegex, result.requestId, (error, matches) => {
+            pageAgent().searchInResource(result.frameId, result.url, searchStringCaseSensitive, caseSensitive, isRegex, result.requestId, (error, matches) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(matches.length === result.matchesCount, `Should find ${result.matchesCount} matches.`);
                 for (let match of matches)
@@ -230,7 +234,7 @@ function test()
             const isRegex = true;
             const caseSensitive = undefined;
 
-            PageAgent.searchInResource(result.frameId, result.url, searchStringRegex, caseSensitive, isRegex, result.requestId, (error, matches) => {
+            pageAgent().searchInResource(result.frameId, result.url, searchStringRegex, caseSensitive, isRegex, result.requestId, (error, matches) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(matches.length === result.matchesCount, `Should find ${result.matchesCount} matches.`);
                 for (let match of matches)
@@ -251,7 +255,7 @@ function test()
             const isRegex = true;
             const caseSensitive = true;
 
-            PageAgent.searchInResource(result.frameId, result.url, searchStringRegex, caseSensitive, isRegex, result.requestId, (error, matches) => {
+            pageAgent().searchInResource(result.frameId, result.url, searchStringRegex, caseSensitive, isRegex, result.requestId, (error, matches) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(matches.length === result.matchesCount, `Should find ${result.matchesCount} matches.`);
                 for (let match of matches)


### PR DESCRIPTION
#### b330d0a4e971cbdd9bdba47877d5955c420cfa00
<pre>
[Site Isolation] Web Inspector: searchInResources.html fails under Site Isolation
<a href="https://rdar.apple.com/184286094">rdar://184286094</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321239">https://bugs.webkit.org/show_bug.cgi?id=321239</a>

Reviewed by BJ Burg.

Under Site Isolation, Page.searchInResources is implemented by
ProxyingPageAgent in the UIProcess. It fans the search out to every
WebContent process, and each process scans both its frames&apos; cached
resources and its BackendResourceDataStore, which is where the buffered
XHR and Worker response bodies live.

The test reached the Page domain through the window.PageAgent global,
which resolves to WI.mainTarget&apos;s Page agent -- that is, the page
target&apos;s in-process InspectorPageAgent. That agent walks only its own
frame tree and delegates XHR and Worker bodies to
enabledNetworkAgent(). Under Site Isolation the legacy
InspectorNetworkAgent is never enabled, since FrameNetworkAgentProxy
and BackendResourceDataStore take its place, so that half of the search
was silently skipped: search-xhr.txt and search-worker.js were absent
from every SearchAllResources result, which in turn made the four
SearchInXHRResource cases reject.

Select the target that owns the live implementation, gating on
WI.networkManager.enabledPageForSiteIsolation the same way
WI.Resource.prototype.requestContentFromBackend already does. The
reported results are identical with and without Site Isolation, so the
expected results are unchanged.

Choosing the target per call site is a stopgap. Every window.*Agent
global resolves to the page target, which is the wrong destination for
the Page domain under Site Isolation in general; that will be handled
along with the removal of the window.*Agent globals, tracked by
webkit.org/b/201149.

* LayoutTests/inspector/page/searchInResources.html:
Now progresses with `run-webkit-tests --site-isolation`.

Canonical link: <a href="https://commits.webkit.org/319070@main">https://commits.webkit.org/319070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cee6d15a9df9a0360cf51cf7af49976543c8f5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180414 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/54359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/55657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183369 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/55657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/48157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/55657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/48157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/55657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/1784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/54075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/192560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/54025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/48157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/192560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/54713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/192560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27372 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/54713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/53230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/48157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/52677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->