### PR TITLE
[LBSE] Apply the synthesized viewBox transform for SVG documents embedded through SVGImage

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
@@ -61,17 +61,6 @@ svg/filters/filter-specified-on-svg-root.html                                   
 svg/filters/feImage-target-attribute-change-with-use-indirection-2.svg                 [ ImageOnlyFailure ]
 svg/filters/feImage-target-attribute-change-with-use-indirection.svg                   [ ImageOnlyFailure ]
 
-# SVGImage support incomplete
-svg/as-image/image-respects-pageScaleFactor-change.html                   [ ImageOnlyFailure ]
-svg/as-image/img-preserveAspectRatio-support-1.html                       [ ImageOnlyFailure ]
-svg/as-image/same-image-two-instances.html                                [ ImageOnlyFailure ]
-svg/as-image/svg-as-image-with-relative-size.html                         [ ImageOnlyFailure ]
-svg/as-image/svg-image-no-viewbox-preserve-aspect-ratio-none.html         [ ImageOnlyFailure ]
-svg/custom/use-image-in-g.svg                                             [ ImageOnlyFailure ]
-svg/zoom/page/zoom-img-preserveAspectRatio-support-1.html                 [ ImageOnlyFailure ]
-# SVG document w/o viewBox + <img> sizing differs to FF/Chrome
-svg/as-background-image/background-image-preserveaspectRatio-support.html [ ImageOnlyFailure ]
-
 # Precision differences
 svg/zoom/page/zoom-zoom-coords.xhtml [ Failure ]
 svg/zoom/zoomed-inline-svg-getscreenctm.html [ Failure ]

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
@@ -107,6 +107,8 @@ bool RenderSVGViewportContainer::needsHasSVGTransformFlags() const
             return true;
         if (!useSVGSVGElement->currentTranslateValue().isZero() || useSVGSVGElement->renderer()->style().usedZoom() != 1)
             return true;
+        if (useSVGSVGElement->hasSynthesizedViewBoxForSVGImage())
+            return true;
         // Need transform flags when the SVG root has a non-zero content box location
         // (e.g., due to border or padding), so that the content box offset is propagated
         // through the transform painting chain to transformed descendants.
@@ -175,19 +177,16 @@ void RenderSVGViewportContainer::updateLayerTransform()
     bool hasCurrentViewEmptyViewBox = true;
     if (useSVGSVGElement->useCurrentView())
         hasCurrentViewEmptyViewBox = useSVGSVGElement->currentView().hasEmptyViewBox();
-    if (useSVGSVGElement->hasAttribute(SVGNames::viewBoxAttr) || !hasCurrentViewEmptyViewBox) {
-        // An empty viewBox disables the rendering -- dirty the visible descendant status!
-        if (useSVGSVGElement->hasEmptyViewBox() && hasCurrentViewEmptyViewBox) {
-            if (hasLayer())
-                layer()->dirtyVisibleContentStatus();
-        } else if (!useSVGSVGElement->viewBox().isEmpty() || !hasCurrentViewEmptyViewBox) {
-            if (auto viewBoxTransform = viewBoxToViewTransform(useSVGSVGElement, viewportSize); !viewBoxTransform.isIdentity()) {
-                if (m_supplementalLayerTransform.isIdentity())
-                    m_supplementalLayerTransform = viewBoxTransform;
-                else
-                    m_supplementalLayerTransform.multiply(viewBoxTransform);
-            }
-        }
+
+    // An empty viewBox disables the rendering -- dirty the visible descendant status!
+    if (useSVGSVGElement->hasEmptyViewBox() && hasCurrentViewEmptyViewBox) {
+        if (hasLayer())
+            layer()->dirtyVisibleContentStatus();
+    } else if (auto viewBoxTransform = viewBoxToViewTransform(useSVGSVGElement, viewportSize); !viewBoxTransform.isIdentity()) {
+        if (m_supplementalLayerTransform.isIdentity())
+            m_supplementalLayerTransform = viewBoxTransform;
+        else
+            m_supplementalLayerTransform.multiply(viewBoxTransform);
     }
 
     // After updating the supplemental layer transform we're able to use it in RenderLayerModelObjects::updateLayerTransform().
@@ -208,16 +207,12 @@ LayoutRect RenderSVGViewportContainer::overflowClipRect(const LayoutPoint& locat
         return LayoutRect::infiniteRect();
     Ref useSVGSVGElement = svgSVGElement();
 
-    auto clipRect = enclosingLayoutRect(viewport());
-    if (useSVGSVGElement->hasAttribute(SVGNames::viewBoxAttr)) {
-        if (useSVGSVGElement->hasEmptyViewBox())
-            return { };
+    if (useSVGSVGElement->hasEmptyViewBox())
+        return { };
 
-        if (!useSVGSVGElement->viewBox().isEmpty()) {
-            if (auto viewBoxTransform = viewBoxToViewTransform(useSVGSVGElement, viewportSize()); !viewBoxTransform.isIdentity())
-                clipRect = enclosingLayoutRect(viewBoxTransform.inverse().value_or(AffineTransform { }).mapRect(viewport()));
-        }
-    }
+    auto clipRect = enclosingLayoutRect(viewport());
+    if (auto viewBoxTransform = viewBoxToViewTransform(useSVGSVGElement, viewportSize()); !viewBoxTransform.isIdentity())
+        clipRect = enclosingLayoutRect(viewBoxTransform.inverse().value_or(AffineTransform { }).mapRect(viewport()));
 
     clipRect.moveBy(location);
     return clipRect;

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -623,6 +623,14 @@ static bool isEmbeddedThroughSVGImage(const SVGSVGElement& element)
     return element.document().documentElement() == &element && isInSVGImage(&element);
 }
 
+bool SVGSVGElement::hasSynthesizedViewBoxForSVGImage() const
+{
+    // An SVG document embedded through SVGImage is resized to the container size chosen by the
+    // embedder. Without an explicit viewBox the content has to stretch to that size, which is
+    // modelled by synthesizing a viewBox from the intrinsic size, see currentViewBoxRect().
+    return !m_useCurrentView && viewBox().isEmpty() && isEmbeddedThroughSVGImage(*this);
+}
+
 FloatRect SVGSVGElement::currentViewBoxRect() const
 {
     if (m_useCurrentView) {
@@ -635,7 +643,7 @@ FloatRect SVGSVGElement::currentViewBoxRect() const
     if (!viewBox.isEmpty())
         return viewBox;
 
-    if (!isEmbeddedThroughSVGImage(*this))
+    if (!hasSynthesizedViewBoxForSVGImage())
         return { };
 
     // If no viewBox is specified but non-relative width/height values, then we
@@ -725,7 +733,7 @@ AffineTransform SVGSVGElement::viewBoxToViewTransform(float viewWidth, float vie
 
         // If we synthesized a viewBox (no explicit viewBox but embedded through SVGImage),
         // we should also synthesize preserveAspectRatio="none" to allow stretching.
-        if (viewBox().isEmpty() && !currentViewBox.isEmpty() && isEmbeddedThroughSVGImage(*this)) {
+        if (hasSynthesizedViewBoxForSVGImage()) {
             auto preserveAspectRatio = SVGPreserveAspectRatioValue(SVGPreserveAspectRatioValue::SVG_PRESERVEASPECTRATIO_NONE, SVGPreserveAspectRatioValue::SVG_MEETORSLICE_MEET);
             return SVGFitToViewBox::viewBoxToViewTransform(currentViewBox, preserveAspectRatio, viewWidth, viewHeight);
         }

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -111,6 +111,7 @@ public:
     void invalidateCachedViewportSizeExcludingZoom() const { m_cachedViewportSizeExcludingZoom = std::nullopt; }
 
     FloatRect currentViewBoxRect() const;
+    bool hasSynthesizedViewBoxForSVGImage() const;
 
     AffineTransform viewBoxToViewTransform(float viewWidth, float viewHeight) const;
     bool hasTransformRelatedAttributes() const final;


### PR DESCRIPTION
#### 04110306d8797967fe679e31fd1a34207975b63a
<pre>
[LBSE] Apply the synthesized viewBox transform for SVG documents embedded through SVGImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=321333">https://bugs.webkit.org/show_bug.cgi?id=321333</a>

Reviewed by Alejandro G. Castro.

An SVG document embedded through SVGImage (&lt;img&gt;, background-image, SVG &lt;image&gt;)
is resized to the container size chosen by the embedder. With no viewBox,
SVGSVGElement synthesizes one from the intrinsic size, plus a preserveAspectRatio
of &quot;none&quot;, so the content stretches to that size.

The legacy engine gets this for free, since buildLocalToBorderBoxTransform() asks
the element for the viewBox transform without checking for a viewBox attribute
first, as LBSE did. Fix LBSE by calling viewBoxToViewTransform() unconditionally.
It returns the identity transform when there is nothing to map, which makes the
surrounding conditions redundant.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations:
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
(WebCore::RenderSVGViewportContainer::needsHasSVGTransformFlags const):
(WebCore::RenderSVGViewportContainer::updateLayerTransform):
(WebCore::RenderSVGViewportContainer::overflowClipRect const):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::hasSynthesizedViewBoxForSVGImage const):
(WebCore::SVGSVGElement::currentViewBoxRect const):
(WebCore::SVGSVGElement::viewBoxToViewTransform const):
* Source/WebCore/svg/SVGSVGElement.h:

Canonical link: <a href="https://commits.webkit.org/319025@main">https://commits.webkit.org/319025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/717b521b39ada78390e1cccfbcbed34acdc2d6eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54167 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190433 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53883 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44223 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/121015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153299 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1592 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41496 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192368 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53833 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/160865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40142 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54521 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149637 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/44282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126784 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121931 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53038 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/15865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52420 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->