### PR TITLE
[ANGLE] Fix --bot-mode crash when a test reports skipped or failed

### DIFF
--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.cpp
@@ -1619,16 +1619,25 @@ bool TestSuite::launchChildTestProcess(uint32_t batchId,
     return true;
 }
 
+// Records a result for the test named at the start of testName, which is a GTest status line with
+// its "[  FAILED  ] "-style prefix already stripped. Three shapes arrive here:
+//
+//   "Foo.Bar/ES2_Metal (1 ms)"                                plain test
+//   "Foo.Bar/ES2_Metal, where GetParam() = ES2_Metal (1 ms)"  parameterized test
+//   "2 tests, listed below:"                                  GTest's summary, not a test
+//
+// So the identifier is everything before the first space, comma or CR, and input without one is
+// skipped. The comma is easy to miss, since leaving it attached still parses but matches no test.
 void ParseTestIdentifierAndSetResult(const std::string &testName,
                                      TestResultType result,
                                      TestResults *results)
 {
-    // Trim off any whitespace + extra stuff at the end of the string.
-    std::string modifiedTestName = testName.substr(0, testName.find(' '));
-    modifiedTestName             = modifiedTestName.substr(0, testName.find('\r'));
+    std::string modifiedTestName = testName.substr(0, testName.find_first_of(" ,\r"));
     TestIdentifier id;
-    bool ok = TestIdentifier::ParseFromString(modifiedTestName, &id);
-    ASSERT(ok);
+    if (!TestIdentifier::ParseFromString(modifiedTestName, &id))
+    {
+        return;
+    }
     results->results[id] = {result};
 }
 
@@ -1637,9 +1646,21 @@ bool TestSuite::finishProcess(ProcessInfo *processInfo)
     // Get test results and merge into main list.
     TestResults batchResults;
 
+    // Timings come from the child's results file. Without it the results below are reconstructed
+    // from the child's stdout, which carries no durations, so remember that and print no timing
+    // rather than the default 0.0, which would be misleading.
+    bool haveTimings = true;
+
     if (!GetTestResultsFromFile(processInfo->resultsFileName.c_str(), &batchResults))
     {
+        haveTimings = false;
+
+#if defined(ANGLE_HAS_RAPIDJSON)
+        // Children write results on both normal exit and crash/timeout, so a missing one means this
+        // child died before either path ran. Without RapidJSON nothing writes them at all, so this
+        // would warn on every batch and mean nothing.
         std::cerr << "Warning: could not find test results file from child process.\n";
+#endif  // defined(ANGLE_HAS_RAPIDJSON)
 
         // First assume all tests get skipped.
         for (const TestIdentifier &id : processInfo->testsInBatch)
@@ -1731,7 +1752,14 @@ bool TestSuite::finishProcess(ProcessInfo *processInfo)
         }
         else if (result.type == TestResultType::Pass)
         {
-            printf(" (%0.1lf ms)\n", result.elapsedTimeSeconds.back() * 1000.0);
+            if (haveTimings)
+            {
+                printf(" (%0.1lf ms)\n", result.elapsedTimeSeconds.back() * 1000.0);
+            }
+            else
+            {
+                printf("\n");
+            }
         }
         else if (result.type == TestResultType::Skip)
         {
@@ -1865,6 +1893,13 @@ int TestSuite::run()
         }
         return retVal;
     }
+
+#if !defined(ANGLE_HAS_RAPIDJSON)
+    printf(
+        "Note: built without RapidJSON, so no results files are written. --results-file and "
+        "--histogram-json-file are no-ops, and batch results are reconstructed from child stdout, "
+        "which carries no per-test timings.\n");
+#endif  // !defined(ANGLE_HAS_RAPIDJSON)
 
     Timer totalRunTime;
     totalRunTime.start();
@@ -2007,11 +2042,18 @@ int TestSuite::printFailuresAndReturnCount() const
         }
         else if (result.type != TestResultType::Pass)
         {
-            const FileLine &fileLine = mTestFileLines.find(id)->second;
+            // Reconstructed results can name a test this process never enumerated, so the lookup
+            // may fail.
+            auto fileLineIter = mTestFileLines.find(id);
 
             std::stringstream failureMessage;
-            failureMessage << id << " (" << fileLine.file << ":" << fileLine.line << ") ("
-                           << ResultTypeToString(result.type) << ")";
+            failureMessage << id;
+            if (fileLineIter != mTestFileLines.end())
+            {
+                failureMessage << " (" << fileLineIter->second.file << ":"
+                               << fileLineIter->second.line << ")";
+            }
+            failureMessage << " (" << ResultTypeToString(result.type) << ")";
             failures.emplace_back(failureMessage.str());
         }
     }


### PR DESCRIPTION
#### ecc30f20f7b490d07e8d78ccc8afee761f1e47f9
<pre>
[ANGLE] Fix --bot-mode crash when a test reports skipped or failed
<a href="https://bugs.webkit.org/show_bug.cgi?id=321300">https://bugs.webkit.org/show_bug.cgi?id=321300</a>
<a href="https://rdar.apple.com/184340969">rdar://184340969</a>

Reviewed by NOBODY (OOPS!).

When an ANGLE test suite is run in bot-mode, the test list is split into batches and each
one runs in its own child process, handing the child a --results-file and merging back
what it writes. WebKit builds ANGLE without RapidJSON, which compiles out both the writer
and the reader, so the parent silently falls back to scraping results out of child stdout.
That fallback mis-parses two kinds of GTest output.

GTest&apos;s end-of-run summary reuses the per-test status prefixes:

  [  SKIPPED ] 1 test, listed below:
  [  SKIPPED ] DebugTest.TimerQueryObjectLabelsEXT/ES1_Metal

Only the second line names a test, but both matched, so &quot;1 test, listed below:&quot; was fed
in as a test name. It failed to parse, which tripped an ASSERT in debug and inserted an
empty TestIdentifier in release, colliding on the next batch and killing the run.

For parameterized tests GTest appends &quot;, where GetParam() = ...&quot; to the status line:

  [  FAILED  ] WebGLCompatibilityTest.DepthRange/ES2_Metal, where GetParam() = ES2_Metal (127 ms)

Trimming at the first space kept the trailing comma, so the name became
&quot;WebGLCompatibilityTest.DepthRange/ES2_Metal,&quot; and matched no real test.
GTest prints that annotation only on failing results, so the &quot;[ RUN      ] &quot; line for the
same test yielded the correct name, which the scraper marks Crash until a completion line
arrives for it. That completion line went to the comma name instead, so a single failing test
produced two wrong entries:

  [1/2] WebGLCompatibilityTest.DepthRange/ES2_Metal (CRASH)
  [2/2] WebGLCompatibilityTest.DepthRange/ES2_Metal, (FAIL)

The comma name is absent from mTestFileLines, and the lookup there was unchecked, so
printFailuresAndReturnCount() crashed on the missing entry. Skip lines that yield no
identifier, trim at the first space, comma or CR, and check the mTestFileLines lookup
before using it.

The per-batch &quot;could not find test results file&quot; warning is meant to flag a child that
died before writing one, but nothing writes them here, so it fired on every batch. Change
to write a single note at startup.

Results scraped from stdout also carry no durations, so every passing test printed
&quot;(0.0 ms)&quot; from elapsedTimeSeconds&apos; initial value. Remove as it is not correct.

Serial runs are untouched, as every change sits after the !mBotMode early return in
TestSuite::run().

* Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.cpp:
(angle::ParseTestIdentifierAndSetResult):
(angle::TestSuite::finishProcess):
(angle::TestSuite::run):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecc30f20f7b490d07e8d78ccc8afee761f1e47f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189263 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143740 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd6d61a1-02d8-4cba-8275-ab5e547015f5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53080 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139923 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96821 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4cb01c42-3f74-4669-b485-098ef0184217) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120375 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9d4e9800-0f1f-412e-ac5a-e13948bbc1b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42202 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40533 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152602 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40175 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/esm-integration/execute-start.tentative.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/716 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191481 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/178834 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53040 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149181 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53721 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148924 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43598 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120888 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52238 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15165 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51623 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51864 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51684 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->