### PR TITLE
[WebDriver][GLIB] Flaky WPEWebProcess portal crashes in eager JSWindowProxy creation

### DIFF
--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -249,8 +249,11 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
         MemoryPressureHandler::singleton().setConfiguration(WTF::move(*parameters.memoryPressureHandlerConfiguration));
 
 #if ENABLE(REMOTE_INSPECTOR)
-    if (!parameters.inspectorServerAddress.isNull())
+    if (!parameters.inspectorServerAddress.isNull()) {
         Inspector::RemoteInspector::setInspectorServerAddress(WTF::move(parameters.inspectorServerAddress));
+        // pre-warm the inspector for the potentially early BiDi-related events like script.realmCreated
+        Inspector::RemoteInspector::singleton();
+    }
 #endif
 
 #if USE(ATSPI)

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -207,7 +207,7 @@
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}, "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/303207"}}
             },
             "test_add_event_handler_dom_content_loaded": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/302058"}, "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/310506"}}
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/302058"}, "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/302058"}}
             },
             "test_add_event_handler_download_will_begin": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288338"}}
@@ -219,7 +219,7 @@
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/287936"}}
             },
             "test_add_event_handler_load": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288340"}, "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/310506"}}
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288340"}, "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/288340"}}
             },
             "test_add_event_handler_navigation_committed": {
                 "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/287934"}}


### PR DESCRIPTION
#### 2865d793ebdc856dd46f35c214c7cac8e640fe85
<pre>
[WebDriver][GLIB] Flaky WPEWebProcess portal crashes in eager JSWindowProxy creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=321277">https://bugs.webkit.org/show_bug.cgi?id=321277</a>

Reviewed by Carlos Alberto Lopez Perez.

Since 310527@main, WebAutomationSession::createBrowsingContext calls
WebAutomationSessionProxy::ensureRealmForInitialEmptyDocument, which in
turn tries to create an early JSWindowProxy for the realm. This can lead
to a race in the RemoteInspector initialization, resulting in dbus
critical messages in the portal negotiation.

While this eager JSWindowProxy eager initialization is properly handled
within bug310506, this commit works around this issue by pre-warming the
RemoteInspector on the WebProcess when its address is set (e.g.
automated pages), allowing the configuration to settle before
ensureRealmForInitialEmptyDocument is called.

Also, drive-by gardening of some related issues mistakenly attributed to
this issue.

* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):
* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/318898@main">https://commits.webkit.org/318898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48b443c0bc13ebcc6025b3acd1f0a2f11945848c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143691 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139889 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96809 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120341 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42166 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40498 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152566 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40508 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/666 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191432 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52991 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149143 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40057 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53672 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148885 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43561 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125944 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120835 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52189 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15131 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51574 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->