### PR TITLE
[WebXR] Remove unused WebGPUXRView.h include in XRGPUBinding

### DIFF
--- a/Source/WebCore/Modules/webxr/XRGPUBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRGPUBinding.cpp
@@ -31,7 +31,6 @@
 #include "GPUDevice.h"
 #include "WebGPUXRBinding.h"
 #include "WebGPUXREye.h"
-#include "WebGPUXRView.h"
 #include "WebXRFrame.h"
 #include "WebXRView.h"
 #include "XRCompositionLayer.h"


### PR DESCRIPTION
#### 3b117838f80abb09560538465b3ee0e805360548
<pre>
[WebXR] Remove unused WebGPUXRView.h include in XRGPUBinding
<a href="https://bugs.webkit.org/show_bug.cgi?id=321325">https://bugs.webkit.org/show_bug.cgi?id=321325</a>
<a href="https://rdar.apple.com/184363202">rdar://184363202</a>

Reviewed by Dan Glastonbury.

XRGPUBinding.cpp includes WebGPUXRView.h but never uses WebGPU::XRView. No change in behavior.

* Source/WebCore/Modules/webxr/XRGPUBinding.cpp:

Canonical link: <a href="https://commits.webkit.org/318985@main">https://commits.webkit.org/318985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01c7001f59926be23a83c0e2cfaa8fab19f05fdb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189313 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143790 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e252e88d-0530-4d0f-82e8-c5109908c077) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139963 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96840 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d773c852-d171-4dc2-9315-9b4c7226835d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182438 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43576 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120415 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/207a856d-404b-42c0-b237-cf7edb6d1f6f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42246 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40572 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152647 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40217 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/esm-integration/execute-start.tentative.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/767 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191534 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53090 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149224 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40113 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53771 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148968 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43638 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126043 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120938 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52288 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15206 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51673 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51914 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51734 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->