### PR TITLE
Cross-site iframe back/forward navigation is silently dropped after a persisted session restore

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -978,6 +978,9 @@ FrameState* WebBackForwardList::findFrameStateInItem(WebCore::BackForwardItemIde
             childFrameItem = parentFrameItem->childItemForFrameName(childFrameName);
         if (!childFrameItem)
             return nullptr;
+
+        if (!childFrameItem->frameID())
+            childFrameItem->updateFrameID(childFrameID);
     }
 
     return &childFrameItem->frameState();

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -916,6 +916,13 @@ final class WebBackForwardList {
             } else {
                 childFrameItem = parentFrameItem.childItemForFrameName(childFrameName)
             }
+            guard let matchedItem = childFrameItem else {
+                return nil
+            }
+            let existingFrameID = Optional(fromCxx: matchedItem.frameID())
+            if existingFrameID == nil {
+                matchedItem.updateFrameID(childFrameID)
+            }
         }
         guard let childFrameItem else {
             return nil

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2934,10 +2934,9 @@ bool WebPageProxy::dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromF
     for (size_t i = 0; i < toChildren.size(); ++i) {
         Ref toChild = toChildren[i];
         auto childFrameID = toChild->frameID();
-        if (!childFrameID)
-            continue;
-        // Stored frameIDs can disagree across entries after a process swap; fall back to position, which is stable across history.
-        RefPtr fromChild = fromFrame.childItemForFrameID(*childFrameID);
+        // Stored frameIDs can disagree across entries, or be entirely unset after a persisted session restore
+        // Fall back to position, which is stable across history, whenever ID-based lookup isn't possible or doesn't find a match.
+        RefPtr fromChild = childFrameID ? fromFrame.childItemForFrameID(*childFrameID) : nullptr;
         // A duplicated frameID in the to tree can resolve two siblings to the same from child; pairing both
         // would dispatch a second traversal to the same live frame and clobber the intended navigation. Fall
         // back to position when the resolved from child is already paired.
@@ -2945,6 +2944,12 @@ bool WebPageProxy::dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromF
             fromChild = fromFrame.childItemAtIndex(i);
         if (!fromChild || !pairedFromChildren.add(fromChild->identifier()).isNewEntry)
             continue;
+
+        if (toChild->frameState().wasRestoredFromSession && !childFrameID) {
+            if (auto fromFrameID = fromChild->frameID(); fromFrameID && !toChild->frameID())
+                toChild->updateFrameID(*fromFrameID);
+        }
+
         if (dispatchPerFrameTraversals(*fromChild, toChild, navigationID, frameLoadType, shouldRestore, publicSuffix))
             anySent = true;
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -5098,6 +5098,38 @@ TEST(SiteIsolation, GoBackReloadsDynamicallyCreatedCrossSiteIframe)
     EXPECT_WK_STREQ("https://webkit.org/a2", [webView objectByEvaluatingJavaScript:@"location.href" inFrame:[webView firstChildFrame]]);
 }
 
+TEST(SiteIsolation, GoBackToCrossSiteIframeAfterPersistedSessionRestore)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/source'></iframe>"_s } },
+        { "/source"_s, { "<script> alert('source'); </script>"_s } },
+        { "/destination"_s, { "<script> alert('destination'); </script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "source");
+
+    [webView evaluateJavaScript:@"location.href = 'https://apple.com/destination'" inFrame:[webView firstChildFrame] completionHandler:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "destination");
+
+    RetainPtr sessionState = [webView _sessionState];
+    RetainPtr persistedSessionState = adoptNS([[_WKSessionState alloc] initWithData:[sessionState data]]);
+
+    auto [newWebView, newNavigationDelegate] = siteIsolatedViewAndDelegate(server);
+    [newWebView _restoreSessionState:persistedSessionState.get() andNavigate:YES];
+    EXPECT_WK_STREQ([newWebView _test_waitForAlert], "destination");
+
+    RetainPtr childFrame = [newWebView firstChildFrame];
+
+    [newWebView goBack];
+    EXPECT_WK_STREQ("source", [newWebView _test_waitForAlert]);
+    EXPECT_WK_STREQ("https://webkit.org/source", [newWebView objectByEvaluatingJavaScript:@"location.href" inFrame:childFrame.get()]);
+
+    [newWebView goForward];
+    EXPECT_WK_STREQ("destination", [newWebView _test_waitForAlert]);
+}
+
 TEST(SiteIsolation, AdvancedPrivacyProtectionsHideScreenMetricsFromBindings)
 {
     auto frameHTML = [NSString stringWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"simple" ofType:@"html"] encoding:NSUTF8StringEncoding error:NULL];


### PR DESCRIPTION
#### 462479883713a6d2f105fcb94b3dffb646dca926
<pre>
Cross-site iframe back/forward navigation is silently dropped after a persisted session restore
<a href="https://bugs.webkit.org/show_bug.cgi?id=321303">https://bugs.webkit.org/show_bug.cgi?id=321303</a>
<a href="https://rdar.apple.com/184343275">rdar://184343275</a>

Reviewed by Sihui Liu.

Persisted session restore, e.g. after an app relaunch, never serializes a child frame&apos;s
FrameIdentifier -- it&apos;s process-local and can&apos;t survive a relaunch -- while
WebBackForwardList::findFrameStateInItem and WebPageProxy::dispatchPerFrameTraversals
both assumed a child frame&apos;s stored FrameState would carry one. With it unset, two separate
lookups broke silently:

- findFrameStateInItem&apos;s name/position fallback (used once the direct ID match fails, which
  is exactly what happens after a persisted restore) found the right FrameState but left its
  identifier unset, so the process WebPage::goToBackForwardItem swapped into afterward
  couldn&apos;t resolve it to any live or provisional frame and dropped the navigation (&quot;No target
  local frame found ... navigation silently dropped&quot;).

- dispatchPerFrameTraversals&apos;s per-child pairing loop skipped a child outright whenever its
  stored FrameState had no identifier, instead of falling back to position the way it already
  does when the identifier is merely stale, so no GoToBackForwardItem message was ever
  dispatched for the frame at all (&quot;walk dispatched no GoToBackForwardItem messages ... will
  be silently dropped&quot;).

Fixed by stamping the live frame&apos;s identifier onto the FrameState/WebBackForwardListFrameItem
matched via either fallback, so downstream identifier-based lookups (WebProcess::webFrame,
WebFrameProxy::webFrame, processForTheFrameItem) can find the right frame and process.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::findFrameStateInItem):
* Source/WebKit/UIProcess/WebBackForwardList.swift:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::dispatchPerFrameTraversals):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, GoBackToCrossSiteIframeAfterPersistedSessionRestore)):

Canonical link: <a href="https://commits.webkit.org/319165@main">https://commits.webkit.org/319165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5d6b9a31db881e14da3858449735b4a2166e656

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144731 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/502b6456-85af-439b-977f-231f3ecb2ee3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140712 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97465 "3 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7fc90ac4-dc07-41a5-8079-7401adf2737d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121164 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8f718033-34eb-49c1-821b-8b4eab06f596) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43042 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41335 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41009 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1780 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192556 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54021 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150065 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54709 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149788 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27427 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44416 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126972 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122134 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53226 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15998 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52608 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52845 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52673 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->