### PR TITLE
[JSC] Align Iterator#join to the latest spec

### DIFF
--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -37,9 +37,6 @@ test/built-ins/Function/prototype/caller/prop-desc.js:
 test/built-ins/Function/prototype/toString/built-in-function-object.js:
   default: 3
   strict mode: 3
-test/built-ins/Iterator/prototype/join/contents-nullish.js:
-  default: 3
-  strict mode: 3
 test/built-ins/Proxy/apply/arguments-realm.js:
   default: 3
   strict mode: 3

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -319,7 +319,7 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncIncludes, (JSGlobalObject* globalObjec
     return { };
 }
 
-// https://tc39.es/proposal-iterator-join/
+// https://tc39.es/proposal-iterator-join/#sec-iterator.prototype.join
 JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncJoin, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -330,6 +330,12 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncJoin, (JSGlobalObject* globalObject, C
     if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Iterator.prototype.join requires that |this| be an Object."_s);
 
+    auto abruptCloseIterator = [&] {
+        scope.release();
+        iteratorClose(globalObject, thisValue);
+        return JSValue::encode(jsUndefined());
+    };
+
     JSValue separatorValue = callFrame->argument(0);
     JSString* separatorString = nullptr;
     if (separatorValue.isUndefined()) {
@@ -337,14 +343,9 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncJoin, (JSGlobalObject* globalObject, C
         separatorString = jsSingleCharacterString(vm, comma);
         RETURN_IF_EXCEPTION(scope, { });
     } else {
-        separatorString = separatorValue.toStringOrNull(globalObject);
-        EXCEPTION_ASSERT(!!scope.exception() == !separatorString);
-        if (!separatorString) {
-            scope.release();
-            iteratorClose(globalObject, thisValue);
-            return { };
-        }
-        RETURN_IF_EXCEPTION(scope, { });
+        separatorString = separatorValue.toString(globalObject);
+        if (scope.exception()) [[unlikely]]
+            return abruptCloseIterator();
     }
 
     IterationRecord iterationRecord = iteratorDirect(globalObject, thisValue);
@@ -362,7 +363,8 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncJoin, (JSGlobalObject* globalObject, C
         cachedCall = &cachedCallHolder.value();
     }
 
-    JSString* result = nullptr;
+    bool first = true;
+    JSRopeString::RopeBuilder<RecordOverflow> ropeBuilder(vm);
     while (true) {
         JSValue next;
         if (cachedCall) [[likely]] {
@@ -373,39 +375,32 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncJoin, (JSGlobalObject* globalObject, C
         RETURN_IF_EXCEPTION(scope, { });
 
         if (next.isFalse())
-            break;
+            return JSValue::encode(ropeBuilder.release());
 
         JSValue nextValue = iteratorValue(globalObject, next);
         RETURN_IF_EXCEPTION(scope, { });
 
+        if (first)
+            first = false;
+        else {
+            if (!ropeBuilder.append(separatorString)) [[unlikely]] {
+                throwOutOfMemoryError(globalObject, scope);
+                return abruptCloseIterator();
+            }
+        }
+
         if (nextValue.isUndefinedOrNull())
             continue;
 
-        JSString* nextString = nextValue.toStringOrNull(globalObject);
-        EXCEPTION_ASSERT(!!scope.exception() == !nextString);
-        if (!nextString) {
-            scope.release();
-            iteratorClose(globalObject, thisValue);
-            return { };
-        }
-        RETURN_IF_EXCEPTION(scope, { });
+        JSString* nextString = nextValue.toString(globalObject);
+        if (scope.exception()) [[unlikely]]
+            return abruptCloseIterator();
 
-        if (!result)
-            result = nextString;
-        else {
-            result = jsString(globalObject, result, separatorString, nextString);
-            EXCEPTION_ASSERT(!!scope.exception() == !result);
-            if (!result) {
-                scope.release();
-                iteratorClose(globalObject, thisValue);
-                return { };
-            }
-            RETURN_IF_EXCEPTION(scope, { });
+        if (!ropeBuilder.append(nextString)) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return abruptCloseIterator();
         }
     }
-    if (!result)
-        result = jsEmptyString(vm);
-    return JSValue::encode(result);
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### 7417386b7da17bdb83f5c8f90aafb25234967e66
<pre>
[JSC] Align Iterator#join to the latest spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=321270">https://bugs.webkit.org/show_bug.cgi?id=321270</a>
<a href="https://rdar.apple.com/184321382">rdar://184321382</a>

Reviewed by Yijia Huang.

Align Iterator#join implementation more to the spec.

1. even if undefined/null element exists, we still need to append a
   separator. This fixes a test262 failure.
2. For efficiency, use JSRopeString::RopeBuilder.

* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/318806@main">https://commits.webkit.org/318806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4104ab6854b6b39b64b61c09bb17275d0ad1201

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53391 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce0439a1-24dc-4b8b-a144-6b364e7436ea) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53102 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/189284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/522022c9-b261-41ab-a430-805eac9ecba5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182409 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cfd02c5d-53e7-4506-b6e6-6faf2db63b08) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/738 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/40727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45997 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191503 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53742 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/148945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27235 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43610 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126014 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52259 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51705 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->