### PR TITLE
[GLib] Fix webkit_favicon_database_get_page_icons() lookups

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
@@ -34,7 +34,7 @@ using namespace WebCore;
 
 // This version number is in the DB and marks the current generation of the schema
 // Currently, a mismatched schema causes the DB to be wiped and reset.
-static const int currentDatabaseVersion = 6;
+static const int currentDatabaseVersion = 7;
 
 // Icons expire once every 4 days.
 static const Seconds iconExpirationTime { 60 * 60 * 24 * 4 };
@@ -132,7 +132,7 @@ bool IconDatabase::createTablesIfNeeded()
 
     m_db->clearAllTables();
 
-    if (!m_db->executeCommand("CREATE TABLE PageURL (url TEXT NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT REPLACE,iconID INTEGER NOT NULL ON CONFLICT FAIL);"_s)) {
+    if (!m_db->executeCommand("CREATE TABLE PageURL (url TEXT NOT NULL ON CONFLICT FAIL, iconID INTEGER NOT NULL ON CONFLICT FAIL, UNIQUE (url, iconID) ON CONFLICT REPLACE);"_s)) {
         RELEASE_LOG_ERROR(IconDatabase, "Could not create PageURL table in database (%i) - %s", m_db->lastError(), m_db->lastErrorMsg());
         m_db->close();
         return false;

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -342,7 +342,7 @@ void webkit_favicon_database_get_page_icons(WebKitFaviconDatabase* database, con
         return g_task_report_new_error(database, callback, userData, 0, WEBKIT_FAVICON_DATABASE_ERROR, WEBKIT_FAVICON_DATABASE_ERROR_FAVICON_NOT_FOUND, _("Page %s does not have a favicon"), pageURI);
 
     auto task = adoptGRef(g_task_new(database, cancellable, callback, userData));
-    database->priv->iconDatabase->loadIconsForPageURL(uriString, IconDatabase::AllowDatabaseWrite::No, [task = WTF::move(task)](Vector<PlatformImagePtr>&& icons) {
+    database->priv->iconDatabase->loadIconsForPageURL(uriString, IconDatabase::AllowDatabaseWrite::Yes, [task = WTF::move(task)](Vector<PlatformImagePtr>&& icons) {
         auto images = icons.map([](PlatformImagePtr image) -> GRefPtr<WebKitImage> {
             SkPixmap pixmap;
             RELEASE_ASSERT(image->peekPixels(&pixmap));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitFaviconDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitFaviconDatabase.cpp
@@ -204,6 +204,27 @@ public:
 #endif // PLATFORM(GTK)
 
 #if ENABLE(2022_GLIB_API)
+    static void getPageIconsCallback(GObject*, GAsyncResult* result, gpointer userData)
+    {
+        auto* test = static_cast<FaviconDatabaseTest*>(userData);
+        g_clear_pointer(&test->m_pageIcons, webkit_image_list_unref);
+        test->m_pageIcons = webkit_favicon_database_get_page_icons_finish(test->m_database.get(), result, &test->m_pageIconsError.outPtr());
+        test->quitMainLoop();
+    }
+
+    void getPageIconsForPageURIAndWaitUntilReady(const char* pageURI)
+    {
+        webkit_favicon_database_get_page_icons(m_database.get(), pageURI, nullptr, getPageIconsCallback, this);
+        g_main_loop_run(m_mainLoop);
+    }
+
+    void reopen()
+    {
+        close();
+        m_database = nullptr;
+        open("reopen");
+    }
+
     void waitUntilLoadFinishedAndPageIconsChanged()
     {
         g_clear_pointer(&m_pageIcons, webkit_image_list_unref);
@@ -306,7 +327,8 @@ public:
 
 #if ENABLE(2022_GLIB_API)
     size_t m_pageIconsNoticationCount { 0 };
-    WebKitImageList* m_pageIcons;
+    WebKitImageList* m_pageIcons { nullptr };
+    GUniqueOutPtr<GError> m_pageIconsError;
 #endif
 
     GRefPtr<WebKitFaviconDatabase> m_database;
@@ -464,7 +486,8 @@ static void testFaviconDatabaseGetPageIcons(FaviconDatabaseTest *test, gconstpoi
 {
     test->open("testFaviconDatabaseGetPageIcons");
 
-    test->loadURI(kServer->getURIForPath("/multipleicons").data());
+    CString pageURI = kServer->getURIForPath("/multipleicons");
+    test->loadURI(pageURI.data());
     test->waitUntilLoadFinishedAndPageIconsChanged();
 
 #if PLATFORM(GTK)
@@ -513,6 +536,12 @@ static void testFaviconDatabaseGetPageIcons(FaviconDatabaseTest *test, gconstpoi
     auto blueIconPixel = getARGBColorAtOrigin(blueIcon);
     g_assert_true(blueIconPixel.has_value());
     g_assert_cmpint(*blueIconPixel, ==, 0xFF0000FF);
+
+    test->reopen();
+    test->getPageIconsForPageURIAndWaitUntilReady(pageURI.data());
+    g_assert_no_error(test->m_pageIconsError.get());
+    g_assert_nonnull(test->m_pageIcons);
+    g_assert_cmpint(webkit_image_list_get_length(test->m_pageIcons), ==, 3);
 }
 #endif // ENABLE(2022_GLIB_API)
 


### PR DESCRIPTION
#### b29eae826faaf0aff766c3a64a48b514fb0efb76
<pre>
[GLib] Fix webkit_favicon_database_get_page_icons() lookups
<a href="https://bugs.webkit.org/show_bug.cgi?id=321310">https://bugs.webkit.org/show_bug.cgi?id=321310</a>

Reviewed by Adrian Perez de Castro.

This fixes two bugs:

The commit introducing this feature used AllowDatabaseWrite::No which meant the
in-memory cache worked but loading it would fail. The database contains a timestamp
of when icons were last used, so it must be writable, otherwise every icon is
considered not recently used and ignored.

The purpose of this API was to return multiple sizes for the same URL, however
the schema was `pageURL (url UNIQUE ..., iconID ...)` which meant there could
only be one entry per URL. Change this to `UNIQUE (url, iconID)` so the combination
must be unique.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitFaviconDatabase.cpp

* Source/WebKit/UIProcess/API/glib/IconDatabase.cpp:
(WebKit::IconDatabase::createTablesIfNeeded):
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(webkit_favicon_database_get_page_icons):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitFaviconDatabase.cpp:
(testFaviconDatabaseGetPageIcons):

Canonical link: <a href="https://commits.webkit.org/318812@main">https://commits.webkit.org/318812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f1ab30f246e0f3e88ea33254746a735741221c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189275 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181306 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139932 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120384 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152610 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40184 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/728 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45988 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191494 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53052 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53733 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148938 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27241 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43601 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126005 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120900 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52250 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15173 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51635 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51876 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->