### PR TITLE
[ANGLE] Nested dFdx/dFdy calls reaches an ASSERT during derivative rewriting

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/RewriteDfdy.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/RewriteDfdy.cpp
@@ -99,13 +99,21 @@ bool Traverser::visitAggregate(Visit visit, TIntermAggregate *node)
 
     // Replace the old dFdx() or dFdy() node with the new node that contains the corrected value
     //
-    // Note the following bugs (anglebug.com/42265816):
+    // Note the following limitations (anglebug.com/42265816):
     //
-    // - Side effects of operand are duplicated with the above
-    // - If the direct child of this node is itself dFdx/y, its queueReplacement will not be
-    //   effective as the parent is also replaced.
+    // - Side effects of operand are duplicated with the above.
+    // - If the operand is itself dFdx/dFdy, the derivatives under it are left unrotated and
+    //   unflipped (see below).
     queueReplacement(rotatedFlippedResult, OriginalNode::IS_DROPPED);
 
+    // Do not recurse into a dFdx/dFdy operand. A queued replacement of the operand records this
+    // node as its parent, which updateTree() redirects to the new expression. The operand is not
+    // a direct child of that expression, so the replacement would fail.
+    TIntermAggregate *operandAgg = operand->getAsAggregate();
+    if (operandAgg && (operandAgg->getOp() == EOpDFdx || operandAgg->getOp() == EOpDFdy))
+    {
+        return false;
+    }
     return true;
 }
 }  // anonymous namespace

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/GLSLTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/GLSLTest.cpp
@@ -7535,6 +7535,53 @@ void main()
     EXPECT_PIXEL_RECT_EQ(0, 0, getWindowWidth(), getWindowHeight(), GLColor::yellow);
 }
 
+// Test that a derivative applied to another derivative compiles. A derivative that is the direct
+// operand of another one used to queue a replacement whose parent was already dropped by the
+// RewriteDfdy pass, tripping ASSERT(replaced) in TIntermTraverser::updateTree().
+TEST_P(GLSLTest_ES3, NestedDerivatives)
+{
+    // The operand has to be non-constant, otherwise the derivatives are folded to zero before the
+    // rewrite runs.
+    constexpr char kFSPrefix[] = R"(#version 300 es
+precision mediump float;
+uniform float u;
+out vec4 color;
+void main()
+{
+    color = vec4()";
+    constexpr char kFSSuffix[] = R"();
+})";
+
+    for (const char *expression : {"dFdy(dFdy(u))", "dFdx(dFdx(u))", "dFdx(dFdy(u))",
+                                   "dFdy(dFdx(u))", "dFdy(dFdy(dFdy(u)))", "dFdy(u + dFdy(u))"})
+    {
+        const std::string fs = std::string(kFSPrefix) + expression + kFSSuffix;
+
+        GLuint shader = CompileShader(GL_FRAGMENT_SHADER, fs.c_str());
+        EXPECT_NE(0u, shader) << expression;
+        glDeleteShader(shader);
+    }
+    ASSERT_GL_NO_ERROR();
+}
+
+// Test that a nested derivative survives the RewriteDfdy rewrite and can be linked and drawn. The
+// value of a derivative of a derivative is implementation defined, so it is not checked.
+TEST_P(GLSLTest_ES3, NestedDerivativesDraw)
+{
+    constexpr char kFS[] = R"(#version 300 es
+precision mediump float;
+uniform float u;
+out vec4 color;
+void main()
+{
+    color = vec4(dFdy(dFdy(u)), 0, 0, 1);
+})";
+
+    ANGLE_GL_PROGRAM(program, essl3_shaders::vs::Simple(), kFS);
+    drawQuad(program, essl3_shaders::PositionAttrib(), 0.5f);
+    ASSERT_GL_NO_ERROR();
+}
+
 // Test that a varying struct that's not statically used in the fragment shader works.
 // GLSL ES 3.00.6 section 4.3.10.
 TEST_P(GLSLTest_ES3, VaryingStructNotStaticallyUsedInFragmentShader)


### PR DESCRIPTION
#### ff7b5ea1d73520cf1c823858d553ff1cf1b477d4
<pre>
[ANGLE] Nested dFdx/dFdy calls reaches an ASSERT during derivative rewriting
<a href="https://bugs.webkit.org/show_bug.cgi?id=321288">https://bugs.webkit.org/show_bug.cgi?id=321288</a>
<a href="https://rdar.apple.com/181803233">rdar://181803233</a>

Reviewed by Kimmo Kinnunen.

In debug builds, compiling a fragment shader in which one dFdx/dFdy call is the
immediate argument of another, such as dFdy(dFdy(u)), hits ASSERT(replaced) in
TIntermTraverser::updateTree().

RewriteDfdy replaces each call with the sum of dFdx(operand) and dFdy(operand)
scaled by the rotation and flip multipliers, queueing the replacement with
OriginalNode::IS_DROPPED, and keeps traversing into the operand. A derivative
operand then queues its own replacement with the outer call as parent. The
updater retargets that parent to the replacement expression, where the operand is
not an immediate child, so the replacement cannot be applied.

Fix by not traversing into a dFdx/dFdy operand. The derivatives under it are then
left unrotated and unflipped, which only affects the value of a derivative of a
derivative.

* Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/RewriteDfdy.cpp:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/GLSLTest.cpp:

Canonical link: <a href="https://commits.webkit.org/321241@main">https://commits.webkit.org/321241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/647ac85cdcef81e1192cd3c1911c940da9e41715

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146056 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58b3bbdb-b89d-490a-acf4-fc5f5952c82d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141852 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98469 "2 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9030e656-62bf-43e9-8e3e-c44e2da7430c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122288 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c57d138-c712-4782-9360-7a4d5c20627b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44226 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42495 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42126 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3113 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193878 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55344 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151266 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41789 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56033 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150970 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45547 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124033 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54546 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17122 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53928 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54167 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53993 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->