### PR TITLE
[Navigation API] Implement Precommit Handler

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7130,14 +7130,7 @@ imported/w3c/web-platform-tests/navigation-api/navigate-event/dangling-navigate-
 imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-infinite.optional.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-history-pushState.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-location.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-redirect.html?currententrychange [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-redirect.html?no-currententrychange [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-reject.tentative.html?currententrychange [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-reject.tentative.html?no-currententrychange [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler.html?currententrychange [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler.html?no-currententrychange [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/precommit-handler/ [ Skip ]
 
 # Require enabling CSS Scroll Anchoring
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -981,7 +981,7 @@ PASS NavigationTransition interface: existence and properties of interface proto
 PASS NavigationTransition interface: existence and properties of interface prototype object's @@unscopables property
 PASS NavigationTransition interface: attribute navigationType
 PASS NavigationTransition interface: attribute from
-FAIL NavigationTransition interface: attribute committed assert_true: The prototype object must have a property "committed" expected true got false
+PASS NavigationTransition interface: attribute committed
 PASS NavigationTransition interface: attribute finished
 PASS NavigationActivation interface: existence and properties of interface object
 PASS NavigationActivation interface object length
@@ -1011,13 +1011,13 @@ PASS NavigateEvent interface: attribute hasUAVisualTransition
 PASS NavigateEvent interface: attribute sourceElement
 PASS NavigateEvent interface: operation intercept(optional NavigationInterceptOptions)
 PASS NavigateEvent interface: operation scroll()
-FAIL NavigationPrecommitController interface: existence and properties of interface object assert_own_property: self does not have own property "NavigationPrecommitController" expected property "NavigationPrecommitController" missing
-FAIL NavigationPrecommitController interface object length assert_own_property: self does not have own property "NavigationPrecommitController" expected property "NavigationPrecommitController" missing
-FAIL NavigationPrecommitController interface object name assert_own_property: self does not have own property "NavigationPrecommitController" expected property "NavigationPrecommitController" missing
-FAIL NavigationPrecommitController interface: existence and properties of interface prototype object assert_own_property: self does not have own property "NavigationPrecommitController" expected property "NavigationPrecommitController" missing
-FAIL NavigationPrecommitController interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "NavigationPrecommitController" expected property "NavigationPrecommitController" missing
-FAIL NavigationPrecommitController interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "NavigationPrecommitController" expected property "NavigationPrecommitController" missing
-FAIL NavigationPrecommitController interface: operation redirect(USVString, optional NavigationNavigateOptions) assert_own_property: self does not have own property "NavigationPrecommitController" expected property "NavigationPrecommitController" missing
+PASS NavigationPrecommitController interface: existence and properties of interface object
+PASS NavigationPrecommitController interface object length
+PASS NavigationPrecommitController interface object name
+PASS NavigationPrecommitController interface: existence and properties of interface prototype object
+PASS NavigationPrecommitController interface: existence and properties of interface prototype object's "constructor" property
+PASS NavigationPrecommitController interface: existence and properties of interface prototype object's @@unscopables property
+PASS NavigationPrecommitController interface: operation redirect(USVString, optional NavigationNavigateOptions)
 PASS NavigationDestination interface: existence and properties of interface object
 PASS NavigationDestination interface object length
 PASS NavigationDestination interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-aborts-previous-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-aborts-previous-navigation-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL <a download> aborts previous navigations promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'transition.committed.then')"
+PASS <a download> aborts previous navigations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-redirect_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-redirect_currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering for same-document navigation.navigate() intercepted by intercept() with a precommitHandler that redirects assert_array_equals: lengths differ, expected array ["navigate", "precommitHandler start", "promise microtask", "precommitHandler async step 1a", "precommitHandler async step 1b", "currententrychange", "handler start", "committed fulfilled", "handler async step 1", "navigatesuccess", "finished fulfilled", "transition.finished fulfilled"] length 12, got ["navigate", "currententrychange", "handler start", "committed fulfilled", "promise microtask", "handler async step 1", "navigatesuccess", "finished fulfilled", "transition.finished fulfilled"] length 9
+PASS event and promise ordering for same-document navigation.navigate() intercepted by intercept() with a precommitHandler that redirects
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-redirect_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-redirect_no-currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering for same-document navigation.navigate() intercepted by intercept() with a precommitHandler that redirects assert_array_equals: lengths differ, expected array ["navigate", "precommitHandler start", "promise microtask", "precommitHandler async step 1a", "precommitHandler async step 1b", "handler start", "committed fulfilled", "handler async step 1", "navigatesuccess", "finished fulfilled", "transition.finished fulfilled"] length 11, got ["navigate", "handler start", "committed fulfilled", "promise microtask", "handler async step 1", "navigatesuccess", "finished fulfilled", "transition.finished fulfilled"] length 8
+PASS event and promise ordering for same-document navigation.navigate() intercepted by intercept() with a precommitHandler that redirects
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-reject.tentative_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-reject.tentative_currententrychange-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT event and promise ordering for same-document navigation.navigate() intercepted by intercept() with a precommitHandler Test timed out
+PASS event and promise ordering for same-document navigation.navigate() intercepted by intercept() with a precommitHandler
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-reject.tentative_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-reject.tentative_no-currententrychange-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT event and promise ordering for same-document navigation.navigate() intercepted by intercept() with a precommitHandler Test timed out
+PASS event and promise ordering for same-document navigation.navigate() intercepted by intercept() with a precommitHandler
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler_currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering for same-document navigation.navigate() intercepted by intercept() with a precommitHandler assert_array_equals: lengths differ, expected array ["navigate", "precommitHandler start", "promise microtask", "precommitHandler async step", "currententrychange", "handler start", "committed fulfilled", "handler async step", "navigatesuccess", "finished fulfilled", "transition.finished fulfilled"] length 11, got ["navigate", "currententrychange", "handler start", "committed fulfilled", "promise microtask", "handler async step", "navigatesuccess", "finished fulfilled", "transition.finished fulfilled"] length 9
+PASS event and promise ordering for same-document navigation.navigate() intercepted by intercept() with a precommitHandler
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler_no-currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering for same-document navigation.navigate() intercepted by intercept() with a precommitHandler assert_array_equals: lengths differ, expected array ["navigate", "precommitHandler start", "promise microtask", "precommitHandler async step", "handler start", "committed fulfilled", "handler async step", "navigatesuccess", "finished fulfilled", "transition.finished fulfilled"] length 10, got ["navigate", "handler start", "committed fulfilled", "promise microtask", "handler async step", "navigatesuccess", "finished fulfilled", "transition.finished fulfilled"] length 8
+PASS event and promise ordering for same-document navigation.navigate() intercepted by intercept() with a precommitHandler
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/multiple-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/multiple-intercept-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL precommitHandler + precommitHandler assert_equals: expected false but got true
-FAIL precommitHandler + (not provided) assert_equals: expected false but got true
-FAIL precommitHandler + handler assert_equals: expected false but got true
-FAIL handler + precommitHandler assert_equals: expected false but got true
+PASS precommitHandler + precommitHandler
+PASS precommitHandler + (not provided)
+PASS precommitHandler + handler
+PASS handler + precommitHandler
 PASS handler + (not provided)
 PASS handler + handler
-FAIL (not provided) + precommitHandler assert_equals: expected false but got true
+PASS (not provided) + precommitHandler
 PASS (not provided) + handler
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-addHandler-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-addHandler-expected.txt
@@ -1,0 +1,4 @@
+
+PASS handler added in addHandler() delays navigation finish
+PASS handler added in addHandler() is executed in the correct order
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-addHandler-throws-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-addHandler-throws-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS addHandler() after finish
+PASS addHandler() after commit
+PASS addHandler() in detached iframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-back-and-forth-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-back-and-forth-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL
+  Test that going back and forward during a precommitHandler ends up in the
+  correct entry
+ promise_test: Unhandled rejection with value: object "AbortError: Navigation aborted"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-new-navigation-before-commit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-new-navigation-before-commit-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Cancel a navigation with a precommitHandler before commit by starting a new navigation assert_equals: expected "" but got "#ShouldNotCommit"
+PASS Cancel a navigation with a precommitHandler before commit by starting a new navigation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-push-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-push-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL precommitHandler for a push navigation, reject before commit assert_unreached: committed must not fulfill Reached unreachable code
+PASS precommitHandler for a push navigation, reject before commit
 PASS precommitHandler for a push navigation, reject after commit
 PASS precommitHandler for a push navigation, success
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-options-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-options-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL precommitHandler redirect() with options dictionary assert_equals: expected "#redirect2" but got "#push"
+PASS precommitHandler redirect() with options dictionary
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-push-changed-to-replace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-push-changed-to-replace-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL precommitHandler redirect() push changed to replace assert_equals: expected "#redirect1" but got "#push"
+PASS precommitHandler redirect() push changed to replace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-push-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-push-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL precommitHandler redirect() push assert_equals: expected "#redirect2" but got "#push"
+PASS precommitHandler redirect() push
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-replace-changed-to-push-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-replace-changed-to-push-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL precommitHandler redirect() replace changed to push assert_equals: expected "#redirect1" but got "#replace"
+PASS precommitHandler redirect() replace changed to push
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-replace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-replace-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL precommitHandler redirect() replace assert_equals: expected "#redirect2" but got "#replace"
+PASS precommitHandler redirect() replace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-throws-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-throws-expected.txt
@@ -1,9 +1,7 @@
 
 
-Harness Error (FAIL), message = Unhandled rejection: assert_throws_dom: function "() => precommit_controller.redirect("#")" threw object "TypeError: undefined is not an object (evaluating 'precommit_controller.redirect')" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
-
-FAIL redirect() after finish assert_throws_dom: function "() => precommit_controller.redirect("#")" threw object "TypeError: undefined is not an object (evaluating 'precommit_controller.redirect')" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
-FAIL redirect() after commit assert_throws_dom: function "() => precommit_controller.redirect("#")" threw object "TypeError: undefined is not an object (evaluating 'precommit_controller.redirect')" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
+PASS redirect() after finish
+PASS redirect() after commit
 PASS redirect() in detached iframe
 PASS redirect() to invalid url
 PASS redirect() to cross-origin url

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-reload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-reload-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (FAIL), message = Unhandled rejection
-
-FAIL precommitHandler for a reload navigation, reject before commit assert_unreached: committed must not fulfill Reached unreachable code
+PASS precommitHandler for a reload navigation, reject before commit
 PASS precommitHandler for a reload navigation, reject after commit
 PASS precommitHandler for a reload navigation, success
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-replace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-replace-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (FAIL), message = Unhandled rejection
-
-FAIL precommitHandler for a replace navigation, reject before commit assert_unreached: committed must not fulfill Reached unreachable code
+PASS precommitHandler for a replace navigation, reject before commit
 PASS precommitHandler for a replace navigation, reject after commit
 PASS precommitHandler for a replace navigation, success
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-traversal-window-stop-before-commit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-traversal-window-stop-before-commit-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL  precommitHandler traverse with window.stop() before commit assert_equals: expected "#2" but got "#1"
+FAIL precommitHandler traversal is not aborted by window.stop() before commit assert_equals: expected "#2" but got "#1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-traverse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-traverse-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: hash after commit expected "#3" but got "#1"
-
-FAIL precommitHandler for a traverse navigation, reject before commit assert_unreached: committed must not fulfill Reached unreachable code
-FAIL precommitHandler for a traverse navigation, reject after commit assert_equals: hash after commit expected "#1" but got ""
-FAIL precommitHandler for a traverse navigation, success assert_equals: hash after commit expected "#3" but got "#1"
+FAIL precommitHandler for a traverse navigation, reject before commit assert_equals: expected object "Error: assert_equals: hash after first async step expected "#4" but got """ but got object "Error: boo!"
+FAIL precommitHandler for a traverse navigation, reject after commit assert_equals: hash after first async step expected "" but got "#1"
+FAIL precommitHandler for a traverse navigation, success assert_equals: hash after first async step expected "#1" but got "#3"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-uncancelable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-uncancelable-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL precommitHandler for an uncancelable traverse navigation assert_throws_dom: function "() => e.intercept({ precommitHandler: async () => {} })" did not throw
+PASS precommitHandler for an uncancelable traverse navigation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-window-stop-before-commit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-window-stop-before-commit-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL  precommitHandler with window.stop() before commit assert_equals: expected "" but got "#ShouldNotCommit"
+PASS Setup
+PASS  precommitHandler with window.stop() before navigation commit
+PASS  precommitHandler with window.stop() before fragment navigation commit
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6309,6 +6309,20 @@ NavigationAPIEnabled:
       "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
+NavigationAPIPrecommitHandlerEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Navigation API Precommit Handler"
+  humanReadableDescription: "Enable Navigation API Precommit Handler"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 NavigatorUserAgentDataJavaScriptAPIEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1435,9 +1435,15 @@ set(WebCore_NON_SVG_IDL_FILES
     page/NavigationActivation.idl
     page/NavigationCurrentEntryChangeEvent.idl
     page/NavigationDestination.idl
+    page/NavigationHistoryBehavior.idl
     page/NavigationHistoryEntry.idl
     page/NavigationInterceptHandler.idl
+    page/NavigationNavigateOptions.idl
     page/NavigationNavigationType.idl
+    page/NavigationOptions.idl
+    page/NavigationPrecommitController.idl
+    page/NavigationPrecommitHandler.idl
+    page/NavigationReloadOptions.idl
     page/NavigationTransition.idl
     page/Navigator.idl
     page/NavigatorUABrandVersion.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1590,9 +1590,15 @@ JS_BINDING_IDLS := \
     $(WebCore)/page/NavigationActivation.idl \
     $(WebCore)/page/NavigationCurrentEntryChangeEvent.idl \
     $(WebCore)/page/NavigationDestination.idl \
+    $(WebCore)/page/NavigationHistoryBehavior.idl \
     $(WebCore)/page/NavigationHistoryEntry.idl \
     $(WebCore)/page/NavigationInterceptHandler.idl \
+    $(WebCore)/page/NavigationNavigateOptions.idl \
     $(WebCore)/page/NavigationNavigationType.idl \
+    $(WebCore)/page/NavigationOptions.idl \
+    $(WebCore)/page/NavigationPrecommitController.idl \
+    $(WebCore)/page/NavigationPrecommitHandler.idl \
+    $(WebCore)/page/NavigationReloadOptions.idl \
     $(WebCore)/page/NavigationTransition.idl \
     $(WebCore)/page/Navigator.idl \
     $(WebCore)/page/NavigatorUA.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2050,6 +2050,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/MemoryRelease.h
     page/ModalContainerTypes.h
     page/NavigationActivation.h
+    page/NavigationHistoryBehavior.h
     page/NavigationNavigationType.h
     page/Navigator.h
     page/NavigatorBase.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -817,6 +817,7 @@ bindings/js/JSMutationObserverCustom.cpp
 bindings/js/JSMutationRecordCustom.cpp
 bindings/js/JSNavigateEventCustom.cpp
 bindings/js/JSNavigationCustom.cpp
+bindings/js/JSNavigationPrecommitControllerCustom.cpp
 bindings/js/JSNavigatorCustom.cpp @cost:3
 bindings/js/JSNodeCustom.cpp
 bindings/js/JSNodeIteratorCustom.cpp
@@ -2309,6 +2310,7 @@ page/NavigationActivation.cpp
 page/NavigationCurrentEntryChangeEvent.cpp
 page/NavigationDestination.cpp
 page/NavigationHistoryEntry.cpp
+page/NavigationPrecommitController.cpp
 page/NavigationTransition.cpp
 page/Navigator.cpp
 page/NavigatorBase.cpp
@@ -4729,11 +4731,17 @@ JSNavigation.cpp @cost:3
 JSNavigationActivation.cpp
 JSNavigationCurrentEntryChangeEvent.cpp
 JSNavigationDestination.cpp
+JSNavigationHistoryBehavior.cpp
 JSNavigationHistoryEntry.cpp
 JSNavigationInterceptHandler.cpp
+JSNavigationNavigateOptions.cpp
 JSNavigationNavigationType.cpp
+JSNavigationOptions.cpp
+JSNavigationPrecommitController.cpp
+JSNavigationPrecommitHandler.cpp
 JSNavigationPreloadManager.cpp
 JSNavigationPreloadState.cpp
+JSNavigationReloadOptions.cpp
 JSNavigationTransition.cpp
 JSNavigator.cpp
 JSNavigatorGPU.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3878,6 +3878,7 @@
 		93B70D6C09EB0C7C009D8468 /* JSPluginElementFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B70D5009EB0C7C009D8468 /* JSPluginElementFunctions.h */; };
 		93B70D7009EB0C7C009D8468 /* ScriptController.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B70D5409EB0C7C009D8468 /* ScriptController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93B77A380ADD792500EA4B81 /* FrameLoaderTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B77A370ADD792500EA4B81 /* FrameLoaderTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		AE01B20C0D0E0F1011121401 /* NavigationHistoryBehavior.h in Headers */ = {isa = PBXBuildFile; fileRef = AE01B20C0D0E0F1011121308 /* NavigationHistoryBehavior.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93C09A530B064DB3005ABD4D /* EventHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 93C09A520B064DB3005ABD4D /* EventHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93C09C860B0657AA005ABD4D /* ScrollTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 93C09C850B0657AA005ABD4D /* ScrollTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93C38BFF164473C700091EB2 /* ScrollingStateFixedNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 93C38BFD164473C700091EB2 /* ScrollingStateFixedNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -11964,6 +11965,7 @@
 		46037DD428400F3500D464FC /* WebCoreOpaqueRoot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebCoreOpaqueRoot.h; sourceTree = "<group>"; };
 		4607DC642C6AC0AC00AB00D4 /* NavigationIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigationIdentifier.h; sourceTree = "<group>"; };
 		460A3C5D2CA4EF7900D043CA /* JSNavigateEventCustom.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSNavigateEventCustom.cpp; sourceTree = "<group>"; };
+		AE01B20C0D0E0F1011121306 /* JSNavigationPrecommitControllerCustom.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSNavigationPrecommitControllerCustom.cpp; sourceTree = "<group>"; };
 		460BB52127A9FC2E00CB782F /* WorkerFetchResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorkerFetchResult.h; sourceTree = "<group>"; };
 		460C70FB28E662D4005F4D74 /* JSObservableArray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSObservableArray.h; sourceTree = "<group>"; };
 		460C70FC28E662D5005F4D74 /* JSObservableArray.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSObservableArray.cpp; sourceTree = "<group>"; };
@@ -18269,6 +18271,13 @@
 		A9C6E65D0D746694006442E9 /* Navigator.idl */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; path = Navigator.idl; sourceTree = "<group>"; };
 		A9C6E65D0D74B694006442E9 /* NavigateEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = NavigateEvent.cpp; sourceTree = "<group>"; };
 		A9C6E65D0D74C694006442E9 /* NavigateEvent.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = NavigateEvent.h; sourceTree = "<group>"; };
+		AE01B20C0D0E0F1011121301 /* NavigationPrecommitController.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NavigationPrecommitController.cpp; sourceTree = "<group>"; };
+		AE01B20C0D0E0F1011121302 /* NavigationPrecommitController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigationPrecommitController.h; sourceTree = "<group>"; };
+		AE01B20C0D0E0F1011121304 /* NavigationPrecommitHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigationPrecommitHandler.h; sourceTree = "<group>"; };
+		AE01B20C0D0E0F1011121308 /* NavigationHistoryBehavior.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigationHistoryBehavior.h; sourceTree = "<group>"; };
+		AE01B20C0D0E0F101112130A /* NavigationOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigationOptions.h; sourceTree = "<group>"; };
+		AE01B20C0D0E0F101112130C /* NavigationNavigateOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigationNavigateOptions.h; sourceTree = "<group>"; };
+		AE01B20C0D0E0F101112130E /* NavigationReloadOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigationReloadOptions.h; sourceTree = "<group>"; };
 		A9C6E65D0D74E694006442E9 /* Navigation.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; path = Navigation.cpp; sourceTree = "<group>"; };
 		A9C6E65D0D74F694006442E9 /* NavigationCurrentEntryChangeEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = NavigationCurrentEntryChangeEvent.cpp; sourceTree = "<group>"; };
 		A9C6E65E0D7466F2006442E9 /* DOMMimeType.idl */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; path = DOMMimeType.idl; sourceTree = "<group>"; };
@@ -19829,6 +19838,12 @@
 		BC63AD522F085C50007B62C4 /* StyleSVGNonInheritedMiscData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleSVGNonInheritedMiscData.h; sourceTree = "<group>"; };
 		BC63AD532F085C50007B62C4 /* StyleSVGNonInheritedMiscData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleSVGNonInheritedMiscData.cpp; sourceTree = "<group>"; };
 		BC63ADDF2F158517007B62C4 /* NavigateEvent.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NavigateEvent.idl; sourceTree = "<group>"; };
+		AE01B20C0D0E0F1011121303 /* NavigationPrecommitController.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NavigationPrecommitController.idl; sourceTree = "<group>"; };
+		AE01B20C0D0E0F1011121305 /* NavigationPrecommitHandler.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NavigationPrecommitHandler.idl; sourceTree = "<group>"; };
+		AE01B20C0D0E0F1011121307 /* NavigationHistoryBehavior.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NavigationHistoryBehavior.idl; sourceTree = "<group>"; };
+		AE01B20C0D0E0F1011121309 /* NavigationOptions.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NavigationOptions.idl; sourceTree = "<group>"; };
+		AE01B20C0D0E0F101112130B /* NavigationNavigateOptions.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NavigationNavigateOptions.idl; sourceTree = "<group>"; };
+		AE01B20C0D0E0F101112130D /* NavigationReloadOptions.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NavigationReloadOptions.idl; sourceTree = "<group>"; };
 		BC64640811D7F304006455B0 /* DOMStringMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DOMStringMap.h; sourceTree = "<group>"; };
 		BC64641A11D7F416006455B0 /* DatasetDOMStringMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DatasetDOMStringMap.h; sourceTree = "<group>"; };
 		BC64641B11D7F416006455B0 /* DatasetDOMStringMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DatasetDOMStringMap.cpp; sourceTree = "<group>"; };
@@ -31310,13 +31325,26 @@
 				A9C6E65D0D740C94006442E9 /* NavigationDestination.cpp */,
 				A9C6E65D0D740D94006442E9 /* NavigationDestination.h */,
 				A9C6E65D0D740E94006442E9 /* NavigationDestination.idl */,
+				AE01B20C0D0E0F1011121308 /* NavigationHistoryBehavior.h */,
+				AE01B20C0D0E0F1011121307 /* NavigationHistoryBehavior.idl */,
 				A9C6E65D0D7400A4006442E9 /* NavigationHistoryEntry.cpp */,
 				A9C6E65D0D7400B4006442E9 /* NavigationHistoryEntry.h */,
 				A9C6E65D0D7400C4006442E9 /* NavigationHistoryEntry.idl */,
 				A9C6E65D0D7400E4006442E9 /* NavigationInterceptHandler.h */,
 				A9C6E65D0D7400F4006442E9 /* NavigationInterceptHandler.idl */,
+				AE01B20C0D0E0F101112130C /* NavigationNavigateOptions.h */,
+				AE01B20C0D0E0F101112130B /* NavigationNavigateOptions.idl */,
 				A9C6E65D0D74000A006442E9 /* NavigationNavigationType.h */,
 				A9C6E65D0D74000E006442E9 /* NavigationNavigationType.idl */,
+				AE01B20C0D0E0F101112130A /* NavigationOptions.h */,
+				AE01B20C0D0E0F1011121309 /* NavigationOptions.idl */,
+				AE01B20C0D0E0F1011121301 /* NavigationPrecommitController.cpp */,
+				AE01B20C0D0E0F1011121302 /* NavigationPrecommitController.h */,
+				AE01B20C0D0E0F1011121303 /* NavigationPrecommitController.idl */,
+				AE01B20C0D0E0F1011121304 /* NavigationPrecommitHandler.h */,
+				AE01B20C0D0E0F1011121305 /* NavigationPrecommitHandler.idl */,
+				AE01B20C0D0E0F101112130E /* NavigationReloadOptions.h */,
+				AE01B20C0D0E0F101112130D /* NavigationReloadOptions.idl */,
 				A9C6E65D0D74000B006442E9 /* NavigationTransition.cpp */,
 				A9C6E65D0D74000C006442E9 /* NavigationTransition.h */,
 				A9C6E65D0D74000D006442E9 /* NavigationTransition.idl */,
@@ -32524,6 +32552,7 @@
 				9B9CADA72165DC7600E8D858 /* JSMutationRecordCustom.cpp */,
 				460A3C5D2CA4EF7900D043CA /* JSNavigateEventCustom.cpp */,
 				46199AAA2EB9B994006C50D9 /* JSNavigationCustom.cpp */,
+				AE01B20C0D0E0F1011121306 /* JSNavigationPrecommitControllerCustom.cpp */,
 				83B5DA451FA9079300B59DF4 /* JSNavigatorCustom.cpp */,
 				BCD9C2600C17AA67005C90A2 /* JSNodeCustom.cpp */,
 				BC9439C2116CF4940048C750 /* JSNodeCustom.h */,
@@ -47645,6 +47674,7 @@
 				E10B9B6C0B747599003ED890 /* NativeXPathNSResolver.h in Headers */,
 				93CCF0270AF6C52900018E89 /* NavigationAction.h in Headers */,
 				EE1A93AA2F2AE00A0054FAE4 /* NavigationActivation.h in Headers */,
+				AE01B20C0D0E0F1011121401 /* NavigationHistoryBehavior.h in Headers */,
 				EE1A93AB2F2AE7D20054FAE4 /* NavigationHistoryEntry.h in Headers */,
 				4607DC652C6AC0AC00AB00D4 /* NavigationIdentifier.h in Headers */,
 				41E2F199274FAECF00A089EE /* NavigationPreloadManager.h in Headers */,

--- a/Source/WebCore/bindings/js/JSNavigationPrecommitControllerCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigationPrecommitControllerCustom.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSNavigationPrecommitController.h"
+
+#include "NavigateEvent.h"
+#include "WebCoreOpaqueRootInlines.h"
+
+namespace WebCore {
+
+template<typename Visitor>
+void JSNavigationPrecommitController::visitAdditionalChildrenInGCThread(Visitor& visitor)
+{
+    addWebCoreOpaqueRoot(visitor, &wrapped().event());
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSNavigationPrecommitController);
+
+} // namespace WebCore

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -342,6 +342,7 @@ namespace WebCore {
     macro(NavigationCurrentEntryChangeEvent) \
     macro(NavigationDestination) \
     macro(NavigationHistoryEntry) \
+    macro(NavigationPrecommitController) \
     macro(NavigationPreloadManager) \
     macro(NavigationTransition) \
     macro(NavigatorCredentials) \

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -29,6 +29,7 @@
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/Element.h>
 #include <WebCore/FrameLoaderTypes.h>
+#include <WebCore/NavigationHistoryBehavior.h>
 #include <WebCore/ReferrerPolicy.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ShouldTreatAsContinuingLoad.h>

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -37,6 +37,7 @@
 #include <WebCore/LayoutMilestone.h>
 #include <WebCore/LoaderMalloc.h>
 #include <WebCore/NavigationAction.h>
+#include <WebCore/NavigationHistoryBehavior.h>
 #include <WebCore/NavigationRequester.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PrivateClickMeasurement.h>

--- a/Source/WebCore/loader/FrameLoaderTypes.h
+++ b/Source/WebCore/loader/FrameLoaderTypes.h
@@ -107,13 +107,6 @@ enum class NavigationType : uint8_t {
     Other
 };
 
-enum class NavigationHistoryBehavior : uint8_t {
-    Auto,
-    Push,
-    Replace,
-    Reload // Internal, not part of the specification
-};
-
 enum class NavigationUpgradeToHTTPSBehavior : uint8_t {
     Disabled,
     HTTPFallback,

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -32,6 +32,7 @@
 
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/LoaderMalloc.h>
+#include <WebCore/NavigationHistoryBehavior.h>
 #include <WebCore/Timer.h>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>

--- a/Source/WebCore/page/History.h
+++ b/Source/WebCore/page/History.h
@@ -29,6 +29,7 @@
 #include "FrameLoaderTypes.h"
 #include "JSValueInWrappedObject.h"
 #include "LocalDOMWindowProperty.h"
+#include "NavigationHistoryBehavior.h"
 #include "ScriptWrappable.h"
 #include "SerializedScriptValue.h"
 #include <wtf/WallTime.h>

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -41,6 +41,7 @@
 #include "Navigation.h"
 #include "NavigationNavigationType.h"
 #include "ScriptWrappableInlines.h"
+#include "Settings.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -114,6 +115,12 @@ JSC::JSValue NavigateEvent::info()
     return m_info.getValue();
 }
 
+void NavigateEvent::setInfo(JSC::JSGlobalObject& globalObject, JSC::JSValue info)
+{
+    Locker<JSC::JSLock> locker(globalObject.vm().apiLock());
+    m_info.set(globalObject, wrapper(), info);
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-intercept
 ExceptionOr<void> NavigateEvent::intercept(Document& document, NavigationInterceptOptions&& options)
 {
@@ -125,6 +132,13 @@ ExceptionOr<void> NavigateEvent::intercept(Document& document, NavigationInterce
 
     if (!isBeingDispatched())
         return Exception { ExceptionCode::InvalidStateError, "Event is not being dispatched"_s };
+
+    if (document.settings().navigationAPIPrecommitHandlerEnabled() && options.precommitHandler) {
+        if (!cancelable())
+            return Exception { ExceptionCode::InvalidStateError, "A precommitHandler can only be used on a cancelable navigation"_s };
+
+        m_precommitHandlers.append(options.precommitHandler.releaseNonNull());
+    }
 
     ASSERT(!m_interceptionState || m_interceptionState == InterceptionState::Intercepted);
 

--- a/Source/WebCore/page/NavigateEvent.h
+++ b/Source/WebCore/page/NavigateEvent.h
@@ -36,6 +36,7 @@
 #include "NavigationDestination.h"
 #include "NavigationInterceptHandler.h"
 #include "NavigationNavigationType.h"
+#include "NavigationPrecommitHandler.h"
 
 namespace WebCore {
 
@@ -84,6 +85,7 @@ public:
     };
 
     struct NavigationInterceptOptions {
+        RefPtr<NavigationPrecommitHandler> precommitHandler;
         RefPtr<NavigationInterceptHandler> handler;
         std::optional<NavigationFocusReset> focusReset;
         std::optional<NavigationScrollBehavior> scroll;
@@ -93,6 +95,7 @@ public:
     static Ref<NavigateEvent> create(RefPtr<DOMWrapperWorld>&&, const AtomString& type, Init&&, AbortController*);
 
     NavigationNavigationType navigationType() const { return m_navigationType; }
+    void setNavigationType(NavigationNavigationType navigationType) { m_navigationType = navigationType; }
     bool canIntercept() const { return m_canIntercept; }
     bool userInitiated() const { return m_userInitiated; }
     bool hashChange() const { return m_hashChange; }
@@ -102,24 +105,27 @@ public:
     DOMFormData* formData() { return m_formData.get(); }
     String downloadRequest() { return m_downloadRequest; }
     JSC::JSValue info();
+    void setInfo(JSC::JSGlobalObject&, JSC::JSValue);
     JSValueInWrappedObject& infoWrapper() LIFETIME_BOUND { return m_info; }
     Element* sourceElement() { return m_sourceElement.get(); }
 
+    ExceptionOr<void> sharedChecks(Document&);
     ExceptionOr<void> intercept(Document&, NavigationInterceptOptions&&);
     ExceptionOr<void> scroll(Document&);
 
     bool wasIntercepted() const { return m_interceptionState.has_value(); }
+    std::optional<InterceptionState> interceptionState() const { return m_interceptionState; }
     void setInterceptionState(InterceptionState interceptionState) { m_interceptionState = interceptionState; }
 
     void finish(Document&, InterceptionHandlersDidFulfill, FocusDidChange);
 
     Vector<Ref<NavigationInterceptHandler>>& handlers() LIFETIME_BOUND { return m_handlers; }
+    Vector<Ref<NavigationPrecommitHandler>>& precommitHandlers() LIFETIME_BOUND { return m_precommitHandlers; }
 
 private:
     NavigateEvent(JSC::JSGlobalObject&, const AtomString& type, Init&&, EventIsTrusted, AbortController*);
     NavigateEvent(RefPtr<DOMWrapperWorld>&&, const AtomString& type, Init&&, EventIsTrusted, AbortController*);
 
-    ExceptionOr<void> sharedChecks(Document&);
     void potentiallyProcessScrollBehavior(Document&);
     void processScrollBehavior(Document&);
 
@@ -129,6 +135,7 @@ private:
     const RefPtr<DOMFormData> m_formData;
     String m_downloadRequest;
     Vector<Ref<NavigationInterceptHandler>> m_handlers;
+    Vector<Ref<NavigationPrecommitHandler>> m_precommitHandlers;
     JSValueInWrappedObject m_info;
     const RefPtr<Element> m_sourceElement;
     bool m_canIntercept { false };

--- a/Source/WebCore/page/NavigateEvent.idl
+++ b/Source/WebCore/page/NavigateEvent.idl
@@ -64,6 +64,7 @@ dictionary NavigateEventInit : EventInit {
 };
 
 dictionary NavigationInterceptOptions {
+  [EnabledBySetting=NavigationAPIPrecommitHandlerEnabled] NavigationPrecommitHandler precommitHandler;
   NavigationInterceptHandler handler;
   NavigationFocusReset focusReset;
   NavigationScrollBehavior scroll;

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -63,6 +63,7 @@
 #include "NavigationDestination.h"
 #include "NavigationHistoryEntry.h"
 #include "NavigationNavigationType.h"
+#include "NavigationPrecommitController.h"
 #include "NavigationScheduler.h"
 #include "NodeDocument.h"
 #include "Page.h"
@@ -450,7 +451,7 @@ Navigation::Result Navigation::apiMethodTrackerDerivedResult(const NavigationAPI
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-reload
-Navigation::Result Navigation::reload(JSC::JSGlobalObject& globalObject, ReloadOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::reload(JSC::JSGlobalObject& globalObject, NavigationReloadOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     auto serializedState = serializeState(options.state);
     if (serializedState.hasException())
@@ -481,7 +482,7 @@ Navigation::Result Navigation::reload(JSC::JSGlobalObject& globalObject, ReloadO
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate
-Navigation::Result Navigation::navigate(JSC::JSGlobalObject& globalObject, const String& url, NavigateOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::navigate(JSC::JSGlobalObject& globalObject, const String& url, NavigationNavigateOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     RefPtr window = this->window();
     auto newURL = protect(window->document())->parseURL(url);
@@ -494,7 +495,7 @@ Navigation::Result Navigation::navigate(JSC::JSGlobalObject& globalObject, const
     if (newURL.protocolIsJavaScript())
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::NotSupportedError, "Navigation API does not support javascript: URLs."_s);
 
-    if (options.history == HistoryBehavior::Push && currentURL.isAboutBlank())
+    if (options.history == NavigationHistoryBehavior::Push && currentURL.isAboutBlank())
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::NotSupportedError, "A \"push\" navigation was explicitly requested, but only a \"replace\" navigation is possible while on an about:blank document."_s);
 
     auto serializedState = serializeState(options.state);
@@ -519,7 +520,7 @@ Navigation::Result Navigation::navigate(JSC::JSGlobalObject& globalObject, const
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#performing-a-navigation-api-traversal
-Navigation::Result Navigation::performTraversal(JSC::JSGlobalObject& globalObject, const String& key, Navigation::Options options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::performTraversal(JSC::JSGlobalObject& globalObject, const String& key, NavigationOptions options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     RefPtr window = this->window();
     if (!protect(window->document())->isFullyActive() || window->document()->unloadCounter())
@@ -586,7 +587,7 @@ NavigationHistoryEntry* Navigation::findEntryByKey(const String& key) const
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-traverseto
-Navigation::Result Navigation::traverseTo(JSC::JSGlobalObject& globalObject, const String& key, Options&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::traverseTo(JSC::JSGlobalObject& globalObject, const String& key, NavigationOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     if (!hasEntryWithKey(key))
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::InvalidStateError, "Invalid key"_s);
@@ -595,7 +596,7 @@ Navigation::Result Navigation::traverseTo(JSC::JSGlobalObject& globalObject, con
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-back
-Navigation::Result Navigation::back(JSC::JSGlobalObject& globalObject, Options&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::back(JSC::JSGlobalObject& globalObject, NavigationOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     if (!canGoBack())
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::InvalidStateError, "Cannot go back"_s);
@@ -606,7 +607,7 @@ Navigation::Result Navigation::back(JSC::JSGlobalObject& globalObject, Options&&
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-forward
-Navigation::Result Navigation::forward(JSC::JSGlobalObject& globalObject, Options&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::forward(JSC::JSGlobalObject& globalObject, NavigationOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     if (!canGoForward())
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::InvalidStateError, "Cannot go forward"_s);
@@ -870,7 +871,7 @@ void Navigation::updateForReactivation(Vector<Ref<HistoryItem>>&& newHistoryItem
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#can-have-its-url-rewritten
-static bool documentCanHaveURLRewritten(const Document& document, const URL& targetURL)
+bool Navigation::documentCanHaveURLRewritten(const Document& document, const URL& targetURL)
 {
     const URL& documentURL = document.url();
     Ref documentOrigin = document.securityOrigin();
@@ -1160,25 +1161,33 @@ private:
     unsigned m_settledPromises { 0 };
 };
 
+bool Navigation::createTransitionForInterception(NavigateEvent& event, NavigationNavigationType navigationType, Document& document)
+{
+    ASSERT(!m_transition);
+
+    RefPtr fromNavigationHistoryEntry = currentEntry();
+    ASSERT(fromNavigationHistoryEntry);
+    if (!fromNavigationHistoryEntry) {
+        abortOngoingNavigation(event);
+        return false;
+    }
+
+    auto& domGlobalObject = *downcast<JSDOMGlobalObject>(document.globalObject());
+    JSC::JSLockHolder locker(domGlobalObject.vm());
+
+    Ref committedPromise = DeferredPromise::create(domGlobalObject, DeferredPromise::Mode::RetainPromiseOnResolve).releaseNonNull();
+    Ref finishedPromise = DeferredPromise::create(domGlobalObject, DeferredPromise::Mode::RetainPromiseOnResolve).releaseNonNull();
+
+    m_transition = NavigationTransition::create(navigationType, *fromNavigationHistoryEntry, WTF::move(committedPromise), WTF::move(finishedPromise));
+    return true;
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm Step 32
 void Navigation::setupInterceptionState(NavigateEvent& event, NavigationNavigationType navigationType, NavigationDestination& destination, Document& document, SerializedScriptValue* classicHistoryAPIState)
 {
     ASSERT(event.wasIntercepted());
 
     event.setInterceptionState(InterceptionState::Committed);
-
-    RefPtr fromNavigationHistoryEntry = currentEntry();
-    ASSERT(fromNavigationHistoryEntry);
-    if (!fromNavigationHistoryEntry) {
-        abortOngoingNavigation(event);
-        return;
-    }
-
-    {
-        auto& domGlobalObject = *downcast<JSDOMGlobalObject>(document.globalObject());
-        JSC::JSLockHolder locker(domGlobalObject.vm());
-        m_transition = NavigationTransition::create(navigationType, *fromNavigationHistoryEntry, DeferredPromise::create(domGlobalObject, DeferredPromise::Mode::RetainPromiseOnResolve).releaseNonNull());
-    }
 
     if (navigationType == NavigationNavigationType::Traverse) {
         m_suppressNormalScrollRestorationDuringOngoingNavigation = true;
@@ -1204,6 +1213,9 @@ void Navigation::setupInterceptionState(NavigateEvent& event, NavigationNavigati
         auto historyHandling = navigationType == NavigationNavigationType::Replace ? NavigationHistoryBehavior::Replace : NavigationHistoryBehavior::Push;
         frame()->loader().updateURLAndHistory(destination.url(), classicHistoryAPIState, historyHandling);
     }
+
+    if (RefPtr transition = m_transition)
+        transition->resolveCommitted();
 }
 
 std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigation(NavigateEvent& event, NavigationNavigationType navigationType, NavigationAPIMethodTracker* apiMethodTracker, AbortController& abortController, Document& document)
@@ -1327,6 +1339,75 @@ std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigati
     return std::nullopt;
 }
 
+void Navigation::runNavigatePrecommitHandlers(NavigateEvent& event, NavigationAPIMethodTracker* apiMethodTracker, AbortController& abortController, Document& document, RefPtr<SerializedScriptValue>&& classicHistoryAPIState)
+{
+    Ref precommitController = NavigationPrecommitController::create(event);
+
+    Vector<Ref<DOMPromise>> promiseList;
+    for (auto& handler : event.precommitHandlers()) {
+        auto callbackResult = handler->invoke(precommitController.get());
+        if (callbackResult.type() != CallbackResultType::UnableToExecute) {
+            Ref promise = callbackResult.releaseReturnValue();
+            // Because rejection is reported as `navigateerror` event, we can mark this as handled.
+            if (!promise->isSuspended())
+                promise->markAsHandled();
+            promiseList.append(WTF::move(promise));
+        }
+    }
+
+    // A precommit handler may have detached the document (e.g., by removing its iframe from the DOM).
+    if (!document.isFullyActive()) {
+        abortOngoingNavigation(event);
+        return;
+    }
+
+    auto successSteps = [weakThis = WeakPtr { this }, event = Ref { event }, apiMethodTracker = RefPtr { apiMethodTracker }, abortController = Ref { abortController }, document = Ref { document }, classicHistoryAPIState = WTF::move(classicHistoryAPIState)]() mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || protectedThis->m_ongoingNavigateEvent != event.ptr())
+            return;
+
+        protectedThis->setupInterceptionState(event.get(), event->navigationType(), event->destination(), document.get(), classicHistoryAPIState.get());
+        // This runs asynchronously after innerDispatchNavigateEvent() has already returned
+        // DispatchResult::Intercepted to its caller, so there is no caller left to report the
+        // DispatchResult to. Discarding the return value here is intentional.
+        protectedThis->handleSameDocumentNavigation(event.get(), event->navigationType(), apiMethodTracker.get(), abortController.get(), document.get());
+    };
+
+    auto failureSteps = [weakThis = WeakPtr { this }, event = Ref { event }, apiMethodTracker = RefPtr { apiMethodTracker }, abortController = Ref { abortController }, document = Ref { document }](JSC::JSValue result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || protectedThis->m_ongoingNavigateEvent != event.ptr())
+            return;
+
+        // The navigation has not been committed yet (interception state is still "intercepted"), so unlike
+        // an intercept handler failure we must not call NavigateEvent::finish() here.
+        abortController->signal().signalAbort(result);
+
+        protectedThis->m_ongoingNavigateEvent = nullptr;
+
+        ErrorInformation errorInformation;
+        String errorMessage;
+        if (auto* errorInstance = dynamicDowncast<JSC::ErrorInstance>(result)) {
+            if (auto extracted = extractErrorInformationFromErrorInstance(protect(protectedThis->scriptExecutionContext())->globalObject(), *errorInstance)) {
+                errorInformation = WTF::move(*extracted);
+                errorMessage = makeString("Uncaught "_s, errorInformation.errorTypeString, ": "_s, errorInformation.message);
+            }
+        }
+
+        auto* navGlobalObject = protect(protectedThis->scriptExecutionContext())->globalObject();
+        protectedThis->dispatchEvent(ErrorEvent::create(*navGlobalObject, eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { navGlobalObject->vm(), result }));
+
+        if (apiMethodTracker) {
+            apiMethodTracker->rejectFinished(result);
+            protectedThis->m_methodTrackers.unregister(*apiMethodTracker);
+        }
+
+        if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
+            transition->rejectPromise(result);
+    };
+
+    PromiseSettlementObserver::waitForAll(document, promiseList, WTF::move(successSteps), WTF::move(failureSteps));
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm
 Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationType, Ref<NavigationDestination>&& destination, const String& downloadRequestFilename, FormState* formState, SerializedScriptValue* classicHistoryAPIState, Element* sourceElement)
 {
@@ -1443,6 +1524,19 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     bool endResultIsSameDocument = event->wasIntercepted() || destination->sameDocument();
 
     // FIXME: Prepare to run script given navigation's relevant settings object.
+
+    if (event->wasIntercepted() && !createTransitionForInterception(event.get(), navigationType, *document))
+        return DispatchResult::Aborted;
+
+    if (document->settings().navigationAPIPrecommitHandlerEnabled() && !event->precommitHandlers().isEmpty()) {
+        runNavigatePrecommitHandlers(event.get(), apiMethodTracker.get(), *abortController, *document, RefPtr { classicHistoryAPIState });
+
+        // If a new event has been dispatched in a precommit handler then we were aborted above.
+        if (m_ongoingNavigateEvent != event.ptr())
+            return DispatchResult::Aborted;
+
+        return DispatchResult::Intercepted;
+    }
 
     // Step 32:
     if (event->wasIntercepted())

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -32,7 +32,10 @@
 #include "LocalDOMWindowProperty.h"
 #include "NavigateEvent.h"
 #include "NavigationHistoryEntry.h"
+#include "NavigationNavigateOptions.h"
 #include "NavigationNavigationType.h"
+#include "NavigationOptions.h"
+#include "NavigationReloadOptions.h"
 #include "NavigationTransition.h"
 #include <JavaScriptCore/JSCJSValue.h>
 #include <wtf/MonotonicTime.h>
@@ -66,6 +69,7 @@ public:
     void setKey(const String& key) { m_key = key; }
     JSValueInWrappedObject& info() { return m_info; }
     SerializedScriptValue* serializedState() const { return m_serializedState.get(); }
+    void setSerializedState(RefPtr<SerializedScriptValue>&& serializedState) { m_serializedState = WTF::move(serializedState); }
     DeferredPromise& committedPromise() { return m_committedPromise; }
     const DeferredPromise& committedPromise() const { return m_committedPromise; }
     DeferredPromise& finishedPromise() { return m_finishedPromise; }
@@ -123,22 +127,7 @@ public:
     using RefCounted::ref;
     using RefCounted::deref;
 
-    using HistoryBehavior = NavigationHistoryBehavior;
-
     struct UpdateCurrentEntryOptions {
-        JSC::JSValue state;
-    };
-
-    struct Options {
-        JSC::JSValue info;
-    };
-
-    struct NavigateOptions : Options {
-        JSC::JSValue state;
-        HistoryBehavior history;
-    };
-
-    struct ReloadOptions : Options {
         JSC::JSValue state;
     };
 
@@ -157,13 +146,13 @@ public:
 
     void initializeForNewWindow(std::optional<NavigationNavigationType>, LocalDOMWindow* previousWindow);
 
-    Result navigate(JSC::JSGlobalObject&, const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result navigate(JSC::JSGlobalObject&, const String& url, NavigationNavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
-    Result reload(JSC::JSGlobalObject&, ReloadOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result reload(JSC::JSGlobalObject&, NavigationReloadOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
-    Result traverseTo(JSC::JSGlobalObject&, const String& key, Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
-    Result back(JSC::JSGlobalObject&, Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
-    Result forward(JSC::JSGlobalObject&, Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result traverseTo(JSC::JSGlobalObject&, const String& key, NavigationOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result back(JSC::JSGlobalObject&, NavigationOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result forward(JSC::JSGlobalObject&, NavigationOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
     ExceptionOr<void> updateCurrentEntry(UpdateCurrentEntryOptions&&);
 
@@ -182,13 +171,19 @@ public:
     NavigationHistoryEntry* findEntryByKey(const String&) const;
     bool suppressNormalScrollRestoration() const { return m_suppressNormalScrollRestorationDuringOngoingNavigation; }
 
+    static bool documentCanHaveURLRewritten(const Document&, const URL&);
+
+    ExceptionOr<RefPtr<SerializedScriptValue>> serializeState(JSC::JSValue state);
+
     void setFocusChanged(FocusDidChange changed) { m_focusChangedDuringOngoingNavigation = changed; }
 
     // EventTarget.
     ScriptExecutionContext* scriptExecutionContext() const final;
 
     void rejectFinishedPromise(NavigationAPIMethodTracker*);
+
     NavigationAPIMethodTracker* upcomingTraverseMethodTracker(const String& key) const;
+    NavigationAPIMethodTracker* ongoingAPIMethodTracker() const { return m_methodTrackers.ongoing(); }
 
     void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor&);
 
@@ -267,11 +262,12 @@ private:
     void derefEventTarget() final { deref(); }
 
     bool hasEntriesAndEventsDisabled() const;
-    Result performTraversal(JSC::JSGlobalObject&, const String& key, Navigation::Options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
-    ExceptionOr<RefPtr<SerializedScriptValue>> serializeState(JSC::JSValue state);
+    Result performTraversal(JSC::JSGlobalObject&, const String& key, NavigationOptions, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
     DispatchResult innerDispatchNavigateEvent(NavigationNavigationType, Ref<NavigationDestination>&&, const String& downloadRequestFilename, FormState* = nullptr, SerializedScriptValue* classicHistoryAPIState = nullptr, Element* sourceElement = nullptr);
     void setupInterceptionState(NavigateEvent&, NavigationNavigationType, NavigationDestination&, Document&, SerializedScriptValue* classicHistoryAPIState);
+    bool createTransitionForInterception(NavigateEvent&, NavigationNavigationType, Document&);
     std::optional<DispatchResult> handleSameDocumentNavigation(NavigateEvent&, NavigationNavigationType, NavigationAPIMethodTracker*, AbortController&, Document&);
+    void runNavigatePrecommitHandlers(NavigateEvent&, NavigationAPIMethodTracker*, AbortController&, Document&, RefPtr<SerializedScriptValue>&& classicHistoryAPIState);
 
     void setActivation(HistoryItem* previousItem, std::optional<NavigationNavigationType>);
 

--- a/Source/WebCore/page/Navigation.idl
+++ b/Source/WebCore/page/Navigation.idl
@@ -57,28 +57,9 @@ dictionary NavigationUpdateCurrentEntryOptions {
   required any state;
 };
 
-dictionary NavigationOptions {
-  any info;
-};
-
-dictionary NavigationNavigateOptions : NavigationOptions {
-  any state;
-  NavigationHistoryBehavior history = "auto";
-};
-
-dictionary NavigationReloadOptions : NavigationOptions {
-  any state;
-};
-
 [
     JSGenerateToJSObject,
 ] dictionary NavigationResult {
   [BypassDocumentFullyActiveCheck] Promise<NavigationHistoryEntry> committed;
   [BypassDocumentFullyActiveCheck] Promise<NavigationHistoryEntry> finished;
-};
-
-enum NavigationHistoryBehavior {
-  "auto",
-  "push",
-  "replace"
 };

--- a/Source/WebCore/page/NavigationHistoryBehavior.h
+++ b/Source/WebCore/page/NavigationHistoryBehavior.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class NavigationHistoryBehavior : uint8_t {
+    Auto,
+    Push,
+    Replace,
+    Reload // Internal, not part of the specification
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/NavigationHistoryBehavior.idl
+++ b/Source/WebCore/page/NavigationHistoryBehavior.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationhistorybehavior
+enum NavigationHistoryBehavior {
+  "auto",
+  "push",
+  "replace"
+};

--- a/Source/WebCore/page/NavigationNavigateOptions.h
+++ b/Source/WebCore/page/NavigationNavigateOptions.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "NavigationHistoryBehavior.h"
+#include "NavigationOptions.h"
+#include <JavaScriptCore/JSCJSValue.h>
+
+namespace WebCore {
+
+struct NavigationNavigateOptions : NavigationOptions {
+    JSC::JSValue state;
+    NavigationHistoryBehavior history { NavigationHistoryBehavior::Auto };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/NavigationNavigateOptions.idl
+++ b/Source/WebCore/page/NavigationNavigateOptions.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationnavigateoptions
+dictionary NavigationNavigateOptions : NavigationOptions {
+  any state;
+  NavigationHistoryBehavior history = "auto";
+};

--- a/Source/WebCore/page/NavigationOptions.h
+++ b/Source/WebCore/page/NavigationOptions.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/JSCJSValue.h>
+
+namespace WebCore {
+
+struct NavigationOptions {
+    JSC::JSValue info;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/NavigationOptions.idl
+++ b/Source/WebCore/page/NavigationOptions.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationoptions
+dictionary NavigationOptions {
+  any info;
+};

--- a/Source/WebCore/page/NavigationPrecommitController.cpp
+++ b/Source/WebCore/page/NavigationPrecommitController.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NavigationPrecommitController.h"
+
+#include "Document.h"
+#include "ExceptionCode.h"
+#include "ExceptionOr.h"
+#include "LocalDOMWindow.h"
+#include "NavigateEvent.h"
+#include "Navigation.h"
+#include "NavigationDestination.h"
+#include "NavigationInterceptHandler.h"
+#include "NavigationNavigateOptions.h"
+#include "SerializedScriptValue.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigationPrecommitController);
+
+NavigationPrecommitController::NavigationPrecommitController(NavigateEvent& event)
+    : m_event(event)
+{
+}
+
+NavigationPrecommitController::~NavigationPrecommitController() = default;
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationprecommitcontroller-redirect
+ExceptionOr<void> NavigationPrecommitController::redirect(JSC::JSGlobalObject& globalObject, Document& document, const String& url, NavigationNavigateOptions&& options)
+{
+    Ref event = m_event;
+
+    ASSERT(event->wasIntercepted());
+
+    if (auto checkResult = event->sharedChecks(document); checkResult.hasException())
+        return checkResult;
+
+    if (event->interceptionState() != InterceptionState::Intercepted)
+        return Exception { ExceptionCode::InvalidStateError, "Navigation has already been committed"_s };
+
+    auto navigationType = event->navigationType();
+    if (navigationType != NavigationNavigationType::Push && navigationType != NavigationNavigationType::Replace)
+        return Exception { ExceptionCode::InvalidStateError, "redirect() can only be called for push or replace navigations"_s };
+
+    URL destinationURL = document.parseURL(url);
+    if (!destinationURL.isValid())
+        return Exception { ExceptionCode::SyntaxError, "Invalid URL"_s };
+
+    if (!Navigation::documentCanHaveURLRewritten(document, destinationURL))
+        return Exception { ExceptionCode::SecurityError, "The document cannot have its URL rewritten to the destination URL"_s };
+
+    if (options.history == NavigationHistoryBehavior::Push || options.history == NavigationHistoryBehavior::Replace)
+        event->setNavigationType(options.history == NavigationHistoryBehavior::Push ? NavigationNavigationType::Push : NavigationNavigationType::Replace);
+
+    if (!options.state.isUndefined()) {
+        RefPtr window = document.window();
+        if (!window)
+            return Exception { ExceptionCode::InvalidStateError, "Invalid state"_s };
+
+        Ref navigation = window->navigation();
+        auto serializedState = navigation->serializeState(options.state);
+        if (serializedState.hasException())
+            return serializedState.releaseException();
+
+        RefPtr state = serializedState.releaseReturnValue();
+        event->destination().setStateObject(state);
+        if (RefPtr tracker = navigation->ongoingAPIMethodTracker())
+            tracker->setSerializedState(WTF::move(state));
+    }
+
+    event->destination().setURL(WTF::move(destinationURL));
+
+    if (!options.info.isUndefined())
+        event->setInfo(globalObject, options.info);
+
+    return { };
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationprecommitcontroller-addhandler
+ExceptionOr<void> NavigationPrecommitController::addHandler(Document& document, Ref<NavigationInterceptHandler>&& handler)
+{
+    Ref event = m_event;
+
+    ASSERT(event->wasIntercepted());
+
+    if (auto checkResult = event->sharedChecks(document); checkResult.hasException())
+        return checkResult;
+
+    if (event->interceptionState() != InterceptionState::Intercepted)
+        return Exception { ExceptionCode::InvalidStateError, "Navigation has already been committed"_s };
+
+    event->handlers().append(WTF::move(handler));
+
+    return { };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/NavigationPrecommitController.h
+++ b/Source/WebCore/page/NavigationPrecommitController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,41 +25,38 @@
 
 #pragma once
 
-#include "EventHandler.h"
-#include "LocalDOMWindowProperty.h"
-#include "NavigationHistoryEntry.h"
 #include "ScriptWrappable.h"
-#include "SerializedScriptValue.h"
+#include <wtf/Forward.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
 
 namespace JSC {
-class JSValue;
+class JSGlobalObject;
 }
 
 namespace WebCore {
 
-class NavigationDestination final : public RefCounted<NavigationDestination>, public ScriptWrappable {
-    WTF_MAKE_TZONE_ALLOCATED(NavigationDestination);
+class Document;
+class NavigateEvent;
+class NavigationInterceptHandler;
+struct NavigationNavigateOptions;
+template<typename> class ExceptionOr;
+
+class NavigationPrecommitController final : public RefCounted<NavigationPrecommitController>, public ScriptWrappable {
+    WTF_MAKE_TZONE_ALLOCATED(NavigationPrecommitController);
 public:
-    static Ref<NavigationDestination> create(const URL& url, RefPtr<NavigationHistoryEntry>&& entry, bool isSameDocument) { return adoptRef(*new NavigationDestination(url, WTF::move(entry), isSameDocument)); };
+    static Ref<NavigationPrecommitController> create(NavigateEvent& event) { return adoptRef(*new NavigationPrecommitController(event)); }
+    ~NavigationPrecommitController();
 
-    ~NavigationDestination();
+    ExceptionOr<void> redirect(JSC::JSGlobalObject&, Document&, const String& url, NavigationNavigateOptions&&);
+    ExceptionOr<void> addHandler(Document&, Ref<NavigationInterceptHandler>&&);
 
-    const URL& url() const LIFETIME_BOUND { return m_url; };
-    void setURL(URL&& url) { m_url = WTF::move(url); }
-    String key() const { return m_entry ? m_entry->key() : String(); };
-    String id() const { return m_entry ? m_entry->id() : String(); };
-    int64_t index() const { return m_entry ? m_entry->index() : -1; };
-    bool sameDocument() const { return m_isSameDocument; };
-    JSC::JSValue getState(JSDOMGlobalObject&) const;
-    void setStateObject(SerializedScriptValue* stateObject) { m_stateObject = stateObject; }
+    NavigateEvent& event() { return m_event.get(); }
 
 private:
-    explicit NavigationDestination(const URL&, RefPtr<NavigationHistoryEntry>&&, bool isSameDocument);
+    explicit NavigationPrecommitController(NavigateEvent&);
 
-    RefPtr<NavigationHistoryEntry> m_entry;
-    URL m_url;
-    bool m_isSameDocument;
-    RefPtr<SerializedScriptValue> m_stateObject;
+    const Ref<NavigateEvent> m_event;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationPrecommitController.idl
+++ b/Source/WebCore/page/NavigationPrecommitController.idl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationprecommitcontroller-interface
+[
+  JSCustomMarkFunction,
+  EnabledBySetting=NavigationAPIPrecommitHandlerEnabled,
+  Exposed=Window
+] interface NavigationPrecommitController {
+  [CallWith=CurrentGlobalObject&RelevantDocument] undefined redirect(USVString url, optional NavigationNavigateOptions options = {});
+  [CallWith=RelevantDocument] undefined addHandler(NavigationInterceptHandler handler);
+};

--- a/Source/WebCore/page/NavigationPrecommitHandler.h
+++ b/Source/WebCore/page/NavigationPrecommitHandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,41 +25,28 @@
 
 #pragma once
 
-#include "JSDOMPromise.h"
-#include "NavigationHistoryEntry.h"
-#include "NavigationNavigationType.h"
+#include "ActiveDOMCallback.h"
+#include "CallbackResult.h"
+#include <wtf/RefCounted.h>
 
 namespace WebCore {
 
 class DOMPromise;
-class DeferredPromise;
-class Exception;
+class NavigationPrecommitController;
 
-class NavigationTransition final : public RefCounted<NavigationTransition> {
-    WTF_MAKE_TZONE_ALLOCATED(NavigationTransition);
+class NavigationPrecommitHandler : public RefCounted<NavigationPrecommitHandler>, public ActiveDOMCallback {
 public:
-    static Ref<NavigationTransition> create(NavigationNavigationType, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
+    using ActiveDOMCallback::ActiveDOMCallback;
 
-    NavigationNavigationType navigationType() { return m_navigationType; };
-    NavigationHistoryEntry& from() { return m_from; };
-    DOMPromise& committed();
-    DOMPromise& finished();
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
-    void resolveCommitted();
-    void resolvePromise();
-    void rejectPromise(Exception&, JSC::JSValue exceptionObject);
-    void rejectPromise(JSC::JSValue exceptionObject);
+    virtual bool isJSNavigationPrecommitHandler() const { return false; }
+    virtual CallbackResult<Ref<DOMPromise>> invoke(NavigationPrecommitController&) = 0;
 
 private:
-    explicit NavigationTransition(NavigationNavigationType, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
-
-    NavigationNavigationType m_navigationType;
-    bool m_committedSettled { false };
-    const Ref<NavigationHistoryEntry> m_from;
-    const Ref<DeferredPromise> m_committed;
-    const Ref<DeferredPromise> m_finished;
-    RefPtr<DOMPromise> m_committedDOMPromise;
-    RefPtr<DOMPromise> m_finishedDOMPromise;
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationPrecommitHandler.idl
+++ b/Source/WebCore/page/NavigationPrecommitHandler.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationprecommithandler
+[
+    EnabledBySetting=NavigationAPIPrecommitHandlerEnabled,
+    GenerateIsReachable=ImplScriptExecutionContext,
+    SkipCallbackInvokeCheck
+] callback NavigationPrecommitHandler = Promise<undefined> (NavigationPrecommitController controller);

--- a/Source/WebCore/page/NavigationReloadOptions.h
+++ b/Source/WebCore/page/NavigationReloadOptions.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "NavigationOptions.h"
+#include <JavaScriptCore/JSCJSValue.h>
+
+namespace WebCore {
+
+struct NavigationReloadOptions : NavigationOptions {
+    JSC::JSValue state;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/NavigationReloadOptions.idl
+++ b/Source/WebCore/page/NavigationReloadOptions.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationreloadoptions
+dictionary NavigationReloadOptions : NavigationOptions {
+  any state;
+};

--- a/Source/WebCore/page/NavigationTransition.cpp
+++ b/Source/WebCore/page/NavigationTransition.cpp
@@ -34,16 +34,25 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigationTransition);
 
-Ref<NavigationTransition> NavigationTransition::create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& finished)
+Ref<NavigationTransition> NavigationTransition::create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    return adoptRef(*new NavigationTransition(type, WTF::move(fromEntry), WTF::move(finished)));
+    return adoptRef(*new NavigationTransition(type, WTF::move(fromEntry), WTF::move(committed), WTF::move(finished)));
 }
 
-NavigationTransition::NavigationTransition(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& finished)
+NavigationTransition::NavigationTransition(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
     : m_navigationType(type)
     , m_from(WTF::move(fromEntry))
+    , m_committed(WTF::move(committed))
     , m_finished(WTF::move(finished))
 {
+}
+
+void NavigationTransition::resolveCommitted()
+{
+    if (m_committedSettled)
+        return;
+    m_committedSettled = true;
+    m_committed->resolve();
 }
 
 void NavigationTransition::resolvePromise()
@@ -53,12 +62,30 @@ void NavigationTransition::resolvePromise()
 
 void NavigationTransition::rejectPromise(Exception& exception, JSC::JSValue exceptionObject)
 {
+    if (!m_committedSettled) {
+        m_committedSettled = true;
+        m_committed->reject(exception, RejectAsHandled::Yes, exceptionObject);
+    }
     m_finished->reject(exception, RejectAsHandled::Yes, exceptionObject);
 }
 
 void NavigationTransition::rejectPromise(JSC::JSValue exceptionObject)
 {
+    if (!m_committedSettled) {
+        m_committedSettled = true;
+        m_committed->reject<IDLAny>(exceptionObject, RejectAsHandled::Yes);
+    }
     m_finished->reject<IDLAny>(exceptionObject, RejectAsHandled::Yes);
+}
+
+DOMPromise& NavigationTransition::committed()
+{
+    if (!m_committedDOMPromise) {
+        auto& promise = *downcast<JSC::JSPromise>(m_committed->promise());
+        m_committedDOMPromise = DOMPromise::create(*m_committed->globalObject(), promise);
+    }
+
+    return *m_committedDOMPromise;
 }
 
 DOMPromise& NavigationTransition::finished()

--- a/Source/WebCore/page/NavigationTransition.idl
+++ b/Source/WebCore/page/NavigationTransition.idl
@@ -4,5 +4,6 @@
 ] interface NavigationTransition {
   readonly attribute NavigationNavigationType navigationType;
   readonly attribute NavigationHistoryEntry from;
+  readonly attribute Promise<undefined> committed;
   readonly attribute Promise<undefined> finished;
 };


### PR DESCRIPTION
#### 45434d689d024c7f54fbf5a316f2f7559af09f4b
<pre>
[Navigation API] Implement Precommit Handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=321260">https://bugs.webkit.org/show_bug.cgi?id=321260</a>
<a href="https://rdar.apple.com/184311803">rdar://184311803</a>

Reviewed by Basuke Suzuki.

This patch implements the Precommit Handler of the Navigation API according
to <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api.">https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api.</a>

This is guarded behind the new NavigationAPIPrecommitHandler feature flag
which is currently marked as &quot;testable&quot;. There are still a few tests that
are not passing yet. Once those are fixed, we will enable the flag in stable.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-addHandler-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-addHandler-throws-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-back-and-forth-expected.txt: Added.
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSNavigationPrecommitControllerCustom.cpp: Added.
(WebCore::JSNavigationPrecommitController::visitAdditionalChildrenInGCThread):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::setInfo):
(WebCore::NavigateEvent::intercept):
* Source/WebCore/page/NavigateEvent.h:
* Source/WebCore/page/NavigateEvent.idl:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::documentCanHaveURLRewritten):
(WebCore::Navigation::createTransitionForInterception):
(WebCore::Navigation::setupInterceptionState):
(WebCore::Navigation::runNavigatePrecommitHandlers):
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::documentCanHaveURLRewritten): Deleted.
(WebCore::Navigation::reload):
(WebCore::Navigation::navigate):
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::traverseTo):
(WebCore::Navigation::back):
(WebCore::Navigation::forward):
* Source/WebCore/page/Navigation.h:
(WebCore::NavigationAPIMethodTracker::setSerializedState):
* Source/WebCore/page/NavigationDestination.h:
* Source/WebCore/page/NavigationPrecommitController.cpp: Added.
(WebCore::NavigationPrecommitController::NavigationPrecommitController):
(WebCore::NavigationPrecommitController::redirect):
(WebCore::NavigationPrecommitController::addHandler):
* Source/WebCore/page/NavigationPrecommitController.h: Added.
* Source/WebCore/page/NavigationPrecommitController.idl: Added.
* Source/WebCore/page/NavigationPrecommitHandler.h: Copied from Source/WebCore/page/NavigationDestination.h.
(WebCore::NavigationPrecommitHandler::isJSNavigationPrecommitHandler const):
* Source/WebCore/page/NavigationPrecommitHandler.idl: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-redirect_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-redirect_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-reject.tentative_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-reject.tentative_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/multiple-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-new-navigation-before-commit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-push-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-options-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-push-changed-to-replace-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-push-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-replace-changed-to-push-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-replace-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-redirect-throws-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-reload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-replace-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-traversal-window-stop-before-commit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-traverse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-uncancelable-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-window-stop-before-commit-expected.txt:
* Source/WebCore/loader/FrameLoaderTypes.h:
* Source/WebCore/page/Navigation.idl:
* Source/WebCore/page/NavigationHistoryBehavior.h: Added.
* Source/WebCore/page/NavigationHistoryBehavior.idl: Added.
* Source/WebCore/page/NavigationNavigateOptions.h: Added.
* Source/WebCore/page/NavigationNavigateOptions.idl: Added.
* Source/WebCore/page/NavigationOptions.h: Added.
* Source/WebCore/page/NavigationOptions.idl: Added.
* Source/WebCore/page/NavigationReloadOptions.h: Added.
* Source/WebCore/page/NavigationReloadOptions.idl: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Headers.cmake:
* Source/WebCore/loader/FrameLoadRequest.h:
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/NavigationScheduler.h:
* Source/WebCore/page/History.h:
* Source/WebCore/page/NavigationTransition.cpp:
(WebCore::NavigationTransition::create):
(WebCore::NavigationTransition::NavigationTransition):
(WebCore::NavigationTransition::resolveCommitted):
(WebCore::NavigationTransition::rejectPromise):
(WebCore::NavigationTransition::committed):
* Source/WebCore/page/NavigationTransition.h:
* Source/WebCore/page/NavigationTransition.idl:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-aborts-previous-navigation-expected.txt:

Canonical link: <a href="https://commits.webkit.org/319084@main">https://commits.webkit.org/319084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaf422f8b132aba68e4f048208dad7a9f9b30947

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144645 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/510e5abe-a504-4ed5-86c1-9cd4ed51fde6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140673 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/872049a3-4524-4072-bd7f-ec6879e0819b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121125 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cae23048-eb6d-40e2-ae90-453aff2e488e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42988 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41281 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3092 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9923 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40967 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1694 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41598 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192470 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160956 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150012 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54623 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149734 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27380 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44368 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126886 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122048 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53140 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15956 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52522 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52759 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52587 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->