### PR TITLE
[iOS] Null TextIndicator dereferences in position information consumers

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -225,7 +225,7 @@ static const CGFloat presentationElementRectPadding = 15;
         return CGRectZero;
 
     RefPtr textIndicator = _positionInformation->textIndicator;
-    if (textIndicator->textRectsInBoundingRectCoordinates().isEmpty())
+    if (!textIndicator || textIndicator->textRectsInBoundingRectCoordinates().isEmpty())
         return CGRectZero;
 
     WebCore::FloatPoint touchLocation = _positionInformation->request.point;
@@ -488,7 +488,8 @@ static bool isJavaScriptURL(NSURL *url)
     if (std::max(leftInset, rightInset) <= minimumAvailableWidthOrHeightRatio * CGRectGetWidth(visibleRect) && std::max(topInset, bottomInset) <= minimumAvailableWidthOrHeightRatio * CGRectGetHeight(visibleRect))
         return WKActionSheetPresentAtTouchLocation;
 
-    if (elementInfo.type == _WKActivatedElementTypeLink && positionInfo.textIndicator->textRectsInBoundingRectCoordinates().size())
+    RefPtr textIndicator = positionInfo.textIndicator;
+    if (elementInfo.type == _WKActivatedElementTypeLink && textIndicator && !textIndicator->textRectsInBoundingRectCoordinates().isEmpty())
         return WKActionSheetPresentAtClosestIndicatorRect;
 
     return WKActionSheetPresentAtElementRect;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -16110,10 +16110,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (UIImage *)_presentationSnapshotForPreviewItemController:(UIPreviewItemController *)controller
 {
-    if (!_positionInformation.textIndicator->contentImage())
+    RefPtr textIndicator = _positionInformation.textIndicator;
+    if (!textIndicator || !textIndicator->contentImage())
         return nullptr;
 
-    auto nativeImage = protect(_positionInformation.textIndicator->contentImage())->nativeImage();
+    auto nativeImage = protect(textIndicator->contentImage())->nativeImage();
     if (!nativeImage)
         return nullptr;
 
@@ -16122,9 +16123,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSArray *)_presentationRectsForPreviewItemController:(UIPreviewItemController *)controller
 {
-    if (_positionInformation.textIndicator->contentImage()) {
-        auto origin = _positionInformation.textIndicator->textBoundingRectInRootViewCoordinates().location();
-        return createNSArray(_positionInformation.textIndicator->textRectsInBoundingRectCoordinates(), [&] (CGRect rect) {
+    RefPtr textIndicator = _positionInformation.textIndicator;
+    if (textIndicator && textIndicator->contentImage()) {
+        auto origin = textIndicator->textBoundingRectInRootViewCoordinates().location();
+        return createNSArray(textIndicator->textRectsInBoundingRectCoordinates(), [&] (CGRect rect) {
             return [NSValue valueWithCGRect:CGRectOffset(rect, origin.x(), origin.y())];
         }).autorelease();
     } else {


### PR DESCRIPTION
#### 57e8347f3e91ae1766dadd7144f7cf32c5f86fd8
<pre>
[iOS] Null TextIndicator dereferences in position information consumers
<a href="https://bugs.webkit.org/show_bug.cgi?id=321322">https://bugs.webkit.org/show_bug.cgi?id=321322</a>
<a href="https://rdar.apple.com/184361817">rdar://184361817</a>

Reviewed by David Kilzer.

InteractionInformationAtPosition::textIndicator is a RefPtr that is only
populated when the request asked for a link indicator and the hit element produced one, but
four iOS consumers dereference it unchecked.

-_presentationStyleForPositionInfo:elementInfo: guards only on the
activated element being a link, so a link whose position information carries no text indicator
crashes while choosing an action sheet presentation style. presentationRectForElementUsingClosestIndicatedRect checks _positionInformation but not the indicator inside it. The two UIPreviewItemController callbacks used by legacy link preview check neither.

Adopt the shape already used by the correctly-guarded call sites nearby, test the RefPtr before dereferencing it, and hoist it into a local where it is used more than once, as WKActionSheetAssistant.mm:1068, WKContentViewInteraction.mm:10320 and :12009 do.

No new test: reaching these paths requires a link whose position information has no text
indicator to arrive at legacy link preview or action sheet presentation, which TestWebKitAPI
cannot currently drive on iOS.

* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant presentationRectForElementUsingClosestIndicatedRect]):
(-[WKActionSheetAssistant _presentationStyleForPositionInfo:elementInfo:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _presentationSnapshotForPreviewItemController:]):
(-[WKContentView _presentationRectsForPreviewItemController:]):

Canonical link: <a href="https://commits.webkit.org/319126@main">https://commits.webkit.org/319126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/018a6d4b8bc93b0edb04fc3e1a0fc4d834c10d94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144808 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a84d3a7-d52d-481e-83e5-433b72d30e17) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140777 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e391b0d1-484d-48b9-8b20-c7ab22cbd380) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44434 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121229 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33481538-9f94-4026-9e96-4e1b413dc499) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43107 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41396 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41073 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1857 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192633 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54098 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150133 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40209 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54786 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149855 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44483 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127049 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122221 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53303 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16062 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52685 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52922 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52750 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->