### PR TITLE
[ASan] Generate a crash log when a process is killed for a failed IPC message check

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -576,12 +576,12 @@ Logger& GPUConnectionToWebProcess::logger()
 void GPUConnectionToWebProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName messageName, const Vector<uint32_t>&)
 {
     RELEASE_LOG_FAULT_WITH_PAYLOAD(IPC, "Received an invalid message %s from WebContent process %" PRIu64 ", requesting for it to be terminated.", description(messageName), m_webProcessIdentifier.toUInt64());
-    terminateWebProcess();
+    terminateWebProcess(messageName);
 }
 
-void GPUConnectionToWebProcess::terminateWebProcess()
+void GPUConnectionToWebProcess::terminateWebProcess(IPC::MessageName invalidMessageName)
 {
-    gpuProcess().terminateWebProcess(m_webProcessIdentifier);
+    gpuProcess().terminateWebProcess(m_webProcessIdentifier, invalidMessageName);
 }
 
 void GPUConnectionToWebProcess::lowMemoryHandler(Critical critical, Synchronous synchronous)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -235,7 +235,7 @@ public:
     void updateSupportedRemoteCommands();
 
     bool allowsExitUnderMemoryPressure() const;
-    void terminateWebProcess();
+    void terminateWebProcess(IPC::MessageName);
 
     void lowMemoryHandler(WTF::Critical, WTF::Synchronous);
 

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -646,9 +646,9 @@ void GPUProcess::webProcessConnectionCountForTesting(CompletionHandler<void(uint
     completionHandler(GPUConnectionToWebProcess::objectCountForTesting());
 }
 
-void GPUProcess::terminateWebProcess(WebCore::ProcessIdentifier identifier)
+void GPUProcess::terminateWebProcess(WebCore::ProcessIdentifier identifier, IPC::MessageName invalidMessageName)
 {
-    protect(parentProcessConnection())->send(Messages::GPUProcessProxy::TerminateWebProcess(identifier), 0);
+    protect(parentProcessConnection())->send(Messages::GPUProcessProxy::TerminateWebProcess(identifier, invalidMessageName), 0);
 }
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -179,7 +179,7 @@ public:
     void registerFonts(Vector<SandboxExtension::Handle>&&);
 #endif
 
-    void terminateWebProcess(WebCore::ProcessIdentifier);
+    void terminateWebProcess(WebCore::ProcessIdentifier, IPC::MessageName);
 
 private:
     GPUProcess();

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -174,9 +174,9 @@ void RemoteGraphicsContextGL::didReceiveInvalidMessage(IPC::StreamServerConnecti
     RefPtr gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get();
     uint64_t webProcessID = gpuConnectionToWebProcess ? gpuConnectionToWebProcess->webProcessIdentifier().toUInt64() : 0;
     RELEASE_LOG_FAULT_WITH_PAYLOAD(IPC, "Received an invalid message %s from WebContent process %" PRIu64 ", requesting for it to be terminated.", description(messageName), webProcessID);
-    callOnMainRunLoop([weakGPUConnectionToWebProcess = m_gpuConnectionToWebProcess] {
+    callOnMainRunLoop([weakGPUConnectionToWebProcess = m_gpuConnectionToWebProcess, messageName] {
         if (RefPtr gpuConnectionToWebProcess = weakGPUConnectionToWebProcess.get())
-            gpuConnectionToWebProcess->terminateWebProcess();
+            gpuConnectionToWebProcess->terminateWebProcess(messageName);
     });
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -173,8 +173,8 @@ void RemoteRenderingBackend::workQueueUninitialize()
 void RemoteRenderingBackend::didReceiveInvalidMessage(IPC::StreamServerConnection&, IPC::MessageName messageName, const Vector<uint32_t>&)
 {
     RELEASE_LOG_FAULT_WITH_PAYLOAD(IPC, "Received an invalid message %s from WebContent process %" PRIu64 ", requesting for it to be terminated.", description(messageName), m_gpuConnectionToWebProcess->webProcessIdentifier().toUInt64());
-    callOnMainRunLoop([gpuConnectionToWebProcess = m_gpuConnectionToWebProcess] {
-        gpuConnectionToWebProcess->terminateWebProcess();
+    callOnMainRunLoop([gpuConnectionToWebProcess = m_gpuConnectionToWebProcess, messageName] {
+        gpuConnectionToWebProcess->terminateWebProcess(messageName);
     });
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -144,9 +144,9 @@ void RemoteGPU::didReceiveInvalidMessage(IPC::StreamServerConnection&, IPC::Mess
     RefPtr gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get();
     uint64_t webProcessID = gpuConnectionToWebProcess ? gpuConnectionToWebProcess->webProcessIdentifier().toUInt64() : 0;
     RELEASE_LOG_FAULT_WITH_PAYLOAD(IPC, "Received an invalid message %s from WebContent process %" PRIu64 ", requesting for it to be terminated.", description(messageName), webProcessID);
-    callOnMainRunLoop([weakGPUConnectionToWebProcess = m_gpuConnectionToWebProcess] {
+    callOnMainRunLoop([weakGPUConnectionToWebProcess = m_gpuConnectionToWebProcess, messageName] {
         if (RefPtr gpuConnectionToWebProcess = weakGPUConnectionToWebProcess.get())
-            gpuConnectionToWebProcess->terminateWebProcess();
+            gpuConnectionToWebProcess->terminateWebProcess(messageName);
     });
 }
 

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
@@ -185,7 +185,7 @@ Logger& ModelConnectionToWebProcess::logger()
 void ModelConnectionToWebProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName messageName, const Vector<uint32_t>&)
 {
     RELEASE_LOG_FAULT_WITH_PAYLOAD(IPC, "Received an invalid message %s from WebContent process %" PRIu64 ", requesting for it to be terminated.", description(messageName), m_webProcessIdentifier.toUInt64());
-    m_modelProcess->parentProcessConnection()->send(Messages::ModelProcessProxy::TerminateWebProcess(m_webProcessIdentifier), 0);
+    m_modelProcess->parentProcessConnection()->send(Messages::ModelProcessProxy::TerminateWebProcess(m_webProcessIdentifier, messageName), 0);
 }
 
 void ModelConnectionToWebProcess::lowMemoryHandler(Critical critical, Synchronous synchronous)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -517,7 +517,7 @@ void NetworkConnectionToWebProcess::didClose(IPC::Connection& connection)
 void NetworkConnectionToWebProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName messageName, const Vector<uint32_t>&)
 {
     RELEASE_LOG_FAULT_WITH_PAYLOAD(IPC, "Received an invalid message %s from WebContent process %" PRIu64 ", requesting for it to be terminated.", description(messageName), m_webProcessIdentifier.toUInt64());
-    protect(m_networkProcess->parentProcessConnection())->send(Messages::NetworkProcessProxy::TerminateWebProcess(m_webProcessIdentifier), 0);
+    protect(m_networkProcess->parentProcessConnection())->send(Messages::NetworkProcessProxy::TerminateWebProcess(m_webProcessIdentifier, messageName), 0);
 }
 
 void NetworkConnectionToWebProcess::createSocketChannel(const ResourceRequest& request, const String& protocol, WebSocketIdentifier identifier, WebPageProxyIdentifier webPageProxyID, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, const ClientOrigin& clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections, WebCore::StoredCredentialsPolicy storedCredentialsPolicy, WebCore::IsInitiatedByDedicatedWorker isInitiatedByDedicatedWorker)

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -515,7 +515,7 @@ public:
 #endif
 
 #if PLATFORM(COCOA) && !USE(EXTENSIONKIT_PROCESS_TERMINATION)
-    bool kill();
+    bool kill(std::optional<MessageName> invalidMessageName = std::nullopt);
 #endif
 
     bool isValid() const { return m_isValid; }

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -734,10 +734,11 @@ std::optional<audit_token_t> Connection::getAuditToken()
 }
 
 #if !USE(EXTENSIONKIT_PROCESS_TERMINATION)
-bool Connection::kill()
+bool Connection::kill(std::optional<MessageName> invalidMessageName)
 {
     if (m_xpcConnection) {
-        terminateWithReason(m_xpcConnection.get(), WebKit::ReasonCode::ConnectionKilled, "Connection::kill");
+        auto reasonCode = invalidMessageName ? WebKit::ReasonCode::MessageCheckKilled : WebKit::ReasonCode::ConnectionKilled;
+        terminateWithReason(m_xpcConnection.get(), reasonCode, "Connection::kill", invalidMessageName);
         m_didRequestProcessTermination = true;
         return true;
     }

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.h
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.h
@@ -25,7 +25,10 @@
 
 #pragma once
 
+#include <optional>
 #include <wtf/darwin/XPCExtras.h>
+
+namespace IPC { enum class MessageName : uint16_t; }
 
 namespace WebKit {
 
@@ -33,10 +36,11 @@ enum class ReasonCode : uint64_t {
     WatchdogTimerFired,
     Invalidation,
     ConnectionKilled,
+    MessageCheckKilled,
 };
 
 #if !USE(EXTENSIONKIT_PROCESS_TERMINATION)
-void terminateWithReason(xpc_connection_t, ReasonCode, const char* reason);
+void terminateWithReason(xpc_connection_t, ReasonCode, const char* reason, std::optional<IPC::MessageName> invalidMessageName = std::nullopt);
 #endif
 
 }

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.mm
@@ -26,15 +26,33 @@
 #include "config.h"
 #include "XPCUtilities.h"
 
+#include <wtf/spi/darwin/ReasonSPI.h>
+
 namespace WebKit {
 
 #if !USE(EXTENSIONKIT_PROCESS_TERMINATION)
-void terminateWithReason(xpc_connection_t connection, ReasonCode, const char*)
+void terminateWithReason(xpc_connection_t connection, ReasonCode reasonCode, const char* reason, std::optional<IPC::MessageName> invalidMessageName)
 {
-    // This could use ReasonSPI.h, but currently does not as the SPI is blocked by the sandbox.
-    // See https://bugs.webkit.org/show_bug.cgi?id=224499 rdar://76396241
     if (!connection)
         return;
+
+#if ASAN_ENABLED
+    // Unlike xpc_connection_kill(), this leaves a crash report that run-webkit-tests can match.
+    // Not done unconditionally because the SPI is blocked for embedders with a sandbox (Bug 224499).
+    if (reasonCode == ReasonCode::MessageCheckKilled || reasonCode == ReasonCode::WatchdogTimerFired) {
+        // Encode the ReasonCode in the low byte; for a message check, pack the failing
+        // IPC message name above it so the crash report identifies which check failed.
+        uint64_t code = std::to_underlying(reasonCode);
+        if (invalidMessageName)
+            code |= static_cast<uint64_t>(std::to_underlying(*invalidMessageName)) << 8;
+        if (!terminate_with_reason(xpc_connection_get_pid(connection), OS_REASON_WEBKIT, code, reason, 0))
+            return;
+    }
+#else
+    UNUSED_PARAM(reasonCode);
+    UNUSED_PARAM(reason);
+    UNUSED_PARAM(invalidMessageName);
+#endif
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     xpc_connection_kill(connection, SIGKILL);

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1146,6 +1146,7 @@ def headers_for_type(type, for_implementation_file=False):
         'Inspector::SearchMatch': ['<WebCore/InspectorResourceUtilities.h>'],
         'Inspector::SearchResult': ['<WebCore/InspectorResourceUtilities.h>'],
         'IPC::AsyncReplyID': ['"Connection.h"'],
+        'IPC::MessageName': ['"MessageNames.h"'],
         'IPC::Signal': ['"IPCEvent.h"'],
         'IPC::Semaphore': ['"IPCSemaphore.h"'],
         'IPC::StreamServerConnectionHandle': ['"StreamServerConnection.h"'],

--- a/Source/WebKit/Scripts/webkit/parser_unittest.py
+++ b/Source/WebKit/Scripts/webkit/parser_unittest.py
@@ -311,6 +311,13 @@ _expected_model_test_with_superclass = {
             ),
             'conditions': (None),
         },
+        {
+            'name': 'TestMessageWithMessageName',
+            'parameters': (
+                ('IPC::MessageName', 'messageName'),
+            ),
+            'conditions': (None),
+        },
     ),
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -313,6 +313,8 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSyncMessage>(globalObject, decoder);
     case MessageName::TestWithSuperclass_TestSynchronousMessage:
         return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSynchronousMessage>(globalObject, decoder);
+    case MessageName::TestWithSuperclass_TestMessageWithMessageName:
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestMessageWithMessageName>(globalObject, decoder);
 #if ENABLE(TEST_FEATURE)
     case MessageName::TestWithSuperclass_TestAsyncMessageReply:
         return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageReply>(globalObject, decoder);
@@ -1130,6 +1132,10 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
     case MessageName::TestWithSuperclass_TestSynchronousMessage:
         return Vector<ArgumentDescription> {
             { "value"_s, "bool"_s },
+        };
+    case MessageName::TestWithSuperclass_TestMessageWithMessageName:
+        return Vector<ArgumentDescription> {
+            { "messageName"_s, "IPC::MessageName"_s },
         };
 #if ENABLE(TEST_FEATURE)
     case MessageName::TestWithSuperclass_TestAsyncMessageReply:

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -125,6 +125,7 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithSuperclass_TestAsyncMessageWithNoArguments"_s, ReceiverName::TestWithSuperclass, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply"_s, ReceiverName::TestWithSuperclass, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
 #endif
+    MessageDescription { "TestWithSuperclass_TestMessageWithMessageName"_s, ReceiverName::TestWithSuperclass, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSwiftConditionallyAndEnabledBy_TestAsyncMessage"_s, ReceiverName::TestWithSwiftConditionallyAndEnabledBy, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSwiftConditionallyAndEnabledBy_TestAsyncMessageReply"_s, ReceiverName::TestWithSwiftConditionallyAndEnabledBy, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSwiftConditionally_TestAsyncMessage"_s, ReceiverName::TestWithSwiftConditionally, false, false, false, ProcessName::Unknown, ProcessName::Unknown },

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -175,6 +175,7 @@ enum class MessageName : uint16_t {
     TestWithSuperclass_TestAsyncMessageWithNoArguments,
     TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply,
 #endif
+    TestWithSuperclass_TestMessageWithMessageName,
     TestWithSwiftConditionallyAndEnabledBy_TestAsyncMessage,
     TestWithSwiftConditionallyAndEnabledBy_TestAsyncMessageReply,
     TestWithSwiftConditionally_TestAsyncMessage,

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclass.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclass.messages.in
@@ -36,4 +36,5 @@ messages -> TestWithSuperclass : WebPageBase {
 #endif
     TestSyncMessage(uint32_t param) -> (uint8_t reply) Synchronous
     TestSynchronousMessage(bool value) -> (std::optional<WebKit::TestClassName> optionalReply) Synchronous
+    TestMessageWithMessageName(enum:uint16_t IPC::MessageName messageName)
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
@@ -28,6 +28,7 @@
 #include "ArgumentCoders.h" // NOLINT
 #include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
+#include "MessageNames.h" // NOLINT
 #include "TestClassName.h" // NOLINT
 #if ENABLE(TEST_FEATURE)
 #include "TestTwoStateEnum.h" // NOLINT
@@ -69,6 +70,12 @@ void TestWithSuperclass::didReceiveMessage(IPC::Connection& connection, IPC::Dec
         IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithConnection>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithConnection);
         return;
     }
+#endif
+    if (decoder.messageName() == Messages::TestWithSuperclass::TestMessageWithMessageName::name()) {
+        IPC::handleMessage<Messages::TestWithSuperclass::TestMessageWithMessageName>(connection, decoder, this, &TestWithSuperclass::testMessageWithMessageName);
+        return;
+    }
+#if ENABLE(TEST_FEATURE)
 #endif
     WebPageBase::didReceiveMessage(connection, decoder);
 }
@@ -153,6 +160,10 @@ template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::Tes
 template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSynchronousMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
 {
     return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestSynchronousMessage::ReplyArguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestMessageWithMessageName>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestMessageWithMessageName::Arguments>(globalObject, decoder);
 }
 #if ENABLE(TEST_FEATURE)
 template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
@@ -32,6 +32,10 @@
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 
+namespace IPC {
+enum class MessageName : uint16_t;
+}
+
 namespace WebKit {
 class TestClassName;
 enum class TestTwoStateEnum : bool;
@@ -278,6 +282,31 @@ public:
 
 private:
     bool m_value;
+};
+
+class TestMessageWithMessageName {
+public:
+    using Arguments = std::tuple<IPC::MessageName>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestMessageWithMessageName; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr bool deferSendingIfSuspended = false;
+
+    explicit TestMessageWithMessageName(IPC::MessageName messageName)
+        : m_messageName(messageName)
+    {
+    }
+
+    template<typename Encoder>
+    void encode(Encoder& encoder)
+    {
+        encoder << m_messageName;
+    }
+
+private:
+    IPC::MessageName m_messageName;
 };
 
 #if ENABLE(TEST_FEATURE)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -214,7 +214,7 @@ void AuxiliaryProcessProxy::connect()
     m_processLauncher = ProcessLauncher::create(this, WTF::move(launchOptions));
 }
 
-void AuxiliaryProcessProxy::terminate()
+void AuxiliaryProcessProxy::terminate(std::optional<IPC::MessageName> invalidMessageName)
 {
     RELEASE_LOG(Process, "AuxiliaryProcessProxy::terminate: PID=%d", processID());
 
@@ -223,9 +223,11 @@ void AuxiliaryProcessProxy::terminate()
 
 #if PLATFORM(COCOA) && !USE(EXTENSIONKIT_PROCESS_TERMINATION)
     if (RefPtr connection = m_connection) {
-        if (connection->kill())
+        if (connection->kill(invalidMessageName))
             return;
     }
+#else
+    UNUSED_PARAM(invalidMessageName);
 #endif
 
     // FIXME: We should really merge process launching into IPC connection creation and get rid of the process launcher.

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -109,7 +109,7 @@ public:
     virtual Type type() const = 0;
 
     void connect();
-    virtual void terminate();
+    virtual void terminate(std::optional<IPC::MessageName> invalidMessageName = std::nullopt);
 
     ProcessThrottler& throttler() { return m_throttler; }
     const ProcessThrottler& throttler() const { return m_throttler; }

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -627,7 +627,7 @@ void GPUProcessProxy::didReceiveInvalidMessage(IPC::Connection& connection, IPC:
     WebProcessPool::didReceiveInvalidMessage(messageName);
 
     // Terminate the GPU process.
-    terminate();
+    terminate(messageName);
 
     // Since we've invalidated the connection we'll never get a IPC::Connection::Client::didClose
     // callback so we'll explicitly call it here instead.
@@ -769,11 +769,11 @@ void GPUProcessProxy::sendProcessDidResume(ResumeReason)
         send(Messages::GPUProcess::ProcessDidResume(), 0);
 }
 
-void GPUProcessProxy::terminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier)
+void GPUProcessProxy::terminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier, IPC::MessageName invalidMessageName)
 {
     RELEASE_LOG_ERROR(Process, "GPUProcessProxy::terminateWebProcess: webProcessIdentifier=%" PRIu64, webProcessIdentifier.toUInt64());
     if (auto process = WebProcessProxy::processForIdentifier(webProcessIdentifier))
-        process->requestTermination(ProcessTerminationReason::RequestedByGPUProcess);
+        process->requestTermination(ProcessTerminationReason::RequestedByGPUProcess, invalidMessageName);
 }
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -218,7 +218,7 @@ private:
     // ResponsivenessTimer::Client
     void didBecomeUnresponsive() final;
 
-    void terminateWebProcess(WebCore::ProcessIdentifier);
+    void terminateWebProcess(WebCore::ProcessIdentifier, IPC::MessageName);
     void processIsReadyToExit();
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
@@ -46,7 +46,7 @@ messages -> GPUProcessProxy {
 #endif
 
     ProcessIsReadyToExit()
-    TerminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier)
+    TerminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier, enum:uint16_t IPC::MessageName invalidMessageName)
 }
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -102,12 +102,12 @@ ModelProcessProxy::ModelProcessProxy()
 
 ModelProcessProxy::~ModelProcessProxy() = default;
 
-void ModelProcessProxy::terminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier)
+void ModelProcessProxy::terminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier, IPC::MessageName invalidMessageName)
 {
     if (auto process = WebProcessProxy::processForIdentifier(webProcessIdentifier)) {
         MESSAGE_CHECK(process->sharedPreferencesForWebProcessValue().modelElementEnabled);
         MESSAGE_CHECK(process->sharedPreferencesForWebProcessValue().modelProcessEnabled);
-        process->requestTermination(ProcessTerminationReason::RequestedByModelProcess);
+        process->requestTermination(ProcessTerminationReason::RequestedByModelProcess, invalidMessageName);
     }
 }
 
@@ -266,7 +266,7 @@ void ModelProcessProxy::didReceiveInvalidMessage(IPC::Connection& connection, IP
     WebProcessPool::didReceiveInvalidMessage(messageName);
 
     // Terminate the model process.
-    terminate();
+    terminate(messageName);
 
     // Since we've invalidated the connection we'll never get a IPC::Connection::Client::didClose
     // callback so we'll explicitly call it here instead.

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
@@ -86,7 +86,7 @@ public:
 private:
     explicit ModelProcessProxy();
 
-    void terminateWebProcess(WebCore::ProcessIdentifier);
+    void terminateWebProcess(WebCore::ProcessIdentifier, IPC::MessageName);
 
     Type type() const final { return Type::Model; }
 

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.messages.in
@@ -29,7 +29,7 @@
 ]
 messages -> ModelProcessProxy {
 
-    TerminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier)
+    TerminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier, enum:uint16_t IPC::MessageName invalidMessageName)
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     DidCreateContextForVisibilityPropagation(WebKit::WebPageProxyIdentifier pageProxyID, WebCore::PageIdentifier pageID, WebKit::LayerHostingContextID contextID)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -164,9 +164,9 @@ Ref<NetworkProcessProxy> NetworkProcessProxy::ensureDefaultNetworkProcess()
     return newNetworkProcess;
 }
 
-void NetworkProcessProxy::terminate()
+void NetworkProcessProxy::terminate(std::optional<IPC::MessageName> invalidMessageName)
 {
-    AuxiliaryProcessProxy::terminate();
+    AuxiliaryProcessProxy::terminate(invalidMessageName);
     if (hasConnection())
         protect(connection())->invalidate();
 }
@@ -534,7 +534,7 @@ bool NetworkProcessProxy::dispatchMessage(IPC::Connection& connection, IPC::Deco
 void NetworkProcessProxy::didReceiveInvalidMessage(IPC::Connection& connection, IPC::MessageName messageName, const Vector<uint32_t>&)
 {
     logInvalidMessage(connection, messageName);
-    terminate();
+    terminate(messageName);
     networkProcessDidTerminate(ProcessTerminationReason::Crash);
 }
 
@@ -643,10 +643,10 @@ void NetworkProcessProxy::logDiagnosticMessage(WebPageProxyIdentifier pageID, co
         page->logDiagnosticMessage(message, description, shouldSample);
 }
 
-void NetworkProcessProxy::terminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier)
+void NetworkProcessProxy::terminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier, IPC::MessageName invalidMessageName)
 {
     if (auto process = WebProcessProxy::processForIdentifier(webProcessIdentifier))
-        process->requestTermination(ProcessTerminationReason::RequestedByNetworkProcess);
+        process->requestTermination(ProcessTerminationReason::RequestedByNetworkProcess, invalidMessageName);
 }
 
 void NetworkProcessProxy::processHasUnresponseServiceWorker(WebCore::ProcessIdentifier processIdentifier)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -383,7 +383,7 @@ private:
     void getLaunchOptions(ProcessLauncher::LaunchOptions&) override;
     void connectionWillOpen(IPC::Connection&) override;
     void processWillShutDown(IPC::Connection&) override;
-    void terminate() final;
+    void terminate(std::optional<IPC::MessageName> invalidMessageName = std::nullopt) final;
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
@@ -426,7 +426,7 @@ private:
     void unregisterRemoteWorkerClientProcess(RemoteWorkerType, WebCore::ProcessIdentifier clientProcessIdentifier, WebCore::ProcessIdentifier remoteWorkerProcessIdentifier);
     void reportConsoleMessage(PAL::SessionID, const URL&, const WebCore::SecurityOriginData&, MessageSource, MessageLevel, const String& message, uint64_t requestIdentifier);
 
-    void terminateWebProcess(WebCore::ProcessIdentifier);
+    void terminateWebProcess(WebCore::ProcessIdentifier, IPC::MessageName);
 
     void considerProcessSwapForNavigationResponse(WebPageProxyIdentifier, WebCore::NavigationIdentifier, WebCore::BrowsingContextGroupSwitchDecision, WebCore::NavigationResponseProcessSwapReason, const WebCore::Site& responseSite, NetworkResourceLoadIdentifier existingNetworkResourceLoadIdentifierToResume, MonotonicTime originalNavigationStartTime, CompletionHandler<void(bool success)>&&);
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -50,7 +50,7 @@ messages -> NetworkProcessProxy WantsDispatchMessage {
     ContentExtensionRules(WebKit::UserContentControllerIdentifier identifier)
 #endif
 
-    TerminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier)
+    TerminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier, enum:uint16_t IPC::MessageName invalidMessageName)
 
     StartServiceWorkerBackgroundProcessing(WebCore::ProcessIdentifier serviceWorkerProcessIdentifier)
     EndServiceWorkerBackgroundProcessing(WebCore::ProcessIdentifier serviceWorkerProcessIdentifier)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1533,7 +1533,7 @@ void WebProcessProxy::didReceiveInvalidMessage(IPC::Connection& connection, IPC:
     WebProcessPool::didReceiveInvalidMessage(messageName);
 
     // Terminate the WebContent process.
-    terminate();
+    terminate(messageName);
 
     // Since we've invalidated the connection we'll never get a IPC::Connection::Client::didClose
     // callback so we'll explicitly call it here instead.
@@ -1957,7 +1957,7 @@ void WebProcessProxy::deleteWebsiteDataForOrigins(PAL::SessionID sessionID, Opti
     });
 }
 
-void WebProcessProxy::requestTermination(ProcessTerminationReason reason)
+void WebProcessProxy::requestTermination(ProcessTerminationReason reason, std::optional<IPC::MessageName> invalidMessageName)
 {
     if (state() == State::Terminated)
         return;
@@ -1965,7 +1965,7 @@ void WebProcessProxy::requestTermination(ProcessTerminationReason reason)
     Ref protectedThis { *this };
     WEBPROCESSPROXY_RELEASE_LOG_ERROR(Process, "requestTermination: reason=%" PUBLIC_LOG_STRING, processTerminationReasonToString(reason).characters());
 
-    AuxiliaryProcessProxy::terminate();
+    AuxiliaryProcessProxy::terminate(invalidMessageName);
 
     processDidTerminateOrFailedToLaunch(reason);
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -370,7 +370,7 @@ public:
     void disableSuddenTermination();
     bool isSuddenTerminationEnabled() { return !m_numberOfTimesSuddenTerminationWasDisabled; }
 
-    void requestTermination(ProcessTerminationReason);
+    void requestTermination(ProcessTerminationReason, std::optional<IPC::MessageName> invalidMessageName = std::nullopt);
 
     RefPtr<API::Object> transformHandlesToObjects(API::Object*);
     static RefPtr<API::Object> transformObjectsToHandles(API::Object*);


### PR DESCRIPTION
#### da21559d05d5532252c21c93a62a2631f3192351
<pre>
[ASan] Generate a crash log when a process is killed for a failed IPC message check
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=321120">https://bugs.webkit.org/show_bug.cgi?id=321120</a>&gt;
&lt;<a href="https://rdar.apple.com/184153814">rdar://184153814</a>&gt;

Reviewed by Mike Wyrzykowski, Zak Ridouh, and Charlie Wolfe.

When an incoming IPC message fails a MESSAGE_CHECK, the receiving
process asks for the process that sent it to be terminated.  On macOS
that termination is a plain SIGKILL sent through
`xpc_connection_kill()`, which carries no `os_reason`, so the kernel
writes no crash report for the killed process.  run-webkit-tests marks
the process crashed but finds no crash log to attach and reports &quot;No
crash log found&quot;.

On ASan builds, terminate such a process with `terminate_with_reason()`
in the `OS_REASON_WEBKIT` namespace instead, so the kernel emits a
crash report attributed to the killed process.  Encode the failing
`IPC::MessageName` above the low reason-code byte so the report&apos;s
termination reason names which message check failed.  Only
message-check and watchdog terminations report this way; ordinary
invalidation and client-requested terminations keep the report-less
`xpc_connection_kill()`.

The kill is always issued by the UI process.  When a GPU, Networking,
or Model process is the one that detects the invalid message, forward
the failing message name to the UI process through the
`TerminateWebProcess` message so that termination occurs the same
way.

No new tests since this change is not directly testable.

* Source/WebKit/Scripts/webkit/messages.py:
- Add `IPC::MessageName` to the `headers_for_type()` special-cases dict
  so message receivers that take an `IPC::MessageName` parameter include
  `&quot;MessageNames.h&quot;` rather than the derived (non-existent)
  `&quot;MessageName.h&quot;`.
* Source/WebKit/Scripts/webkit/parser_unittest.py:
(_expected_model_test_with_superclass):
- Add the new TestMessageWithMessageName message so the expected model
  matches the TestWithSuperclass.messages.in fixture.
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclass.messages.in:
(TestWithSuperclass::TestMessageWithMessageName): Add.
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp:
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::didReceiveInvalidMessage):
(WebKit::GPUConnectionToWebProcess::terminateWebProcess):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
(WebKit::GPUConnectionToWebProcess::terminateWebProcess):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::terminateWebProcess):
* Source/WebKit/GPUProcess/GPUProcess.h:
(WebKit::GPUProcess::terminateWebProcess):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::didReceiveInvalidMessage):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::didReceiveInvalidMessage):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::didReceiveInvalidMessage):
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp:
(WebKit::ModelConnectionToWebProcess::didReceiveInvalidMessage):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::didReceiveInvalidMessage):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::kill):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::kill):
* Source/WebKit/Platform/cocoa/XPCUtilities.h:
(WebKit::ReasonCode):
(WebKit::terminateWithReason):
* Source/WebKit/Platform/cocoa/XPCUtilities.mm:
(WebKit::terminateWithReason):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::terminate):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::terminate):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::didReceiveInvalidMessage):
(WebKit::GPUProcessProxy::terminateWebProcess):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
(WebKit::GPUProcessProxy::terminateWebProcess):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
(WebKit::ModelProcessProxy::terminateWebProcess):
(WebKit::ModelProcessProxy::didReceiveInvalidMessage):
* Source/WebKit/UIProcess/Model/ModelProcessProxy.h:
(WebKit::ModelProcessProxy::terminateWebProcess):
* Source/WebKit/UIProcess/Model/ModelProcessProxy.messages.in:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::terminate):
(WebKit::NetworkProcessProxy::didReceiveInvalidMessage):
(WebKit::NetworkProcessProxy::terminateWebProcess):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
(WebKit::NetworkProcessProxy::terminate):
(WebKit::NetworkProcessProxy::terminateWebProcess):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didReceiveInvalidMessage):
(WebKit::WebProcessProxy::requestTermination):
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::requestTermination):

Canonical link: <a href="https://commits.webkit.org/318804@main">https://commits.webkit.org/318804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c2d56542d468dbce717f911f6ceecee0964d1a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189245 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/116bdcfe-3344-4ffb-af00-d4aad3f22ede) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139912 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce5664ac-baec-4cde-a71a-00244394f995) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43516 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160662 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120364 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89ee5d6f-096d-46fb-9411-f2f3b460b422) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178738 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40167 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/697 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191463 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53022 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53703 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148911 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27234 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43586 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125975 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120870 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52220 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15156 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51605 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51846 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51666 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->