### PR TITLE
[JSC] SerializedScriptValue is not carrying memory64 flag

### DIFF
--- a/JSTests/wasm/stress/memory64-shared-broadcast-address-type.js
+++ b/JSTests/wasm/stress/memory64-shared-broadcast-address-type.js
@@ -1,0 +1,41 @@
+//@ requireOptions("--useWasmJSTypes=1")
+//@ skip if $addressBits <= 32
+import * as assert from "../assert.js";
+
+// A shared memory handed to another agent has to arrive with the address type it was created with.
+// Nothing about the shared contents records it, and a memory declared with a maximum of zero has no
+// shared contents at all.
+
+const agentSource = `
+$.agent.receiveBroadcast(function (memory) {
+    let report = [];
+    report.push("address=" + memory.type().address);
+    report.push("minimum=" + typeof memory.type().minimum);
+    try {
+        report.push("grow(0n)=" + typeof memory.grow(0n));
+    } catch (error) {
+        report.push("grow(0n) threw " + error.name);
+    }
+    $.agent.report(report.join(" "));
+    $.agent.leaving();
+});
+`;
+
+function broadcastAndCollect(memory) {
+    $.agent.start(agentSource);
+    $.agent.broadcast(memory);
+    let report = null;
+    while ((report = $.agent.getReport()) === null)
+        $.agent.sleep(1);
+    return report;
+}
+
+assert.eq(broadcastAndCollect(new WebAssembly.Memory({ address: "i64", initial: 1n, maximum: 4n, shared: true })),
+    "address=i64 minimum=bigint grow(0n)=bigint");
+
+// Zero maximum: there are no shared contents for the address type to travel with.
+assert.eq(broadcastAndCollect(new WebAssembly.Memory({ address: "i64", initial: 0n, maximum: 0n, shared: true })),
+    "address=i64 minimum=bigint grow(0n)=bigint");
+
+assert.eq(broadcastAndCollect(new WebAssembly.Memory({ initial: 1, maximum: 4, shared: true })),
+    "address=i32 minimum=number grow(0n) threw TypeError");

--- a/LayoutTests/js/dom/webassembly-memory-shared-zero-maximum-clone-expected.txt
+++ b/LayoutTests/js/dom/webassembly-memory-shared-zero-maximum-clone-expected.txt
@@ -1,0 +1,16 @@
+Test cloning a shared WebAssembly.Memory that was declared with a maximum of zero. Such a memory has no shared contents at all, which the memory cost computation has to tolerate.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS zeroI32.buffer.byteLength is 0
+PASS cloneI32 instanceof WebAssembly.Memory is true
+PASS cloneI32.buffer.byteLength is 0
+PASS cloneI32.grow(0) is 0
+PASS cloneI64 instanceof WebAssembly.Memory is true
+PASS cloneI64.buffer.byteLength is 0
+PASS cloneI64.grow(0n) is 0n
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/dom/webassembly-memory-shared-zero-maximum-clone.html
+++ b/LayoutTests/js/dom/webassembly-memory-shared-zero-maximum-clone.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+
+description("Test cloning a shared WebAssembly.Memory that was declared with a maximum of zero. Such a memory has no shared contents at all, which the memory cost computation has to tolerate.");
+
+if (typeof WebAssembly !== 'undefined') {
+    zeroI32 = new WebAssembly.Memory({ initial: 0, maximum: 0, shared: true });
+    shouldBe(`zeroI32.buffer.byteLength`, `0`);
+    cloneI32 = structuredClone(zeroI32);
+    shouldBeTrue(`cloneI32 instanceof WebAssembly.Memory`);
+    shouldBe(`cloneI32.buffer.byteLength`, `0`);
+    shouldBe(`cloneI32.grow(0)`, `0`);
+
+    zeroI64 = new WebAssembly.Memory({ address: "i64", initial: 0n, maximum: 0n, shared: true });
+    cloneI64 = structuredClone(zeroI64);
+    shouldBeTrue(`cloneI64 instanceof WebAssembly.Memory`);
+    shouldBe(`cloneI64.buffer.byteLength`, `0`);
+    shouldBe(`cloneI64.grow(0n)`, `0n`);
+}
+
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -237,7 +237,11 @@ static void checkException(GlobalObject*, bool isLastFile, bool hasException, JS
 class Message : public ThreadSafeRefCounted<Message> {
 public:
 #if ENABLE(WEBASSEMBLY)
-    using Content = Variant<ArrayBufferContents, RefPtr<SharedArrayBufferContents>>;
+    struct WasmMemory {
+        RefPtr<SharedArrayBufferContents> contents;
+        Wasm::AddressType addressType;
+    };
+    using Content = Variant<ArrayBufferContents, WasmMemory>;
 #else
     using Content = Variant<ArrayBufferContents>;
 #endif
@@ -2631,14 +2635,15 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarAgentReceiveBroadcast, (JSGlobalObject* g
             return JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(sharingMode), WTF::move(nativeBuffer));
         }
 #if ENABLE(WEBASSEMBLY)
-        if (std::holds_alternative<RefPtr<SharedArrayBufferContents>>(content)) {
+        if (std::holds_alternative<Message::WasmMemory>(content)) {
             JSWebAssemblyMemory* jsMemory = JSC::JSWebAssemblyMemory::create(vm, globalObject->webAssemblyMemoryStructure());
             auto handler = [&vm, jsMemory](Wasm::Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) { jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount); };
+            auto wasmMemory = std::get<Message::WasmMemory>(WTF::move(content));
             RefPtr<Wasm::Memory> memory;
-            if (auto shared = std::get<RefPtr<SharedArrayBufferContents>>(WTF::move(content)))
-                memory = Wasm::Memory::create(shared.releaseNonNull(), jsMemory->memory().addressType(), WTF::move(handler));
+            if (auto shared = WTF::move(wasmMemory.contents))
+                memory = Wasm::Memory::create(shared.releaseNonNull(), wasmMemory.addressType, WTF::move(handler));
             else
-                memory = Wasm::Memory::createZeroSized(MemorySharingMode::Shared, jsMemory->memory().addressType(), WTF::move(handler));
+                memory = Wasm::Memory::createZeroSized(MemorySharingMode::Shared, wasmMemory.addressType, WTF::move(handler));
             jsMemory->adopt(memory.releaseNonNull());
             return jsMemory;
         }
@@ -2706,8 +2711,8 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarAgentBroadcast, (JSGlobalObject* globalOb
     if (memory && memory->memory().sharingMode() == MemorySharingMode::Shared) {
         Workers::singleton().broadcast(
             [&] (const AbstractLocker& locker, Worker& worker) {
-                RefPtr<SharedArrayBufferContents> contents { memory->memory().shared() };
-                RefPtr<Message> message = adoptRef(new Message(WTF::move(contents), index));
+                Message::WasmMemory wasmMemory { memory->memory().shared(), memory->memory().addressType() };
+                RefPtr<Message> message = adoptRef(new Message(WTF::move(wasmMemory), index));
                 worker.enqueue(locker, message);
             });
         return JSValue::encode(jsUndefined());

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1361,6 +1361,10 @@ public:
             write(WasmMemoryTag);
             write(agentClusterIDFromGlobalObject(*m_lexicalGlobalObject));
             write(index);
+            // The address type is not recoverable from the shared contents, and a memory declared with a
+            // maximum of zero has no contents at all. This record is never persisted (forStorage is
+            // rejected above), so it needs no version guard.
+            write(memory->memory().addressType().is64Bit());
             return true;
         }
 #endif
@@ -3710,6 +3714,14 @@ public:
                 return JSValue();
             }
 
+            bool isMemory64;
+            if (!read(isMemory64)) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
+            }
+            JSC::Wasm::AddressType addressType { isMemory64 };
+
             auto& vm = m_lexicalGlobalObject->vm();
             JSWebAssemblyMemory* result = JSC::JSWebAssemblyMemory::create(vm, m_globalObject->webAssemblyMemoryStructure());
             RefPtr<Wasm::Memory> memory;
@@ -3720,10 +3732,10 @@ public:
                     fail();
                     return JSValue();
                 }
-                memory = Wasm::Memory::create(contents.releaseNonNull(), result->memory().addressType(), WTF::move(handler));
+                memory = Wasm::Memory::create(contents.releaseNonNull(), addressType, WTF::move(handler));
             } else {
                 // zero size & max-size.
-                memory = Wasm::Memory::createZeroSized(JSC::MemorySharingMode::Shared, result->memory().addressType(), WTF::move(handler));
+                memory = Wasm::Memory::createZeroSized(JSC::MemorySharingMode::Shared, addressType, WTF::move(handler));
             }
 
             result->adopt(memory.releaseNonNull());
@@ -4258,8 +4270,11 @@ size_t SerializedScriptValue::computeMemoryCost() const
 #if ENABLE(WEBASSEMBLY)
     // We are not supporting WebAssembly Module memory estimation yet.
     if (m_internals->wasmMemoryHandlesArray) {
-        for (auto& content : *m_internals->wasmMemoryHandlesArray)
-            cost += content->sizeInBytes(std::memory_order_relaxed);
+        // A shared memory declared with a maximum of zero has no contents at all.
+        for (auto& content : *m_internals->wasmMemoryHandlesArray) {
+            if (content)
+                cost += content->sizeInBytes(std::memory_order_relaxed);
+        }
     }
 #endif
 #if ENABLE(WEB_CODECS)


### PR DESCRIPTION
#### 3e351c7849f30e38846e49f2ed1c5e94d9a59d29
<pre>
[JSC] SerializedScriptValue is not carrying memory64 flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=321332">https://bugs.webkit.org/show_bug.cgi?id=321332</a>
<a href="https://rdar.apple.com/184365775">rdar://184365775</a>

Reviewed by Yijia Huang.

Memory64 Wasm Memory was not correctly propagating memory64 flag. And
SerializedScriptValue is incorrectly accessing addressType() of non
attached memory, this is not correct. This patch fixes it.

Tests: JSTests/wasm/stress/memory64-shared-broadcast-address-type.js
       js/dom/webassembly-memory-shared-zero-maximum-clone.html

* JSTests/wasm/stress/memory64-shared-broadcast-address-type.js: Added.
(const.agentSource.agent.receiveBroadcast):
(broadcastAndCollect):
* LayoutTests/js/dom/webassembly-memory-shared-zero-maximum-clone-expected.txt: Added.
* LayoutTests/js/dom/webassembly-memory-shared-zero-maximum-clone.html: Added.
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpDerivedTerminal):
(WebCore::CloneDeserializer::readDerivedTerminal):
(WebCore::SerializedScriptValue::computeMemoryCost const):

Canonical link: <a href="https://commits.webkit.org/318831@main">https://commits.webkit.org/318831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64019bd9ed113cc4cd3b14793603f0e04e804bf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189328 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/007c6d7b-03d2-46ba-8438-09886f221341) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139975 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c50f82a-742f-49fb-adba-4966294f386a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120427 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7bc1484b-bcca-491e-9564-6ebc782fdef7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40582 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2397 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9203 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152662 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40224 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/esm-integration/execute-start.tentative.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/782 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40771 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191549 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149238 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53786 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148982 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27257 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43650 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126058 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120956 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52303 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15213 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51688 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51929 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51749 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->