### PR TITLE
[JSC] Add counting-sort to 1-byte element TypedArrays

### DIFF
--- a/JSTests/microbenchmarks/int8array-sort-large-array.js
+++ b/JSTests/microbenchmarks/int8array-sort-large-array.js
@@ -1,0 +1,20 @@
+var length = 4096;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed >>> 24;
+}
+
+var source = new Int8Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom();
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Int8Array(length);
+for (var i = 0; i < 30000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/uint8array-sort-large-array.js
+++ b/JSTests/microbenchmarks/uint8array-sort-large-array.js
@@ -1,0 +1,20 @@
+var length = 4096;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed >>> 24;
+}
+
+var source = new Uint8Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom();
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Uint8Array(length);
+for (var i = 0; i < 30000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/uint8array-sort-low-entropy.js
+++ b/JSTests/microbenchmarks/uint8array-sort-low-entropy.js
@@ -1,0 +1,20 @@
+var length = 4096;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed >>> 24;
+}
+
+var source = new Uint8Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = (nextRandom() & 1) ? 200 : 7;
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Uint8Array(length);
+for (var i = 0; i < 30000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/uint8array-sort-medium-array.js
+++ b/JSTests/microbenchmarks/uint8array-sort-medium-array.js
@@ -1,0 +1,20 @@
+var length = 512;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed >>> 24;
+}
+
+var source = new Uint8Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom();
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Uint8Array(length);
+for (var i = 0; i < 200000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/uint8array-sort-presorted.js
+++ b/JSTests/microbenchmarks/uint8array-sort-presorted.js
@@ -1,0 +1,12 @@
+var length = 4096;
+
+var source = new Uint8Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = (i * 256 / length) | 0;
+
+// Keep the input sorted every iteration; sorting it again must stay cheap.
+var array = new Uint8Array(length);
+for (var i = 0; i < 60000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/uint8array-sort-small-array.js
+++ b/JSTests/microbenchmarks/uint8array-sort-small-array.js
@@ -1,0 +1,20 @@
+var length = 192;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed >>> 24;
+}
+
+var source = new Uint8Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom();
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Uint8Array(length);
+for (var i = 0; i < 300000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/uint8array-sort-tiny-array.js
+++ b/JSTests/microbenchmarks/uint8array-sort-tiny-array.js
@@ -1,0 +1,20 @@
+var length = 64;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed >>> 24;
+}
+
+var source = new Uint8Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom();
+
+// Short enough to stay on the comparison sort, which guards the counting sort threshold.
+var array = new Uint8Array(length);
+for (var i = 0; i < 500000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/stress/typed-array-sort-counting-sort.js
+++ b/JSTests/stress/typed-array-sort-counting-sort.js
@@ -1,0 +1,160 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' (expected ' + expected + ')');
+}
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed >>> 24;
+}
+
+function sortedReference(array) {
+    return Array.from(array).sort(function (a, b) { return a - b; });
+}
+
+function shouldMatchReference(array) {
+    var expected = sortedReference(array);
+    shouldBe(array.sort(), array);
+    for (var i = 0; i < expected.length; ++i)
+        shouldBe(array[i], expected[i]);
+}
+
+var constructors = [Int8Array, Uint8Array, Uint8ClampedArray];
+
+// Straddle the length at which the engine switches to counting sort, from well below to well above.
+var lengths = [0, 1, 2, 8, 64, 100, 191, 192, 193, 255, 256, 257, 1000];
+
+var patterns = {
+    random: function (i, length) { return nextRandom(); },
+    identical: function (i, length) { return 42; },
+    ascending: function (i, length) { return i; },
+    descending: function (i, length) { return length - i; },
+    extremes: function (i, length) { return (i % 3 === 0) ? -128 : ((i % 3 === 1) ? 255 : 0); },
+    twoValues: function (i, length) { return (i % 2) ? 200 : 7; },
+};
+
+for (var ctor of constructors) {
+    for (var length of lengths) {
+        for (var name in patterns) {
+            var array = new ctor(length);
+            for (var i = 0; i < length; ++i)
+                array[i] = patterns[name](i, length);
+            shouldMatchReference(array);
+        }
+    }
+}
+
+// toSorted takes the same no-comparator path, and must not disturb the receiver.
+for (var ctor of constructors) {
+    var array = new ctor(300);
+    for (var i = 0; i < array.length; ++i)
+        array[i] = nextRandom();
+    var expectedReceiver = Array.from(array);
+    var expected = sortedReference(array);
+
+    var sorted = array.toSorted();
+    shouldBe(sorted instanceof ctor, true);
+    shouldBe(sorted === array, false);
+    shouldBe(sorted.length, array.length);
+    for (var i = 0; i < expected.length; ++i) {
+        shouldBe(sorted[i], expected[i]);
+        shouldBe(array[i], expectedReceiver[i]);
+    }
+}
+
+// A view over part of a buffer must not write outside its own range.
+for (var ctor of constructors) {
+    var elementCount = 300;
+    var guard = 16;
+    var buffer = new ArrayBuffer(elementCount + guard * 2);
+    var whole = new Uint8Array(buffer);
+    whole.fill(0xab);
+
+    var view = new ctor(buffer, guard, elementCount);
+    for (var i = 0; i < elementCount; ++i)
+        view[i] = nextRandom();
+    var expected = sortedReference(view);
+
+    shouldBe(view.sort(), view);
+    for (var i = 0; i < elementCount; ++i)
+        shouldBe(view[i], expected[i]);
+    for (var i = 0; i < guard; ++i) {
+        shouldBe(whole[i], 0xab);
+        shouldBe(whole[guard + elementCount + i], 0xab);
+    }
+}
+
+// Auto-length views over a resizable buffer read their length through a different path.
+for (var ctor of constructors) {
+    var buffer = new ArrayBuffer(300, { maxByteLength: 600 });
+    var array = new ctor(buffer);
+    for (var i = 0; i < array.length; ++i)
+        array[i] = nextRandom();
+    shouldMatchReference(array);
+
+    buffer.resize(600);
+    shouldBe(array.length, 600);
+    for (var i = 0; i < array.length; ++i)
+        array[i] = nextRandom();
+    shouldMatchReference(array);
+
+    buffer.resize(70);
+    shouldBe(array.length, 70);
+    for (var i = 0; i < array.length; ++i)
+        array[i] = nextRandom();
+    shouldMatchReference(array);
+}
+
+// An array that is sorted apart from one adjacent pair, with that pair placed at every position in
+// turn. This pins the block-at-a-time presortedness scan: a boundary it fails to cover would leave
+// the array unsorted for exactly one of these positions.
+for (var ctor of constructors) {
+    var base = (ctor === Int8Array) ? -128 : 0;
+    for (var length of [128, 129, 130, 143, 144, 145, 159, 160, 161, 200, 256]) {
+        var expected = [];
+        for (var i = 0; i < length; ++i)
+            expected.push(base + i);
+
+        for (var position = 0; position + 1 < length; ++position) {
+            var array = new ctor(length);
+            for (var i = 0; i < length; ++i)
+                array[i] = base + i;
+            // Swapping neighbours leaves this as the only descending pair.
+            array[position] = base + position + 1;
+            array[position + 1] = base + position;
+
+            array.sort();
+            for (var i = 0; i < length; ++i) {
+                if (array[i] !== expected[i])
+                    throw new Error('unsorted at index ' + i + ' for inversion at ' + position + ', length ' + length + ', ' + ctor.name);
+            }
+        }
+    }
+}
+
+if (typeof SharedArrayBuffer !== 'undefined') {
+    for (var ctor of constructors) {
+        var buffer = new SharedArrayBuffer(300);
+        var array = new ctor(buffer);
+        for (var i = 0; i < array.length; ++i)
+            array[i] = nextRandom();
+        shouldMatchReference(array);
+    }
+
+    for (var ctor of constructors) {
+        var buffer = new SharedArrayBuffer(300, { maxByteLength: 600 });
+        var array = new ctor(buffer);
+        for (var i = 0; i < array.length; ++i)
+            array[i] = nextRandom();
+        shouldMatchReference(array);
+
+        buffer.grow(600);
+        shouldBe(array.length, 600);
+        for (var i = 0; i < array.length; ++i)
+            array[i] = nextRandom();
+        shouldMatchReference(array);
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -214,6 +214,9 @@ protected:
     // are 1 and only the MSB of the mantissa is 1. So, NaN is recognized as the largest integral numbers.
 
     template<typename IntegralType> inline void sortFloat(ElementType* begin, ElementType* end);
+
+    inline void countingSort(std::span<ElementType>);
+    template<typename CounterType> inline void countingSortWithCounters(std::span<ElementType>);
 };
 
 template<typename PassedAdaptor>

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/TypeError.h>
 #include <JavaScriptCore/TypedArrays.h>
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/SIMDHelpers.h>
 #include <wtf/text/MakeString.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -897,7 +898,6 @@ template<typename Adaptor> inline auto JSGenericTypedArrayView<Adaptor>::toAdapt
 template<typename Adaptor> inline auto JSGenericTypedArrayView<Adaptor>::sort() -> SortResult
 {
     RELEASE_ASSERT(!isDetached());
-    Vector<ElementType, 16> forShared;
     IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
     auto lengthValue = integerIndexedObjectLength(this, getter);
     if (!lengthValue)
@@ -906,7 +906,19 @@ template<typename Adaptor> inline auto JSGenericTypedArrayView<Adaptor>::sort() 
     size_t length = lengthValue.value();
 
     auto originalSpan = typedSpan();
+
+    if constexpr (Adaptor::typeValue == TypeInt8 || Adaptor::typeValue == TypeUint8 || Adaptor::typeValue == TypeUint8Clamped) {
+        // Measured crossover. Below this, clearing the histograms costs more than std::sort, which
+        // uses insertion sort on inputs this short.
+        constexpr size_t countingSortThreshold = 128;
+        if (length >= countingSortThreshold) {
+            countingSort(originalSpan.first(length));
+            return SortResult::Success;
+        }
+    }
+
     auto array = originalSpan.data();
+    Vector<ElementType, 16> forShared;
     if (isShared()) {
         if (!forShared.tryGrow(length)) [[unlikely]]
             return SortResult::OutOfMemory;
@@ -998,6 +1010,102 @@ inline void JSGenericTypedArrayView<Adaptor>::sortFloat(ElementType* begin, Elem
             return a < b;
         return a > b;
     });
+}
+
+template<typename Adaptor>
+inline void JSGenericTypedArrayView<Adaptor>::countingSort(std::span<ElementType> elements)
+{
+    static_assert(sizeof(ElementType) == 1);
+
+    auto isNonDescending = [](std::span<ElementType> elements) ALWAYS_INLINE_LAMBDA {
+        constexpr size_t stride = SIMD::stride<ElementType>;
+        ASSERT(elements.size() > stride);
+
+        auto* data = elements.data();
+        auto hasInversion = [&](size_t index) ALWAYS_INLINE_LAMBDA {
+            simde_uint8x16_t inversions;
+            if constexpr (std::is_signed_v<ElementType>)
+                inversions = simde_vcltq_s8(simde_vld1q_s8(data + index + 1), simde_vld1q_s8(data + index));
+            else
+                inversions = simde_vcltq_u8(simde_vld1q_u8(data + index + 1), simde_vld1q_u8(data + index));
+            return SIMD::isNonZero(inversions);
+        };
+
+        size_t lastBlock = elements.size() - 1 - stride;
+        for (size_t index = 0; index < lastBlock; index += stride) {
+            if (hasInversion(index))
+                return false;
+        }
+        return !hasInversion(lastBlock);
+    };
+
+    // This stops at the first inversion, so it costs one block of comparisons on unsorted input, and
+    // it reduces the already sorted case to a single scan.
+    if (isNonDescending(elements))
+        return;
+
+    if constexpr (sizeof(size_t) > sizeof(uint32_t)) {
+        if (elements.size() > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
+            countingSortWithCounters<uint64_t>(elements);
+            return;
+        }
+    }
+    countingSortWithCounters<uint32_t>(elements);
+}
+
+template<typename Adaptor>
+template<typename CounterType>
+inline void JSGenericTypedArrayView<Adaptor>::countingSortWithCounters(std::span<ElementType> elements)
+{
+    // Flipping the sign bit orders signed values the same way as unsigned ones, putting -128 in
+    // bucket 0 and 127 in bucket 255.
+    constexpr uint8_t signBias = std::is_signed_v<ElementType> ? 0x80 : 0;
+
+    constexpr size_t bucketCount = 256;
+
+    // Interleaving several histograms keeps repeated values from serializing. Incrementing a counter
+    // otherwise has to wait for the previous increment of that same counter to forward out of the
+    // store buffer, which costs several cycles per element on inputs with few distinct values.
+    constexpr size_t histogramCount = 4;
+    std::array<std::array<CounterType, bucketCount>, histogramCount> counts { };
+
+    size_t index = 0;
+    for (; index + histogramCount <= elements.size(); index += histogramCount) {
+        for (size_t histogram = 0; histogram < histogramCount; ++histogram)
+            ++counts[histogram][static_cast<uint8_t>(elements[index + histogram]) ^ signBias];
+    }
+    for (; index < elements.size(); ++index)
+        ++counts[0][static_cast<uint8_t>(elements[index]) ^ signBias];
+
+    // While this is scanning 256 elements twice, actually this is faster due to removing branch mis-prediction
+    // for sparse results.
+    std::array<CounterType, bucketCount> totals;
+    std::array<uint64_t, bucketCount / 64> occupied;
+    for (unsigned word = 0; word < occupied.size(); ++word) {
+        uint64_t bits = 0;
+        for (unsigned bit = 0; bit < 64; ++bit) {
+            unsigned bucket = word * 64 + bit;
+            CounterType count = 0;
+            for (size_t histogram = 0; histogram < histogramCount; ++histogram)
+                count += counts[histogram][bucket];
+            totals[bucket] = count;
+            bits |= static_cast<uint64_t>(!!count) << bit;
+        }
+        occupied[word] = bits;
+    }
+
+    auto* cursor = elements.data();
+    for (unsigned word = 0; word < occupied.size(); ++word) {
+        uint64_t bits = occupied[word];
+        while (bits) {
+            unsigned bucket = word * 64 + std::countr_zero(bits);
+            bits &= bits - 1;
+            CounterType count = totals[bucket];
+            std::fill_n(cursor, count, static_cast<ElementType>(bucket ^ signBias));
+            cursor += count;
+        }
+    }
+    ASSERT(cursor == elements.data() + elements.size());
 }
 
 template<typename PassedAdaptor> inline Structure* JSGenericResizableOrGrowableSharedTypedArrayView<PassedAdaptor>::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)


### PR DESCRIPTION
#### fedbb7bdc250525145431ecbc2243004bc754fef
<pre>
[JSC] Add counting-sort to 1-byte element TypedArrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=321263">https://bugs.webkit.org/show_bug.cgi?id=321263</a>
<a href="https://rdar.apple.com/184313545">rdar://184313545</a>

Reviewed by Sosuke Suzuki.

Since 1-byte element is only having 256 patterns, we can apply
counting-sort easily. This patch applies counting-sort to 1-byte element
TypedArrays.

1. We use 128-size threshold, this is picked based on empirical
   measurement.
2. Before starting counting-sort, we scan elements via SIMD to detect
   &quot;no sorting is necessary&quot; case. This is relatively frequently
   happening in the wild, and cost is cheap.
3. Then we do counting-sort.
3.1. We have 4-way histogram to avoid repeated read-update-write in
     various places to the same places to make pipeline smoother. We do
     not need to wait for the previous element&apos;s update and we can do
     pipeline with 4-way histogram.
3.2. Then we scan this and construct the pattern (1) which element
     exists (2) how many counts. This requires additional one time scan
     of histogram, but in fact this makes filling faster due to removal
     of branch prediction miss (typically more than 30% faster).
3.3. Then we fill the destination array with the accumulated sequence
     data from 3.2.

                                             ToT                     Patched

    uint8array-sort-large-array       611.3374+-0.7106     ^     51.1908+-0.4178        ^ definitely 11.9423x faster
    int8array-sort-large-array        611.3211+-0.5981     ^     52.4664+-0.3827        ^ definitely 11.6517x faster
    uint8array-sort-medium-array      435.9760+-0.7050     ^    120.1770+-1.1086        ^ definitely 3.6278x faster
    uint8array-sort-small-array       233.2745+-0.4947     ^     92.9591+-1.1352        ^ definitely 2.5094x faster
    uint8array-sort-presorted         323.2663+-0.5266     ^      8.4205+-0.0350        ^ definitely 38.3902x faster
    uint8array-sort-low-entropy       170.4761+-0.8698     ^     51.0791+-0.0686        ^ definitely 3.3375x faster
    uint8array-sort-tiny-array        103.8720+-0.2649     ^    103.2340+-0.3650        ^ definitely 1.0062x faster

Tests: JSTests/microbenchmarks/int8array-sort-large-array.js
       JSTests/microbenchmarks/uint8array-sort-large-array.js
       JSTests/microbenchmarks/uint8array-sort-low-entropy.js
       JSTests/microbenchmarks/uint8array-sort-medium-array.js
       JSTests/microbenchmarks/uint8array-sort-presorted.js
       JSTests/microbenchmarks/uint8array-sort-small-array.js
       JSTests/microbenchmarks/uint8array-sort-tiny-array.js
       JSTests/stress/typed-array-sort-counting-sort.js

* JSTests/microbenchmarks/int8array-sort-large-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/uint8array-sort-large-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/uint8array-sort-low-entropy.js: Added.
(nextRandom):
* JSTests/microbenchmarks/uint8array-sort-medium-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/uint8array-sort-presorted.js: Added.
* JSTests/microbenchmarks/uint8array-sort-small-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/uint8array-sort-tiny-array.js: Added.
(nextRandom):
* JSTests/stress/typed-array-sort-counting-sort.js: Added.
(shouldBe):
(nextRandom):
(sortedReference):
(shouldMatchReference):
(patterns.random):
(patterns.identical):
(patterns.ascending):
(patterns.descending):
(patterns.extremes):
(patterns.twoValues):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::sort):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::countingSort):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::countingSortWithCounters):

Canonical link: <a href="https://commits.webkit.org/318927@main">https://commits.webkit.org/318927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe4771141446f8116ac0129266a7c81e4be38e34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189197 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143674 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139874 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96805 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120326 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42151 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40483 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2296 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9108 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152551 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40128 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/649 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40640 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191415 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52974 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149128 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53655 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36755 "Too many flaky failures: http/tests/media/now-playing-info-default-artwork-favicon.html, http/tests/misc/policy-delegate-called-twice.html, http/tests/navigation/post-308-response.html, http/tests/resourceLoadStatistics/do-not-block-top-level-navigation-redirect.html, http/tests/security/cannot-read-cssrules.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/iframe-srcdoc-external-script.html, http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https.html, http/tests/site-isolation/frame-index.html, http/tests/site-isolation/inspector/network/cross-origin-iframe-network-events-have-correct-frame-id.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148870 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27311 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43546 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125927 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120800 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52172 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15114 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51557 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51798 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51618 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->