### PR TITLE
[WPE][cross-toolchain-helper] webkitdevci builds fail on hosts with glibc 2.43 (e.g. Ubuntu 26.04 SDK)

### DIFF
--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -835,3 +835,22 @@ index 2355936..0820dd9 100644
          if ${@bb.utils.contains('PACKAGECONFIG', 'dhcp-ethernet', 'true', 'false', d)}; then
                 install -D -m0644 ${WORKDIR}/wired.network ${D}${systemd_unitdir}/network/80-wired.network
          fi
+diff --git a/sources/poky/meta/recipes-devtools/pseudo/pseudo_git.bb b/sources/poky/meta/recipes-devtools/pseudo/pseudo_git.bb
+index 3ae5604..4a1e2cc 100644
+--- a/sources/poky/meta/recipes-devtools/pseudo/pseudo_git.bb
++++ b/sources/poky/meta/recipes-devtools/pseudo/pseudo_git.bb
+@@ -12,9 +12,12 @@ SRC_URI:append:class-nativesdk = " \
+     file://older-glibc-symbols.patch"
+ SRC_URI[prebuilt.sha256sum] = "ed9f456856e9d86359f169f46a70ad7be4190d6040282b84c8d97b99072485aa"
+ 
+-SRCREV = "56e1f8df4761da60e41812fc32b1de797d1765e9"
++# The pinned revision only had a dummy openat2() wrapper that returns ENOSYS.
++# Hosts with glibc >= 2.43 ship a tar that calls openat2() and has no fallback,
++# so every fakeroot task using tar fails. Bump past 6533a53 which implements it.
++SRCREV = "ba8887e5f1e922f866681ec7dec1a00b602a9328"
+ S = "${WORKDIR}/git"
+-PV = "1.9.3+git"
++PV = "1.9.11+git"
+ 
+ # largefile and 64bit time_t support adds these macros via compiler flags globally
+ # remove them for pseudo since pseudo intercepts some of the functions which will be


### PR DESCRIPTION
#### 18a9a4ac61884fe28c374d84757469e20161bd95
<pre>
[WPE][cross-toolchain-helper] webkitdevci builds fail on hosts with glibc 2.43 (e.g. Ubuntu 26.04 SDK)
<a href="https://bugs.webkit.org/show_bug.cgi?id=321337">https://bugs.webkit.org/show_bug.cgi?id=321337</a>

Reviewed by Carlos Alberto Lopez Perez.

The do_package task dies while copying a recipe&apos;s image directory:

    tar: ./usr/share: Cannot mkdir: Function not implemented

pseudo 1.9.3, the revision pinned by poky scarthgap 5.0.18, wraps openat2()
with an unconditional ENOSYS and hopes that callers fall back to an older
syscall. GNU tar linked against glibc 2.43 calls openat2() and reports the
error instead of falling back, so every do_package fails. tar is currently
the only entry in tmp/hosttools that references openat2.

Upstream pseudo implements the openat2() wrapper since 1.9.9, so bump the
pseudo recipe to upstream master until poky ships a new enough revision.

* Tools/yocto/meta-openembedded_and_meta-webkit.patch:

Canonical link: <a href="https://commits.webkit.org/318819@main">https://commits.webkit.org/318819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/684f23f8a9f9139e80dfdd702f70933d56a802b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53438 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189331 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53149 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/139979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182456 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120431 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/785 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191552 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53108 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/160238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53789 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148984 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27249 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43652 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120959 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52306 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/15216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51691 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51932 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->