### PR TITLE
Fix crash from double-consuming the pending exception in DeferredPromise::reject() during Navigation reload()/navigate() error handling

### DIFF
--- a/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash-expected.txt
@@ -1,0 +1,18 @@
+Tests that navigation.navigate() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. This is the navigate() counterpart of navigation-reload-state-clone-exception-crash.html: navigate() and reload() share the same Navigation::createErrorResult(), which used to call DeferredPromise::reject() twice with the same ExceptionCode::ExistingExceptionError exception, and only the first call could recover the pending JS exception.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof result is 'object'
+PASS 'committed' in result is true
+PASS 'finished' in result is true
+PASS result.committed instanceof Promise is true
+PASS result.finished instanceof Promise is true
+PASS committedError.message is "state clone error"
+PASS finishedError.message is "state clone error"
+PASS committedError === finishedError is true
+PASS did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash.html
+++ b/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.navigate() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. This is the navigate() counterpart of navigation-reload-state-clone-exception-crash.html: navigate() and reload() share the same Navigation::createErrorResult(), which used to call DeferredPromise::reject() twice with the same ExceptionCode::ExistingExceptionError exception, and only the first call could recover the pending JS exception.");
+
+jsTestIsAsync = true;
+
+var result;
+var committedError;
+var finishedError;
+
+window.onload = async () => {
+    result = navigation.navigate("about:blank#navigated", { state: { get x() { throw new Error("state clone error"); } } });
+
+    shouldBe("typeof result", "'object'");
+    shouldBeTrue("'committed' in result");
+    shouldBeTrue("'finished' in result");
+    shouldBeTrue("result.committed instanceof Promise");
+    shouldBeTrue("result.finished instanceof Promise");
+
+    try {
+        await result.committed;
+        testFailed("committed promise should be rejected");
+    } catch (e) {
+        committedError = e;
+    }
+    shouldBeEqualToString("committedError.message", "state clone error");
+
+    try {
+        await result.finished;
+        testFailed("finished promise should be rejected");
+    } catch (e) {
+        finishedError = e;
+    }
+    shouldBeEqualToString("finishedError.message", "state clone error");
+
+    shouldBeTrue("committedError === finishedError");
+
+    testPassed("did not crash");
+    finishJSTest();
+};
+</script>

--- a/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash-expected.txt
@@ -1,0 +1,18 @@
+Tests that navigation.reload() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. Found by a fuzzer: a throwing getter on the state object made Navigation::serializeState() fail with ExceptionCode::ExistingExceptionError, and DeferredPromise::reject() was only able to recover the pending JS exception once, so the second of the two reject() calls in Navigation::createErrorResult() hit an assertion.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof result is 'object'
+PASS 'committed' in result is true
+PASS 'finished' in result is true
+PASS result.committed instanceof Promise is true
+PASS result.finished instanceof Promise is true
+PASS committedError.message is "state clone error"
+PASS finishedError.message is "state clone error"
+PASS committedError === finishedError is true
+PASS did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash.html
+++ b/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.reload() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. Found by a fuzzer: a throwing getter on the state object made Navigation::serializeState() fail with ExceptionCode::ExistingExceptionError, and DeferredPromise::reject() was only able to recover the pending JS exception once, so the second of the two reject() calls in Navigation::createErrorResult() hit an assertion.");
+
+jsTestIsAsync = true;
+
+var result;
+var committedError;
+var finishedError;
+
+window.onload = async () => {
+    result = navigation.reload({ state: { get x() { throw new Error("state clone error"); } } });
+
+    shouldBe("typeof result", "'object'");
+    shouldBeTrue("'committed' in result");
+    shouldBeTrue("'finished' in result");
+    shouldBeTrue("result.committed instanceof Promise");
+    shouldBeTrue("result.finished instanceof Promise");
+
+    try {
+        await result.committed;
+        testFailed("committed promise should be rejected");
+    } catch (e) {
+        committedError = e;
+    }
+    shouldBeEqualToString("committedError.message", "state clone error");
+
+    try {
+        await result.finished;
+        testFailed("finished promise should be rejected");
+    } catch (e) {
+        finishedError = e;
+    }
+    shouldBeEqualToString("finishedError.message", "state clone error");
+
+    shouldBeTrue("committedError === finishedError");
+
+    testPassed("did not crash");
+    finishJSTest();
+};
+</script>

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -192,13 +192,15 @@ void DeferredPromise::reject(Exception exception, RejectAsHandled rejectAsHandle
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     if (exception.code() == ExceptionCode::ExistingExceptionError) {
-        EXCEPTION_ASSERT(scope.exception());
-        auto error = scope.exception()->value();
-        bool isTerminating = handleTerminationExceptionIfNeeded(scope, lexicalGlobalObject);
-        if (!isTerminating) {
+        if (exceptionObject.isEmpty()) {
+            EXCEPTION_ASSERT(scope.exception());
+            auto error = scope.exception()->value();
+            if (handleTerminationExceptionIfNeeded(scope, lexicalGlobalObject))
+                return;
             scope.clearException();
-            reject<IDLAny>(error, rejectAsHandled);
+            exceptionObject = error;
         }
+        reject<IDLAny>(exceptionObject, rejectAsHandled);
         return;
     }
 


### PR DESCRIPTION
#### 37cfccb3c6c9ae9cc09b9d9908c190286ac2e858
<pre>
Fix crash from double-consuming the pending exception in DeferredPromise::reject() during Navigation reload()/navigate() error handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=321250">https://bugs.webkit.org/show_bug.cgi?id=321250</a>
<a href="https://rdar.apple.com/183911429">rdar://183911429</a>

Reviewed by Rupin Mittal.

Navigation::createErrorResult() rejects both the committed and finished promises with the same Exception. When that exception carries ExceptionCode::ExistingExceptionError — the
sentinel meaning &quot;the real JS exception is already sitting on the VM&apos;s exception scope&quot; — DeferredPromise::reject() pulled the value straight off scope.exception() and called
scope.clearException() as a side effect. That works for the first reject() call, but clears the exception before the second call runs, so it finds nothing there: an assert in
debug/ASan builds, a null-pointer read of Exception::m_value in release builds — either way, a crash on every reload()/navigate() whose state argument throws during
structured-clone.

The fix reuses the exceptionObject out-parameter that&apos;s already threaded through both reject() calls (the same parameter the plain-ExceptionCode branch a few lines below already
uses to build the DOMException once and share it across calls). On the first call, if exceptionObject is still empty, it extracts the value from the exception scope, clears it, and
caches the result in exceptionObject; on the second call, exceptionObject is already populated, so it skips touching the exception scope entirely and just rejects with the cached
value. This matches the pattern already used elsewhere in Navigation.cpp (rejectFinishedPromise, which precomputes a DOMException once and passes it to both promise rejections),
and it satisfies the spec requirement that committed and finished reject with the identical error value — which a &quot;swallow and fall back to a generic error&quot; fix would not have.

Tests: navigation-api/navigation-navigate-state-clone-exception-crash.html
       navigation-api/navigation-reload-state-clone-exception-crash.html

* LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash-expected.txt: Added.
* LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash.html: Added.
* LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash-expected.txt: Added.
* LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash.html: Added.
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
(WebCore::DeferredPromise::reject):

Canonical link: <a href="https://commits.webkit.org/318836@main">https://commits.webkit.org/318836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad42e0b6c8f291664d4e915135c73e91d7557b94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189181 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143658 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139860 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120312 "Passed tests") | | ⏳ 🛠 vision-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178674 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42136 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40467 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152536 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40111 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/632 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191399 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52958 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149114 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53639 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148857 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27262 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43530 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125911 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120773 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52156 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15097 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51541 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51782 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51602 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->