### PR TITLE
[ANGLE] Update the update-angle script

### DIFF
--- a/Tools/Scripts/update-angle
+++ b/Tools/Scripts/update-angle
@@ -291,6 +291,12 @@ def phase_prepare(ctx):
         # config.
         git(["config", "diff.objcpp.xfuncname", r"^[-+@a-zA-Z_].*$"], cwd=work)
         git(["config", "diff.objcppheader.xfuncname", r"^[@a-zA-Z_].*$"], cwd=work)
+        # The synthetic commit identity has no signing key.
+        git(["config", "commit.gpgsign", "false"], cwd=work)
+        # run_code_generation.py calls `git cl format`, which aborts unless it
+        # can name a commit to diff against. It normally uses the branch
+        # upstream, but the merge worktree is detached, so point it at HEAD.
+        git(["config", "rietveld.upstream-branch", "HEAD"], cwd=work)
 
     # Read the previously-imported upstream commit from ANGLE.plist.
     plist = os.path.join(ANGLE_DIR, "ANGLE.plist")
@@ -469,8 +475,8 @@ def phase_codegen_a(ctx):
         res = run([sys.executable, "scripts/run_code_generation.py"],
                   cwd=merge, check=False)
         if res.returncode != 0:
-            warn("run_code_generation.py returned %d; continuing with "
-                 "merged outputs." % res.returncode)
+            fail("run_code_generation.py returned %d; refusing to export stale "
+                 "or conflicted generated outputs." % res.returncode)
     finally:
         # Remove the overlay symlinks so they never reach bookkeep/export.
         for rel in links:
@@ -749,6 +755,27 @@ def phase_codegen_b(ctx):
     _run_webkit_source_generators(merge)
 
 
+_CMAKE_SRC_REF_RE = re.compile(
+    r'"((?:src|include)/[^"\s${}*]+\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx|inl|inc|mm|m))"')
+
+
+def _check_cmake_source_refs(merge):
+    """Return sources named in CMakeLists.txt / *.cmake but absent from the merged
+    tree, which are files upstream removed that WebKit's build lists still name, which
+    breaks the CMake build. Matches literal quoted paths only."""
+    missing = set()
+    build_files = [os.path.join(merge, "CMakeLists.txt")]
+    build_files += sorted(glob.glob(os.path.join(merge, "*.cmake")))
+    for bf in build_files:
+        if not os.path.exists(bf):
+            continue
+        with open(bf) as f:
+            for ref in _CMAKE_SRC_REF_RE.findall(f.read()):
+                if not os.path.exists(os.path.join(merge, ref)):
+                    missing.add(ref)
+    return sorted(missing)
+
+
 def phase_bookkeep(ctx):
     """Update ANGLE.plist and changes.diff, and write the commit message."""
     work = ctx["work"]
@@ -756,6 +783,15 @@ def phase_bookkeep(ctx):
     target_hash = ctx["state"].data["target_hash"]
     prev_hash = ctx["state"].data["previous_hash"]
     target_date = git(["show", "-s", "--format=%cs", target_hash], cwd=work)
+
+    # Flag stale build-list refs (see _check_cmake_source_refs).
+    missing_refs = _check_cmake_source_refs(merge)
+    if missing_refs:
+        warn("CMakeLists.txt / *.cmake still reference %d file(s) missing from the "
+             "merged tree (removed upstream?); the CMake build will fail:"
+             % len(missing_refs))
+        for p in missing_refs:
+            warn("    %s" % p)
 
     # ANGLE.plist: 40-char hash (appears in OpenSourceVersion and the SCM
     # checkout command) + Update date (the target commit's date).


### PR DESCRIPTION
#### c9066d908eb5a9ccd0198e1360b62dd88857a393
<pre>
[ANGLE] Update the update-angle script
<a href="https://bugs.webkit.org/show_bug.cgi?id=321327">https://bugs.webkit.org/show_bug.cgi?id=321327</a>
<a href="https://rdar.apple.com/184363140">rdar://184363140</a>

Reviewed by Kimmo Kinnunen.

Four fixes found while updating ANGLE:

1. The temp work repository has no local config, so it can inherit a global
   commit.gpgsign. Its synthetic identity has no signing key, so the merge
   commit fails. Set commit.gpgsign=false there.

2. run_code_generation.py calls depot_tools&apos; `git cl format --full`, which
   aborts unless it can name a commit to diff against. It normally takes one
   from the current branch&apos;s upstream, but the merge worktree is detached.
   git cl reads rietveld.upstream-branch when there is no branch, so set
   that to HEAD in the work repo&apos;s config.

3. Code generation failure was a warning, so incomplete output reached finalize
   alongside hash files describing content that no longer existed. Make it
   fatal.

4. Warn when CMakeLists.txt or *.cmake still name a source deleted upstream,
   which breaks the CMake ports.

* Tools/Scripts/update-angle:
(phase_prepare):
(phase_codegen_a):
(_check_cmake_source_refs):
(phase_bookkeep):
(phase_codegen_b):

Canonical link: <a href="https://commits.webkit.org/318974@main">https://commits.webkit.org/318974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50ea5a27dd242ee66030cefa83edded06d59195d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144244 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0d1b970-fd03-43c4-a692-6c21ab7db756) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140307 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9816c2a1-0f36-40d6-99d5-856a73f66d0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161088 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120758 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c527f8ff-85b6-4f42-946d-e4959bd02b65) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42630 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40949 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40615 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1294 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192068 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53537 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149641 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40107 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54224 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37226 "Too many flaky failures: http/tests/media/reload-after-dialog.html, http/tests/misc/slow-preload-cancel.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/no-third-party-cookie-blocking-when-itp-is-off.html, http/tests/security/canvas-remote-read-remote-video-allowed-anonymous.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/report-uri.py, http/tests/site-isolation/iframe-dark-mode.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss.html, http/tests/websocket/tests/hybi/cross-origin.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149370 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44017 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121544 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52741 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15601 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52123 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52361 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52187 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->