### PR TITLE
Add initial `portal-action` support

### DIFF
--- a/LayoutTests/spatial-css/resources/spatial-portal-utils.js
+++ b/LayoutTests/spatial-css/resources/spatial-portal-utils.js
@@ -1,4 +1,4 @@
-const createPortal = (test, { width, height, portalTransform } = {}) => {
+const createPortal = (test, { width, height, portalTransform, portalAction } = {}) => {
     const portal = document.createElement("div");
     portal.className = "portal";
     if (width)
@@ -7,13 +7,17 @@ const createPortal = (test, { width, height, portalTransform } = {}) => {
         portal.style.height = height;
     if (portalTransform)
         portal.style.portalTransform = portalTransform;
+    if (portalAction)
+        portal.style.portalAction = portalAction;
     document.body.appendChild(portal);
     test.add_cleanup(() => portal.remove());
     return portal;
 };
 
-const appendModel = (portal, asset) => {
+const appendModel = (portal, asset, stageMode) => {
     const model = document.createElement("model");
+    if (stageMode)
+        model.stageMode = stageMode;
     portal.appendChild(model);
     const source = document.createElement("source");
     source.src = `../model-element/resources/${asset}`;

--- a/LayoutTests/spatial-css/spatial-portal-action-dynamic-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-action-dynamic-expected.txt
@@ -1,0 +1,8 @@
+
+PASS portal-action switches portal-transform: auto between the bounding box and bounding sphere fits
+PASS portal-action: orbit recomputes the fit against the merged bounding sphere when a model is added
+PASS portal-action: orbit does not fit the content when portal-transform is none
+PASS portal-action drives the portal's gesture handling
+PASS portal-action: orbit removes its gesture handling once when the portal is removed
+PASS portal-action: orbit behavior is restored after toggling the display property off and back on
+

--- a/LayoutTests/spatial-css/spatial-portal-action-dynamic.html
+++ b/LayoutTests/spatial-css/spatial-portal-action-dynamic.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 40cm; height: 20cm; }
+</style>
+<body>
+<script>
+'use strict';
+
+internals.disableModelLoadDelaysForTesting();
+
+const centeredCube = "2x2x2-center.usdz";
+const offsetCube = "2x2x2-at-100x50x200.usdz";
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, centeredCube);
+
+    await model.ready;
+    const boxFit = await waitForPortalTransform(portal, portalTransformIsResolved, "initial bounding box fit");
+
+    portal.style.portalAction = "orbit";
+    const sphereFit = await waitForPortalTransform(portal, transform => transform && !portalTransformsApproxEqual(transform, boxFit), "bounding sphere fit after switching to orbit");
+
+    assert_true(sphereFit.m11 < boxFit.m11, `the bounding sphere scale is smaller than the bounding box scale (${sphereFit.m11} < ${boxFit.m11})`);
+
+    portal.style.portalAction = "none";
+    const restoredFit = await waitForPortalTransform(portal, transform => transform && !portalTransformsApproxEqual(transform, sphereFit), "bounding box fit after switching back to none");
+    assert_3d_matrix_approx_equals(restoredFit, boxFit);
+}, `portal-action switches portal-transform: auto between the bounding box and bounding sphere fits`);
+
+promise_test(async t => {
+    const portal = createPortal(t, { portalAction: "orbit" });
+    const centered = appendModel(portal, centeredCube);
+
+    await centered.ready;
+    const before = await waitForPortalTransform(portal, portalTransformIsResolved, "sphere fit with one model");
+
+    const offset = appendModel(portal, offsetCube);
+    await offset.ready;
+    const after = await waitForPortalTransform(portal, transform => transform && !portalTransformsApproxEqual(transform, before), "sphere fit with both models");
+
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 2, "the portal hosts both models");
+    assert_true(after.m11 < before.m11, `the merged bounding sphere is larger, so the fit scale shrinks (${after.m11} < ${before.m11})`);
+}, `portal-action: orbit recomputes the fit against the merged bounding sphere when a model is added`);
+
+promise_test(async t => {
+    const portal = createPortal(t, { portalTransform: "none" });
+    const model = appendModel(portal, centeredCube);
+
+    await model.ready;
+    const before = await waitForPortalTransform(portal, portalTransformIsResolved, "initial 1:1 mapping");
+    assert_true(portalTransformScaleIsUnit(before), "portal-transform: none yields a 1:1 CSS unit mapping");
+
+    portal.style.portalAction = "orbit";
+    await UIHelper.ensureStablePresentationUpdate();
+
+    // portal-transform: none opts out of fitting entirely, so orbit must not change the mapping.
+    const after = await waitForPortalTransform(portal, portalTransformIsResolved, "1:1 mapping after switching to orbit");
+    assert_true(portalTransformScaleIsUnit(after), "portal-transform: none still yields a 1:1 CSS unit mapping");
+}, `portal-action: orbit does not fit the content when portal-transform is none`);
+
+// Only a portal taking part in the gesture registers touch handlers and advertises a model element to
+// the page, so the two follow portal-action together.
+promise_test(async t => {
+    const before = internals.touchEventHandlerCount();
+
+    const portal = createPortal(t);
+    await UIHelper.ensureStablePresentationUpdate();
+    assert_equals(internals.touchEventHandlerCount(), before, "portal-action: none registers no touch handlers");
+
+    portal.style.portalAction = "orbit";
+    await UIHelper.ensureStablePresentationUpdate();
+    assert_greater_than(internals.touchEventHandlerCount(), before, "orbit registers touch handlers");
+
+    portal.style.portalAction = "none";
+    await UIHelper.ensureStablePresentationUpdate();
+    assert_equals(internals.touchEventHandlerCount(), before, "switching back to none removes them");
+}, `portal-action drives the portal's gesture handling`);
+
+promise_test(async t => {
+    const before = internals.touchEventHandlerCount();
+
+    const portal = createPortal(t, { portalAction: "orbit" });
+    await UIHelper.ensureStablePresentationUpdate();
+    assert_greater_than(internals.touchEventHandlerCount(), before, "orbit registers touch handlers");
+
+    portal.style.portalAction = "none";
+    await UIHelper.ensureStablePresentationUpdate();
+    portal.remove();
+    await UIHelper.ensureStablePresentationUpdate();
+    assert_equals(internals.touchEventHandlerCount(), before, "removing the portal removes them exactly once");
+}, `portal-action: orbit removes its gesture handling once when the portal is removed`);
+
+promise_test(async t => {
+    const before = internals.touchEventHandlerCount();
+
+    const portal = createPortal(t, { portalAction: "orbit" });
+    const model = appendModel(portal, centeredCube);
+
+    await model.ready;
+    const fit = await waitForPortalTransform(portal, portalTransformIsResolved, "initial bounding sphere fit");
+    const withOrbit = internals.touchEventHandlerCount();
+    assert_greater_than(withOrbit, before, "orbit registers touch handlers");
+
+    portal.style.display = "none";
+    await UIHelper.ensureStablePresentationUpdate();
+    assert_false(internals.establishesSpatialPortal(portal), "the element no longer establishes a portal");
+    assert_equals(internals.touchEventHandlerCount(), before, "its touch handlers are removed");
+    await waitForPortalTransform(portal, portalTransformIsCleared, "the resolved transform is cleared");
+
+    portal.style.display = "block";
+    await UIHelper.ensureStablePresentationUpdate();
+    assert_true(internals.establishesSpatialPortal(portal), "the element establishes a portal again");
+    assert_equals(internals.touchEventHandlerCount(), withOrbit, "its touch handlers are registered again");
+
+    const refit = await waitForPortalTransform(portal, portalTransformIsResolved, "bounding sphere fit once the box is back");
+    assert_3d_matrix_approx_equals(refit, fit);
+}, `portal-action: orbit behavior is restored after toggling the display property off and back on`);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-action-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-action-expected.txt
@@ -1,0 +1,3 @@
+
+PASS portal-action: orbit fits the portal's content to its bounding sphere
+

--- a/LayoutTests/spatial-css/spatial-portal-action-multi-model-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-action-multi-model-expected.txt
@@ -1,0 +1,5 @@
+
+PASS portal-action: none fits the merged bounds independently of model load order
+PASS portal-action: orbit fits the merged bounds independently of model load order
+PASS portal-action: orbit fits the merged bounds the same whether models load one by one or together
+

--- a/LayoutTests/spatial-css/spatial-portal-action-multi-model.html
+++ b/LayoutTests/spatial-css/spatial-portal-action-multi-model.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 40cm; height: 20cm; }
+</style>
+<body>
+<script>
+'use strict';
+
+internals.disableModelLoadDelaysForTesting();
+
+// Deliberately spread out, so the merged bounds move as each one loads.
+const spreadAssets = ["2x2x2-center.usdz", "2x2x2-at-100x50x200.usdz", "2x2x2-positive.usdz"];
+
+const loadPortalInOrder = async (test, assets, options) => {
+    const portal = createPortal(test, options);
+
+    let previous = null;
+    for (const [index, asset] of assets.entries()) {
+        const model = appendModel(portal, asset);
+        await model.ready;
+        await UIHelper.ensureStablePresentationUpdate();
+
+        assert_equals(internals.numberOfLoadedModelsInSpatialPortal(portal), index + 1, `${index + 1} model(s) loaded after ${asset}`);
+
+        const transform = await waitForPortalTransform(portal, portalTransformIsResolved, `fit after loading ${asset}`);
+        if (previous)
+            assert_less_than_equal(transform.m11, previous.m11, `the scale does not grow when ${asset} joins the merged bounds`);
+        previous = transform;
+    }
+
+    return portal;
+};
+
+for (const portalAction of ["none", "orbit"]) {
+    promise_test(async t => {
+        const forward = await loadPortalInOrder(t, spreadAssets, { portalAction });
+        const reversed = await loadPortalInOrder(t, [...spreadAssets].reverse(), { portalAction });
+
+        assert_3d_matrix_approx_equals(resolvedPortalTransform(reversed), resolvedPortalTransform(forward));
+    }, `portal-action: ${portalAction} fits the merged bounds independently of model load order`);
+}
+
+promise_test(async t => {
+    const incremental = await loadPortalInOrder(t, spreadAssets, { portalAction: "orbit" });
+
+    const batched = createPortal(t, { portalAction: "orbit" });
+    await Promise.all(spreadAssets.map(asset => appendModel(batched, asset).ready));
+    await waitForPortalTransform(batched, portalTransformIsResolved, "batched portal");
+
+    assert_3d_matrix_approx_equals(resolvedPortalTransform(batched), resolvedPortalTransform(incremental));
+}, `portal-action: orbit fits the merged bounds the same whether models load one by one or together`);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-action-off-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-action-off-expected.txt
@@ -1,0 +1,3 @@
+portal-action is supported: false
+portal-action computed style is exposed: false
+portal-action survives in cssText: false

--- a/LayoutTests/spatial-css/spatial-portal-action-off.html
+++ b/LayoutTests/spatial-css/spatial-portal-action-off.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SpatialPortalEnabled=false ] -->
+<html>
+<style>
+    #portal { spatial: portal; width: 300px; height: 150px; portal-action: orbit; }
+</style>
+<body>
+<div id="portal">
+    <span id="content">Hello!</span>
+</div>
+<pre id="results"></pre>
+<script>
+    window.testRunner?.dumpAsText();
+
+    const portal = document.getElementById("portal");
+    const lines = [];
+
+    lines.push(`portal-action is supported: ${CSS.supports("portal-action", "orbit")}`);
+    lines.push(`portal-action computed style is exposed: ${getComputedStyle(portal).portalAction !== undefined}`);
+
+    portal.style.portalAction = "orbit";
+    lines.push(`portal-action survives in cssText: ${portal.style.cssText.includes("portal-action")}`);
+
+    results.textContent = lines.join("\n");
+
+    portal.remove();
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-action-parsing-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-action-parsing-expected.txt
@@ -1,0 +1,7 @@
+
+PASS portal-action initial value is none, whether or not the element establishes a portal
+PASS portal-action accepts none and orbit
+PASS portal-action is a supported property
+PASS portal-action ignores invalid values
+PASS portal-action ignores not yet supported values
+

--- a/LayoutTests/spatial-css/spatial-portal-action-parsing.html
+++ b/LayoutTests/spatial-css/spatial-portal-action-parsing.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+'use strict';
+
+function makeElement(t, establishesPortal) {
+    const element = document.createElement("div");
+    if (establishesPortal)
+        element.style.spatial = "portal";
+    document.body.appendChild(element);
+    t.add_cleanup(() => element.remove());
+    return element;
+}
+
+test(t => {
+    assert_equals(getComputedStyle(makeElement(t, true)).portalAction, "none", "on a portal");
+    assert_equals(getComputedStyle(makeElement(t, false)).portalAction, "none", "on a non-portal");
+}, "portal-action initial value is none, whether or not the element establishes a portal");
+
+test(t => {
+    for (const value of ["none", "orbit"]) {
+        const element = makeElement(t, true);
+        element.style.portalAction = value;
+        assert_equals(element.style.portalAction, value, `specified value of "${value}"`);
+        assert_equals(getComputedStyle(element).portalAction, value, `computed value of "${value}"`);
+    }
+}, "portal-action accepts none and orbit");
+
+test(() => {
+    assert_true(CSS.supports("portal-action", "none"), "none");
+    assert_true(CSS.supports("portal-action", "orbit"), "orbit");
+}, "portal-action is a supported property");
+
+const alwaysInvalid = ["3px", "10", "red", "auto", "none none", "orbit orbit", "none orbit", "orbit none", "none, orbit"];
+
+const notYetSupported = ["pan", "pan-x", "pan-y", "pan-z", "pan-inline", "pan-block", "orbit pan", "orbit pan-z"];
+
+for (const [description, values] of [["invalid", alwaysInvalid], ["not yet supported", notYetSupported]]) {
+    test(t => {
+        for (const value of values) {
+            const element = makeElement(t, true);
+            element.style.portalAction = value;
+            assert_equals(element.style.portalAction, "", `"${value}" is not accepted`);
+            assert_equals(getComputedStyle(element).portalAction, "none", `"${value}" leaves the initial value in place`);
+        }
+    }, `portal-action ignores ${description} values`);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-action-requires-auto-transform-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-action-requires-auto-transform-expected.txt
@@ -1,0 +1,5 @@
+
+PASS portal-action: orbit leaves the transform of a portal-transform: none portal alone
+PASS portal-action: orbit only sets up interaction when portal-transform contains auto
+PASS portal-action: orbit becomes noop when portal-transform stops containing auto
+

--- a/LayoutTests/spatial-css/spatial-portal-action-requires-auto-transform.html
+++ b/LayoutTests/spatial-css/spatial-portal-action-requires-auto-transform.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 40cm; height: 20cm; }
+</style>
+<body>
+<script>
+'use strict';
+
+internals.disableModelLoadDelaysForTesting();
+
+const centeredCube = "2x2x2-center.usdz";
+
+promise_test(async t => {
+    const inert = createPortal(t, { portalTransform: "none", portalAction: "orbit" });
+    const inertModel = appendModel(inert, centeredCube);
+
+    const baseline = createPortal(t, { portalTransform: "none" });
+    const baselineModel = appendModel(baseline, centeredCube);
+
+    await inertModel.ready;
+    await baselineModel.ready;
+    await UIHelper.ensureStablePresentationUpdate();
+
+    const inertFit = await waitForPortalTransform(inert, portalTransformIsResolved, "portal-transform: none with orbit");
+    const baselineFit = await waitForPortalTransform(baseline, portalTransformIsResolved, "portal-transform: none without orbit");
+
+    assert_true(portalTransformScaleIsUnit(inertFit), "portal-transform: none still yields a 1:1 CSS unit mapping");
+    assert_3d_matrix_approx_equals(inertFit, baselineFit);
+}, `portal-action: orbit leaves the transform of a portal-transform: none portal alone`);
+
+promise_test(async t => {
+    const before = internals.touchEventHandlerCount();
+
+    const inert = createPortal(t, { portalTransform: "none", portalAction: "orbit" });
+    await UIHelper.ensureStablePresentationUpdate();
+    assert_equals(internals.touchEventHandlerCount(), before, "orbit registers no touch handlers without an auto portal-transform");
+    assert_true(internals.establishesSpatialPortal(inert), "the inert element still establishes a portal");
+
+    createPortal(t, { portalAction: "orbit" });
+    await UIHelper.ensureStablePresentationUpdate();
+    assert_greater_than(internals.touchEventHandlerCount(), before, "orbit registers touch handlers when portal-transform is auto");
+}, `portal-action: orbit only sets up interaction when portal-transform contains auto`);
+
+promise_test(async t => {
+    const portal = createPortal(t, { portalAction: "orbit" });
+    const model = appendModel(portal, centeredCube);
+
+    await model.ready;
+    const sphereFit = await waitForPortalTransform(portal, portalTransformIsResolved, "bounding sphere fit");
+    const withInteraction = internals.touchEventHandlerCount();
+
+    portal.style.portalTransform = "none";
+    await UIHelper.ensureStablePresentationUpdate();
+
+    const unfitted = await waitForPortalTransform(portal, transform => transform && !portalTransformsApproxEqual(transform, sphereFit), "1:1 mapping after opting out of the fit");
+    assert_true(portalTransformScaleIsUnit(unfitted), "the portal falls back to a 1:1 CSS unit mapping");
+    assert_less_than(internals.touchEventHandlerCount(), withInteraction, "the orbit touch handlers are withdrawn");
+}, `portal-action: orbit becomes noop when portal-transform stops containing auto`);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-action.html
+++ b/LayoutTests/spatial-css/spatial-portal-action.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 40cm; height: 20cm; }
+</style>
+<body>
+<script>
+'use strict';
+
+internals.disableModelLoadDelaysForTesting();
+
+const centeredCube = "2x2x2-center.usdz";
+
+promise_test(async t => {
+    const staticPortal = createPortal(t);
+    const staticModel = appendModel(staticPortal, centeredCube);
+
+    const orbitPortal = createPortal(t, { portalAction: "orbit" });
+    const orbitModel = appendModel(orbitPortal, centeredCube);
+
+    await staticModel.ready;
+    await orbitModel.ready;
+
+    const boxFit = await waitForPortalTransform(staticPortal, portalTransformIsResolved, "portal-action: none");
+    const sphereFit = await waitForPortalTransform(orbitPortal, portalTransformIsResolved, "portal-action: orbit");
+
+    assert_true(sphereFit.m11 < boxFit.m11, `orbit fits the bounding sphere (${sphereFit.m11} < ${boxFit.m11})`);
+}, `portal-action: orbit fits the portal's content to its bounding sphere`);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-determines-if-scroll-gesture-updates-position-information-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-determines-if-scroll-gesture-updates-position-information-expected.txt
@@ -1,0 +1,17 @@
+ensurePositionInformationIsUpToDate should be called when a scroll gesture occurs if a spatial portal takes part in the interaction gesture, whether or not it contains any model elements.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was false, expected false
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was false, expected false
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was false, expected false
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was false, expected false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/spatial-css/spatial-portal-determines-if-scroll-gesture-updates-position-information.html
+++ b/LayoutTests/spatial-css/spatial-portal-determines-if-scroll-gesture-updates-position-information.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="../resources/js-test.js"></script>
+    <script src="../resources/basic-gestures.js"></script>
+    <script src="../resources/ui-helper.js"></script>
+    <style>
+        html, body {
+            padding: 0;
+            margin: 0;
+        }
+
+        #overflow_container {
+            height: 300px;
+            overflow: scroll;
+            border: 2px solid black;
+        }
+
+        #overflow {
+            background: linear-gradient(180deg, rgba(255, 199, 153, 1) 0%, rgba(255, 0, 102, 1) 100%);
+            height: 600px;
+        }
+
+        .portal {
+            spatial: portal;
+            portal-action: orbit;
+            width: 200px;
+            height: 100px;
+        }
+    </style>
+</head>
+<script>
+    jsTestIsAsync = true;
+    testRunner.dumpAsText();
+
+    async function scroll() {
+        var fromX = overflow_container.offsetLeft + 50;
+        var fromY = overflow_container.offsetTop + overflow_container.offsetHeight - 5;
+        var toX = fromX;
+        var toY = fromY - 100;
+        await touchAndDragFromPointToPoint(fromX, fromY, toX, toY);
+        await liftUpAtPoint(toX, toY);
+        overflow_container.scrollTop = 0;
+    }
+
+    async function scrollAndCheckIfPositionInformationUpdated(correctValue) {
+        await scroll();
+        didWait = await UIHelper.didCallEnsurePositionInformationIsUpToDateSinceLastCheck();
+        const msg = "didCallEnsurePositionInformationIsUpToDateSinceLastCheck was " + didWait + ", expected " + correctValue;
+        if (didWait == correctValue)
+            testPassed(msg);
+        else
+            testFailed(msg);
+    }
+
+    addEventListener("load", async () => {
+        var didWait;
+        var portalContainer = document.getElementById("portal-container");
+
+        if (window.testRunner) {
+            await UIHelper.clearEnsurePositionInformationIsUpToDateTracking();
+
+            description(`ensurePositionInformationIsUpToDate should be called when a scroll gesture occurs if a spatial
+                portal takes part in the interaction gesture, whether or not it contains any model elements.`);
+
+            // Page has one empty spatial portal handling the gesture.
+            await scrollAndCheckIfPositionInformationUpdated(true);
+
+            portal.style.portalAction = "none"; // The portal no longer takes part in the gesture.
+            await scrollAndCheckIfPositionInformationUpdated(false);
+
+            portal.style.portalAction = "orbit";
+            await scrollAndCheckIfPositionInformationUpdated(true);
+
+            portal.remove(); // Page now has no spatial portals.
+            await scrollAndCheckIfPositionInformationUpdated(false);
+
+            var newPortal = document.createElement("div");
+            newPortal.className = "portal";
+            portalContainer.appendChild(newPortal); // Page now has one spatial portal.
+            await scrollAndCheckIfPositionInformationUpdated(true);
+
+            newPortal.style.spatial = "none"; // The element no longer establishes a portal.
+            await scrollAndCheckIfPositionInformationUpdated(false);
+
+            newPortal.style.spatial = "portal";
+            await scrollAndCheckIfPositionInformationUpdated(true);
+
+            portalContainer.innerHTML = ""; // Page now has no spatial portals.
+            await scrollAndCheckIfPositionInformationUpdated(false);
+
+            finishJSTest();
+        }
+    });
+</script>
+<body>
+    <div id="overflow_container">
+        <div id="overflow"></div>
+    </div>
+    <div id="portal-container">
+        <div id="portal" class="portal"></div>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-nested-model-stagemode-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-nested-model-stagemode-expected.txt
@@ -1,0 +1,7 @@
+
+PASS stagemode on a nested <model> is ignored: the bounding box fit is unchanged
+PASS portal-action on the portal takes effect regardless of a nested <model>'s stagemode
+PASS stagemode on a standalone <model> is still honored
+PASS portal-action: orbit fits the content the same way stagemode: orbit fits a standalone <model>
+PASS stagemode becomes live again when a <model> is moved out of a spatial portal
+

--- a/LayoutTests/spatial-css/spatial-portal-nested-model-stagemode.html
+++ b/LayoutTests/spatial-css/spatial-portal-nested-model-stagemode.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 40cm; height: 20cm; }
+</style>
+<body>
+<script>
+'use strict';
+
+internals.disableModelLoadDelaysForTesting();
+
+const centeredCube = "2x2x2-center.usdz";
+
+const portalWidth = "40cm";
+const portalHeight = "20cm";
+
+const appendStandaloneModel = (test, asset, stageMode) => {
+    const model = appendModel(document.body, asset, stageMode);
+    model.style.width = portalWidth;
+    model.style.height = portalHeight;
+    test.add_cleanup(() => model.remove());
+    return model;
+};
+
+promise_test(async t => {
+    const plainPortal = createPortal(t);
+    const plainModel = appendModel(plainPortal, centeredCube);
+
+    const stageModePortal = createPortal(t);
+    const stageModeModel = appendModel(stageModePortal, centeredCube, "orbit");
+
+    await plainModel.ready;
+    await stageModeModel.ready;
+
+    const plainTransform = await waitForPortalTransform(plainPortal, portalTransformIsResolved, "portal with a plain model");
+    const stageModeTransform = await waitForPortalTransform(stageModePortal, portalTransformIsResolved, "portal with a stagemode model");
+
+    assert_equals(stageModeModel.stageMode, "orbit", "the attribute is still reflected");
+    assert_3d_matrix_approx_equals(stageModeTransform, plainTransform);
+}, `stagemode on a nested <model> is ignored: the bounding box fit is unchanged`);
+
+promise_test(async t => {
+    const boxPortal = createPortal(t);
+    const boxModel = appendModel(boxPortal, centeredCube);
+
+    const orbitPortal = createPortal(t, { portalAction: "orbit" });
+    const orbitModel = appendModel(orbitPortal, centeredCube, "orbit");
+
+    await boxModel.ready;
+    await orbitModel.ready;
+
+    const boxFit = await waitForPortalTransform(boxPortal, portalTransformIsResolved, "bounding box fit");
+    const sphereFit = await waitForPortalTransform(orbitPortal, portalTransformIsResolved, "bounding sphere fit");
+
+    assert_true(sphereFit.m11 < boxFit.m11, `the portal uses the bounding sphere fit (${sphereFit.m11} < ${boxFit.m11})`);
+}, `portal-action on the portal takes effect regardless of a nested <model>'s stagemode`);
+
+promise_test(async t => {
+    const model = appendStandaloneModel(t, centeredCube, "orbit");
+    await model.ready;
+
+    assert_throws_dom("InvalidStateError", () => {
+        model.entityTransform = new DOMMatrix();
+    }, "entityTransform is read-only while stagemode is orbit");
+}, `stagemode on a standalone <model> is still honored`);
+
+promise_test(async t => {
+    const portal = createPortal(t, { width: portalWidth, height: portalHeight, portalAction: "orbit" });
+    const nested = appendModel(portal, centeredCube);
+    const standalone = appendStandaloneModel(t, centeredCube, "orbit");
+
+    await nested.ready;
+    await standalone.ready;
+    await UIHelper.ensureStablePresentationUpdate();
+
+    const portalFit = await waitForPortalTransform(portal, portalTransformIsResolved, "portal-action: orbit fit");
+
+    assert_3d_matrix_approx_equals(portalFit, standalone.entityTransform);
+}, `portal-action: orbit fits the content the same way stagemode: orbit fits a standalone <model>`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, centeredCube, "orbit");
+
+    await model.ready;
+    await waitForPortalTransform(portal, portalTransformIsResolved, "transform while nested");
+
+    const container = document.createElement("div");
+    container.style.width = "40cm";
+    container.style.height = "20cm";
+    document.body.appendChild(container);
+    t.add_cleanup(() => container.remove());
+    container.appendChild(model);
+
+    await waitForPortalTransform(portal, portalTransformIsCleared, "transform after the model leaves the portal");
+    await model.ready;
+
+    assert_throws_dom("InvalidStateError", () => {
+        model.entityTransform = new DOMMatrix();
+    }, "entityTransform is read-only once the model is no longer nested");
+}, `stagemode becomes live again when a <model> is moved out of a spatial portal`);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -619,6 +619,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/model-element/ModelPlayerIdentifier.h
     Modules/model-element/ModelPlayerProvider.h
     Modules/model-element/ModelPlayerTransformState.h
+    Modules/model-element/PortalAction.h
     Modules/model-element/PortalTransform.h
     Modules/model-element/SpatialPortalController.h
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -416,6 +416,11 @@ SpatialPortalController* HTMLModelElement::findPortalController() const
     return ancestor ? ancestor->spatialPortalController() : nullptr;
 }
 
+SpatialPortalController* HTMLModelElement::lastRegisteredPortalController() const
+{
+    return m_lastRegisteredPortalController.get();
+}
+
 void HTMLModelElement::updateSpatialPortalController()
 {
     CheckedPtr controller = findPortalController();
@@ -449,6 +454,10 @@ void HTMLModelElement::didFailLoadingInsidePortal(const ResourceError&)
 void HTMLModelElement::spatialPortalContextDidChange()
 {
     updateSpatialPortalController();
+
+#if ENABLE(MODEL_ELEMENT_STAGE_MODE)
+    updateStageMode();
+#endif
 
     queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [](auto& element) {
         element.deletePendingModelPlayer();
@@ -1552,6 +1561,11 @@ void HTMLModelElement::setCurrentTime(double currentTime)
 
 WebCore::StageModeOperation HTMLModelElement::stageMode() const
 {
+#if ENABLE(SPATIAL_PORTAL)
+    if (isInsidePortal())
+        return WebCore::StageModeOperation::None;
+#endif
+
     String attr = attributeWithoutSynchronization(HTMLNames::stagemodeAttr);
     if (equalLettersIgnoringASCIICase(attr, "orbit"_s))
         return WebCore::StageModeOperation::Orbit;
@@ -1573,12 +1587,10 @@ void HTMLModelElement::updateStageMode()
         addEventListener(eventNames().touchstartEvent, *m_eventListener, { });
         addEventListener(eventNames().touchmoveEvent, *m_eventListener, { });
         addEventListener(eventNames().touchendEvent, *m_eventListener, { });
-        document().didAddTouchEventHandler(*this);
     } else {
         removeEventListener(eventNames().touchstartEvent, *m_eventListener, { });
         removeEventListener(eventNames().touchmoveEvent, *m_eventListener, { });
         removeEventListener(eventNames().touchendEvent, *m_eventListener, { });
-        document().didRemoveTouchEventHandler(*this);
     }
 
 #endif

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -108,6 +108,7 @@ public:
     void didFinishLoadingInsidePortal();
     void didFailLoadingInsidePortal(const ResourceError&);
     void spatialPortalContextDidChange();
+    SpatialPortalController* lastRegisteredPortalController() const;
 #endif
 
     std::optional<PlatformLayerIdentifier> layerID() const;

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -195,6 +195,10 @@ void ModelPlayer::setPortalTransform(PortalTransformKind)
 {
 }
 
+void ModelPlayer::setPortalAction(PortalActionKind)
+{
+}
+
 #endif
 
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE)

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -47,6 +47,7 @@
 #endif
 
 #if ENABLE(SPATIAL_PORTAL)
+#include <WebCore/PortalAction.h>
 #include <WebCore/PortalTransform.h>
 #endif
 
@@ -161,6 +162,7 @@ public:
 
 #if ENABLE(SPATIAL_PORTAL)
     virtual void setPortalTransform(PortalTransformKind);
+    virtual void setPortalAction(PortalActionKind);
 #endif
 
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE)

--- a/Source/WebCore/Modules/model-element/PortalAction.h
+++ b/Source/WebCore/Modules/model-element/PortalAction.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(SPATIAL_PORTAL)
+
+namespace WebCore {
+
+enum class PortalActionKind : bool {
+    None,
+    Orbit,
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(SPATIAL_PORTAL)

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
@@ -28,11 +28,14 @@
 
 #if ENABLE(SPATIAL_PORTAL)
 
+#include "AbortSignal.h"
 #include "ContainerNodeInlines.h"
 #include "Document.h"
 #include "DocumentPage.h"
 #include "Element.h"
 #include "ElementInlines.h"
+#include "EventListener.h"
+#include "EventNames.h"
 #include "GraphicsLayer.h"
 #include "HTMLModelElement.h"
 #include "IntersectionObserver.h"
@@ -56,6 +59,23 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SpatialPortalController);
+
+#if ENABLE(TOUCH_EVENTS)
+class SpatialPortalEventListener final : public EventListener {
+public:
+    static Ref<SpatialPortalEventListener> create()
+    {
+        return adoptRef(*new SpatialPortalEventListener());
+    }
+
+    void handleEvent(ScriptExecutionContext&, Event&) override { }
+
+private:
+    explicit SpatialPortalEventListener()
+        : EventListener(EventListener::CPPEventListenerType)
+    { }
+};
+#endif
 
 class PortalModelPlayerClient final : public RefCounted<PortalModelPlayerClient>, public ModelPlayerClient {
 public:
@@ -177,13 +197,26 @@ private:
 SpatialPortalController::SpatialPortalController(Element& element)
     : m_portalElement(element)
 {
+#if ENABLE(MODEL_PROCESS)
+    if (RefPtr page = element.document().page())
+        m_page = *page;
+#endif
 }
 
 SpatialPortalController::~SpatialPortalController()
 {
     if (RefPtr observer = m_intersectionObserver)
         observer->disconnect();
+
+    ASSERT(!m_handlesGesture);
+
     deleteModelPlayer();
+}
+
+void SpatialPortalController::prepareForRemoval()
+{
+    m_portalAction = PortalActionKind::None;
+    updateGestureHandling();
 }
 
 unsigned SpatialPortalController::numberOfLoadedModels() const
@@ -341,6 +374,7 @@ ModelPlayer* SpatialPortalController::ensureModelPlayer()
         return nullptr;
 
     m_modelPlayer->setPortalTransform(m_portalTransform);
+    m_modelPlayer->setPortalAction(m_portalAction);
 
     return m_modelPlayer.get();
 }
@@ -355,6 +389,98 @@ void SpatialPortalController::setPortalTransform(PortalTransformKind kind)
     if (RefPtr player = m_modelPlayer)
         player->setPortalTransform(m_portalTransform);
 }
+
+void SpatialPortalController::setPortalAction(PortalActionKind kind)
+{
+    if (m_portalAction == kind)
+        return;
+
+    m_portalAction = kind;
+
+    if (RefPtr player = m_modelPlayer)
+        player->setPortalAction(m_portalAction);
+
+    updateGestureHandling();
+}
+
+void SpatialPortalController::updateGestureHandling()
+{
+    bool shouldHandleGesture = m_portalAction != PortalActionKind::None;
+    if (m_handlesGesture == shouldHandleGesture)
+        return;
+
+    m_handlesGesture = shouldHandleGesture;
+
+#if ENABLE(TOUCH_EVENTS)
+    if (RefPtr element = m_portalElement.get()) {
+        if (!m_eventListener)
+            m_eventListener = SpatialPortalEventListener::create();
+
+        if (shouldHandleGesture) {
+            element->addEventListener(eventNames().touchstartEvent, *m_eventListener, { });
+            element->addEventListener(eventNames().touchmoveEvent, *m_eventListener, { });
+            element->addEventListener(eventNames().touchendEvent, *m_eventListener, { });
+        } else {
+            element->removeEventListener(eventNames().touchstartEvent, *m_eventListener, { });
+            element->removeEventListener(eventNames().touchmoveEvent, *m_eventListener, { });
+            element->removeEventListener(eventNames().touchendEvent, *m_eventListener, { });
+        }
+    }
+#endif
+
+#if ENABLE(MODEL_PROCESS)
+    if (RefPtr page = m_page.get()) {
+        if (shouldHandleGesture)
+            page->incrementModelElementCount();
+        else
+            page->decrementModelElementCount();
+    }
+#endif
+}
+
+#if ENABLE(MODEL_ELEMENT_STAGE_MODE_INTERACTION)
+
+CheckedPtr<SpatialPortalController> SpatialPortalController::interactiveControllerForHitTestedElement(Element* element)
+{
+    if (!element)
+        return nullptr;
+
+    CheckedPtr controller = element->spatialPortalController();
+    if (!controller) {
+        if (RefPtr model = dynamicDowncast<HTMLModelElement>(*element))
+            controller = model->lastRegisteredPortalController();
+    }
+
+    if (!controller || !controller->supportsInteraction())
+        return nullptr;
+
+    return controller;
+}
+
+bool SpatialPortalController::supportsInteraction() const
+{
+    return m_portalAction != PortalActionKind::None;
+}
+
+void SpatialPortalController::beginStageModeTransform(const TransformationMatrix& transform)
+{
+    if (RefPtr player = m_modelPlayer)
+        player->beginStageModeTransform(transform);
+}
+
+void SpatialPortalController::updateStageModeTransform(const TransformationMatrix& transform)
+{
+    if (RefPtr player = m_modelPlayer)
+        player->updateStageModeTransform(transform);
+}
+
+void SpatialPortalController::endStageModeInteraction()
+{
+    if (RefPtr player = m_modelPlayer)
+        player->endStageModeInteraction();
+}
+
+#endif
 
 void SpatialPortalController::deleteModelPlayer()
 {

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.h
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.h
@@ -29,6 +29,7 @@
 
 #include "LayoutSize.h"
 #include <WebCore/NodeIdentifier.h>
+#include <WebCore/PortalAction.h>
 #include <WebCore/PortalTransform.h>
 #include <WebCore/TransformationMatrix.h>
 #include <wtf/CheckedPtr.h>
@@ -48,8 +49,10 @@ class IntersectionObserver;
 class Model;
 class ModelPlayer;
 class ModelPlayerProvider;
+class Page;
 class PortalModelPlayerClient;
 class ResourceError;
+class SpatialPortalEventListener;
 class WeakPtrImplWithEventTargetData;
 
 // Manages the portal / ModelPlayer for an element with `spatial: portal`.
@@ -62,11 +65,14 @@ public:
     explicit SpatialPortalController(Element&);
     ~SpatialPortalController();
 
+    void prepareForRemoval();
+
     void unregisterChildModel(HTMLModelElement&);
     void registerChildModel(HTMLModelElement&);
     void childModelDidChange(HTMLModelElement&);
 
     ModelPlayer* modelPlayer() const { return m_modelPlayer.get(); }
+    Element* portalElement() const { return m_portalElement.get(); }
     unsigned numberOfHostedModels() const { return m_hostedModels.size(); }
     WEBCORE_EXPORT unsigned numberOfLoadedModels() const;
     void configureGraphicsLayer(GraphicsLayer&, const Color& backgroundColor);
@@ -74,6 +80,16 @@ public:
 
     void setPortalTransform(PortalTransformKind);
     const std::optional<TransformationMatrix>& resolvedPortalTransform() const { return m_resolvedPortalTransform; }
+
+    void setPortalAction(PortalActionKind);
+
+#if ENABLE(MODEL_ELEMENT_STAGE_MODE_INTERACTION)
+    WEBCORE_EXPORT static CheckedPtr<SpatialPortalController> interactiveControllerForHitTestedElement(Element*);
+    WEBCORE_EXPORT bool supportsInteraction() const;
+    WEBCORE_EXPORT void beginStageModeTransform(const TransformationMatrix&);
+    WEBCORE_EXPORT void updateStageModeTransform(const TransformationMatrix&);
+    WEBCORE_EXPORT void endStageModeInteraction();
+#endif
 
     bool isPortalVisible() const;
 
@@ -96,6 +112,7 @@ private:
     void reconfigurePortalLayer();
     void observePortalVisibility();
     LayoutSize portalContentSize() const;
+    void updateGestureHandling();
 
     const WeakPtr<Element, WeakPtrImplWithEventTargetData> m_portalElement;
 
@@ -106,12 +123,20 @@ private:
     HashMap<NodeIdentifier, HostedModel> m_hostedModels;
 
     WeakPtr<ModelPlayerProvider> m_modelPlayerProvider;
+#if ENABLE(MODEL_PROCESS)
+    WeakPtr<Page> m_page;
+#endif
     RefPtr<ModelPlayer> m_modelPlayer;
     const RefPtr<PortalModelPlayerClient> m_playerClient;
     RefPtr<IntersectionObserver> m_intersectionObserver;
+#if ENABLE(TOUCH_EVENTS)
+    RefPtr<SpatialPortalEventListener> m_eventListener;
+#endif
     std::optional<LayoutSize> m_lastPushedContentSize;
     std::optional<TransformationMatrix> m_resolvedPortalTransform;
     PortalTransformKind m_portalTransform { PortalTransformKind::Auto };
+    PortalActionKind m_portalAction { PortalActionKind::None };
+    bool m_handlesGesture { false };
     bool m_isIntersectingViewport { false };
 };
 

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -82,7 +82,9 @@
 		0318396A0000000000000011 /* PathArcLengthMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0318396A0000000000000001 /* PathArcLengthMapper.h */; };
 		0318396A0000000000000013 /* PathCurveSubdivision.h in Headers */ = {isa = PBXBuildFile; fileRef = 0318396A0000000000000003 /* PathCurveSubdivision.h */; };
 		043934662F229202E82AB23F /* UnifiedSource55-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3230252036F492BB47909DD0 /* UnifiedSource55-header-RenderStyleGetters.cpp */; };
+		0A1B2C3D4E5F60718293A4B5 /* PortalAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F2E3D4C5B6A79880716253F /* PortalAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		053F6589A66D76BEEA136C23 /* PortalTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 329D390B53E4795024178E9D /* PortalTransform.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B6621299300A6EA900330D60 /* SpatialPortalController.h in Headers */ = {isa = PBXBuildFile; fileRef = B6621297300A6EA900330D60 /* SpatialPortalController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0562F9611573F88F0031CA16 /* PlatformLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0562F9601573F88F0031CA16 /* PlatformLayer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		056A7AC8256C4F48002F9DDC /* ShadowRootInit.h in Headers */ = {isa = PBXBuildFile; fileRef = 054E3A33256C3BD90072C5B9 /* ShadowRootInit.h */; };
 		056A7AC8256C4F48002F9DDF /* GetHTMLOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 054E3A33256C3BD90072C5BF /* GetHTMLOptions.h */; };
@@ -7926,6 +7928,7 @@
 		072DBC0725DC6EDA00A1350E /* JSMediaSessionCoordinator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSMediaSessionCoordinator.cpp; sourceTree = "<group>"; };
 		072F696C2E74FC2100281FC5 /* TextListParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextListParser.h; sourceTree = "<group>"; };
 		072F696E2E755BFA00281FC5 /* TextListParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextListParser.cpp; sourceTree = "<group>"; };
+		1F2E3D4C5B6A79880716253F /* PortalAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PortalAction.h; sourceTree = "<group>"; };
 		07307B792DA06AEC00A5EF65 /* MediaSessionManagerInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionManagerInterface.h; sourceTree = "<group>"; };
 		07307B912DA4B5C500A5EF65 /* PlatformMediaSessionInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformMediaSessionInterface.h; sourceTree = "<group>"; };
 		07354A272CD11FAC00D229CB /* MediaSourceConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSourceConfiguration.h; sourceTree = "<group>"; };
@@ -32078,6 +32081,7 @@
 				52597BB82DC412F500CAAF01 /* ModelPlayerTransformState.h */,
 				52597BE62DC6533200CAAF01 /* PlaceholderModelPlayer.cpp */,
 				52597BE52DC6533200CAAF01 /* PlaceholderModelPlayer.h */,
+				1F2E3D4C5B6A79880716253F /* PortalAction.h */,
 				329D390B53E4795024178E9D /* PortalTransform.h */,
 				B6621298300A6EA900330D60 /* SpatialPortalController.cpp */,
 				B6621297300A6EA900330D60 /* SpatialPortalController.h */,
@@ -47944,6 +47948,7 @@
 				ABC128770B33AA6D00C693D5 /* PopupMenuClient.h in Headers */,
 				BC3BE12B0E98092F00835588 /* PopupMenuStyle.h in Headers */,
 				37F567CE165358F400DDE92B /* PopupOpeningObserver.h in Headers */,
+				0A1B2C3D4E5F60718293A4B5 /* PortalAction.h in Headers */,
 				053F6589A66D76BEEA136C23 /* PortalTransform.h in Headers */,
 				86EB71C0298C0A0F00C1DC77 /* PortIdentifier.h in Headers */,
 				93F199DE08245E59001E9ABC /* Position.h in Headers */,
@@ -48712,6 +48717,7 @@
 				B9CA3B402CAB1D3E00B2607C /* SpatialImageControls.h in Headers */,
 				B6D814722EE0C6D400397547 /* SpatialImageTypes.h in Headers */,
 				626CDE0F1140424C001E5A68 /* SpatialNavigation.h in Headers */,
+				B6621299300A6EA900330D60 /* SpatialPortalController.h in Headers */,
 				BA4E976A2E3A52290033CC0D /* SpeculationRules.h in Headers */,
 				BA6920702E0E93A80014E98A /* SpeculationRulesMatcher.h in Headers */,
 				934950CD253943610099F171 /* SpeechRecognition.h in Headers */,

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7944,6 +7944,26 @@
                 "url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty"
             }
         },
+        "portal-action": {
+            "animation-type": "discrete",
+            "initial": "none",
+            "values": [
+                "none",
+                "orbit"
+            ],
+            "codegen-properties": {
+                "enable-if": "ENABLE_SPATIAL_PORTAL",
+                "settings-flag": "spatialPortalEnabled",
+                "computed-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "computed-style-storage-kind": "enum",
+                "computed-style-type": "PortalActionType",
+                "parser-grammar": "<<values>>"
+            },
+            "specification": {
+                "url": "https://webkit.github.io/explainers/css-spatial/Overview.html#stage-interactivity"
+            },
+            "status": "in development"
+        },
         "portal-transform": {
             "animation-type": "discrete",
             "initial": "auto",

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1988,3 +1988,4 @@ no-ellipsis
 
 // CSS Spatial Layout (spatial: portal)
 portal enable-if=ENABLE_SPATIAL_PORTAL
+orbit enable-if=ENABLE_SPATIAL_PORTAL

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5838,8 +5838,13 @@ SpatialPortalController* Element::spatialPortalController() const
 
 void Element::clearSpatialPortalController()
 {
-    if (hasRareData())
-        elementRareData()->setSpatialPortalController(nullptr);
+    if (!hasRareData())
+        return;
+
+    if (CheckedPtr controller = elementRareData()->spatialPortalController())
+        controller->prepareForRemoval();
+
+    elementRareData()->setSpatialPortalController(nullptr);
 }
 
 bool Element::establishesSpatialPortal() const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -82,7 +82,6 @@ class RenderTreePosition;
 class Settings;
 class ShadowRoot;
 class SpaceSplitString;
-class SpatialPortalController;
 class StylePropertyMap;
 class StylePropertyMapReadOnly;
 class Text;
@@ -95,6 +94,10 @@ class WebAnimation;
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 class AttachmentAssociatedElement;
+#endif
+
+#if ENABLE(SPATIAL_PORTAL)
+class SpatialPortalController;
 #endif
 
 enum CSSPropertyID : uint16_t;

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -75,6 +75,10 @@
 #import <WebKitAdditions/EventHandlerIOSTouch.cpp>
 #endif
 
+#if ENABLE(SPATIAL_PORTAL)
+#import "SpatialPortalController.h"
+#endif
+
 namespace WebCore {
 
 static RetainPtr<WebEvent>& currentEventSlot()
@@ -695,6 +699,19 @@ std::optional<NodeIdentifier> EventHandler::requestInteractiveModelElementAtPoin
     }
 
     RefPtr targetElement = hitTestedMouseEvent.hitTestResult().targetElement();
+
+#if ENABLE(SPATIAL_PORTAL)
+    if (CheckedPtr controller = SpatialPortalController::interactiveControllerForHitTestedElement(targetElement.get())) {
+        if (RefPtr portalElement = controller->portalElement()) {
+            auto transform = TransformationMatrix::identity;
+            transform.translate(clientPosition.x(), clientPosition.y());
+
+            controller->beginStageModeTransform(transform);
+            return portalElement->nodeIdentifier();
+        }
+    }
+#endif
+
     if (RefPtr modelElement = dynamicDowncast<HTMLModelElement>(targetElement)) {
         if (modelElement->supportsStageModeInteraction()) {
             auto transform = TransformationMatrix::identity;
@@ -717,6 +734,15 @@ void EventHandler::stageModeSessionDidUpdate(std::optional<NodeIdentifier> nodeI
     if (!node)
         return;
 
+#if ENABLE(SPATIAL_PORTAL)
+    if (RefPtr element = dynamicDowncast<Element>(node.get())) {
+        if (CheckedPtr controller = element->spatialPortalController(); controller && controller->supportsInteraction()) {
+            controller->updateStageModeTransform(transform);
+            return;
+        }
+    }
+#endif
+
     RefPtr modelElement = dynamicDowncast<HTMLModelElement>(node);
     if (!modelElement)
         return;
@@ -736,6 +762,15 @@ void EventHandler::stageModeSessionDidEnd(std::optional<NodeIdentifier> nodeID)
     RefPtr node = Node::fromIdentifier(*nodeID);
     if (!node)
         return;
+
+#if ENABLE(SPATIAL_PORTAL)
+    if (RefPtr element = dynamicDowncast<Element>(node.get())) {
+        if (CheckedPtr controller = element->spatialPortalController(); controller && controller->supportsInteraction()) {
+            controller->endStageModeInteraction();
+            return;
+        }
+    }
+#endif
 
     RefPtr modelElement = dynamicDowncast<HTMLModelElement>(node);
     if (!modelElement)

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -207,6 +207,13 @@ void RenderBox::willBeDestroyed()
             layoutContext().removeScrollerFromAnchorScrollAdjusters(*this);
     }
 
+#if ENABLE(SPATIAL_PORTAL)
+    if (hasInitializedStyle() && style().spatial() == SpatialType::Portal) {
+        if (RefPtr element = this->element())
+            element->clearSpatialPortalController();
+    }
+#endif
+
     RenderBoxModelObject::willBeDestroyed();
 }
 
@@ -362,6 +369,43 @@ static bool isNestedInsideSpatialPortal(const Element& element)
     return false;
 }
 
+// TODO: rdar://182292652
+static PortalTransformKind portalTransformKind(const Style::PortalTransform& portalTransform)
+{
+    return portalTransform.switchOn(
+        [](CSS::Keyword::None) { return PortalTransformKind::None; },
+        [](CSS::Keyword::Auto) { return PortalTransformKind::Auto; }
+    );
+}
+
+static PortalActionKind portalActionKind(PortalActionType portalAction)
+{
+    switch (portalAction) {
+    case PortalActionType::None:
+        return PortalActionKind::None;
+    case PortalActionType::Orbit:
+        return PortalActionKind::Orbit;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+// `portal-action: orbit` requires `auto` to be part of the `portal-transform`.
+static PortalActionKind usedPortalActionKind(PortalActionKind portalAction, PortalTransformKind portalTransform)
+{
+    if (portalTransform != PortalTransformKind::Auto)
+        return PortalActionKind::None;
+    return portalAction;
+}
+
+static void pushSpatialPortalProperties(Element& element, const Style::ComputedStyle& style)
+{
+    if (CheckedPtr controller = element.spatialPortalController()) {
+        auto portalTransform = portalTransformKind(style.portalTransform());
+        controller->setPortalTransform(portalTransform);
+        controller->setPortalAction(usedPortalActionKind(portalActionKind(style.portalAction()), portalTransform));
+    }
+}
+
 static void updateSpatialPortalController(Element& element)
 {
     bool hadController = element.establishesSpatialPortal();
@@ -373,6 +417,8 @@ static void updateSpatialPortalController(Element& element)
         element.clearSpatialPortalController();
 
     if (box && hadController != element.establishesSpatialPortal()) {
+        pushSpatialPortalProperties(element, box->style());
+
         if (CheckedPtr layer = box->layer())
             layer->setNeedsCompositingConfigurationUpdate();
     }
@@ -389,15 +435,6 @@ static void spatialPortalStyleDidChange(Element& element)
 
     for (Ref model : descendantsOfType<HTMLModelElement>(element))
         model->spatialPortalContextDidChange();
-}
-
-// TODO: rdar://182292652
-static PortalTransformKind portalTransformKind(const Style::PortalTransform& portalTransform)
-{
-    return portalTransform.switchOn(
-        [](CSS::Keyword::None) { return PortalTransformKind::None; },
-        [](CSS::Keyword::Auto) { return PortalTransformKind::Auto; }
-    );
 }
 #endif
 
@@ -483,7 +520,7 @@ void RenderBox::styleDidChange(Style::Difference diff, const Style::ComputedStyl
 
     if (isDocElementRenderer || isBodyRenderer) {
         protect(view())->frameView().recalculateScrollbarOverlayStyle();
-        
+
         if (diff != Style::DifferenceResult::Equal)
             view().compositor().rootOrBodyStyleChanged(*this, oldStyle);
     }
@@ -522,10 +559,8 @@ void RenderBox::styleDidChange(Style::Difference diff, const Style::ComputedStyl
         if (oldSpatial != newStyle.spatial())
             spatialPortalStyleDidChange(*element);
 
-        if (newStyle.spatial() == SpatialType::Portal) {
-            if (CheckedPtr controller = element->spatialPortalController())
-                controller->setPortalTransform(portalTransformKind(newStyle.portalTransform()));
-        }
+        if (newStyle.spatial() == SpatialType::Portal)
+            pushSpatialPortalProperties(*element, newStyle);
     }
 #endif
 }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1060,6 +1060,15 @@ TextStream& operator<<(TextStream& ts, SpatialType spatial)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, PortalActionType portalAction)
+{
+    switch (portalAction) {
+    case PortalActionType::None: ts << "None"_s; break;
+    case PortalActionType::Orbit: ts << "Orbit"_s; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, TextCombine textCombine)
 {
     switch (textCombine) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -292,6 +292,11 @@ enum class SpatialType : bool {
     Portal
 };
 
+enum class PortalActionType : bool {
+    None,
+    Orbit
+};
+
 enum class TextCombine : bool {
     None,
     All
@@ -1221,6 +1226,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, WebCore::Overflow);
 WTF::TextStream& operator<<(WTF::TextStream&, OverflowAlignment);
 WTF::TextStream& operator<<(WTF::TextStream&, OverflowWrap);
 WTF::TextStream& operator<<(WTF::TextStream&, PointerEvents);
+WTF::TextStream& operator<<(WTF::TextStream&, PortalActionType);
 WTF::TextStream& operator<<(WTF::TextStream&, PositionType);
 WTF::TextStream& operator<<(WTF::TextStream&, PrintColorAdjust);
 WTF::TextStream& operator<<(WTF::TextStream&, PseudoElementType);

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
@@ -108,6 +108,7 @@ NonInheritedRareData::NonInheritedRareData()
     , blockStepInsert(static_cast<unsigned>(ComputedStyle::initialBlockStepInsert()))
     , blockStepRound(static_cast<unsigned>(ComputedStyle::initialBlockStepRound()))
     , spatial(static_cast<unsigned>(SpatialType::None))
+    , portalAction(static_cast<unsigned>(PortalActionType::None))
     , overscrollBehaviorX(static_cast<unsigned>(ComputedStyle::initialOverscrollBehaviorX()))
     , overscrollBehaviorY(static_cast<unsigned>(ComputedStyle::initialOverscrollBehaviorY()))
     , transformStyle3D(static_cast<unsigned>(ComputedStyle::initialTransformStyle3D()))
@@ -221,6 +222,7 @@ inline NonInheritedRareData::NonInheritedRareData(const NonInheritedRareData& o)
     , blockStepInsert(o.blockStepInsert)
     , blockStepRound(o.blockStepRound)
     , spatial(o.spatial)
+    , portalAction(o.portalAction)
     , overscrollBehaviorX(o.overscrollBehaviorX)
     , overscrollBehaviorY(o.overscrollBehaviorY)
     , transformStyle3D(o.transformStyle3D)
@@ -339,6 +341,7 @@ bool NonInheritedRareData::operator==(const NonInheritedRareData& o) const
         && blockStepInsert == o.blockStepInsert
         && blockStepRound == o.blockStepRound
         && spatial == o.spatial
+        && portalAction == o.portalAction
         && overscrollBehaviorX == o.overscrollBehaviorX
         && overscrollBehaviorY == o.overscrollBehaviorY
         && transformStyle3D == o.transformStyle3D
@@ -497,6 +500,7 @@ void NonInheritedRareData::dumpDifferences(TextStream& ts, const NonInheritedRar
     LOG_IF_DIFFERENT_WITH_CAST(BlockStepInsert, blockStepInsert);
     LOG_IF_DIFFERENT_WITH_CAST(BlockStepRound, blockStepRound);
     LOG_IF_DIFFERENT_WITH_CAST(SpatialType, spatial);
+    LOG_IF_DIFFERENT_WITH_CAST(PortalActionType, portalAction);
 
     LOG_IF_DIFFERENT_WITH_CAST(OverscrollBehavior, overscrollBehaviorX);
     LOG_IF_DIFFERENT_WITH_CAST(OverscrollBehavior, overscrollBehaviorY);

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
@@ -219,6 +219,7 @@ public:
     PREFERRED_TYPE(BlockStepInsert) unsigned blockStepInsert : 2;
     PREFERRED_TYPE(BlockStepRound) unsigned blockStepRound : 2;
     PREFERRED_TYPE(SpatialType) unsigned spatial : 1;
+    PREFERRED_TYPE(PortalActionType) unsigned portalAction : 1;
 
     PREFERRED_TYPE(OverscrollBehavior) unsigned overscrollBehaviorX : 2;
     PREFERRED_TYPE(OverscrollBehavior) unsigned overscrollBehaviorY : 2;

--- a/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
+++ b/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
@@ -1010,6 +1010,12 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
+
+#define TYPE PortalActionType
+#define FOR_EACH(CASE) CASE(None) CASE(Orbit)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
 #endif
 
 constexpr CSSValueID toCSSValueID(Style::TextAlign e)

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -170,6 +170,7 @@ public:
     void setHasPortal(bool) final;
 #if ENABLE(SPATIAL_PORTAL)
     void setPortalTransform(WebCore::PortalTransformKind) final;
+    void setPortalAction(WebCore::PortalActionKind) final;
 #endif
     void setStageMode(WebCore::StageModeOperation) final;
     void beginStageModeTransform(const WebCore::TransformationMatrix&) final;
@@ -215,6 +216,7 @@ private:
     void applyEnvironmentMapDataAndRelease(CompletionHandler<void()>&&);
     void applyStageModeOperationToDriver();
     bool stageModeInteractionInProgress() const;
+    WebCore::StageModeOperation effectiveStageModeOperation() const;
     void updateTransformSRT();
     void notifyModelPlayerOfTransformChange();
     void applyDefaultIBL();
@@ -267,6 +269,7 @@ private:
     bool m_hasPortal { true };
 #if ENABLE(SPATIAL_PORTAL)
     WebCore::PortalTransformKind m_portalTransform { WebCore::PortalTransformKind::Auto };
+    WebCore::PortalActionKind m_portalAction { WebCore::PortalActionKind::None };
 #endif
 
     // For interactions

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -48,6 +48,7 @@ messages -> ModelProcessModelPlayerProxy {
     SetHasPortal(bool hasPortal)
 #if ENABLE(SPATIAL_PORTAL)
     [EnabledBy=SpatialPortalEnabled] SetPortalTransform(enum:uint8_t WebCore::PortalTransformKind kind)
+    [EnabledBy=SpatialPortalEnabled] SetPortalAction(enum:bool WebCore::PortalActionKind kind)
 #endif
     SetStageMode(enum:bool WebCore::StageModeOperation stagemodeOp)
     BeginStageModeTransform(WebCore::TransformationMatrix transform)

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -668,9 +668,9 @@ void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
     }
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    RESRT newSRT = computeSRT(m_layer.get(), boundingBoxExtents, boundingBoxCenter, boundingRadius, m_hasPortal, effectivePointsPerMeter(m_layer.get()), m_stageModeOperation, currentModelRotation, m_immersivePresentation);
+    RESRT newSRT = computeSRT(m_layer.get(), boundingBoxExtents, boundingBoxCenter, boundingRadius, m_hasPortal, effectivePointsPerMeter(m_layer.get()), effectiveStageModeOperation(), currentModelRotation, m_immersivePresentation);
 #else
-    RESRT newSRT = computeSRT(m_layer.get(), boundingBoxExtents, boundingBoxCenter, boundingRadius, m_hasPortal, effectivePointsPerMeter(m_layer.get()), m_stageModeOperation, currentModelRotation, false);
+    RESRT newSRT = computeSRT(m_layer.get(), boundingBoxExtents, boundingBoxCenter, boundingRadius, m_hasPortal, effectivePointsPerMeter(m_layer.get()), effectiveStageModeOperation(), currentModelRotation, false);
 #endif
     m_transformSRT = newSRT;
 
@@ -721,7 +721,7 @@ void ModelProcessModelPlayerProxy::updateTransformAfterLayout()
 {
     if (m_transformNeedsUpdateAfterNextLayout) {
         m_transformNeedsUpdateAfterNextLayout = false;
-        if (m_stageModeOperation == WebCore::StageModeOperation::None) {
+        if (effectiveStageModeOperation() == WebCore::StageModeOperation::None) {
             if (!m_entityTransformSetByScript)
                 computeTransform(false);
             updateTransform();
@@ -822,7 +822,7 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
     }
 
 #if HAVE(CORE_RE)
-    applyStageModeOperationToDriver();
+    [m_stageModeInteractionDriver setContainerTransformInPortal];
 #endif // HAVE(CORE_RE)
 
     if (m_entityTransformToRestore) {
@@ -835,7 +835,7 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
     }
 
 #if HAVE(CORE_RE)
-    [m_stageModeInteractionDriver setContainerTransformInPortal];
+    applyStageModeOperationToDriver();
 #endif // HAVE(CORE_RE)
 
     updateOpacity();
@@ -1329,7 +1329,7 @@ void ModelProcessModelPlayerProxy::resetModelTransformAfterDrag()
 void ModelProcessModelPlayerProxy::stageModeInteractionDidUpdateModel()
 {
 #if HAVE(CORE_RE)
-    if (stageModeInteractionInProgress() && m_modelRKEntity)
+    if (stageModeInteractionInProgress())
         updateTransformSRT();
 #endif
 }
@@ -1424,15 +1424,40 @@ void ModelProcessModelPlayerProxy::setPortalTransform(WebCore::PortalTransformKi
 
     m_portalTransform = kind;
 
-    computeTransform(m_stageModeOperation == WebCore::StageModeOperation::None);
+    computeTransform(effectiveStageModeOperation() == WebCore::StageModeOperation::None);
     updateTransform();
+}
+
+void ModelProcessModelPlayerProxy::setPortalAction(WebCore::PortalActionKind kind)
+{
+    if (m_portalAction == kind)
+        return;
+
+    m_portalAction = kind;
+
+    if (m_portalAction == WebCore::PortalActionKind::None) {
+        computeTransform(true);
+        updateTransform();
+    }
+
+    updateForCurrentStageMode();
 }
 
 #endif
 
+WebCore::StageModeOperation ModelProcessModelPlayerProxy::effectiveStageModeOperation() const
+{
+#if ENABLE(SPATIAL_PORTAL)
+    if (m_portalAction == WebCore::PortalActionKind::Orbit)
+        return WebCore::StageModeOperation::Orbit;
+#endif
+
+    return m_stageModeOperation;
+}
+
 void ModelProcessModelPlayerProxy::updateForCurrentStageMode()
 {
-    if (m_stageModeOperation != WebCore::StageModeOperation::None) {
+    if (effectiveStageModeOperation() != WebCore::StageModeOperation::None) {
         computeTransform(false);
 #if HAVE(CORE_RE)
         [m_containerEntityWrapper recenterEntityAtTransform:WKEntityTransform({ m_transformSRT.scale, m_transformSRT.rotation, m_transformSRT.translation })];
@@ -1490,7 +1515,7 @@ void ModelProcessModelPlayerProxy::updateTransformSRT()
 #if HAVE(CORE_RE)
 void ModelProcessModelPlayerProxy::applyStageModeOperationToDriver()
 {
-    switch (m_stageModeOperation) {
+    switch (effectiveStageModeOperation()) {
     case WebCore::StageModeOperation::Orbit: {
         [m_stageModeInteractionDriver operationDidUpdate:WKStageModeOperationOrbit];
         break;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1392,6 +1392,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::PlaybackTargetClientContextID': ['<WebCore/PlaybackTargetClientContextIdentifier.h>'],
         'WebCore::PluginInfo': ['<WebCore/PluginData.h>'],
         'WebCore::PolicyAction': ['<WebCore/FrameLoaderTypes.h>'],
+        'WebCore::PortalActionKind': ['<WebCore/PortalAction.h>'],
         'WebCore::PortalTransformKind': ['<WebCore/PortalTransform.h>'],
         'WebCore::NonSerializedDataIdentifier': ['<WebCore/NonSerializedDataIdentifier.h>'],
         'WebCore::PreserveResolution': ['<WebCore/ImageBufferBackend.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7004,6 +7004,9 @@ enum class WebCore::PortalTransformKind : uint8_t {
     None,
     Auto
 };
+
+header: <WebCore/PortalAction.h>
+enum class WebCore::PortalActionKind : bool;
 #endif
 
 header: <WebCore/FixedContainerEdges.h>

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -516,6 +516,15 @@ void ModelProcessModelPlayer::setPortalTransform(WebCore::PortalTransformKind ki
     send(Messages::ModelProcessModelPlayerProxy::SetPortalTransform(m_portalTransform));
 }
 
+void ModelProcessModelPlayer::setPortalAction(WebCore::PortalActionKind kind)
+{
+    if (m_portalAction == kind)
+        return;
+
+    m_portalAction = kind;
+    send(Messages::ModelProcessModelPlayerProxy::SetPortalAction(m_portalAction));
+}
+
 #endif
 
 void ModelProcessModelPlayer::setStageMode(WebCore::StageModeOperation stagemodeOp)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -135,6 +135,7 @@ private:
     void setHasPortal(bool) final;
 #if ENABLE(SPATIAL_PORTAL)
     void setPortalTransform(WebCore::PortalTransformKind) final;
+    void setPortalAction(WebCore::PortalActionKind) final;
 #endif
     void setStageMode(WebCore::StageModeOperation) final;
     void beginStageModeTransform(const WebCore::TransformationMatrix&) final;
@@ -160,6 +161,7 @@ private:
     bool m_hasPortal { true };
 #if ENABLE(SPATIAL_PORTAL)
     WebCore::PortalTransformKind m_portalTransform { WebCore::PortalTransformKind::Auto };
+    WebCore::PortalActionKind m_portalAction { WebCore::PortalActionKind::None };
 #endif
     WebCore::StageModeOperation m_stageModeOperation { WebCore::StageModeOperation::None };
     HashMap<WebCore::NodeIdentifier, NodeAnimationState> m_animationStates;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -77,6 +77,10 @@
 #import <WebCore/VisibleUnits.h>
 #import <wtf/text/StringToIntegerConversion.h>
 
+#if ENABLE(SPATIAL_PORTAL)
+#import <WebCore/SpatialPortalController.h>
+#endif
+
 namespace WebKit {
 
 static void focusedElementPositionInformation(WebPage& page, WebCore::Element& focusedElement, const InteractionInformationRequest& request, InteractionInformationAtPosition& info)
@@ -735,6 +739,13 @@ InteractionInformationAtPosition positionInformationForWebPage(WebPage& page, co
 #if ENABLE(MODEL_PROCESS)
     if (RefPtr modelElement = dynamicDowncast<WebCore::HTMLModelElement>(hitTestNode))
         info.isInteractiveModel = modelElement->model() && modelElement->supportsStageModeInteraction();
+#endif
+
+#if ENABLE(SPATIAL_PORTAL)
+    if (!info.isInteractiveModel) {
+        RefPtr element = dynamicDowncast<WebCore::Element>(hitTestNode);
+        info.isInteractiveModel = !!WebCore::SpatialPortalController::interactiveControllerForHitTestedElement(element.get());
+    }
 #endif
 
 #if ENABLE(MODEL_ELEMENT)


### PR DESCRIPTION
#### 6daf3354b443781966cd5717c06f7e9cc2a824d3
<pre>
Add initial `portal-action` support
<a href="https://bugs.webkit.org/show_bug.cgi?id=321293">https://bugs.webkit.org/show_bug.cgi?id=321293</a>
&lt;<a href="https://rdar.apple.com/182292331">rdar://182292331</a>&gt;

Reviewed by Mike Wyrzykowski.

Add initial `portal-orbit` support for Spatial Portals. Only `orbit` is
supported initially and it matches the `stagemode=orbit` behavior of
HTMLModelElement.

Tests: spatial-css/spatial-portal-action-dynamic.html
       spatial-css/spatial-portal-action-multi-model.html
       spatial-css/spatial-portal-action-off.html
       spatial-css/spatial-portal-action-parsing.html
       spatial-css/spatial-portal-action-requires-auto-transform.html
       spatial-css/spatial-portal-action.html
       spatial-css/spatial-portal-determines-if-scroll-gesture-updates-position-information.html
       spatial-css/spatial-portal-nested-model-stagemode.html

* LayoutTests/spatial-css/resources/spatial-portal-utils.js:
(const.createPortal):
(const.appendModel):
* LayoutTests/spatial-css/spatial-portal-action-dynamic-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-action-dynamic.html: Added.
* LayoutTests/spatial-css/spatial-portal-action-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-action-multi-model-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-action-multi-model.html: Added.
* LayoutTests/spatial-css/spatial-portal-action-off-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-action-off.html: Added.
* LayoutTests/spatial-css/spatial-portal-action-parsing-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-action-parsing.html: Added.
* LayoutTests/spatial-css/spatial-portal-action-requires-auto-transform-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-action-requires-auto-transform.html: Added.
* LayoutTests/spatial-css/spatial-portal-action.html: Added.
* LayoutTests/spatial-css/spatial-portal-determines-if-scroll-gesture-updates-position-information-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-determines-if-scroll-gesture-updates-position-information.html: Added.
* LayoutTests/spatial-css/spatial-portal-nested-model-stagemode-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-nested-model-stagemode.html: Added.
Add new tests covering:
- the &quot;fitting&quot; behavior with multiple models
- the relationship between `portal-action` and `portal-transform`
- the relationship between `portal-action` and the HTMLModelElement
  `stagemode` attribute
- the property parsing
- the gesture handlers / position information

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/model-element/PortalAction.h: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::willBeDestroyed):
(WebCore::portalTransformKind):
(WebCore::portalActionKind):
(WebCore::usedPortalActionKind):
(WebCore::pushSpatialPortalProperties):
(WebCore::updateSpatialPortalController):
(WebCore::spatialPortalStyleDidChange):
(WebCore::RenderBox::styleDidChange):
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp:
(WebCore::Style::NonInheritedRareData::NonInheritedRareData):
(WebCore::Style::NonInheritedRareData::operator== const):
(WebCore::Style::NonInheritedRareData::dumpDifferences const):
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.h:
* Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h:
Introduce the `portal-action` CSS property, defaults to `none`.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::lastRegisteredPortalController const):
(WebCore::HTMLModelElement::spatialPortalContextDidChange):
(WebCore::HTMLModelElement::stageMode const):
`stagemode` is ignore while the model is nested inside of a portal.
(WebCore::HTMLModelElement::updateStageMode):
Remove superfluous calls to `didAddTouchEventHandler` /
`didRemoveTouchEventHandler`.

* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::setPortalAction):
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/SpatialPortalController.cpp:
(WebCore::SpatialPortalController::SpatialPortalController):
(WebCore::SpatialPortalController::~SpatialPortalController):
(WebCore::SpatialPortalController::prepareForRemoval):
(WebCore::SpatialPortalController::ensureModelPlayer):
(WebCore::SpatialPortalController::setPortalAction):
(WebCore::SpatialPortalController::updateGestureHandling):
(WebCore::SpatialPortalController::interactiveControllerForHitTestedElement):
(WebCore::SpatialPortalController::supportsInteraction const):
(WebCore::SpatialPortalController::beginStageModeTransform):
(WebCore::SpatialPortalController::updateStageModeTransform):
(WebCore::SpatialPortalController::endStageModeInteraction):
* Source/WebCore/Modules/model-element/SpatialPortalController.h:
(WebCore::SpatialPortalController::portalElement const):
Add PortalAction and stage mode gesture support to the
SpatialPortalController.
Only configure gesture handlers / position information when the portal
wants orbit.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::clearSpatialPortalController):
Make sure we prepare (remove event handlers) before removging the
SpatialPortalController.

* Source/WebCore/dom/Element.h:
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::requestInteractiveModelElementAtPoint):
(WebCore::EventHandler::stageModeSessionDidUpdate):
(WebCore::EventHandler::stageModeSessionDidEnd):
* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
(WebKit::positionInformationForWebPage):
Add portal support to the StageMode hit-testing code.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::computeTransform):
(WebKit::ModelProcessModelPlayerProxy::updateTransformAfterLayout):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::stageModeInteractionDidUpdateModel):
(WebKit::ModelProcessModelPlayerProxy::setPortalTransform):
(WebKit::ModelProcessModelPlayerProxy::setPortalAction):
(WebKit::ModelProcessModelPlayerProxy::effectiveStageModeOperation const):
(WebKit::ModelProcessModelPlayerProxy::updateForCurrentStageMode):
(WebKit::ModelProcessModelPlayerProxy::applyStageModeOperationToDriver):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::setPortalAction):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
Implement `portal-action` for the ModelProcessModelPlayer.

Canonical link: <a href="https://commits.webkit.org/318961@main">https://commits.webkit.org/318961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6886bf037c3cf239fb8da1c69c30bd0f98441d84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189493 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143970 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0524265-3377-45c8-ba0f-b8a9bf156ab4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140123 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96949 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9de06672-d677-41a9-9c56-4341f215dbe0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120575 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fa300cc-cc57-4a3d-b05c-17a35ba70d3b) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178986 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42402 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40725 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152803 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40378 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/947 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191715 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160381 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149390 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40097 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53951 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149134 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43793 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126223 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121227 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52468 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15369 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51853 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52094 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51914 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->