### PR TITLE
Cherry-pick 318812@main (b29eae826faa). https://bugs.webkit.org/show_bug.cgi?id=321310

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
@@ -34,7 +34,7 @@ using namespace WebCore;
 
 // This version number is in the DB and marks the current generation of the schema
 // Currently, a mismatched schema causes the DB to be wiped and reset.
-static const int currentDatabaseVersion = 6;
+static const int currentDatabaseVersion = 7;
 
 // Icons expire once every 4 days.
 static const Seconds iconExpirationTime { 60 * 60 * 24 * 4 };
@@ -132,7 +132,7 @@ bool IconDatabase::createTablesIfNeeded()
 
     m_db->clearAllTables();
 
-    if (!m_db->executeCommand("CREATE TABLE PageURL (url TEXT NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT REPLACE,iconID INTEGER NOT NULL ON CONFLICT FAIL);"_s)) {
+    if (!m_db->executeCommand("CREATE TABLE PageURL (url TEXT NOT NULL ON CONFLICT FAIL, iconID INTEGER NOT NULL ON CONFLICT FAIL, UNIQUE (url, iconID) ON CONFLICT REPLACE);"_s)) {
         RELEASE_LOG_ERROR(IconDatabase, "Could not create PageURL table in database (%i) - %s", m_db->lastError(), m_db->lastErrorMsg());
         m_db->close();
         return false;

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -342,7 +342,7 @@ void webkit_favicon_database_get_page_icons(WebKitFaviconDatabase* database, con
         return g_task_report_new_error(database, callback, userData, 0, WEBKIT_FAVICON_DATABASE_ERROR, WEBKIT_FAVICON_DATABASE_ERROR_FAVICON_NOT_FOUND, _("Page %s does not have a favicon"), pageURI);
 
     auto task = adoptGRef(g_task_new(database, cancellable, callback, userData));
-    database->priv->iconDatabase->loadIconsForPageURL(uriString, IconDatabase::AllowDatabaseWrite::No, [task = WTF::move(task)](Vector<PlatformImagePtr>&& icons) {
+    database->priv->iconDatabase->loadIconsForPageURL(uriString, IconDatabase::AllowDatabaseWrite::Yes, [task = WTF::move(task)](Vector<PlatformImagePtr>&& icons) {
         auto images = icons.map([](PlatformImagePtr image) -> GRefPtr<WebKitImage> {
             SkPixmap pixmap;
             RELEASE_ASSERT(image->peekPixels(&pixmap));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitFaviconDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitFaviconDatabase.cpp
@@ -204,6 +204,27 @@ public:
 #endif // PLATFORM(GTK)
 
 #if ENABLE(2022_GLIB_API)
+    static void getPageIconsCallback(GObject*, GAsyncResult* result, gpointer userData)
+    {
+        auto* test = static_cast<FaviconDatabaseTest*>(userData);
+        g_clear_pointer(&test->m_pageIcons, webkit_image_list_unref);
+        test->m_pageIcons = webkit_favicon_database_get_page_icons_finish(test->m_database.get(), result, &test->m_pageIconsError.outPtr());
+        test->quitMainLoop();
+    }
+
+    void getPageIconsForPageURIAndWaitUntilReady(const char* pageURI)
+    {
+        webkit_favicon_database_get_page_icons(m_database.get(), pageURI, nullptr, getPageIconsCallback, this);
+        g_main_loop_run(m_mainLoop);
+    }
+
+    void reopen()
+    {
+        close();
+        m_database = nullptr;
+        open("reopen");
+    }
+
     void waitUntilLoadFinishedAndPageIconsChanged()
     {
         g_clear_pointer(&m_pageIcons, webkit_image_list_unref);
@@ -306,7 +327,8 @@ public:
 
 #if ENABLE(2022_GLIB_API)
     size_t m_pageIconsNoticationCount { 0 };
-    WebKitImageList* m_pageIcons;
+    WebKitImageList* m_pageIcons { nullptr };
+    GUniqueOutPtr<GError> m_pageIconsError;
 #endif
 
     GRefPtr<WebKitFaviconDatabase> m_database;
@@ -464,7 +486,8 @@ static void testFaviconDatabaseGetPageIcons(FaviconDatabaseTest *test, gconstpoi
 {
     test->open("testFaviconDatabaseGetPageIcons");
 
-    test->loadURI(kServer->getURIForPath("/multipleicons").data());
+    CString pageURI = kServer->getURIForPath("/multipleicons");
+    test->loadURI(pageURI.data());
     test->waitUntilLoadFinishedAndPageIconsChanged();
 
 #if PLATFORM(GTK)
@@ -513,6 +536,12 @@ static void testFaviconDatabaseGetPageIcons(FaviconDatabaseTest *test, gconstpoi
     auto blueIconPixel = getARGBColorAtOrigin(blueIcon);
     g_assert_true(blueIconPixel.has_value());
     g_assert_cmpint(*blueIconPixel, ==, 0xFF0000FF);
+
+    test->reopen();
+    test->getPageIconsForPageURIAndWaitUntilReady(pageURI.data());
+    g_assert_no_error(test->m_pageIconsError.get());
+    g_assert_nonnull(test->m_pageIcons);
+    g_assert_cmpint(webkit_image_list_get_length(test->m_pageIcons), ==, 3);
 }
 #endif // ENABLE(2022_GLIB_API)
 


### PR DESCRIPTION
#### eafad0cc1c57b60fc60a078b367ce797fdf5dd5e
<pre>
Cherry-pick 318812@main (b29eae826faa). <a href="https://bugs.webkit.org/show_bug.cgi?id=321310">https://bugs.webkit.org/show_bug.cgi?id=321310</a>

Unreviewed backport.

    [GLib] Fix webkit_favicon_database_get_page_icons() lookups
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321310">https://bugs.webkit.org/show_bug.cgi?id=321310</a>

    Reviewed by Adrian Perez de Castro.

    This fixes two bugs:

    The commit introducing this feature used AllowDatabaseWrite::No which meant the
    in-memory cache worked but loading it would fail. The database contains a timestamp
    of when icons were last used, so it must be writable, otherwise every icon is
    considered not recently used and ignored.

    The purpose of this API was to return multiple sizes for the same URL, however
    the schema was `pageURL (url UNIQUE ..., iconID ...)` which meant there could
    only be one entry per URL. Change this to `UNIQUE (url, iconID)` so the combination
    must be unique.

    Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitFaviconDatabase.cpp

    * Source/WebKit/UIProcess/API/glib/IconDatabase.cpp:
    (WebKit::IconDatabase::createTablesIfNeeded):
    * Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
    (webkit_favicon_database_get_page_icons):
    * Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitFaviconDatabase.cpp:
    (testFaviconDatabaseGetPageIcons):

    Canonical link: <a href="https://commits.webkit.org/318812@main">https://commits.webkit.org/318812@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.71@webkitglib/2.54">https://commits.webkit.org/317695.71@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2de69b8630322cb9dc4478db929e5adec2910c5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179488 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53427 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47224 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189320 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143797 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181351 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54721 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53138 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143797 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182445 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54721 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47224 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120432 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54721 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53138 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47224 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54721 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47224 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/774 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46033 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53138 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191541 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53097 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47224 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53778 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47224 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148974 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27250 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53778 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126050 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120948 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52295 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47224 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51680 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51921 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51741 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->