### PR TITLE
[SwiftBrowser] URL field does not reflect the committed URL after navigation

### DIFF
--- a/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
@@ -161,7 +161,9 @@ final class BrowserViewModel {
     }
 
     func didReceiveNavigationEvent(_ event: WebPage.NavigationEvent) {
-        Self.logger.info("Did receive navigation event \(String(describing: event))")
+        Self.logger.info(
+            "Did receive navigation event \(String(describing: event)) (url: \(self.page.url?.absoluteString ?? "nil", privacy: .sensitive))"
+        )
 
         if event == .committed {
             displayedURL = page.url?.absoluteString ?? ""
@@ -169,8 +171,6 @@ final class BrowserViewModel {
     }
 
     func navigateToSubmittedURL() {
-        displayedURL = displayedURL.addingProtocolIfNecessary()
-
         guard let url = URL(userTypedString: displayedURL) else {
             return
         }
@@ -200,7 +200,7 @@ final class BrowserViewModel {
     func didExportPDF(result: Result<URL, any Error>) {
         switch result {
         case .success(let url):
-            Self.logger.info("Exported PDF to \(url)")
+            Self.logger.info("Exported PDF to \(url.absoluteString, privacy: .sensitive)")
 
         case .failure(let error):
             Self.logger.error("Failed to export PDF: \(error)")

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -124,7 +124,7 @@ struct ContentView: View {
                 .task {
                     do {
                         for try await event in viewModel.page.navigations {
-                            print(event)
+                            viewModel.didReceiveNavigationEvent(event)
                         }
                     } catch {
                         print(error)


### PR DESCRIPTION
#### acf8a9bd09120f8b9dd8974c16cc499047fd8d56
<pre>
[SwiftBrowser] URL field does not reflect the committed URL after navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=321267">https://bugs.webkit.org/show_bug.cgi?id=321267</a>
<a href="https://rdar.apple.com/184318736">rdar://184318736</a>

Reviewed by Pascoe and Richard Robinson.

SwiftBrowser consumed the async navigation sequence but it only printed
each event and did not invoke didReceiveNavigationEvent(). This is the
method responsible  for syncinc displayedURL against page.url after a
navigation is committed. As such, the field kept whatever text was
submitted, and did not reflect the final URL the page committed to.

This bug manifested itself in a stale address bar for navigations that
produced a known-host HTTPS upgrade (such as apple.com).

To fix this, we simply route navigation events through the correct
handler. We also include the event&apos;s URL in the logging to make
navigation state easier to follow.

A couple of drive-by fixes:
1. Mark the pre-existing &quot;Exported PDF to …&quot; log as privacy: .sensitive
   for consistency.
2. Drop the now redundant addingProtocolIfNecessary() adjustment in
   navigateToSubmittedURL(). The userTypedString: init already applies
   scheme inference and the field is now drive entirely by page.url.

* Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift:
(BrowserViewModel.didReceiveNavigationEvent(_:)):
(BrowserViewModel.navigateToSubmittedURL):
(BrowserViewModel.didExportPDF(_:any:)):
* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(ContentView.body):

Canonical link: <a href="https://commits.webkit.org/318811@main">https://commits.webkit.org/318811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83319b57371c4ab28281da91f7fbf2857d7a4952

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189287 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/febd9073-0f63-4a47-9565-d701d7dda304) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139939 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/59edd65d-1716-499b-8e59-4a33b61ef34b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43553 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120391 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42457d2d-300f-433a-b710-a82df19e445d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152624 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/741 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191507 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53064 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53745 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148946 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27240 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43611 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120912 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52262 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15182 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51647 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51888 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51708 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->