### PR TITLE
Cherry-pick 318775@main (a1678ffa5ff1). https://bugs.webkit.org/show_bug.cgi?id=321157

### DIFF
--- a/LayoutTests/fast/selectors/focus-visible-script-focus-after-dialog-dismiss-expected.txt
+++ b/LayoutTests/fast/selectors/focus-visible-script-focus-after-dialog-dismiss-expected.txt
@@ -1,0 +1,6 @@
+Dismissing a modal dialog by clicking a close button inside it, and restoring focus to the element that opened it, should not show :focus-visible on that element.
+
+Open
+
+PASS focus() restored after dismissing a modal <dialog> should not show :focus-visible
+

--- a/LayoutTests/fast/selectors/focus-visible-script-focus-after-dialog-dismiss.html
+++ b/LayoutTests/fast/selectors/focus-visible-script-focus-after-dialog-dismiss.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>:focus-visible should not match when focus is restored after dismissing a modal dialog</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        *:focus,
+        *:focus-visible {
+            outline: none;
+        }
+        #trigger:focus-visible {
+            outline: 3px solid red;
+        }
+        #close {
+            width: 60px;
+            height: 30px;
+        }
+    </style>
+</head>
+<body>
+    <p>Dismissing a modal dialog by clicking a close button inside it, and restoring focus to the
+    element that opened it, should not show :focus-visible on that element.</p>
+
+    <button id="trigger" type="button">Open</button>
+
+    <dialog id="dialog">
+        <button id="close" type="button" aria-label="Close"></button>
+    </dialog>
+
+    <script>
+    // showModal()'s focusing steps reset the document's recorded focus trigger,
+    // so unlike the [tabindex] variant of this test, this one does not
+    // depend on being the document's first interaction.
+    promise_test(async t => {
+        const trigger = document.getElementById("trigger");
+        const dialog = document.getElementById("dialog");
+        const close = document.getElementById("close");
+        t.add_cleanup(() => { if (dialog.open) dialog.close(); trigger.blur(); });
+
+        dialog.showModal();
+        dialog.focus();
+
+        // The dialog itself must be focused: an open <dialog> can be focused by clicking, so a
+        // click inside it finds an ancestor that can take focus yet leaves the focus unchanged.
+        assert_equals(document.activeElement, dialog, "dialog should be focused while open");
+
+        close.addEventListener("click", () => { dialog.close(); trigger.focus(); }, { once: true });
+
+        // #close is empty, so the click lands on the button itself, and clicking a <button> does
+        // not focus it on macOS or iOS.
+        const rect = close.getBoundingClientRect();
+        await UIHelper.activateAt(rect.x + rect.width / 2, rect.y + rect.height / 2);
+
+        assert_equals(document.activeElement, trigger, "trigger should be focused after dismissal");
+        assert_false(trigger.matches(":focus-visible"),
+            ":focus-visible should not match on the opener after focus() restored from dismissing the dialog");
+    }, "focus() restored after dismissing a modal <dialog> should not show :focus-visible");
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/selectors/focus-visible-script-focus-inside-focused-ancestor-expected.txt
+++ b/LayoutTests/fast/selectors/focus-visible-script-focus-inside-focused-ancestor-expected.txt
@@ -1,0 +1,7 @@
+Clicking a button that is not mouse-focusable should record a click focus trigger, even when the button is inside an ancestor which is focusable and already focused, so that a later element.focus() does not show :focus-visible.
+
+Open
+
+
+PASS focus() after clicking a non-mouse-focusable button inside an already-focused ancestor should not show :focus-visible
+

--- a/LayoutTests/fast/selectors/focus-visible-script-focus-inside-focused-ancestor.html
+++ b/LayoutTests/fast/selectors/focus-visible-script-focus-inside-focused-ancestor.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>:focus-visible should not match after focus() following a click inside a focused ancestor</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        *:focus,
+        *:focus-visible {
+            outline: none;
+        }
+        #trigger:focus-visible {
+            outline: 3px solid red;
+        }
+        #close {
+            width: 60px;
+            height: 30px;
+        }
+    </style>
+</head>
+<body>
+    <p>Clicking a button that is not mouse-focusable should record a click focus trigger, even when
+    the button is inside an ancestor which is focusable and already focused, so that a later
+    element.focus() does not show :focus-visible.</p>
+
+    <button id="trigger" type="button">Open</button>
+
+    <div id="container" tabindex="-1"><button id="close" type="button"></button></div>
+
+    <script>
+    // This must be the document's first user interaction. Once a click has been recorded, nothing
+    // resets it -- a programmatic focus() deliberately leaves the recorded trigger alone -- so a
+    // second click-based test in this document would pass regardless of the behavior under test.
+    promise_test(async t => {
+        const trigger = document.getElementById("trigger");
+        const container = document.getElementById("container");
+        const close = document.getElementById("close");
+
+        // Focusing by script does not record a click trigger, so the container is focused but the
+        // document has still never seen a click.
+        container.focus();
+        assert_equals(document.activeElement, container, "container should be focused");
+
+        close.addEventListener("click", () => { trigger.focus(); }, { once: true });
+
+        // #close is empty, so the click lands on the button itself, and clicking a <button> does
+        // not focus it on macOS or iOS.
+        const rect = close.getBoundingClientRect();
+        await UIHelper.activateAt(rect.x + rect.width / 2, rect.y + rect.height / 2);
+
+        assert_equals(document.activeElement, trigger, "trigger should be focused");
+        assert_false(trigger.matches(":focus-visible"),
+            ":focus-visible should not match on trigger after focus() from a click on a button inside an already-focused ancestor");
+    }, "focus() after clicking a non-mouse-focusable button inside an already-focused ancestor should not show :focus-visible");
+    </script>
+</body>
+</html>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3409,8 +3409,9 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
     // Form control elements are not mouse focusable on some platforms (see HTMLFormControlElement::isMouseFocusable())
     // which makes us behave differently than other browsers when a button is clicked,
     // because the button is not actually focused so we don't set the latest FocusTrigger.
-    if (!element && m_elementUnderMouse) {
-        for (RefPtr ancestor = m_elementUnderMouse.get(); ancestor; ancestor = ancestor->parentElementInComposedTree()) {
+    if (m_elementUnderMouse) {
+        // Stop at element: setFocusedElement records the trigger for it, unless it is already focused.
+        for (RefPtr ancestor = m_elementUnderMouse.get(); ancestor && ancestor != element; ancestor = ancestor->parentElementInComposedTree()) {
             if (is<HTMLFormControlElement>(*ancestor) && !ancestor->isMouseFocusable()) {
                 frame->document()->setLatestFocusTrigger(FocusTrigger::Click);
                 break;


### PR DESCRIPTION
#### b9cb3459aa14d526eb11597c3dcde51d377dc8e0
<pre>
Cherry-pick 318775@main (a1678ffa5ff1). <a href="https://bugs.webkit.org/show_bug.cgi?id=321157">https://bugs.webkit.org/show_bug.cgi?id=321157</a>

Unreviewed backport.

    REGRESSION(311768@main): :focus-visible incorrectly shown after focus() inside a focused ancestor
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321157">https://bugs.webkit.org/show_bug.cgi?id=321157</a>
    <a href="https://rdar.apple.com/181570771">rdar://181570771</a>

    Reviewed by Abrar Rahman Protyasha.

    Buttons are not mouse-focusable on macOS/iOS, so a workaround records
    that the last focus trigger was a click. 311768@main stopped that
    workaround from running when the clicked button sits inside an ancestor
    that can take focus, such as a &lt;dialog&gt;. Usually the ancestor is focused
    instead and the click is recorded there, but not when it is already
    focused. Nothing recorded the click, so the programmatic focus() that
    followed showed :focus-visible.

    music.apple.com opens its now-playing player as a &lt;dialog&gt;. Dismissing
    it left a red focus ring on the mini player.

    Walk the ancestors only up to the element that will be focused, instead
    of skipping the workaround whenever there is one.

    Tests: fast/selectors/focus-visible-script-focus-after-dialog-dismiss.html
           fast/selectors/focus-visible-script-focus-inside-focused-ancestor.html

    * LayoutTests/fast/selectors/focus-visible-script-focus-after-dialog-dismiss-expected.txt: Added.
    * LayoutTests/fast/selectors/focus-visible-script-focus-after-dialog-dismiss.html: Added.
    * LayoutTests/fast/selectors/focus-visible-script-focus-inside-focused-ancestor-expected.txt: Added.
    * LayoutTests/fast/selectors/focus-visible-script-focus-inside-focused-ancestor.html: Added.
    * Source/WebCore/page/EventHandler.cpp:
    (WebCore::EventHandler::dispatchMouseEvent):

    Canonical link: <a href="https://commits.webkit.org/318775@main">https://commits.webkit.org/318775@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.70@webkitglib/2.54">https://commits.webkit.org/317695.70@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59bf18eb726f8463900422206c5e65d630093594

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179440 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53379 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47176 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189272 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143749 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181303 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54673 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53089 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139928 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143749 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182397 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54673 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47176 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120380 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54673 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53089 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47176 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54673 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47176 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/725 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/45985 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53089 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191490 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53049 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47176 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149187 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53730 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47176 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148930 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27244 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53730 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126002 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120897 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52247 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47176 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51632 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51873 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51693 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->