### PR TITLE
[JSC] Fix Wasm memory64 memarg offset parsing

### DIFF
--- a/JSTests/wasm/stress/memarg-offset-u64-encoding.js
+++ b/JSTests/wasm/stress/memarg-offset-u64-encoding.js
@@ -1,0 +1,87 @@
+import * as assert from "../assert.js";
+
+// memarg's offset field is a u64 for every memory; only its value is restricted by the memory's
+// address type. An in-range offset written with a wider-than-minimal LEB is still well formed.
+
+const SECTION_TYPE = 1;
+const SECTION_FUNCTION = 3;
+const SECTION_MEMORY = 5;
+const SECTION_CODE = 10;
+
+function leb(value) {
+    let bytes = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value)
+            byte |= 0x80;
+        bytes.push(byte);
+    } while (value);
+    return bytes;
+}
+
+// The value's minimal encoding, padded out to byteCount bytes with redundant continuation bytes.
+function paddedLeb(value, byteCount) {
+    let bytes = [];
+    for (let i = 0; i < byteCount; ++i) {
+        bytes.push(Number(value & 0x7fn) | (i + 1 < byteCount ? 0x80 : 0));
+        value >>= 7n;
+    }
+    if (value)
+        throw new Error(`${value} does not fit in ${byteCount} LEB bytes`);
+    return bytes;
+}
+
+function section(id, payload) {
+    return [id, ...leb(payload.length), ...payload];
+}
+
+function moduleBytes(isMemory64, body) {
+    let bytes = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+    bytes.push(...section(SECTION_TYPE, [0x01, 0x60, 0x00, 0x00]));
+    bytes.push(...section(SECTION_FUNCTION, [0x01, 0x00]));
+    bytes.push(...section(SECTION_MEMORY, [0x01, isMemory64 ? 0x04 : 0x00, 0x01]));
+    const code = [0x00, ...body, 0x0b];
+    bytes.push(...section(SECTION_CODE, [0x01, ...leb(code.length), ...code]));
+    return new Uint8Array(bytes);
+}
+
+// i32.const 0 / i32.load align=4 offset=<offset> / drop
+const load32 = (offsetBytes) => [0x41, 0x00, 0x28, 0x02, ...offsetBytes, 0x1a];
+// i64.const 0 / i32.load align=4 offset=<offset> / drop
+const load64 = (offsetBytes) => [0x42, 0x00, 0x28, 0x02, ...offsetBytes, 0x1a];
+
+function assertValid(description, isMemory64, body) {
+    try {
+        new WebAssembly.Module(moduleBytes(isMemory64, body));
+    } catch (error) {
+        throw new Error(`${description}: expected to compile, got ${error}`);
+    }
+}
+
+function assertInvalid(description, isMemory64, body) {
+    try {
+        new WebAssembly.Module(moduleBytes(isMemory64, body));
+    } catch (error) {
+        assert.truthy(error instanceof WebAssembly.CompileError, `${description}: expected CompileError, got ${error}`);
+        return;
+    }
+    throw new Error(`${description}: module was accepted but is invalid`);
+}
+
+// An in-range offset is accepted at every encoded width, up to u64's maximum of ten bytes.
+for (let byteCount = 1; byteCount <= 10; ++byteCount) {
+    assertValid(`memory32 offset 0 in ${byteCount} LEB bytes`, false, load32(paddedLeb(0n, byteCount)));
+    assertValid(`memory64 offset 0 in ${byteCount} LEB bytes`, true, load64(paddedLeb(0n, byteCount)));
+}
+for (let byteCount = 5; byteCount <= 10; ++byteCount)
+    assertValid(`memory32 offset 0xffffffff in ${byteCount} LEB bytes`, false, load32(paddedLeb(0xffffffffn, byteCount)));
+
+// An offset that does not fit the memory's address type is still rejected.
+assertInvalid("memory32 offset 2^32", false, load32(paddedLeb(0x100000000n, 5)));
+assertInvalid("memory32 offset 2^64-1", false, load32(paddedLeb(0xffffffffffffffffn, 10)));
+assertValid("memory64 offset 2^32", true, load64(paddedLeb(0x100000000n, 5)));
+assertValid("memory64 offset 2^64-1", true, load64(paddedLeb(0xffffffffffffffffn, 10)));
+
+// Eleven bytes cannot encode a u64.
+assertInvalid("memory64 offset in 11 LEB bytes", true, load64([...paddedLeb(0n, 10).slice(0, 9), 0x80, 0x00]));

--- a/JSTests/wasm/stress/unreachable-immediates-validation.js
+++ b/JSTests/wasm/stress/unreachable-immediates-validation.js
@@ -1,0 +1,79 @@
+import * as assert from "../assert.js";
+
+// Immediates in unreachable code are still validated: the spec's validation rules do not depend on
+// reachability. These modules are assembled by hand because a text assembler rejects them outright.
+
+const SECTION_TYPE = 1;
+const SECTION_FUNCTION = 3;
+const SECTION_TABLE = 4;
+const SECTION_MEMORY = 5;
+const SECTION_CODE = 10;
+
+function leb(value) {
+    let bytes = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value)
+            byte |= 0x80;
+        bytes.push(byte);
+    } while (value);
+    return bytes;
+}
+
+function section(id, payload) {
+    return [id, ...leb(payload.length), ...payload];
+}
+
+function moduleBytes({ withMemory = false, withTable = false, body }) {
+    let bytes = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+    bytes.push(...section(SECTION_TYPE, [0x01, 0x60, 0x00, 0x00])); // one type: () -> ()
+    bytes.push(...section(SECTION_FUNCTION, [0x01, 0x00]));
+    if (withTable)
+        bytes.push(...section(SECTION_TABLE, [0x01, 0x70, 0x00, 0x01])); // one funcref table, min 1
+    if (withMemory)
+        bytes.push(...section(SECTION_MEMORY, [0x01, 0x00, 0x01])); // one memory, min 1
+    const code = [0x00, 0x00, ...body, 0x0b]; // no locals, unreachable, body, end
+    bytes.push(...section(SECTION_CODE, [0x01, ...leb(code.length), ...code]));
+    return new Uint8Array(bytes);
+}
+
+function assertInvalid(description, options) {
+    const bytes = moduleBytes(options);
+    try {
+        new WebAssembly.Module(bytes);
+    } catch (error) {
+        assert.truthy(error instanceof WebAssembly.CompileError, `${description}: expected CompileError, got ${error}`);
+        return;
+    }
+    throw new Error(`${description}: module was accepted but is invalid`);
+}
+
+function assertValid(description, options) {
+    new WebAssembly.Module(moduleBytes(options));
+}
+
+// A memarg alignment above the access's natural alignment is invalid.
+assertInvalid("i32.load align=8", { withMemory: true, body: [0x28, 0x03, 0x00] });
+assertInvalid("i32.load align=2^63", { withMemory: true, body: [0x28, 0x3f, 0x00] });
+assertInvalid("i32.store align=8", { withMemory: true, body: [0x36, 0x03, 0x00] });
+assertInvalid("i32.load8_s align=2", { withMemory: true, body: [0x2c, 0x01, 0x00] });
+assertInvalid("i64.load align=16", { withMemory: true, body: [0x29, 0x04, 0x00] });
+assertValid("i32.load align=4", { withMemory: true, body: [0x28, 0x02, 0x00] });
+assertValid("i32.load align=1", { withMemory: true, body: [0x28, 0x00, 0x00] });
+
+// A table index must exist. Only index 0 does here.
+assertInvalid("table.get 5", { withTable: true, body: [0x25, 0x05] });
+assertInvalid("table.set 5", { withTable: true, body: [0x26, 0x05] });
+assertInvalid("table.get 0, no table section", { body: [0x25, 0x00] });
+assertValid("table.get 0", { withTable: true, body: [0x25, 0x00] });
+
+// call_indirect validates both of its immediates, and needs a table at all.
+assertInvalid("call_indirect type 0 table 7", { withTable: true, body: [0x11, 0x00, 0x07] });
+assertInvalid("call_indirect type 99 table 0", { withTable: true, body: [0x11, 0x63, 0x00] });
+assertInvalid("call_indirect with no table section", { body: [0x11, 0x00, 0x00] });
+assertValid("call_indirect type 0 table 0", { withTable: true, body: [0x11, 0x00, 0x00] });
+
+// ref.func needs an index inside the function index space, and a declaration.
+assertInvalid("ref.func 99", { body: [0xd2, 0x63, 0x1a] });
+assertInvalid("ref.func 0 undeclared", { body: [0xd2, 0x00, 0x1a] });

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -300,6 +300,7 @@ private:
     [[nodiscard]] PartialResult parseMemoryIndex(uint8_t&);
     [[nodiscard]] PartialResult parseMemoryIndexForBulkOp(uint8_t&); // FIXME: when wasm spec tests are updated no need for this
     [[nodiscard]] PartialResult parseMemoryIndexAndFixupAlignment(uint32_t&, uint8_t&);
+    [[nodiscard]] PartialResult parseMemoryOffset(uint8_t memoryIndex, uint64_t&);
 
     [[nodiscard]] PartialResult parseIndexForLocal(uint32_t&);
     [[nodiscard]] PartialResult parseIndexForGlobal(uint32_t&);
@@ -761,13 +762,7 @@ auto FunctionParser<Context>::load(Type memoryType) -> PartialResult
 
     WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds load's natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
 
-    if (m_info.memory(memoryIndex).isMemory64())
-        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get load offset"_s);
-    else {
-        uint32_t offset32;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get load offset"_s);
-        offset = offset32;
-    }
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
 
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer"_s);
 
@@ -794,13 +789,7 @@ auto FunctionParser<Context>::store(Type memoryType) -> PartialResult
 
     WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds store's natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
 
-    if (m_info.memory(memoryIndex).isMemory64())
-        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get store offset"_s);
-    else {
-        uint32_t offset32;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get store offset"_s);
-        offset = offset32;
-    }
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer"_s);
 
@@ -839,13 +828,7 @@ auto FunctionParser<Context>::atomicLoad(ExtAtomicOpType op, Type memoryType) ->
     WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
 
-    if (m_info.memory(memoryIndex).isMemory64())
-        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get load offset"_s);
-    else {
-        uint32_t offset32;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get load offset"_s);
-        offset = offset32;
-    }
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer"_s);
 
     WASM_VALIDATOR_FAIL_IF(pointer.type().kind() != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
@@ -869,13 +852,7 @@ auto FunctionParser<Context>::atomicStore(ExtAtomicOpType op, Type memoryType) -
     uint8_t memoryIndex;
     WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-    if (m_info.memory(memoryIndex).isMemory64())
-        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get store offset"_s);
-    else {
-        uint32_t offset32;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get store offset"_s);
-        offset = offset32;
-    }
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
 
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer"_s);
@@ -900,13 +877,7 @@ auto FunctionParser<Context>::atomicBinaryRMW(ExtAtomicOpType op, Type memoryTyp
     uint8_t memoryIndex;
     WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-    if (m_info.memory(memoryIndex).isMemory64())
-        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get load offset"_s);
-    else {
-        uint32_t offset32;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get load offset"_s);
-        offset = offset32;
-    }
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
@@ -933,13 +904,7 @@ auto FunctionParser<Context>::atomicCompareExchange(ExtAtomicOpType op, Type mem
     uint8_t memoryIndex;
     WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
     WASM_PARSER_FAIL_IF(alignment !=  memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-    if (m_info.memory(memoryIndex).isMemory64())
-        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get load offset"_s);
-    else {
-        uint32_t offset32;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get load offset"_s);
-        offset = offset32;
-    }
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(expected, "expected"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
@@ -968,13 +933,7 @@ auto FunctionParser<Context>::atomicWait(ExtAtomicOpType op, Type memoryType) ->
     uint8_t memoryIndex;
     WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-    if (m_info.memory(memoryIndex).isMemory64())
-        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get load offset"_s);
-    else {
-        uint32_t offset32;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get load offset"_s);
-        offset = offset32;
-    }
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
     WASM_TRY_POP_EXPRESSION_STACK_INTO(timeout, "timeout"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
@@ -1002,13 +961,7 @@ auto FunctionParser<Context>::atomicNotify(ExtAtomicOpType op) -> PartialResult
     uint8_t memoryIndex;
     WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-    if (m_info.memory(memoryIndex).isMemory64())
-        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get load offset"_s);
-    else {
-        uint32_t offset32;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get load offset"_s);
-        offset = offset32;
-    }
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
     WASM_TRY_POP_EXPRESSION_STACK_INTO(count, "count"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
@@ -1093,13 +1046,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         uint32_t alignment;
         WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get simd memory op alignment"_s);
         WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get simd memory index"_s);
-        if (m_info.memory(memoryIndex).isMemory64())
-            WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get simd memory op offset"_s);
-        else {
-            uint32_t offset32;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get simd memory op offset"_s);
-            offset = offset32;
-        }
+        WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
 
         WASM_VALIDATOR_FAIL_IF(alignment > maxAlignment, "alignment: "_s, alignment, " can't be larger than max alignment for simd operation: "_s, maxAlignment);
 
@@ -1764,6 +1711,16 @@ auto FunctionParser<Context>::parseMemoryIndexAndFixupAlignment(uint32_t& alignm
     result = 0;
     if (hasMemoryIndex)
         WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndex(result));
+    return { };
+}
+
+template<typename Context>
+auto FunctionParser<Context>::parseMemoryOffset(uint8_t memoryIndex, uint64_t& result) -> PartialResult
+{
+    // The offset is encoded as a u64 whatever the memory's address type is; only its value is
+    // restricted to the range the address type can hold.
+    WASM_PARSER_FAIL_IF(!parseVarUInt64(result), "can't get memory offset"_s);
+    WASM_VALIDATOR_FAIL_IF(!m_info.memory(memoryIndex).isMemory64() && result > UINT32_MAX, "memory offset "_s, result, " is out of range for an i32 memory"_s);
     return { };
 }
 
@@ -4182,10 +4139,13 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         WASM_PARSER_FAIL_IF(!Options::useWasmTailCalls(), "wasm tail calls are not enabled"_s);
         [[fallthrough]];
     case CallIndirect: {
-        uint32_t unused;
-        uint32_t unused2;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get call_indirect's signature index in unreachable context"_s);
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused2), "can't get call_indirect's reserved byte in unreachable context"_s);
+        uint32_t signatureIndex;
+        uint32_t tableIndex;
+        WASM_PARSER_FAIL_IF(!m_info.tableCount(), "call_indirect is only valid when a table is defined or imported"_s);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(signatureIndex), "can't get call_indirect's signature index in unreachable context"_s);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't get call_indirect's table index in unreachable context"_s);
+        WASM_PARSER_FAIL_IF(tableIndex >= m_info.tableCount(), "call_indirect's table index "_s, tableIndex, " invalid, limit is "_s, m_info.tableCount());
+        WASM_PARSER_FAIL_IF(m_info.typeCount() <= signatureIndex, "call_indirect's signature index "_s, signatureIndex, " exceeds known signatures "_s, m_info.typeCount());
         return { };
     }
 
@@ -4218,13 +4178,9 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get first immediate for "_s, m_currentOpcode, " in unreachable context"_s);
         uint8_t memoryIndex;
         WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
-        if (m_info.memory(memoryIndex).isMemory64()) {
-            uint64_t unused64;
-            WASM_PARSER_FAIL_IF(!parseVarUInt64(unused64), "can't get second immediate for "_s, m_currentOpcode, " in unreachable context"_s);
-        } else {
-            uint32_t unused32;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused32), "can't get second immediate for "_s, m_currentOpcode, " in unreachable context"_s);
-        }
+        WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds "_s, m_currentOpcode, "'s natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
+        uint64_t unusedOffset;
+        WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, unusedOffset));
         return { };
     }
 
@@ -4367,9 +4323,10 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     case TableGet:
     case TableSet: {
         unsigned tableIndex;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't parse table index"_s);
-        [[fallthrough]];
+        WASM_FAIL_IF_HELPER_FAILS(parseTableIndex(tableIndex));
+        return { };
     }
+
     case RefIsNull: {
         return { };
     }
@@ -4381,8 +4338,11 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     }
 
     case RefFunc: {
-        uint32_t unused;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get immediate for "_s, m_currentOpcode, " in unreachable context"_s);
+        FunctionSpaceIndex index;
+        WASM_FAIL_IF_HELPER_FAILS(parseFunctionIndex(index));
+        // Function references don't need to be declared in constant expression contexts.
+        if constexpr (!std::is_same<Context, ConstExprGenerator>())
+            WASM_VALIDATOR_FAIL_IF(!m_info.isDeclaredFunction(index), "ref.func index "_s, index, " isn't declared"_s);
         return { };
     }
 
@@ -4601,13 +4561,8 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             uint8_t memoryIndex;
             WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
             WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-            if (m_info.memory(memoryIndex).isMemory64()) {
-                uint64_t unused64;
-                WASM_PARSER_FAIL_IF(!parseVarUInt64(unused64), "can't get first immediate for atomic "_s, static_cast<unsigned>(op), " in unreachable context"_s);
-            } else {
-                uint32_t unused32;
-                WASM_PARSER_FAIL_IF(!parseVarUInt32(unused32), "can't get first immediate for atomic "_s, static_cast<unsigned>(op), " in unreachable context"_s);
-            }
+            uint64_t unusedOffset;
+            WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, unusedOffset));
             break;
         }
         case ExtAtomicOpType::AtomicFence: {


### PR DESCRIPTION
#### 2e8a96a8c5857b071f073feea215c90803f22520
<pre>
[JSC] Fix Wasm memory64 memarg offset parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=321328">https://bugs.webkit.org/show_bug.cgi?id=321328</a>
<a href="https://rdar.apple.com/184364662">rdar://184364662</a>

Reviewed by Yijia Huang.

Regardless of memory64 / memory32, memarg offset is u64. This patch
fixes that by introducing `parseMemoryOffset`. We decode VarUInt64, and
then do range check for memory32 case. IPInt side is already using
VarUInt decoding so it does not need a change. Also we fix several Call,
Table related offset scanning in parseUnreachableExpression.

Tests: JSTests/wasm/stress/memarg-offset-u64-encoding.js
       JSTests/wasm/stress/unreachable-immediates-validation.js

* JSTests/wasm/stress/memarg-offset-u64-encoding.js: Added.
(leb):
(paddedLeb):
(section):
(moduleBytes):
(assertValid):
* JSTests/wasm/stress/unreachable-immediates-validation.js: Added.
(leb):
(section):
(moduleBytes):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::load):
(JSC::Wasm::FunctionParser&lt;Context&gt;::store):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicLoad):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicStore):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicBinaryRMW):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicCompareExchange):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicWait):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicNotify):
(JSC::Wasm::FunctionParser&lt;Context&gt;::simd):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseMemoryOffset):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):

Canonical link: <a href="https://commits.webkit.org/318826@main">https://commits.webkit.org/318826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26f8b48741f9850b088d3d805d43e79890dcee4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189319 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b660c4b-d70f-4a47-9911-0734ba85f4b3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139968 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b50b0853-e403-4713-b703-1781357948a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120420 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc09db6b-baf6-479d-835f-daf34ca8c73e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2390 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9200 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40221 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/773 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40762 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46032 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44822 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191540 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53096 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149229 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53777 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148973 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27253 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43642 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126049 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120947 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52294 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15210 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51679 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51920 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51740 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->