### PR TITLE
Label default action incorrectly triggers when clicked interactive content removes itself

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/label-default-action-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/label-default-action-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Label default action should not trigger when clicked button removes itself assert_false: expected false got true
+PASS Label default action should not trigger when clicked button removes itself
 

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -144,7 +144,12 @@ bool HTMLLabelElement::isEventTargetedAtInteractiveDescendants(Event& event) con
     if (!node)
         return false;
 
-    if (!isShadowIncludingInclusiveAncestorOf(node.get()))
+    // Interactive content (e.g. a <button>) may remove itself while handling the
+    // click, detaching it from the label before the label's default action runs.
+    // The event path was computed before that mutation, so the label still
+    // default-handles the click and must do nothing. Only bail when the target
+    // is still connected but outside the label.
+    if (node->isConnected() && !isShadowIncludingInclusiveAncestorOf(node.get()))
         return false;
 
     for (RefPtr it = node; it && it != this; it = it->parentElementInComposedTree()) {


### PR DESCRIPTION
#### c110cc1814093427588f3c7c421aed4587087ff2
<pre>
Label default action incorrectly triggers when clicked interactive content removes itself
<a href="https://bugs.webkit.org/show_bug.cgi?id=321257">https://bugs.webkit.org/show_bug.cgi?id=321257</a>

Reviewed by Ryosuke Niwa.

When a &lt;label&gt; contains interactive content (e.g. a &lt;button&gt;), the label&apos;s
activation behavior must do nothing for clicks targeting that interactive
content, per <a href="https://html.spec.whatwg.org/#the-label-element.">https://html.spec.whatwg.org/#the-label-element.</a>

HTMLLabelElement::isEventTargetedAtInteractiveDescendants determined this by
walking the live composed tree from the event target up to the label. But the
event path is computed once, up front, at dispatch time, so the label still
default-handles the click even if the interactive content removes itself from
the tree while handling that same click. In that case the target is no longer
a descendant of the label, the isShadowIncludingInclusiveAncestorOf() guard
bailed early returning false, and the label went on to activate its control.

Only reject a target that is still connected but outside the label. A
disconnected target means interactive content removed itself mid-dispatch; its
own subtree and ancestor chain remain intact, so the interactive-content walk
below still detects it and correctly does nothing.

No new tests, rebaselined existing WPT test. This test was already passing
in both Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/dom/events/label-default-action-expected.txt:
* Source/WebCore/html/HTMLLabelElement.cpp:
(WebCore::HTMLLabelElement::isEventTargetedAtInteractiveDescendants const):

Canonical link: <a href="https://commits.webkit.org/318827@main">https://commits.webkit.org/318827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46e802122ae68910d772d11a62783a9f935c6b09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143666 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74e6750a-52a2-4a8a-9df5-66405603118e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139869 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a788173d-4a5a-4a26-94e9-8bd2022b5883) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160616 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120321 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b763784-77df-4464-9fa7-cc33a7e9ab46) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178682 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42143 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40475 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152543 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40121 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/641 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191407 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52966 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149123 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40017 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53647 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148865 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43539 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125919 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120789 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52164 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15107 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51549 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51790 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51610 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->