### PR TITLE
Stop including <objc/objc-runtime.h> and forbid it via check-webkit-style

### DIFF
--- a/Source/JavaScriptCore/API/JSWrapperMap.h
+++ b/Source/JavaScriptCore/API/JSWrapperMap.h
@@ -25,7 +25,7 @@
 
 #import "JSValueInternal.h"
 #import <JavaScriptCore/JavaScriptCore.h>
-#import <objc/objc-runtime.h>
+#import <objc/runtime.h>
 
 #if JSC_OBJC_API_ENABLED
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -46,7 +46,6 @@
 #import <JavaScriptCore/JSCellInlines.h>
 #import <JavaScriptCore/JSGlobalObjectInlines.h>
 #import <JavaScriptCore/TypedArrayInlines.h>
-#import <objc/objc-runtime.h>
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <wtf/FileSystem.h>
 #import <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
@@ -37,7 +37,6 @@
 #import <AVFoundation/AVAsset.h>
 #import <AVFoundation/AVAssetResourceLoader.h>
 #import <JavaScriptCore/TypedArrayInlines.h>
-#import <objc/objc-runtime.h>
 #import <wtf/LoggerHelper.h>
 #import <wtf/MainThread.h>
 #import <wtf/SoftLinking.h>

--- a/Source/WebCore/platform/ios/WebCoreMotionManager.mm
+++ b/Source/WebCore/platform/ios/WebCoreMotionManager.mm
@@ -34,7 +34,6 @@
 #import "WebCoreThreadRun.h"
 #import <CoreLocation/CoreLocation.h>
 #import <numbers>
-#import <objc/objc-runtime.h>
 #import <pal/spi/cocoa/CoreMotionSPI.h>
 #import <wtf/MathExtras.h>
 #import <wtf/SoftLinking.h>

--- a/Source/WebKitLegacy/ios/Misc/WebGeolocationCoreLocationProvider.mm
+++ b/Source/WebKitLegacy/ios/Misc/WebGeolocationCoreLocationProvider.mm
@@ -32,7 +32,6 @@
 #import <CoreLocation/CoreLocation.h>
 #import <WebCore/GeolocationPositionData.h>
 #import <WebKitLogging.h>
-#import <objc/objc-runtime.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/SoftLinking.h>

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -4211,6 +4211,11 @@ def check_include_line(filename, file_extension, clean_lines, line_number, inclu
               'Replace WTF::BlockPtr with WTF::Function. '
               'WTF::BlockPtr is not safe to use until JavaScriptCore builds with ARC enabled.')
 
+    if include == 'objc/objc-runtime.h':
+        error(line_number, 'build/objc_runtime_header', 5,
+              'Do not include <objc/objc-runtime.h>; it is not available in all SDKs.  '
+              'Include <objc/message.h> and/or <objc/runtime.h> instead.')
+
     # Look for any of the stream classes that are part of standard C++.
     if match(r'(f|ind|io|i|o|parse|pf|stdio|str|)?stream$', include):
         error(line_number, 'readability/streams', 3,
@@ -5250,6 +5255,7 @@ class CppChecker(object):
         'build/include_order',
         'build/include_what_you_use',
         'build/namespaces',
+        'build/objc_runtime_header',
         'build/printf_format',
         'build/storage_class',
         'build/using_std',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -293,6 +293,7 @@ class CppStyleTestBase(unittest.TestCase):
                              '+build/include',
                              '+build/include_order',
                              '+build/namespaces',
+                             '+build/objc_runtime_header',
                              '+runtime/rtti',
                              '+security/javascriptcore_wtf_blockptr')
         return self.perform_lint(code, filename, basic_error_rules, lines_to_check=lines_to_check)
@@ -3605,6 +3606,23 @@ class OrderOfIncludesTest(CppStyleTestBase):
             'BlockPtr<void(WebItemProviderFileCallback)> _callback;\n',
             '',
             file_name='Source/WebCore/foo.mm')
+
+    def test_check_objc_runtime_header_include(self):
+        expected = ('Do not include <objc/objc-runtime.h>; it is not available in all SDKs.'
+                    '  Include <objc/message.h> and/or <objc/runtime.h> instead.'
+                    '  [build/objc_runtime_header] [5]')
+        self.assert_language_rules_check('Source/JavaScriptCore/API/JSWrapperMap.h',
+                                         '#import <objc/objc-runtime.h>\n', expected)
+        self.assert_language_rules_check('Source/WebCore/foo.mm',
+                                         '#import <objc/objc-runtime.h>\n', expected)
+        self.assert_language_rules_check('Source/WebCore/foo.mm',
+                                         '#include <objc/objc-runtime.h>\n', expected)
+
+        # The individual headers the umbrella pulls in are allowed.
+        self.assert_language_rules_check('Source/WebCore/foo.mm',
+                                         '#import <objc/message.h>\n', '')
+        self.assert_language_rules_check('Source/WebCore/foo.mm',
+                                         '#import <objc/runtime.h>\n', '')
 
     def test_check_line_break_after_own_header(self):
         self.assert_language_rules_check('foo.cpp',


### PR DESCRIPTION
#### 75bb1892f1b4d3fd773e008cbf93802f192ca6ca
<pre>
Stop including &lt;objc/objc-runtime.h&gt; and forbid it via check-webkit-style
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=321315">https://bugs.webkit.org/show_bug.cgi?id=321315</a>&gt;
&lt;<a href="https://rdar.apple.com/184350335">rdar://184350335</a>&gt;

Reviewed by Zak Ridouh and Yusuke Suzuki.

The legacy `&lt;objc/objc-runtime.h&gt;` umbrella header is not present in
the iOS 27 SDK (it remains in the macOS SDK), so every file that
imports it fails to compile against that SDK.

Import only the specific `&lt;objc/...&gt;` headers that each file uses
(`&lt;objc/runtime.h&gt;` and/or `&lt;objc/message.h&gt;` if needed), instead of
the umbrella.

Add an always-on `check-webkit-style` rule that flags any new `#include`
or `#import` of `&lt;objc/objc-runtime.h&gt;` and directs authors to the
individual headers, so the pattern is not reintroduced.

Covered by a new test in cpp_unittest.py.

* Source/JavaScriptCore/API/JSWrapperMap.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm:
* Source/WebCore/platform/ios/WebCoreMotionManager.mm:
* Source/WebKitLegacy/ios/Misc/WebGeolocationCoreLocationProvider.mm:
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_include_line):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CppStyleTestBase.perform_language_rules_check):
(OrderOfIncludesTest.test_check_objc_runtime_header_include): Add.

Canonical link: <a href="https://commits.webkit.org/318848@main">https://commits.webkit.org/318848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71828253fa834e9fc15d5e09fc9c2286da7ea36a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143780 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f21202e-007f-4bbc-8fc0-e13c61ef096c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53121 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139954 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/544c4b55-f337-4c95-840e-db6098ffef2b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120406 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/444246b0-49ba-49d8-93b5-750007afda51) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178796 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42235 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40564 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2376 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9187 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40208 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/757 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40746 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191524 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53080 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149215 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53761 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148960 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27277 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43627 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126033 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120928 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52278 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15197 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51663 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51904 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->