### PR TITLE
[webkitscmpy][ews-build] Reviewer checks disagree about what counts as a reviewer line

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -7310,14 +7310,9 @@ class ValidateCommitMessage(steps.ShellSequence, ShellMixin, AddToLogMixin):
     name = 'validate-commit-message'
     haltOnFailure = False
     flunkOnFailure = True
-    OOPS_RE = 'OO*PP*S!'
-    REVIEWED_STRINGS = (
-        'Reviewed by',
-        'Rubber-stamped by',
-        'Rubber stamped by',
-        'Unreviewed',
-        'Versioning.',
-    )
+    OOPS_RE = '^[^-]*OO*PP*S!*'
+    REVIEWED_STRINGS = ('Reviewed by', 'Rubber-stamped by', 'Rubber stamped by',)
+    UNREVIEWED_STRINGS = ('Unreviewed', 'Versioning\\.',)
     RE_CHANGELOG = br'^(\+\+\+)\s+(.*/ChangeLog.*)'
     BY_RE = re.compile(r'.+\s+by\s+(.+)$')
     SPLIT_RE = re.compile(r'\s+and\s+|,\s*and\s*|,\s*')
@@ -7370,13 +7365,13 @@ class ValidateCommitMessage(steps.ShellSequence, ShellMixin, AddToLogMixin):
             reviewer_error_msg = invalid_msg.format(', '.join(invalid_reviewers))
 
         self.commands = []
-        reviewed_strings = '\\|'.join(self.REVIEWED_STRINGS)
-        reviewed_by_strings = '\\|'.join(self.REVIEWED_STRINGS[:3])
+        reviewer_strings = '\\|'.join(self.REVIEWED_STRINGS)
+        all_strings = '\\|'.join(self.REVIEWED_STRINGS + self.UNREVIEWED_STRINGS)
         commands = [
-            f"git log {head_ref} ^{base_ref} | grep -q '{self.OOPS_RE}' && echo 'Commit message contains (OOPS!){reviewer_error_msg}' || test $? -eq 1",
-            f"git log {head_ref} ^{base_ref} | grep -q 'by NOBODY' && echo 'Commit message contains \"by NOBODY\"{reviewer_error_msg}' || test $? -eq 1",
-            f"git log --format=%B {head_ref} ^{base_ref} > commit_msg.txt; grep -q '^[[:space:]]*\\({reviewed_strings}\\)' commit_msg.txt || echo 'No reviewer information in commit message';",
-            f"git log --format=%B {head_ref} ^{base_ref} | grep '^[[:space:]]*\\({reviewed_by_strings}\\)' || true",
+            f"git log --format=%B {head_ref} ^{base_ref} | grep -q '{self.OOPS_RE}' && echo 'Commit message contains (OOPS!){reviewer_error_msg}' || test $? -eq 1",
+            f"git log --format=%B {head_ref} ^{base_ref} | grep -q 'by NOBODY' && echo 'Commit message contains \"by NOBODY\"{reviewer_error_msg}' || test $? -eq 1",
+            f"git log --format=%B {head_ref} ^{base_ref} > commit_msg.txt; grep -q '^[[:space:]]*\\({all_strings}\\)' commit_msg.txt || echo 'No reviewer information in commit message';",
+            f"git log --format=%B {head_ref} ^{base_ref} | grep '^[[:space:]]*\\({reviewer_strings}\\)' || true",
         ]
         for command in commands:
             self.commands.append(util.ShellArg(command=self.shell_command(command), logname='stdio', haltOnFailure=True))

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -9938,19 +9938,19 @@ class TestValidateCommitMessage(BuildStepMixinAdditions, unittest.TestCase):
                         log_environ=False,
                         timeout=60,
                         command=['/bin/bash', '--posix', '-o', 'pipefail', '-c',
-                                 "git log eng/pull-request-branch ^main | grep -q 'OO*PP*S!' && echo 'Commit message contains (OOPS!) and no valid reviewer found' || test $? -eq 1"])
+                                 "git log --format=%B eng/pull-request-branch ^main | grep -q '^[^-]*OO*PP*S!*' && echo 'Commit message contains (OOPS!) and no valid reviewer found' || test $? -eq 1"])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
                         timeout=60,
                         command=['/bin/bash', '--posix', '-o', 'pipefail', '-c',
-                                 "git log eng/pull-request-branch ^main | grep -q 'by NOBODY' && echo 'Commit message contains \"by NOBODY\" and no valid reviewer found' || test $? -eq 1"])
+                                 "git log --format=%B eng/pull-request-branch ^main | grep -q 'by NOBODY' && echo 'Commit message contains \"by NOBODY\" and no valid reviewer found' || test $? -eq 1"])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
                         timeout=60,
                         command=['/bin/bash', '--posix', '-o', 'pipefail', '-c',
-                                 "git log --format=%B eng/pull-request-branch ^main > commit_msg.txt; grep -q '^[[:space:]]*\\(Reviewed by\\|Rubber-stamped by\\|Rubber stamped by\\|Unreviewed\\|Versioning.\\)' commit_msg.txt || echo 'No reviewer information in commit message';"])
+                                 "git log --format=%B eng/pull-request-branch ^main > commit_msg.txt; grep -q '^[[:space:]]*\\(Reviewed by\\|Rubber-stamped by\\|Rubber stamped by\\|Unreviewed\\|Versioning\\.\\)' commit_msg.txt || echo 'No reviewer information in commit message';"])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -9981,17 +9981,17 @@ class TestValidateCommitMessage(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         log_environ=False,
                         timeout=60,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log HEAD ^origin/main | grep -q 'OO*PP*S!' && echo 'Commit message contains (OOPS!) and no valid reviewer found' || test $? -eq 1"])
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log --format=%B HEAD ^origin/main | grep -q '^[^-]*OO*PP*S!*' && echo 'Commit message contains (OOPS!) and no valid reviewer found' || test $? -eq 1"])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
                         timeout=60,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log HEAD ^origin/main | grep -q 'by NOBODY' && echo 'Commit message contains \"by NOBODY\" and no valid reviewer found' || test $? -eq 1"])
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log --format=%B HEAD ^origin/main | grep -q 'by NOBODY' && echo 'Commit message contains \"by NOBODY\" and no valid reviewer found' || test $? -eq 1"])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
                         timeout=60,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log --format=%B HEAD ^origin/main > commit_msg.txt; grep -q '^[[:space:]]*\\(Reviewed by\\|Rubber-stamped by\\|Rubber stamped by\\|Unreviewed\\|Versioning.\\)' commit_msg.txt || echo 'No reviewer information in commit message';"])
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log --format=%B HEAD ^origin/main > commit_msg.txt; grep -q '^[[:space:]]*\\(Reviewed by\\|Rubber-stamped by\\|Rubber stamped by\\|Unreviewed\\|Versioning\\.\\)' commit_msg.txt || echo 'No reviewer information in commit message';"])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -10017,6 +10017,15 @@ class TestValidateCommitMessage(BuildStepMixinAdditions, unittest.TestCase):
         ValidateCommitMessage._files = lambda x: ['+++ Tools/CISupport/ews-build/steps.py']
         self.setUpCommonProperties()
         expected_remote_command_output = '    Reviewed by WebKit Reviewer.\n'
+        self.expectCommonRemoteCommandsWithOutput(expected_remote_command_output)
+        self.expect_outcome(result=SUCCESS, state_string='Validated commit message')
+        return self.run_step()
+
+    def test_success_rubber_stamped(self):
+        self.setup_step(ValidateCommitMessage())
+        ValidateCommitMessage._files = lambda x: ['+++ Tools/CISupport/ews-build/steps.py']
+        self.setUpCommonProperties()
+        expected_remote_command_output = 'Rubber-stamped by WebKit Reviewer.\n'
         self.expectCommonRemoteCommandsWithOutput(expected_remote_command_output)
         self.expect_outcome(result=SUCCESS, state_string='Validated commit message')
         return self.run_step()
@@ -10057,17 +10066,17 @@ class TestValidateCommitMessage(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         log_environ=False,
                         timeout=60,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log eng/pull-request-branch ^main | grep -q 'OO*PP*S!' && echo 'Commit message contains (OOPS!) and Web Kit is not a reviewer' || test $? -eq 1"])
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log --format=%B eng/pull-request-branch ^main | grep -q '^[^-]*OO*PP*S!*' && echo 'Commit message contains (OOPS!) and Web Kit is not a reviewer' || test $? -eq 1"])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
                         timeout=60,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log eng/pull-request-branch ^main | grep -q 'by NOBODY' && echo 'Commit message contains \"by NOBODY\" and Web Kit is not a reviewer' || test $? -eq 1"])
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log --format=%B eng/pull-request-branch ^main | grep -q 'by NOBODY' && echo 'Commit message contains \"by NOBODY\" and Web Kit is not a reviewer' || test $? -eq 1"])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
                         timeout=60,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log --format=%B eng/pull-request-branch ^main > commit_msg.txt; grep -q '^[[:space:]]*\\(Reviewed by\\|Rubber-stamped by\\|Rubber stamped by\\|Unreviewed\\|Versioning.\\)' commit_msg.txt || echo 'No reviewer information in commit message';"])
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log --format=%B eng/pull-request-branch ^main > commit_msg.txt; grep -q '^[[:space:]]*\\(Reviewed by\\|Rubber-stamped by\\|Rubber stamped by\\|Unreviewed\\|Versioning\\.\\)' commit_msg.txt || echo 'No reviewer information in commit message';"])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -10088,7 +10097,7 @@ class TestValidateCommitMessage(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         log_environ=False,
                         timeout=60,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log eng/pull-request-branch ^main | grep -q 'OO*PP*S!' && echo 'Commit message contains (OOPS!) and no valid reviewer found' || test $? -eq 1"])
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log --format=%B eng/pull-request-branch ^main | grep -q '^[^-]*OO*PP*S!*' && echo 'Commit message contains (OOPS!) and no valid reviewer found' || test $? -eq 1"])
             .exit(1)
             .log('stdio', stdout='Commit message contains (OOPS!) and no valid reviewer found\n'),
         )
@@ -10106,7 +10115,7 @@ class TestValidateCommitMessage(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         log_environ=False,
                         timeout=60,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log eng/pull-request-branch ^main | grep -q 'OO*PP*S!' && echo 'Commit message contains (OOPS!) and Web Kit, Kit Web are not reviewers' || test $? -eq 1"])
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log --format=%B eng/pull-request-branch ^main | grep -q '^[^-]*OO*PP*S!*' && echo 'Commit message contains (OOPS!) and Web Kit, Kit Web are not reviewers' || test $? -eq 1"])
             .exit(1)
             .log('stdio', stdout='Commit message contains (OOPS!) and Web Kit, Kit Web are not reviewers\n'),
         )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py
@@ -46,7 +46,12 @@ TEST_PATTERN_HEADER = re.compile('^Tests?: (.*)$')
 TEST_PATTERN_EXTENSION = re.compile('\\.[a-zA-Z0-9]+$')
 NO_TEST_PATTERN = re.compile('^No new tests \\(OOPS!\\)\\.$')
 TEST_CONTENT_PATTERN = re.compile('^ +.*$')
-REVIEWED_BY_PATTERN = re.compile('^Reviewed by .*$')
+
+REVIEWED = '(?:Reviewed|Rubber[- ]stamped) by'
+REVIEWER_PATTERN = re.compile(f'^{REVIEWED} .*$')
+REVIEWED_BY_LINE_RE = re.compile(rf'^\s*{REVIEWED} (?P<approver>.+)\n?', re.MULTILINE)
+UNREVIEWED_LINE_RE = re.compile(r'^\s*(Unreviewed|Versioning\.)', re.MULTILINE)
+OOPS_LINE_RE = re.compile(r'^[^-]*\(O+P+S!*\)', re.MULTILINE)
 
 
 class CommitMessageParser:
@@ -112,7 +117,7 @@ class CommitMessageParser:
                 continue
 
             if state == ParseState.STATE_TITLE:
-                if REVIEWED_BY_PATTERN.match(line):
+                if REVIEWER_PATTERN.match(line):
                     state = ParseState.STATE_REVIEWED_BY
                     self.reviewed_by_lines.append(line)
                 elif MODIFIED_FILE_PATTERN.match(line):
@@ -126,7 +131,7 @@ class CommitMessageParser:
 
             # Parse the section with "Reviewed by"
             elif state == ParseState.STATE_REVIEWED_BY:
-                if REVIEWED_BY_PATTERN.match(line):
+                if REVIEWER_PATTERN.match(line):
                     self.reviewed_by_lines.append(line)
                 elif line == '':
                     state = ParseState.STATE_DESCRIPTION

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
@@ -36,6 +36,7 @@ from argparse import Namespace
 from webkitbugspy import Tracker
 from webkitcorepy import arguments, run, string_utils, Terminal
 from webkitscmpy import Commit, local, log, remote
+from webkitscmpy.commit_parser import REVIEWED_BY_LINE_RE, OOPS_LINE_RE
 
 
 class Land(Command):
@@ -43,8 +44,6 @@ class Land(Command):
     help = 'If on a pull-request or commit-queue branch, rebase the ' \
            'current branch onto the target production branch and push.'
 
-    OOPS_RE = re.compile(r'^[^-]+\(O+P+S!*\)')
-    REVIEWED_BY_RE = re.compile('^Reviewed by (?P<approver>.+)', re.MULTILINE)
     GIT_SVN_COMMITTED_RE = re.compile(r'Committed r(?P<revision>\d+)')
     REMOTE = 'origin'
     MIRROR_TIMEOUT = 60
@@ -208,8 +207,8 @@ class Land(Command):
                 return 1
             need_review = False
             if pull_request.approvers:
-                review_lines = [cls.REVIEWED_BY_RE.search(commit.message) for commit in commits]
-                need_review = any([cls.OOPS_RE.search(match.group('approver')) for match in review_lines if match])
+                review_lines = [REVIEWED_BY_LINE_RE.search(commit.message) for commit in commits]
+                need_review = any([OOPS_LINE_RE.search(match.group('approver')) for match in review_lines if match])
             if need_review and (args.defaults or Terminal.choose("Set '{}' as your reviewer{}?".format(
                 string_utils.join([p.name for p in pull_request.approvers]),
                 's' if len(pull_request.approvers) > 1 else '',
@@ -242,13 +241,13 @@ class Land(Command):
         elif not pull_request:
             sys.stderr.write("Failed to find pull-request associated with '{}'\n".format(source_branch))
 
-        if not args.oops and any([cls.OOPS_RE.search(commit.message) for commit in commits if commit.message]):
+        if not args.oops and any([OOPS_LINE_RE.search(commit.message) for commit in commits if commit.message]):
             sys.stderr.write("Found '(OOPS!)' message in commit messages, please resolve before committing\n")
             return 1
 
         if not args.oops:
             for line in repository.diff(base=branch_point.hash, head=source_branch):
-                if cls.OOPS_RE.search(line):
+                if OOPS_LINE_RE.search(line):
                     sys.stderr.write("Found '(OOPS!)' in commit diff, please resolve before committing\n")
                     return 1
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -35,6 +35,7 @@ from .squash import Squash
 from webkitbugspy import Tracker, radar
 from webkitcorepy import arguments, run, string_utils, Terminal, OutputCapture
 from webkitscmpy import local, log, remote
+from webkitscmpy.commit_parser import REVIEWED_BY_LINE_RE, UNREVIEWED_LINE_RE
 
 
 class PullRequest(Command):
@@ -502,9 +503,11 @@ class PullRequest(Command):
             for issue in commit.issues
         ]
 
-        unreviewed = re.compile(r'(Unreviewed|Versioning.)', re.IGNORECASE)
-        reviewed = re.compile(r'^Reviewed by .+', re.IGNORECASE | re.MULTILINE)
-        bad_commits = [c for c in commits if c.message and unreviewed.search(c.message) and reviewed.search(c.message)]
+        bad_commits = [
+            c for c in commits if c.message
+            and UNREVIEWED_LINE_RE.search(c.message)
+            and REVIEWED_BY_LINE_RE.search(c.message)
+        ]
 
         if bad_commits:
             if len(bad_commits) > 1:
@@ -516,7 +519,7 @@ class PullRequest(Command):
                 default='Yes',
             )
             if response == 'Yes':
-                cleaned = re.sub(r'Reviewed by .+\n?', '', bad_commits[0].message)
+                cleaned = REVIEWED_BY_LINE_RE.sub('', bad_commits[0].message)
                 if run([repository.executable(), 'commit', '--amend', '-m', cleaned], cwd=repository.root_path).returncode:
                     sys.stderr.write("Failed to amend commit message\n")
                     return 1

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
@@ -36,25 +36,24 @@ from webkitscmpy import Commit, Contributor, local, mocks, program
 from webkitscmpy.program.canonicalize import IdentifierTrailer
 
 
-def repository(path, has_oops=True, remote=None, remotes=None, git_svn=False, issue_url=None):
+def repository(path, remote=None, remotes=None, git_svn=False, issue_url=None, reviewed_by='Reviewed by', approver='NOBODY (OOPS!)', body=''):
     branch = 'eng/example'
     result = mocks.local.Git(path, remote=remote, remotes=remotes, git_svn=git_svn)
+    issue_line = f'{issue_url}\n' if issue_url else ''
+    svn_id = ''
+    if git_svn:
+        host = result.remote.split('@')[-1].split(':')[0]
+        svn_id = f'\ngit-svn-id: https://svn.{host}/repository/{os.path.basename(result.path)}/trunk@10 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'
+
     result.commits[branch] = [
         result.commits[result.default_branch][2],
         Commit(
             hash='a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd',
-            identifier='3.1@{}'.format(branch),
+            identifier=f'3.1@{branch}',
             revision=10,
             timestamp=int(time.time()) - 60,
             author=Contributor('Tim Committer', ['tcommitter@webkit.org']),
-            message='To Be Committed\n{}\nReviewed by {}.\n{}'.format(
-                '{}\n'.format(issue_url) if issue_url else '',
-                {True: 'NOBODY (OOPS!)', False: 'Ricky Reviewer'}.get(has_oops, has_oops),
-                '\ngit-svn-id: https://svn.{}/repository/{}/trunk@10 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'.format(
-                    result.remote.split('@')[-1].split(':')[0],
-                    os.path.basename(result.path),
-                ) if git_svn else '',
-            ),
+            message=f'To Be Committed\n{issue_line}{body}\n{reviewed_by} {approver}.\n{svn_id}',
         )
     ]
     result.head = result.commits[branch][-1]
@@ -119,7 +118,7 @@ class TestLand(testing.PathTestCase):
         self.assertEqual(captured.stdout.getvalue(), '')
 
     def test_with_removed_oops(self):
-        with OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops='- NOBODY (OOPS!)') as repo, mocks.local.Svn(), MockTerminal.input('n'):
+        with OutputCapture(level=logging.INFO) as captured, repository(self.path, approver='- NOBODY (OOPS!)') as repo, mocks.local.Svn(), MockTerminal.input('n'):
             self.assertEqual(0, program.main(
                 args=('land', '-v'),
                 path=self.path,
@@ -145,8 +144,21 @@ class TestLand(testing.PathTestCase):
             "Delete branch 'eng/example'? ([Yes]/No): \n",
         )
 
+    def test_with_oops_after_bullet(self):
+        with OutputCapture(level=logging.INFO) as captured, repository(self.path, body='\n- A bulleted line\n'), mocks.local.Svn():
+            self.assertEqual(1, program.main(
+                args=('land', '-v'),
+                path=self.path,
+            ))
+            self.assertEqual(str(local.Git(self.path).commit()), '3.1@eng/example')
+
+        self.assertIn(
+            "Found '(OOPS!)' message in commit messages, please resolve before committing\n",
+            captured.stderr.getvalue(),
+        )
+
     def test_default(self):
-        with OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False), mocks.local.Svn(), MockTerminal.input('n'):
+        with OutputCapture(level=logging.INFO) as captured, repository(self.path, approver='Ricky Reviewer'), mocks.local.Svn(), MockTerminal.input('n'):
             self.assertEqual(0, program.main(
                 args=('land', '-v'),
                 path=self.path,
@@ -173,7 +185,7 @@ class TestLand(testing.PathTestCase):
         )
 
     def test_canonicalize(self):
-        with OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False), mocks.local.Svn(), MockTerminal.input('n'):
+        with OutputCapture(level=logging.INFO) as captured, repository(self.path, approver='Ricky Reviewer'), mocks.local.Svn(), MockTerminal.input('n'):
             self.assertEqual(0, program.main(
                 args=('land', '-v'),
                 path=self.path,
@@ -215,7 +227,7 @@ class TestLand(testing.PathTestCase):
         )
 
     def test_canonicalize_with_identifier_trailer(self):
-        with OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False), mocks.local.Svn(), MockTerminal.input('n'):
+        with OutputCapture(level=logging.INFO) as captured, repository(self.path, approver='Ricky Reviewer'), mocks.local.Svn(), MockTerminal.input('n'):
             self.assertEqual(0, program.main(
                 args=('land', '-v'),
                 path=self.path,
@@ -241,7 +253,7 @@ class TestLand(testing.PathTestCase):
         )
 
     def test_no_svn_canonical_svn(self):
-        with OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False), mocks.local.Svn():
+        with OutputCapture(level=logging.INFO) as captured, repository(self.path, approver='Ricky Reviewer'), mocks.local.Svn():
             self.assertEqual(1, program.main(
                 args=('land', '-v'),
                 path=self.path, canonical_svn=True,
@@ -255,7 +267,7 @@ class TestLand(testing.PathTestCase):
         self.assertEqual(captured.stdout.getvalue(), '')
 
     def test_svn(self):
-        with MockTime, OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False, git_svn=True), mocks.local.Svn(), MockTerminal.input('n'):
+        with MockTime, OutputCapture(level=logging.INFO) as captured, repository(self.path, approver='Ricky Reviewer', git_svn=True), mocks.local.Svn(), MockTerminal.input('n'):
             self.assertEqual(0, program.main(
                 args=('land', '-v'),
                 path=self.path, canonical_svn=True,
@@ -282,7 +294,7 @@ class TestLand(testing.PathTestCase):
         )
 
     def test_default_with_radar(self):
-        with OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False, issue_url='<rdar://problem/1>'), mocks.local.Svn(), \
+        with OutputCapture(level=logging.INFO) as captured, repository(self.path, approver='Ricky Reviewer', issue_url='<rdar://problem/1>'), mocks.local.Svn(), \
                 MockTerminal.input('n'), Environment(RADAR_USERNAME='tcontributor'), bmocks.Radar(issues=bmocks.ISSUES), \
                 patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
 
@@ -317,7 +329,7 @@ class TestLand(testing.PathTestCase):
         )
 
     def test_canonicalize_with_bugzilla(self):
-        with OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False, issue_url='{}/show_bug.cgi?id=1'.format(self.BUGZILLA)), \
+        with OutputCapture(level=logging.INFO) as captured, repository(self.path, approver='Ricky Reviewer', issue_url='{}/show_bug.cgi?id=1'.format(self.BUGZILLA)), \
                 mocks.local.Svn(), MockTerminal.input('n'), bmocks.Bugzilla(
                     self.BUGZILLA.split('://')[-1],
                     issues=bmocks.ISSUES,
@@ -374,7 +386,7 @@ class TestLand(testing.PathTestCase):
 
     def test_svn_with_bugzilla(self):
         with MockTime, OutputCapture(level=logging.INFO) as captured, \
-                repository(self.path, has_oops=False, git_svn=True, issue_url='{}/show_bug.cgi?id=1'.format(self.BUGZILLA)), \
+                repository(self.path, approver='Ricky Reviewer', git_svn=True, issue_url='{}/show_bug.cgi?id=1'.format(self.BUGZILLA)), \
                 mocks.local.Svn(), MockTerminal.input('n'), bmocks.Bugzilla(
                     self.BUGZILLA.split('://')[-1],
                     issues=bmocks.ISSUES,
@@ -492,7 +504,7 @@ class TestLandGitHub(testing.PathTestCase):
 
     def test_blocking_reviewer(self):
         with OutputCapture(level=logging.INFO) as captured, self.webserver(approved=False) as remote, \
-                repository(self.path, has_oops=False, remote='https://{}'.format(remote.remote)), mocks.local.Svn():
+                repository(self.path, approver='Ricky Reviewer', remote='https://{}'.format(remote.remote)), mocks.local.Svn():
 
             self.assertEqual(1, program.main(
                 args=('land', '-v'),
@@ -515,7 +527,7 @@ class TestLandGitHub(testing.PathTestCase):
     def test_insert_review(self):
         with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('y', 'n'), self.webserver(
                 approved=True) as remote, \
-                repository(self.path, has_oops=True, remote='https://{}'.format(remote.remote)), mocks.local.Svn():
+                repository(self.path, remote='https://{}'.format(remote.remote)), mocks.local.Svn():
             self.assertEqual(0, program.main(
                 args=('land', '-v'),
                 path=self.path,
@@ -547,6 +559,28 @@ class TestLandGitHub(testing.PathTestCase):
             "Delete branch 'eng/example'? ([Yes]/No): \n",
         )
 
+    def test_insert_review_indented(self):
+        with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('y', 'n'), self.webserver(
+                approved=True) as remote, \
+                repository(self.path, reviewed_by='    Reviewed by', remote='https://{}'.format(remote.remote)), mocks.local.Svn():
+            self.assertEqual(0, program.main(
+                args=('land', '-v'),
+                path=self.path,
+            ))
+
+        self.assertIn('Setting Ricky Reviewer as reviewer', captured.root.log.getvalue())
+
+    def test_insert_review_rubber_stamped(self):
+        with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('y', 'n'), self.webserver(
+                approved=True) as remote, \
+                repository(self.path, reviewed_by='Rubber-stamped by', remote='https://{}'.format(remote.remote)), mocks.local.Svn():
+            self.assertEqual(0, program.main(
+                args=('land', '-v'),
+                path=self.path,
+            ))
+
+        self.assertIn('Setting Ricky Reviewer as reviewer', captured.root.log.getvalue())
+
     def test_merge_queue(self):
         with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('y', 'n'), self.webserver(
             approved=True, labels={'merge-queue': dict(color='3AE653', description="Send PR to merge-queue")},
@@ -555,7 +589,7 @@ class TestLandGitHub(testing.PathTestCase):
                 GITHUB_EXAMPLE_COM_TOKEN='token',
             ),
         ) as remote, mocks.local.Svn(), repository(
-            self.path, has_oops=True,
+            self.path,
             remote='https://{}'.format(remote.remote),
             remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
         ):
@@ -599,7 +633,7 @@ class TestLandGitHub(testing.PathTestCase):
                 GITHUB_EXAMPLE_COM_TOKEN='token',
             ),
         ) as remote, mocks.local.Svn(), repository(
-            self.path, has_oops=True,
+            self.path,
             issue_url='{}/show_bug.cgi?id=1'.format(self.BUGZILLA),
             remote='https://{}'.format(remote.remote),
             remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
@@ -720,7 +754,7 @@ class TestLandBitBucket(testing.PathTestCase):
 
     def test_blocking_reviewer(self):
         with OutputCapture(level=logging.INFO) as captured, self.webserver(approved=False) as remote, repository(
-                self.path, has_oops=False, remote='ssh://git@{}/{}/{}.git'.format(
+                self.path, approver='Ricky Reviewer', remote='ssh://git@{}/{}/{}.git'.format(
                     remote.hosts[0], remote.project.split('/')[1], remote.project.split('/')[3],
                 )), mocks.local.Svn():
 
@@ -744,7 +778,7 @@ class TestLandBitBucket(testing.PathTestCase):
 
     def test_insert_review(self):
         with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('y', 'n'), self.webserver(approved=True) as remote, repository(
-                self.path, has_oops=True, remote='ssh://git@{}/{}/{}.git'.format(
+                self.path, remote='ssh://git@{}/{}/{}.git'.format(
                     remote.hosts[0], remote.project.split('/')[1], remote.project.split('/')[3],
                 )), mocks.local.Svn():
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -980,6 +980,57 @@ No pre-PR checks to run""")
             captured.stderr.getvalue(),
         )
 
+    def test_unreviewed_removal_collapses_blank_lines(self):
+        message = 'Unreviewed, fix the build.\n\n\nReviewed by Sam Sneddon.\n\nSome description.\n'
+        with self._unreviewed_with_reviewed_by_repo(message=message) as (repo, captured), MockTerminal.input('y'):
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history'),
+                path=self.path,
+            ))
+            self.assertEqual(repo.head.message, 'Unreviewed, fix the build.\n\nSome description.')
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_unreviewed_with_indented_reviewed_by(self):
+        message = 'Unreviewed, fix the build.\n\n    Reviewed by Sam Sneddon.\n'
+        with self._unreviewed_with_reviewed_by_repo(message=message) as (repo, captured), MockTerminal.input('y'):
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history'),
+                path=self.path,
+            ))
+            self.assertNotIn('Reviewed by', repo.head.message)
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_unreviewed_with_rubber_stamped_by(self):
+        message = 'Unreviewed, fix the build.\n\nRubber-stamped by Sam Sneddon.\n'
+        with self._unreviewed_with_reviewed_by_repo(message=message) as (repo, captured), MockTerminal.input('y'):
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history'),
+                path=self.path,
+            ))
+            self.assertNotIn('Rubber-stamped by', repo.head.message)
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_unreviewed_below_title(self):
+        message = 'Fix the build\n\nUnreviewed follow-up.\n\nReviewed by Sam Sneddon.\n'
+        with self._unreviewed_with_reviewed_by_repo(message=message) as (repo, captured), MockTerminal.input('y'):
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history'),
+                path=self.path,
+            ))
+            self.assertNotIn('Reviewed by', repo.head.message)
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_versioning_word_is_not_a_versioning_commit(self):
+        message = 'Fix the build\n\nVersionings happen often.\n\nReviewed by Sam Sneddon.\n'
+        with self._unreviewed_with_reviewed_by_repo(message=message) as (repo, captured), MockTerminal.input('n'):
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history'),
+                path=self.path,
+            ))
+            self.assertIn('Reviewed by Sam Sneddon.', repo.head.message)
+        self.assertNotIn('contains a', captured.stdout.getvalue())
+        self.assertEqual(captured.stderr.getvalue(), '')
+
 
     def test_github_bugzilla(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(


### PR DESCRIPTION
#### ca9bdcf6212c7f02eb301e132149182576d6956f
<pre>
[webkitscmpy][ews-build] Reviewer checks disagree about what counts as a reviewer line
<a href="https://bugs.webkit.org/show_bug.cgi?id=321244">https://bugs.webkit.org/show_bug.cgi?id=321244</a>
<a href="https://rdar.apple.com/184291423">rdar://184291423</a>

Reviewed by NOBODY (OOPS!).

EWS, `git-webkit pr`, `git-webkit land` and the commit message parser each
recognized a different set of reviewer lines. Only EWS knew about rubber
stamping, so `pr` never warned about a rubber-stamped commit marked
&quot;Unreviewed&quot;, `land` never offered to substitute the approver on one, and the
parser classified the line as description, which made `prepare-commit-msg`
inject a second &quot;Reviewed by NOBODY (OOPS!).&quot; on amend. Only some of them
tolerated the indentation `git-webkit cherry-pick` adds to the original
message.

Define the reviewer alternation once in commit_parser and use it for the
parser, `pr` and `land`, so a new reviewer form only has to be added in one
place. `pr` reuses the compiled pattern for both detecting and removing the
line, which is what previously let detection and removal disagree.

Anchor the &quot;Unreviewed&quot;/&quot;Versioning.&quot; check so a commit that merely mentions
either word in its body no longer triggers the prompt, and escape the dot in
&quot;Versioning.&quot; so it stops matching words like &quot;Versionings&quot;.

Land&apos;s (OOPS!) check was missing re.MULTILINE, so its `^[^-]+` prefix was
anchored to the start of the whole message and any earlier dash, such as a
bulleted line, defeated the check. On the EWS side, feed the same
`git log --format=%B` output to all four greps rather than only the last two,
and match land&apos;s (OOPS!) tolerance so a commit that removes an OOPS is not
allowed locally but blocked by EWS.

* Tools/CISupport/ews-build/steps.py:
(ValidateCommitMessage):
(ValidateCommitMessage.run):
* Tools/CISupport/ews-build/steps_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py:
(CommitMessageParser.parse_message):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py:
(Land):
(Land.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest):
(PullRequest.create_pull_request):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py:
(repository):
(TestLand.test_with_removed_oops):
(TestLand.test_with_oops_after_bullet):
(TestLand.test_default):
(TestLand.test_canonicalize):
(TestLand.test_no_svn_canonical_svn):
(TestLand.test_svn):
(TestLand.test_default_with_radar):
(TestLand.test_canonicalize_with_bugzilla):
(TestLand.test_svn_with_bugzilla):
(TestLandGitHub):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca9bdcf6212c7f02eb301e132149182576d6956f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147130 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184704 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142706 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99090 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123135 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182168 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45114 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43367 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42993 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4231 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195000 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182243 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56434 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152160 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57139 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39606 "Too many flaky failures: fast/mediastream/video-rotation-gpu-process-crash.html, http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/contentextensions/video-element-resource-type.html, http/tests/navigation/post-basic.html, http/tests/privateClickMeasurement/store-private-click-measurement.html, http/tests/resourceLoadStatistics/grandfathering.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/image-with-http-url-allowed-by-csp-img-src-star.html, http/tests/security/mixedContent/redirect-https-to-http-image-secure-cookies-UpgradeMixedContent.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151856 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46422 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125490 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55647 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18003 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55018 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55255 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55085 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->