### PR TITLE
scrollend event is not fired when wheel-scrolling a subframe

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-cross-origin-iframes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-cross-origin-iframes-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify sibling cross-origin iframes can wheel-scroll. Test timed out
+PASS Verify sibling cross-origin iframes can wheel-scroll.
 

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -65,7 +65,6 @@ http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture
 http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html [ Failure ]
 http/wpt/css/css-view-transitions/navigation/old_vt_promises_bfcache.html [ Failure ]
 imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Failure ]
-imported/w3c/web-platform-tests/dom/events/scrolling/scroll-cross-origin-iframes.html [ Failure ]
 imported/w3c/web-platform-tests/fetch/api/basic/keepalive.any.html
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html [ Failure ]
 imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html [ Failure ]

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -319,6 +319,11 @@ void ScrollAnimator::didStopAnimatedScroll()
     scrollableArea->scrollDidEnd();
 }
 
+void ScrollAnimator::didStopWheelEventScroll()
+{
+    protect(m_scrollableArea)->scrollDidEnd();
+}
+
 #if HAVE(RUBBER_BANDING)
 IntSize ScrollAnimator::stretchAmount() const
 {

--- a/Source/WebCore/platform/ScrollAnimator.h
+++ b/Source/WebCore/platform/ScrollAnimator.h
@@ -157,6 +157,8 @@ private:
     void willStartAnimatedScroll() final;
     void didStopAnimatedScroll() final;
 
+    void didStopWheelEventScroll() final;
+
     void immediateScrollBy(const FloatSize&, ScrollClamping = ScrollClamping::Clamped) final;
     void adjustScrollPositionToBoundsIfNecessary() final;
 


### PR DESCRIPTION
#### 3c2f9abf7173b999417f7b09c02f4c91fb43615f
<pre>
scrollend event is not fired when wheel-scrolling a subframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=321265">https://bugs.webkit.org/show_bug.cgi?id=321265</a>

Reviewed by Darin Adler.

A subframe (and any scrollable area without an asynchronous scrolling node)
is wheel-scrolled synchronously on the main thread, driven by ScrollAnimator&apos;s
ScrollingEffectsController. When such a scroll ends, the controller calls
ScrollingEffectsControllerClient::didStopWheelEventScroll(), but ScrollAnimator
never overrode it, so the empty base implementation ran and ScrollableArea::
scrollDidEnd() was never called. As a result no scrollend event was dispatched
for main-thread wheel scrolls, even though the scroll (and scroll events) worked
correctly.

Areas with an async scrolling node were unaffected because their scrollend is
driven by the scrolling tree delegate (ScrollingTreeScrollingNodeDelegateMac),
which does implement didStopWheelEventScroll(). Programmatic/animated scrolls
were also fine because ScrollAnimator already overrides didStopAnimatedScroll()
to call scrollDidEnd().

Fix this by overriding didStopWheelEventScroll() in ScrollAnimator to call
scrollDidEnd(), mirroring didStopAnimatedScroll(). This covers both gesture-phase
wheel ends and discrete mouse-wheel scrolls (via the scrollend timer). It cannot
double-fire: scrollDidEnd() is guarded by isAwaitingScrollend() and only runs
when a scroll actually occurred, and async-scrolled areas use a separate
ScrollingEffectsController instance.

This makes the imported WPT test scroll-cross-origin-iframes.html pass, which
previously timed out waiting for a scrollend handshake from the iframes.

No new tests, rebaselined existing WPT test that was previously timing out
in WebKit. This test is passing in both Chrome and Firefox already.

* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-cross-origin-iframes-expected.txt:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::ScrollAnimator::didStopWheelEventScroll):
* Source/WebCore/platform/ScrollAnimator.h:

Canonical link: <a href="https://commits.webkit.org/318805@main">https://commits.webkit.org/318805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/755b9b1c82383194e0d935b815f267d833c6582b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189199 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139876 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120328 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42152 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40484 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152552 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40130 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/651 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191417 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52976 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149130 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40007 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53657 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36757 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148872 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43547 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125929 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120802 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52174 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15116 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51559 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51800 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51620 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->