### PR TITLE
[GTK][WPE][CMake] Do not allow to build with make, require ninja instead.

### DIFF
--- a/Source/cmake/WebKitCommon.cmake
+++ b/Source/cmake/WebKitCommon.cmake
@@ -101,6 +101,19 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
 
     string(TOLOWER ${PORT} WEBKIT_PORT_DIR)
 
+    # -----------------------------------------------------------------------------
+    # Check the CMake generator.
+    # -----------------------------------------------------------------------------
+    # The GTK and WPE ports only support the Ninja generator.
+    # Ninja has its own dependency graph, used for dependencies between targets
+    if (PORT STREQUAL "GTK" OR PORT STREQUAL "WPE")
+        if (NOT CMAKE_GENERATOR MATCHES "Ninja")
+            message(FATAL_ERROR "The ${PORT} port requires the Ninja generator, but this build "
+                "directory was configured with the \"${CMAKE_GENERATOR}\" generator.\n"
+                "Re-run CMake with -GNinja or export CMAKE_GENERATOR=Ninja\n")
+        endif ()
+    endif ()
+
     set(_stamp_content "")
     foreach (_var IN LISTS WEBKIT_IDENTITY_VARS)
         if (DEFINED CACHE{${_var}})

--- a/Tools/Scripts/make-dist
+++ b/Tools/Scripts/make-dist
@@ -244,18 +244,19 @@ class Distcheck(object):
         create_dir(build_dir, "build")
         create_dir(install_dir, "install")
 
-        command = ['cmake', '-DPORT=%s' % port, '-DCMAKE_INSTALL_PREFIX=%s' % install_dir, '-DCMAKE_BUILD_TYPE=Release', dist_dir]
+        command = ['cmake', '-GNinja', '-DPORT=%s' % port, '-DCMAKE_INSTALL_PREFIX=%s' % install_dir, '-DCMAKE_BUILD_TYPE=Release', dist_dir]
         if not build_unified:
             command.append('-DENABLE_UNIFIED_BUILDS=OFF')
         subprocess.check_call(command, cwd=build_dir)
 
     def build(self, build_dir):
-        command = ['make']
+        command = ['cmake', '--build', '.']
         make_args = os.getenv('MAKE_ARGS')
         if make_args:
+            command.append('--')
             command.extend(make_args.split(' '))
         else:
-            command.append('-j%d' % multiprocessing.cpu_count())
+            command.extend(['-j', '%d' % multiprocessing.cpu_count()])
         subprocess.check_call(command, cwd=build_dir)
 
     def check_symbols(self, build_dir):
@@ -269,7 +270,7 @@ class Distcheck(object):
         subprocess.check_call([check_version_script, version_script, libwk])
 
     def install(self, build_dir):
-        subprocess.check_call(['make', 'install'], cwd=build_dir)
+        subprocess.check_call(['cmake', '--install', '.'], cwd=build_dir)
 
     def clean(self, dist_dir):
         shutil.rmtree(dist_dir)


### PR DESCRIPTION
#### aa6c61fcb0020c75099f15ccbfaa14380fb55c89
<pre>
[GTK][WPE][CMake] Do not allow to build with make, require ninja instead.
<a href="https://bugs.webkit.org/show_bug.cgi?id=321266">https://bugs.webkit.org/show_bug.cgi?id=321266</a>

Reviewed by Carlos Garcia Campos.

Currently for building GTK or WPE there are two ways: use the build-webkit script
or use CMake directly. The build-webkit script is only intended for webkit
developers, for production releases or users of webkit the idea is to use cmake
directly.

The problem is that we have a split on how WebKit is built. With build-webkit
ninja is used by default, but when using cmake directly it uses whatever cmake
generator has as default (make usually) and that is causing issues because of
build errors due to dependencies between targets, ninja has its own dependency
graph, but plain makefiles don&apos;t.

And this causes issues when someone tries to use make because no one usually
tests the make build.

This patch makes ninja mandatory for GTK and WPE ports and also changes the
make-dist script to use it.

* Source/cmake/WebKitCommon.cmake:
* Tools/Scripts/make-dist:
(Distcheck.configure):
(Distcheck.build):
(Distcheck.install):

Canonical link: <a href="https://commits.webkit.org/318773@main">https://commits.webkit.org/318773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5aee56cf7d17df84e46a326378bd92063a3f7fde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189202 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181233 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139879 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182327 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43484 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120331 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2301 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9112 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40132 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/654 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40645 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191420 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52979 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53660 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148875 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27218 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43549 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120812 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52177 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15118 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51562 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->