### PR TITLE
Embedded PDFs do not re-fit when the plugin frame is resized

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1341,8 +1341,12 @@ bool UnifiedPDFPlugin::geometryDidChange(const IntSize& pluginSize, const Affine
         activeAnnotation->updateGeometry();
 #endif
 
-    if (sizeChanged)
-        updateLayout();
+    // A subframe PDF should keep fitting to its frame when the frame's size changes,
+    // until the user zooms. Pinning would freeze the scale computed at install time.
+    if (sizeChanged) {
+        bool shouldRefitToFrame = !isFullMainFramePlugin() && m_shouldUpdateAutoSizeScale == ShouldUpdateAutoSizeScale::Yes;
+        updateLayout(shouldRefitToFrame ? AdjustScaleAfterLayout::Yes : AdjustScaleAfterLayout::No);
+    }
 
 #if ENABLE(PDF_PAGE_NUMBER_INDICATOR)
     updatePageNumberIndicator();
@@ -1429,7 +1433,7 @@ void UnifiedPDFPlugin::updateLayout(AdjustScaleAfterLayout shouldAdjustScale, st
         LOG_WITH_STREAM(PDF, stream << "UnifiedPDFPlugin::updateLayout - on first layout, chose scale for actual size " << initialScaleFactor);
         setScaleFactor(initialScaleFactor);
 
-        if (!shouldSizeToFitContent())
+        if (!shouldSizeToFitContent() && isFullMainFramePlugin())
             m_shouldUpdateAutoSizeScale = ShouldUpdateAutoSizeScale::No;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -463,6 +463,146 @@ UNIFIED_PDF_TEST(SelectionHighlightColorDoesNotAdaptToColorScheme)
 
 #endif // PLATFORM(MAC)
 
+enum class PDFEmbedElement : uint8_t { IFrame, Embed, Object };
+
+using EmbeddedPDFFitsToFrameParams = std::tuple<PDFEmbedElement, bool, bool, bool>;
+
+class EmbeddedPDFFitsToFrame : public testing::TestWithParam<EmbeddedPDFFitsToFrameParams> {
+public:
+    PDFEmbedElement embedElement() const { return std::get<0>(GetParam()); }
+    bool crossOrigin() const { return std::get<1>(GetParam()); }
+    bool siteIsolationEnabled() const { return std::get<2>(GetParam()); }
+    bool siteIsolationSharedProcessEnabled() const { return std::get<3>(GetParam()); }
+
+    void SetUp() override
+    {
+        server = makeUnique<HTTPServer>(std::initializer_list<std::pair<String, HTTPResponse>> {
+            { "/test.pdf"_s, HTTPResponse { { { "Content-Type"_s, "application/pdf"_s } }, testPDFDataWithLink() } },
+        }, HTTPServer::Protocol::HttpsProxy);
+
+        configuration = configurationForWebViewTestingUnifiedPDF();
+        [configuration setWebsiteDataStore:[server->httpsProxyConfiguration() websiteDataStore]];
+        for (_WKFeature *feature in [WKPreferences _features]) {
+            NSString *key = feature.key;
+            if ([key isEqualToString:@"SiteIsolationEnabled"])
+                [[configuration preferences] _setEnabled:siteIsolationEnabled() forFeature:feature];
+            else if ([key isEqualToString:@"SiteIsolationSharedProcessEnabled"])
+                [[configuration preferences] _setEnabled:siteIsolationSharedProcessEnabled() forFeature:feature];
+        }
+
+        navigationDelegate = adoptNS([TestNavigationDelegate new]);
+        [navigationDelegate allowAnyTLSCertificate];
+        webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+        [webView setNavigationDelegate:navigationDelegate];
+    }
+
+    static std::string testNameGenerator(testing::TestParamInfo<EmbeddedPDFFitsToFrameParams> info)
+    {
+        std::string element = [embedElement = std::get<0>(info.param)] {
+            switch (embedElement) {
+            case PDFEmbedElement::IFrame:
+                return "IFrame";
+            case PDFEmbedElement::Embed:
+                return "Embed";
+            case PDFEmbedElement::Object:
+                return "Object";
+            }
+            ASSERT_NOT_REACHED();
+            return "";
+        }();
+        return element
+            + (std::get<1>(info.param) ? "_CrossOrigin" : "_SameOrigin")
+            + "_SiteIsolation" + (std::get<2>(info.param) ? "Enabled" : "Disabled")
+            + "_SiteIsolationSharedProcess" + (std::get<3>(info.param) ? "Enabled" : "Disabled");
+    }
+
+    std::unique_ptr<HTTPServer> server;
+    RetainPtr<WKWebViewConfiguration> configuration;
+    RetainPtr<TestNavigationDelegate> navigationDelegate;
+    RetainPtr<TestWKWebView> webView;
+};
+
+TEST_P(EmbeddedPDFFitsToFrame, Test)
+{
+    // FIXME: Replace with GTEST_SKIP() after webkit.org/b/321271 is resolved.
+#if PLATFORM(IOS_FAMILY)
+        if (embedElement() == PDFEmbedElement::IFrame)
+            return;
+#endif
+
+    auto mainHTML = [crossOrigin = crossOrigin(), embedElement = embedElement()] {
+        auto layout = "style='position:absolute; left:0; top:0; border:0; width:600px; height:0'"_s;
+        auto pdfURL = makeString("https://"_s, crossOrigin ? "webkit.org"_s : "example.com"_s, "/test.pdf"_s);
+        switch (embedElement) {
+        case PDFEmbedElement::IFrame:
+            return makeString("<iframe id='pdf' "_s, layout, " src='"_s, pdfURL, "'></iframe>"_s);
+        case PDFEmbedElement::Embed:
+            return makeString("<embed id='pdf' "_s, layout, " src='"_s, pdfURL, "'>"_s);
+        case PDFEmbedElement::Object:
+            return makeString("<object id='pdf' "_s, layout, " type='application/pdf' data='"_s, pdfURL, "'></object>"_s);
+        }
+        ASSERT_NOT_REACHED();
+        return String { };
+    }();
+    server->addResponse("/main"_s, HTTPResponse { { { "Content-Type"_s, "text/html"_s } }, mainHTML });
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    static constexpr double pluginWidth = 120;
+    static constexpr double tolerance = 4;
+
+    bool inSubframe = embedElement() == PDFEmbedElement::IFrame;
+    RetainPtr<NSString> pluginSelector = inSubframe ? @"document.querySelector('embed')" : @"document.getElementById('pdf')";
+    RetainPtr<NSString> readStateJS = adoptNS([[NSString alloc] initWithFormat:@"(() => {"
+        "  const plugin = %@;"
+        "  if (!plugin) return { count: -1 };"
+        "  const box = plugin.getBoundingClientRect();"
+        "  const rects = internals.pdfAnnotationRectsForTesting(plugin);"
+        "  if (!rects || !rects.length) return { count: 0, innerWidth: window.innerWidth, elementWidth: box.width };"
+        "  let maxX = 0;"
+        "  for (const r of rects) maxX = Math.max(maxX, r.x + r.width);"
+        "  return { count: rects.length, innerWidth: window.innerWidth, elementWidth: box.width, maxX };"
+        "})()", pluginSelector.get()]);
+
+    auto readState = [webView = RetainPtr { this->webView }, readStateJS, inSubframe] {
+        return dynamic_objc_cast<NSDictionary>([webView objectByEvaluatingJavaScript:readStateJS inFrame:(inSubframe ? [webView firstChildFrame] : nil)]);
+    };
+
+    // The PDF installed and fit against the provisional (wide) size.
+    bool installedWhileWide = TestWebKitAPI::Util::waitFor([&readState] {
+        RetainPtr result = readState();
+        return result
+            && [[result objectForKey:@"count"] intValue] > 0
+            && [[result objectForKey:@"elementWidth"] doubleValue] > 400;
+    });
+    EXPECT_TRUE(installedWhileWide);
+
+    [webView objectByEvaluatingJavaScript:@"const pdf = document.getElementById('pdf'); pdf.style.width = '120px'; pdf.style.height = '90px';"];
+
+    // Wait until the resize reaches the plugin's frame (true whether or not the PDF re-fits, so the
+    // failing case doesn't burn a fit-timeout), then assert the PDF re-fit to the new width.
+    bool narrowed = TestWebKitAPI::Util::waitFor([&readState] {
+        RetainPtr result = readState();
+        if (!result || [[result objectForKey:@"count"] intValue] <= 0)
+            return false;
+
+        return [[result objectForKey:@"innerWidth"] doubleValue] < 200
+            || [[result objectForKey:@"elementWidth"] doubleValue] < 200
+            || [[result objectForKey:@"maxX"] doubleValue] <= pluginWidth + tolerance;
+    });
+    EXPECT_TRUE(narrowed);
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr finalState = readState();
+    EXPECT_GT([[finalState objectForKey:@"count"] intValue], 0);
+
+    // Ensure that the annotation bounds are within the plugin frame.
+    EXPECT_LE([[finalState objectForKey:@"maxX"] doubleValue], pluginWidth + tolerance);
+}
+
+INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFFitsToFrame, testing::Combine(testing::Values(PDFEmbedElement::IFrame, PDFEmbedElement::Embed, PDFEmbedElement::Object), testing::Bool(), testing::Bool(), testing::Bool()), &EmbeddedPDFFitsToFrame::testNameGenerator);
+
 #if ENABLE(PDF_HUD)
 
 UNIFIED_PDF_TEST(SetPageZoomFactorDoesNotBailIncorrectly)
@@ -767,8 +907,6 @@ UNIFIED_PDF_TEST(PDFHUDMultipleIFrames)
     EXPECT_TRUE(hadLeftFrame);
     EXPECT_TRUE(hadRightFrame);
 }
-
-enum class PDFEmbedElement : uint8_t { IFrame, Embed, Object };
 
 using EmbeddedPDFHUDSiteIsolationParams = std::tuple<PDFEmbedElement, bool, bool, bool>;
 


### PR DESCRIPTION
#### f1111014c1d28387fcb7dbdd673e69e6ffcc2004
<pre>
Embedded PDFs do not re-fit when the plugin frame is resized
<a href="https://bugs.webkit.org/show_bug.cgi?id=321241">https://bugs.webkit.org/show_bug.cgi?id=321241</a>
<a href="https://rdar.apple.com/160319744">rdar://160319744</a>

Reviewed by Richard Robinson and Megan Gardner.

The PDF plugin computes (and pins to) a scale from the frame&apos;s width
after the first layout, so a main frame PDF maintains user zoom across
window resizes. However, since subframe PDFs follow this same logic,
they are never re-fit when the _plugin frame_ itself is resized.

This is most notable with Site Isolation enabled since a cross origin
&lt;iframe src=pdf&gt; will often do its first layout pass with a provisional
frame (that is window sized) and then proceed to keep that bad scale
when the real size does eventually arrive (asynchronously). However, we
see the same issue when we modify the width attribute of any embedded
PDF div.

To fix this issue, we make subframe PDFs recompute its document layout
scale (and initialScale()) whenever its frame is resized, until of
course user zoom is applied and auto-resizing is disabled
unconditionally anyway.

Test: TestWebKitAPI.UnifiedPDF.EmbeddedPDFFitsToFrame

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::geometryDidChange):
(WebKit::UnifiedPDFPlugin::updateLayout):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::EmbeddedPDFFitsToFrame::embedElement const):
(TestWebKitAPI::EmbeddedPDFFitsToFrame::crossOrigin const):
(TestWebKitAPI::EmbeddedPDFFitsToFrame::siteIsolationEnabled const):
(TestWebKitAPI::EmbeddedPDFFitsToFrame::siteIsolationSharedProcessEnabled const):
(TestWebKitAPI::EmbeddedPDFFitsToFrame::testNameGenerator):
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/318837@main">https://commits.webkit.org/318837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef5fb9ba1809c52b629e190ee0536974d86a5e9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189321 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dae75ca5-222a-43bd-a651-45f928b2fd5f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139969 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120421 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb59cd89-5dee-4623-8d8c-3da49dbd974f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40576 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40226 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/775 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191542 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53098 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149231 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53779 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148975 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27263 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43643 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126051 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120949 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52296 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15215 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51681 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51922 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51742 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->