### PR TITLE
Update CMAKE files for Cmake 4

### DIFF
--- a/Source/JavaScriptCore/PlatformCocoa.cmake
+++ b/Source/JavaScriptCore/PlatformCocoa.cmake
@@ -273,7 +273,7 @@ if (WEBKIT_SDK_IS_IOS_FAMILY)
         inspector/scripts/codegen/objc_generator_templates.py
     )
 
-    make_directory("${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/JavaScriptCore.framework")
+    file(MAKE_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/JavaScriptCore.framework")
     configure_file(${JAVASCRIPTCORE_DIR}/framework.sb ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/JavaScriptCore.framework/framework.sb COPYONLY)
     configure_file(${JAVASCRIPTCORE_DIR}/JavaScriptCore.modulemap ${CMAKE_BINARY_DIR}/JavaScriptCore/Modules/module.modulemap COPYONLY)
     configure_file("${JAVASCRIPTCORE_DIR}/JavaScriptCore_Private.modulemap" ${CMAKE_BINARY_DIR}/JavaScriptCore/Modules/module.private.modulemap COPYONLY)

--- a/Source/ThirdParty/capstone/CMakeLists.txt
+++ b/Source/ThirdParty/capstone/CMakeLists.txt
@@ -1,16 +1,3 @@
-if(POLICY CMP0042)
-  # http://www.cmake.org/cmake/help/v3.0/policy/CMP0042.html
-  cmake_policy(SET CMP0042 NEW)
-endif(POLICY CMP0042)
-
-if (POLICY CMP0048)
-  # use old policy to honor version set using VERSION_* variables to preserve backwards
-  # compatibility. change OLD to NEW when minimum cmake version is updated to 3.* and
-  # set VERSION using project(capstone VERSION 4.0.0).
-  # http://www.cmake.org/cmake/help/v3.0/policy/CMP0048.html
-  cmake_policy (SET CMP0048 OLD)
-endif()
-
 add_definitions(-DCAPSTONE_USE_SYS_DYN_MEM)
 
 ## sources

--- a/Source/WebCore/PlatformCocoa.cmake
+++ b/Source/WebCore/PlatformCocoa.cmake
@@ -9,7 +9,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
     )
 endif ()
 
-make_directory("${CMAKE_BINARY_DIR}/WebCore/Modules")
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/WebCore/Modules")
 configure_file(${WEBCORE_DIR}/WebCore.modulemap ${CMAKE_BINARY_DIR}/WebCore/Modules/module.modulemap COPYONLY)
 configure_file(${WEBCORE_DIR}/WebCore_Private.modulemap ${CMAKE_BINARY_DIR}/WebCore/Modules/module.private.modulemap COPYONLY)
 

--- a/Source/WebGPU/WebGPU/CMakeLists.txt
+++ b/Source/WebGPU/WebGPU/CMakeLists.txt
@@ -133,7 +133,7 @@ target_include_directories(WebGPU PUBLIC ${WebGPU_FRAMEWORK_HEADERS_DIR})
 target_include_directories(WebGPU PRIVATE ${WebGPU_PRIVATE_FRAMEWORK_HEADERS_DIR})
 
 if (APPLE)
-    make_directory("${CMAKE_BINARY_DIR}/WebGPU/Modules")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/WebGPU/Modules")
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/WebGPU.modulemap
         ${CMAKE_BINARY_DIR}/WebGPU/Modules/module.modulemap COPYONLY)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/WebGPU_Private.modulemap
@@ -141,11 +141,11 @@ if (APPLE)
 
     set(_webgpu_fw "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebGPU.framework")
     if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
-        make_directory("${_webgpu_fw}")
+        file(MAKE_DIRECTORY "${_webgpu_fw}")
 
         if (SWIFT_REQUIRED)
             set(_webgpu_swiftmodule_dir "${CMAKE_BINARY_DIR}/WebGPU/Modules/WebGPU.swiftmodule")
-            make_directory(${_webgpu_swiftmodule_dir})
+            file(MAKE_DIRECTORY ${_webgpu_swiftmodule_dir})
             set(_webgpu_swift_output "${CMAKE_CURRENT_BINARY_DIR}")
             set(_webgpu_swift_arch "${CMAKE_OSX_ARCHITECTURES}")
             if (NOT _webgpu_swift_arch)
@@ -201,7 +201,7 @@ if (APPLE)
             COMMAND codesign --force --sign - ${_webgpu_fw}
             COMMENT "Populating WebGPU.framework PrivateHeaders/, Modules/, and codesigning")
     else ()
-        make_directory("${_webgpu_fw}/Versions/A")
+        file(MAKE_DIRECTORY "${_webgpu_fw}/Versions/A")
         if (NOT EXISTS "${_webgpu_fw}/Versions/Current")
             file(CREATE_LINK "A" "${_webgpu_fw}/Versions/Current" SYMBOLIC)
         endif ()

--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -1544,10 +1544,10 @@ configure_file(${WEBKIT_DIR}/Modules/iOS.modulemap ${CMAKE_BINARY_DIR}/WebKit/Mo
 
 # FIXME: Generate module.private.modulemap. https://bugs.webkit.org/show_bug.cgi?id=312083
 
-make_directory("${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework")
+file(MAKE_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework")
 
 set(_webkit_swiftmodule_dir "${CMAKE_BINARY_DIR}/WebKit/Modules/WebKit.swiftmodule")
-make_directory(${_webkit_swiftmodule_dir})
+file(MAKE_DIRECTORY ${_webkit_swiftmodule_dir})
 set(_webkit_swift_output "${CMAKE_BINARY_DIR}/Source/WebKit")
 set(_webkit_swift_arch "${CMAKE_OSX_ARCHITECTURES}")
 if (NOT _webkit_swift_arch)
@@ -1600,7 +1600,7 @@ add_custom_command(
 )
 add_custom_target(WebKit_StageSwiftModule DEPENDS ${_webkit_staged_swiftmodule_artifacts})
 
-make_directory("${CMAKE_BINARY_DIR}/WebKit/Modules/WebKit.swiftcrossimport")
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/WebKit/Modules/WebKit.swiftcrossimport")
 file(WRITE "${CMAKE_BINARY_DIR}/WebKit/Modules/WebKit.swiftcrossimport/SwiftUI.swiftoverlay"
 "---\nversion: 1\nmodules:\n- name: _WebKit_SwiftUI\n")
 
@@ -1759,7 +1759,7 @@ with open(sys.argv[2], 'wb') as f:
 
     function(WEBKIT_IOS_XPC_SERVICE _target _bundle_identifier _info_plist _executable_name _xpc_entitlements)
         set(_service_dir ${WebKit_XPC_SERVICE_DIR}/${_bundle_identifier}.xpc)
-        make_directory(${_service_dir})
+        file(MAKE_DIRECTORY ${_service_dir})
 
         set(BUNDLE_VERSION ${MACOSX_FRAMEWORK_BUNDLE_VERSION})
         set(SHORT_VERSION_STRING ${WEBKIT_MAC_VERSION})
@@ -1923,7 +1923,7 @@ with open(sys.argv[2], 'wb') as f:
     function(WEBKIT_IOS_EXTENSION _name _bundle_id _info_plist _swift_source _entitlements)
         set(_appex_dir ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${_name}.appex)
         set(_executable_name ${_bundle_id})
-        make_directory(${_appex_dir})
+        file(MAKE_DIRECTORY ${_appex_dir})
 
         set(BUNDLE_VERSION ${MACOSX_FRAMEWORK_BUNDLE_VERSION})
         set(EXECUTABLE_NAME ${_executable_name})
@@ -2028,7 +2028,7 @@ with open(sys.argv[2], 'wb') as f:
 
     set(_sb_profiles_dir "${WEBKIT_DIR}/Resources/SandboxProfiles/ios")
     set(_sb_output_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Resources")
-    make_directory(${_sb_output_dir})
+    file(MAKE_DIRECTORY ${_sb_output_dir})
 
     set(_sb_include_flags
         -I ${WEBKIT_DIR}
@@ -2540,15 +2540,15 @@ function(WEBKIT_DEFINE_XPC_SERVICES)
     set(RUNLOOP_TYPE NSRunLoop)
     set(WebKit_XPC_SERVICE_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Versions/A/XPCServices)
     # Relative symlink (matches Xcode layout; absolute breaks if build dir is moved).
-    make_directory("${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework")
+    file(MAKE_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework")
     file(CREATE_LINK "Versions/Current/XPCServices"
                      "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/XPCServices" SYMBOLIC)
 
     function(WEBKIT_XPC_SERVICE _target _bundle_identifier _info_plist _executable_name)
         set(_service_dir ${WebKit_XPC_SERVICE_DIR}/${_bundle_identifier}.xpc/Contents)
-        make_directory(${_service_dir}/MacOS)
-        make_directory(${_service_dir}/_CodeSignature)
-        make_directory(${_service_dir}/Resources)
+        file(MAKE_DIRECTORY ${_service_dir}/MacOS)
+        file(MAKE_DIRECTORY ${_service_dir}/_CodeSignature)
+        file(MAKE_DIRECTORY ${_service_dir}/Resources)
 
         # FIXME: These version strings don't match Xcode's.
         set(BUNDLE_VERSION ${WEBKIT_VERSION})

--- a/Source/WebKitLegacy/PlatformCocoa.cmake
+++ b/Source/WebKitLegacy/PlatformCocoa.cmake
@@ -1177,8 +1177,8 @@ foreach (_file ${WebKitLegacy_LEGACY_FORWARDING_HEADERS_FILES})
 endforeach ()
 
 set(_wkl_fw "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKitLegacy.framework")
-make_directory("${_wkl_fw}")
-make_directory("${_wkl_fw}/Modules")
+file(MAKE_DIRECTORY "${_wkl_fw}")
+file(MAKE_DIRECTORY "${_wkl_fw}/Modules")
 
 if (NOT EXISTS "${_wkl_fw}/PrivateHeaders")
     file(CREATE_LINK "${WebKitLegacy_FRAMEWORK_HEADERS_DIR}/WebKitLegacy"

--- a/Tools/MiniBrowser/mac/CMakeLists.txt
+++ b/Tools/MiniBrowser/mac/CMakeLists.txt
@@ -50,7 +50,7 @@ set(EXECUTABLE_NAME MiniBrowser)
 set(PRODUCT_NAME MiniBrowser)
 
 set(MiniBrowser_Contents_Directory ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MiniBrowser.app/Contents)
-make_directory(${MiniBrowser_Contents_Directory}/Resources)
+file(MAKE_DIRECTORY ${MiniBrowser_Contents_Directory}/Resources)
 add_custom_command(OUTPUT ${MiniBrowser_Contents_Directory}/Resources/BrowserWindow.nib
     COMMAND ibtool --compile ${MiniBrowser_Contents_Directory}/Resources/BrowserWindow.nib ${MINIBROWSER_DIR}/BrowserWindow.xib VERBATIM)
 add_custom_command(OUTPUT ${MiniBrowser_Contents_Directory}/Resources/ExtensionManagerWindowController.nib


### PR DESCRIPTION
#### 283a44eb95ccc7d9d219dad06f9f028cc2083fa8
<pre>
Update CMAKE files for Cmake 4
<a href="https://bugs.webkit.org/show_bug.cgi?id=321292">https://bugs.webkit.org/show_bug.cgi?id=321292</a>

Reviewed by Fujii Hironori.

CMP0048 old behaviour is dropped in cmake 4; Drive-by fixes for
make_directory too.

Canonical link: <a href="https://commits.webkit.org/318903@main">https://commits.webkit.org/318903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d24103a9a31f6f08b2d3e472c6518f8ace597dfa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143728 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181282 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139915 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96816 "2 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120367 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42196 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40525 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2337 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9152 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40172 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/703 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40694 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191469 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53028 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149173 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40061 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53709 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36801 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148916 "Found 1 new API test failure: TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43588 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125981 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120876 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52226 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15161 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51611 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51852 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->