### PR TITLE
GTEST_SKIP() is reported as a test failure

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -375,7 +375,15 @@ class Manager(object):
             return Manager.FAILED_TESTS
 
         successful = runner.result_map_by_status(runner.STATUS_PASSED)
-        disabled = len(runner.result_map_by_status(runner.STATUS_DISABLED))
+        # STATUS_DISABLED covers both DISABLED_ prefixed tests, which never launch, and
+        # tests that ran and called GTEST_SKIP(). Only the latter are reported as skipped:
+        # they were expected to run, and their output records (optionally) why they did not.
+        did_not_run = runner.result_map_by_status(runner.STATUS_DISABLED)
+        disabled = len(did_not_run)
+        skipped_at_runtime = {
+            test: output for test, output in iteritems(did_not_run)
+            if not Runner.is_disabled_test(test)
+        }
 
         # Check if running in test-parallel-safety mode
         test_parallel_safety_tests = self._port.get_option('test_parallel_safety') or []
@@ -450,8 +458,10 @@ class Manager(object):
         all_skipped_tests = list(skipped_by_expectation | skipped_as_failing | skipped_as_flaky)
         for test in all_skipped_tests:
             result_dictionary['Skipped'].append({'name': test, 'output': None})
-        if all_skipped_tests:
-            self._stream.writeln(f'Skipped {len(all_skipped_tests)} tests')
+        for test, output in iteritems(skipped_at_runtime):
+            result_dictionary['Skipped'].append({'name': test, 'output': output or None})
+        if result_dictionary['Skipped']:
+            self._stream.writeln(f"Skipped {len(result_dictionary['Skipped'])} tests")
             self._stream.writeln('')
 
         if unexpected_failures:

--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -77,6 +77,13 @@ def run_test_parallel_safety_single_iteration(test_name):
         _log.error(f'Error in test-parallel-safety iteration for {test_name}: {e}')
         raise  # Re-raise so TaskPool can handle the error appropriately
 
+
+def _status_precedence(status):
+    # Any real result outranks a disabled/skipped test, and the rest
+    # are already ordered by severity, so they keep their own values.
+    return -1 if status == Runner.STATUS_DISABLED else status
+
+
 def report_result(worker, test, status, output, elapsed=None):
     if elapsed < Runner.ELAPSED_THRESHOLD and status == Runner.STATUS_PASSED and (not output or Runner.instance.port.get_option('quiet')):
         Runner.instance.printer.write_update(f'{worker} {test} {Runner.NAME_FOR_STATUS[status]}')
@@ -85,7 +92,9 @@ def report_result(worker, test, status, output, elapsed=None):
         Runner.instance.printer.writeln(f'{worker} {test} {Runner.NAME_FOR_STATUS[status]}{elapsed_log}')
     if test in Runner.instance.results:
         existing_status = Runner.instance.results[test][0]
-        if status > existing_status or (status == existing_status and status != Runner.STATUS_PASSED):
+        precedence = _status_precedence(status)
+        existing_precedence = _status_precedence(existing_status)
+        if precedence > existing_precedence or (precedence == existing_precedence and status != Runner.STATUS_PASSED):
             Runner.instance.results[test] = status, output, elapsed
     else:
         Runner.instance.results[test] = status, output, elapsed
@@ -112,6 +121,12 @@ class Runner(object):
         'Timeout',
         'Disabled',
     ]
+
+    STATUS_FOR_TOKEN = {
+        '**PASS**': STATUS_PASSED,
+        '**FAIL**': STATUS_FAILED,
+        '**DISABLED**': STATUS_DISABLED,
+    }
 
     instance = None
 
@@ -163,8 +178,15 @@ class Runner(object):
                 shards[f"{test}.{i}"] = [test]
         return shards
 
+    @classmethod
+    def status_for_output_line(cls, line):
+        for token, status in cls.STATUS_FOR_TOKEN.items():
+            if token in line:
+                return status
+        return None
+
     @staticmethod
-    def _is_disabled_test(test_name):
+    def is_disabled_test(test_name):
         # gtest never runs a test whose method component is prefixed with
         # DISABLED_.  test_name is the full binary.suite.method form; strip the
         # binary name, then check the method component.
@@ -180,7 +202,7 @@ class Runner(object):
         runnable = []
         disabled = []
         for test in tests:
-            if Runner._is_disabled_test(test):
+            if Runner.is_disabled_test(test):
                 disabled.append(test)
             else:
                 runnable.append(test)
@@ -367,7 +389,8 @@ class _Worker(object):
             env=self._port.environment_for_api_tests())
 
         status = Runner.STATUS_RUNNING
-        if Runner._is_disabled_test(f'{binary_name}.{test}') and not self._port.get_option('force'):
+        disabled_by_name = Runner.is_disabled_test(f'{binary_name}.{test}') and not self._port.get_option('force')
+        if disabled_by_name:
             status = Runner.STATUS_DISABLED
 
         stdout_buffer = ''
@@ -376,7 +399,7 @@ class _Worker(object):
 
         try:
             started = time.time()
-            if status != Runner.STATUS_DISABLED:
+            if not disabled_by_name:
                 server_process.start()
 
             while status == Runner.STATUS_RUNNING:
@@ -401,17 +424,14 @@ class _Worker(object):
                     _log.error(stderr_line[:-1])
                 if stdout_line:
                     stdout_line = string_utils.decode(stdout_line, target_type=str)
-                    if '**PASS**' in stdout_line:
-                        status = Runner.STATUS_PASSED
-                    elif '**FAIL**' in stdout_line:
-                        status = Runner.STATUS_FAILED
-                    elif '**DISABLED**' in stdout_line:
-                        status = Runner.STATUS_DISABLED
+                    status_from_line = Runner.status_for_output_line(stdout_line)
+                    if status_from_line is not None:
+                        status = status_from_line
                     else:
                         stdout_buffer += stdout_line
                         _log.error(stdout_line[:-1])
 
-            if status == Runner.STATUS_DISABLED:
+            if disabled_by_name:
                 pass
             elif server_process.timed_out:
                 status = Runner.STATUS_TIMEOUT
@@ -430,7 +450,11 @@ class _Worker(object):
                     status = Runner.STATUS_FAILED
                     line = self.EXCEEDED_LOG_LINE_MESSAGE.format(self.log_limit)
 
-                _log.error(line)
+                # Output trailing a **DISABLED** token is (likely) a GTEST_SKIP() reason, not an error.
+                if status == Runner.STATUS_DISABLED:
+                    _log.info(line)
+                else:
+                    _log.error(line)
                 output_buffer += line + '\n'
 
                 if line_count > self.log_limit:
@@ -495,8 +519,9 @@ class _Worker(object):
                     if last_test is not None:
                         remaining_tests.remove(last_test)
 
+                        log_line = _log.info if last_status == Runner.STATUS_DISABLED else _log.error
                         for line in buffer.splitlines(False):
-                            _log.error(line)
+                            log_line(line)
                         line_count = 0
                         TaskPool.Process.queue.send(TaskPool.Task(
                             report_result, None, TaskPool.Process.name,
@@ -507,10 +532,7 @@ class _Worker(object):
                         started = time.time()
                         buffer = ''
 
-                    if '**PASS**' == stdout_split[0]:
-                        last_status = Runner.STATUS_PASSED
-                    else:
-                        last_status = Runner.STATUS_FAILED
+                    last_status = Runner.STATUS_FOR_TOKEN.get(stdout_split[0], Runner.STATUS_FAILED)
                     last_test = stdout_split[1]
 
                 # We assume that stderr is only relevant if there is a crash (meaning we triggered an assert)
@@ -518,12 +540,13 @@ class _Worker(object):
                     remaining_tests.remove(last_test)
                     stdout_buffer = string_utils.decode(server_process.pop_all_buffered_stdout(), target_type=str)
                     stderr_buffer = string_utils.decode(server_process.pop_all_buffered_stderr(), target_type=str) if last_status == Runner.STATUS_CRASHED else ''
+                    log_line = _log.info if last_status == Runner.STATUS_DISABLED else _log.error
                     for line in (stdout_buffer + stderr_buffer).splitlines():
                         line_count += 1
                         if line_count > self.log_limit:
                             break
                         buffer += line
-                        _log.error(line[:-1])
+                        log_line(line[:-1])
 
                     if line_count > self.log_limit:
                         last_status = Runner.STATUS_FAILED

--- a/Tools/Scripts/webkitpy/api_tests/runner_unittest.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner_unittest.py
@@ -24,16 +24,16 @@
 
 import unittest
 
-from webkitpy.api_tests.runner import Runner
+from webkitpy.api_tests.runner import Runner, report_result
 
 
 class RunnerTest(unittest.TestCase):
     def test_is_disabled_test_detects_disabled_method(self):
-        self.assertTrue(Runner._is_disabled_test(
+        self.assertTrue(Runner.is_disabled_test(
             "TestWebKitAPI.SiteIsolation.DISABLED_PostMessageWithMessagePorts"))
 
     def test_is_disabled_test_allows_enabled_test(self):
-        self.assertFalse(Runner._is_disabled_test(
+        self.assertFalse(Runner.is_disabled_test(
             "TestWebKitAPI.SiteIsolation.LoadingCallbacksAndPostMessage"))
 
     def test_parallel_safety_tests_excludes_disabled(self):
@@ -59,6 +59,111 @@ class RunnerTest(unittest.TestCase):
         runnable, disabled = Runner._partition_parallel_safety_tests(supplied)
         self.assertEqual(runnable, supplied)
         self.assertEqual(disabled, [])
+
+    def test_status_for_output_line_passed(self):
+        self.assertEqual(
+            Runner.STATUS_PASSED,
+            Runner.status_for_output_line("**PASS** SiteIsolation.GrandchildIframe\n"))
+
+    def test_status_for_output_line_failed(self):
+        self.assertEqual(
+            Runner.STATUS_FAILED,
+            Runner.status_for_output_line("**FAIL** SiteIsolation.GrandchildIframe\n"))
+
+    def test_status_for_output_line_skipped_is_disabled(self):
+        # A test that called GTEST_SKIP() reports **DISABLED**, because it did not run.
+        self.assertEqual(
+            Runner.STATUS_DISABLED,
+            Runner.status_for_output_line(
+                "**DISABLED** UnifiedPDF/EmbeddedPDFFitsToFrame.Test/IFrame_CrossOrigin\n"))
+
+    def test_status_for_output_line_ignores_non_status_output(self):
+        self.assertIsNone(Runner.status_for_output_line("Skipping <iframe src=pdf> variants\n"))
+
+    def test_shard_token_lookup_covers_every_status_token(self):
+        # The shard parser looks up the exact token, so every token the binaries emit must
+        # be present. A missing one falls back to STATUS_FAILED, which is how skipped tests
+        # used to be miscounted as failures.
+        self.assertEqual(Runner.STATUS_PASSED, Runner.STATUS_FOR_TOKEN.get('**PASS**'))
+        self.assertEqual(Runner.STATUS_FAILED, Runner.STATUS_FOR_TOKEN.get('**FAIL**'))
+        self.assertEqual(Runner.STATUS_DISABLED, Runner.STATUS_FOR_TOKEN.get('**DISABLED**'))
+        self.assertIsNone(Runner.STATUS_FOR_TOKEN.get('**BOGUS**'))
+
+    def test_name_for_status_is_indexed_by_status(self):
+        self.assertEqual('Passed', Runner.NAME_FOR_STATUS[Runner.STATUS_PASSED])
+        self.assertEqual('Disabled', Runner.NAME_FOR_STATUS[Runner.STATUS_DISABLED])
+
+
+class _StubPrinter:
+    def write_update(self, line):
+        pass
+
+    def writeln(self, line):
+        pass
+
+
+class _StubPort:
+    def get_option(self, name, default=None):
+        return default
+
+
+class _StubRunner:
+    def __init__(self):
+        self.printer = _StubPrinter()
+        self.port = _StubPort()
+        self.results = {}
+
+
+class ReportResultTest(unittest.TestCase):
+    TEST_NAME = "TestWebKitAPI.WebKit.Foo"
+
+    def setUp(self):
+        self._saved_instance = Runner.instance
+        Runner.instance = _StubRunner()
+
+    def tearDown(self):
+        Runner.instance = self._saved_instance
+
+    def _report(self, status):
+        report_result('worker/0', self.TEST_NAME, status, '', elapsed=0.1)
+
+    def _recorded_status(self):
+        return Runner.instance.results[self.TEST_NAME][0]
+
+    def test_failure_survives_a_later_non_run(self):
+        self._report(Runner.STATUS_FAILED)
+        self._report(Runner.STATUS_DISABLED)
+        self.assertEqual(Runner.STATUS_FAILED, self._recorded_status())
+
+    def test_pass_survives_a_later_non_run(self):
+        self._report(Runner.STATUS_PASSED)
+        self._report(Runner.STATUS_DISABLED)
+        self.assertEqual(Runner.STATUS_PASSED, self._recorded_status())
+
+    def test_failure_replaces_an_earlier_non_run(self):
+        self._report(Runner.STATUS_DISABLED)
+        self._report(Runner.STATUS_FAILED)
+        self.assertEqual(Runner.STATUS_FAILED, self._recorded_status())
+
+    def test_repeated_non_run_stays_disabled(self):
+        self._report(Runner.STATUS_DISABLED)
+        self._report(Runner.STATUS_DISABLED)
+        self.assertEqual(Runner.STATUS_DISABLED, self._recorded_status())
+
+    def test_crash_still_outranks_a_failure(self):
+        self._report(Runner.STATUS_FAILED)
+        self._report(Runner.STATUS_CRASHED)
+        self.assertEqual(Runner.STATUS_CRASHED, self._recorded_status())
+
+    def test_pass_replaces_an_earlier_non_run(self):
+        self._report(Runner.STATUS_DISABLED)
+        self._report(Runner.STATUS_PASSED)
+        self.assertEqual(Runner.STATUS_PASSED, self._recorded_status())
+
+    def test_failure_is_not_downgraded_by_a_later_pass(self):
+        self._report(Runner.STATUS_FAILED)
+        self._report(Runner.STATUS_PASSED)
+        self.assertEqual(Runner.STATUS_FAILED, self._recorded_status())
 
 
 if __name__ == '__main__':

--- a/Tools/TestWebKitAPI/Runner/TestsController.cpp
+++ b/Tools/TestWebKitAPI/Runner/TestsController.cpp
@@ -34,11 +34,8 @@
 namespace TestWebKitAPI {
 
 class Printer : public ::testing::EmptyTestEventListener {
-    virtual void OnTestPartResult(const ::testing::TestPartResult& test_part_result)
+    static std::string descriptionFor(const ::testing::TestPartResult& test_part_result)
     {
-        if (!test_part_result.failed())
-            return;
-
         std::stringstream stream;
         stream << "\n";
         if (test_part_result.file_name())
@@ -46,20 +43,33 @@ class Printer : public ::testing::EmptyTestEventListener {
         else
             stream << "File name unavailable";
         stream << "\n" << test_part_result.summary() << "\n\n";
-        failures += stream.str();
+        return stream.str();
+    }
+
+    virtual void OnTestPartResult(const ::testing::TestPartResult& test_part_result)
+    {
+        if (test_part_result.skipped())
+            skips += descriptionFor(test_part_result);
+        else if (test_part_result.failed())
+            failures += descriptionFor(test_part_result);
     }
 
     virtual void OnTestEnd(const ::testing::TestInfo& test_info)
     {
-        if (test_info.result()->Passed())
+        const auto& result = *test_info.result();
+        if (result.Passed())
             std::cout << "**PASS** " << test_info.test_case_name() << "." << test_info.name() << "\n";
+        else if (result.Skipped())
+            std::cout << "**DISABLED** " << test_info.test_case_name() << "." << test_info.name() << "\n" << skips;
         else
             std::cout << "**FAIL** " << test_info.test_case_name() << "." << test_info.name() << "\n" << failures;
 
         failures = std::string();
+        skips = std::string();
     }
 
     std::string failures;
+    std::string skips;
 };
 
 TestsController& TestsController::singleton()


### PR DESCRIPTION
#### d08e11a3acba55b456fce016e65461b65db4e8d8
<pre>
GTEST_SKIP() is reported as a test failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=321271">https://bugs.webkit.org/show_bug.cgi?id=321271</a>
<a href="https://rdar.apple.com/184321285">rdar://184321285</a>

Reviewed by NOBODY (OOPS!).

On ToT, we treat gtest as having two outcomes. However, there is a third
mutually exclusive outcome -- for GTEST_SKIP(). We conflate this with
failure because TWKAPI&apos;s custom gtest result printer (and listener)
considers anything not **PASS** to be a failure.

In this patch, we retrofit the **DISABLED** status, which currently
works for DISABLED_ gtest cases and skipped Swift Testing cases, to also
work with GTEST_SKIP().

This status reuse means that it is no longer true that the status
implies no TWKAPI process was _launched_, so we fix two assumptions:

1. Run singly now has to key off disabled_By_name so a test that skips
   and then crashes during teardown is still reported as a crash.
2. Deprioritize STATUS_DISABLED output below every real result type, so
   a runtime skip in one iteration doesn&apos;t displace a real failure from
   a later iteration.

* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager.run):
* Tools/Scripts/webkitpy/api_tests/runner.py:
(_status_precedence):
(report_result):
(Runner):
(Runner.status_for_output_line):
(Runner.is_disabled_test):
(Runner._partition_parallel_safety_tests):
(_Worker._run_single_test):
(_Worker.run):
(Runner._is_disabled_test): Deleted.
* Tools/Scripts/webkitpy/api_tests/runner_unittest.py:
(RunnerTest.test_is_disabled_test_detects_disabled_method):
(RunnerTest.test_is_disabled_test_allows_enabled_test):
(RunnerTest.test_status_for_output_line_passed):
(RunnerTest):
(RunnerTest.test_status_for_output_line_failed):
(RunnerTest.test_status_for_output_line_skipped_is_disabled):
(RunnerTest.test_status_for_output_line_ignores_non_status_output):
(RunnerTest.test_shard_token_lookup_covers_every_status_token):
(RunnerTest.test_name_for_status_is_indexed_by_status):
(_StubPrinter):
(_StubPrinter.write_update):
(_StubPrinter.writeln):
(_StubPort):
(_StubPort.get_option):
(_StubRunner):
(_StubRunner.__init__):
(ReportResultTest):
(ReportResultTest.setUp):
(ReportResultTest.tearDown):
(ReportResultTest._report):
(ReportResultTest._recorded_status):
(ReportResultTest.test_failure_survives_a_later_non_run):
(ReportResultTest.test_pass_survives_a_later_non_run):
(ReportResultTest.test_failure_replaces_an_earlier_non_run):
(ReportResultTest.test_repeated_non_run_stays_disabled):
(ReportResultTest.test_crash_still_outranks_a_failure):
(ReportResultTest.test_pass_replaces_an_earlier_non_run):
(ReportResultTest.test_failure_is_not_downgraded_by_a_later_pass):
* Tools/TestWebKitAPI/Runner/TestsController.cpp:
(TestWebKitAPI::Printer::descriptionFor):
(TestWebKitAPI::Printer::OnTestPartResult):
(TestWebKitAPI::Printer::OnTestEnd):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d08e11a3acba55b456fce016e65461b65db4e8d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189209 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143686 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd8221d9-9a0c-4ca8-b86d-45eefc1666e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53026 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139884 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; 6 flakes 2 failures; Uploaded test results; 1 failures; Compiled WebKit (warnings); 1 failures; Passed layout tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96807 "1 flakes 2 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf3222bf-f219-45fd-9695-f368690a1ad8) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182334 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120336 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178702 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42161 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40493 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152561 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40139 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/661 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191427 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52986 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149138 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53667 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148880 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43556 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120829 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52184 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15126 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51569 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51810 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51630 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->