### PR TITLE
Cherry-pick 2f80bcf1940f. https://bugs.webkit.org/show_bug.cgi?id=313866

### DIFF
--- a/LayoutTests/fast/shadow-dom/manual-slot-assign-renderer-teardown-crash-expected.txt
+++ b/LayoutTests/fast/shadow-dom/manual-slot-assign-renderer-teardown-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/shadow-dom/manual-slot-assign-renderer-teardown-crash.html
+++ b/LayoutTests/fast/shadow-dom/manual-slot-assign-renderer-teardown-crash.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<body>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function setup(ghosts, pumps) {
+    const host = document.body.appendChild(document.createElement('div'));
+    const shadowRoot = host.attachShadow({ mode: 'open', slotAssignment: 'manual' });
+
+    const targetSlot = shadowRoot.appendChild(document.createElement('slot'));
+    const otherSlot = shadowRoot.appendChild(document.createElement('slot'));
+    const childA = host.appendChild(document.createElement('span'));
+    const childB = host.appendChild(document.createElement('span'));
+    targetSlot.assign(childA);
+    otherSlot.assign(childB);
+
+    // Insert and remove ghost slots so m_slots accumulates entries whose WeakPtr keys go null after GC.
+    for (let i = 0; i < ghosts; ++i)
+        shadowRoot.appendChild(document.createElement('slot')).remove();
+
+    return { host, targetSlot, pumps };
+}
+
+function trigger({ host, targetSlot, pumps }) {
+    // Advance the WeakHashMap operation counter toward its amortized-cleanup threshold.
+    for (let i = 0; i < pumps; ++i)
+        targetSlot.assignedNodes();
+
+    // Reassigning targetSlot tears down renderers; the composed-tree iterator visits otherSlot,
+    // re-enters assignedNodesForSlot, and may trigger a rehash that frees the bucket array.
+    targetSlot.assign(host.appendChild(document.createElement('span')));
+    host.remove();
+}
+
+// Each case uses its own shadow root (its own m_slots), and GC only nulls the ghost WeakPtr keys
+// without touching the operation counter, so building every case before a single GCController.collect()
+// is equivalent to collecting per case but avoids ~1000 separate full GCs.
+//
+// The reentrant rehash fires when the WeakHashMap operation counter crosses its amortized-cleanup
+// threshold, which is reset to 2 * table size after each cleanup. With ~ghosts entries in the table
+// that threshold sits near 2 * ghosts, so sweep a band of pump counts bracketing it.
+const cases = [];
+for (let ghosts = 20; ghosts <= 100; ghosts += 10)
+    for (let pumps = ghosts; pumps <= ghosts * 3; ++pumps)
+        cases.push(setup(ghosts, pumps));
+
+if (window.GCController)
+    GCController.collect();
+
+// One layout pass gives every host a renderer so tearDownRenderersAfterSlotChange traverses the
+// composed tree. Doing it once up front (rather than per case) avoids O(n^2) relayout, since each
+// host.remove() below would otherwise re-dirty the document for the next case's forced layout.
+document.body.offsetHeight;
+
+for (const testCase of cases)
+    trigger(testCase);
+
+document.body.textContent = 'This test passes if it does not crash.';
+</script>
+</body>

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -544,15 +544,19 @@ void ManualSlotAssignment::slotManualAssignmentDidChange(HTMLSlotElement& slot, 
     }
 
     ++m_slottableVersion;
-    auto effectiveCurrent = assignedNodesForSlot(slot, shadowRoot);
+    // Compute effectiveCurrent as a local copy rather than via assignedNodesForSlot, which would
+    // return a raw pointer into m_slots. tearDownRenderersAfterSlotChange below can re-enter
+    // assignedNodesForSlot via ComposedTreeIterator and trigger a WeakHashMap rehash, freeing the
+    // bucket array such a pointer would address.
+    auto effectiveCurrent = effectiveAssignedNodes(shadowRoot, current);
 
     auto scheduleSlotChangeEventIfNeeded = [&]() {
-        if (effectivePrevious.size() != (effectiveCurrent ? effectiveCurrent->size() : 0)) {
+        if (effectivePrevious.size() != effectiveCurrent.size()) {
             slot.enqueueSlotChangeEvent();
             return;
         }
-        for (unsigned i = 0; i < effectivePrevious.size();++i) {
-            if (effectivePrevious[i] != effectiveCurrent->at(i)) {
+        for (unsigned i = 0; i < effectivePrevious.size(); ++i) {
+            if (effectivePrevious[i] != effectiveCurrent[i]) {
                 slot.enqueueSlotChangeEvent();
                 return;
             }

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1371,7 +1371,10 @@ void NetworkConnectionToWebProcess::removeStorageAccessForFrame(FrameIdentifier 
 
 void NetworkConnectionToWebProcess::logUserInteraction(RegistrableDomain&& domain)
 {
-    MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, domain) == NetworkProcess::AllowCookieAccess::Allow);
+    if (m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, domain) != NetworkProcess::AllowCookieAccess::Allow) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
 
     if (CheckedPtr networkSession = this->networkSession()) {
         if (RefPtr resourceLoadStatistics = networkSession->resourceLoadStatistics())

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1409,13 +1409,17 @@ void NetworkResourceLoader::continueWillSendRedirectedRequest(ResourceRequest&& 
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler({ });
+    
+        Ref connection = protectedThis->m_connection;
+        if (!connection->connection().isValid())
+            return completionHandler({ });
+
+        if (newRequest.isNull())
+            return completionHandler({ });
 
         if (newRequest.firstPartyForCookies() != firstPartyForCookiesFromRedirectRequest) {
-            Ref connection = protectedThis->m_connection;
-            auto allowCookieAccess = connection->networkProcess().allowsFirstPartyForCookies(
-                connection->webProcessIdentifier(), newRequest.firstPartyForCookies());
-            MESSAGE_CHECK_COMPLETION_BASE(allowCookieAccess == NetworkProcess::AllowCookieAccess::Allow,
-                connection->connection(), completionHandler({ }));
+            auto allowCookieAccess = connection->networkProcess().allowsFirstPartyForCookies(connection->webProcessIdentifier(), newRequest.firstPartyForCookies());
+            MESSAGE_CHECK_COMPLETION_BASE(allowCookieAccess == NetworkProcess::AllowCookieAccess::Allow, connection->connection(), completionHandler({ }));
         }
 
         protectedThis->continueWillSendRequest(WTF::move(newRequest), isAllowedToAskUserForCredentials, WTF::move(completionHandler));


### PR DESCRIPTION
#### 9879ca6dcc00d46a565b361623760242f007510f
<pre>
Cherry-pick 2f80bcf1940f. <a href="https://bugs.webkit.org/show_bug.cgi?id=313866">https://bugs.webkit.org/show_bug.cgi?id=313866</a>

Unreviewed backport.

    WebResourceLoader::WillSendRequest reply may lead to cross-origin cookie access
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313866">https://bugs.webkit.org/show_bug.cgi?id=313866</a>
    <a href="https://rdar.apple.com/180785211">rdar://180785211</a>

    Reviewed by Charlie Wolfe.

    Consider this sequence of events:
    1. A compromised web process schedules a load with its own origin used for
       firstPartyForCookies.
    2. NetworkConnectionToWebProcess::scheduleResourceLoad() is called and the
       message check passes.
    3. The request goes through and the server responds with 302 (redirect).
    4. NetworkResourceLoader::continueWillSendRedirectedRequest() calls
       WebResourceLoader::WillSendRequest() which gives the web process the chance
       to alter the request that will be sent to perform the redirect.
    5. The compromised web process alters the request so that firstPartyForCookies
       is now a different origin.
    6. NetworkResourceLoader::continueWillSendRequest() receives this altered
       request and passes it off to CFNetwork.
    7. The result of this request is that the compromised web process receives
       the cookies of this different origin.

    There are multiple callsites of continueWillSendRequest(), but only one place
    which allows the web process to alter the request before it&apos;s given to
    continueWillSendRequest(). So we fix this by adding a message check right
    before that callsite that will double check that the origin contained in this
    potentially modified request from the web process is in this web process&apos;s
    allowed list. If not, the web process will be killed so that it doesn&apos;t recieve
    the cross-origin cookies.

    We also only do this message check if the web process actually changes the
    origin. This is because there are cases where the origin is not yet in the
    allowlist but not because the web process modified it (like in:
    imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html?origin=cross-site-redirect
    where there is a cross-site redirect as part of a prefetch, so the cross-site
    origin is supplied by the server but hasn&apos;t made it into the allow list since
    the navigation to it is not complete).

    When we a previously attempted to add this message check, we found that it
    resulted in users hitting the message check in the wild. Based on the fault logs,
    we speculate that the issue could be:

    1. A network load is scheduled with the keep alive option.
    2. NetworkResourceLoader::continueWillSendRedirectedRequest() sends the IPC
       WebResourceLoader::WillSendRequest().
    3. Before the web process can respond, it exits. So the web process does not
       call the completion handler.
    4. The IPC connection between the network and web process is torn down by
       Connection::dispatchDidCloseAndInvalidate().
    5. This function first calls NetworkProcessConnectionToWebProcess::didClose()
       which keeps the NetworkResourceLoader alive because of the keepalive option
       and removes the web process from m_allowedFirstPartiesForCookies.
    6. Then it calls Connection::invalidate() which calls cancelAsyncReplyHandlers()
       which calls the completionHandler with a default constructed ResourceRequest.
    7. In the completionHandler, the NetworkResourceLoader is alive and the default
       constructed request&apos;s firstPartyForCookies is empty (which doesn&apos;t match the
       likely non-empty stored firstPartyForCookiesFromRedirectRequest), so we
       proceed to the check. Since the web process is no longer in
       m_allowedFirstPartiesForCookies, allowsFirstPartyForCookies returns Disallow
       and the message check is hit.

    So if the completionHandler is called because of the web process exiting (and
    thus the connection being torn down), we early return before doing the check.

    We also early return in the case where WebResourceLoader::willSendRequest()
    responds with a default constucted ResourceRequest if there is no coreLoader.

    * Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
    (WebKit::NetworkResourceLoader::continueWillSendRedirectedRequest):

    Identifier: 305413.1058@safari-7624.5-branch

    Canonical link: <a href="https://commits.webkit.org/305413.1017@safari-7624.4-branch">https://commits.webkit.org/305413.1017@safari-7624.4-branch</a>

Canonical link: <a href="https://commits.webkit.org/305877.1060@webkitglib/2.52">https://commits.webkit.org/305877.1060@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 520c31517003e2fdfa33e01cf9628fda9f4bf01e
<pre>
Cherry-pick 8d9bf389bc0f. <a href="https://bugs.webkit.org/show_bug.cgi?id=318244">https://bugs.webkit.org/show_bug.cgi?id=318244</a>

    Validate several ITP and storage access IPC messages
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318244">https://bugs.webkit.org/show_bug.cgi?id=318244</a>
    <a href="https://rdar.apple.com/180785498">rdar://180785498</a>

    Reviewed by Matthew Finkel.

    This relands the validation that was reverted in <a href="https://rdar.apple.com/180738421">rdar://180738421</a>. Telemetry indicates the
    LogUserInteraction MESSAGE_CHECK could rarely fail. It is unclear how this could happen, so it has
    been replaced with an early return and assertion to avoid crashing the WebContent process.

    Test: ipc/forged-resource-load-statistics-storage-access.html

    * LayoutTests/ipc/forged-resource-load-statistics-storage-access-expected.txt: Added.
    * LayoutTests/ipc/forged-resource-load-statistics-storage-access.html: Added.
    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
    (WebKit::NetworkConnectionToWebProcess::logUserInteraction):
    (WebKit::resourceLoadStatisticsContainsOnlyObservableFields):
    (WebKit::NetworkConnectionToWebProcess::resourceLoadStatisticsUpdated):
    (WebKit::NetworkConnectionToWebProcess::requestStorageAccessUnderOpener):

    Identifier: 305413.1052@safari-7624.5-branch

    Canonical link: <a href="https://commits.webkit.org/305413.1015@safari-7624.4-branch">https://commits.webkit.org/305413.1015@safari-7624.4-branch</a>

Canonical link: <a href="https://commits.webkit.org/305877.1059@webkitglib/2.52">https://commits.webkit.org/305877.1059@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### be936366954ae571e3e05653255b58e6615d474a
<pre>
Cherry-pick ddc8b3fae09f. <a href="https://bugs.webkit.org/show_bug.cgi?id=317552">https://bugs.webkit.org/show_bug.cgi?id=317552</a>

    UAF in ManualSlotAssignment via WeakHashMap rehash during reentrant composed-tree teardown
    <a href="https://bugs.webkit.org/show_bug.cgi?id=REDACTED">https://bugs.webkit.org/show_bug.cgi?id=REDACTED</a>
    <a href="https://rdar.apple.com/179729192">rdar://179729192</a>

    Reviewed by Anne van Kesteren.

    ManualSlotAssignment::slotManualAssignmentDidChange computed effectiveCurrent
    by calling assignedNodesForSlot, which returns a raw pointer to the
    cachedAssignment Vector inside a Slot value stored directly in the m_slots
    WeakHashMap bucket array. It then called
    RenderTreeUpdater::tearDownRenderersAfterSlotChange, whose composed-tree
    traversal can call HTMLSlotElement::assignedNodes on a sibling slot and
    re-enter ManualSlotAssignment::assignedNodesForSlot. The reentrant
    m_slots.ensure call may invoke the WeakHashMap amortized cleanup, sweep
    null-keyed entries left by previously inserted, removed and GC-collected slot
    elements, and rehash the table, freeing the bucket array effectiveCurrent
    points into. The stale pointer was then dereferenced in
    scheduleSlotChangeEventIfNeeded.

    Compute effectiveCurrent as a local Vector via effectiveAssignedNodes,
    mirroring effectivePrevious, so no pointer into m_slots is held across the
    render-tree teardown.

    * LayoutTests/fast/shadow-dom/manual-slot-assign-renderer-teardown-crash-expected.txt: Added.
    * LayoutTests/fast/shadow-dom/manual-slot-assign-renderer-teardown-crash.html: Added.
    * Source/WebCore/dom/SlotAssignment.cpp:
    (WebCore::ManualSlotAssignment::slotManualAssignmentDidChange):

    Identifier: 305413.1004@safari-7624.5-branch

    Canonical link: <a href="https://commits.webkit.org/305413.1001@safari-7624.4-branch">https://commits.webkit.org/305413.1001@safari-7624.4-branch</a>

Canonical link: <a href="https://commits.webkit.org/305877.1058@webkitglib/2.52">https://commits.webkit.org/305877.1058@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e9b3eb55a4e0bb1f11600973a0f365284bfc815

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179492 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53431 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47228 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189324 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143801 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181355 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54725 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53142 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143801 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182449 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54725 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47228 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/120425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54725 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53142 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47228 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54725 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47228 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/778 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46037 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53142 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191545 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53101 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47228 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53782 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47228 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/148978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27247 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53782 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126054 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120952 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52299 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47228 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51684 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51925 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51745 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->