### PR TITLE
[WebDriver][WPE] Gardening W32 2026 edition

### DIFF
--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -194,11 +194,20 @@
 
     "imported/selenium/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py": {
         "subtests": {
+            "test_get_tree_with_child": {
+                "expected": {"all": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/310506"}}
+            },
+            "test_reload_browsing_context": {
+                "expected": {"all": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/310506"}}
+            },
+            "test_reload_with_readiness_state": {
+                "expected": {"wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/310506"}}
+            },
             "test_add_event_handler_context_created": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}, "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/303207"}}
             },
             "test_add_event_handler_dom_content_loaded": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/302058"}}
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/302058"}, "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/310506"}}
             },
             "test_add_event_handler_download_will_begin": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288338"}}
@@ -210,7 +219,7 @@
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/287936"}}
             },
             "test_add_event_handler_load": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288340"}}
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288340"}, "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/310506"}}
             },
             "test_add_event_handler_navigation_committed": {
                 "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/287934"}}
@@ -228,7 +237,7 @@
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
             },
             "test_concurrent_event_handler_registration": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}, "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/310506"}}
             },
             "test_event_callback_data_consistency": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}


### PR DESCRIPTION
#### f261a909c8d9b0b93313035017599dee5ee7090f
<pre>
[WebDriver][WPE] Gardening W32 2026 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=321152">https://bugs.webkit.org/show_bug.cgi?id=321152</a>

Unreviewed test gardening.

Gardening the most persistent flakies.

* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/318766@main">https://commits.webkit.org/318766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6b02e802b50e20f8b086898c074f2ad926a8438

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179344 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52993 "Build is in progress. Recent messages:") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/189176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182301 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/52993 "Build is in progress. Recent messages:") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/627 "Built successfully") | 
| | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/52993 "Build is in progress. Recent messages:") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191394 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/52953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/160120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/148851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27212 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120766 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/15094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->