### PR TITLE
[JSC] Wasm table.copy should not use index to check identity

### DIFF
--- a/JSTests/wasm/stress/table-copy-aliased-import.js
+++ b/JSTests/wasm/stress/table-copy-aliased-import.js
@@ -1,0 +1,58 @@
+//@ skip if $addressBits <= 32
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// Supplying one JS table for two table imports makes two table indices name the same table, so
+// table.copy between those indices has to behave like memmove.
+
+let wat = (addressType) => `
+(module
+    (import "m" "a" (table $a ${addressType} 10 externref))
+    (import "m" "b" (table $b ${addressType} 10 externref))
+    (func (export "copyAB") (param $d ${addressType}) (param $s ${addressType}) (param $n ${addressType})
+        (local.get $d)
+        (local.get $s)
+        (local.get $n)
+        (table.copy $a $b)
+    )
+    (func (export "copyAA") (param $d ${addressType}) (param $s ${addressType}) (param $n ${addressType})
+        (local.get $d)
+        (local.get $s)
+        (local.get $n)
+        (table.copy $a $a)
+    )
+)`;
+
+function reset(table, numOrBig) {
+    for (let i = 0; i < 10; ++i)
+        table.set(numOrBig(i), "v" + i);
+}
+
+function contents(table, numOrBig) {
+    let result = [];
+    for (let i = 0; i < 10; ++i)
+        result.push(table.get(numOrBig(i)));
+    return result.join(",");
+}
+
+function test(copy, table, numOrBig, d, s, n, expected) {
+    reset(table, numOrBig);
+    copy(numOrBig(d), numOrBig(s), numOrBig(n));
+    assert.eq(contents(table, numOrBig), expected);
+}
+
+for (const addressType of ["i32", "i64"]) {
+    const numOrBig = (val) => addressType == "i32" ? Number(val) : BigInt(val);
+    const table = new WebAssembly.Table({ element: "externref", initial: numOrBig(10), address: addressType });
+    const instance = await instantiate(wat(addressType), { m: { a: table, b: table } }, { memory64: true });
+    const { copyAB, copyAA } = instance.exports;
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        for (const copy of [copyAB, copyAA]) {
+            test(copy, table, numOrBig, 2, 0, 5, "v0,v1,v0,v1,v2,v3,v4,v7,v8,v9");
+            test(copy, table, numOrBig, 0, 2, 5, "v2,v3,v4,v5,v6,v5,v6,v7,v8,v9");
+            test(copy, table, numOrBig, 2, 2, 5, "v0,v1,v2,v3,v4,v5,v6,v7,v8,v9");
+            test(copy, table, numOrBig, 0, 0, 0, "v0,v1,v2,v3,v4,v5,v6,v7,v8,v9");
+        }
+    }
+}

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -496,15 +496,15 @@ void JSWebAssemblyInstance::tableCopy(uint32_t dstOffset, uint32_t srcOffset, ui
     RELEASE_ASSERT(dstTable->type() == srcTable->type());
 
     auto forEachTableElement = [&](auto fn) {
-        if (dstTableIndex == srcTableIndex && dstOffset > srcOffset) {
+        if (dstTable == srcTable && dstOffset == srcOffset)
+            return;
+        if (dstOffset > srcOffset) {
             for (uint32_t index = length; index--;)
                 fn(dstTable, srcTable, dstOffset + index, srcOffset + index);
-        } else if (dstTableIndex == srcTableIndex && dstOffset == srcOffset)
             return;
-        else {
-            for (uint32_t index = 0; index < length; ++index)
-                fn(dstTable, srcTable, dstOffset + index, srcOffset + index);
         }
+        for (uint32_t index = 0; index < length; ++index)
+            fn(dstTable, srcTable, dstOffset + index, srcOffset + index);
     };
 
     if (dstTable->isExternrefTable()) {


### PR DESCRIPTION
#### b1b0566f244ebf72f8cdd87ea3e9de08b768eff8
<pre>
[JSC] Wasm table.copy should not use index to check identity
<a href="https://bugs.webkit.org/show_bug.cgi?id=321316">https://bugs.webkit.org/show_bug.cgi?id=321316</a>
<a href="https://rdar.apple.com/184355393">rdar://184355393</a>

Reviewed by Yijia Huang.

You can set the same tables in different table index. So you cannot
check the table identity by table index. We should check the actual
table&apos;s pointer.

Test: JSTests/wasm/stress/table-copy-aliased-import.js

* JSTests/wasm/stress/table-copy-aliased-import.js: Added.
(reset):
(contents):
(test):
(string_appeared_here.const.instance.await.instantiate.wat):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::tableCopy):

Canonical link: <a href="https://commits.webkit.org/318825@main">https://commits.webkit.org/318825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3e4f659e17f971b372d35bb805bff2471c8c23c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189297 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ec75ad4-fa63-4e53-a9ad-e34fa1e09b73) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139948 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120400 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40556 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2370 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9177 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152639 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40227 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/751 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40740 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191518 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53074 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149209 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53755 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148954 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27252 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43621 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126027 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120922 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52272 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15187 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51657 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51898 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51718 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->