### PR TITLE
Add support for scripting.ExecutionWorld

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
@@ -150,6 +150,18 @@ String toWebAPI(WebExtension::InjectionTime injectionTime)
     }
 }
 
+SUPPRESS_NODELETE NSDictionary *WebExtensionAPIScripting::executionWorld()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/ExecutionWorld
+
+    static NSDictionary *worlds = @{
+        @"ISOLATED": @"ISOLATED",
+        @"MAIN": @"MAIN",
+    };
+
+    return worlds;
+}
+
 void WebExtensionAPIScripting::executeScript(NSDictionary *script, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
@@ -45,6 +45,8 @@ class WebExtensionAPIScripting : public WebExtensionAPIObject, public JSWebExten
 
 public:
 #if PLATFORM(COCOA)
+    NSDictionary *NODELETE executionWorld();
+
     void executeScript(NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void insertCSS(NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void removeCSS(NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIScripting.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIScripting.idl
@@ -37,4 +37,6 @@
     [RaisesException] void getRegisteredContentScripts([Optional, NSDictionary] any filter, [Optional, CallbackHandler] function callback);
     [RaisesException] void unregisterContentScripts([Optional, NSDictionary] any filter, [Optional, CallbackHandler] function callback);
     [RaisesException] void updateContentScripts([NSArray=NSDictionary] array scripts, [Optional, CallbackHandler] function callback);
+
+    [ImplementedAs=executionWorld] readonly attribute any ExecutionWorld;
 };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
@@ -759,6 +759,22 @@ TEST(WKWebExtensionAPIScripting, CSSAuthorOrigin)
     [manager run];
 }
 
+TEST(WKWebExtensionAPIScripting, ExecutionWorld)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(typeof browser.scripting.ExecutionWorld, 'object', 'ExecutionWorld should be an object')",
+
+        @"browser.test.assertEq(browser.scripting.ExecutionWorld.ISOLATED, 'ISOLATED', 'ISOLATED should be defined')",
+        @"browser.test.assertEq(browser.scripting.ExecutionWorld.MAIN, 'MAIN', 'MAIN should be defined')",
+
+        @"browser.test.assertDeepEq(Object.keys(browser.scripting.ExecutionWorld).sort(), [ 'ISOLATED', 'MAIN' ], 'ExecutionWorld should only define ISOLATED and MAIN')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    Util::loadAndRunExtension(scriptingManifest, @{ @"background.js": backgroundScript });
+}
+
 TEST(WKWebExtensionAPIScripting, World)
 {
     TestWebKitAPI::HTTPServer server({


### PR DESCRIPTION
#### 132cc094ace96536261b48ffdd45c51aecc0bcf4
<pre>
Add support for scripting.ExecutionWorld
<a href="https://bugs.webkit.org/show_bug.cgi?id=321237">https://bugs.webkit.org/show_bug.cgi?id=321237</a>
<a href="https://rdar.apple.com/184284891">rdar://184284891</a>

Reviewed by Timothy Hatcher.

Add support for scripting.ExecutionWorld, which should simply return an object containing the two
different world types.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::WebExtensionAPIScripting::executionWorld):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIScripting.idl:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ExecutionWorld)):

Canonical link: <a href="https://commits.webkit.org/319009@main">https://commits.webkit.org/319009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fd9bc571fe6f246a18fdd19f6274995dc39dd07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144373 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8412ca6-51b7-43ad-83fa-607115c277d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140417 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120868 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42745 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41059 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40725 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1423 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192198 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53666 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149760 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40130 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54353 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149491 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44132 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126616 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121723 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52870 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15713 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52253 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52490 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52316 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->