### PR TITLE
[JSC] Propagate uint64_t index until we do bound-check for TypedArray

### DIFF
--- a/JSTests/stress/typedarray-put-out-of-range-canonical-numeric-index.js
+++ b/JSTests/stress/typedarray-put-out-of-range-canonical-numeric-index.js
@@ -1,0 +1,41 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected}, got ${actual}`);
+}
+
+// A canonical numeric index string outside the valid integer index range must be a no-op store, not a
+// store at the index narrowed to the width of size_t. The low 32 bits of each key below are within the
+// array's length, so a narrowing store would land on an element.
+const keys = ["4294967295", "4294967296", "4294967299", "8589934592", "1e+21"];
+
+for (const constructor of [Uint8Array, Int32Array, Float64Array, BigInt64Array]) {
+    const zero = constructor === BigInt64Array ? 0n : 0;
+    const value = constructor === BigInt64Array ? 42n : 42;
+
+    for (const key of keys) {
+        const array = new constructor(8);
+        let coerced = 0;
+        array[key] = { valueOf() { ++coerced; return value; } };
+
+        shouldBe(coerced, 1); // TypedArraySetElement coerces the RHS before validating the index.
+        shouldBe(array[key], undefined);
+        shouldBe(Object.getOwnPropertyDescriptor(array, key), undefined);
+        shouldBe(Object.prototype.hasOwnProperty.call(array, key), false);
+        for (let i = 0; i < array.length; ++i)
+            shouldBe(array[i], zero);
+    }
+
+    // The same keys through defineProperty, which must throw rather than store.
+    for (const key of keys) {
+        const array = new constructor(8);
+        let threw = false;
+        try {
+            Object.defineProperty(array, key, { value });
+        } catch (error) {
+            threw = error instanceof TypeError;
+        }
+        shouldBe(threw, true);
+        for (let i = 0; i < array.length; ++i)
+            shouldBe(array[i], zero);
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -117,7 +117,7 @@ public:
     inline JSValue getIndexQuickly(size_t) const;
     inline void setIndexQuicklyToNativeValue(size_t, typename Adaptor::Type);
     inline void setIndexQuickly(size_t, JSValue);
-    inline bool setIndex(JSGlobalObject*, size_t, JSValue);
+    inline bool setIndex(JSGlobalObject*, uint64_t, JSValue);
 
     static inline ElementType toAdaptorNativeFromValue(JSGlobalObject*, JSValue);
     static inline std::optional<ElementType> toAdaptorNativeFromValueWithoutCoercion(JSValue);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -638,7 +638,7 @@ bool JSGenericTypedArrayView<Adaptor>::defineOwnProperty(
 
         scope.release();
         if (descriptor.value())
-            thisObject->setIndex(globalObject, static_cast<size_t>(index.value()), descriptor.value());
+            thisObject->setIndex(globalObject, index.value(), descriptor.value());
 
         return true;
     }
@@ -866,7 +866,7 @@ template<typename Adaptor> inline void JSGenericTypedArrayView<Adaptor>::setInde
     setIndexQuicklyToNativeValue(i, toNativeFromValue<Adaptor>(value));
 }
 
-template<typename Adaptor> inline bool JSGenericTypedArrayView<Adaptor>::setIndex(JSGlobalObject* globalObject, size_t i, JSValue jsValue)
+template<typename Adaptor> inline bool JSGenericTypedArrayView<Adaptor>::setIndex(JSGlobalObject* globalObject, uint64_t i, JSValue jsValue)
 {
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -880,7 +880,7 @@ template<typename Adaptor> inline bool JSGenericTypedArrayView<Adaptor>::setInde
     if (!inBounds(i))
         return false;
 
-    setIndexQuicklyToNativeValue(i, value);
+    setIndexQuicklyToNativeValue(static_cast<size_t>(i), value); // inBounds() has shown it is a length, so it fits.
     return true;
 }
 


### PR DESCRIPTION
#### c7ed9fcf795770aaef1c237379693dbfc4b205c3
<pre>
[JSC] Propagate uint64_t index until we do bound-check for TypedArray
<a href="https://bugs.webkit.org/show_bug.cgi?id=321317">https://bugs.webkit.org/show_bug.cgi?id=321317</a>
<a href="https://rdar.apple.com/184355743">rdar://184355743</a>

Reviewed by Yijia Huang.

It is 32bit only issue. We should propagate uint64_t index until we do
bound check, after that, we can use size_t. In 64bit, it does not matter
since sizeof(uint64_t) == sizeof(size_t).

Test: JSTests/stress/typedarray-put-out-of-range-canonical-numeric-index.js

* JSTests/stress/typedarray-put-out-of-range-canonical-numeric-index.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::defineOwnProperty):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::setIndex):

Canonical link: <a href="https://commits.webkit.org/318821@main">https://commits.webkit.org/318821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59762e9bba1c3935ae3bd5c56636f23749f33bec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189300 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139957 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120409 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/380b9bbc-4042-4d4b-8d5f-e034b86b216a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/2379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9183 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40204 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/754 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40743 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46013 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191521 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53077 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53758 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148958 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27251 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43625 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126030 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120925 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52275 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15193 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51660 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51901 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51721 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->