### PR TITLE
[CoreText] Compensate glyph origins when substituting a space's base advance

### DIFF
--- a/LayoutTests/fast/text/combining-mark-on-space-paint-offset-expected.txt
+++ b/LayoutTests/fast/text/combining-mark-on-space-paint-offset-expected.txt
@@ -1,0 +1,13 @@
+This test makes sure that a combining mark whose grapheme cluster base is a space is not painted on top of the glyph preceding the space, that a combining mark applied directly to an ideograph keeps overlapping that ideograph, and that a mark Core Text already fit inside the space is not moved out of it.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS markOnSpaceLeavesPrecedingIdeographUntouched is true
+PASS markOnSpaceIsStillPainted is true
+PASS markOnIdeographStillOverlapsIdeograph is true
+PASS narrowMarkOnSpaceStaysInsideTheSpace is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/text/combining-mark-on-space-paint-offset.html
+++ b/LayoutTests/fast/text/combining-mark-on-space-paint-offset.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("This test makes sure that a combining mark whose grapheme cluster base is a space is not painted on top of the glyph preceding the space, that a combining mark applied directly to an ideograph keeps overlapping that ideograph, and that a mark Core Text already fit inside the space is not moved out of it.");
+
+// The bug needs a wide spacing mark glyph: U+0336 COMBINING LONG STROKE OVERLAY is one em wide in
+// Hiragino, so pin the family. Other fonts take the trivial pass below.
+const ideograph = "陸";
+const mark = "̶";
+// U+0301 COMBINING ACUTE ACCENT is narrow enough that Core Text leaves the space's advance alone and
+// centers the accent inside it, so no compensation is owed and the accent must not move.
+const narrowMark = "́";
+const font = "64px 'Hiragino Kaku Gothic Pro', 'Hiragino Sans', sans-serif";
+const canvasWidth = 400;
+const canvasHeight = 128;
+const originX = 20;
+const baselineY = 96;
+const inkThreshold = 32;
+
+function createContext() {
+    const canvas = document.createElement("canvas");
+    canvas.width = canvasWidth;
+    canvas.height = canvasHeight;
+    const context = canvas.getContext("2d");
+    context.font = font;
+    context.fillStyle = "black";
+    context.textBaseline = "alphabetic";
+    return context;
+}
+
+// fillText() uses the same text painting path as the DOM, so it sees the same glyph origins.
+function render(text) {
+    const context = createContext();
+    context.fillText(text, originX, baselineY);
+    return context.getImageData(0, 0, canvasWidth, canvasHeight).data;
+}
+
+function alphaAt(pixels, x, y) {
+    return pixels[4 * (y * canvasWidth + x) + 3];
+}
+
+function inkColumnRange(pixels) {
+    let left = -1;
+    let right = -1;
+    for (let x = 0; x < canvasWidth; ++x) {
+        for (let y = 0; y < canvasHeight; ++y) {
+            if (alphaAt(pixels, x, y) > inkThreshold) {
+                if (left < 0)
+                    left = x;
+                right = x;
+                break;
+            }
+        }
+    }
+    return { left: left, right: right };
+}
+
+// Does drawing "text" put ink into any column of [left, right] where the ideograph alone had none?
+function addsInkInColumns(pixels, ideographOnly, left, right) {
+    for (let x = left; x <= right; ++x) {
+        for (let y = 0; y < canvasHeight; ++y) {
+            if (alphaAt(pixels, x, y) - alphaAt(ideographOnly, x, y) > inkThreshold)
+                return true;
+        }
+    }
+    return false;
+}
+
+// The columns "text" inks that "basePixels" did not, which for a mark is where the mark landed.
+function addedInkColumnRange(pixels, basePixels) {
+    let left = -1;
+    let right = -1;
+    for (let x = 0; x < canvasWidth; ++x) {
+        for (let y = 0; y < canvasHeight; ++y) {
+            if (alphaAt(pixels, x, y) - alphaAt(basePixels, x, y) > inkThreshold) {
+                if (left < 0)
+                    left = x;
+                right = x;
+                break;
+            }
+        }
+    }
+    return { left: left, right: right };
+}
+
+const metricsContext = createContext();
+const spaceAdvance = metricsContext.measureText(" ").width;
+const markMetrics = metricsContext.measureText(mark);
+// A lone combining mark always measures zero wide, so its ink box is the only proxy for its advance here.
+// Require ink entirely right of the origin and wider than a space; otherwise pass trivially.
+const triggerPresent = spaceAdvance > 0
+    && metricsContext.measureText(ideograph).width > 0
+    && markMetrics.actualBoundingBoxLeft <= 0.5
+    && markMetrics.actualBoundingBoxRight > spaceAdvance + 1;
+
+var markOnSpaceLeavesPrecedingIdeographUntouched = true;
+var markOnSpaceIsStillPainted = true;
+var markOnIdeographStillOverlapsIdeograph = true;
+var narrowMarkOnSpaceStaysInsideTheSpace = true;
+
+if (triggerPresent) {
+    const ideographOnly = render(ideograph);
+    const markOnSpace = render(ideograph + " " + mark);
+    const markOnIdeograph = render(ideograph + mark);
+    const ideographInk = inkColumnRange(ideographOnly);
+
+    // The stroke belongs in the gap after the space, so it must add no ink over the preceding ideograph.
+    markOnSpaceLeavesPrecedingIdeographUntouched = !addsInkInColumns(markOnSpace, ideographOnly, ideographInk.left, ideographInk.right);
+
+    // It does still have to be painted, somewhere to the right of the ideograph.
+    markOnSpaceIsStillPainted = inkColumnRange(markOnSpace).right > ideographInk.right;
+
+    // An ideograph base has no space advance to substitute, so Core Text's deliberate strike-through
+    // placement has to survive unchanged.
+    markOnIdeographStillOverlapsIdeograph = addsInkInColumns(markOnIdeograph, ideographOnly, ideographInk.left, ideographInk.right);
+
+    // Core Text already fits an accent this narrow inside the space, so nothing is owed to its origin and it must
+    // not move; Chrome and Firefox instead paint it past the space.
+    const narrowMarkOnSpace = render(ideograph + " " + narrowMark);
+    const narrowMarkInk = addedInkColumnRange(narrowMarkOnSpace, ideographOnly);
+    const spaceBoxRight = originX + metricsContext.measureText(ideograph).width + spaceAdvance;
+    // Only meaningful when the accent is in fact narrow enough to fit inside the space.
+    if (narrowMarkInk.left >= 0 && narrowMarkInk.right - narrowMarkInk.left < spaceAdvance)
+        narrowMarkOnSpaceStaysInsideTheSpace = narrowMarkInk.right <= spaceBoxRight + 1;
+}
+
+shouldBeTrue("markOnSpaceLeavesPrecedingIdeographUntouched");
+shouldBeTrue("markOnSpaceIsStillPainted");
+shouldBeTrue("markOnIdeographStillOverlapsIdeograph");
+shouldBeTrue("narrowMarkOnSpaceStaysInsideTheSpace");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -712,7 +712,8 @@ void ComplexTextController::adjustGlyphsAndAdvances()
         unsigned glyphCount = complexTextRun->glyphCount();
         Ref font = complexTextRun->font();
 
-        if (!complexTextRun->isLTR())
+        bool runIsLTR = complexTextRun->isLTR();
+        if (!runIsLTR)
             m_isLTROnly = false;
 
         auto glyphs = complexTextRun->glyphs();
@@ -724,6 +725,9 @@ void ComplexTextController::adjustGlyphsAndAdvances()
         FloatPoint glyphOrigin;
         unsigned previousCharacterIndex = m_run->ltr() ? std::numeric_limits<unsigned>::min() : std::numeric_limits<unsigned>::max();
         bool isMonotonic = true;
+        // What the cluster's base owes the origins of the marks that follow it; zero until a base is emitted.
+        // FIXME: Handle a cluster CoreText split across two runs, whose base is the previous run's last glyph.
+        float originCompensationOwedToMarks = 0;
 
 #if USE(CORE_TEXT) || USE(SKIA)
         auto boundsForGlyphs = font->boundsForGlyphs(glyphs);
@@ -741,10 +745,15 @@ void ComplexTextController::adjustGlyphsAndAdvances()
             char16_t character = charactersSpan[characterIndex];
 
             bool treatAsSpace = FontCascade::treatAsSpace(character);
+            bool isTabWithTabStops = character == tabCharacter && m_run->allowTabs();
+            // Every treatAsSpace() character but a tab with tab stops takes the font's space width below, moving the
+            // pen its marks are positioned against. CoreText emits glyphs in visual order, so only an LTR cluster's
+            // marks follow their base and are affected by that.
+            bool shouldCompensateMarkOrigins = treatAsSpace && !isTabWithTabStops && runIsLTR;
             CGGlyph glyph = glyphs[glyphIndex];
             FloatSize advance = treatAsSpace ? FloatSize(spaceWidth, advances[glyphIndex].height()) : advances[glyphIndex];
 
-            if (character == tabCharacter && m_run->allowTabs()) {
+            if (isTabWithTabStops) {
                 advance.setWidth(m_fontCascade->tabWidth(font.get(), m_run->tabSize(), m_run->xPos() + m_totalAdvance.width(), Font::SyntheticBoldInclusion::Exclude));
                 // Like simple text path in WidthIterator::applyCSSVisibilityRules,
                 // make tabCharacter glyph invisible after advancing.
@@ -877,10 +886,20 @@ void ComplexTextController::adjustGlyphsAndAdvances()
             }
 
             m_adjustedBaseAdvances.append(advance);
+            // A glyph that advances the pen is a cluster base and keeps its own origin; the zero-advance glyphs
+            // after it are its marks, and take the compensation their base recorded.
+            float originCompensation = originCompensationOwedToMarks;
+            if (advances[glyphIndex].width()) {
+                originCompensation = 0;
+                // CoreText guarantees only the sum of a cluster's base advances and glyph origins, so adding the
+                // difference back to the marks' origins moves the cluster as a whole.
+                // FIXME: Compensate the synthetic bold, letter-spacing, expansion and word-spacing adjustments too.
+                originCompensationOwedToMarks = shouldCompensateMarkOrigins ? advances[glyphIndex].width() - spaceWidth : 0;
+            }
             if (auto origins = complexTextRun->glyphOrigins(); !origins.empty()) {
                 ASSERT(m_glyphOrigins.size() < m_adjustedBaseAdvances.size());
                 m_glyphOrigins.grow(m_adjustedBaseAdvances.size());
-                m_glyphOrigins[m_glyphOrigins.size() - 1] = origins[glyphIndex] + FloatSize(textAutoSpaceSpacing, 0);
+                m_glyphOrigins[m_glyphOrigins.size() - 1] = origins[glyphIndex] + FloatSize(textAutoSpaceSpacing + originCompensation, 0);
                 ASSERT(m_glyphOrigins.size() == m_adjustedBaseAdvances.size());
             }
             m_adjustedGlyphs.append(glyph);

--- a/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
@@ -258,6 +258,91 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTLNoOrigins)
     EXPECT_NEAR(height(glyphBuffer.advanceAt(3)), 12.368896925859, 0.0001);
 }
 
+// Core Text fits a wide combining mark by widening its base's advance and giving the mark a negative origin, so
+// substituting the font's space width for a space base moves the pen the following mark is positioned against. In
+// an LTR run that mark has to be compensated by the same amount, or it slides left onto the preceding glyph.
+TEST_F(ComplexTextControllerTest, SubstitutedSpaceAdvanceCompensatesFollowingMarkInLTR)
+{
+    FontCascadeDescription description;
+    description.setOneFamily("Times"_s);
+    description.setComputedSize(80);
+    FontCascade font(WTF::move(description));
+    font.update();
+    auto spaceWidth = font.primaryFont().spaceWidth(Font::SyntheticBoldInclusion::Exclude);
+
+    // 'a', then a [space, combining mark] cluster whose whole 100pt advance Core Text put on the space.
+    Vector<FloatSize> advances = { FloatSize(40, 0), FloatSize(100, 0), FloatSize() };
+    Vector<FloatPoint> origins = { FloatPoint(), FloatPoint(), FloatPoint(-100, -20) };
+
+    std::array<char16_t, 3> characters { 'a', 0x20, 0x336 };
+    TextRun textRun { StringView(characters) };
+    auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 3, 500 }, { 0, 1, 2 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 0, 3, true);
+    Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
+    runs.append(WTF::move(run));
+    ComplexTextController controller(font, textRun, runs);
+
+    // Only the space's layout advance is substituted; the mark stays zero width.
+    EXPECT_NEAR(controller.totalAdvance().width(), advances[0].width() + spaceWidth, 0.0001);
+    GlyphBuffer glyphBuffer;
+    controller.advance(3, &glyphBuffer);
+    EXPECT_EQ(glyphBuffer.size(), 3U);
+    EXPECT_NEAR(width(glyphBuffer.initialAdvance()), 0, 0.0001);
+    EXPECT_NEAR(width(glyphBuffer.advanceAt(0)), advances[0].width(), 0.0001);
+    // The mark's origin gains (100 - spaceWidth), so it is still painted at the space's left edge where Core Text
+    // put it, rather than (100 - spaceWidth) further left, on top of the 'a'.
+    EXPECT_NEAR(width(glyphBuffer.advanceAt(1)), 0, 0.0001);
+    EXPECT_NEAR(width(glyphBuffer.advanceAt(2)), spaceWidth, 0.0001);
+    EXPECT_NEAR(height(glyphBuffer.advanceAt(0)), 0, 0.0001);
+    EXPECT_NEAR(height(glyphBuffer.advanceAt(1)), -origins[2].y(), 0.0001);
+    EXPECT_NEAR(height(glyphBuffer.advanceAt(2)), origins[2].y(), 0.0001);
+}
+
+// The other half of the same claim: Core Text emits glyphs in visual order, so in an RTL run a cluster's marks
+// precede their base and the glyph before a mark is the neighboring cluster's, not its own base. Compensating
+// there would shift a mark by an amount owed to a space it is not attached to.
+TEST_F(ComplexTextControllerTest, SubstitutedSpaceAdvanceDoesNotCompensateInRTL)
+{
+    FontCascadeDescription description;
+    description.setOneFamily("Times"_s);
+    description.setComputedSize(80);
+    FontCascade font(WTF::move(description));
+    font.update();
+    auto spaceWidth = font.primaryFont().spaceWidth(Font::SyntheticBoldInclusion::Exclude);
+
+    // [alef, mark] then [space, mark], in visual order: the space's mark, the space, the alef's mark, the alef.
+    // Core Text widened the space to 100pt to hold its mark, so a compensation here would be (100 - spaceWidth).
+    Vector<FloatSize> advances = { FloatSize(), FloatSize(100, 0), FloatSize(), FloatSize(60, 0) };
+    Vector<FloatPoint> origins = { FloatPoint(-100, -30), FloatPoint(), FloatPoint(-60, -20), FloatPoint() };
+
+    // As in the other RTL tests, a leading zero-advance glyph's origin is also reported as the initial advance.
+    FloatSize initialAdvance = FloatSize(-100, -30);
+
+    std::array<char16_t, 4> characters { 0x627, 0x336, 0x20, 0x336 };
+    TextRun textRun(StringView(characters), 0, 0, ExpansionBehavior::defaultBehavior(), TextDirection::RTL);
+    auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 500, 3, 500, 227 }, { 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 4, false);
+    Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
+    runs.append(WTF::move(run));
+    ComplexTextController controller(font, textRun, runs);
+
+    EXPECT_NEAR(controller.totalAdvance().width(), spaceWidth + advances[3].width(), 0.0001);
+    GlyphBuffer glyphBuffer;
+    controller.advance(4, &glyphBuffer);
+    EXPECT_EQ(glyphBuffer.size(), 4U);
+    EXPECT_NEAR(width(glyphBuffer.initialAdvance()), initialAdvance.width(), 0.0001);
+    EXPECT_NEAR(height(glyphBuffer.initialAdvance()), initialAdvance.height(), 0.0001);
+    EXPECT_NEAR(width(glyphBuffer.advanceAt(0)), advances[3].width(), 0.0001);
+    // The alef's mark keeps the offset Core Text gave it. Compensating it would make this -origins[2].x() - (100 -
+    // spaceWidth) and slide the mark off the alef.
+    EXPECT_NEAR(width(glyphBuffer.advanceAt(1)), -origins[2].x(), 0.0001);
+    EXPECT_NEAR(width(glyphBuffer.advanceAt(2)), spaceWidth + origins[2].x(), 0.0001);
+    // The space's own mark precedes the space, so the substitution never moved the pen it is positioned against.
+    EXPECT_NEAR(width(glyphBuffer.advanceAt(3)), -origins[0].x(), 0.0001);
+    EXPECT_NEAR(height(glyphBuffer.advanceAt(0)), 0, 0.0001);
+    EXPECT_NEAR(height(glyphBuffer.advanceAt(1)), origins[2].y(), 0.0001);
+    EXPECT_NEAR(height(glyphBuffer.advanceAt(2)), -origins[2].y(), 0.0001);
+    EXPECT_NEAR(height(glyphBuffer.advanceAt(3)), origins[0].y(), 0.0001);
+}
+
 TEST_F(ComplexTextControllerTest, LeftExpansion)
 {
     FontCascadeDescription description;


### PR DESCRIPTION
#### 8554625dd5ad243cee47dbfb3aaab6a22adebdc0
<pre>
[CoreText] Compensate glyph origins when substituting a space&apos;s base advance
<a href="https://bugs.webkit.org/show_bug.cgi?id=321246">https://bugs.webkit.org/show_bug.cgi?id=321246</a>
&lt;<a href="https://rdar.apple.com/180227130">rdar://180227130</a>&gt;

Reviewed by Vitor Roriz.

ComplexTextController::adjustGlyphsAndAdvances() replaces CoreText&apos;s base advance with the
font&apos;s space width for treatAsSpace glyphs, but leaves CoreText&apos;s glyph origins untouched.
CoreText only guarantees the sum of its advances and origins, so for a [space, combining mark]
grapheme cluster (where it attributes the cluster&apos;s whole advance to the space and gives
the mark a negative origin) the substitution slides the mark relative to its base instead
of moving the cluster as a whole.

With a one-em-wide mark such as U+0336 COMBINING LONG STROKE OVERLAY in Hiragino, the mark
lands a full em to the left of where CoreText placed it, striking through the preceding glyph.

This patch addresses this by adding the opposite amount to the origins of the cluster&apos;s
trailing zero-advance glyphs, so the cluster moves as a unit. Layout advances but ink bounds
and m_adjustedGlyphs are untouched.

CoreText emits glyphs in visual order, so a right-to-left cluster&apos;s marks precede their base
and the substitution never moves the pen they are positioned against. We do not need to
make special corrections for RTL cases. The two new API tests pin that reasoning down: they
run the same [space, wide mark] geometry through an LTR and an RTL run, and the RTL one is
the case the direction check exists for, since there the glyph preceding a mark is the
neighboring cluster&apos;s base rather than the mark&apos;s own.

Tests: fast/text/combining-mark-on-space-paint-offset.html
       TestWebKitAPI.ComplexTextControllerTest.SubstitutedSpaceAdvanceCompensatesFollowingMarkInLTR
       TestWebKitAPI.ComplexTextControllerTest.SubstitutedSpaceAdvanceDoesNotCompensateInRTL

* LayoutTests/fast/text/combining-mark-on-space-paint-offset-expected.txt: Added.
* LayoutTests/fast/text/combining-mark-on-space-paint-offset.html: Added.
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::adjustGlyphsAndAdvances):
* Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/319556@main">https://commits.webkit.org/319556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e84776935fa91471febbfb715be04853e76c2ccb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146159 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3e73f50-e7a1-4237-9b43-a86a48534ff3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141941 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e2bd9119-c1c8-41c8-b64a-802ed697857c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122377 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd3d8fa8-8843-4a83-a389-20aa1410684a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44309 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42580 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42214 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3217 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48408 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193982 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162186 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151355 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40530 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56136 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151060 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45632 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128419 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124178 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54649 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17210 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54031 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54270 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54096 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->