### PR TITLE
[JSC] Intl.Locale's collections should be sorted

### DIFF
--- a/JSTests/stress/intl-locale-info.js
+++ b/JSTests/stress/intl-locale-info.js
@@ -64,7 +64,7 @@ function shouldBeOneOf(actual, expectedArray) {
 {
     let locale = new Intl.Locale("ja")
     shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","japanese"]`);
-    shouldBe(JSON.stringify(locale.getCollations()), `["unihan","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["emoji","eor","unihan"]`);
     shouldBe(locale.hourCycle, undefined);
     shouldBe(JSON.stringify(locale.getHourCycles()), `["h23"]`);
     shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
@@ -73,7 +73,7 @@ function shouldBeOneOf(actual, expectedArray) {
 {
     let locale = new Intl.Locale("ja-JP")
     shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","japanese"]`);
-    shouldBe(JSON.stringify(locale.getCollations()), `["unihan","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["emoji","eor","unihan"]`);
     shouldBe(locale.hourCycle, undefined);
     shouldBe(JSON.stringify(locale.getHourCycles()), `["h23"]`);
     shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
@@ -100,7 +100,7 @@ function shouldBeOneOf(actual, expectedArray) {
 {
     let locale = new Intl.Locale("zh")
     shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","chinese"]`);
-    shouldBeForICUVersion(74, JSON.stringify(locale.getCollations()), `["pinyin","stroke","unihan","zhuyin","emoji","eor"]`);
+    shouldBeForICUVersion(74, JSON.stringify(locale.getCollations()), `["emoji","eor","pinyin","stroke","unihan","zhuyin"]`);
     shouldBe(locale.hourCycle, undefined);
     shouldBeOneOf(JSON.stringify(locale.getHourCycles()), [ `["h23"]`, `["h12"]` ]);
     shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
@@ -109,7 +109,7 @@ function shouldBeOneOf(actual, expectedArray) {
 {
     let locale = new Intl.Locale("zh-TW")
     shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","roc","chinese"]`);
-    shouldBeForICUVersion(74, JSON.stringify(locale.getCollations()), `["stroke","pinyin","unihan","zhuyin","emoji","eor"]`);
+    shouldBeForICUVersion(74, JSON.stringify(locale.getCollations()), `["emoji","eor","pinyin","stroke","unihan","zhuyin"]`);
     shouldBe(locale.hourCycle, undefined);
     shouldBe(JSON.stringify(locale.getHourCycles()), `["h12"]`);
     shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
@@ -118,7 +118,7 @@ function shouldBeOneOf(actual, expectedArray) {
 {
     let locale = new Intl.Locale("zh-HK")
     shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","chinese"]`);
-    shouldBeForICUVersion(74, JSON.stringify(locale.getCollations()), `["stroke","pinyin","unihan","zhuyin","emoji","eor"]`);
+    shouldBeForICUVersion(74, JSON.stringify(locale.getCollations()), `["emoji","eor","pinyin","stroke","unihan","zhuyin"]`);
     shouldBe(locale.hourCycle, undefined);
     shouldBe(JSON.stringify(locale.getHourCycles()), `["h12"]`);
     shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -64,9 +64,6 @@ test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage-empty.js:
 test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage.js:
   default: 3
   strict mode: 3
-test/intl402/Locale/prototype/getCollations/output-array-sorted.js:
-  default: 3
-  strict mode: 3
 test/intl402/Locale/prototype/getHourCycles/region-priority.js:
   default: 3
   strict mode: 3

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -861,6 +861,11 @@ JSArray* IntlLocale::collations(JSGlobalObject* globalObject)
         return nullptr;
     }
 
+    std::ranges::sort(elements.mutableSpan(),
+        [](const String& a, const String& b) {
+            return WTF::codePointCompare(a, b) < 0;
+        });
+
     RELEASE_AND_RETURN(scope, createArrayFromStringVector(globalObject, WTF::move(elements)));
 }
 
@@ -969,6 +974,11 @@ JSValue IntlLocale::timeZones(JSGlobalObject* globalObject)
         throwTypeError(globalObject, scope, "invalid locale"_s);
         return { };
     }
+
+    std::ranges::sort(elements.mutableSpan(),
+        [](const String& a, const String& b) {
+            return WTF::codePointCompare(a, b) < 0;
+        });
 
     RELEASE_AND_RETURN(scope, createArrayFromStringVector(globalObject, WTF::move(elements)));
 }


### PR DESCRIPTION
#### 9ef04dabf52d7432a3e7ab13f44f9d8b4bd933a0
<pre>
[JSC] Intl.Locale&apos;s collections should be sorted
<a href="https://bugs.webkit.org/show_bug.cgi?id=321273">https://bugs.webkit.org/show_bug.cgi?id=321273</a>
<a href="https://rdar.apple.com/184322384">rdar://184322384</a>

Reviewed by Yijia Huang.

Intl.Locale&apos;s returned arrays should be sorted according to the spec[1].

[1]: <a href="https://tc39.es/proposal-intl-locale-info/#sec-collations-of-locale">https://tc39.es/proposal-intl-locale-info/#sec-collations-of-locale</a>

* JSTests/stress/intl-locale-info.js:
(shouldBe):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::IntlLocale::collations):
(JSC::IntlLocale::timeZones):

Canonical link: <a href="https://commits.webkit.org/318808@main">https://commits.webkit.org/318808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93d189175df34ec80aa48c2fd7af0080bf0a04ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53390 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189283 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62c91bf1-6a65-421d-b1c7-9697c2eb13be) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53101 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43549 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/120389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8891d5d6-1d98-4987-b3e6-54c040e1e1e2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/2359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/9171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/736 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40726 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45996 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191502 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53060 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/160203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53741 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/148944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27237 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43609 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126013 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120908 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52258 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/15181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51643 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->