### PR TITLE
[Tools][WPE] run-mvt-tests: configure Selenium so the browser logs are shown by default

### DIFF
--- a/Tools/Scripts/run-mvt-tests
+++ b/Tools/Scripts/run-mvt-tests
@@ -34,6 +34,7 @@ maybe_enter_webkit_container_sdk()
 import argparse
 import json
 import logging
+import subprocess
 import traceback
 import urllib3
 from selenium.webdriver.common.by import By
@@ -171,7 +172,7 @@ class MVTWebDriverRunner():
         if retry_if_failure_to_start:
             return self._retry_if_timeout(self.start_driver, None, False)
         # Start the service (WebDriver) in its own process group to ensure cleaning everything at stop_driver()
-        self.driver_service = self.driver_service_class(executable_path=self._run_webdriver_script_path, env=self.environ_for_test,
+        self.driver_service = self.driver_service_class(executable_path=self._run_webdriver_script_path, env=self.environ_for_test, log_output=subprocess.STDOUT,
                           service_args=[f"--{self.configuration}", f"--{self.platform}"], popen_kw={"process_group": 0})
         self.driver = self.driver_class(options=self.driver_options, service=self.driver_service)
         self.driver.maximize_window()


### PR DESCRIPTION
#### c5e28398bb0c7e992a3fd7404bc5ecd85224db70
<pre>
[Tools][WPE] run-mvt-tests: configure Selenium so the browser logs are shown by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=321309">https://bugs.webkit.org/show_bug.cgi?id=321309</a>

Reviewed by Nikolas Zimmermann.

Selenium by default sends the browser stdout/stderr to /dev/null.
This was hiding useful debug information on run-mvt-tests script.

Fix that by telling selenium to forward the logs to the terminal.

* Tools/Scripts/run-mvt-tests:

Canonical link: <a href="https://commits.webkit.org/318892@main">https://commits.webkit.org/318892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/199f66df212a584e9a28d91068e0e3b669bb6bf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143758 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139935 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96826 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120387 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42216 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40542 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152617 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40191 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/esm-integration/execute-start.tentative.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/734 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191500 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53058 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149198 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53739 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148943 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27297 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43605 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120906 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52256 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15180 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51641 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51882 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->