### PR TITLE
Restrict length values passed via script for the ViewTimelineOptions inset member to computationally independent values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
@@ -2,11 +2,6 @@
 PASS View timeline with px based inset.
 PASS View timeline with percent based inset.
 PASS view timeline with inset auto.
-FAIL view timeline inset as string assert_throws_js: function "() => {
-    new ViewTimeline({
-      subject: target,
-      inset: "1em 2em"
-    });
-  }" did not throw
+PASS view timeline inset as string
 PASS view timeline with invalid inset
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -906,7 +906,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     animation/TimelineRangeOffset.h
     animation/TimelineRangeValue.h
     animation/ViewTimeline.h
-    animation/ViewTimelineOptions.h
     animation/WebAnimation.h
     animation/WebAnimationTime.h
     animation/WebAnimationTypes.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -58,7 +58,6 @@ accessibility/AccessibilityRenderObject.cpp
 animation/BlendingKeyframes.cpp
 animation/KeyframeEffect.cpp
 animation/StyleOriginatedAnimation.cpp
-animation/ViewTimeline.cpp
 animation/WebAnimation.cpp
 bindings/js/DOMPromiseProxy.h
 bindings/js/JSAudioBufferSourceNodeCustom.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -670,6 +670,7 @@ animation/StyleOriginatedAnimationEvent.cpp
 animation/StyleOriginatedTimelinesController.cpp
 animation/TimelineRangeValue.cpp
 animation/ViewTimeline.cpp @header:RenderStyleGetters
+animation/ViewTimelineInsetValue.cpp
 animation/WebAnimation.cpp
 animation/WebAnimationTime.cpp
 animation/WebAnimationUtilities.cpp @header:RenderStyleGetters

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2933,7 +2933,6 @@
 		713516982AE6D2AE00718EBE /* ScrollAxis.h in Headers */ = {isa = PBXBuildFile; fileRef = 713516962AE6D29600718EBE /* ScrollAxis.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		713516992AE6D2B200718EBE /* ScrollTimelineOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 713516942AE6D29600718EBE /* ScrollTimelineOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		713516A22AE6EF3500718EBE /* ViewTimeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 7135169F2AE6EF2900718EBE /* ViewTimeline.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		713516A32AE6EF3A00718EBE /* ViewTimelineOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7135169E2AE6EF2900718EBE /* ViewTimelineOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		713922BE2518AB77005DB3C2 /* Styleable.h in Headers */ = {isa = PBXBuildFile; fileRef = 713922BC2518AB70005DB3C2 /* Styleable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		713F1D5A23DF1D8D003F5EFA /* GetAnimationsOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 713F1D5923DF1D7D003F5EFA /* GetAnimationsOptions.h */; };
 		713F1D5D23DF2582003F5EFA /* JSGetAnimationsOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 713F1D5B23DF2560003F5EFA /* JSGetAnimationsOptions.h */; };
@@ -20315,6 +20314,9 @@
 		BCB2F88D275BEE57007231BF /* ColorNormalization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ColorNormalization.h; sourceTree = "<group>"; };
 		BCB308073022631300228BBA /* JSTimelineRangeOffset.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSTimelineRangeOffset.h; sourceTree = "<group>"; };
 		BCB308083022631300228BBA /* JSTimelineRangeOffset.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSTimelineRangeOffset.cpp; sourceTree = "<group>"; };
+		BCB308253024FE8100228BBA /* ViewTimelineInsetValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewTimelineInsetValue.h; sourceTree = "<group>"; };
+		BCB308263024FE8100228BBA /* ViewTimelineInsetValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ViewTimelineInsetValue.cpp; sourceTree = "<group>"; };
+		BCB316FA302635DE00228BBA /* StylePrimitiveNumericTypes+TypedCSSOMConversions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StylePrimitiveNumericTypes+TypedCSSOMConversions.h"; sourceTree = "<group>"; };
 		BCB4779725D46EFF005EF0C8 /* RenderModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RenderModel.h; sourceTree = "<group>"; };
 		BCB4779825D46EFF005EF0C8 /* RenderModel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RenderModel.cpp; sourceTree = "<group>"; };
 		BCB917692FC6115A00BA905E /* DeprecatedCSSOMCustomValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeprecatedCSSOMCustomValue.h; sourceTree = "<group>"; };
@@ -31783,6 +31785,8 @@
 				7135169D2AE6EF2800718EBE /* ViewTimeline.cpp */,
 				7135169F2AE6EF2900718EBE /* ViewTimeline.h */,
 				713516A12AE6EF2A00718EBE /* ViewTimeline.idl */,
+				BCB308263024FE8100228BBA /* ViewTimelineInsetValue.cpp */,
+				BCB308253024FE8100228BBA /* ViewTimelineInsetValue.h */,
 				7135169E2AE6EF2900718EBE /* ViewTimelineOptions.h */,
 				713516A02AE6EF2900718EBE /* ViewTimelineOptions.idl */,
 				71025EC31F99F096004A250C /* WebAnimation.cpp */,
@@ -39061,6 +39065,7 @@
 				BC9BE3EF2CFE297D00D8C2CA /* StylePrimitiveNumericTypes+Logging.h */,
 				BCEC09E32F3132C1009A3938 /* StylePrimitiveNumericTypes+Rounding.h */,
 				BC3CC1B52DE136830032971C /* StylePrimitiveNumericTypes+Serialization.h */,
+				BCB316FA302635DE00228BBA /* StylePrimitiveNumericTypes+TypedCSSOMConversions.h */,
 				BCB271EE2CC0156E00265123 /* StylePrimitiveNumericTypes.h */,
 				BCD9F05B2E1C297600D1C3DF /* StyleRatio.cpp */,
 				BC23875F2D84A59400698102 /* StyleRatio.h */,
@@ -49746,7 +49751,6 @@
 				CEF418CF1179678C009D112C /* ViewportArguments.h in Headers */,
 				26F9A83918A046AC00AEB88A /* ViewportConfiguration.h in Headers */,
 				713516A22AE6EF3500718EBE /* ViewTimeline.h in Headers */,
-				713516A32AE6EF3A00718EBE /* ViewTimelineOptions.h in Headers */,
 				7A10958A28C7CEB20056F3BE /* ViolationReportType.h in Headers */,
 				F4FC07D62BB3A6220090B808 /* VisibilityAdjustment.h in Headers */,
 				83407FC11E8D9C1700E048D3 /* VisibilityChangeClient.h in Headers */,

--- a/Source/WebCore/animation/TimelineRangeValue.cpp
+++ b/Source/WebCore/animation/TimelineRangeValue.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,15 +27,9 @@
 #include "config.h"
 #include "TimelineRangeValue.h"
 
-#include "CSSCalcValue.h"
-#include "CSSMathValue.h"
-#include "CSSOMKeywordValue.h"
-#include "CSSPrimitiveNumericUnits.h"
 #include "CSSPropertyParserConsumer+Timeline.h"
-#include "CSSUnevaluatedCalc.h"
-#include "CSSUnitValue.h"
 #include "Document.h"
-#include "StylePrimitiveNumericTypes+Conversions.h"
+#include "StylePrimitiveNumericTypes+TypedCSSOMConversions.h"
 #include "StyleSingleAnimationRange.h"
 #include "TimelineRangeOffset.h"
 
@@ -42,30 +37,7 @@ namespace WebCore {
 
 static std::optional<Style::SingleAnimationRangeEdgeOffset> convertToOffset(Ref<CSSNumericValue>&& numericValue)
 {
-    using OffsetCSSType = Style::SingleAnimationRangeEdgeOffset::CSS;
-
-    if (RefPtr unitValue = dynamicDowncast<CSSUnitValue>(numericValue)) {
-        auto lengthPercentageUnit = CSS::toLengthPercentageUnit(unitValue->unitEnum());
-        if (!lengthPercentageUnit)
-            return std::nullopt;
-        if (CSS::conversionToCanonicalUnitRequiresConversionData(*lengthPercentageUnit))
-            return std::nullopt;
-
-        return Style::toStyle(typename OffsetCSSType::Raw { *lengthPercentageUnit, static_cast<float>(unitValue->value()) }, NoConversionDataRequiredToken { });
-    }
-    if (RefPtr mathValue = dynamicDowncast<CSSMathValue>(numericValue)) {
-        auto calcValue = mathValue->toCSSCalcValue();
-        if (!calcValue)
-            return std::nullopt;
-        if (auto category = calcValue->category(); category != CSS::Category::LengthPercentage && category != CSS::Category::Length && category != CSS::Category::Percentage)
-            return std::nullopt;
-        if (calcValue->requiresConversionData())
-            return std::nullopt;
-
-        return Style::toStyle(typename OffsetCSSType::Calc { calcValue.releaseNonNull() }, NoConversionDataRequiredToken { });
-    }
-
-    return std::nullopt;
+    return Style::toAbsoluteStyleFromCSSNumericValue<Style::SingleAnimationRangeEdgeOffset>(WTF::move(numericValue));
 }
 
 template<typename RangeEdge>

--- a/Source/WebCore/animation/TimelineRangeValue.h
+++ b/Source/WebCore/animation/TimelineRangeValue.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -29,8 +29,6 @@
 #include "AnimationTimelinesController.h"
 #include "CSSKeywordValueInlines.h"
 #include "CSSNumericFactory.h"
-#include "CSSPropertyParserConsumer+Timeline.h"
-#include "CSSValuePair.h"
 #include "Document.h"
 #include "Element.h"
 #include "FloatQuad.h"
@@ -45,42 +43,23 @@
 #include "StyleableInlines.h"
 #include "StyleBuilderState.h"
 #include "StyleKeyword+Logging.h"
-#include "StylePrimitiveNumericOrKeyword+CSSValueConversion.h"
-#include "StylePrimitiveNumericOrKeyword+DeprecatedCSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
 #include "StyleScrollPadding.h"
 #include "StyleSingleAnimationRange.h"
+#include "ViewTimelineOptions.h"
 #include "WebAnimation.h"
 
 namespace WebCore {
 
-static bool isValidInset(const RefPtr<CSSValue>& inset)
-{
-    if (!inset)
-        return true;
-
-    if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(*inset))
-        return keywordValue->valueID() == CSSValueAuto;
-    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(*inset))
-        return primitiveValue->isLength() || primitiveValue->isPercentage();
-
-    return false;
-}
-
 ExceptionOr<Ref<ViewTimeline>> ViewTimeline::create(Document& document, ViewTimelineOptions&& options)
 {
-    auto viewTimeline = adoptRef(*new ViewTimeline(options.axis));
-
-    auto specifiedInsetsOrException = viewTimeline->validateSpecifiedInsets(options.inset, document);
-    if (specifiedInsetsOrException.hasException())
-        return specifiedInsetsOrException.releaseException();
-
-    auto specifiedInsets = specifiedInsetsOrException.releaseReturnValue();
-    if (!isValidInset(specifiedInsets.start) || !isValidInset(specifiedInsets.end))
+    auto insets = validateViewTimelineInset(WTF::move(options.inset), document);
+    if (!insets)
         return Exception { ExceptionCode::TypeError };
 
-    viewTimeline->m_specifiedInsets = WTF::move(specifiedInsets);
+    auto viewTimeline = ViewTimeline::create(nullAtom(), options.axis, WTF::move(*insets), Style::ZoomFactor::none());
+
     viewTimeline->setSubject(options.subject.get());
     if (auto subject = options.subject)
         protect(subject->document())->updateLayoutIgnorePendingStylesheets();
@@ -94,81 +73,10 @@ Ref<ViewTimeline> ViewTimeline::create(const AtomString& name, ScrollAxis axis, 
     return adoptRef(*new ViewTimeline(name, axis, insets, usedZoomForLength));
 }
 
-ViewTimeline::ViewTimeline(ScrollAxis axis)
-    : ScrollTimeline(nullAtom(), axis)
-    , m_insets({ .insets = CSS::Keyword::Auto { }, .zoom = Style::ZoomFactor::none() })
-{
-}
-
 ViewTimeline::ViewTimeline(const AtomString& name, ScrollAxis axis, const Style::ViewTimelineInsetItem& insets, const Style::ZoomFactor& usedZoomForLength)
     : ScrollTimeline(name, axis)
     , m_insets({ .insets = insets, .zoom = usedZoomForLength })
 {
-}
-
-ExceptionOr<ViewTimeline::SpecifiedViewTimelineInsets> ViewTimeline::validateSpecifiedInsets(const ViewTimelineInsetValue inset, const Document& document)
-{
-    // https://drafts.csswg.org/scroll-animations-1/#dom-viewtimeline-viewtimeline
-
-    // FIXME: note that we use CSSOMKeywordish instead of CSSOMKeywordValue to match Chrome,
-    // issue being tracked at https://github.com/w3c/csswg-drafts/issues/11477.
-
-    // If a DOMString value is provided as an inset, parse it as a <'view-timeline-inset'> value;
-    if (auto* insetString = std::get_if<String>(&inset)) {
-        if (insetString->isEmpty())
-            return Exception { ExceptionCode::TypeError };
-        auto consumedInset = CSSPropertyParserHelpers::parseSingleViewTimelineInsetItem(*insetString, Ref { document }->cssParserContext());
-        if (!consumedInset)
-            return Exception { ExceptionCode::TypeError };
-
-        if (RefPtr insetPair = dynamicDowncast<CSSValuePair>(consumedInset))
-            return { { insetPair->first(), insetPair->second() } };
-        return { { consumedInset, nullptr } };
-    }
-
-    auto cssValueForCSSNumericValue = [&](Ref<CSSNumericValue> numericValue) -> ExceptionOr<RefPtr<CSSValue>> {
-        if (RefPtr insetValue = dynamicDowncast<CSSUnitValue>(numericValue))
-            return upcast<CSSValue>(dynamicDowncast<CSSPrimitiveValue>(insetValue->toCSSValue()));
-        return nullptr;
-    };
-
-    auto cssValueForCSSKeywordValue = [&](Ref<CSSOMKeywordValue> keywordValue) -> ExceptionOr<RefPtr<CSSValue>> {
-        if (keywordValue->value() != "auto"_s)
-            return Exception { ExceptionCode::TypeError };
-        return nullptr;
-    };
-
-    auto cssValueForIndividualInset = [&](ViewTimelineIndividualInset individualInset) -> ExceptionOr<RefPtr<CSSValue>> {
-        if (auto* numericInset = std::get_if<Ref<CSSNumericValue>>(&individualInset))
-            return cssValueForCSSNumericValue(*numericInset);
-        if (auto* stringInset = std::get_if<String>(&individualInset))
-            return cssValueForCSSKeywordValue(CSSOMKeywordValue::rectifyKeywordish(*stringInset));
-        ASSERT(std::holds_alternative<Ref<CSSOMKeywordValue>>(individualInset));
-        return cssValueForCSSKeywordValue(CSSOMKeywordValue::rectifyKeywordish(std::get<Ref<CSSOMKeywordValue>>(individualInset)));
-    };
-
-    // if a sequence is provided, the first value represents the start inset and the second value represents the end inset.
-    // If the sequence has only one value, it is duplicated. If it has zero values or more than two values, or if it contains
-    // a CSSOMKeywordValue whose value is not "auto", throw a TypeError.
-    auto insetList = std::get<Vector<ViewTimelineIndividualInset>>(inset);
-    auto numberOfInsets = insetList.size();
-
-    if (!numberOfInsets || numberOfInsets > 2)
-        return Exception { ExceptionCode::TypeError };
-
-    auto startInsetOrException = cssValueForIndividualInset(insetList.at(0));
-    if (startInsetOrException.hasException())
-        return startInsetOrException.releaseException();
-    auto startInset = startInsetOrException.releaseReturnValue();
-
-    if (numberOfInsets == 1)
-        return { { startInset, startInset } };
-
-    auto endInsetOrException = cssValueForIndividualInset(insetList.at(1));
-    if (endInsetOrException.hasException())
-        return endInsetOrException.releaseException();
-    auto endInset = endInsetOrException.releaseReturnValue();
-    return { { startInset, endInset } };
 }
 
 const Element* ViewTimeline::subject() const
@@ -355,49 +263,6 @@ void ViewTimeline::cacheCurrentTime()
         }();
 
         auto subjectSize = scrollDirection.isVertical ? subjectBounds.height() : subjectBounds.width();
-
-        if (m_specifiedInsets) {
-            auto conversionData = CSSToLengthConversionData::tryCreateForNonStyleBuildingResolution(subject->element);
-
-            auto computedInset = [&](const CSSValue& specifiedInset) {
-                if (!conversionData)
-                    return Style::deprecatedToStyleFromCSSValue<Style::ViewTimelineInsetItem::Offset>(specifiedInset).value_or(Style::ViewTimelineInsetItem::Offset { CSS::Keyword::Auto { } });
-                return Style::toStyleFromCSSValue<Style::ViewTimelineInsetItem::Offset>(*conversionData, specifiedInset);
-            };
-
-            if (m_specifiedInsets->start && m_specifiedInsets->end) {
-                m_insets = {
-                    .insets = {
-                        computedInset(protect(*m_specifiedInsets->start)),
-                        computedInset(protect(*m_specifiedInsets->end)),
-                    },
-                    .zoom = Style::ZoomFactor::none(),
-                };
-            } else if (m_specifiedInsets->start) {
-                m_insets = {
-                    .insets {
-                        computedInset(protect(*m_specifiedInsets->start)),
-                    },
-                    .zoom = Style::ZoomFactor::none(),
-                };
-            } else if (m_specifiedInsets->end) {
-                m_insets = {
-                    .insets {
-                        Style::ViewTimelineInsetItem::Offset { CSS::Keyword::Auto { } },
-                        computedInset(protect(*m_specifiedInsets->end)),
-                    },
-                    .zoom = Style::ZoomFactor::none(),
-                };
-            } else {
-                m_insets = {
-                    .insets {
-                        Style::ViewTimelineInsetItem::Offset { CSS::Keyword::Auto { } },
-                        Style::ViewTimelineInsetItem::Offset { CSS::Keyword::Auto { } },
-                    },
-                    .zoom = Style::ZoomFactor::none(),
-                };
-            }
-        }
 
         auto scrollPaddingStart = [&] {
             CheckedRef style = sourceRenderer->style();

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -31,7 +31,6 @@
 #include <WebCore/ScrollTimeline.h>
 #include <WebCore/StyleViewFunction.h>
 #include <WebCore/Styleable.h>
-#include <WebCore/ViewTimelineOptions.h>
 #include <wtf/Ref.h>
 #include <wtf/WeakPtr.h>
 
@@ -43,6 +42,7 @@ enum class SingleAnimationRangeName : uint8_t;
 
 class Element;
 class StickyPositionViewportConstraints;
+struct ViewTimelineOptions;
 
 struct StickinessAdjustmentData {
     bool operator==(const StickinessAdjustmentData& other) const = default;
@@ -71,7 +71,7 @@ struct StickinessAdjustmentData {
 
 class ViewTimeline final : public ScrollTimeline {
 public:
-    static ExceptionOr<Ref<ViewTimeline>> create(Document&, ViewTimelineOptions&& = { });
+    static ExceptionOr<Ref<ViewTimeline>> create(Document&, ViewTimelineOptions&&);
     static Ref<ViewTimeline> create(const AtomString&, ScrollAxis, const Style::ViewTimelineInsetItem&, const Style::ZoomFactor&);
 
     const Element* NODELETE subject() const;
@@ -102,12 +102,11 @@ public:
     WebAnimationTime NODELETE epsilon() const;
 
 private:
+    ViewTimeline(const AtomString&, ScrollAxis, const Style::ViewTimelineInsetItem&, const Style::ZoomFactor&);
+
     ScrollTimeline::Data computeTimelineData(UseCachedCurrentTime = UseCachedCurrentTime::Yes) const final;
     std::pair<double, double> intervalForTimelineRangeName(const ScrollTimeline::Data&, Style::SingleAnimationRangeName) const;
     template<typename F> double mapOffsetToTimelineRange(const ScrollTimeline::Data&, Style::SingleAnimationRangeName, F&&) const;
-
-    explicit ViewTimeline(ScrollAxis);
-    explicit ViewTimeline(const AtomString&, ScrollAxis, const Style::ViewTimelineInsetItem&, const Style::ZoomFactor&);
 
     bool isViewTimeline() const final { return true; }
 
@@ -124,15 +123,7 @@ private:
 
     void cacheCurrentTime();
 
-    struct SpecifiedViewTimelineInsets {
-        RefPtr<CSSValue> start;
-        RefPtr<CSSValue> end;
-    };
-
-    ExceptionOr<SpecifiedViewTimelineInsets> validateSpecifiedInsets(const ViewTimelineInsetValue, const Document&);
-
     WeakStyleable m_subject;
-    std::optional<SpecifiedViewTimelineInsets> m_specifiedInsets;
     ResolvableViewTimelineInsets m_insets;
 
     CurrentTimeData m_cachedCurrentTimeData { };

--- a/Source/WebCore/animation/ViewTimelineInsetValue.cpp
+++ b/Source/WebCore/animation/ViewTimelineInsetValue.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ViewTimelineInsetValue.h"
+
+#include "CSSPropertyParserConsumer+Timeline.h"
+#include "Document.h"
+#include "StylePrimitiveNumericTypes+TypedCSSOMConversions.h"
+#include "StyleViewTimelineInsetItem.h"
+
+namespace WebCore {
+
+static std::optional<Style::ViewTimelineInsetItem::Offset> convertToInsetOffset(Ref<CSSNumericValue>&& numericValue)
+{
+    if (auto offset = Style::toAbsoluteStyleFromCSSNumericValue<Style::ViewTimelineInsetItem::Offset::Numeric>(WTF::move(numericValue)))
+        return Style::ViewTimelineInsetItem::Offset { WTF::move(*offset) };
+    return std::nullopt;
+}
+
+static std::optional<Style::ViewTimelineInsetItem::Offset> convertToInsetOffset(String&& string)
+{
+    if (string == "auto"_s)
+        return Style::ViewTimelineInsetItem::Offset { CSS::Keyword::Auto { } };
+    return std::nullopt;
+}
+
+static std::optional<Style::ViewTimelineInsetItem::Offset> convertToInsetOffset(Ref<CSSOMKeywordValue>&& keywordValue)
+{
+    if (keywordValue->value() == "auto"_s)
+        return Style::ViewTimelineInsetItem::Offset { CSS::Keyword::Auto { } };
+    return std::nullopt;
+}
+
+static std::optional<Style::ViewTimelineInsetItem::Offset> convertToInsetOffset(ViewTimelineIndividualInset&& value)
+{
+    return WTF::switchOn(WTF::move(value),
+        [](auto&& value) {
+            return convertToInsetOffset(WTF::move(value));
+        }
+    );
+}
+
+std::optional<Style::ViewTimelineInsetItem> validateViewTimelineInset(ViewTimelineInsetValue&& value, const Document& document)
+{
+    return WTF::switchOn(WTF::move(value),
+        [&](String&& rangeString) -> std::optional<Style::ViewTimelineInsetItem> {
+            return CSSPropertyParserHelpers::parseAbsoluteSingleViewTimelineInsetItemRaw(rangeString, document.cssParserContext(), document);
+        },
+        [&](Vector<ViewTimelineIndividualInset>&& sequence) -> std::optional<Style::ViewTimelineInsetItem> {
+            auto numberOfInsets = sequence.size();
+            if (!numberOfInsets || numberOfInsets > 2)
+                return std::nullopt;
+
+            auto start = convertToInsetOffset(WTF::move(sequence[0]));
+            if (!start)
+                return std::nullopt;
+
+            if (numberOfInsets == 1)
+                return Style::ViewTimelineInsetItem { WTF::move(*start) };
+
+            auto end = convertToInsetOffset(WTF::move(sequence[1]));
+            if (!end)
+                return std::nullopt;
+
+            return Style::ViewTimelineInsetItem { WTF::move(*start), WTF::move(*end) };
+        }
+    );
+}
+
+} // namespace WebCore

--- a/Source/WebCore/animation/ViewTimelineInsetValue.h
+++ b/Source/WebCore/animation/ViewTimelineInsetValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,16 +25,33 @@
 
 #pragma once
 
-#include "ViewTimelineInsetValue.h"
-#include "Element.h"
-#include "ScrollAxis.h"
+#include "CSSNumericValue.h"
+#include "CSSOMKeywordValue.h"
+#include <optional>
+#include <wtf/text/WTFString.h>
+#include <wtf/Variant.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
-struct ViewTimelineOptions {
-    RefPtr<Element> subject;
-    ScrollAxis axis;
-    ViewTimelineInsetValue inset;
-};
+class Document;
+
+namespace Style {
+struct ViewTimelineInsetItem;
+}
+
+// https://drafts.csswg.org/scroll-animations-1/#dom-viewtimelineoptions-inset
+
+// FIXME: This diverges from the spec to match Chrome by using the union
+// `(CSSNumericValue or CSSOMKeywordish)` instead of the union
+// `(CSSNumericValue or CSSOMKeywordValue)`. You don't see `CSSOMKeywordish`
+// below because it is defined as the union `(DOMString or CSSOMKeywordValue)`
+// which gets flattened into the union `(CSSNumericValue or DOMString or CSSOMKeywordValue)`.
+// Tracked via https://github.com/w3c/csswg-drafts/issues/11477
+
+using ViewTimelineIndividualInset = Variant<Ref<CSSNumericValue>, String, Ref<CSSOMKeywordValue>>;
+using ViewTimelineInsetValue = Variant<String, Vector<ViewTimelineIndividualInset>>;
+
+std::optional<Style::ViewTimelineInsetItem> validateViewTimelineInset(ViewTimelineInsetValue&&, const Document&);
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2024 Apple Inc. All rights reserved.
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,7 @@
 #include "CSSViewValue.h"
 #include "StyleBuilderState.h"
 #include "StyleSingleAnimationRange.h"
+#include "StyleViewTimelineInsetItem.h"
 
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
@@ -169,7 +170,7 @@ RefPtr<CSSValue> consumeSingleViewTimelineInsetItem(CSSParserTokenRange& range, 
     return startInset;
 }
 
-RefPtr<CSSValue> parseSingleViewTimelineInsetItem(const String& string, const CSSParserContext& context)
+std::optional<Style::ViewTimelineInsetItem> parseAbsoluteSingleViewTimelineInsetItemRaw(const String& string, const CSSParserContext& context, const Document& document)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();
@@ -177,8 +178,10 @@ RefPtr<CSSValue> parseSingleViewTimelineInsetItem(const String& string, const CS
     // Handle leading whitespace.
     range.consumeWhitespace();
 
-    auto state = CSS::PropertyParserState { .context = context };
-    auto result = consumeSingleViewTimelineInsetItem(range, state);
+    auto state = CSS::PropertyParserState { .context = context, .absoluteLengthUnitsOnly = true };
+    auto parsedValue = consumeSingleViewTimelineInsetItem(range, state);
+    if (!parsedValue)
+        return { };
 
     // Handle trailing whitespace.
     range.consumeWhitespace();
@@ -186,7 +189,12 @@ RefPtr<CSSValue> parseSingleViewTimelineInsetItem(const String& string, const CS
     if (!range.atEnd())
         return { };
 
-    return result;
+    auto dummyStyle = Style::ComputedStyle::create();
+    auto dummyState = Style::BuilderState::create(dummyStyle, Style::BuilderContext { document });
+
+    ASSERT(parsedValue->canResolveDependenciesWithConversionData(dummyState->cssToLengthConversionData()));
+
+    return Style::toStyleFromCSSValue<Style::ViewTimelineInsetItem>(*CheckedPtr { dummyState.ptr() }, *parsedValue);
 }
 
 RefPtr<CSSValue> consumeSingleAnimationRange(CSSParserTokenRange& range, CSS::PropertyParserState& state, Style::SingleAnimationRangeType type)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2024 Apple Inc. All rights reserved.
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,7 @@ enum class SingleAnimationRangeName : uint8_t;
 enum class SingleAnimationRangeType : bool;
 struct SingleAnimationRangeEnd;
 struct SingleAnimationRangeStart;
+struct ViewTimelineInsetItem;
 }
 
 namespace CSSPropertyParserHelpers {
@@ -65,7 +66,8 @@ RefPtr<CSSValue> consumeAnimationTimelineView(CSSParserTokenRange&, CSS::Propert
 // <single-view-timeline-inset-item> = <single-view-timeline-inset>{1,2}
 // https://drafts.csswg.org/scroll-animations-1/#propdef-view-timeline-inset
 RefPtr<CSSValue> consumeSingleViewTimelineInsetItem(CSSParserTokenRange&, CSS::PropertyParserState&);
-RefPtr<CSSValue> parseSingleViewTimelineInsetItem(const String&, const CSSParserContext&);
+
+std::optional<Style::ViewTimelineInsetItem> parseAbsoluteSingleViewTimelineInsetItemRaw(const String&, const CSSParserContext&, const Document&);
 
 // <single-animation-range> = normal | <length-percentage> | <timeline-range-name> <length-percentage>?
 // https://drafts.csswg.org/scroll-animations-1/#propdef-animation-range-start

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+TypedCSSOMConversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+TypedCSSOMConversions.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSCalcValue.h"
+#include "CSSMathValue.h"
+#include "CSSOMKeywordValue.h"
+#include "CSSPrimitiveNumericUnits.h"
+#include "CSSUnevaluatedCalc.h"
+#include "CSSUnitValue.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
+
+namespace WebCore {
+namespace Style {
+
+template<typename StyleType> struct AbsoluteCSSNumericValueConversion;
+
+template<typename StyleType> struct AbsoluteCSSNumericValueConversionInvoker {
+    template<typename... Rest> std::optional<StyleType> operator()(const CSSNumericValue& value, Rest&&... rest) const
+    {
+        return AbsoluteCSSNumericValueConversion<StyleType>{}(value, std::forward<Rest>(rest)...);
+    }
+};
+template<typename StyleType> inline constexpr AbsoluteCSSNumericValueConversionInvoker<StyleType> toAbsoluteStyleFromCSSNumericValue{};
+
+template<auto R, typename T> struct AbsoluteCSSNumericValueConversion<LengthPercentage<R, T>> {
+    using StyleType = LengthPercentage<R, T>;
+    using CSSType = StyleType::CSS;
+
+    std::optional<StyleType> operator()(const CSSNumericValue& value) const
+    {
+        if (RefPtr unitValue = dynamicDowncast<CSSUnitValue>(value)) {
+            auto lengthPercentageUnit = CSS::toLengthPercentageUnit(unitValue->unitEnum());
+            if (!lengthPercentageUnit)
+                return std::nullopt;
+            if (CSS::conversionToCanonicalUnitRequiresConversionData(*lengthPercentageUnit))
+                return std::nullopt;
+
+            return toStyle(typename CSSType::Raw { *lengthPercentageUnit, static_cast<float>(unitValue->value()) }, NoConversionDataRequiredToken { });
+        }
+        if (RefPtr mathValue = dynamicDowncast<CSSMathValue>(value)) {
+            auto calcValue = mathValue->toCSSCalcValue();
+            if (!calcValue)
+                return std::nullopt;
+            if (auto category = calcValue->category(); category != CSS::Category::LengthPercentage && category != CSS::Category::Length && category != CSS::Category::Percentage)
+                return std::nullopt;
+            if (calcValue->requiresConversionData())
+                return std::nullopt;
+
+            return toStyle(typename CSSType::Calc { calcValue.releaseNonNull() }, NoConversionDataRequiredToken { });
+        }
+
+        return std::nullopt;
+    }
+};
+
+} // namespace Style
+} // namespace WebCore


### PR DESCRIPTION
#### c82907a171552bc351a0a59b1c655abd0fc6284a
<pre>
Restrict length values passed via script for the ViewTimelineOptions inset member to computationally independent values
<a href="https://bugs.webkit.org/show_bug.cgi?id=321294">https://bugs.webkit.org/show_bug.cgi?id=321294</a>

Reviewed by Darin Adler.

Restrict length values passed via script for the ViewTimelineOptions inset member to
computationally independent values.

This is being resolved on by the CSSWG in w3c/csswg-drafts#13852
and has already been changed in WPT web-platform-tests/wpt@d645ced

Made computationally independent conversion from typed CSSOM numeric value to style
type generic and moved it to StylePrimitiveNumericTypes+TypedCSSOMConversions.h to
share the implementation with TimelineRangeValue conversion.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/TimelineRangeValue.cpp:
* Source/WebCore/animation/ViewTimeline.cpp:
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/animation/ViewTimelineInsetValue.cpp: Added.
* Source/WebCore/animation/ViewTimelineInsetValue.h: Added.
* Source/WebCore/animation/ViewTimelineOptions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+TypedCSSOMConversions.h: Added.

Canonical link: <a href="https://commits.webkit.org/318883@main">https://commits.webkit.org/318883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d2e12b886c20ed5897634259576b78eac13c58b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179735 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144046 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140195 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120646 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42470 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40789 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152871 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40442 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/esm-integration/execute-start.tentative.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1021 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191789 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53344 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149469 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40050 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54025 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149203 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43858 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126297 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121315 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52542 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15433 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52168 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->