### PR TITLE
[YARR] JIT string-list alternative with a non-BMP character matches after only its leading characters

### DIFF
--- a/JSTests/stress/regexp-string-list-non-bmp-alternative.js
+++ b/JSTests/stress/regexp-string-list-non-bmp-alternative.js
@@ -1,0 +1,56 @@
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error((message ? message + ": " : "") + "expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+function shouldBeMatch(result, expected, message) {
+    if (expected === null) {
+        shouldBe(result, null, message);
+        return;
+    }
+    if (result === null)
+        throw new Error((message ? message + ": " : "") + "expected a match but got null");
+    shouldBe(result.length, 1, message + " (length)");
+    shouldBe(result[0], expected, message + " [0]");
+    shouldBe(result.index, 0, message + " (index)");
+}
+
+function test(re, subject, expected) {
+    // Append a 16-bit character so the subject is a 16-bit string.
+    var input = subject + "ā";
+    shouldBeMatch(re.exec(input), expected, re + ".exec(" + JSON.stringify(input) + ")");
+}
+
+// A non-last alternative containing a non-BMP character must not succeed after
+// matching only the characters before it.
+test(/^(?:a\u{1F600}|qa)/u, "azk", null);
+test(/^(?:a\u{1F600}|qa)/u, "z\u{1F600}", null);
+test(/^(?:a\u{1F600}|qa)/u, "a\u{1F600}", "a\u{1F600}");
+test(/^(?:a\u{1F600}|qa)/u, "qa", "qa");
+test(/^(?:a\u{1F600}|qa)/v, "azk", null);
+
+test(/^(?:a\u{1F600}c|q)/u, "azkc", null);
+test(/^(?:a\u{1F600}c|q)/u, "a\u{1F600}z", null);
+test(/^(?:a\u{1F600}c|q)/u, "a\u{1F600}c", "a\u{1F600}c");
+test(/^(?:a\u{1F600}c|q)/u, "q", "q");
+
+test(/^(?:foo|a\u{1F600}b|bar)/u, "axyz", null);
+test(/^(?:foo|a\u{1F600}b|bar)/u, "a\u{1F600}b", "a\u{1F600}b");
+test(/^(?:foo|a\u{1F600}b|bar)/u, "bar", "bar");
+
+test(/^(?:abcd\u{1F600}|abcdz)$/u, "abcdā", null);
+test(/^(?:abcd\u{1F600}|abcdz)$/u, "abcd\u{1F600}", null);
+shouldBeMatch(/^(?:abcd\u{1F600}|abcdz)$/u.exec("abcd\u{1F600}"), "abcd\u{1F600}", "EOL string list exact");
+shouldBeMatch(/^(?:abcd\u{1F600}|abcdz)$/u.exec("abcdz"), "abcdz", "EOL string list second alternative");
+
+// Lone surrogate literal splits the run the same way.
+test(/^(?:a\uD83D|qa)/u, "azk", null);
+test(/^(?:a\uD83D|qa)/u, "qa", "qa");
+
+// Non-BMP character first in the alternative.
+test(/^(?:\u{1F600}ab|q)/u, "\u{1F600}az", null);
+test(/^(?:\u{1F600}ab|q)/u, "\u{1F600}ab", "\u{1F600}ab");
+
+// Non-BMP character in the last alternative already worked.
+test(/^(?:qa|a\u{1F600})/u, "azk", null);
+test(/^(?:qa|a\u{1F600})/u, "a\u{1F600}", "a\u{1F600}");

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2981,7 +2981,7 @@ class YarrGenerator final : public YarrJITInfo {
 
             auto numRealCharsToCheck = roundUpToPowerOfTwo(lastCharInLoad - firstCharInLoad + 1);
 
-            MatchTargets* matchTargetForFinalComparison = (opListIdx + numCharsToCheck >= opList.size()) ? &lastMatchTargets : &defaultMatchTargets;
+            MatchTargets* matchTargetForFinalComparison = (opListIdx + numCharsToCheck >= opList.size() && m_ops[opIndex + opList.size()].m_op != YarrOpCode::Term) ? &lastMatchTargets : &defaultMatchTargets;
 
             if (m_charSize == CharSize::Char8) {
                 auto check1 = [&] (Checked<unsigned> offset, char32_t characters, uint16_t caseMask, MatchTargets& matchTargets) {


### PR DESCRIPTION
#### dc35ebdb9bf4758406098b665ee7974f1b28cb76
<pre>
[YARR] JIT string-list alternative with a non-BMP character matches after only its leading characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=321251">https://bugs.webkit.org/show_bug.cgi?id=321251</a>

Reviewed by Yusuke Suzuki.

In a string-list group, a non-last alternative may branch to the group&apos;s
success target only from the comparison of its last character.
generatePatternCharacterOnce() collects adjacent characters into opList but,
with a 16-bit subject and /u or /v, stops at a non-BMP or lone surrogate
character, which is matched by its own Term afterwards. Since 292003@main
the success branch was emitted on reaching the end of opList rather than the
end of the alternative:

  /^(?:a\u{1F600}|qa)/u.exec(&quot;azk\u0101&quot;)        // [&quot;azk&quot;], expected null
  /^(?:a\u{1F600}|qa)/u.exec(&quot;z\u{1F600}\u0101&quot;) // [&quot;z\u{1F600}&quot;], expected null

Only use lastMatchTargets when m_ops[opIndex + opList.size()] is not a Term,
as 290791@main originally did.

Test: JSTests/stress/regexp-string-list-non-bmp-alternative.js

* JSTests/stress/regexp-string-list-non-bmp-alternative.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/318956@main">https://commits.webkit.org/318956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1a2b1692567c2597a6259485cd361224fed15a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179348 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189180 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143657 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139859 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96797 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120311 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178673 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42137 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40466 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2281 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9094 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152537 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40114 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/631 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40623 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191398 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52957 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149112 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40092 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53638 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148855 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43528 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125910 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120772 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52155 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15100 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51540 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51781 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->