### PR TITLE
[iOS] Pinching native video controls requests fullscreen repeatedly

### DIFF
--- a/LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-controls-pinch-enters-fullscreen-once-expected.txt
+++ b/LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-controls-pinch-enters-fullscreen-once-expected.txt
@@ -1,0 +1,13 @@
+Testing that IOSInlineMediaControls only enters fullscreen once per pinch gesture.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS fullscreenRequestCount is 1
+PASS fullscreenRequestCount is 1
+PASS fullscreenRequestCount is 1
+PASS fullscreenRequestCount is 2
+
+PASS successfullyParsed is true
+
+TEST COMPLETE

--- a/LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-controls-pinch-enters-fullscreen-once-expected.txt
+++ b/LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-controls-pinch-enters-fullscreen-once-expected.txt
@@ -11,3 +11,4 @@ PASS fullscreenRequestCount is 2
 PASS successfullyParsed is true
 
 TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-controls-pinch-enters-fullscreen-once.html
+++ b/LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-controls-pinch-enters-fullscreen-once.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/media-controls-loader.js" type="text/javascript"></script>
+<body>
+<script type="text/javascript">
+
+description("Testing that <code>IOSInlineMediaControls</code> only enters fullscreen once per pinch gesture.");
+
+let fullscreenRequestCount = 0;
+const mediaControls = new IOSInlineMediaControls;
+mediaControls.delegate = {
+    iOSInlineMediaControlsRecognizedPinchInGesture()
+    {
+        ++fullscreenRequestCount;
+    }
+};
+
+const recognizer = mediaControls._pinchGestureRecognizer;
+recognizer.state = GestureRecognizer.States.Began;
+recognizer.scale = IOSInlineMediaControls.MinimumScaleToEnterFullscreen + 0.1;
+recognizer.state = GestureRecognizer.States.Changed;
+shouldBe("fullscreenRequestCount", "1");
+
+recognizer.scale += 0.1;
+recognizer.state = GestureRecognizer.States.Changed;
+shouldBe("fullscreenRequestCount", "1");
+
+recognizer.state = GestureRecognizer.States.Ended;
+shouldBe("fullscreenRequestCount", "1");
+
+recognizer.state = GestureRecognizer.States.Began;
+recognizer.scale = IOSInlineMediaControls.MinimumScaleToEnterFullscreen + 0.1;
+recognizer.state = GestureRecognizer.States.Changed;
+shouldBe("fullscreenRequestCount", "2");
+
+debug("");
+
+</script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/controls/ios-inline-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/ios-inline-media-controls.js
@@ -180,11 +180,18 @@ class IOSInlineMediaControls extends InlineMediaControls
     _pinchGestureRecognizerStateDidChange(recognizer)
     {
         console.assert(this.visible);
-        if (recognizer.state !== GestureRecognizer.States.Recognized && recognizer.state !== GestureRecognizer.States.Changed)
+        if (recognizer.state === GestureRecognizer.States.Began) {
+            this._didRecognizePinchInGesture = false;
+            return;
+        }
+
+        if (recognizer.state !== GestureRecognizer.States.Changed || this._didRecognizePinchInGesture)
             return;
 
-        if (recognizer.scale > IOSInlineMediaControls.MinimumScaleToEnterFullscreen && this.delegate && typeof this.delegate.iOSInlineMediaControlsRecognizedPinchInGesture === "function")
+        if (recognizer.scale > IOSInlineMediaControls.MinimumScaleToEnterFullscreen && this.delegate && typeof this.delegate.iOSInlineMediaControlsRecognizedPinchInGesture === "function") {
+            this._didRecognizePinchInGesture = true;
             this.delegate.iOSInlineMediaControlsRecognizedPinchInGesture();
+        }
     }
 
     _tapGestureRecognizerStateDidChange(recognizer)


### PR DESCRIPTION
[iOS] Pinching native video controls requests fullscreen repeatedly
https://bugs.webkit.org/show_bug.cgi?id=321330

Reviewed by NOBODY (OOPS!).

Only request fullscreen once after a pinch exceeds the fullscreen threshold,
and reset that state when a new gesture begins. This prevents subsequent
Changed and Ended states from calling webkitEnterFullscreen() while the
fullscreen transition is already in progress.

* LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-controls-pinch-enters-fullscreen-once-expected.txt: Added.
* LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-controls-pinch-enters-fullscreen-once.html: Added.
* Source/WebCore/Modules/modern-media-controls/controls/ios-inline-media-controls.js:
(IOSInlineMediaControls.prototype._pinchGestureRecognizerStateDidChange):
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46c693cb0c9d4b5930e778b3861bc30aee006733

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144099 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140240 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97061 "6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120691 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42518 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40839 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152919 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40496 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1074 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191842 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149521 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54078 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149255 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43909 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126350 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121382 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52595 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15486 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51980 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52221 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->