### PR TITLE
[JSC] WebAssembly.Memory.prototype.type() needs to report current size

### DIFF
--- a/JSTests/wasm/stress/memory-type-reflects-current-size.js
+++ b/JSTests/wasm/stress/memory-type-reflects-current-size.js
@@ -1,0 +1,51 @@
+//@ requireOptions("--useWasmJSTypes=1", "--useSharedArrayBuffer=1")
+//@ skip if $addressBits <= 32
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// The minimum a memory or table reflects is its current size, not the size it was declared with, so
+// that feeding a reflected type back into the constructor reproduces the object it came from.
+
+function check(object, expected) {
+    const type = object.type();
+    assert.eq(type.minimum, expected.minimum);
+    assert.eq(type.maximum, expected.maximum);
+    assert.eq(type.address, expected.address);
+}
+
+for (const shared of [false, true]) {
+    const memory = new WebAssembly.Memory({ initial: 1, maximum: 10, shared });
+    check(memory, { minimum: 1, maximum: 10, address: "i32" });
+    memory.grow(3);
+    check(memory, { minimum: 4, maximum: 10, address: "i32" });
+    assert.eq(memory.buffer.byteLength, 4 * 65536);
+    assert.eq(new WebAssembly.Memory(memory.type()).buffer.byteLength, memory.buffer.byteLength);
+
+    const memory64 = new WebAssembly.Memory({ address: "i64", initial: 1n, maximum: 10n, shared });
+    check(memory64, { minimum: 1n, maximum: 10n, address: "i64" });
+    memory64.grow(3n);
+    check(memory64, { minimum: 4n, maximum: 10n, address: "i64" });
+    assert.eq(new WebAssembly.Memory(memory64.type()).buffer.byteLength, memory64.buffer.byteLength);
+}
+
+// A memory grown by the wasm memory.grow instruction reflects the new size too.
+for (const addressType of ["i32", "i64"]) {
+    const numOrBig = (val) => addressType == "i32" ? Number(val) : BigInt(val);
+    const { grow, memory } = (await instantiate(`
+(module
+    (memory (export "memory") ${addressType} 1 10)
+    (func (export "grow") (param ${addressType}) (result ${addressType})
+        (memory.grow (local.get 0)))
+)`, {}, { memory64: true })).exports;
+    check(memory, { minimum: numOrBig(1), maximum: numOrBig(10), address: addressType });
+    assert.eq(grow(numOrBig(2)), numOrBig(1));
+    check(memory, { minimum: numOrBig(3), maximum: numOrBig(10), address: addressType });
+}
+
+// A memory with no declared maximum still reflects its current size.
+{
+    const memory = new WebAssembly.Memory({ initial: 2 });
+    check(memory, { minimum: 2, maximum: undefined, address: "i32" });
+    memory.grow(1);
+    check(memory, { minimum: 3, maximum: undefined, address: "i32" });
+}

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
@@ -251,7 +251,7 @@ JSObject* JSWebAssemblyMemory::type(JSGlobalObject* globalObject)
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    PageCount minimum = m_memory->initial();
+    PageCount minimum = PageCount::fromBytes(m_memory->size());
     PageCount maximum = m_memory->maximum();
     auto addressType = m_memory->addressType();
 


### PR DESCRIPTION
#### 707048fdabb7f80ccb5222e342ca5a4257eb1dd2
<pre>
[JSC] WebAssembly.Memory.prototype.type() needs to report current size
<a href="https://bugs.webkit.org/show_bug.cgi?id=321329">https://bugs.webkit.org/show_bug.cgi?id=321329</a>
<a href="https://rdar.apple.com/184364939">rdar://184364939</a>

Reviewed by Yijia Huang.

WebAssembly.Memory.prototype.type()&apos;s minimum size is mem_type&apos;s
minimum limit[2], which is the current size of the memory, not initially
declared size.

[1]: <a href="https://webassembly.github.io/js-types/js-api/index.html#dom-memory-type">https://webassembly.github.io/js-types/js-api/index.html#dom-memory-type</a>
[2]: <a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-mem-type">https://webassembly.github.io/spec/core/appendix/embedding.html#embed-mem-type</a>

Test: JSTests/wasm/stress/memory-type-reflects-current-size.js

* JSTests/wasm/stress/memory-type-reflects-current-size.js: Added.
(check):
(string_appeared_here.await.instantiate.module.memory):
(string_appeared_here.memory.grow):
(maximum.numOrBig):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp:
(JSC::JSWebAssemblyMemory::type):

Canonical link: <a href="https://commits.webkit.org/318830@main">https://commits.webkit.org/318830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6e4342c9ea2dd172566be61ed88d01ddeaebda4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189322 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8ec02a7-8ff3-438d-86c5-f4b66a2c187c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139971 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8920833-f09d-4f14-ac3d-69ce0b4342a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120423 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29300787-fba7-4d68-aace-85cd19c4d067) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40577 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2393 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9199 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40220 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/776 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40765 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191543 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53099 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149233 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53780 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148977 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27256 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43647 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126052 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120950 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52297 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15209 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51682 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51923 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51743 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->