### PR TITLE
[JSC] Align Iterator#chunk / Iterator#windows to the latest spec

### DIFF
--- a/JSTests/stress/iterator-prototype-chunks.js
+++ b/JSTests/stress/iterator-prototype-chunks.js
@@ -144,14 +144,24 @@ function shouldThrow(fn, error, message) {
 {
     const invalidChunkSizes = [
         undefined,
+        null,
         "test",
+        "1",
+        true,
         {},
+        [1],
+        Symbol("symbol"),
+        NaN,
+        0.5,
+        1.5,
+        Infinity,
+        -Infinity,
     ];
     const validIter = (function* gen() {})();
     for (const invalidChunkSize of invalidChunkSizes) {
         shouldThrow(function () {
             Iterator.prototype.chunks.call(validIter, invalidChunkSize);
-        }, RangeError, "Iterator.prototype.chunks requires that first argument not be NaN.");
+        }, TypeError, "Iterator.prototype.chunks requires that first argument be an integral Number.");
     }
 }
 
@@ -159,8 +169,9 @@ function shouldThrow(fn, error, message) {
     const invalidChunkSizes = [
         -1,
         0,
+        -0,
         2 ** 32,
-        null,
+        2 ** 53,
     ];
     const validIter = (function* gen() {})();
     for (const invalidChunkSize of invalidChunkSizes) {
@@ -168,4 +179,57 @@ function shouldThrow(fn, error, message) {
             Iterator.prototype.chunks.call(validIter, invalidChunkSize);
         }, RangeError, "Iterator.prototype.chunks requires that first argument be between 1 and 2**32 - 1.");
     }
+
+    validIter.chunks(1);
+    validIter.chunks(2 ** 32 - 1);
+}
+
+{
+    const validIter = (function* gen() {})();
+    shouldThrow(function () {
+        validIter.chunks({ valueOf() { throw new Error("chunkSize must not be coerced"); } });
+    }, TypeError, "Iterator.prototype.chunks requires that first argument be an integral Number.");
+}
+
+{
+    let closeCount = 0;
+    const closable = {
+        __proto__: Iterator.prototype,
+        get next() {
+            throw new Error("next must not be read before the arguments are validated");
+        },
+        return() {
+            ++closeCount;
+            return {};
+        },
+    };
+
+    shouldThrow(function () {
+        closable.chunks();
+    }, TypeError, "Iterator.prototype.chunks requires that first argument be an integral Number.");
+    assert(closeCount === 1);
+
+    shouldThrow(function () {
+        closable.chunks(0);
+    }, RangeError, "Iterator.prototype.chunks requires that first argument be between 1 and 2**32 - 1.");
+    assert(closeCount === 2);
+}
+
+{
+    let returnGets = 0;
+    const closable = {
+        __proto__: Iterator.prototype,
+        get next() {
+            throw new Error("next must not be read before the arguments are validated");
+        },
+        get return() {
+            ++returnGets;
+            throw new Error("this error must be masked by the validation error");
+        },
+    };
+
+    shouldThrow(function () {
+        closable.chunks(0);
+    }, RangeError, "Iterator.prototype.chunks requires that first argument be between 1 and 2**32 - 1.");
+    assert(returnGets === 1);
 }

--- a/JSTests/stress/iterator-prototype-windows.js
+++ b/JSTests/stress/iterator-prototype-windows.js
@@ -363,14 +363,24 @@ function shouldThrow(fn, error, message) {
 {
     const invalidWindowSizes = [
         undefined,
+        null,
         "test",
+        "1",
+        true,
         {},
+        [1],
+        Symbol("symbol"),
+        NaN,
+        0.5,
+        1.5,
+        Infinity,
+        -Infinity,
     ];
     const validIter = (function* gen() {})();
     for (const invalidWindowSize of invalidWindowSizes) {
         shouldThrow(function () {
             Iterator.prototype.windows.call(validIter, invalidWindowSize);
-        }, RangeError, "Iterator.prototype.windows requires that first argument not be NaN.");
+        }, TypeError, "Iterator.prototype.windows requires that first argument be an integral Number.");
     }
 }
 
@@ -378,8 +388,9 @@ function shouldThrow(fn, error, message) {
     const invalidWindowSizes = [
         -1,
         0,
+        -0,
         2 ** 32,
-        null,
+        2 ** 53,
     ];
     const validIter = (function* gen() {})();
     for (const invalidWindowSize of invalidWindowSizes) {
@@ -387,9 +398,85 @@ function shouldThrow(fn, error, message) {
             Iterator.prototype.windows.call(validIter, invalidWindowSize);
         }, RangeError, "Iterator.prototype.windows requires that first argument be between 1 and 2**32 - 1.");
     }
+
+    validIter.windows(1);
+    validIter.windows(2 ** 32 - 1);
 }
 
-shouldThrow(function () {
+{
     const validIter = (function* gen() {})();
-    validIter.windows(1, "invalid");
-}, TypeError, "Iterator.prototype.windows requires that second argument be \"only-full\" or \"allow-partial\".");
+    shouldThrow(function () {
+        validIter.windows({ valueOf() { throw new Error("windowSize must not be coerced"); } });
+    }, TypeError, "Iterator.prototype.windows requires that first argument be an integral Number.");
+}
+
+{
+    const invalidUndersizedValues = [
+        null,
+        "",
+        "invalid",
+        0,
+        true,
+        false,
+        {},
+        Symbol("symbol"),
+    ];
+    const validIter = (function* gen() {})();
+    for (const invalidUndersized of invalidUndersizedValues) {
+        shouldThrow(function () {
+            validIter.windows(1, invalidUndersized);
+        }, TypeError, "Iterator.prototype.windows requires that second argument be \"only-full\" or \"allow-partial\".");
+    }
+
+    validIter.windows(1, undefined);
+    validIter.windows(1, "only-full");
+    validIter.windows(1, "allow-partial");
+}
+
+{
+    let closeCount = 0;
+    const closable = {
+        __proto__: Iterator.prototype,
+        get next() {
+            throw new Error("next must not be read before the arguments are validated");
+        },
+        return() {
+            ++closeCount;
+            return {};
+        },
+    };
+
+    shouldThrow(function () {
+        closable.windows();
+    }, TypeError, "Iterator.prototype.windows requires that first argument be an integral Number.");
+    assert(closeCount === 1);
+
+    shouldThrow(function () {
+        closable.windows(0);
+    }, RangeError, "Iterator.prototype.windows requires that first argument be between 1 and 2**32 - 1.");
+    assert(closeCount === 2);
+
+    shouldThrow(function () {
+        closable.windows(1, "invalid");
+    }, TypeError, "Iterator.prototype.windows requires that second argument be \"only-full\" or \"allow-partial\".");
+    assert(closeCount === 3);
+}
+
+{
+    let returnGets = 0;
+    const closable = {
+        __proto__: Iterator.prototype,
+        get next() {
+            throw new Error("next must not be read before the arguments are validated");
+        },
+        get return() {
+            ++returnGets;
+            throw new Error("this error must be masked by the validation error");
+        },
+    };
+
+    shouldThrow(function () {
+        closable.windows(1, "invalid");
+    }, TypeError, "Iterator.prototype.windows requires that second argument be \"only-full\" or \"allow-partial\".");
+    assert(returnGets === 1);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -37,40 +37,7 @@ test/built-ins/Function/prototype/caller/prop-desc.js:
 test/built-ins/Function/prototype/toString/built-in-function-object.js:
   default: 3
   strict mode: 3
-test/built-ins/Iterator/prototype/chunks/argument-validation-failure-close-throws.js:
-  default: 3
-  strict mode: 3
-test/built-ins/Iterator/prototype/chunks/argument-validation-failure-closes-underlying.js:
-  default: 3
-  strict mode: 3
-test/built-ins/Iterator/prototype/chunks/chunkSize-no-coercion.js:
-  default: 3
-  strict mode: 3
-test/built-ins/Iterator/prototype/chunks/chunkSize-not-a-number.js:
-  default: 3
-  strict mode: 3
-test/built-ins/Iterator/prototype/chunks/chunkSize-out-of-range.js:
-  default: 3
-  strict mode: 3
 test/built-ins/Iterator/prototype/join/contents-nullish.js:
-  default: 3
-  strict mode: 3
-test/built-ins/Iterator/prototype/windows/argument-validation-failure-close-throws.js:
-  default: 3
-  strict mode: 3
-test/built-ins/Iterator/prototype/windows/argument-validation-failure-closes-underlying.js:
-  default: 3
-  strict mode: 3
-test/built-ins/Iterator/prototype/windows/undersized-invalid.js:
-  default: 3
-  strict mode: 3
-test/built-ins/Iterator/prototype/windows/windowSize-no-coercion.js:
-  default: 3
-  strict mode: 3
-test/built-ins/Iterator/prototype/windows/windowSize-not-a-number.js:
-  default: 3
-  strict mode: 3
-test/built-ins/Iterator/prototype/windows/windowSize-out-of-range.js:
   default: 3
   strict mode: 3
 test/built-ins/Proxy/apply/arguments-realm.js:

--- a/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
@@ -395,13 +395,21 @@ function chunks(chunkSize)
     if (!@isObject(this))
         @throwTypeError("Iterator.prototype.chunks requires that |this| be an Object.");
 
-    var numChunkSize = @toNumber(chunkSize);
-    if (numChunkSize !== numChunkSize)
-        @throwRangeError("Iterator.prototype.chunks requires that first argument not be NaN.");
+    if (typeof chunkSize !== "number" || chunkSize % 1 !== 0) {
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwTypeError("Iterator.prototype.chunks requires that first argument be an integral Number.");
+        }
+    }
 
-    var intChunkSize = @toIntegerOrInfinity(numChunkSize);
-    if (intChunkSize < 1 || intChunkSize > @MAX_ARRAY_INDEX)
-        @throwRangeError("Iterator.prototype.chunks requires that first argument be between 1 and 2**32 - 1.");
+    if (chunkSize < 1 || chunkSize > 4294967295) {
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwRangeError("Iterator.prototype.chunks requires that first argument be between 1 and 2**32 - 1.");
+        }
+    }
 
     var iterated = this;
     var iteratedNextMethod = this.next;
@@ -419,7 +427,7 @@ function chunks(chunkSize)
 
             @arrayPush(buffer, result.value);
 
-            if (buffer.length === intChunkSize) {
+            if (buffer.length === chunkSize) {
                 @ifAbruptCloseIterator(iterated, (
                     yield buffer
                 ));
@@ -440,17 +448,32 @@ function windows(windowSize /*, undersized */)
     if (!@isObject(this))
         @throwTypeError("Iterator.prototype.windows requires that |this| be an Object.");
 
-    var numWindowSize = @toNumber(windowSize);
-    if (numWindowSize !== numWindowSize)
-        @throwRangeError("Iterator.prototype.windows requires that first argument not be NaN.");
+    if (typeof windowSize !== "number" || windowSize % 1 !== 0) {
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwTypeError("Iterator.prototype.windows requires that first argument be an integral Number.");
+        }
+    }
 
-    var intWindowSize = @toIntegerOrInfinity(numWindowSize);
-    if (intWindowSize < 1 || intWindowSize > @MAX_ARRAY_INDEX)
-        @throwRangeError("Iterator.prototype.windows requires that first argument be between 1 and 2**32 - 1.");
+    if (windowSize < 1 || windowSize > 4294967295) {
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwRangeError("Iterator.prototype.windows requires that first argument be between 1 and 2**32 - 1.");
+        }
+    }
 
-    var undersized = @argument(1) ?? "only-full";
-    if (undersized !== "only-full" && undersized !== "allow-partial")
-        @throwTypeError("Iterator.prototype.windows requires that second argument be \"only-full\" or \"allow-partial\".");
+    var undersized = @argument(1);
+    if (undersized === @undefined)
+        undersized = "only-full";
+    else if (undersized !== "only-full" && undersized !== "allow-partial") {
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwTypeError("Iterator.prototype.windows requires that second argument be \"only-full\" or \"allow-partial\".");
+        }
+    }
 
     var iterated = this;
     var iteratedNextMethod = this.next;
@@ -461,19 +484,19 @@ function windows(windowSize /*, undersized */)
         for (;;) {
             var result = @iteratorGenericNext(iteratedNextMethod, iterated);
             if (result.done) {
-                if (undersized === "allow-partial" && buffer.length && buffer.length < intWindowSize)
+                if (undersized === "allow-partial" && buffer.length && buffer.length < windowSize)
                     yield buffer;
                 return;
             }
 
-            if (buffer.length === intWindowSize) {
+            if (buffer.length === windowSize) {
                 for (var i = 0; i < buffer.length - 1; ++i)
                     buffer[i] = buffer[i + 1];
                 buffer[buffer.length - 1] = result.value;
             } else
                 @arrayPush(buffer, result.value);
 
-            if (buffer.length === intWindowSize) {
+            if (buffer.length === windowSize) {
                 var copy = @newArrayWithSize(buffer.length);
                 for (var i = 0; i < buffer.length; ++i)
                     copy[i] = buffer[i];


### PR DESCRIPTION
#### 547e1555ce4d3fc9a0b016c2cc6cd84c29fe03ce
<pre>
[JSC] Align Iterator#chunk / Iterator#windows to the latest spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=321272">https://bugs.webkit.org/show_bug.cgi?id=321272</a>
<a href="https://rdar.apple.com/184321801">rdar://184321801</a>

Reviewed by Yijia Huang.

Iterator#chunk / Iterator#windows handles input chunk-size / window-size
differently. This patch fixes them to align them to the latest spec.

* JSTests/stress/iterator-prototype-chunks.js:
(const.invalidChunkSize.of.invalidChunkSizes.shouldThrow):
(Iterator.prototype.chunks.call):
(validIter.chunks.const.validIter):
(validIter.chunks):
(const.closable.get next):
(const.closable.return):
(shouldThrow):
(assert.const.closable.get next):
(assert.const.closable.get return):
(assert):
* JSTests/stress/iterator-prototype-windows.js:
(const.invalidWindowSize.of.invalidWindowSizes.shouldThrow):
(Iterator.prototype.windows.call):
(validIter.windows.const.validIter):
(validIter.windows):
(const.invalidUndersized.of.invalidUndersizedValues.shouldThrow):
(validIter.windows.const.closable.get next):
(assert.const.closable.get next):
(assert.const.closable.get return):
(assert):
(shouldThrow.const.validIter): Deleted.
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/JSIteratorPrototype.js:
(chunks.generator):
(chunks):
(windows.generator):
(windows):

Canonical link: <a href="https://commits.webkit.org/318802@main">https://commits.webkit.org/318802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5eccb6e426e05027066f02f1ac0236803214d0c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189208 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98f9b384-11e8-4201-8821-f1379d2ec91c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139883 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a098e38-f4a1-44fe-87df-e9d0d1e2e0e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120335 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fb4702f-cc63-4574-9e54-7f1fde94d20a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40492 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2305 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9118 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152560 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40138 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/660 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40651 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191426 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52985 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149137 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53666 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148879 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27233 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43555 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125938 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120828 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52183 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15125 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51568 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51809 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51629 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->