### PR TITLE
[JSC][Temporal] Replace the four monthCode search walks with one primitive

### DIFF
--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -261,7 +261,7 @@ std::optional<Duration> parseDuration(StringView string)
 
 enum class Second60Mode { Accept, Reject };
 template<typename CharacterType>
-static std::optional<PlainTime> parseTimeSpec(StringParsingBuffer<CharacterType>& buffer, Second60Mode second60Mode, bool parseSubMinutePrecision = true, bool* outHasSeconds = nullptr)
+static std::optional<PlainTime> parseTimeSpec(StringParsingBuffer<CharacterType>& buffer, Second60Mode second60Mode, SubMinutePrecision subMinutePrecision = SubMinutePrecision::Yes, bool* outHasSeconds = nullptr)
 {
     // https://tc39.es/proposal-temporal/#prod-TimeSpec
     // TimeSpec :
@@ -326,7 +326,7 @@ static std::optional<PlainTime> parseTimeSpec(StringParsingBuffer<CharacterType>
     } else if (!(*buffer >= '0' && (second60Mode == Second60Mode::Accept ? (*buffer <= '6') : (*buffer <= '5'))))
         return PlainTime(hour, minute, 0, 0, 0, 0);
 
-    if (!parseSubMinutePrecision)
+    if (subMinutePrecision == SubMinutePrecision::No)
         return std::nullopt;
 
     if (outHasSeconds)
@@ -382,7 +382,7 @@ static std::optional<PlainTime> parseTimeSpec(StringParsingBuffer<CharacterType>
 }
 
 template<typename CharacterType>
-static std::optional<int64_t> parseUTCOffset(StringParsingBuffer<CharacterType>& buffer, bool parseSubMinutePrecision = true, bool* outHasSubMinutePrecision = nullptr)
+static std::optional<int64_t> parseUTCOffset(StringParsingBuffer<CharacterType>& buffer, SubMinutePrecision subMinutePrecision = SubMinutePrecision::Yes, bool* outHasSubMinutePrecision = nullptr)
 {
     // UTCOffset[SubMinutePrecision] :
     //     ASCIISign Hour
@@ -410,7 +410,7 @@ static std::optional<int64_t> parseUTCOffset(StringParsingBuffer<CharacterType>&
         return std::nullopt;
 
     bool hasSeconds = false;
-    auto plainTime = parseTimeSpec(buffer, Second60Mode::Reject, parseSubMinutePrecision, &hasSeconds);
+    auto plainTime = parseTimeSpec(buffer, Second60Mode::Reject, subMinutePrecision, &hasSeconds);
     if (!plainTime)
         return std::nullopt;
 
@@ -427,10 +427,10 @@ static std::optional<int64_t> parseUTCOffset(StringParsingBuffer<CharacterType>&
     return (nsPerHour * hour + nsPerMinute * minute + nsPerSecond * second + nsPerMillisecond * millisecond + nsPerMicrosecond * microsecond + nanosecond) * factor;
 }
 
-std::optional<int64_t> parseUTCOffset(StringView string, bool parseSubMinutePrecision)
+std::optional<int64_t> parseUTCOffset(StringView string, SubMinutePrecision subMinutePrecision)
 {
-    return readCharactersForParsing(string, [parseSubMinutePrecision](auto buffer) -> std::optional<int64_t> {
-        auto result = parseUTCOffset(buffer, parseSubMinutePrecision);
+    return readCharactersForParsing(string, [subMinutePrecision](auto buffer) -> std::optional<int64_t> {
+        auto result = parseUTCOffset(buffer, subMinutePrecision);
         if (!buffer.atEnd())
             return std::nullopt;
         return result;
@@ -698,7 +698,7 @@ static std::optional<TimeZoneIdentifierParseRecord> parseTimeZoneIdentifier(Stri
     }
 
     // Steps 4-6: parseUTCOffset matches |UTCOffset[~SubMinutePrecision]| and converts it in one call.
-    auto offsetNanoseconds = parseUTCOffset(buffer, /* parseSubMinutePrecision */ false);
+    auto offsetNanoseconds = parseUTCOffset(buffer, SubMinutePrecision::No);
 
     // Step 2: If parseResult is a List of errors, throw a RangeError exception.
     if (!offsetNanoseconds)
@@ -1100,7 +1100,7 @@ static std::optional<ISO8601ParseTokens> tokenizeTemporalInstantString(StringPar
         buffer.advance();
     } else if (*buffer == '+' || *buffer == '-') {
         bool subMinute = false;
-        auto off = parseUTCOffset(buffer, true, &subMinute);
+        auto off = parseUTCOffset(buffer, SubMinutePrecision::Yes, &subMinute);
         if (!off)
             return std::nullopt;
         tokens.utcOffsetNs = *off;
@@ -1145,7 +1145,7 @@ static std::optional<ISO8601ParseTokens> tokenizeTemporalDateTimeString(StringPa
                 buffer.advance();
             } else if (*buffer == '+' || *buffer == '-') {
                 bool subMinute = false;
-                auto off = parseUTCOffset(buffer, true, &subMinute);
+                auto off = parseUTCOffset(buffer, SubMinutePrecision::Yes, &subMinute);
                 if (!off)
                     return std::nullopt;
                 tokens.utcOffsetNs = *off;
@@ -1230,7 +1230,7 @@ static std::optional<ISO8601ParseTokens> tokenizeTemporalAnnotatedTime(StringPar
             return std::nullopt; // DateTimeUTCOffset[~Z] forbids Z.
         if (*buffer == '+' || *buffer == '-') {
             bool subMinute = false;
-            auto off = parseUTCOffset(buffer, true, &subMinute);
+            auto off = parseUTCOffset(buffer, SubMinutePrecision::Yes, &subMinute);
             if (!off)
                 return std::nullopt;
             tokens.utcOffsetNs = *off;
@@ -1398,10 +1398,10 @@ std::optional<ParsedISODateTime> parseISODateTime(StringView string, TemporalPro
         time = timeFields;
 
     // Step 24. timeZoneResult = { [[Z]]: false, [[OffsetString]]: ~empty~, [[TimeZoneAnnotation]]: ~empty~ }.
-    std::optional<TimeZoneRecord> timeZoneResult;
+    std::optional<ISOStringTimeZoneParseRecord> timeZoneResult;
     bool anyTzInfo = parseResult->hasUTCDesignator || parseResult->utcOffsetNs.has_value() || !std::holds_alternative<std::monostate>(parseResult->tzAnnotation);
     if (anyTzInfo) {
-        TimeZoneRecord tz;
+        ISOStringTimeZoneParseRecord tz;
         // Step 25. Set [[TimeZoneAnnotation]].
         if (auto* name = std::get_if<Vector<Latin1Character>>(&parseResult->tzAnnotation))
             tz.m_nameOrOffset = WTF::move(*name);

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -485,8 +485,8 @@ private:
 static_assert(sizeof(PlainYearMonth) == sizeof(PlainDate));
 
 // https://tc39.es/proposal-temporal/#sec-temporal-iso-string-time-zone-parse-records
-// ISO String Time Zone Parse Record { [[Z]], [[OffsetString]], [[TimeZoneAnnotation]] }.
-struct TimeZoneRecord {
+// { [[Z]], [[OffsetString]], [[TimeZoneAnnotation]] }.
+struct ISOStringTimeZoneParseRecord {
     bool m_z { false };
     std::optional<int64_t> m_offset;
     // [[TimeZoneAnnotation]]; an empty Vector is ~empty~.
@@ -508,7 +508,8 @@ struct RFC9557Annotation {
 // https://tc39.es/proposal-temporal/#sec-getavailablenamedtimezoneidentifier
 JS_EXPORT_PRIVATE std::optional<TimeZoneID> parseTimeZoneName(StringView);
 std::optional<Duration> parseDuration(StringView);
-std::optional<int64_t> parseUTCOffset(StringView, bool parseSubMinutePrecision = true);
+enum class SubMinutePrecision : bool { No, Yes };
+std::optional<int64_t> parseUTCOffset(StringView, SubMinutePrecision = SubMinutePrecision::Yes);
 std::optional<int64_t> parseUTCOffsetInMinutes(StringView);
 enum class ValidateTimeZoneID : bool { No, Yes };
 using CalendarID = RFC9557Value;
@@ -526,7 +527,7 @@ using TemporalProductionSet = OptionSet<TemporalProduction>;
 struct ParsedISODateTime {
     std::optional<PlainDate> date;
     std::optional<PlainTime> time;
-    std::optional<TimeZoneRecord> timeZone;
+    std::optional<ISOStringTimeZoneParseRecord> timeZone;
     std::optional<CalendarID> calendar;
     TemporalProduction matched { };
     // True when the matched goal was the SHORT FORM:

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
@@ -135,7 +135,7 @@ ISO8601::PlainDateTime TemporalZonedDateTime::getLocalDateTime(JSGlobalObject* g
     return *result;
 }
 
-std::optional<TimeZone> timeZoneFromRecord(const ISO8601::TimeZoneRecord& tzRecord)
+std::optional<TimeZone> timeZoneFromRecord(const ISO8601::ISOStringTimeZoneParseRecord& tzRecord)
 {
     auto& nameOrOffset = tzRecord.m_nameOrOffset;
     if (auto* offsetNanoseconds = std::get_if<int64_t>(&nameOrOffset))

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.h
@@ -35,7 +35,7 @@
 
 namespace JSC {
 
-JS_EXPORT_PRIVATE std::optional<TimeZone> timeZoneFromRecord(const ISO8601::TimeZoneRecord&);
+JS_EXPORT_PRIVATE std::optional<TimeZone> timeZoneFromRecord(const ISO8601::ISOStringTimeZoneParseRecord&);
 
 class TemporalZonedDateTime final : public JSNonFinalObject {
 public:

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -591,6 +591,63 @@ static LunisolarMonthAdvanceResult advanceToNextLunisolarMonth(UCalendar* cal, C
     return LunisolarMonthAdvanceResult::Error;
 }
 
+// Where a month-code walk stopped, and why; the caller applies the constrain rule. Neither exact
+// nor overshot means the walk left the year without reaching the target.
+struct MonthCodeSearchResult {
+    uint8_t ordinal { 1 }; // 1-based ordinal of the month stopped on.
+    bool exact { false }; // targetCode found, so the fields describe it exactly.
+    bool overshot { false }; // Stopped past the target, so it is absent from this year.
+    double stoppedMonthMs { 0 }; // Start of the month stopped on.
+    double previousMonthMs { 0 }; // Start of the last month at or before the target.
+};
+
+static std::optional<MonthCodeSearchResult> searchYearForMonthCode(UCalendar* cal, CalendarID calendarId, const String& targetCode)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    bool isChineseBased = calendarId == chineseCalendarID() || calendarId == dangiCalendarID();
+    // Chinese/Dangi year rollover is detected by the M01 sentinel, so UCAL_EXTENDED_YEAR is not read.
+    int32_t savedYear = isChineseBased ? 0 : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    double startMs = ucal_getMillis(cal, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+
+    MonthCodeSearchResult result;
+    result.stoppedMonthMs = startMs;
+    result.previousMonthMs = startMs;
+    // 14 covers the longest year (13 months) plus the step that detects the rollover.
+    for (int i = 0; i < 14; ++i) {
+        result.ordinal = static_cast<uint8_t>(i + 1);
+        auto curCode = getMonthCode(cal, calendarId);
+        if (!curCode) [[unlikely]]
+            return std::nullopt;
+        result.stoppedMonthMs = ucal_getMillis(cal, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        if (*curCode == targetCode) {
+            result.exact = true;
+            return result;
+        }
+        if (codePointCompare(*curCode, targetCode) > 0) {
+            result.overshot = true;
+            return result;
+        }
+        result.previousMonthMs = result.stoppedMonthMs;
+        if (advanceToNextLunisolarMonth(cal, calendarId, status) != LunisolarMonthAdvanceResult::Advanced) [[unlikely]]
+            return std::nullopt;
+        int32_t curYear = isChineseBased ? savedYear : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        auto nextCode = isChineseBased ? getMonthCode(cal, calendarId) : std::optional<String> { };
+        if (U_FAILURE(status) || (isChineseBased && !nextCode)) [[unlikely]]
+            return std::nullopt;
+        if ((isChineseBased && *nextCode == "M01"_s) || (!isChineseBased && curYear != savedYear)) {
+            // Left the year. ordinal and previousMonthMs still describe the last month inside it.
+            return result;
+        }
+    }
+    return std::nullopt;
+}
+
 static std::optional<int32_t> stableLunisolarYear(UCalendar* cal, CalendarID calendarId, UErrorCode& status)
 {
     auto anchor = lunisolarYearAnchor(cal, calendarId, status);
@@ -1050,13 +1107,9 @@ TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::Plain
         return gregorianArithmeticYearFieldsFor(calendarId, isoDate.year()).year;
     if (calendarUsesISOFallbackForExtremeYear(calendarId, isoDate.year()))
         return isoDate.year();
-    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        UErrorCode status = U_ZERO_ERROR;
+    return withCalendarSetToDate(calendarId, isoDate, [&](UCalendar* cal) -> TemporalResult<int32_t> {
         if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID()) {
+            UErrorCode status = U_ZERO_ERROR;
             auto year = stableLunisolarYear(cal, calendarId, status);
             if (!year) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -1064,16 +1117,9 @@ TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::Plain
         }
         // Older ICU versions expose an Amete Mihret-relative UCAL_EXTENDED_YEAR for Ethioaa;
         // newer versions may make UCAL_YEAR and UCAL_EXTENDED_YEAR equal.
-        if (calendarId == ethioaaCalendarID()) {
-            int32_t eraYear = ucal_get(cal, UCAL_YEAR, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            return eraYear;
-        }
-        auto result = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        return result;
+        if (calendarId == ethioaaCalendarID())
+            return readICUField(cal, UCAL_YEAR);
+        return readICUField(cal, UCAL_EXTENDED_YEAR);
     });
 }
 
@@ -1402,86 +1448,24 @@ static std::optional<int> setCalendarToMonthCode(UCalendar* cal, CalendarID cale
     if (!parsed)
         return std::nullopt;
 
-    UErrorCode status = U_ZERO_ERROR;
-    if (calendarId == hebrewCalendarID()) {
-        // Hebrew: walk months in the target year to find the matching month code.
-        // NOTE: UCAL_ACTUAL_MAXIMUM is unreliable for Hebrew; walk is correct and safe.
-        int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return std::nullopt;
-        if (!resetCalendarToMonthStart(cal)) [[unlikely]]
-            return std::nullopt;
-
-        for (int i = 0; i < 15; i++) {
-            auto curCode = getMonthCode(cal, calendarId);
-            if (!curCode) [[unlikely]]
-                return std::nullopt;
-            if (*curCode == monthCode)
-                return 1; // exact match
-            ucal_add(cal, UCAL_MONTH, 1, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return std::nullopt;
-            if (!forceICUFieldReresolution(cal)) [[unlikely]]
-                return std::nullopt;
-            int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return std::nullopt;
-            if (curYear != savedYear) {
-                // Month code doesn't exist in this year.
-                // For M05L (Adar I), constrain to M06 (Adar, slot 5 in non-leap year).
-                ucal_set(cal, UCAL_EXTENDED_YEAR, savedYear);
-                ucal_set(cal, UCAL_MONTH, 5);
-                ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
-                ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
-                return 0; // constrained
-            }
-        }
-        return std::nullopt;
-    }
-
-    // Chinese/Dangi: walk months from start of year to find matching month code.
-    int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return std::nullopt;
+    // NOTE: UCAL_ACTUAL_MAXIMUM is unreliable for Hebrew, so the month code is located by walking.
     if (!resetCalendarToMonthStart(cal)) [[unlikely]]
         return std::nullopt;
-    double previousMonthStartMs = ucal_getMillis(cal, &status);
+    auto found = searchYearForMonthCode(cal, calendarId, monthCode);
+    if (!found) [[unlikely]]
+        return std::nullopt;
+    if (found->exact)
+        return 1;
+
+    // Absent from this year, so constrain; Hebrew M05L goes forward to M06, so it stays put.
+    // Only an overshoot may stay put: a walk that left the year is positioned outside it.
+    if (calendarId == hebrewCalendarID() && found->overshot)
+        return 0;
+    UErrorCode status = U_ZERO_ERROR;
+    ucal_setMillis(cal, found->previousMonthMs, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
-
-    for (int i = 0; i < 14; i++) {
-        auto curCode = getMonthCode(cal, calendarId);
-        if (!curCode) [[unlikely]]
-            return std::nullopt;
-        if (*curCode == monthCode)
-            return 1; // exact match
-        // If we've walked past the target monthCode lexicographically, the requested code
-        // (a leap month) doesn't exist in this year — constrain to the base month by
-        // reverting to the previous position (Chinese/Dangi convention, matches temporal_rs).
-        // Without this early-stop, walking to year-end would incorrectly land on M12.
-        if (codePointCompare(*curCode, monthCode) > 0) {
-            ucal_setMillis(cal, previousMonthStartMs, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return std::nullopt;
-            return 0; // constrained to base month
-        }
-        previousMonthStartMs = ucal_getMillis(cal, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return std::nullopt;
-        if (advanceToNextLunisolarMonth(cal, calendarId, status) != LunisolarMonthAdvanceResult::Advanced) [[unlikely]]
-            return std::nullopt;
-        int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return std::nullopt;
-        if (curYear != savedYear) {
-            // Month code sorts after every month in the year (e.g., "M99") — constrain to last month.
-            ucal_setMillis(cal, previousMonthStartMs, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return std::nullopt;
-            return 0; // constrained
-        }
-    }
-    return std::nullopt;
+    return 0;
 }
 
 // compareSurpassesLexicographic — icu4x: compare_surpasses_lexicographic (components/calendar/src/calendar_arithmetic.rs)
@@ -1538,41 +1522,18 @@ static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& mo
         if (!cal) [[unlikely]]
             return 1;
         UErrorCode status = U_ZERO_ERROR;
-        auto yearField = calendarArithmeticYearField(calendarId);
         if (!positionCalendarToYearStart(cal, calendarId, year, status)) [[unlikely]]
             return 1;
-
-        int32_t savedYear = ucal_get(cal, yearField, &status);
-        if (U_FAILURE(status)) [[unlikely]]
+        auto found = searchYearForMonthCode(cal, calendarId, monthCode);
+        if (!found) [[unlikely]]
             return 1;
-        int32_t lastOrdinal = 1;
-        for (int i = 0; i < 14; i++) {
-            auto curCode = getMonthCode(cal, calendarId);
-            if (!curCode) [[unlikely]]
-                return lastOrdinal;
-            if (*curCode == monthCode)
-                return i + 1;
-            if (codePointCompare(*curCode, monthCode) > 0) {
-                // Hebrew M05L (Adar I) constrains FORWARD to M06 (Adar) in non-leap years.
-                // icu4x components/calendar/src/cal/hebrew.rs ordinal_from_month: M05L -> ordinal 6 with Overflow::Constrain.
-                // All other calendars constrain backward to the previous existing month.
-                if (calendarId == hebrewCalendarID() && monthCode == "M05L"_s)
-                    return i + 1;
-                return lastOrdinal;
-            }
-            lastOrdinal = i + 1;
-            ucal_add(cal, UCAL_MONTH, 1, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return lastOrdinal;
-            if (!forceICUFieldReresolution(cal)) [[unlikely]]
-                return lastOrdinal;
-            int32_t curYear = ucal_get(cal, yearField, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return lastOrdinal;
-            if (curYear != savedYear)
-                return lastOrdinal;
-        }
-        return lastOrdinal;
+        if (found->exact)
+            return found->ordinal;
+        // Hebrew M05L keeps the stopped-on ordinal (icu4x hebrew.rs ordinal_from_month: -> 6 under
+        // Overflow::Constrain). A ran-out stop already sits on the year's last month.
+        if (found->overshot && !(calendarId == hebrewCalendarID() && monthCode == "M05L"_s))
+            return std::max(1, found->ordinal - 1);
+        return found->ordinal;
     });
 }
 
@@ -2660,7 +2621,6 @@ TemporalResult<ISO8601::PlainDate> nonISOCalendarDateToISO(CalendarID calendarId
 
         setICUCalendarYear(cal, calendarId, year);
 
-        bool isChineseBased = calendarId == chineseCalendarID() || calendarId == dangiCalendarID();
         if (monthCode) {
             // Step 2: ConstrainMonthCode + position ICU cursor for downstream day/millis reads.
             if (calendarIsLunisolar(calendarId)) {
@@ -2674,56 +2634,31 @@ TemporalResult<ISO8601::PlainDate> nonISOCalendarDateToISO(CalendarID calendarId
 
                 String targetCode = makeString("M"_s, monthCode->monthNumber < 10 ? "0"_s : ""_s,
                     monthCode->monthNumber, monthCode->isLeapMonth ? "L"_s : ""_s);
-                int32_t savedYear = isChineseBased ? 0 : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-                if (U_FAILURE(status)) [[unlikely]]
-                    return makeUnexpected(rangeError(icuReadCalendarFailed));
-                double previousMonthMs = ucal_getMillis(cal, &status);
-                if (U_FAILURE(status)) [[unlikely]]
-                    return makeUnexpected(rangeError(icuReadCalendarFailed));
-                bool found = false;
-                for (int i = 0; i < 14; i++) {
-                    auto curCode = getMonthCode(cal, calendarId);
-                    if (!curCode) [[unlikely]]
-                        return makeUnexpected(rangeError(icuReadCalendarFailed));
-                    if (*curCode == targetCode) {
-                        found = true;
-                        break;
-                    }
-                    // For constrain: if we've passed the target code, stop at previous.
-                    if (codePointCompare(*curCode, targetCode) > 0) {
-                        // Leap month doesn't exist — constrain to previous month.
-                        if (overflow == TemporalOverflow::Constrain && monthCode->isLeapMonth) {
-                            if (calendarId == hebrewCalendarID()) {
-                                // M05L -> M06 (Adar), which is this current month.
-                                found = true;
-                            } else {
-                                // Chinese/Dangi: M01L->M01, revert one step.
-                                ucal_setMillis(cal, previousMonthMs, &status);
-                                if (U_FAILURE(status)) [[unlikely]]
-                                    return makeUnexpected(rangeError(icuSetCalendarFailed));
-                                found = true;
-                            }
-                        }
-                        break;
-                    }
-                    previousMonthMs = ucal_getMillis(cal, &status);
-                    if (U_FAILURE(status)) [[unlikely]]
-                        return makeUnexpected(rangeError(icuReadCalendarFailed));
-                    auto advanceResult = advanceToNextLunisolarMonth(cal, calendarId, status);
-                    if (advanceResult == LunisolarMonthAdvanceResult::Error) [[unlikely]]
-                        return makeUnexpected(rangeError(U_FAILURE(status) ? icuReadCalendarFailed : icuCalendarArithmeticFailed));
-                    int32_t curYear = isChineseBased ? savedYear : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-                    auto nextCode = isChineseBased ? getMonthCode(cal, calendarId) : std::optional<String> { };
-                    if (U_FAILURE(status) || (isChineseBased && !nextCode)) [[unlikely]]
-                        return makeUnexpected(rangeError(icuReadCalendarFailed));
-                    if ((isChineseBased && *nextCode == "M01"_s) || (!isChineseBased && curYear != savedYear)) {
-                        ucal_setMillis(cal, previousMonthMs, &status);
-                        if (U_FAILURE(status)) [[unlikely]]
+                auto found = searchYearForMonthCode(cal, calendarId, targetCode);
+                if (!found) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                auto rewindToPreviousMonth = [&]() -> bool {
+                    ucal_setMillis(cal, found->previousMonthMs, &status);
+                    return !U_FAILURE(status);
+                };
+                bool resolved = false;
+                if (found->exact)
+                    resolved = true;
+                else if (found->overshot) {
+                    // Only a leap code constrains, and only under ~constrain~; otherwise leave the
+                    // cursor alone and let ~reject~ throw below. Hebrew M05L goes forward to M06
+                    // (stay put), Chinese/Dangi M{n}L back to M{n}.
+                    if (overflow == TemporalOverflow::Constrain && monthCode->isLeapMonth) {
+                        if (calendarId != hebrewCalendarID() && !rewindToPreviousMonth()) [[unlikely]]
                             return makeUnexpected(rangeError(icuSetCalendarFailed));
-                        break;
+                        resolved = true;
                     }
+                } else {
+                    // Walked out of the year: sit on its last month. Still unresolved.
+                    if (!rewindToPreviousMonth()) [[unlikely]]
+                        return makeUnexpected(rangeError(icuSetCalendarFailed));
                 }
-                if (!found && overflow == TemporalOverflow::Reject) [[unlikely]]
+                if (!resolved && overflow == TemporalOverflow::Reject) [[unlikely]]
                     return makeUnexpected(rangeError("monthCode does not exist in this calendar year"_s));
             } else {
                 // Non-lunisolar with monthCode (Gregorian-based calendars).


### PR DESCRIPTION
#### e07ecf4c4a07c61d5c331dfe900266ee50785cdf
<pre>
[JSC][Temporal] Replace the four monthCode search walks with one primitive
<a href="https://bugs.webkit.org/show_bug.cgi?id=321313">https://bugs.webkit.org/show_bug.cgi?id=321313</a>
<a href="https://rdar.apple.com/184352721">rdar://184352721</a>

Reviewed by Yusuke Suzuki.

setCalendarToMonthCode walked the months of a calendar year twice, once for
Hebrew and once for everything else, and resolveMonthCodeToOrdinal and
nonISOCalendarDateToISO each walked once more: four loops in three functions.
searchYearForMonthCode does it once and reports where it stopped and why,
leaving each caller its own constrain rule and its own answer to give. The
constrain rule is the part that genuinely differed: Hebrew M05L (Adar I)
constrains forward to M06, every other calendar backward.

No behaviour change. Hebrew&apos;s forward constrain is now guarded on the overshoot
stop it applies to — M05L is the only monthCode that can be absent from a Hebrew
year — so a walk that leaves the year rewinds like every other calendar.

calendarYear now reaches ICU through withCalendarSetToDate and readICUField like
the rest of the accessor family.

parseUTCOffset and parseTimeSpec take SubMinutePrecision instead of a bool,
naming the UTCOffset[SubMinutePrecision] grammar parameter, and TimeZoneRecord
becomes ISOStringTimeZoneParseRecord after the record it implements.

Canonical link: <a href="https://commits.webkit.org/318829@main">https://commits.webkit.org/318829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c02d4d8b2aca3c0e78eaa5a0e236c2d57373a01f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189290 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e25a39e4-5445-4e13-a199-87b27a3676a2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139942 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/041a89db-fb76-4aee-b095-315bba2392e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120394 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e91e942b-2301-4f4b-86fa-6ee135bfa59c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42224 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40551 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2364 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9174 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152625 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40195 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/744 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40733 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191510 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53067 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149203 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53748 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148948 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27255 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43613 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126020 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120915 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52265 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15184 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51650 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51891 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51711 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->