### PR TITLE
Cherry-pick 1207b71f0518. https://bugs.webkit.org/show_bug.cgi?id=313521

### DIFF
--- a/LayoutTests/fast/forms/datalist/datalist-button-change-input-type-on-click-crash-expected.txt
+++ b/LayoutTests/fast/forms/datalist/datalist-button-change-input-type-on-click-crash-expected.txt
@@ -1,0 +1,5 @@
+PASS if no crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/datalist/datalist-button-change-input-type-on-click-crash.html
+++ b/LayoutTests/fast/forms/datalist/datalist-button-change-input-type-on-click-crash.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+input {
+    width: 300px;
+    height: 50px;
+}
+</style>
+</head>
+<body>
+<input id="input" type="text" list="list">
+<datalist id="list"><option value="a"><option value="b"></datalist>
+<script>
+
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    input.addEventListener('click', (e) => {
+        input.type = 'button';
+        gc();
+    }, { once: true });
+
+    if (window.internals) {
+        let shadow = internals.shadowRoot(input);
+        let listButton = shadow.querySelector("div[useragentpart='-webkit-list-button']");
+
+        await UIHelper.activateElement(listButton);
+    }
+
+    debug("PASS if no crash.");
+    finishJSTest();
+});
+
+</script>
+</body>
+</html>

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/event.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/event.cc
@@ -17,6 +17,7 @@
 
 #include "api/units/time_delta.h"
 #include "rtc_base/checks.h"
+#include "rtc_base/logging.h"
 #include "rtc_base/synchronization/yield_policy.h"
 #include "rtc_base/system/warn_current_thread_is_deadlocked.h"
 
@@ -161,9 +162,30 @@ bool Event::Wait(TimeDelta give_up_after, TimeDelta warn_after) {
   ScopedYieldPolicy::YieldExecution();
   pthread_mutex_lock(&event_mutex_);
 
+  bool has_logged_error = false;
   // Wait for `event_cond_` to trigger and `event_status_` to be set, with the
   // given timeout (or without a timeout if none is given).
   const auto wait = [&](const std::optional<timespec> timeout_ts) {
+#if WEBRTC_WEBKIT_BUILD
+    while (!event_status_) {
+      if (timeout_ts == std::nullopt) {
+        auto result = pthread_cond_wait(&event_cond_, &event_mutex_);
+        if (result && result != ETIMEDOUT && !has_logged_error) {
+          has_logged_error = true;
+          RTC_LOG(LS_ERROR) << "Event::Wait pthread_cond_wait failed with error " << result;
+        }
+      } else {
+        auto result = pthread_cond_timedwait(&event_cond_, &event_mutex_, &*timeout_ts);
+        if (result == ETIMEDOUT) {
+          return ETIMEDOUT;
+        } else if (result && !has_logged_error) {
+          has_logged_error = true;
+          RTC_LOG(LS_ERROR) << "Event::Wait pthread_cond_timedwait failed with error " << result;
+        }
+      }
+    }
+    return 0;
+#else
     int error = 0;
     while (!event_status_ && error == 0) {
       if (timeout_ts == std::nullopt) {
@@ -179,6 +201,7 @@ bool Event::Wait(TimeDelta give_up_after, TimeDelta warn_after) {
       }
     }
     return error;
+#endif
   };
 
   int error;

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -420,6 +420,8 @@ void TextFieldInputType::removeShadowSubtree()
     if (RefPtr autoFillButton = m_autoFillButton.get())
         autoFillButton->removeOwner();
     m_autoFillButton = nullptr;
+    if (RefPtr dataListDropdownIndicator = m_dataListDropdownIndicator)
+        dataListDropdownIndicator->removeOwner();
     m_dataListDropdownIndicator = nullptr;
     m_container = nullptr;
 }

--- a/Source/WebCore/html/shadow/DataListButtonElement.cpp
+++ b/Source/WebCore/html/shadow/DataListButtonElement.cpp
@@ -64,7 +64,8 @@ void DataListButtonElement::defaultEventHandler(Event& event)
     }
 
     if (isAnyClick(*mouseEvent)) {
-        m_owner.dataListButtonElementWasClicked();
+        if (RefPtr owner = m_owner)
+            owner->dataListButtonElementWasClicked();
         event.setDefaultHandled();
     }
 

--- a/Source/WebCore/html/shadow/DataListButtonElement.h
+++ b/Source/WebCore/html/shadow/DataListButtonElement.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "HTMLDivElement.h"
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -35,7 +36,7 @@ class DataListButtonElement final : public HTMLDivElement {
     WTF_MAKE_TZONE_ALLOCATED(DataListButtonElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DataListButtonElement);
 public:
-    class DataListButtonOwner {
+    class DataListButtonOwner : public AbstractRefCountedAndCanMakeWeakPtr<DataListButtonOwner> {
     public:
         virtual ~DataListButtonOwner() = default;
         virtual void dataListButtonElementWasClicked() = 0;
@@ -47,6 +48,8 @@ public:
 
     bool canAdjustStyleForAppearance() const { return m_canAdjustStyleForAppearance; }
 
+    void removeOwner() { m_owner = nullptr; }
+
 private:
     explicit DataListButtonElement(Document&, DataListButtonOwner&);
 
@@ -56,7 +59,7 @@ private:
     void defaultEventHandler(Event&) override;
     bool isDisabledFormControl() const override;
 
-    DataListButtonOwner& m_owner;
+    WeakPtr<DataListButtonOwner> m_owner;
     bool m_canAdjustStyleForAppearance { true };
 };
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4871,7 +4871,8 @@ std::pair<RefPtr<Frame>, CreatedNewPage> createWindow(LocalFrame& openerFrame, F
     if (!request.frameName().isEmpty() && !isBlankTargetFrameName(request.frameName())) {
         if (RefPtr frame = openerFrame.loader().findFrameForNavigation(request.frameName(), openerFrame.protectedDocument().get())) {
             if (!isSelfTargetFrameName(request.frameName())) {
-                if (RefPtr page = frame->page(); page && isInVisibleAndActivePage(openerFrame))
+                RefPtr openerWindow = openerFrame.window();
+                if (RefPtr page = frame->page(); page && isInVisibleAndActivePage(openerFrame) && openerWindow && openerWindow->consumeTransientActivation())
                     page->chrome().focus();
             }
             frame->updateOpener(openerFrame);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm
@@ -269,6 +269,70 @@ TEST(VerifyUserGesture, PopunderPreventedByConsumedAction)
     // during popup creation.
     EXPECT_FALSE(focusCalled);
 }
+
+TEST(VerifyUserGesture, PopunderPreventedViaDualEventListeners)
+{
+    auto openerHTML = "<script>"
+        "window.name = 'opener';"
+        "let popup;"
+        "let opened = false;"
+        "addEventListener('pointerdown', () => {"
+        "    if (!opened) {"
+        "        opened = true;"
+        "        popup = window.open('https://domain2.com/popup');"
+        "    }"
+        "});"
+        "addEventListener('click', () => {"
+        "    if (popup && popup.refocusOpener) popup.refocusOpener();"
+        "});"
+        "</script>"_s;
+    auto popupHTML = "<script>"
+        "function refocusOpener() { window.open('', 'opener'); }"
+        "</script>"_s;
+    HTTPServer server({
+        { "/opener"_s, { openerHTML } },
+        { "/popup"_s, { popupHTML } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [openerWebView setNavigationDelegate:navigationDelegate.get()];
+    [openerWebView setUIDelegate:uiDelegate.get()];
+    [openerWebView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
+
+    __block RetainPtr<TestWKWebView> popupWebView;
+    __block RetainPtr<TestNavigationDelegate> popupNavigationDelegate;
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *navigationAction, WKWindowFeatures *) {
+        [navigationAction._userInitiatedAction consume];
+        popupNavigationDelegate = adoptNS([TestNavigationDelegate new]);
+        [popupNavigationDelegate allowAnyTLSCertificate];
+        popupWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+        [popupWebView setNavigationDelegate:popupNavigationDelegate.get()];
+        return popupWebView.get();
+    };
+
+    __block bool focusCalled = false;
+    uiDelegate.get().focusWebView = ^(WKWebView *) {
+        focusCalled = true;
+    };
+
+    [openerWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/opener"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [openerWebView mouseDownAtPoint:CGPointMake(50, 50) simulatePressure:NO];
+    [openerWebView mouseUpAtPoint:CGPointMake(50, 50)];
+    [openerWebView waitForPendingMouseEvents];
+    while (!popupWebView)
+        Util::spinRunLoop();
+    [popupNavigationDelegate waitForDidFinishNavigation];
+
+    Util::spinRunLoop(10);
+
+    EXPECT_FALSE(focusCalled);
+}
 #endif
 
 }


### PR DESCRIPTION
#### 2bc4405358f08e0b65ff19be976a03e9c355ae7d
<pre>
Cherry-pick 1207b71f0518. <a href="https://bugs.webkit.org/show_bug.cgi?id=313521">https://bugs.webkit.org/show_bug.cgi?id=313521</a>

Unreviewed backport.

    [WebCore] Use-after-free in `DataListButtonElement::defaultEventHandler`
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313521">https://bugs.webkit.org/show_bug.cgi?id=313521</a>
    <a href="https://rdar.apple.com/175672489">rdar://175672489</a>

    Reviewed by Ryosuke Niwa.

    `DataListButtonElement` stores its owner as a raw `DataListButtonOwner&amp; m_owner`.
    The only `DataListButtonOwner` is `TextFieldInputType`. When the type of the
    owning input element is changed, `HTMLInputElement::updateType()` calls
    `removeShadowSubtree()`. This will null out `m_dataListDropdownIndicator` but
    does not clear the owner member in `DataListButtonElement`. Changing the type
    inside a `click` listener results in the `TextFieldInputType` being freed while
    event dispatch is in progress. Eventually, `DataListButtonElement::defaultEventHandler()`
    is called, calling `m_owner.dataListButtonElementWasClicked()` after `m_owner`
    was already freed.

    Fix storing the owner as a `WeakPtr` and by clearing it out in
    `removeShadowSubtree()`. This matches the implementation of `SpinButtonElement`.

    * LayoutTests/fast/forms/datalist/datalist-button-change-input-type-on-click-crash-expected.txt: Added.
    * LayoutTests/fast/forms/datalist/datalist-button-change-input-type-on-click-crash.html: Added.
    * Source/WebCore/html/TextFieldInputType.cpp:
    (WebCore::TextFieldInputType::removeShadowSubtree):
    * Source/WebCore/html/shadow/DataListButtonElement.cpp:
    (WebCore::DataListButtonElement::defaultEventHandler):
    * Source/WebCore/html/shadow/DataListButtonElement.h:

    Identifier: 305413.1011@safari-7624.5-branch

    Canonical link: <a href="https://commits.webkit.org/305413.1052@safari-7624.4.5.10-branch">https://commits.webkit.org/305413.1052@safari-7624.4.5.10-branch</a>

Canonical link: <a href="https://commits.webkit.org/305877.1057@webkitglib/2.52">https://commits.webkit.org/305877.1057@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9ff16dd5c8a23dff079c9b006eb81afd21d54bbb
<pre>
Cherry-pick 3c99db1f1186. <a href="https://bugs.webkit.org/show_bug.cgi?id=316816">https://bugs.webkit.org/show_bug.cgi?id=316816</a>

    Crash in libwebrtc.dylib:  void absl::internal_any_invocable::LocalInvoker&lt;false, void, webrtc::MethodCall&lt;webrtc::PeerConnectionInterface, void, webrtc::CreateSessionDescriptionObserver*
    <a href="https://rdar.apple.com/181124228">rdar://181124228</a>

    Reviewed by Jean-Yves Avenard and David Kilzer.

    We are seeing crashes when calling Event::Wait(kForever) with the following principles:
    - Event::Wait(kForever) is returning earlier than expected as the main thread should be blocked on the executing of the event task.
    - Event::Wait(kForever) is doing a 3 seconds wait, then, if not yet settled, a forever wait, but only in case the 3 seconds wait is ETIMEDOUT.
    - Some crashes show that the process lifetime was less than 3 seconds, which shows that the 3 seconds wait is returning earlier than 3 seconds, so not as ETIMEDOUT.

    To prevent this, we change how wait is done.
    Instead of returning once pthread_cond_timedwait returns, we now only return if pthread_cond_timedwait returns ETIMEDOUT.
    Any other returned value will trigger a new pthread_cond_timedwait call so that we wait for the actual timeout (3 seconds or forever for instance) or for the task being executed.
    We add some logging as this may help further investigations.

    Looking at Chromium code, they override the webrtc::Event class with their own version.
    As a follow-up, we should probably do the same and use a simple BinarySemaphore approach (at least for forever calls).

    * Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/event.cc:

    Identifier: 305413.1104@safari-7624.5-branch

    Canonical link: <a href="https://commits.webkit.org/305413.1045@safari-7624.4.5.10-branch">https://commits.webkit.org/305413.1045@safari-7624.4.5.10-branch</a>

Canonical link: <a href="https://commits.webkit.org/305877.1056@webkitglib/2.52">https://commits.webkit.org/305877.1056@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9d4566c36595a8a9e96d65171179925e6d4bf5c7
<pre>
Cherry-pick 2057f457fb75. <a href="https://bugs.webkit.org/show_bug.cgi?id=316816">https://bugs.webkit.org/show_bug.cgi?id=316816</a>

    Popunder bypass via overlappping transient activations
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316816">https://bugs.webkit.org/show_bug.cgi?id=316816</a>
    <a href="https://rdar.apple.com/177442177">rdar://177442177</a>

    Reviewed by Charlie Wolfe and Abrar Rahman Protyasha.

    We should consume transient activations to avoid popunders.

    Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm

    * Source/WebCore/loader/FrameLoader.cpp:
    (WebCore::createWindow):
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm:
    (TestWebKitAPI::TEST(VerifyUserGesture, PopunderPreventedViaDualEventListeners)):

    Identifier: 305413.1061@safari-7624.5-branch

    Canonical link: <a href="https://commits.webkit.org/305413.1019@safari-7624.4-branch">https://commits.webkit.org/305413.1019@safari-7624.4-branch</a>

Canonical link: <a href="https://commits.webkit.org/305877.1055@webkitglib/2.52">https://commits.webkit.org/305877.1055@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dc0fb24c1bc8e044ec8b00a45dc6cf84521e153

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179406 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53345 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47140 "The change is no longer eligible for processing.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189238 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143715 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181269 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54639 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53055 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139903 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143715 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182363 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54639 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47140 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120355 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54639 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53055 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47140 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54639 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47140 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/690 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45951 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53055 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191456 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53015 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47140 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149159 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53696 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47140 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148902 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27231 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53696 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/125968 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120863 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52213 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47140 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51598 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51839 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51659 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->