### PR TITLE
[YARR] `\P{...}` on the right side of a v-mode `&&` or `--` becomes a union

### DIFF
--- a/JSTests/stress/regexp-v-flag-class-set-op-inverted-property.js
+++ b/JSTests/stress/regexp-v-flag-class-set-op-inverted-property.js
@@ -1,0 +1,127 @@
+function shouldBe(actual, expected, description) {
+    if (actual !== expected)
+        throw new Error(`${description}: expected ${expected} but got ${actual}`);
+}
+
+function shouldThrowSyntaxError(pattern) {
+    let error = null;
+    try {
+        new RegExp(pattern, "v");
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof SyntaxError))
+        throw new Error(`/${pattern}/v: expected SyntaxError but got ${error}`);
+}
+
+function test(pattern, input, expected, flags = "v") {
+    const regexp = new RegExp(pattern, flags);
+    shouldBe(regexp.test(input), expected, `/${pattern}/${flags}.test(${JSON.stringify(input)})`);
+}
+
+// \P{...} as the right-hand operand of an intersection.
+test("^[\\P{Number}&&\\P{Alphabetic}]$", "A", false);
+test("^[\\P{Number}&&\\P{Alphabetic}]$", "1", false);
+test("^[\\P{Number}&&\\P{Alphabetic}]$", "!", true);
+test("^[\\p{L}&&\\P{Lu}]$", "A", false);
+test("^[\\p{L}&&\\P{Lu}]$", "a", true);
+test("^[\\p{L}&&\\P{Lu}]$", "1", false);
+test("^[[a-z]&&\\P{Lu}]$", "a", true);
+test("^[[a-z]&&\\P{Lu}]$", "1", false);
+test("^[\\P{Lu}&&\\P{Ll}&&\\P{N}]$", "!", true);
+test("^[\\P{Lu}&&\\P{Ll}&&\\P{N}]$", "A", false);
+test("^[\\P{Lu}&&\\P{Ll}&&\\P{N}]$", "a", false);
+test("^[\\P{Lu}&&\\P{Ll}&&\\P{N}]$", "1", false);
+test("^[\\p{Any}&&\\P{ASCII}]$", "\u{10000}", true);
+test("^[\\p{Any}&&\\P{ASCII}]$", "a", false);
+
+// \P{...} as the right-hand operand of a subtraction.
+test("^[\\P{Lu}--\\P{L}]$", "a", true);
+test("^[\\P{Lu}--\\P{L}]$", "A", false);
+test("^[\\P{Lu}--\\P{L}]$", "1", false);
+test("^[\\p{ASCII}--\\P{L}]$", "a", true);
+test("^[\\p{ASCII}--\\P{L}]$", "1", false);
+test("^[\\p{Any}--\\P{ASCII}]$", "a", true);
+test("^[\\p{Any}--\\P{ASCII}]$", "\u{10000}", false);
+test("^[\\p{Any}--\\P{L}--\\P{Lu}]$", "A", true);
+test("^[\\p{Any}--\\P{L}--\\P{Lu}]$", "a", false);
+test("^[\\p{Any}--\\P{L}--\\P{Lu}]$", "1", false);
+
+// Complement code points around the Latin-1 / non-Latin-1 split and isolated complement code points inside Latin-1.
+// U+00FF and U+0100 are both letters; U+00D7 and U+00F7 are non-letters surrounded by letters; U+00B5 is a letter surrounded by non-letters.
+test("^[\\p{Any}&&\\P{L}]$", "\xff", false);
+test("^[\\p{Any}&&\\P{L}]$", "Ā", false);
+test("^[\\p{Any}&&\\P{L}]$", "\xd7", true);
+test("^[\\p{Any}&&\\P{L}]$", "\xf7", true);
+test("^[\\p{Any}&&\\P{L}]$", "\xb5", false);
+test("^[\\p{Any}&&\\P{L}]$", "\xb4", true);
+test("^[\\p{Any}&&\\P{L}]$", "\xb6", true);
+test("^[\\p{Any}--\\P{L}]$", "\xff", true);
+test("^[\\p{Any}--\\P{L}]$", "Ā", true);
+test("^[\\p{Any}--\\P{L}]$", "\xf7", false);
+test("^[\\p{Any}--\\P{L}]$", "\xb5", true);
+test("^[\\p{Any}--\\P{L}]$", "\xb6", false);
+
+// The inverted property has no Latin-1 code points at all, so its complement covers all of Latin-1.
+test("^[\\p{Any}&&\\P{Script=Greek}]$", "a", true);
+test("^[\\p{Any}&&\\P{Script=Greek}]$", "\xff", true);
+test("^[\\p{Any}&&\\P{Script=Greek}]$", "α", false);
+test("^[\\p{Any}&&\\P{Script=Greek}]$", "\u{10000}", true);
+test("^[[a-zα-ω]--\\P{Script=Greek}]$", "α", true);
+test("^[[a-zα-ω]--\\P{Script=Greek}]$", "a", false);
+
+// The inverted property covers everything, so its complement is empty.
+test("^[\\p{L}&&\\P{Any}]$", "a", false);
+test("^[\\p{L}&&\\P{Any}]$", "\u{10000}", false);
+test("^[\\p{L}--\\P{Any}]$", "a", true);
+test("^[\\p{L}--\\P{Any}]$", "\u{10400}", true);
+test("^[\\p{L}--\\P{Any}]$", "1", false);
+
+// \P{...} as the second and later operand of an explicit union (juxtaposition).
+test("^[0\\P{L}]$", "0", true);
+test("^[0\\P{L}]$", "1", true);
+test("^[0\\P{L}]$", "a", false);
+test("^[0\\P{L}\\P{N}]$", "a", true);
+test("^[0\\P{L}\\P{N}]$", "0", true);
+test("^[\\q{ab}\\P{L}]$", "ab", true);
+test("^[\\q{ab}\\P{L}]$", "1", true);
+test("^[\\q{ab}\\P{L}]$", "a", false);
+
+// The left-hand operand contains strings.
+test("^[\\q{ab|c|1}&&\\P{L}]$", "1", true);
+test("^[\\q{ab|c|1}&&\\P{L}]$", "ab", false);
+test("^[\\q{ab|c|1}&&\\P{L}]$", "c", false);
+test("^[\\q{ab|c|1}--\\P{L}]$", "ab", true);
+test("^[\\q{ab|c|1}--\\P{L}]$", "c", true);
+test("^[\\q{ab|c|1}--\\P{L}]$", "1", false);
+
+// Inside a nested class and under an outer negation.
+test("^[[\\p{L}&&\\P{Lu}]1]$", "a", true);
+test("^[[\\p{L}&&\\P{Lu}]1]$", "1", true);
+test("^[[\\p{L}&&\\P{Lu}]1]$", "A", false);
+test("^[\\p{N}&&[\\p{Any}--\\P{Nd}]]$", "1", true);
+test("^[\\p{N}&&[\\p{Any}--\\P{Nd}]]$", "\xb2", false);
+test("^[^\\p{L}&&\\P{Lu}]$", "A", true);
+test("^[^\\p{L}&&\\P{Lu}]$", "1", true);
+test("^[^\\p{L}&&\\P{Lu}]$", "a", false);
+
+// With the ignoreCase flag, using properties that have no case mappings.
+test("^[\\p{N}&&\\P{Nd}]$", "\xb2", true, "vi");
+test("^[\\p{N}&&\\P{Nd}]$", "1", false, "vi");
+test("^[\\p{N}&&\\P{Nd}]$", "a", false, "vi");
+test("^[\\p{N}--\\P{Nd}]$", "1", true, "vi");
+test("^[\\p{N}--\\P{Nd}]$", "\xb2", false, "vi");
+
+// A negated property of strings is still a SyntaxError when it is the right-hand operand of a set operation.
+shouldThrowSyntaxError("[\\p{L}&&\\P{RGI_Emoji}]");
+shouldThrowSyntaxError("[\\p{L}--\\P{RGI_Emoji}]");
+
+// \P{...} as the left-hand operand or wrapped in a nested class was already correct.
+test("^[\\P{L}&&\\p{ASCII}]$", "1", true);
+test("^[\\P{L}&&\\p{ASCII}]$", "a", false);
+test("^[\\P{L}&&[0-9]]$", "1", true);
+test("^[\\P{L}&&[0-9]]$", "!", false);
+test("^[[\\P{L}]&&[\\P{N}]]$", "!", true);
+test("^[[\\P{L}]&&[\\P{N}]]$", "1", false);
+test("^[\\p{L}&&[\\P{Lu}]]$", "a", true);
+test("^[\\p{L}&&[\\P{Lu}]]$", "A", false);

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -152,6 +152,16 @@ public:
             m_invertedStrings = true;
         }
 
+        if (!isUnionSetOp()) {
+            // FIXME: Flipping the pending op (intersect with complement == subtract, and vice versa)
+            // would avoid materializing the complement, but m_strings still needs the original op.
+            CharacterClass inverted;
+            addSortedInverted(0, 0xff, other->m_matches8, other->m_ranges8, inverted.m_matches8, inverted.m_ranges8);
+            addSortedInverted(0x100, UCHAR_MAX_VALUE, other->m_matches32, other->m_ranges32, inverted.m_matches32, inverted.m_ranges32);
+            append(&inverted);
+            return;
+        }
+
         addSortedInverted(0, 0xff, other->m_matches8, other->m_ranges8, m_matches8, m_ranges8);
         addSortedInverted(0x100, UCHAR_MAX_VALUE, other->m_matches32, other->m_ranges32, m_matches32, m_ranges32);
     }


### PR DESCRIPTION
#### 7b5e7da783f58bd8ee2321ff0a399617f0d2acc8
<pre>
[YARR] `\P{...}` on the right side of a v-mode `&amp;&amp;` or `--` becomes a union
<a href="https://bugs.webkit.org/show_bug.cgi?id=321252">https://bugs.webkit.org/show_bug.cgi?id=321252</a>

Reviewed by Yusuke Suzuki.

appendInverted() adds the complement of its operand directly to the accumulated
matches and ranges without consulting m_setOp, so a pending &amp;&amp; or -- turns into a union.

    /[\p{L}&amp;&amp;\P{Lu}]/v.test(&quot;A&quot;)        // true, should be false
    /^[\q{ab|c|1}&amp;&amp;\P{L}]$/v.test(&quot;ab&quot;) // true, should be false

When an intersection or subtraction is pending, materialize the complement into a
temporary CharacterClass and funnel it through append(), which dispatches on m_setOp
for both matches and strings. addSortedInverted()&apos;s adjacent-merge branch targets the
member range vectors, but it cannot fire for the temporary since complement pieces
are always separated by an element of the operand.

Test: JSTests/stress/regexp-v-flag-class-set-op-inverted-property.js

* JSTests/stress/regexp-v-flag-class-set-op-inverted-property.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::appendInverted):

Canonical link: <a href="https://commits.webkit.org/318854@main">https://commits.webkit.org/318854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e83fe0383b21fc72963ccbd733b7f0d46c6bb238

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189186 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143663 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139865 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96799 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120317 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42140 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40472 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2287 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9097 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40117 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/637 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40629 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191404 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52963 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149120 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40026 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53644 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148862 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43538 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125916 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120784 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52161 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15103 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51546 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51787 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->