### PR TITLE
Unreviewed, fix weird formatting

### DIFF
--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.cpp
@@ -56,9 +56,7 @@ CheckPrivateBrandStatus CheckPrivateBrandStatus::computeForBaseline(CodeBlock* b
     CheckPrivateBrandStatus result;
 
 #if ENABLE(DFG_JIT)
-    result = computeForPropertyInlineCacheWithoutExitSiteFeedback(
-        locker, baselineBlock, map.get(CodeOrigin(bytecodeIndex)).propertyCache);
-
+    result = computeForPropertyInlineCacheWithoutExitSiteFeedback(locker, baselineBlock, map.get(CodeOrigin(bytecodeIndex)).propertyCache);
     if (didExit)
         return result.slowVersion();
 #else
@@ -154,8 +152,7 @@ CheckPrivateBrandStatus CheckPrivateBrandStatus::computeFor(
             CheckPrivateBrandStatus result;
             {
                 ConcurrentJSLocker locker(context->optimizedCodeBlock->m_lock);
-                result = computeForPropertyInlineCacheWithoutExitSiteFeedback(
-                    locker, context->optimizedCodeBlock, status.propertyCache);
+                result = computeForPropertyInlineCacheWithoutExitSiteFeedback(locker, context->optimizedCodeBlock, status.propertyCache);
             }
             if (result.isSet())
                 return bless(result);

--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.h
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.h
@@ -98,8 +98,7 @@ private:
 
     static CheckPrivateBrandStatus computeForBaseline(CodeBlock*, ICStatusMap&, BytecodeIndex, ExitFlag);
 #if ENABLE(JIT)
-    static CheckPrivateBrandStatus computeForPropertyInlineCacheWithoutExitSiteFeedback(
-        const ConcurrentJSLocker&, CodeBlock* profiledBlock, PropertyInlineCache*);
+    static CheckPrivateBrandStatus computeForPropertyInlineCacheWithoutExitSiteFeedback(const ConcurrentJSLocker&, CodeBlock* profiledBlock, PropertyInlineCache*);
 #endif
 
     Vector<CheckPrivateBrandVariant, 1> m_variants;

--- a/Source/JavaScriptCore/bytecode/DeleteByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/DeleteByStatus.cpp
@@ -55,9 +55,7 @@ DeleteByStatus DeleteByStatus::computeForBaseline(CodeBlock* baselineBlock, ICSt
     DeleteByStatus result;
 
 #if ENABLE(DFG_JIT)
-    result = computeForPropertyInlineCacheWithoutExitSiteFeedback(
-        locker, baselineBlock, map.get(CodeOrigin(bytecodeIndex)).propertyCache);
-
+    result = computeForPropertyInlineCacheWithoutExitSiteFeedback(locker, baselineBlock, map.get(CodeOrigin(bytecodeIndex)).propertyCache);
     if (didExit)
         return result.slowVersion();
 #else
@@ -174,8 +172,7 @@ DeleteByStatus DeleteByStatus::computeFor(
             DeleteByStatus result;
             {
                 ConcurrentJSLocker locker(context->optimizedCodeBlock->m_lock);
-                result = computeForPropertyInlineCacheWithoutExitSiteFeedback(
-                    locker, context->optimizedCodeBlock, status.propertyCache);
+                result = computeForPropertyInlineCacheWithoutExitSiteFeedback(locker, context->optimizedCodeBlock, status.propertyCache);
             }
             if (result.isSet())
                 return bless(result);

--- a/Source/JavaScriptCore/bytecode/DeleteByStatus.h
+++ b/Source/JavaScriptCore/bytecode/DeleteByStatus.h
@@ -97,8 +97,7 @@ private:
 
     static DeleteByStatus computeForBaseline(CodeBlock*, ICStatusMap&, BytecodeIndex, ExitFlag);
 #if ENABLE(JIT)
-    static DeleteByStatus computeForPropertyInlineCacheWithoutExitSiteFeedback(
-        const ConcurrentJSLocker&, CodeBlock* profiledBlock, PropertyInlineCache*);
+    static DeleteByStatus computeForPropertyInlineCacheWithoutExitSiteFeedback(const ConcurrentJSLocker&, CodeBlock* profiledBlock, PropertyInlineCache*);
 #endif
 
     Vector<DeleteByVariant, 1> m_variants;

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -203,7 +203,6 @@ GetByStatus GetByStatus::computeFor(CodeBlock* profiledBlock, ICStatusMap& map, 
 
 #if ENABLE(DFG_JIT)
     result = computeForPropertyInlineCacheWithoutExitSiteFeedback(locker, profiledBlock, map.get(CodeOrigin(codeOrigin.bytecodeIndex())).propertyCache, callExitSiteData, codeOrigin);
-    
     if (didExit)
         return result.slowVersion();
 #else

--- a/Source/JavaScriptCore/bytecode/InByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/InByStatus.cpp
@@ -59,7 +59,6 @@ InByStatus InByStatus::computeFor(CodeBlock* profiledBlock, ICStatusMap& map, By
 
 #if ENABLE(DFG_JIT)
     result = computeForPropertyInlineCacheWithoutExitSiteFeedback(locker, profiledBlock, map.get(CodeOrigin(bytecodeIndex)).propertyCache, callExitSiteData, codeOrigin);
-
     if (!result.takesSlowPath() && didExit)
         return InByStatus(TakesSlowPath);
 #else

--- a/Source/JavaScriptCore/bytecode/InstanceOfStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/InstanceOfStatus.cpp
@@ -51,8 +51,7 @@ InstanceOfStatus InstanceOfStatus::computeFor(
     
     InstanceOfStatus result;
 #if ENABLE(DFG_JIT)
-    result = computeForPropertyInlineCache
-(locker, codeBlock->vm(), infoMap.get(CodeOrigin(bytecodeIndex)).propertyCache);
+    result = computeForPropertyInlineCache(locker, codeBlock->vm(), infoMap.get(CodeOrigin(bytecodeIndex)).propertyCache);
 
     if (!result.takesSlowPath()) {
         UnlinkedCodeBlock* unlinkedCodeBlock = codeBlock->unlinkedCodeBlock();
@@ -72,8 +71,7 @@ InstanceOfStatus InstanceOfStatus::computeFor(
 }
 
 #if ENABLE(DFG_JIT)
-InstanceOfStatus InstanceOfStatus::computeForPropertyInlineCache
-(const ConcurrentJSLocker& locker, VM& vm, PropertyInlineCache* propertyCache)
+InstanceOfStatus InstanceOfStatus::computeForPropertyInlineCache(const ConcurrentJSLocker& locker, VM& vm, PropertyInlineCache* propertyCache)
 {
     // FIXME: We wouldn't have to bail for nonCell if we taught MatchStructure how to handle non
     // cells. If we fixed that then we wouldn't be able to use summary();

--- a/Source/JavaScriptCore/bytecode/InstanceOfStatus.h
+++ b/Source/JavaScriptCore/bytecode/InstanceOfStatus.h
@@ -89,8 +89,7 @@ public:
     static InstanceOfStatus computeFor(CodeBlock*, ICStatusMap&, BytecodeIndex);
     
 #if ENABLE(DFG_JIT)
-    static InstanceOfStatus computeForPropertyInlineCache
-(const ConcurrentJSLocker&, VM&, PropertyInlineCache*);
+    static InstanceOfStatus computeForPropertyInlineCache(const ConcurrentJSLocker&, VM&, PropertyInlineCache*);
 #endif
     
     State state() const { return m_state; }

--- a/Source/JavaScriptCore/bytecode/PutByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.cpp
@@ -151,8 +151,7 @@ PutByStatus PutByStatus::computeFor(CodeBlock* profiledBlock, ICStatusMap& map, 
         return PutByStatus(LikelyTakesSlowPath);
     
     PropertyInlineCache* propertyCache = map.get(CodeOrigin(bytecodeIndex)).propertyCache;
-    PutByStatus result = computeForPropertyInlineCache
-(locker, profiledBlock, propertyCache, callExitSiteData, CodeOrigin(bytecodeIndex));
+    PutByStatus result = computeForPropertyInlineCache(locker, profiledBlock, propertyCache, callExitSiteData, CodeOrigin(bytecodeIndex));
     if (!result)
         return computeFromLLInt(profiledBlock, bytecodeIndex);
     
@@ -165,15 +164,12 @@ PutByStatus PutByStatus::computeFor(CodeBlock* profiledBlock, ICStatusMap& map, 
 #endif // ENABLE(JIT)
 }
 
-PutByStatus PutByStatus::computeForPropertyInlineCache
-(const ConcurrentJSLocker& locker, CodeBlock* baselineBlock, PropertyInlineCache* propertyCache, CodeOrigin codeOrigin)
+PutByStatus PutByStatus::computeForPropertyInlineCache(const ConcurrentJSLocker& locker, CodeBlock* baselineBlock, PropertyInlineCache* propertyCache, CodeOrigin codeOrigin)
 {
-    return computeForPropertyInlineCache
-(locker, baselineBlock, propertyCache, CallLinkStatus::computeExitSiteData(baselineBlock, codeOrigin.bytecodeIndex()), codeOrigin);
+    return computeForPropertyInlineCache(locker, baselineBlock, propertyCache, CallLinkStatus::computeExitSiteData(baselineBlock, codeOrigin.bytecodeIndex()), codeOrigin);
 }
 
-PutByStatus PutByStatus::computeForPropertyInlineCache
-(const ConcurrentJSLocker& locker, CodeBlock* profiledBlock, PropertyInlineCache* propertyCache, CallLinkStatus::ExitSiteData callExitSiteData, CodeOrigin)
+PutByStatus PutByStatus::computeForPropertyInlineCache(const ConcurrentJSLocker& locker, CodeBlock* profiledBlock, PropertyInlineCache* propertyCache, CallLinkStatus::ExitSiteData callExitSiteData, CodeOrigin)
 {
     PropertyInlineCacheSummary summary = PropertyInlineCache::summary(locker, profiledBlock->vm(), propertyCache);
     if (!isInlineable(summary))
@@ -352,8 +348,7 @@ PutByStatus PutByStatus::computeFor(CodeBlock* baselineBlock, ICStatusMap& basel
             PutByStatus result;
             {
                 ConcurrentJSLocker locker(context->optimizedCodeBlock->m_lock);
-                result = computeForPropertyInlineCache
-(locker, context->optimizedCodeBlock, status.propertyCache, callExitSiteData, codeOrigin);
+                result = computeForPropertyInlineCache(locker, context->optimizedCodeBlock, status.propertyCache, callExitSiteData, codeOrigin);
             }
             if (result.isSet())
                 return bless(result);

--- a/Source/JavaScriptCore/bytecode/PutByStatus.h
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.h
@@ -106,8 +106,7 @@ public:
     static PutByStatus computeFor(CodeBlock* baselineBlock, ICStatusMap& baselineMap, ICStatusContextStack&, CodeOrigin);
 
 #if ENABLE(JIT)
-    static PutByStatus computeForPropertyInlineCache
-(const ConcurrentJSLocker&, CodeBlock* baselineBlock, PropertyInlineCache*, CodeOrigin);
+    static PutByStatus computeForPropertyInlineCache(const ConcurrentJSLocker&, CodeBlock* baselineBlock, PropertyInlineCache*, CodeOrigin);
 #endif
     
     State state() const { return m_state; }
@@ -159,8 +158,7 @@ public:
     
 private:
 #if ENABLE(JIT)
-    static PutByStatus computeForPropertyInlineCache
-(const ConcurrentJSLocker&, CodeBlock*, PropertyInlineCache*, CallLinkStatus::ExitSiteData, CodeOrigin);
+    static PutByStatus computeForPropertyInlineCache(const ConcurrentJSLocker&, CodeBlock*, PropertyInlineCache*, CallLinkStatus::ExitSiteData, CodeOrigin);
 #endif
     static PutByStatus computeFromLLInt(CodeBlock*, BytecodeIndex);
     

--- a/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.cpp
@@ -56,9 +56,7 @@ SetPrivateBrandStatus SetPrivateBrandStatus::computeForBaseline(CodeBlock* basel
     SetPrivateBrandStatus result;
 
 #if ENABLE(DFG_JIT)
-    result = computeForPropertyInlineCacheWithoutExitSiteFeedback(
-        locker, baselineBlock, map.get(CodeOrigin(bytecodeIndex)).propertyCache);
-
+    result = computeForPropertyInlineCacheWithoutExitSiteFeedback(locker, baselineBlock, map.get(CodeOrigin(bytecodeIndex)).propertyCache);
     if (didExit)
         return result.slowVersion();
 #else
@@ -159,8 +157,7 @@ SetPrivateBrandStatus SetPrivateBrandStatus::computeFor(
             SetPrivateBrandStatus result;
             {
                 ConcurrentJSLocker locker(context->optimizedCodeBlock->m_lock);
-                result = computeForPropertyInlineCacheWithoutExitSiteFeedback(
-                    locker, context->optimizedCodeBlock, status.propertyCache);
+                result = computeForPropertyInlineCacheWithoutExitSiteFeedback(locker, context->optimizedCodeBlock, status.propertyCache);
             }
             if (result.isSet())
                 return bless(result);

--- a/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.h
+++ b/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.h
@@ -99,8 +99,7 @@ private:
 
     static SetPrivateBrandStatus computeForBaseline(CodeBlock*, ICStatusMap&, BytecodeIndex, ExitFlag);
 #if ENABLE(JIT)
-    static SetPrivateBrandStatus computeForPropertyInlineCacheWithoutExitSiteFeedback(
-        const ConcurrentJSLocker&, CodeBlock* profiledBlock, PropertyInlineCache*);
+    static SetPrivateBrandStatus computeForPropertyInlineCacheWithoutExitSiteFeedback(const ConcurrentJSLocker&, CodeBlock* profiledBlock, PropertyInlineCache*);
 #endif
 
     Vector<SetPrivateBrandVariant, 1> m_variants;


### PR DESCRIPTION
#### 039dce84d4e0eda9e1e6b3a58964d50731e8e581
<pre>
Unreviewed, fix weird formatting
<a href="https://bugs.webkit.org/show_bug.cgi?id=321321">https://bugs.webkit.org/show_bug.cgi?id=321321</a>
<a href="https://rdar.apple.com/184361372">rdar://184361372</a>

* Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.cpp:
(JSC::CheckPrivateBrandStatus::computeForBaseline):
(JSC::CheckPrivateBrandStatus::computeFor):
* Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.h:
* Source/JavaScriptCore/bytecode/DeleteByStatus.cpp:
(JSC::DeleteByStatus::computeForBaseline):
(JSC::DeleteByStatus::computeFor):
* Source/JavaScriptCore/bytecode/DeleteByStatus.h:
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeFor):
* Source/JavaScriptCore/bytecode/InByStatus.cpp:
(JSC::InByStatus::computeFor):
* Source/JavaScriptCore/bytecode/InstanceOfStatus.cpp:
(JSC::InstanceOfStatus::computeFor):
(JSC::InstanceOfStatus::computeForPropertyInlineCache):
* Source/JavaScriptCore/bytecode/InstanceOfStatus.h:
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
(JSC::PutByStatus::computeFor):
(JSC::PutByStatus::computeForPropertyInlineCache):
* Source/JavaScriptCore/bytecode/PutByStatus.h:
* Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.cpp:
(JSC::SetPrivateBrandStatus::computeForBaseline):
(JSC::SetPrivateBrandStatus::computeFor):
* Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.h:

Canonical link: <a href="https://commits.webkit.org/318813@main">https://commits.webkit.org/318813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ecbc0c4b085f437e188525ead94b93e0b306874

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53415 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54709 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53126 "Failed to checkout and rebase branch from PR 71175") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/189308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182433 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/53126 "Failed to checkout and rebase branch from PR 71175") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/189308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/40751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/53126 "Failed to checkout and rebase branch from PR 71175") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/191529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/191529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53766 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/191529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27242 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/43633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52283 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51729 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->