### PR TITLE
[text shaping] Arabic letters in adjacent inline boxes are not joined when the content is followed by simple code path text

### DIFF
--- a/LayoutTests/fast/text/shaping-across-inline-boxes-with-font-change-expected.html
+++ b/LayoutTests/fast/text/shaping-across-inline-boxes-with-font-change-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>A font change inside content that is shaped across inline boxes should only terminate the shaping range</title>
+<style>
+@font-face {
+    font-family: "WebFont";
+    src: url("resources/Gulf-regular.ttf") format("truetype");
+}
+@font-face {
+    /* Same font file under a different family name: content using it renders identically
+       but has a different font cascade, which is what terminates a shaping range. */
+    font-family: "WebFontUnderAnotherName";
+    src: url("resources/Gulf-regular.ttf") format("truetype");
+}
+div {
+    font: 32px WebFont;
+}
+.otherFontCascade {
+    font-family: WebFontUnderAnotherName;
+}
+</style>
+</head>
+<body>
+<p>When Arabic content spanning multiple inline boxes changes font, the content in front of the font
+change still has to stay joined and so does the content after it. This test passes if each line
+below renders the same as the reference.</p>
+<div dir="rtl" lang="ar"><span>ٱلْوا</span><span class="otherFontCascade">حِدة</span></div>
+<div dir="rtl" lang="ar"><span>ٱلْوا</span><span class="otherFontCascade">حِدة</span><span>.</span></div>
+<div dir="rtl" lang="ar"><span>ٱلْوا</span><span class="otherFontCascade">حِدة</span><span>ٱلْوا</span></div>
+</body>
+</html>

--- a/LayoutTests/fast/text/shaping-across-inline-boxes-with-font-change.html
+++ b/LayoutTests/fast/text/shaping-across-inline-boxes-with-font-change.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>A font change inside content that is shaped across inline boxes should only terminate the shaping range</title>
+<style>
+@font-face {
+    font-family: "WebFont";
+    src: url("resources/Gulf-regular.ttf") format("truetype");
+}
+@font-face {
+    /* Same font file under a different family name: content using it renders identically
+       but has a different font cascade, which is what terminates a shaping range. */
+    font-family: "WebFontUnderAnotherName";
+    src: url("resources/Gulf-regular.ttf") format("truetype");
+}
+div {
+    font: 32px WebFont;
+}
+.otherFontCascade {
+    font-family: WebFontUnderAnotherName;
+}
+</style>
+</head>
+<body>
+<p>When Arabic content spanning multiple inline boxes changes font, the content in front of the font
+change still has to stay joined and so does the content after it. This test passes if each line
+below renders the same as the reference.</p>
+<div dir="rtl" lang="ar"><span>ٱ</span><span>ل</span><span>ْ</span><span>و</span><span>ا</span><span class="otherFontCascade">ح</span><span class="otherFontCascade">ِ</span><span class="otherFontCascade">د</span><span class="otherFontCascade">ة</span></div>
+<div dir="rtl" lang="ar"><span>ٱ</span><span>ل</span><span>ْ</span><span>و</span><span>ا</span><span class="otherFontCascade">ح</span><span class="otherFontCascade">ِ</span><span class="otherFontCascade">د</span><span class="otherFontCascade">ة</span><span>.</span></div>
+<div dir="rtl" lang="ar"><span>ٱ</span><span>ل</span><span>ْ</span><span>و</span><span>ا</span><span class="otherFontCascade">ح</span><span class="otherFontCascade">ِ</span><span class="otherFontCascade">د</span><span class="otherFontCascade">ة</span><span>ٱ</span><span>ل</span><span>ْ</span><span>و</span><span>ا</span></div>
+</body>
+</html>

--- a/LayoutTests/fast/text/shaping-across-inline-boxes-with-trailing-simple-text-expected.html
+++ b/LayoutTests/fast/text/shaping-across-inline-boxes-with-trailing-simple-text-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Shaping across inline boxes should not be dropped when the shaped content is followed by content that can't be shaped</title>
+<style>
+@font-face {
+    font-family: "WebFont";
+    src: url("resources/Gulf-regular.ttf") format("truetype");
+}
+div {
+    font: 32px WebFont;
+}
+</style>
+</head>
+<body>
+<p>Arabic content spanning multiple inline boxes has to stay joined even when it is followed by
+content that is not eligible for shaping (e.g. simple code path text like a full stop). This test
+passes if each line below renders the same as the reference (i.e. the letters are joined).</p>
+<div dir="rtl" lang="ar"><span>عِنْدهُ</span><span> </span><span>شَيْء</span><span> </span><span>في</span><span> </span><span>ٱلْسّاعة</span><span> </span><span>ٱلْواحِدة</span><span>.</span></div>
+<div dir="rtl" lang="ar"><span>عِنْدهُ</span><span> </span><span>شَيْء</span><span> </span><span>في</span><span> </span><span>ٱلْسّاعة</span><span> </span><span>ٱلْواحِدة</span><span>!</span></div>
+<div dir="rtl" lang="ar"><span>عِنْدهُ</span><span> </span><span>شَيْء</span><span> </span><span>في</span><span> </span><span>ٱلْسّاعة</span><span> </span><span>ٱلْواحِدة</span><span>x</span></div>
+<div dir="rtl" lang="ar"><span>عِنْدهُ</span><span> </span><span>شَيْء</span><span> </span><span>في</span><span> </span><span>ٱلْسّاعة</span><span> </span><span>ٱلْواحِدة</span><span>.</span><span>ٱلْواحِدة</span></div>
+</body>
+</html>

--- a/LayoutTests/fast/text/shaping-across-inline-boxes-with-trailing-simple-text.html
+++ b/LayoutTests/fast/text/shaping-across-inline-boxes-with-trailing-simple-text.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Shaping across inline boxes should not be dropped when the shaped content is followed by content that can't be shaped</title>
+<style>
+@font-face {
+    font-family: "WebFont";
+    src: url("resources/Gulf-regular.ttf") format("truetype");
+}
+div {
+    font: 32px WebFont;
+}
+</style>
+</head>
+<body>
+<p>Arabic content spanning multiple inline boxes has to stay joined even when it is followed by
+content that is not eligible for shaping (e.g. simple code path text like a full stop). This test
+passes if each line below renders the same as the reference (i.e. the letters are joined).</p>
+<div dir="rtl" lang="ar"><span>ع</span><span>ِ</span><span>ن</span><span>ْ</span><span>د</span><span>ه</span><span>ُ</span><span> </span><span>ش</span><span>َ</span><span>ي</span><span>ْ</span><span>ء</span><span> </span><span>ف</span><span>ي</span><span> </span><span>ٱ</span><span>ل</span><span>ْ</span><span>س</span><span>ّ</span><span>ا</span><span>ع</span><span>ة</span><span> </span><span>ٱ</span><span>ل</span><span>ْ</span><span>و</span><span>ا</span><span>ح</span><span>ِ</span><span>د</span><span>ة</span><span>.</span></div>
+<div dir="rtl" lang="ar"><span>ع</span><span>ِ</span><span>ن</span><span>ْ</span><span>د</span><span>ه</span><span>ُ</span><span> </span><span>ش</span><span>َ</span><span>ي</span><span>ْ</span><span>ء</span><span> </span><span>ف</span><span>ي</span><span> </span><span>ٱ</span><span>ل</span><span>ْ</span><span>س</span><span>ّ</span><span>ا</span><span>ع</span><span>ة</span><span> </span><span>ٱ</span><span>ل</span><span>ْ</span><span>و</span><span>ا</span><span>ح</span><span>ِ</span><span>د</span><span>ة</span><span>!</span></div>
+<div dir="rtl" lang="ar"><span>ع</span><span>ِ</span><span>ن</span><span>ْ</span><span>د</span><span>ه</span><span>ُ</span><span> </span><span>ش</span><span>َ</span><span>ي</span><span>ْ</span><span>ء</span><span> </span><span>ف</span><span>ي</span><span> </span><span>ٱ</span><span>ل</span><span>ْ</span><span>س</span><span>ّ</span><span>ا</span><span>ع</span><span>ة</span><span> </span><span>ٱ</span><span>ل</span><span>ْ</span><span>و</span><span>ا</span><span>ح</span><span>ِ</span><span>د</span><span>ة</span><span>x</span></div>
+<div dir="rtl" lang="ar"><span>ع</span><span>ِ</span><span>ن</span><span>ْ</span><span>د</span><span>ه</span><span>ُ</span><span> </span><span>ش</span><span>َ</span><span>ي</span><span>ْ</span><span>ء</span><span> </span><span>ف</span><span>ي</span><span> </span><span>ٱ</span><span>ل</span><span>ْ</span><span>س</span><span>ّ</span><span>ا</span><span>ع</span><span>ة</span><span> </span><span>ٱ</span><span>ل</span><span>ْ</span><span>و</span><span>ا</span><span>ح</span><span>ِ</span><span>د</span><span>ة</span><span>.</span><span>ٱ</span><span>ل</span><span>ْ</span><span>و</span><span>ا</span><span>ح</span><span>ِ</span><span>د</span><span>ة</span></div>
+</body>
+</html>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -910,8 +910,12 @@ Vector<std::pair<size_t, size_t>> LineBuilder::collectShapeRanges(const LineCand
                 auto hasMatchingFontCascade = *lastFontCascade.get() == styleToUse.fontCascade();
                 if (isEligibleText && hasMatchingFontCascade)
                     trailingContentRunIndex = entry.index;
-                else
-                    resetCandidateRange();
+                else {
+                    commitIfHasContentAndReset();
+                    if (isEligibleText)
+                        leadingContentRunIndex = entry.index;
+                    lastFontCascade = &styleToUse.fontCascade();
+                }
             } else if (!isEligibleText)
                 resetCandidateRange();
             break;


### PR DESCRIPTION
#### 553a9a78402334c54130e294c5d5638b8bfb3971
<pre>
[text shaping] Arabic letters in adjacent inline boxes are not joined when the content is followed by simple code path text
<a href="https://bugs.webkit.org/show_bug.cgi?id=321259">https://bugs.webkit.org/show_bug.cgi?id=321259</a>
<a href="https://rdar.apple.com/184071471">rdar://184071471</a>

Reviewed by Alan Baradlay.

LineBuilder::collectShapeRanges walks the candidate content and collects the ranges of
shapable content that span inline box boundaries. When it ran into content that cannot be
part of the current range -either because the content is not eligible for shaping (simple
code path, combined text or non-RTL) or because it uses a different font- it discarded the
entire candidate range instead of closing it.

A single trailing full stop was therefore enough to lose shaping for the whole word e.g.

    &lt;div dir=rtl lang=ar&gt;&lt;span&gt;&amp;#x671;&lt;/span&gt;...&lt;span&gt;&amp;#x629;&lt;/span&gt;&lt;span&gt;.&lt;/span&gt;&lt;/div&gt;

Here the &apos;.&apos; text box takes the simple code path, so the accumulated range for the Arabic
content in front of it got dropped and each character ended up being shaped on its own and
rendered in isolated form (which also made the content measure wider than the equivalent
plain text).

Content that is not eligible for shaping should only terminate the shaping range. Let&apos;s
commit what we have collected so far instead of throwing it away and, when the terminating
content is itself eligible for shaping (i.e. this is the font change case), start a new
range at it (and remember its font as the one to match against).

Both tests are reference tests so that the letter forms are checked and not just the
resolved width. The reference has the same inline box structure as the test, except that
the content which has to end up in one shaping range is put in a single inline box (where
shaping across inline boxes is not needed at all). The font change test uses the same font
file under two family names so that the two halves of the content have mismatching font
cascades while still rendering identically.

* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::collectShapeRanges const):
* LayoutTests/fast/text/shaping-across-inline-boxes-with-font-change-expected.html: Added.
* LayoutTests/fast/text/shaping-across-inline-boxes-with-font-change.html: Added.
* LayoutTests/fast/text/shaping-across-inline-boxes-with-trailing-simple-text-expected.html: Added.
* LayoutTests/fast/text/shaping-across-inline-boxes-with-trailing-simple-text.html: Added.

Canonical link: <a href="https://commits.webkit.org/319209@main">https://commits.webkit.org/319209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2762651fc59c318e0424ae042b4ca18e2e642640

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191000 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145110 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc84debc-8aef-4e03-99ca-4a1effabe08e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54448 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141023 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06b6b73d-92ad-4f40-b043-5011136a3539) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44686 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121475 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bd5a5e15-6392-4f40-9e2b-995c5e50835d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41310 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2161 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47344 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192935 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161299 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40257 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55086 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150124 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44720 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122638 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53603 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16303 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52985 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53222 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->