### PR TITLE
Root font relative units in canvas ctx.font resolve against the canvas element instead of the root element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/2d.text-root-font-relative-units-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/2d.text-root-font-relative-units-expected.txt
@@ -1,0 +1,13 @@
+
+PASS font: rem resolves against the root element, not the canvas element
+PASS font: em still resolves against the canvas element
+PASS font: rem tracks a change to the root font-size
+PASS font: re-setting the same rem font string picks up the new root font-size
+PASS font: rem picks up a pending root font-size change
+PASS font: rem is unaffected by the canvas element font-size
+PASS font: save and restore keep the root-resolved font of each saved state
+PASS font: rex resolves against the root element
+PASS font: rch resolves against the root element
+PASS font: rcap resolves against the root element
+PASS font: ric resolves against the root element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/2d.text-root-font-relative-units.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/2d.text-root-font-relative-units.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Canvas root font relative units resolve against the root element</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-font">
+<link rel="help" href="https://drafts.csswg.org/css-values/#font-relative-lengths">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+html {
+    font-size: 5px;
+}
+#container {
+    font-size: 10px;
+}
+</style>
+<div id="log"></div>
+<div id="container">
+    <canvas id="canvas" style="font-size: 20px"></canvas>
+</div>
+<script>
+const canvas = document.getElementById('canvas');
+const container = document.getElementById('container');
+const ctx = canvas.getContext('2d');
+
+function reset()
+{
+    document.documentElement.style.fontSize = '';
+    container.style.fontSize = '10px';
+    canvas.style.fontSize = '20px';
+    ctx.font = '10px sans-serif';
+}
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    ctx.font = '2rem sans-serif';
+    assert_equals(ctx.font, '10px sans-serif', '2rem is 2 x the 5px root font-size');
+}, 'font: rem resolves against the root element, not the canvas element');
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    ctx.font = '2em sans-serif';
+    assert_equals(ctx.font, '40px sans-serif', '2em is 2 x the 20px canvas font-size');
+}, 'font: em still resolves against the canvas element');
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    document.documentElement.style.fontSize = '8px';
+    ctx.font = '3rem sans-serif';
+    assert_equals(ctx.font, '24px sans-serif', '3rem tracks the updated root font-size');
+}, 'font: rem tracks a change to the root font-size');
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    ctx.font = '2rem sans-serif';
+    assert_equals(ctx.font, '10px sans-serif', 'resolved against the initial root font-size');
+
+    document.documentElement.style.fontSize = '8px';
+    ctx.font = '2rem sans-serif';
+    assert_equals(ctx.font, '16px sans-serif', 're-resolved against the updated root font-size');
+}, 'font: re-setting the same rem font string picks up the new root font-size');
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    document.documentElement.style.fontSize = '8px';
+    ctx.font = '4rem sans-serif';
+    assert_equals(ctx.font, '32px sans-serif', '4rem uses the pending root font-size');
+}, 'font: rem picks up a pending root font-size change');
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    ctx.font = '2rem sans-serif';
+    assert_equals(ctx.font, '10px sans-serif', 'resolved against the root');
+
+    canvas.style.fontSize = '100px';
+    ctx.font = '2rem sans-serif';
+    assert_equals(ctx.font, '10px sans-serif', 'still resolved against the root');
+}, 'font: rem is unaffected by the canvas element font-size');
+
+test(function(t) {
+    t.add_cleanup(reset);
+
+    ctx.font = '2rem sans-serif';
+    ctx.save();
+
+    document.documentElement.style.fontSize = '8px';
+    ctx.font = '2rem sans-serif';
+    assert_equals(ctx.font, '16px sans-serif', 're-resolved against the updated root font-size');
+
+    ctx.restore();
+    assert_equals(ctx.font, '10px sans-serif', 'restored to the font resolved before the root changed');
+}, 'font: save and restore keep the root-resolved font of each saved state');
+
+function testRootFontUnit(unit)
+{
+    test(function(t) {
+        t.add_cleanup(reset);
+
+        ctx.font = `10${unit} sans-serif`;
+        const rootRelative = ctx.font;
+        assert_not_equals(rootRelative, '10px sans-serif', `10${unit} was resolved`);
+
+        canvas.style.fontSize = '40px';
+        ctx.font = `10${unit} sans-serif`;
+        assert_equals(ctx.font, rootRelative, `${unit} ignores the canvas element font-size`);
+
+        document.documentElement.style.fontSize = '10px';
+        ctx.font = `10${unit} sans-serif`;
+        assert_not_equals(ctx.font, rootRelative, `${unit} tracks the root font-size`);
+    }, `font: ${unit} resolves against the root element`);
+}
+
+testRootFontUnit('rex');
+testRootFontUnit('rch');
+testRootFontUnit('rcap');
+testRootFontUnit('ric');
+</script>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -239,7 +239,13 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
         fontDescription.setComputedSize(DefaultFontSize);
     }
 
-    if (newFont == state().unparsedFont && state().font.realized() && fontDescription == state().fontResolutionBase)
+    // Root font relative values ('rem', 'rex', ...) additionally depend on the root element's font.
+    // When there is no root font, they resolve against `fontDescription` and are covered by it.
+    CheckedPtr rootFontCascade = Style::rootFontCascadeForRootFontUnits(document.get());
+
+    if (newFont == state().unparsedFont && state().font.realized()
+        && fontDescription == state().fontResolutionBase
+        && (!rootFontCascade || rootFontCascade->fontDescription() == state().rootFontResolutionBase))
         return;
 
     // According to http://lists.w3.org/Archives/Public/public-html/2009Jul/0947.html,
@@ -258,6 +264,7 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
     realizeSaves();
     modifiableState().unparsedFont = newFontSafeCopy;
     modifiableState().fontResolutionBase = WTF::move(fontDescription);
+    modifiableState().rootFontResolutionBase = rootFontCascade ? rootFontCascade->fontDescription() : FontCascadeDescription { };
 
     modifiableState().font.initialize(protect(document->fontSelector()), *fontCascade);
     ASSERT(state().font.realized());

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3307,7 +3307,10 @@ void CanvasRenderingContext2DBase::setLetterSpacing(const String& letterSpacing)
         return;
 
     CheckedRef fontCascade = fontProxy()->fontCascade();
-    double pixels = Style::resolveLength(rawLength->value, rawLength->unit, CSSPropertyLetterSpacing, fontCascade, nullptr);
+    // FIXME: Passing null for the root font means root font relative units ('rem', 'rex', ...) still
+    //        resolve against the font of the context here, even though unitAllowedForSpacing() admits
+    //        them. Fixing it needs this setter to update style first, so it is done separately.
+    double pixels = Style::resolveLength(rawLength->value, rawLength->unit, CSSPropertyLetterSpacing, fontCascade, nullptr, nullptr);
 
     modifiableState().letterSpacing = CSS::serializationForCSS(CSS::defaultSerializationContext(), *rawLength);
     modifiableState().font.setLetterSpacing(pixels);
@@ -3335,7 +3338,8 @@ void CanvasRenderingContext2DBase::setWordSpacing(const String& wordSpacing)
         return;
 
     CheckedRef fontCascade = fontProxy()->fontCascade();
-    double pixels = Style::resolveLength(rawLength->value, rawLength->unit, CSSPropertyWordSpacing, fontCascade, nullptr);
+    // FIXME: See the comment about the root font in setLetterSpacing().
+    double pixels = Style::resolveLength(rawLength->value, rawLength->unit, CSSPropertyWordSpacing, fontCascade, nullptr, nullptr);
 
     modifiableState().wordSpacing = CSS::serializationForCSS(CSS::defaultSerializationContext(), *rawLength);
     modifiableState().font.setWordSpacing(pixels);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -338,6 +338,8 @@ public:
         // The font description `unparsedFont` was resolved against. Relative values in the font
         // shorthand depend on it, so `font` is stale once it no longer matches the canvas element.
         FontCascadeDescription fontResolutionBase;
+        // Likewise for the root element's font, which root font relative values depend on.
+        FontCascadeDescription rootFontResolutionBase;
 
         RefPtr<CanvasLayerContextSwitcher> targetSwitcher;
 

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -42,12 +42,14 @@
 #include "CSSValueList.h"
 #include "CSSValuePair.h"
 #include "Document.h"
+#include "Element.h"
 #include "FontCascade.h"
 #include "FontCascadeDescription.h"
 #include "FontSelectionValueInlines.h"
 #include "ScriptExecutionContext.h"
 #include "Settings.h"
 #include "StyleBuilderChecking.h"
+#include "StyleComputedStyle+GettersInlines.h"
 #include "StyleComputedStyle.h"
 #include "StyleFontFamily.h"
 #include "StyleFontSizeFunctions.h"
@@ -271,11 +273,14 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
                             //        It's unclear in the specification if they're expected to work on OffscreenCanvas, given
                             //        that it's off-screen and therefore doesn't strictly have an associated viewport.
                             //        This needs clarification and possibly fixing.
-                            // FIXME: How should root font units work in OffscreenCanvas?
+                            // Root font units resolve against the root element's font whenever the context is a document,
+                            // including for an OffscreenCanvas created in a window. They fall back to the element's own
+                            // font only in a worker, where there is no root element.
 
                             RefPtr document = dynamicDowncast<Document>(context);
+                            CheckedPtr rootFontCascade = rootFontCascadeForRootFontUnits(context);
                             return {
-                                .size = static_cast<float>(Style::resolveLength(lengthPercentage.value, lengthUnit, CSSPropertyFontSize, fontCascade, document ? document->renderView() : nullptr)),
+                                .size = static_cast<float>(Style::resolveLength(lengthPercentage.value, lengthUnit, CSSPropertyFontSize, fontCascade, rootFontCascade.get(), document ? document->renderView() : nullptr)),
                                 .keyword = CSSValueInvalid
                             };
                         }
@@ -345,6 +350,25 @@ static ResolvedFontFamily fontFamilyFromUnresolvedFontFamily(const CSSPropertyPa
         .families = WTF::move(families),
         .hasAuthorSpecifiedNonGenericPrimaryFont = hasAuthorSpecifiedNonGenericPrimaryFont
     };
+}
+
+// MARK: - Root Font Units
+
+const FontCascade* rootFontCascadeForRootFontUnits(ScriptExecutionContext& context)
+{
+    RefPtr document = dynamicDowncast<Document>(context);
+    if (!document)
+        return nullptr;
+    RefPtr documentElement = document->documentElement();
+    if (!documentElement)
+        return nullptr;
+
+    // Deliberately does not resolve style. Callers run with script disallowed and update style
+    // before getting here, so a missing style means there is nothing to resolve against.
+    CheckedPtr rootStyle = documentElement->existingComputedStyle();
+    if (!rootStyle)
+        return nullptr;
+    return &rootStyle->fontCascade();
 }
 
 // MARK: - Unresolved Font Shorthand Resolution

--- a/Source/WebCore/style/StyleResolveForFont.h
+++ b/Source/WebCore/style/StyleResolveForFont.h
@@ -55,5 +55,10 @@ std::optional<FontSelectionValue> fontStyleFromCSSValueDeprecated(const CSSValue
 
 std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpers::UnresolvedFont&, FontCascadeDescription&&, ScriptExecutionContext&);
 
+// The font of the root element, for resolving root font relative units ('rem', 'rex', 'rcap',
+// 'rch', 'ric') outside of normal style resolution. Null when there is no root element with an
+// already resolved style, e.g. for an OffscreenCanvas in a worker.
+const FontCascade* rootFontCascadeForRootFontUnits(ScriptExecutionContext&);
+
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -412,6 +412,7 @@ struct CSSToLengthConversionDataAdaptor {
 struct DirectDataAdaptor {
     CSSPropertyID propertyToCompute;
     const FontCascade& fontCascadeForUnit;
+    const FontCascade* rootFontCascadeForUnit;
     const RenderView* renderViewForUnit;
 
     void setUsesViewportUnits() const
@@ -440,7 +441,9 @@ struct DirectDataAdaptor {
 
     const FontCascade& fontCascadeForRootFontUnits() const
     {
-        return fontCascadeForUnit;
+        // Callers without access to the root element's font (e.g. an OffscreenCanvas in a worker)
+        // fall back to resolving root font units against the element's font.
+        return rootFontCascadeForUnit ? *rootFontCascadeForUnit : fontCascadeForUnit;
     }
 
     const ComputedStyle* styleForLineHeightUnits() const
@@ -665,11 +668,12 @@ double resolveLength(double value, CSS::LengthUnit lengthUnit, const CSSToLength
     });
 }
 
-double resolveLength(double value, CSS::LengthUnit lengthUnit, CSSPropertyID propertyToCompute, const FontCascade& fontCascadeForUnit, const RenderView* renderViewForUnit)
+double resolveLength(double value, CSS::LengthUnit lengthUnit, CSSPropertyID propertyToCompute, const FontCascade& fontCascadeForUnit, const FontCascade* rootFontCascadeForUnit, const RenderView* renderViewForUnit)
 {
     return resolveLengthImpl(value, lengthUnit, DirectDataAdaptor {
         .propertyToCompute = propertyToCompute,
         .fontCascadeForUnit = fontCascadeForUnit,
+        .rootFontCascadeForUnit = rootFontCascadeForUnit,
         .renderViewForUnit = renderViewForUnit,
     });
 }

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.h
@@ -53,11 +53,15 @@ double resolveLength(double value, CSS::LengthUnit, const CSSToLengthConversionD
 // Only valid for absolute length units (Px, Cm, Mm, Q, In, Pt, Pc).
 double resolveLength(double value, CSS::LengthUnit, NoConversionDataRequiredToken);
 
+// If `rootFontCascadeForUnit` is nullptr, the following LengthUnits will all be resolved against
+// `fontCascadeForUnit` rather than the root element's font:
+//    Rem, Rex, Rcap, Rch, Ric (root font relative units)
+//
 // If `RenderView` is nullptr, the following LengthUnits will all cause a return value of zero:
 //    Vw, Vh, Vb, Vi, Svw, Svh, Svb, Svi, Lvw, Lvh, Lvb, Lvi, Dvw, Dvh, Dvb, Dvi (width/height/block/inline viewport-percentage units)
 // and the following LengthUnits will all cause a return value of `value`:
 //    Vmin, Vmax, Svmin, Svmax, Lvmin, Lvmax, Dvmin, Dvmax (min/max viewport-percentage units)
-double resolveLength(double value, CSS::LengthUnit, CSSPropertyID, const FontCascade& fontCascadeForUnit, const RenderView*);
+double resolveLength(double value, CSS::LengthUnit, CSSPropertyID, const FontCascade& fontCascadeForUnit, const FontCascade* rootFontCascadeForUnit, const RenderView*);
 
 // True if `resolveLength` would produce identical results when resolved against both these styles.
 bool equalForLengthResolution(const ComputedStyle&, const ComputedStyle&);


### PR DESCRIPTION
#### b39ff6eade649d249a47a165792381996a87a374
<pre>
Root font relative units in canvas ctx.font resolve against the canvas element instead of the root element
<a href="https://bugs.webkit.org/show_bug.cgi?id=321297">https://bugs.webkit.org/show_bug.cgi?id=321297</a>
<a href="https://rdar.apple.com/184337961">rdar://184337961</a>

Reviewed by NOBODY (OOPS!).

Style::resolveLength()&apos;s DirectDataAdaptor took a single FontCascade and returned it from both
fontCascadeForFontUnits() and fontCascadeForRootFontUnits(), so &apos;rem&apos; was an alias for &apos;em&apos;. With
`html { font-size: 5px }` and a canvas element at 20px, `ctx.font = &quot;2rem sans-serif&quot;` produced 40px
rather than the correct 10px. The sibling CSSToLengthConversionData adaptor already gets this right
via conversionData.rootStyle().

Give DirectDataAdaptor a second, nullable FontCascade for the root font and return it from
fontCascadeForRootFontUnits(). That one accessor feeds all five root font relative units, so rex,
rcap, rch and ric are fixed along with rem. Style::resolveLength() grows a matching parameter; when
it is null the units resolve against the element&apos;s font as before, which is what a worker gets.

Add Style::rootFontCascadeForRootFontUnits(), which returns the document element&apos;s
existingComputedStyle()-&gt;fontCascade(). It deliberately never resolves style: callers run under
ScriptDisallowedScope and the entry points are responsible for flushing.

Recording the root font also has to be part of the memoization in
CanvasRenderingContext2D::setFontWithoutUpdatingStyle(). It compared only the canvas element&apos;s font
description, which does not observe a root font-size change, so `ctx.font = &quot;2rem X&quot;` assigned twice
across a root restyle would stay stale.

HTML does not yet say how non-absolute &lt;length&gt; values behave here; that is open in
<a href="https://github.com/whatwg/html/issues/10893">https://github.com/whatwg/html/issues/10893</a>, where one suggestion is that the root font relative
units simply alias the non-root ones. Resolving them against the root element is what they mean in
CSS and what the CSSToLengthConversionData path already does for the document case, so take that
for now. Viewport and container units, and the fully detached OffscreenCanvas case, are left alone.

ctx.letterSpacing and ctx.wordSpacing reach the same resolveLength overload and have the same bug,
but fixing them needs those setters to update style first, which is a larger change; they pass null
for now with a FIXME.

* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::setFontWithoutUpdatingStyle):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::setLetterSpacing):
(WebCore::CanvasRenderingContext2DBase::setWordSpacing):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontSizeFromUnresolvedFontSize):
(WebCore::Style::rootFontCascadeForRootFontUnits):
* Source/WebCore/style/StyleResolveForFont.h:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
(WebCore::Style::DirectDataAdaptor::fontCascadeForRootFontUnits const):
(WebCore::Style::resolveLength):
* Source/WebCore/style/values/primitives/StyleLengthResolution.h:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/2d.text-root-font-relative-units-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/2d.text-root-font-relative-units.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b39ff6eade649d249a47a165792381996a87a374

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192961 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147032 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9237d169-073e-4aae-ae90-0659ee9185e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142619 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99027 "3 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/120c880c-ffef-4ffa-952a-f194f95d1287) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123054 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13fd65ee-f565-4945-ba99-1310880cb6dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45031 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43282 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42911 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4133 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194903 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152079 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57041 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39530 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151776 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46348 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129309 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125342 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55549 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17914 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54921 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55159 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54987 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->