### PR TITLE
[YARR] Interpreter should skip every once-through alternative after advancing the start position

### DIFF
--- a/JSTests/stress/regexp-once-through-advance-edge-cases.js
+++ b/JSTests/stress/regexp-once-through-advance-edge-cases.js
@@ -1,0 +1,67 @@
+function shouldBe(actual, expected, context) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error("bad value: " + JSON.stringify(actual) + " expected: " + JSON.stringify(expected) + " for " + context);
+}
+
+function check(re, string, expected, expectedIndex) {
+    const context = re + " against " + JSON.stringify(string) + " from lastIndex " + re.lastIndex;
+    const result = re.exec(string);
+    shouldBe(result === null ? null : Array.from(result, (x) => x === undefined ? null : x), expected, context);
+    if (result !== null)
+        shouldBe(result.index, expectedIndex, context + " (index)");
+}
+
+let re;
+
+re = /a|^x|aa/g;
+re.lastIndex = 2;
+check(re, "xxcaa", ["a"], 3);
+shouldBe(re.lastIndex, 4, "/a|^x|aa/g lastIndex after match");
+re = /a|^x|aa/y;
+re.lastIndex = 1;
+check(re, "caa", ["a"], 1);
+re = /a|^x|aa/y;
+re.lastIndex = 0;
+check(re, "caa", null);
+
+check(/a|^b|c|^d|ab|^e/, "xab", ["a"], 1);
+check(/a|aa|^x/, "caa", ["a"], 1);
+check(/ab|a|^x|abc/, "cabc", ["ab"], 1);
+check(/aaaa|^x|a/, "ca", ["a"], 1);
+check(/a|^x|aa|(?:^y|b)/, "caa", ["a"], 1);
+check(/b|^x|(?:^y|a)|aa/, "caa", ["a"], 1);
+check(/(?:a|^x|aa)/, "caa", ["a"], 1);
+
+check(/(a)|^(b)|(a)a/, "caa", ["a", "a", null, null], 1);
+check(/(?<n>a)|^x|(?<n>a)a/, "caa", ["a", "a", null], 1);
+shouldBe("caab".replace(/a|^x|(a+)b/, "[$&,$1]"), "c[a,]ab", "replace with capture");
+
+check(/a|(?:^x)|aa/, "caa", ["a"], 1);
+check(/a|(^)x|aa/, "caa", ["a", null], 1);
+check(/a|(?:^x)?b|ab/, "cab", ["a"], 1);
+check(/a|(?=^)x|aa/, "caa", ["a"], 1);
+check(/a|(?<=^)x|aa/, "caa", ["a"], 1);
+check(/a|(?<=^c)a|aa|^x/, "caa", ["a"], 1);
+check(/(?<=c)a|^x|aa/, "caa", ["a"], 1);
+check(/(?<!c)a|^x|a+/, "caa", ["aa"], 1);
+check(/b(?<=(a)b)|^x|(b)c/, "abc", ["b", "a", null], 1);
+check(/a(?!a)|^x|a+/, "caa", ["aa"], 1);
+check(/a\b|^x|a\B./, "caa", ["aa"], 1);
+check(/\ba|^x|a/, "c a", ["a"], 2);
+check(/a$|^x|aa$/, "caa", ["aa"], 1);
+
+check(/|^x|a/, "ca", [""], 0);
+check(/a|^x|/, "ca", [""], 0);
+
+check(/A|^X|AA/i, "caa", ["a"], 1);
+check(/b.|^x|b/s, "ab\n", ["b\n"], 1);
+check(/b.|^x|b/, "ab\n", ["b"], 1);
+check(/a|^x|aa/m, "c\nxaa", ["x"], 2);
+
+check(/b|^x|bb/u, "\u{1F600}bb", ["b"], 2);
+check(/\u{1F600}|^x|\u{1F600}\u{1F600}/u, "a\u{1F600}\u{1F600}", ["\u{1F600}"], 1);
+check(/\uD83D|^x|\uD83D\uDE00/, "a\uD83D\uDE00", ["\uD83D"], 1);
+
+shouldBe("caa xaa".split(/a|^x|aa/), ["c", "", " x", "", ""], "split");
+shouldBe(Array.from("caa".matchAll(/a|^x|(a)a/g), (m) => m[0]), ["a", "a"], "matchAll");
+shouldBe("caa xaa".replace(/a|^x|aa/g, "_"), "c__ x__", "replace /g");

--- a/JSTests/stress/regexp-once-through-advance-tries-loop-alternatives-first.js
+++ b/JSTests/stress/regexp-once-through-advance-tries-loop-alternatives-first.js
@@ -1,0 +1,26 @@
+function shouldBe(actual, expected, context) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error("bad value: " + JSON.stringify(actual) + " expected: " + JSON.stringify(expected) + " for " + context);
+}
+
+function check(re, string, expected) {
+    const result = re.exec(string);
+    shouldBe(result === null ? null : Array.from(result), expected, re + " against " + JSON.stringify(string));
+}
+
+check(/a|^x|aa/, "caa", ["a"]);
+check(/(?:^|[^g])x6|ar?/, "gax6", ["ax6"]);
+check(/(^|[^g])hz+|w/, "uwhz", ["whz", "w"]);
+check(/(?:^-|^\+)?d|dd/, "xdd", ["d"]);
+shouldBe("caa xaa".replace(/a|^x|aa/g, "_"), "c__ x__", "replace /a|^x|aa/g");
+
+check(/a(?<!q)|^x|aa/, "caa", ["a"]);
+check(/foo(?<=foo)|^=|foobar/, " foobar", ["foo"]);
+check(/(?<![a-z])b|^#|bb+/, "1bbb", ["b"]);
+
+check(/^x|^y|a|aa/, "caa", ["a"]);
+check(/^q|aa|^r|a/, "xcaa", ["aa"]);
+check(/^a|^b/, "xab", null);
+check(/^a(?<!b)|^b/, "xab", null);
+check(/^a/, "ba", null);
+check(/^a(?<!b)/, "ba", null);

--- a/JSTests/stress/regexp-once-through-without-loop-alternatives.js
+++ b/JSTests/stress/regexp-once-through-without-loop-alternatives.js
@@ -1,0 +1,46 @@
+function shouldBe(actual, expected, context) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error("bad value: " + JSON.stringify(actual) + " expected: " + JSON.stringify(expected) + " for " + context);
+}
+
+function check(re, string, expected, expectedIndex) {
+    const context = re + " against " + JSON.stringify(string) + " from lastIndex " + re.lastIndex;
+    const result = re.exec(string);
+    shouldBe(result === null ? null : Array.from(result, (x) => x === undefined ? null : x), expected, context);
+    if (result !== null)
+        shouldBe(result.index, expectedIndex, context + " (index)");
+}
+
+let re;
+
+check(/^a/, "ba", null);
+check(/^a/, "", null);
+check(/^a|^b/, "xab", null);
+check(/^a|^b/, "b", ["b"], 0);
+check(/^a|^b/, "", null);
+check(/^(a)|^b/, "xb", null);
+check(/(?:^a)+|^b/, "xab", null);
+check(/(^a|^c)|^b/, "xab", null);
+check(/(?=^)a|^b/, "xa", null);
+check(/(?=^a)\w|^b/, "xa", null);
+
+check(/^A|^B/i, "xab", null);
+check(/^.a|^b/s, "x\nab", null);
+check(/^a|^b/u, "\u{1F600}a", null);
+check(/^a|^b/m, "x\nb", ["b"], 2);
+
+re = /^a|^b/g;
+re.lastIndex = 1;
+check(re, "aab", null);
+shouldBe(re.lastIndex, 0, "lastIndex reset after failing from lastIndex 1");
+re = /^a|^b/y;
+re.lastIndex = 1;
+check(re, "xab", null);
+shouldBe("abab".match(/^a|^b/g), ["a"], "match /g");
+shouldBe("bab".replace(/^b|^a/g, "_"), "_ab", "replace /g");
+shouldBe("aXbX".split(/^a|^b/), ["", "XbX"], "split");
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(/^a/.test("b".repeat(i & 0xff)), false, "/^a/ long input");
+    shouldBe(/^a|^b(?<!c)/.exec("x".repeat(i & 0xff) + "ab"), (i & 0xff) ? null : ["a"], "/^a|^b(?<!c)/ long input");
+}

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -2161,8 +2161,14 @@ public:
 
             context->matchBegin = input.getPos();
 
-            if (currentTerm().alternative.onceThrough)
-                context->term += currentTerm().alternative.next;
+            while (currentTerm().alternative.onceThrough) {
+                int next = currentTerm().alternative.next;
+                if (next <= 0) {
+                    DUMP_EXTRA("- Return NoMatch\n");
+                    return JSRegExpResult::NoMatch;
+                }
+                context->term += next;
+            }
 
             MATCH_NEXT();
         }


### PR DESCRIPTION
#### 6a1ef9a1ef991163b6a0dc04f85891624ec3af7d
<pre>
[YARR] Interpreter should skip every once-through alternative after advancing the start position
<a href="https://bugs.webkit.org/show_bug.cgi?id=321253">https://bugs.webkit.org/show_bug.cgi?id=321253</a>

Reviewed by Yusuke Suzuki.

optimizeBOL() marks the body alternatives as once-through and appends copies of
the non-`^` ones as the looping set, so once-through alternatives must only be
tried at the initial start position.

When advancing the start position, the interpreter skipped only the first
once-through alternative and resumed at the second one, so a later alternative
could win over the first, e.g. /a|^x|aa/.exec(&quot;caa&quot;) returned &quot;aa&quot; instead of
&quot;a&quot;. The JIT emits the two sets separately and is not affected.

Skip all once-through alternatives after advancing, and return NoMatch when
there is no looping alternative (e.g. /^a|^b/), matching the JIT.

Tests: JSTests/stress/regexp-once-through-advance-edge-cases.js
       JSTests/stress/regexp-once-through-advance-tries-loop-alternatives-first.js
       JSTests/stress/regexp-once-through-without-loop-alternatives.js

* JSTests/stress/regexp-once-through-advance-edge-cases.js: Added.
(shouldBe):
(check):
* JSTests/stress/regexp-once-through-advance-tries-loop-alternatives-first.js: Added.
(shouldBe):
(check):
* JSTests/stress/regexp-once-through-without-loop-alternatives.js: Added.
(shouldBe):
(check):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::matchDisjunction):

Canonical link: <a href="https://commits.webkit.org/318872@main">https://commits.webkit.org/318872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c5b3e6ee057750077e7d0bc31e7e816d7e058bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189544 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144021 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140168 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120619 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40776 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2588 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9392 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40422 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/998 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40987 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191766 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53321 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149445 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40044 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54002 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149180 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43836 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126274 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121292 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52519 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15413 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51904 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->