### PR TITLE
REGRESSION(283572@main): Canvas ctx.font keywords larger and smaller scale by 1.02 instead of ~1.2

### DIFF
--- a/LayoutTests/fast/canvas/canvas-font-size-larger-smaller-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-font-size-larger-smaller-expected.txt
@@ -1,0 +1,9 @@
+
+PASS The canvas element and the reference element start from the same font-size
+PASS canvas 'larger' scales up by a ratio in the 1.2-1.5 range the specification recommends
+PASS canvas 'smaller' scales down by a ratio in the 1.2-1.5 range the specification recommends
+PASS canvas 'larger' resolves to the same size as CSS font-size: larger
+PASS canvas 'smaller' resolves to the same size as CSS font-size: smaller
+PASS canvas 'larger' tracks the font-size of the canvas element
+PASS canvas 'larger' and 'smaller' are inverses of each other
+

--- a/LayoutTests/fast/canvas/canvas-font-size-larger-smaller.html
+++ b/LayoutTests/fast/canvas/canvas-font-size-larger-smaller.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Canvas font-size keywords 'larger' and 'smaller' scale by the same ratio as CSS</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<!-- The canvas inherits its font-size from the container, so the canvas element and the reference
+     span resolve 'larger'/'smaller' against the same parent size. -->
+<div id="container" style="font-size: 20px">
+    <canvas id="canvas"></canvas>
+    <span id="reference"></span>
+</div>
+<script>
+const canvas = document.getElementById('canvas');
+const reference = document.getElementById('reference');
+const container = document.getElementById('container');
+const ctx = canvas.getContext('2d');
+
+const parentSize = 20;
+
+function resolvedCanvasFontSize(size)
+{
+    ctx.font = `${size} sans-serif`;
+    const match = /^(\d+(?:\.\d+)?)px sans-serif$/.exec(ctx.font);
+    assert_not_equals(match, null, `ctx.font serialized as a px size, got "${ctx.font}"`);
+    return parseFloat(match[1]);
+}
+
+function resolvedCSSFontSize(size)
+{
+    reference.style.fontSize = size;
+    return parseFloat(getComputedStyle(reference).fontSize);
+}
+
+// https://drafts.csswg.org/css-fonts-4/#typedef-relative-size
+// "User agents may instead use a simple ratio to increase or decrease the font size relative to the
+//  parent element. The specific ratio is unspecified, but should be around 1.2-1.5."
+//
+// The ratio is up to the UA, so rather than hard coding WebKit's choice these tests assert the two
+// things the specification does constrain: that the ratio is in the 1.2-1.5 range, and that canvas
+// agrees with CSS. A ratio of 1.02, which is what canvas used, satisfies neither.
+
+test(function() {
+    // Everything below compares canvas against CSS, which is only meaningful if the canvas element
+    // and the reference span resolve the keyword against the same parent size.
+    assert_equals(getComputedStyle(canvas).fontSize, `${parentSize}px`, 'the canvas element inherits the container font-size');
+    assert_equals(getComputedStyle(reference).fontSize, `${parentSize}px`, 'the reference span inherits the container font-size');
+}, 'The canvas element and the reference element start from the same font-size');
+
+test(function(t) {
+    t.add_cleanup(() => { reference.style.fontSize = ''; });
+
+    const ratio = resolvedCanvasFontSize('larger') / parentSize;
+    assert_greater_than_equal(ratio, 1.2, 'larger scales up by at least 1.2');
+    assert_less_than_equal(ratio, 1.5, 'larger scales up by at most 1.5');
+}, `canvas 'larger' scales up by a ratio in the 1.2-1.5 range the specification recommends`);
+
+test(function(t) {
+    t.add_cleanup(() => { reference.style.fontSize = ''; });
+
+    const ratio = parentSize / resolvedCanvasFontSize('smaller');
+    assert_greater_than_equal(ratio, 1.2, 'smaller scales down by at least 1.2');
+    assert_less_than_equal(ratio, 1.5, 'smaller scales down by at most 1.5');
+}, `canvas 'smaller' scales down by a ratio in the 1.2-1.5 range the specification recommends`);
+
+test(function(t) {
+    t.add_cleanup(() => { reference.style.fontSize = ''; });
+
+    assert_approx_equals(resolvedCanvasFontSize('larger'), resolvedCSSFontSize('larger'), 0.01,
+        'canvas and CSS agree on larger');
+}, `canvas 'larger' resolves to the same size as CSS font-size: larger`);
+
+test(function(t) {
+    t.add_cleanup(() => { reference.style.fontSize = ''; });
+
+    assert_approx_equals(resolvedCanvasFontSize('smaller'), resolvedCSSFontSize('smaller'), 0.01,
+        'canvas and CSS agree on smaller');
+}, `canvas 'smaller' resolves to the same size as CSS font-size: smaller`);
+
+test(function(t) {
+    t.add_cleanup(() => {
+        container.style.fontSize = '20px';
+        reference.style.fontSize = '';
+    });
+
+    // The keyword resolves against the parent size each time it is set, so it has to track a change
+    // to the font-size the canvas element inherits.
+    const initial = resolvedCanvasFontSize('larger');
+
+    container.style.fontSize = '40px';
+    const doubled = resolvedCanvasFontSize('larger');
+    assert_approx_equals(doubled, initial * 2, 0.01, 'larger tracks the parent font-size');
+    assert_approx_equals(doubled, resolvedCSSFontSize('larger'), 0.01, 'canvas and CSS still agree');
+}, `canvas 'larger' tracks the font-size of the canvas element`);
+
+test(function(t) {
+    t.add_cleanup(() => { reference.style.fontSize = ''; });
+
+    // 'larger' and 'smaller' are relative, so they must compose in opposite directions rather than
+    // both being near no-ops.
+    const larger = resolvedCanvasFontSize('larger');
+    const smaller = resolvedCanvasFontSize('smaller');
+    assert_greater_than(larger, parentSize, 'larger is bigger than the parent size');
+    assert_less_than(smaller, parentSize, 'smaller is smaller than the parent size');
+    assert_approx_equals(larger / parentSize, parentSize / smaller, 0.01,
+        'larger and smaller use the same ratio in opposite directions');
+}, `canvas 'larger' and 'smaller' are inverses of each other`);
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -229,13 +229,13 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
 
             case CSSValueLarger:
                 return {
-                    .size = parentSize * 1.02f,
+                    .size = parentSize * 1.2f,
                     .keyword = CSSValueInvalid
                 };
 
             case CSSValueSmaller:
                 return {
-                    .size = parentSize / 1.02f,
+                    .size = parentSize / 1.2f,
                     .keyword = CSSValueInvalid
                 };
 


### PR DESCRIPTION
#### b86307c97d1abc50ea819a0d102be09f3b04a73e
<pre>
REGRESSION(283572@main): Canvas ctx.font keywords larger and smaller scale by 1.02 instead of ~1.2
<a href="https://bugs.webkit.org/show_bug.cgi?id=321261">https://bugs.webkit.org/show_bug.cgi?id=321261</a>
<a href="https://rdar.apple.com/184312611">rdar://184312611</a>

Reviewed by Sam Weinig.

The relative-size keywords may be resolved either through the absolute size keyword mapping table or
by a simple ratio, and of the latter the specification says &quot;The specific ratio is unspecified, but
should be around 1.2-1.5&quot; [1].

Canvas used 1.02, which is not in that range, so `ctx.font = &quot;larger sans-serif&quot;` on a canvas whose
font-size is 20px produced 20.4px rather than 24px, making both keywords very nearly no-ops. CSS
resolution is unaffected and uses 1.2 (BuilderCustom::largerFontSize).

The value was a transcription typo. 283572@main moved this logic into StyleResolveForFontRaw.cpp
while replacing eager evaluation of calc() in the font consumers, and turned `parentSize * 1.2f` into
`parentSize * 1.02f` in a change that was otherwise a pure refactor. 1.02f appears nowhere else in
the tree.

The new test asserts the two things the specification actually constrains rather than hard coding
WebKit&apos;s ratio: that the ratio falls in the 1.2-1.5 range, and that canvas agrees with CSS resolution
for the same parent font-size.

[1] <a href="https://drafts.csswg.org/css-fonts-4/#typedef-relative-size">https://drafts.csswg.org/css-fonts-4/#typedef-relative-size</a>

Test: fast/canvas/canvas-font-size-larger-smaller.html

* LayoutTests/fast/canvas/canvas-font-size-larger-smaller-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-font-size-larger-smaller.html: Added.
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontSizeFromUnresolvedFontSize):

Canonical link: <a href="https://commits.webkit.org/318798@main">https://commits.webkit.org/318798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eed5248101e9ba5cc356fc1e726b52c0ea3e8cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189194 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a79f10c-d4fe-46e8-b92a-c9e28e49dcfb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139872 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc50fae3-a4eb-4a0d-b613-0c3663991676) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120324 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d10ce98c-02c7-4370-ae93-4efc1f3051c5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42150 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40480 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152550 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40125 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/646 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191412 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149126 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40001 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53652 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148868 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43544 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125924 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120797 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52169 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15111 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51554 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51795 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51615 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->