### PR TITLE
[Site Isolation] http/tests/site-isolation/fullscreen-escape-key.html is a flaky failure

### DIFF
--- a/LayoutTests/http/tests/site-isolation/fullscreen-escape-key-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-escape-key-expected.txt
@@ -1,7 +1,7 @@
 supportsFullScreen() == true
 enterFullScreenForElement()
-beganEnterFullScreen() - initialRect.size: {800, 600}, finalRect.size: {800, 600}
+beganEnterFullScreen() - initialRect.size: {300, 150}, finalRect.size: {800, 600}
 exitFullScreenForElement()
-beganExitFullScreen() - initialRect.size: {800, 600}, finalRect.size: {800, 600}
+beganExitFullScreen() - initialRect.size: {800, 600}, finalRect.size: {300, 150}
 
 

--- a/LayoutTests/http/tests/site-isolation/resources/fullscreen-escape-key.html
+++ b/LayoutTests/http/tests/site-isolation/resources/fullscreen-escape-key.html
@@ -6,11 +6,19 @@
 
     document.documentElement.addEventListener("fullscreenchange", () => { if (!document.fullscreenElement) { window.parent.postMessage("Exited",  "*"); }});
 
+    async function waitUntilSizedByParent() {
+        while (window.innerWidth !== 300 || window.innerHeight !== 150)
+            await new Promise(requestAnimationFrame);
+    }
+
     if (window.internals) {
-        internals.withUserGesture(async () => {
-            await enterFullScreen();
-            window.parent.postMessage("Entered", "*");
-        });
+        (async () => {
+            await waitUntilSizedByParent();
+            internals.withUserGesture(async () => {
+                await enterFullScreen();
+                window.parent.postMessage("Entered", "*");
+            });
+        })();
     }
 </script>
 <button onclick="enterFullScreen()">Enter</button>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1655,7 +1655,6 @@ editing/input/scroll-viewport-page-up-down.html [ Pass Failure ]
 # webkit.org/b/282046 REGRESSION(285592@main): [ macOS iOS wk2 ] http/tests/site-isolation/load-event.html are near constant failures.
 http/tests/site-isolation/load-event.html [ Pass Failure ]
 webkit.org/b/289347 http/tests/site-isolation/fullscreen.html [ Pass Failure ]
-webkit.org/b/289347 http/tests/site-isolation/fullscreen-escape-key.html [ Pass Failure ]
 
 # webkit.org/b/281923  [ Sequoia+ ] 3 tests in http/tests/cookies/same-site are constant failure (failure in EWS)
 [ Sequoia+ ] http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]


### PR DESCRIPTION
#### daf27727d7fd9a01b5abda9bc9c3e6a956d5e8b8
<pre>
[Site Isolation] http/tests/site-isolation/fullscreen-escape-key.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=321262">https://bugs.webkit.org/show_bug.cgi?id=321262</a>
<a href="https://rdar.apple.com/184313220">rdar://184313220</a>

Reviewed by Jean-Yves Avenard.

The cross-origin child requested fullscreen before its parent had assigned it a frame rect.
A site-isolated child&apos;s frame view is sized from ProvisionalFrameCreationParameters::initialRect,
which the UI process only has once the parent has broadcast a FrameRect frame-tree sync
(WebPageProxy::broadcastFrameTreeSyncData -&gt; WebFrameProxy::setRemoteFrameRect); until that
arrives the child sits at the default 800x600 viewport instead of the 300x150 given to it by the
&lt;iframe&gt;. WebFullScreenManager::performEnterFullScreen samples the pre-transition rect with no
barrier against that sync, so beganEnterFullScreen() reported 800x600 when the request won the
race and the correct 300x150 when it lost, at a load-dependent 4-9% locally.

Wait for the parent-assigned size before requesting fullscreen so the pre-transition rect is
sampled deterministically, and update the baseline to the pre-fullscreen 300x150. The previous
baseline recorded the raced value; the sizes now match http/tests/site-isolation/fullscreen.html
and the non-site-isolated dumpFullScreenCallbacks() tests, which all report the element&apos;s size
before the transition in initialRect.

* LayoutTests/http/tests/site-isolation/fullscreen-escape-key-expected.txt:
* LayoutTests/http/tests/site-isolation/resources/fullscreen-escape-key.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/318986@main">https://commits.webkit.org/318986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1afb299765b328f42ada7a1f83b3a04524d77bcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189195 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143672 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139873 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96804 "2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15286e82-17ef-49ba-a560-4b2d4d616776) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43479 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120325 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc7d51da-466a-4656-baa6-ef2e51e33b71) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42149 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40481 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152549 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40478 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/647 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191413 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52972 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149127 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40114 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53653 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148869 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43545 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120798 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52170 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15162 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51555 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51796 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51616 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->