### PR TITLE
[Site Isolation] Right click Lookup on a word shows the word displaced

### DIFF
--- a/Source/WebCore/editing/cocoa/DictionaryLookup.mm
+++ b/Source/WebCore/editing/cocoa/DictionaryLookup.mm
@@ -311,11 +311,13 @@ std::optional<SimpleRange> DictionaryLookup::rangeAtHitTestResult(const HitTestR
     if (position.isNull())
         position = firstPositionInOrBeforeNode(node.get());
 
-    RefPtr focusedOrMainFrame = frame->page()->focusController().focusedOrMainFrame();
-    if (!focusedOrMainFrame)
-        return std::nullopt;
+    // focusedOrMainFrame() is null in a site-isolated subframe process. The selection that gives a
+    // hit test its context is the hit frame's own.
+    RefPtr selectionFrame = frame->page()->focusController().focusedOrMainFrame();
+    if (!selectionFrame)
+        selectionFrame = frame;
 
-    auto selection = focusedOrMainFrame->selection().selection();
+    auto selection = selectionFrame->selection().selection();
     NSRange selectionRange;
     NSUInteger hitIndex;
     std::optional<SimpleRange> fullCharacterRange;

--- a/Source/WebKit/Headers.cmake
+++ b/Source/WebKit/Headers.cmake
@@ -245,6 +245,7 @@ list(APPEND WebKit_PRIVATE_FRAMEWORK_HEADERS
     Shared/API/Cocoa/WebKitPrivate.h
     Shared/API/Cocoa/_WKFrameHandle.h
     Shared/API/Cocoa/_WKHitTestResult.h
+    Shared/API/Cocoa/_WKHitTestResultPrivateForTesting.h
     Shared/API/Cocoa/_WKNSFileManagerExtras.h
     Shared/API/Cocoa/_WKNSWindowExtras.h
     Shared/API/Cocoa/_WKRemoteObjectInterface.h

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
@@ -67,6 +67,8 @@ WK_CLASS_AVAILABLE(macos(10.12), ios(16.0))
 
 @property (nonatomic, readonly) CGRect elementBoundingBox;
 
+@property (nonatomic, readonly) CGRect _dictionaryPopupTextBoundingRectForTesting;
+
 @property (nonatomic, readonly) _WKHitTestResultElementType elementType WK_API_AVAILABLE(macos(14.4), ios(17.4), visionos(1.1));
 
 @property (nonatomic, readonly) WKFrameInfo *frameInfo WK_API_AVAILABLE(macos(14.4), ios(17.4), visionos(1.1));

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -30,6 +30,7 @@
 #import "WebFrameProxy.h"
 #import "WebPageProxy.h"
 #import "_WKFrameHandleInternal.h"
+#import "_WKHitTestResultPrivateForTesting.h"
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/URL.h>
 
@@ -145,6 +146,14 @@ static NSURL *URLFromString(const WTF::String& urlString)
 - (CGRect)elementBoundingBox
 {
     return _hitTestResult->elementBoundingBox();
+}
+
+- (CGRect)_dictionaryPopupTextBoundingRectForTesting
+{
+    RefPtr textIndicator = _hitTestResult->dictionaryPopupTextIndicator();
+    if (!textIndicator)
+        return CGRectZero;
+    return textIndicator->textBoundingRectInRootViewCoordinates();
 }
 
 - (_WKHitTestResultElementType)elementType

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -147,6 +147,11 @@ static NSURL *URLFromString(const WTF::String& urlString)
     return _hitTestResult->elementBoundingBox();
 }
 
+- (CGRect)_dictionaryPopupTextBoundingRectForTesting
+{
+    return _hitTestResult->dictionaryPopupTextBoundingRect();
+}
+
 - (_WKHitTestResultElementType)elementType
 {
     switch (_hitTestResult->elementType()) {

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResultPrivateForTesting.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResultPrivateForTesting.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/_WKHitTestResult.h>
+
+#if TARGET_OS_OSX || TARGET_OS_IOS || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+
+@interface _WKHitTestResult (WKTesting)
+
+// The Look Up text indicator's bounding rect, in the top-level frame's root view coordinates.
+@property (nonatomic, readonly) CGRect _dictionaryPopupTextBoundingRectForTesting;
+
+@end
+
+#endif

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.h
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.h
@@ -27,6 +27,7 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/PageOverlay.h>
 #include <WebCore/SharedMemory.h>
+#include <WebCore/TextIndicator.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
 #include <wtf/WeakPtr.h>
@@ -60,6 +61,8 @@ public:
     bool isContentEditable() const { return m_data.isContentEditable; }
 
     WebCore::IntRect elementBoundingBox() const { return m_data.elementBoundingBox; }
+
+    RefPtr<const WebCore::TextIndicator> dictionaryPopupTextIndicator() const { return m_data.dictionaryPopupInfo.textIndicator; }
 
     bool isScrollbar() const { return m_data.isScrollbar != WebKit::WebHitTestResultData::IsScrollbar::No; }
 

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.h
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.h
@@ -24,6 +24,7 @@
 #include "WebPageProxy.h"
 #include <WebCore/DictionaryPopupInfo.h>
 #include <WebCore/FloatPoint.h>
+#include <WebCore/FloatRect.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PageOverlay.h>
 #include <WebCore/SharedMemory.h>
@@ -60,6 +61,13 @@ public:
     bool isContentEditable() const { return m_data.isContentEditable; }
 
     WebCore::IntRect elementBoundingBox() const { return m_data.elementBoundingBox; }
+
+    // The Look Up text indicator's bounding rect, in the top-level frame's root view coordinates.
+    WebCore::FloatRect dictionaryPopupTextBoundingRect() const
+    {
+        RefPtr textIndicator = m_data.dictionaryPopupInfo.textIndicator;
+        return textIndicator ? textIndicator->textBoundingRectInRootViewCoordinates() : WebCore::FloatRect { };
+    }
 
     bool isScrollbar() const { return m_data.isScrollbar != WebKit::WebHitTestResultData::IsScrollbar::No; }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -17158,21 +17158,9 @@ void WebPageProxy::immediateActionDidComplete()
 
 void WebPageProxy::didPerformImmediateActionHitTest(IPC::Connection& connection, WebHitTestResultData&& result, bool contentPreventsDefault, const UserData& userData)
 {
-    if (protect(preferences())->siteIsolationEnabled()) {
-        if (result.remoteUserInputEventData) {
-            performImmediateActionHitTestAtLocation(result.remoteUserInputEventData->targetFrameID, FloatPoint(result.remoteUserInputEventData->transformedPoint));
-            return;
-        }
-        if (auto parentFrameID = result.frameInfo->parentFrameID) {
-            sendWithAsyncReplyToProcessContainingFrame(parentFrameID, Messages::WebPage::RemoteDictionaryPopupInfoToRootView(result.frameInfo->frameID, result.dictionaryPopupInfo), [protectedThis = Ref { *this }, userData, result = WTF::move(result), contentPreventsDefault] (IPC::Connection* connection, WebCore::DictionaryPopupInfo popupInfo) mutable {
-                result.dictionaryPopupInfo = popupInfo;
-                if (!connection)
-                    return;
-                if (RefPtr pageClient = protectedThis->pageClient())
-                    pageClient->didPerformImmediateActionHitTest(result, contentPreventsDefault, WebProcessProxy::fromConnection(*connection)->transformHandlesToObjects(protect(userData.object()).get()).get());
-            });
-            return;
-        }
+    if (protect(preferences())->siteIsolationEnabled() && result.remoteUserInputEventData) {
+        performImmediateActionHitTestAtLocation(result.remoteUserInputEventData->targetFrameID, FloatPoint(result.remoteUserInputEventData->transformedPoint));
+        return;
     }
     if (RefPtr pageClient = this->pageClient())
         pageClient->didPerformImmediateActionHitTest(result, contentPreventsDefault, WebProcessProxy::fromConnection(connection)->transformHandlesToObjects(protect(userData.object()).get()).get());

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16838,21 +16838,9 @@ void WebPageProxy::immediateActionDidComplete()
 
 void WebPageProxy::didPerformImmediateActionHitTest(IPC::Connection& connection, WebHitTestResultData&& result, bool contentPreventsDefault, const UserData& userData)
 {
-    if (protect(preferences())->siteIsolationEnabled()) {
-        if (result.remoteUserInputEventData) {
-            performImmediateActionHitTestAtLocation(result.remoteUserInputEventData->targetFrameID, FloatPoint(result.remoteUserInputEventData->transformedPoint));
-            return;
-        }
-        if (auto parentFrameID = result.frameInfo->parentFrameID) {
-            sendWithAsyncReplyToProcessContainingFrame(parentFrameID, Messages::WebPage::RemoteDictionaryPopupInfoToRootView(result.frameInfo->frameID, result.dictionaryPopupInfo), [protectedThis = Ref { *this }, userData, result = WTF::move(result), contentPreventsDefault] (IPC::Connection* connection, WebCore::DictionaryPopupInfo popupInfo) mutable {
-                result.dictionaryPopupInfo = popupInfo;
-                if (!connection)
-                    return;
-                if (RefPtr pageClient = protectedThis->pageClient())
-                    pageClient->didPerformImmediateActionHitTest(result, contentPreventsDefault, WebProcessProxy::fromConnection(*connection)->transformHandlesToObjects(protect(userData.object()).get()).get());
-            });
-            return;
-        }
+    if (protect(preferences())->siteIsolationEnabled() && result.remoteUserInputEventData) {
+        performImmediateActionHitTestAtLocation(result.remoteUserInputEventData->targetFrameID, FloatPoint(result.remoteUserInputEventData->transformedPoint));
+        return;
     }
     if (RefPtr pageClient = this->pageClient())
         pageClient->didPerformImmediateActionHitTest(result, contentPreventsDefault, WebProcessProxy::fromConnection(connection)->transformHandlesToObjects(protect(userData.object()).get()).get());

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1904,6 +1904,7 @@
 		93D6B7B5255268D70058DD3A /* SpeechRecognitionPermissionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 93D6B7B2255268A20058DD3A /* SpeechRecognitionPermissionManager.h */; };
 		93E05E40282CD560000B69EB /* ProcessStateMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 93E05E3E282CD55D000B69EB /* ProcessStateMonitor.h */; };
 		93E6A4EE1BC5DD3900F8A0E7 /* _WKHitTestResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 93E6A4ED1BC5DD3900F8A0E7 /* _WKHitTestResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2A1B3C4D2F00000100000002 /* _WKHitTestResultPrivateForTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A1B3C4D2F00000100000001 /* _WKHitTestResultPrivateForTesting.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93E799882756FAC20074008A /* WebFileSystemStorageConnectionMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 93E799812756FA530074008A /* WebFileSystemStorageConnectionMessages.h */; };
 		93E799C7276027460074008A /* StorageAreaRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 93E799C6276027370074008A /* StorageAreaRegistry.h */; };
 		93E799CE2760497B0074008A /* SessionStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 93E799CA2760497A0074008A /* SessionStorageManager.h */; };
@@ -7560,6 +7561,7 @@
 		93E05E3E282CD55D000B69EB /* ProcessStateMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessStateMonitor.h; sourceTree = "<group>"; };
 		93E05E3F282CD55F000B69EB /* ProcessStateMonitor.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ProcessStateMonitor.mm; sourceTree = "<group>"; };
 		93E6A4ED1BC5DD3900F8A0E7 /* _WKHitTestResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKHitTestResult.h; sourceTree = "<group>"; };
+		2A1B3C4D2F00000100000001 /* _WKHitTestResultPrivateForTesting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKHitTestResultPrivateForTesting.h; sourceTree = "<group>"; };
 		93E7997E2756F6700074008A /* WebFileSystemStorageConnection.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebFileSystemStorageConnection.messages.in; sourceTree = "<group>"; };
 		93E799812756FA530074008A /* WebFileSystemStorageConnectionMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebFileSystemStorageConnectionMessages.h; sourceTree = "<group>"; };
 		93E799822756FA540074008A /* WebFileSystemStorageConnectionMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebFileSystemStorageConnectionMessageReceiver.cpp; sourceTree = "<group>"; };
@@ -13565,6 +13567,7 @@
 				93E6A4ED1BC5DD3900F8A0E7 /* _WKHitTestResult.h */,
 				93A88B371BC70F2E00ABA5C2 /* _WKHitTestResult.mm */,
 				93A88B3A1BC710D900ABA5C2 /* _WKHitTestResultInternal.h */,
+				2A1B3C4D2F00000100000001 /* _WKHitTestResultPrivateForTesting.h */,
 				A118A9F11908B8EA00F7C92B /* _WKNSFileManagerExtras.h */,
 				A118A9F01908B8EA00F7C92B /* _WKNSFileManagerExtras.mm */,
 				A5C0F0A62000654400536536 /* _WKNSWindowExtras.h */,
@@ -18022,6 +18025,7 @@
 				63C32C281E98119000699BD0 /* _WKGeolocationPositionInternal.h in Headers */,
 				93E6A4EE1BC5DD3900F8A0E7 /* _WKHitTestResult.h in Headers */,
 				93A88B3B1BC710D900ABA5C2 /* _WKHitTestResultInternal.h in Headers */,
+				2A1B3C4D2F00000100000002 /* _WKHitTestResultPrivateForTesting.h in Headers */,
 				510F59101DDE296900412FF5 /* _WKIconLoadingDelegate.h in Headers */,
 				37A64E5518F38E3C00EB30F1 /* _WKInputDelegate.h in Headers */,
 				5CAFDE452130846300B1F7E1 /* _WKInspector.h in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -431,6 +431,37 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
 
 #endif
 
+    // The rects above stop at the local root, since contentsToRootView() can't cross a process
+    // boundary. Map them the rest of the way to the top-level frame. Runs on the local root's view,
+    // not this frame's, which would count an intervening same-origin frame twice. The local root can
+    // be behind a RemoteFrame even when the main frame is local (a.com embeds b.com embeds a.com),
+    // hence isMainFrame() rather than localMainFrame().
+    Ref rootFrame = frame.rootFrame();
+    if (!rootFrame->isMainFrame()) {
+        if (RefPtr rootView = rootFrame->view()) {
+            auto convertRect = [&](FloatRect rect) {
+                return rootView->convertToRootViewAcrossIsolatedFrames(rect);
+            };
+
+            dictionaryPopupInfo.origin = rootView->convertToRootViewAcrossIsolatedFrames(dictionaryPopupInfo.origin);
+
+            // These are offsets from the bounding rect, so convert them in root view coordinates.
+            auto boundingRect = textIndicator->textBoundingRectInRootViewCoordinates();
+            auto convertedBoundingRect = convertRect(boundingRect);
+            auto textRects = textIndicator->textRectsInBoundingRectCoordinates().map([&](auto rect) {
+                rect.moveBy(boundingRect.location());
+                rect = convertRect(rect);
+                rect.moveBy(-convertedBoundingRect.location());
+                return rect;
+            });
+
+            textIndicator->setTextBoundingRectInRootViewCoordinates(convertedBoundingRect);
+            textIndicator->setTextRectsInBoundingRectCoordinates(WTF::move(textRects));
+            textIndicator->setSelectionRectInRootViewCoordinates(convertRect(textIndicator->selectionRectInRootViewCoordinates()));
+            textIndicator->setContentImageWithoutSelectionRectInRootViewCoordinates(convertRect(textIndicator->contentImageWithoutSelectionRectInRootViewCoordinates()));
+        }
+    }
+
     editor->setIsGettingDictionaryPopupInfo(false);
     return dictionaryPopupInfo;
 }

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -431,6 +431,42 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
 
 #endif
 
+    // In a site-isolated subframe the rects above are all in the local root frame's root view
+    // coordinates, because Widget::convertToRootView() stops at the local root -- the parent frame
+    // lives in another process. Map them the rest of the way to the top-level frame here, applying the
+    // CSS transforms on the remote ancestor frames rather than a plain translation, so the UI process
+    // can position the popover and the text indicator without an IPC round trip per nesting level.
+    //
+    // The conversion runs on the local root frame's view, not this frame's view, because the rects
+    // have already been walked up the widget tree to the local root. Starting from this frame's view
+    // would count the offset of any same-origin frame between it and the local root twice.
+    if (!frame.localMainFrame()) {
+        if (RefPtr rootView = frame.rootFrame().view()) {
+            auto convertRect = [&](FloatRect rect) {
+                return rootView->convertToRootViewAcrossIsolatedFrames(rect);
+            };
+
+            dictionaryPopupInfo.origin = rootView->convertToRootViewAcrossIsolatedFrames(dictionaryPopupInfo.origin);
+
+            // textRectsInBoundingRectCoordinates are offsets from the text bounding rect's location,
+            // so lift each one back into root view coordinates to convert it, then re-relativize it
+            // against the converted bounding rect.
+            auto boundingRect = textIndicator->textBoundingRectInRootViewCoordinates();
+            auto convertedBoundingRect = convertRect(boundingRect);
+            auto textRects = textIndicator->textRectsInBoundingRectCoordinates().map([&](auto rect) {
+                rect.moveBy(boundingRect.location());
+                rect = convertRect(rect);
+                rect.moveBy(-convertedBoundingRect.location());
+                return rect;
+            });
+
+            textIndicator->setTextBoundingRectInRootViewCoordinates(convertedBoundingRect);
+            textIndicator->setTextRectsInBoundingRectCoordinates(WTF::move(textRects));
+            textIndicator->setSelectionRectInRootViewCoordinates(convertRect(textIndicator->selectionRectInRootViewCoordinates()));
+            textIndicator->setContentImageWithoutSelectionRectInRootViewCoordinates(convertRect(textIndicator->contentImageWithoutSelectionRectInRootViewCoordinates()));
+        }
+    }
+
     editor->setIsGettingDictionaryPopupInfo(false);
     return dictionaryPopupInfo;
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10780,24 +10780,6 @@ void WebPage::contentsToRootViewPoint(FrameIdentifier frameID, FloatPoint point,
     completionHandler(contentsToRootView(frameID, point));
 }
 
-void WebPage::remoteDictionaryPopupInfoToRootView(WebCore::FrameIdentifier frameID, WebCore::DictionaryPopupInfo popupInfo, CompletionHandler<void(WebCore::DictionaryPopupInfo)>&& completionHandler)
-{
-    RefPtr textIndicator = popupInfo.textIndicator;
-    popupInfo.origin = contentsToRootView<FloatPoint>(frameID, popupInfo.origin);
-    if (!textIndicator)
-        return completionHandler(popupInfo);
-#if PLATFORM(COCOA)
-    auto textIndicatorData = textIndicator->data();
-    textIndicatorData.selectionRectInRootViewCoordinates = contentsToRootView<FloatRect>(frameID, popupInfo.textIndicator->selectionRectInRootViewCoordinates());
-    textIndicatorData.textBoundingRectInRootViewCoordinates = contentsToRootView<FloatRect>(frameID, popupInfo.textIndicator->textBoundingRectInRootViewCoordinates());
-    textIndicatorData.contentImageWithoutSelectionRectInRootViewCoordinates = contentsToRootView<FloatRect>(frameID, popupInfo.textIndicator->contentImageWithoutSelectionRectInRootViewCoordinates());
-
-    for (auto& textRect : textIndicatorData.textRectsInBoundingRectCoordinates)
-        textRect = contentsToRootView<FloatRect>(frameID, textRect);
-#endif
-    completionHandler(popupInfo);
-}
-
 void WebPage::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point, const ContentWorldData& worldData, CompletionHandler<void(NodeHitTestResult)>&& completionHandler)
 {
     RefPtr frame = WebFrame::webFrame(frameID);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10688,24 +10688,6 @@ void WebPage::contentsToRootViewPoint(FrameIdentifier frameID, FloatPoint point,
     completionHandler(contentsToRootView(frameID, point));
 }
 
-void WebPage::remoteDictionaryPopupInfoToRootView(WebCore::FrameIdentifier frameID, WebCore::DictionaryPopupInfo popupInfo, CompletionHandler<void(WebCore::DictionaryPopupInfo)>&& completionHandler)
-{
-    RefPtr textIndicator = popupInfo.textIndicator;
-    popupInfo.origin = contentsToRootView<FloatPoint>(frameID, popupInfo.origin);
-    if (!textIndicator)
-        return completionHandler(popupInfo);
-#if PLATFORM(COCOA)
-    auto textIndicatorData = textIndicator->data();
-    textIndicatorData.selectionRectInRootViewCoordinates = contentsToRootView<FloatRect>(frameID, popupInfo.textIndicator->selectionRectInRootViewCoordinates());
-    textIndicatorData.textBoundingRectInRootViewCoordinates = contentsToRootView<FloatRect>(frameID, popupInfo.textIndicator->textBoundingRectInRootViewCoordinates());
-    textIndicatorData.contentImageWithoutSelectionRectInRootViewCoordinates = contentsToRootView<FloatRect>(frameID, popupInfo.textIndicator->contentImageWithoutSelectionRectInRootViewCoordinates());
-
-    for (auto& textRect : textIndicatorData.textRectsInBoundingRectCoordinates)
-        textRect = contentsToRootView<FloatRect>(frameID, textRect);
-#endif
-    completionHandler(popupInfo);
-}
-
 void WebPage::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point, CompletionHandler<void(NodeHitTestResult)>&& completionHandler)
 {
     RefPtr frame = WebFrame::webFrame(frameID);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2809,7 +2809,6 @@ private:
     void contentsToRootViewRect(WebCore::FrameIdentifier, WebCore::FloatRect, CompletionHandler<void(WebCore::FloatRect)>&&);
     void contentsToRootViewRects(WebCore::FrameIdentifier, Vector<WebCore::FloatRect>, CompletionHandler<void(Vector<WebCore::FloatRect>)>&&);
     void contentsToRootViewPoint(WebCore::FrameIdentifier, WebCore::FloatPoint, CompletionHandler<void(WebCore::FloatPoint)>&&);
-    void remoteDictionaryPopupInfoToRootView(WebCore::FrameIdentifier, WebCore::DictionaryPopupInfo, CompletionHandler<void(WebCore::DictionaryPopupInfo)>&&);
 
     void hitTestAtPoint(WebCore::FrameIdentifier, WebCore::FloatPoint, CompletionHandler<void(NodeHitTestResult)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2820,7 +2820,6 @@ private:
     void contentsToRootViewRect(WebCore::FrameIdentifier, WebCore::FloatRect, CompletionHandler<void(WebCore::FloatRect)>&&);
     void contentsToRootViewRects(WebCore::FrameIdentifier, Vector<WebCore::FloatRect>, CompletionHandler<void(Vector<WebCore::FloatRect>)>&&);
     void contentsToRootViewPoint(WebCore::FrameIdentifier, WebCore::FloatPoint, CompletionHandler<void(WebCore::FloatPoint)>&&);
-    void remoteDictionaryPopupInfoToRootView(WebCore::FrameIdentifier, WebCore::DictionaryPopupInfo, CompletionHandler<void(WebCore::DictionaryPopupInfo)>&&);
 
     void hitTestAtPoint(WebCore::FrameIdentifier, WebCore::FloatPoint, const ContentWorldData&, CompletionHandler<void(NodeHitTestResult)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -954,7 +954,6 @@ messages -> WebPage WantsAsyncDispatchMessage {
     ContentsToRootViewRect(WebCore::FrameIdentifier frameID, WebCore::FloatRect rect) -> (WebCore::FloatRect rect)
     ContentsToRootViewRects(WebCore::FrameIdentifier frameID, Vector<WebCore::FloatRect> rects) -> (Vector<WebCore::FloatRect> rects)
     ContentsToRootViewPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point) -> (WebCore::FloatPoint point)
-    RemoteDictionaryPopupInfoToRootView(WebCore::FrameIdentifier frameID, struct WebCore::DictionaryPopupInfo popupInfo) -> (struct WebCore::DictionaryPopupInfo popupInfo)
     HitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point) -> (struct WebKit::NodeHitTestResult result)
 
 #if HAVE(SPATIAL_TRACKING_LABEL)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -960,7 +960,6 @@ messages -> WebPage WantsAsyncDispatchMessage {
     ContentsToRootViewRect(WebCore::FrameIdentifier frameID, WebCore::FloatRect rect) -> (WebCore::FloatRect rect)
     ContentsToRootViewRects(WebCore::FrameIdentifier frameID, Vector<WebCore::FloatRect> rects) -> (Vector<WebCore::FloatRect> rects)
     ContentsToRootViewPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point) -> (WebCore::FloatPoint point)
-    RemoteDictionaryPopupInfoToRootView(WebCore::FrameIdentifier frameID, struct WebCore::DictionaryPopupInfo popupInfo) -> (struct WebCore::DictionaryPopupInfo popupInfo)
     HitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point, struct WebKit::ContentWorldData world) -> (struct WebKit::NodeHitTestResult result)
 
 #if HAVE(SPATIAL_TRACKING_LABEL)

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -824,11 +824,6 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FrameIdentifier f
         }
     }
 
-    RefPtr focusedOrMainFrame = corePage()->focusController().focusedOrMainFrame();
-    if (!focusedOrMainFrame)
-        return;
-    auto selectionRange = focusedOrMainFrame->selection().selection().firstRange();
-
     auto indicatorOptions = [&](const SimpleRange& range) {
         OptionSet<TextIndicatorOption> options { TextIndicatorOption::UseBoundingRectAndPaintAllContentForComplexRanges, TextIndicatorOption::UseUserSelectAllCommonAncestor };
         if (ImageOverlay::isInsideOverlay(range))
@@ -913,6 +908,8 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FrameIdentifier f
 std::optional<WebCore::SimpleRange> WebPage::lookupTextAtLocation(FrameIdentifier frameID, FloatPoint locationInViewCoordinates)
 {
     RefPtr currentFrame = WebProcess::singleton().webFrame(frameID);
+    if (!currentFrame)
+        return std::nullopt;
     RefPtr localCurrentFrame = dynamicDowncast<LocalFrame>(currentFrame->coreFrame());
     if (!localCurrentFrame || !localCurrentFrame->view() || !localCurrentFrame->view()->renderView())
         return std::nullopt;

--- a/Tools/TestWebKitAPI/Helpers/mac/WKWebViewForTestingImmediateActions.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/WKWebViewForTestingImmediateActions.mm
@@ -86,7 +86,8 @@ static NSPoint swizzledImmediateActionLocationInView(id, SEL, NSView *)
     gSwizzledImmediateActionLocation = location;
     [immediateActionGesture.delegate immediateActionRecognizerWillPrepare:immediateActionGesture];
 
-    TestWebKitAPI::Util::run(&_hasReturnedImmediateActionController);
+    // Bounded, so a web process that never replies fails here instead of spinning forever.
+    EXPECT_TRUE(TestWebKitAPI::Util::runFor(&_hasReturnedImmediateActionController, 10_s));
 
     _hasReturnedImmediateActionController = false;
     return { std::exchange(_hitTestResult, nil), std::exchange(_actionType, _WKImmediateActionNone) };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -84,6 +84,9 @@
 #endif
 
 #if PLATFORM(MAC)
+#import "Helpers/mac/WKWebViewForTestingImmediateActions.h"
+#import <WebKit/_WKHitTestResult.h>
+
 @interface NSApplication ()
 - (void)_setKeyWindow:(NSWindow *)newKeyWindow;
 @end
@@ -9530,6 +9533,117 @@ TEST(SiteIsolation, SelectElementPopupAfterFocusChangesDuringTracking)
     EXPECT_TRUE(Util::waitFor([&] {
         return [[webView objectByEvaluatingJavaScript:@"document.getElementById('sel').value"] isEqualToString:@"c"];
     }));
+}
+
+static std::pair<RetainPtr<WKWebViewForTestingImmediateActions>, RetainPtr<TestNavigationDelegate>> siteIsolatedImmediateActionViewAndDelegate(const HTTPServer& server, CGRect viewRect)
+{
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    enableSiteIsolation(configuration.get());
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+
+    RetainPtr webView = adoptNS([[WKWebViewForTestingImmediateActions alloc] initWithFrame:viewRect configuration:configuration.get()]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
+}
+
+// Performs a Look Up over a word and returns the bounding rect of the resulting text indicator, which
+// is what positions both the Reveal popover's highlight and the indicator layer. The web process
+// reports it in the top-level frame's root view coordinates.
+static CGRect lookUpTextBoundingRect(WKWebViewForTestingImmediateActions *webView, NSPoint location)
+{
+    auto result = [webView simulateImmediateAction:location];
+    if (!result.first)
+        return CGRectZero;
+    return [result.first _dictionaryPopupTextBoundingRectForTesting];
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInCrossOriginIframeUsesMainFrameCoordinates)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/iframe'></iframe></body>"_s } },
+        { "/iframe"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // The word sits at (100, 100) in the main frame. Without the conversion the subframe reports its
+    // own local root view coordinates, putting the indicator near the origin instead.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(110, 115));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_GT(CGRectGetMinX(rect), 90);
+    EXPECT_GT(CGRectGetMinY(rect), 90);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInNestedCrossOriginIframesUsesMainFrameCoordinates)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://domain2.com/middle'></iframe></body>"_s } },
+        { "/middle"_s, { "<!DOCTYPE html><body style='margin: 0'><iframe style='margin: 50px; width: 200px; height: 150px; border: none;' src='https://domain3.com/inner'></iframe></body>"_s } },
+        { "/inner"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // Both cross-process hops must be applied: (100, 100) for domain2 plus (50, 50) for domain3.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(160, 165));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_GT(CGRectGetMinX(rect), 140);
+    EXPECT_GT(CGRectGetMinY(rect), 140);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInSameOriginIframeInsideCrossOriginIframe)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/middle'></iframe></body>"_s } },
+        { "/middle"_s, { "<!DOCTYPE html><body style='margin: 0'><iframe style='margin: 50px; width: 200px; height: 150px; border: none;' src='https://webkit.org/inner'></iframe></body>"_s } },
+        { "/inner"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // Both webkit.org frames share a process, so the rect arrives already relative to the outer one.
+    // The conversion therefore has to start at the local root and add only (100, 100), landing the word
+    // at (150, 150). Converting from the inner frame's own view would count its 50px offset twice and
+    // land near (200, 200).
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(160, 165));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_GT(CGRectGetMinX(rect), 140);
+    EXPECT_LT(CGRectGetMinX(rect), 180);
+    EXPECT_GT(CGRectGetMinY(rect), 140);
+    EXPECT_LT(CGRectGetMinY(rect), 180);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInMainFrameIsNotOffset)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // The word is in the main frame, so no conversion applies and the rect stays at the top left.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(10, 15));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_LT(CGRectGetMinX(rect), 50);
+    EXPECT_LT(CGRectGetMinY(rect), 50);
 }
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -85,6 +85,8 @@
 
 #if PLATFORM(MAC)
 #import "Helpers/mac/AppKitSPI.h"
+#import "Helpers/mac/WKWebViewForTestingImmediateActions.h"
+#import <WebKit/_WKHitTestResultPrivateForTesting.h>
 
 @interface NSApplication ()
 - (void)_setKeyWindow:(NSWindow *)newKeyWindow;
@@ -10029,6 +10031,132 @@ TEST(SiteIsolation, SelectElementPopupAfterFocusChangesDuringTracking)
     }));
 }
 
+static std::pair<RetainPtr<WKWebViewForTestingImmediateActions>, RetainPtr<TestNavigationDelegate>> siteIsolatedImmediateActionViewAndDelegate(const HTTPServer& server, CGRect viewRect)
+{
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    enableSiteIsolation(configuration.get());
+    disableSharedProcess(configuration.get());
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+
+    RetainPtr webView = adoptNS([[WKWebViewForTestingImmediateActions alloc] initWithFrame:viewRect configuration:configuration.get()]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
+}
+
+// Returns the text indicator rect that positions the Reveal highlight, in top-level root view coordinates.
+static CGRect lookUpTextBoundingRect(WKWebViewForTestingImmediateActions *webView, NSPoint location)
+{
+    auto [hitTestResult, actionType] = [webView simulateImmediateAction:location];
+    EXPECT_NOT_NULL(hitTestResult.get());
+    if (!hitTestResult)
+        return CGRectZero;
+    EXPECT_EQ(actionType, _WKImmediateActionLookupText);
+    EXPECT_WK_STREQ([hitTestResult lookupText], "test");
+    return [hitTestResult _dictionaryPopupTextBoundingRectForTesting];
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInCrossOriginIframeUsesMainFrameCoordinates)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/iframe'></iframe></body>"_s } },
+        { "/iframe"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // Content origin (100, 100) less TextIndicator's default (2, 1) margin. Unconverted: (-2, -1).
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(110, 115));
+    EXPECT_EQ(CGRectGetMinX(rect), 98);
+    EXPECT_EQ(CGRectGetMinY(rect), 99);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInNestedCrossOriginIframesUsesMainFrameCoordinates)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://domain2.com/middle'></iframe></body>"_s } },
+        { "/middle"_s, { "<!DOCTYPE html><body style='margin: 0'><iframe style='margin: 50px; width: 200px; height: 150px; border: none;' src='https://domain3.com/inner'></iframe></body>"_s } },
+        { "/inner"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // Both hops must apply: 100 for domain2 plus 50 for domain3, less the (2, 1) margin.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(160, 165));
+    EXPECT_EQ(CGRectGetMinX(rect), 148);
+    EXPECT_EQ(CGRectGetMinY(rect), 149);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInSameOriginIframeInsideCrossOriginIframe)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/middle'></iframe></body>"_s } },
+        { "/middle"_s, { "<!DOCTYPE html><body style='margin: 0'><iframe style='margin: 50px; width: 200px; height: 150px; border: none;' src='https://webkit.org/inner'></iframe></body>"_s } },
+        { "/inner"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // Both webkit.org frames share a process, so only the outer 100 is missing. Converting from the
+    // inner frame's view instead would double its 50 and land at 198.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(160, 165));
+    EXPECT_EQ(CGRectGetMinX(rect), 148);
+    EXPECT_EQ(CGRectGetMinY(rect), 149);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInSameSiteIframeBehindCrossOriginIframe)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/middle'></iframe></body>"_s } },
+        { "/middle"_s, { "<!DOCTYPE html><body style='margin: 0'><iframe style='margin: 50px; width: 200px; height: 150px; border: none;' src='https://example.com/inner'></iframe></body>"_s } },
+        { "/inner"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // The inner frame is same-site with the main frame, so the main frame is local, but the inner
+    // frame is still its own local root behind a RemoteFrame.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(160, 165));
+    EXPECT_EQ(CGRectGetMinX(rect), 148);
+    EXPECT_EQ(CGRectGetMinY(rect), 149);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInMainFrameIsNotOffset)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // Smoke test: the conversion is an identity in the main frame, so this only checks Look Up still
+    // works with site isolation on.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(10, 15));
+    EXPECT_EQ(CGRectGetMinX(rect), -2);
+    EXPECT_EQ(CGRectGetMinY(rect), -1);
+}
+
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -10402,8 +10530,8 @@ TEST(SiteIsolation, SelectionBoundingRectInMainFrameIsNotOffset)
         Util::spinRunLoop();
     }
 
-    EXPECT_LT(CGRectGetMinX(rect), 50);
-    EXPECT_LT(CGRectGetMinY(rect), 50);
+    EXPECT_LT(CGRectGetMinX(rect), 5);
+    EXPECT_LT(CGRectGetMinY(rect), 5);
 }
 
 TEST(SiteIsolation, SelectionInCrossOriginIframeTracksMainFrameScroll)


### PR DESCRIPTION
#### 8f76e836cd75a3a61e8db292d1bbeb06f93113b5
<pre>
[Site Isolation] Right click Lookup on a word shows the word displaced
<a href="https://bugs.webkit.org/show_bug.cgi?id=321331">https://bugs.webkit.org/show_bug.cgi?id=321331</a>
<a href="https://rdar.apple.com/130518304">rdar://130518304</a>

Reviewed by NOBODY (OOPS!).

Right-clicking a word in a cross-origin iframe and choosing Look Up drew the highlighted word
at the wrong place, offset by the iframe&apos;s position in the page.

Look Up runs in the iframe&apos;s own process, where dictionaryPopupInfoForRange() computes the
popup origin and the TextIndicator&apos;s rects with contentsToRootView(). That stops at the local
root, since the parent frame is in another process, so the rects were relative to the iframe
instead of the page. DidPerformDictionaryLookup carries no frame identifier, so the UI process
handed them to Reveal unchanged.

Convert them with FrameView::convertToRootViewAcrossIsolatedFrames(), which covers any nesting
depth in one pass and handles CSS transforms on the remote ancestor frames. It runs on the local
root frame&apos;s view, because the rects have already been walked up to the local root; starting
from the hit frame&apos;s view would count an intervening same-origin frame twice.
textRectsInBoundingRectCoordinates are offsets from the bounding rect, so they are converted in
root view coordinates and then re-relativized.

The conversion is gated on the local root not being the top-level frame, rather than on the main
frame being remote in this process. Those differ when a frame is same-site with the main frame but
is separated from it by a cross-origin ancestor (a.com embeds b.com embeds a.com): both a.com frames
share a process, so localMainFrame() is non-null, yet the inner frame is still its own local root
behind a RemoteFrame and its rects are relative to itself.

RemoteDictionaryPopupInfoToRootView is removed rather than extended. It only ever converted the
origin; TextIndicator::data() returns by value, so its edits to the indicator&apos;s rects were dropped,
and it hopped just one frame. For a same-origin subframe of a local main frame it also ran in the
same process the rects came from, adding that subframe&apos;s offset a second time.

performImmediateActionHitTestAtLocation() needed a fix to reach the conversion at all. It bailed
out before computing any of the result when focusController().focusedOrMainFrame() was null, which
is always the case in a subframe process: nothing is focused yet and the main frame is remote. The
frame was only used for a selectionRange local whose last consumer went away in 146173, so both
are gone. lookupTextAtLocation(), newly reachable in subframe processes as a result, dereferenced
its WebFrame without a null check; dispatchMouseForceWillBegin() above it can run author script
that detaches the frame, so it is checked now.

DictionaryLookup::rangeAtHitTestResult() carried the same focusedOrMainFrame() bailout, so the
hit-test path found no range in a subframe process and the popup info stayed empty, leaving the
conversion above with nothing to convert. It consults the focused frame only to pick up a range
selection for surrounding context; under site isolation that selection is in another process and
belongs to a different document anyway, so it falls back to the frame that was hit.
focusedOrMainFrame() only returns null when site isolation is enabled, so no other configuration
changes behaviour. rangeForSelection(), which the right-click gesture uses, takes the selection as
an argument and never had the gate.

That does not on its own make the force-touch gesture work in a cross-origin iframe.
WKImmediateActionController waits for DidPerformImmediateActionHitTest on the main frame process&apos;s
connection, so the main frame&apos;s reply -- the one carrying remoteUserInputEventData -- satisfies the
wait, the state stays Pending, and the gesture is cancelled before the subframe&apos;s reply arrives on
its own connection. Fixing that wait is a separate change, and once it is fixed three sibling
fields of WebHitTestResultData need the same conversion as dictionaryPopupInfo: linkTextIndicator,
elementBoundingBox, and platformData.detectedData*, which position the QuickLook popover and the
data detector highlight and are still relative to the local root. The tests here drive
immediateActionRecognizerWillPrepare: directly, so they cover the web process&apos;s half.

_WKHitTestResult holds its API::HitTestResult in an AlignedStorage, so calling a non-trivial
member function on it trips alpha.webkit.UncountedCallArgsChecker. API::HitTestResult therefore
exposes the text indicator with a trivial getter and the null check lives in the caller.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebCore/editing/cocoa/DictionaryLookup.mm:
(WebCore::DictionaryLookup::rangeAtHitTestResult):
* Source/WebKit/Headers.cmake:
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm:
(-[_WKHitTestResult _dictionaryPopupTextBoundingRectForTesting]):
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResultPrivateForTesting.h: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/UIProcess/API/APIHitTestResult.h:
(API::HitTestResult::dictionaryPopupTextIndicator const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didPerformImmediateActionHitTest):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::dictionaryPopupInfoForRange):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::remoteDictionaryPopupInfoToRootView): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performImmediateActionHitTestAtLocation):
(WebKit::WebPage::lookupTextAtLocation):
* Tools/TestWebKitAPI/Helpers/mac/WKWebViewForTestingImmediateActions.mm:
(-[WKWebViewForTestingImmediateActions simulateImmediateAction:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, LookUpTextIndicatorRectInCrossOriginIframeUsesMainFrameCoordinates)):
(TestWebKitAPI::(SiteIsolation, LookUpTextIndicatorRectInNestedCrossOriginIframesUsesMainFrameCoordinates)):
(TestWebKitAPI::(SiteIsolation, LookUpTextIndicatorRectInSameOriginIframeInsideCrossOriginIframe)):
(TestWebKitAPI::(SiteIsolation, LookUpTextIndicatorRectInSameSiteIframeBehindCrossOriginIframe)):
(TestWebKitAPI::(SiteIsolation, LookUpTextIndicatorRectInMainFrameIsNotOffset)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f76e836cd75a3a61e8db292d1bbeb06f93113b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182912 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56835 "Hash 8f76e836 for PR 71186 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50648 "Hash 8f76e836 for PR 71186 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147200 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71d7bb75-9c85-4a95-b1d7-fc357e2ceb31) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184774 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58177 "Hash 8f76e836 for PR 71186 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56570 "Hash 8f76e836 for PR 71186 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142763 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99130 "6 flakes 3 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7bebfa24-9b3a-43f5-9e1a-ce097c1063a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185867 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/58177 "Hash 8f76e836 for PR 71186 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/50648 "Hash 8f76e836 for PR 71186 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123191 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e080553d-1d9b-430a-8c42-a6b433df2394) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/58177 "Hash 8f76e836 for PR 71186 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/56570 "Hash 8f76e836 for PR 71186 does not build (failure)") | | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/50648 "Hash 8f76e836 for PR 71186 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/58177 "Hash 8f76e836 for PR 71186 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/50648 "Hash 8f76e836 for PR 71186 does not build (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4302 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49482 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/56570 "Hash 8f76e836 for PR 71186 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195070 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56504 "Hash 8f76e836 for PR 71186 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/50648 "Hash 8f76e836 for PR 71186 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152225 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57209 "Hash 8f76e836 for PR 71186 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/50648 "Hash 8f76e836 for PR 71186 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151922 "Passed tests") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/57209 "Hash 8f76e836 for PR 71186 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129478 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125566 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55717 "Hash 8f76e836 for PR 71186 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/50648 "Hash 8f76e836 for PR 71186 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55088 "Hash 8f76e836 for PR 71186 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55325 "Hash 8f76e836 for PR 71186 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55155 "Hash 8f76e836 for PR 71186 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->