### PR TITLE
[Site Isolation]

### DIFF
--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -602,4 +602,20 @@ FloatRect FrameView::rootViewToContentsAcrossIsolatedFrames(FloatRect rect) cons
     return viewToContents(convertFromRootViewAcrossIsolatedFrames(rect));
 }
 
+FloatRect FrameView::convertToContainingWindowAcrossIsolatedFrames(FloatRect rect) const
+{
+    // The root-view-to-window step needs a platform widget, which only the root of this process's
+    // widget tree has.
+    RefPtr<const Widget> widgetTreeRoot = this;
+    while (RefPtr parent = widgetTreeRoot->parent())
+        widgetTreeRoot = WTF::move(parent);
+
+    return widgetTreeRoot->convertToContainingWindow(convertToRootViewAcrossIsolatedFrames(rect));
+}
+
+FloatRect FrameView::contentsToWindowAcrossIsolatedFrames(FloatRect rect) const
+{
+    return convertToContainingWindowAcrossIsolatedFrames(contentsToView(rect));
+}
+
 }

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -124,13 +124,15 @@ public:
     // (Widget::m_parent is not populated for a RemoteFrameView when Site Isolation is enabled) and
     // apply any CSS transforms on the intervening frame-owner elements. "RootView" here is the
     // coordinate space of the top-level (main) frame's view; for a same-process frame tree these are
-    // equivalent to the plain convertFromRootView / rootViewToContents.
+    // equivalent to their plain Widget / ScrollView counterparts.
     WEBCORE_EXPORT FloatPoint convertFromRootViewAcrossIsolatedFrames(FloatPoint) const;
     WEBCORE_EXPORT FloatRect convertFromRootViewAcrossIsolatedFrames(FloatRect) const;
     WEBCORE_EXPORT FloatPoint convertToRootViewAcrossIsolatedFrames(FloatPoint) const;
     WEBCORE_EXPORT FloatRect convertToRootViewAcrossIsolatedFrames(FloatRect) const;
     WEBCORE_EXPORT FloatQuad convertToRootViewAcrossIsolatedFrames(const FloatQuad&) const;
     WEBCORE_EXPORT FloatRect rootViewToContentsAcrossIsolatedFrames(FloatRect) const;
+    WEBCORE_EXPORT FloatRect convertToContainingWindowAcrossIsolatedFrames(FloatRect) const;
+    WEBCORE_EXPORT FloatRect contentsToWindowAcrossIsolatedFrames(FloatRect) const;
 
     WEBCORE_EXPORT virtual LayoutRect layoutViewportRect() const = 0;
 

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
@@ -67,6 +67,8 @@ WK_CLASS_AVAILABLE(macos(10.12), ios(16.0))
 
 @property (nonatomic, readonly) CGRect elementBoundingBox;
 
+@property (nonatomic, readonly) CGRect _dictionaryPopupTextBoundingRectForTesting;
+
 @property (nonatomic, readonly) _WKHitTestResultElementType elementType WK_API_AVAILABLE(macos(14.4), ios(17.4), visionos(1.1));
 
 @property (nonatomic, readonly) WKFrameInfo *frameInfo WK_API_AVAILABLE(macos(14.4), ios(17.4), visionos(1.1));

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -147,6 +147,11 @@ static NSURL *URLFromString(const WTF::String& urlString)
     return _hitTestResult->elementBoundingBox();
 }
 
+- (CGRect)_dictionaryPopupTextBoundingRectForTesting
+{
+    return _hitTestResult->dictionaryPopupTextBoundingRect();
+}
+
 - (_WKHitTestResultElementType)elementType
 {
     switch (_hitTestResult->elementType()) {

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.h
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.h
@@ -24,6 +24,7 @@
 #include "WebPageProxy.h"
 #include <WebCore/DictionaryPopupInfo.h>
 #include <WebCore/FloatPoint.h>
+#include <WebCore/FloatRect.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PageOverlay.h>
 #include <WebCore/SharedMemory.h>
@@ -60,6 +61,13 @@ public:
     bool isContentEditable() const { return m_data.isContentEditable; }
 
     WebCore::IntRect elementBoundingBox() const { return m_data.elementBoundingBox; }
+
+    // The Look Up text indicator's bounding rect, in the top-level frame's root view coordinates.
+    WebCore::FloatRect dictionaryPopupTextBoundingRect() const
+    {
+        RefPtr textIndicator = m_data.dictionaryPopupInfo.textIndicator;
+        return textIndicator ? textIndicator->textBoundingRectInRootViewCoordinates() : WebCore::FloatRect { };
+    }
 
     bool isScrollbar() const { return m_data.isScrollbar != WebKit::WebHitTestResultData::IsScrollbar::No; }
 

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.h
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.h
@@ -24,6 +24,7 @@
 #include "WebPageProxy.h"
 #include <WebCore/DictionaryPopupInfo.h>
 #include <WebCore/FloatPoint.h>
+#include <WebCore/FloatRect.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PageOverlay.h>
 #include <WebCore/SharedMemory.h>
@@ -60,6 +61,12 @@ public:
     bool isContentEditable() const { return m_data.isContentEditable; }
 
     WebCore::IntRect elementBoundingBox() const { return m_data.elementBoundingBox; }
+
+    WebCore::FloatRect dictionaryPopupTextBoundingRect() const
+    {
+        RefPtr textIndicator = m_data.dictionaryPopupInfo.textIndicator;
+        return textIndicator ? textIndicator->textBoundingRectInRootViewCoordinates() : WebCore::FloatRect { };
+    }
 
     bool isScrollbar() const { return m_data.isScrollbar != WebKit::WebHitTestResultData::IsScrollbar::No; }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -93,6 +93,7 @@
 #import <WebCore/PlaybackSessionInterfaceAVKitLegacy.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
 #import <WebCore/PlaybackSessionInterfaceTVOS.h>
+#import <WebCore/RemoteUserInputEventData.h>
 #import <WebCore/RunLoopObserver.h>
 #import <WebCore/SearchPopupMenuCocoa.h>
 #import <WebCore/SleepDisabler.h>
@@ -568,8 +569,24 @@ void WebPageProxy::performDictionaryLookupAtLocation(const WebCore::FloatPoint& 
 {
     if (!hasRunningProcess())
         return;
-    
-    protect(legacyMainFrameProcess())->send(Messages::WebPage::PerformDictionaryLookupAtLocation(point), webPageIDInMainFrameProcess());
+
+    RefPtr mainFrame = m_mainFrame;
+    if (!mainFrame)
+        return;
+
+    performDictionaryLookupAtLocationInFrame(mainFrame->frameID(), point);
+}
+
+// The hit test runs in one process at a time and cannot descend into a site-isolated iframe, so it
+// reports the frame the point landed over and the lookup is retried there, one frame per hop.
+void WebPageProxy::performDictionaryLookupAtLocationInFrame(WebCore::FrameIdentifier frameID, const WebCore::FloatPoint& point)
+{
+    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::PerformDictionaryLookupAtLocation(frameID, point), [weakThis = WeakPtr { *this }](std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !remoteUserInputEventData)
+            return;
+        protectedThis->performDictionaryLookupAtLocationInFrame(remoteUserInputEventData->targetFrameID, WebCore::FloatPoint(remoteUserInputEventData->transformedPoint));
+    });
 }
 
 void WebPageProxy::insertDictatedTextAsync(const String& text, const EditingRange& replacementRange, const Vector<TextAlternativeWithRange>& dictationAlternativesWithRange, InsertTextOptions&& options)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -93,6 +93,7 @@
 #import <WebCore/PlaybackSessionInterfaceAVKitLegacy.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
 #import <WebCore/PlaybackSessionInterfaceTVOS.h>
+#import <WebCore/RemoteUserInputEventData.h>
 #import <WebCore/RunLoopObserver.h>
 #import <WebCore/SearchPopupMenuCocoa.h>
 #import <WebCore/SleepDisabler.h>
@@ -566,8 +567,22 @@ void WebPageProxy::performDictionaryLookupAtLocation(const WebCore::FloatPoint& 
 {
     if (!hasRunningProcess())
         return;
-    
-    protect(legacyMainFrameProcess())->send(Messages::WebPage::PerformDictionaryLookupAtLocation(point), webPageIDInMainFrameProcess());
+
+    RefPtr mainFrame = m_mainFrame;
+    if (!mainFrame)
+        return;
+
+    performDictionaryLookupAtLocationInFrame(mainFrame->frameID(), point);
+}
+
+void WebPageProxy::performDictionaryLookupAtLocationInFrame(WebCore::FrameIdentifier frameID, const WebCore::FloatPoint& point)
+{
+    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::PerformDictionaryLookupAtLocation(frameID, point), [weakThis = WeakPtr { *this }](std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !remoteUserInputEventData)
+            return;
+        protectedThis->performDictionaryLookupAtLocationInFrame(remoteUserInputEventData->targetFrameID, WebCore::FloatPoint(remoteUserInputEventData->transformedPoint));
+    });
 }
 
 void WebPageProxy::insertDictatedTextAsync(const String& text, const EditingRange& replacementRange, const Vector<TextAlternativeWithRange>& dictationAlternativesWithRange, InsertTextOptions&& options)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16838,21 +16838,9 @@ void WebPageProxy::immediateActionDidComplete()
 
 void WebPageProxy::didPerformImmediateActionHitTest(IPC::Connection& connection, WebHitTestResultData&& result, bool contentPreventsDefault, const UserData& userData)
 {
-    if (protect(preferences())->siteIsolationEnabled()) {
-        if (result.remoteUserInputEventData) {
-            performImmediateActionHitTestAtLocation(result.remoteUserInputEventData->targetFrameID, FloatPoint(result.remoteUserInputEventData->transformedPoint));
-            return;
-        }
-        if (auto parentFrameID = result.frameInfo->parentFrameID) {
-            sendWithAsyncReplyToProcessContainingFrame(parentFrameID, Messages::WebPage::RemoteDictionaryPopupInfoToRootView(result.frameInfo->frameID, result.dictionaryPopupInfo), [protectedThis = Ref { *this }, userData, result = WTF::move(result), contentPreventsDefault] (IPC::Connection* connection, WebCore::DictionaryPopupInfo popupInfo) mutable {
-                result.dictionaryPopupInfo = popupInfo;
-                if (!connection)
-                    return;
-                if (RefPtr pageClient = protectedThis->pageClient())
-                    pageClient->didPerformImmediateActionHitTest(result, contentPreventsDefault, WebProcessProxy::fromConnection(*connection)->transformHandlesToObjects(protect(userData.object()).get()).get());
-            });
-            return;
-        }
+    if (protect(preferences())->siteIsolationEnabled() && result.remoteUserInputEventData) {
+        performImmediateActionHitTestAtLocation(result.remoteUserInputEventData->targetFrameID, FloatPoint(result.remoteUserInputEventData->transformedPoint));
+        return;
     }
     if (RefPtr pageClient = this->pageClient())
         pageClient->didPerformImmediateActionHitTest(result, contentPreventsDefault, WebProcessProxy::fromConnection(connection)->transformHandlesToObjects(protect(userData.object()).get()).get());

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -17352,21 +17352,9 @@ void WebPageProxy::immediateActionDidComplete()
 
 void WebPageProxy::didPerformImmediateActionHitTest(IPC::Connection& connection, WebHitTestResultData&& result, bool contentPreventsDefault, const UserData& userData)
 {
-    if (protect(preferences())->siteIsolationEnabled()) {
-        if (result.remoteUserInputEventData) {
-            performImmediateActionHitTestAtLocation(result.remoteUserInputEventData->targetFrameID, FloatPoint(result.remoteUserInputEventData->transformedPoint));
-            return;
-        }
-        if (auto parentFrameID = result.frameInfo->parentFrameID) {
-            sendWithAsyncReplyToProcessContainingFrame(parentFrameID, Messages::WebPage::RemoteDictionaryPopupInfoToRootView(result.frameInfo->frameID, result.dictionaryPopupInfo), [protectedThis = Ref { *this }, userData, result = WTF::move(result), contentPreventsDefault] (IPC::Connection* connection, WebCore::DictionaryPopupInfo popupInfo) mutable {
-                result.dictionaryPopupInfo = popupInfo;
-                if (!connection)
-                    return;
-                if (RefPtr pageClient = protectedThis->pageClient())
-                    pageClient->didPerformImmediateActionHitTest(result, contentPreventsDefault, WebProcessProxy::fromConnection(*connection)->transformHandlesToObjects(protect(userData.object()).get()).get());
-            });
-            return;
-        }
+    if (protect(preferences())->siteIsolationEnabled() && result.remoteUserInputEventData) {
+        performImmediateActionHitTestAtLocation(result.remoteUserInputEventData->targetFrameID, FloatPoint(result.remoteUserInputEventData->transformedPoint));
+        return;
     }
     if (RefPtr pageClient = this->pageClient())
         pageClient->didPerformImmediateActionHitTest(result, contentPreventsDefault, WebProcessProxy::fromConnection(connection)->transformHandlesToObjects(protect(userData.object()).get()).get());

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1771,6 +1771,7 @@ public:
 
 #if PLATFORM(COCOA)
     void performDictionaryLookupAtLocation(const WebCore::FloatPoint&);
+    void performDictionaryLookupAtLocationInFrame(WebCore::FrameIdentifier, const WebCore::FloatPoint&);
 #endif
 
     enum class WillContinueLoadInNewProcess : bool { No, Yes };

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1800,6 +1800,7 @@ public:
 
 #if PLATFORM(COCOA)
     void performDictionaryLookupAtLocation(const WebCore::FloatPoint&);
+    void performDictionaryLookupAtLocationInFrame(WebCore::FrameIdentifier, const WebCore::FloatPoint&);
 #endif
 
     enum class WillContinueLoadInNewProcess : bool { No, Yes };

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -321,31 +321,42 @@ bool WebPage::shouldUsePDFPlugin(const String& contentType, StringView path) con
 }
 #endif
 
-void WebPage::performDictionaryLookupAtLocation(const FloatPoint& floatPoint)
+void WebPage::performDictionaryLookupAtLocation(FrameIdentifier frameID, const FloatPoint& floatPoint, CompletionHandler<void(std::optional<RemoteUserInputEventData>)>&& completionHandler)
 {
 #if ENABLE(PDF_PLUGIN)
     if (RefPtr pluginView = mainFramePlugIn()) {
         if (pluginView->performDictionaryLookupAtLocation(floatPoint))
-            return;
+            return completionHandler(std::nullopt);
     }
 #endif
-    
-    RefPtr localMainFrame = corePage()->localMainFrame();
-    if (!localMainFrame)
-        return;
+
+    RefPtr webFrame = WebFrame::webFrame(frameID);
+    RefPtr localFrame = webFrame ? webFrame->coreLocalFrame() : nullptr;
+    RefPtr view = localFrame ? localFrame->view() : nullptr;
+    if (!view)
+        return completionHandler(std::nullopt);
+
     // Find the frame the point is over.
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
-    auto result = localMainFrame->eventHandler().hitTestResultAtPoint(protect(localMainFrame->view())->windowToContents(roundedIntPoint(floatPoint)), hitType);
+    auto result = localFrame->eventHandler().hitTestResultAtPoint(view->rootViewToContents(roundedIntPoint(floatPoint)), hitType);
+
+    // AllowChildFrameContent cannot descend into a RemoteFrameView, so over a site-isolated iframe the
+    // hit test stops at its owner element and finds no text. Report the frame back instead so the UI
+    // process can retry the lookup in that frame's process, as the immediate action path does.
+    auto subframe = EventHandler::subframeForTargetNode(protect(result.targetNode()).get());
+    if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(subframe).get()) {
+        if (RefPtr remoteFrameView = remoteFrame->view())
+            return completionHandler(RemoteUserInputEventData { remoteFrame->frameID(), remoteFrameView->convertFromRootView(roundedIntPoint(floatPoint)) });
+    }
 
     RefPtr frame = result.innerNonSharedNode() ? result.innerNonSharedNode()->document().frame() : corePage()->focusController().focusedOrMainFrame();
     if (!frame)
-        return;
+        return completionHandler(std::nullopt);
 
-    auto rangeResult = DictionaryLookup::rangeAtHitTestResult(result);
-    if (!rangeResult)
-        return;
+    if (auto rangeResult = DictionaryLookup::rangeAtHitTestResult(result))
+        performDictionaryLookupForRange(*frame, *rangeResult, TextIndicatorPresentationTransition::Bounce);
 
-    performDictionaryLookupForRange(*frame, *rangeResult, TextIndicatorPresentationTransition::Bounce);
+    completionHandler(std::nullopt);
 }
 
 void WebPage::performDictionaryLookupForSelection(LocalFrame& frame, const VisibleSelection& selection, TextIndicatorPresentationTransition presentationTransition)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -431,6 +431,42 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
 
 #endif
 
+    // In a site-isolated subframe the rects above are all in the local root frame's root view
+    // coordinates, because Widget::convertToRootView() stops at the local root -- the parent frame
+    // lives in another process. Map them the rest of the way to the top-level frame here, applying the
+    // CSS transforms on the remote ancestor frames rather than a plain translation, so the UI process
+    // can position the popover and the text indicator without an IPC round trip per nesting level.
+    //
+    // The conversion runs on the local root frame's view, not this frame's view, because the rects
+    // have already been walked up the widget tree to the local root. Starting from this frame's view
+    // would count the offset of any same-origin frame between it and the local root twice.
+    if (!frame.localMainFrame()) {
+        if (RefPtr rootView = frame.rootFrame().view()) {
+            auto convertRect = [&](FloatRect rect) {
+                return rootView->convertToRootViewAcrossIsolatedFrames(rect);
+            };
+
+            dictionaryPopupInfo.origin = rootView->convertToRootViewAcrossIsolatedFrames(dictionaryPopupInfo.origin);
+
+            // textRectsInBoundingRectCoordinates are offsets from the text bounding rect's location,
+            // so lift each one back into root view coordinates to convert it, then re-relativize it
+            // against the converted bounding rect.
+            auto boundingRect = textIndicator->textBoundingRectInRootViewCoordinates();
+            auto convertedBoundingRect = convertRect(boundingRect);
+            auto textRects = textIndicator->textRectsInBoundingRectCoordinates().map([&](auto rect) {
+                rect.moveBy(boundingRect.location());
+                rect = convertRect(rect);
+                rect.moveBy(-convertedBoundingRect.location());
+                return rect;
+            });
+
+            textIndicator->setTextBoundingRectInRootViewCoordinates(convertedBoundingRect);
+            textIndicator->setTextRectsInBoundingRectCoordinates(WTF::move(textRects));
+            textIndicator->setSelectionRectInRootViewCoordinates(convertRect(textIndicator->selectionRectInRootViewCoordinates()));
+            textIndicator->setContentImageWithoutSelectionRectInRootViewCoordinates(convertRect(textIndicator->contentImageWithoutSelectionRectInRootViewCoordinates()));
+        }
+    }
+
     editor->setIsGettingDictionaryPopupInfo(false);
     return dictionaryPopupInfo;
 }

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -321,31 +321,40 @@ bool WebPage::shouldUsePDFPlugin(const String& contentType, StringView path) con
 }
 #endif
 
-void WebPage::performDictionaryLookupAtLocation(const FloatPoint& floatPoint)
+void WebPage::performDictionaryLookupAtLocation(FrameIdentifier frameID, const FloatPoint& floatPoint, CompletionHandler<void(std::optional<RemoteUserInputEventData>)>&& completionHandler)
 {
 #if ENABLE(PDF_PLUGIN)
     if (RefPtr pluginView = mainFramePlugIn()) {
         if (pluginView->performDictionaryLookupAtLocation(floatPoint))
-            return;
+            return completionHandler(std::nullopt);
     }
 #endif
-    
-    RefPtr localMainFrame = corePage()->localMainFrame();
-    if (!localMainFrame)
-        return;
+
+    RefPtr webFrame = WebFrame::webFrame(frameID);
+    RefPtr localFrame = webFrame ? webFrame->coreLocalFrame() : nullptr;
+    RefPtr view = localFrame ? localFrame->view() : nullptr;
+    if (!view)
+        return completionHandler(std::nullopt);
+
     // Find the frame the point is over.
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
-    auto result = localMainFrame->eventHandler().hitTestResultAtPoint(protect(localMainFrame->view())->windowToContents(roundedIntPoint(floatPoint)), hitType);
+    auto result = localFrame->eventHandler().hitTestResultAtPoint(view->rootViewToContents(roundedIntPoint(floatPoint)), hitType);
+
+    // AllowChildFrameContent cannot descend into a RemoteFrameView, so retry in that frame's process.
+    auto subframe = EventHandler::subframeForTargetNode(protect(result.targetNode()).get());
+    if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(subframe).get()) {
+        if (RefPtr remoteFrameView = remoteFrame->view())
+            return completionHandler(RemoteUserInputEventData { remoteFrame->frameID(), remoteFrameView->convertFromRootView(roundedIntPoint(floatPoint)) });
+    }
 
     RefPtr frame = result.innerNonSharedNode() ? result.innerNonSharedNode()->document().frame() : corePage()->focusController().focusedOrMainFrame();
     if (!frame)
-        return;
+        return completionHandler(std::nullopt);
 
-    auto rangeResult = DictionaryLookup::rangeAtHitTestResult(result);
-    if (!rangeResult)
-        return;
+    if (auto rangeResult = DictionaryLookup::rangeAtHitTestResult(result))
+        performDictionaryLookupForRange(*frame, *rangeResult, TextIndicatorPresentationTransition::Bounce);
 
-    performDictionaryLookupForRange(*frame, *rangeResult, TextIndicatorPresentationTransition::Bounce);
+    completionHandler(std::nullopt);
 }
 
 void WebPage::performDictionaryLookupForSelection(LocalFrame& frame, const VisibleSelection& selection, TextIndicatorPresentationTransition presentationTransition)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -380,7 +380,7 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
 
     DictionaryPopupInfo dictionaryPopupInfo;
 
-    IntRect rangeRect = protect(frame.view())->contentsToWindow(quads[0].enclosingBoundingBox());
+    auto rangeRect = protect(frame.view())->contentsToWindowAcrossIsolatedFrames(quads[0].enclosingBoundingBox());
 
     const CheckedPtr style = range.startContainer().renderStyle();
     float scaledAscent = style ? style->metricsOfPrimaryFont().intAscent() * pageScaleFactor() : 0;
@@ -430,6 +430,30 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
 #endif
 
 #endif
+
+    // TextIndicator's rects are in the local root's root view coordinates, and stay that way at the
+    // source because page overlays in this process draw with them. Convert here, on the way out to the
+    // UI process, from the local root's view: they have already been walked up the widget tree to it,
+    // so starting from this frame's view would count an intervening same-origin frame twice.
+    if (!frame.localMainFrame()) {
+        if (RefPtr rootView = frame.rootFrame().view()) {
+            // textRectsInBoundingRectCoordinates are offsets from the bounding rect, so lift each one
+            // back into root view coordinates to convert it, then re-relativize it.
+            auto boundingRect = textIndicator->textBoundingRectInRootViewCoordinates();
+            auto convertedBoundingRect = rootView->convertToRootViewAcrossIsolatedFrames(boundingRect);
+            auto textRects = textIndicator->textRectsInBoundingRectCoordinates().map([&](auto rect) {
+                rect.moveBy(boundingRect.location());
+                rect = rootView->convertToRootViewAcrossIsolatedFrames(rect);
+                rect.moveBy(-convertedBoundingRect.location());
+                return rect;
+            });
+
+            textIndicator->setTextBoundingRectInRootViewCoordinates(convertedBoundingRect);
+            textIndicator->setTextRectsInBoundingRectCoordinates(WTF::move(textRects));
+            textIndicator->setSelectionRectInRootViewCoordinates(rootView->convertToRootViewAcrossIsolatedFrames(textIndicator->selectionRectInRootViewCoordinates()));
+            textIndicator->setContentImageWithoutSelectionRectInRootViewCoordinates(rootView->convertToRootViewAcrossIsolatedFrames(textIndicator->contentImageWithoutSelectionRectInRootViewCoordinates()));
+        }
+    }
 
     editor->setIsGettingDictionaryPopupInfo(false);
     return dictionaryPopupInfo;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10688,24 +10688,6 @@ void WebPage::contentsToRootViewPoint(FrameIdentifier frameID, FloatPoint point,
     completionHandler(contentsToRootView(frameID, point));
 }
 
-void WebPage::remoteDictionaryPopupInfoToRootView(WebCore::FrameIdentifier frameID, WebCore::DictionaryPopupInfo popupInfo, CompletionHandler<void(WebCore::DictionaryPopupInfo)>&& completionHandler)
-{
-    RefPtr textIndicator = popupInfo.textIndicator;
-    popupInfo.origin = contentsToRootView<FloatPoint>(frameID, popupInfo.origin);
-    if (!textIndicator)
-        return completionHandler(popupInfo);
-#if PLATFORM(COCOA)
-    auto textIndicatorData = textIndicator->data();
-    textIndicatorData.selectionRectInRootViewCoordinates = contentsToRootView<FloatRect>(frameID, popupInfo.textIndicator->selectionRectInRootViewCoordinates());
-    textIndicatorData.textBoundingRectInRootViewCoordinates = contentsToRootView<FloatRect>(frameID, popupInfo.textIndicator->textBoundingRectInRootViewCoordinates());
-    textIndicatorData.contentImageWithoutSelectionRectInRootViewCoordinates = contentsToRootView<FloatRect>(frameID, popupInfo.textIndicator->contentImageWithoutSelectionRectInRootViewCoordinates());
-
-    for (auto& textRect : textIndicatorData.textRectsInBoundingRectCoordinates)
-        textRect = contentsToRootView<FloatRect>(frameID, textRect);
-#endif
-    completionHandler(popupInfo);
-}
-
 void WebPage::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point, CompletionHandler<void(NodeHitTestResult)>&& completionHandler)
 {
     RefPtr frame = WebFrame::webFrame(frameID);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10744,24 +10744,6 @@ void WebPage::contentsToRootViewPoint(FrameIdentifier frameID, FloatPoint point,
     completionHandler(contentsToRootView(frameID, point));
 }
 
-void WebPage::remoteDictionaryPopupInfoToRootView(WebCore::FrameIdentifier frameID, WebCore::DictionaryPopupInfo popupInfo, CompletionHandler<void(WebCore::DictionaryPopupInfo)>&& completionHandler)
-{
-    RefPtr textIndicator = popupInfo.textIndicator;
-    popupInfo.origin = contentsToRootView<FloatPoint>(frameID, popupInfo.origin);
-    if (!textIndicator)
-        return completionHandler(popupInfo);
-#if PLATFORM(COCOA)
-    auto textIndicatorData = textIndicator->data();
-    textIndicatorData.selectionRectInRootViewCoordinates = contentsToRootView<FloatRect>(frameID, popupInfo.textIndicator->selectionRectInRootViewCoordinates());
-    textIndicatorData.textBoundingRectInRootViewCoordinates = contentsToRootView<FloatRect>(frameID, popupInfo.textIndicator->textBoundingRectInRootViewCoordinates());
-    textIndicatorData.contentImageWithoutSelectionRectInRootViewCoordinates = contentsToRootView<FloatRect>(frameID, popupInfo.textIndicator->contentImageWithoutSelectionRectInRootViewCoordinates());
-
-    for (auto& textRect : textIndicatorData.textRectsInBoundingRectCoordinates)
-        textRect = contentsToRootView<FloatRect>(frameID, textRect);
-#endif
-    completionHandler(popupInfo);
-}
-
 void WebPage::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point, const ContentWorldData& worldData, CompletionHandler<void(NodeHitTestResult)>&& completionHandler)
 {
     RefPtr frame = WebFrame::webFrame(frameID);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2819,7 +2819,6 @@ private:
     void contentsToRootViewRect(WebCore::FrameIdentifier, WebCore::FloatRect, CompletionHandler<void(WebCore::FloatRect)>&&);
     void contentsToRootViewRects(WebCore::FrameIdentifier, Vector<WebCore::FloatRect>, CompletionHandler<void(Vector<WebCore::FloatRect>)>&&);
     void contentsToRootViewPoint(WebCore::FrameIdentifier, WebCore::FloatPoint, CompletionHandler<void(WebCore::FloatPoint)>&&);
-    void remoteDictionaryPopupInfoToRootView(WebCore::FrameIdentifier, WebCore::DictionaryPopupInfo, CompletionHandler<void(WebCore::DictionaryPopupInfo)>&&);
 
     void hitTestAtPoint(WebCore::FrameIdentifier, WebCore::FloatPoint, const ContentWorldData&, CompletionHandler<void(NodeHitTestResult)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2809,7 +2809,6 @@ private:
     void contentsToRootViewRect(WebCore::FrameIdentifier, WebCore::FloatRect, CompletionHandler<void(WebCore::FloatRect)>&&);
     void contentsToRootViewRects(WebCore::FrameIdentifier, Vector<WebCore::FloatRect>, CompletionHandler<void(Vector<WebCore::FloatRect>)>&&);
     void contentsToRootViewPoint(WebCore::FrameIdentifier, WebCore::FloatPoint, CompletionHandler<void(WebCore::FloatPoint)>&&);
-    void remoteDictionaryPopupInfoToRootView(WebCore::FrameIdentifier, WebCore::DictionaryPopupInfo, CompletionHandler<void(WebCore::DictionaryPopupInfo)>&&);
 
     void hitTestAtPoint(WebCore::FrameIdentifier, WebCore::FloatPoint, CompletionHandler<void(NodeHitTestResult)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2497,7 +2497,7 @@ private:
     void resume(CompletionHandler<void(bool)>&&);
 
 #if PLATFORM(COCOA)
-    void performDictionaryLookupAtLocation(const WebCore::FloatPoint&);
+    void performDictionaryLookupAtLocation(WebCore::FrameIdentifier, const WebCore::FloatPoint&, CompletionHandler<void(std::optional<WebCore::RemoteUserInputEventData>)>&&);
     void performDictionaryLookupForRange(WebCore::LocalFrame&, const WebCore::SimpleRange&, WebCore::TextIndicatorPresentationTransition);
     WebCore::DictionaryPopupInfo dictionaryPopupInfoForRange(WebCore::LocalFrame&, const WebCore::SimpleRange&, WebCore::TextIndicatorPresentationTransition);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2506,7 +2506,7 @@ private:
     void resume(CompletionHandler<void(bool)>&&);
 
 #if PLATFORM(COCOA)
-    void performDictionaryLookupAtLocation(const WebCore::FloatPoint&);
+    void performDictionaryLookupAtLocation(WebCore::FrameIdentifier, const WebCore::FloatPoint&, CompletionHandler<void(std::optional<WebCore::RemoteUserInputEventData>)>&&);
     void performDictionaryLookupForRange(WebCore::LocalFrame&, const WebCore::SimpleRange&, WebCore::TextIndicatorPresentationTransition);
     WebCore::DictionaryPopupInfo dictionaryPopupInfoForRange(WebCore::LocalFrame&, const WebCore::SimpleRange&, WebCore::TextIndicatorPresentationTransition);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -959,7 +959,6 @@ messages -> WebPage WantsAsyncDispatchMessage {
     ContentsToRootViewRect(WebCore::FrameIdentifier frameID, WebCore::FloatRect rect) -> (WebCore::FloatRect rect)
     ContentsToRootViewRects(WebCore::FrameIdentifier frameID, Vector<WebCore::FloatRect> rects) -> (Vector<WebCore::FloatRect> rects)
     ContentsToRootViewPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point) -> (WebCore::FloatPoint point)
-    RemoteDictionaryPopupInfoToRootView(WebCore::FrameIdentifier frameID, struct WebCore::DictionaryPopupInfo popupInfo) -> (struct WebCore::DictionaryPopupInfo popupInfo)
     HitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point, struct WebKit::ContentWorldData world) -> (struct WebKit::NodeHitTestResult result)
 
 #if HAVE(SPATIAL_TRACKING_LABEL)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -954,7 +954,6 @@ messages -> WebPage WantsAsyncDispatchMessage {
     ContentsToRootViewRect(WebCore::FrameIdentifier frameID, WebCore::FloatRect rect) -> (WebCore::FloatRect rect)
     ContentsToRootViewRects(WebCore::FrameIdentifier frameID, Vector<WebCore::FloatRect> rects) -> (Vector<WebCore::FloatRect> rects)
     ContentsToRootViewPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point) -> (WebCore::FloatPoint point)
-    RemoteDictionaryPopupInfoToRootView(WebCore::FrameIdentifier frameID, struct WebCore::DictionaryPopupInfo popupInfo) -> (struct WebCore::DictionaryPopupInfo popupInfo)
     HitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point) -> (struct WebKit::NodeHitTestResult result)
 
 #if HAVE(SPATIAL_TRACKING_LABEL)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -290,7 +290,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
 #if PLATFORM(COCOA)
     # Dictionary support.
-    PerformDictionaryLookupAtLocation(WebCore::FloatPoint point)
+    PerformDictionaryLookupAtLocation(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point) -> (struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
 #endif
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -291,7 +291,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
 #if PLATFORM(COCOA)
     # Dictionary support.
-    PerformDictionaryLookupAtLocation(WebCore::FloatPoint point)
+    PerformDictionaryLookupAtLocation(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point) -> (struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
 #endif
 
 #if ENABLE(DATA_DETECTION)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -84,6 +84,9 @@
 #endif
 
 #if PLATFORM(MAC)
+#import "Helpers/mac/WKWebViewForTestingImmediateActions.h"
+#import <WebKit/_WKHitTestResult.h>
+
 @interface NSApplication ()
 - (void)_setKeyWindow:(NSWindow *)newKeyWindow;
 @end
@@ -9530,6 +9533,117 @@ TEST(SiteIsolation, SelectElementPopupAfterFocusChangesDuringTracking)
     EXPECT_TRUE(Util::waitFor([&] {
         return [[webView objectByEvaluatingJavaScript:@"document.getElementById('sel').value"] isEqualToString:@"c"];
     }));
+}
+
+static std::pair<RetainPtr<WKWebViewForTestingImmediateActions>, RetainPtr<TestNavigationDelegate>> siteIsolatedImmediateActionViewAndDelegate(const HTTPServer& server, CGRect viewRect)
+{
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    enableSiteIsolation(configuration.get());
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+
+    RetainPtr webView = adoptNS([[WKWebViewForTestingImmediateActions alloc] initWithFrame:viewRect configuration:configuration.get()]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
+}
+
+// Performs a Look Up over a word and returns the bounding rect of the resulting text indicator, which
+// is what positions both the Reveal popover's highlight and the indicator layer. The web process
+// reports it in the top-level frame's root view coordinates.
+static CGRect lookUpTextBoundingRect(WKWebViewForTestingImmediateActions *webView, NSPoint location)
+{
+    auto result = [webView simulateImmediateAction:location];
+    if (!result.first)
+        return CGRectZero;
+    return [result.first _dictionaryPopupTextBoundingRectForTesting];
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInCrossOriginIframeUsesMainFrameCoordinates)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/iframe'></iframe></body>"_s } },
+        { "/iframe"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // The word sits at (100, 100) in the main frame. Without the conversion the subframe reports its
+    // own local root view coordinates, putting the indicator near the origin instead.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(110, 115));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_GT(CGRectGetMinX(rect), 90);
+    EXPECT_GT(CGRectGetMinY(rect), 90);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInNestedCrossOriginIframesUsesMainFrameCoordinates)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://domain2.com/middle'></iframe></body>"_s } },
+        { "/middle"_s, { "<!DOCTYPE html><body style='margin: 0'><iframe style='margin: 50px; width: 200px; height: 150px; border: none;' src='https://domain3.com/inner'></iframe></body>"_s } },
+        { "/inner"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // Both cross-process hops must be applied: (100, 100) for domain2 plus (50, 50) for domain3.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(160, 165));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_GT(CGRectGetMinX(rect), 140);
+    EXPECT_GT(CGRectGetMinY(rect), 140);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInSameOriginIframeInsideCrossOriginIframe)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/middle'></iframe></body>"_s } },
+        { "/middle"_s, { "<!DOCTYPE html><body style='margin: 0'><iframe style='margin: 50px; width: 200px; height: 150px; border: none;' src='https://webkit.org/inner'></iframe></body>"_s } },
+        { "/inner"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // Both webkit.org frames share a process, so the rect arrives already relative to the outer one.
+    // The conversion therefore has to start at the local root and add only (100, 100), landing the word
+    // at (150, 150). Converting from the inner frame's own view would count its 50px offset twice and
+    // land near (200, 200).
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(160, 165));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_GT(CGRectGetMinX(rect), 140);
+    EXPECT_LT(CGRectGetMinX(rect), 180);
+    EXPECT_GT(CGRectGetMinY(rect), 140);
+    EXPECT_LT(CGRectGetMinY(rect), 180);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInMainFrameIsNotOffset)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // The word is in the main frame, so no conversion applies and the rect stays at the top left.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(10, 15));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_LT(CGRectGetMinX(rect), 50);
+    EXPECT_LT(CGRectGetMinY(rect), 50);
 }
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -86,6 +86,8 @@
 
 #if PLATFORM(MAC)
 #import "Helpers/mac/AppKitSPI.h"
+#import "Helpers/mac/WKWebViewForTestingImmediateActions.h"
+#import <WebKit/_WKHitTestResult.h>
 
 @interface NSApplication ()
 - (void)_setKeyWindow:(NSWindow *)newKeyWindow;
@@ -10364,6 +10366,156 @@ TEST(SiteIsolation, SelectElementPopupAfterFocusChangesDuringTracking)
     EXPECT_TRUE(Util::waitFor([&] {
         return [[webView objectByEvaluatingJavaScript:@"document.getElementById('sel').value"] isEqualToString:@"c"];
     }));
+}
+
+static std::pair<RetainPtr<WKWebViewForTestingImmediateActions>, RetainPtr<TestNavigationDelegate>> siteIsolatedImmediateActionViewAndDelegate(const HTTPServer& server, CGRect viewRect)
+{
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    enableSiteIsolation(configuration.get());
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+
+    RetainPtr webView = adoptNS([[WKWebViewForTestingImmediateActions alloc] initWithFrame:viewRect configuration:configuration.get()]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
+}
+
+static CGRect lookUpTextBoundingRect(WKWebViewForTestingImmediateActions *webView, NSPoint location)
+{
+    auto result = [webView simulateImmediateAction:location];
+    if (!result.first)
+        return CGRectZero;
+    return [result.first _dictionaryPopupTextBoundingRectForTesting];
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInCrossOriginIframeUsesMainFrameCoordinates)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/iframe'></iframe></body>"_s } },
+        { "/iframe"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // The word sits at (100, 100) in the main frame.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(110, 115));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_GT(CGRectGetMinX(rect), 90);
+    EXPECT_GT(CGRectGetMinY(rect), 90);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInNestedCrossOriginIframesUsesMainFrameCoordinates)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://domain2.com/middle'></iframe></body>"_s } },
+        { "/middle"_s, { "<!DOCTYPE html><body style='margin: 0'><iframe style='margin: 50px; width: 200px; height: 150px; border: none;' src='https://domain3.com/inner'></iframe></body>"_s } },
+        { "/inner"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // Both cross-process hops must be applied: (100, 100) for domain2 plus (50, 50) for domain3.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(160, 165));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_GT(CGRectGetMinX(rect), 140);
+    EXPECT_GT(CGRectGetMinY(rect), 140);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInSameOriginIframeInsideCrossOriginIframe)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/middle'></iframe></body>"_s } },
+        { "/middle"_s, { "<!DOCTYPE html><body style='margin: 0'><iframe style='margin: 50px; width: 200px; height: 150px; border: none;' src='https://webkit.org/inner'></iframe></body>"_s } },
+        { "/inner"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // Both webkit.org frames share a process, so the rect arrives relative to the outer one and only
+    // (100, 100) is added, landing at (150, 150). Starting from the inner frame's own view would count
+    // its 50px offset twice and land near (200, 200).
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(160, 165));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_GT(CGRectGetMinX(rect), 140);
+    EXPECT_LT(CGRectGetMinX(rect), 180);
+    EXPECT_GT(CGRectGetMinY(rect), 140);
+    EXPECT_LT(CGRectGetMinY(rect), 180);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInMainFrameIsNotOffset)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0; font-size: 32px'>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(10, 15));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_LT(CGRectGetMinX(rect), 50);
+    EXPECT_LT(CGRectGetMinY(rect), 50);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInCrossOriginIframeBelowSpacer)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/iframe'></iframe></body>"_s } },
+        { "/iframe"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'><div style='height: 150px'></div>test</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // The word is 150px down inside the iframe, so it sits at (100, 250) in the main frame.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(110, 265));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_GT(CGRectGetMinX(rect), 90);
+    EXPECT_LT(CGRectGetMinX(rect), 160);
+    EXPECT_GT(CGRectGetMinY(rect), 240);
+    EXPECT_LT(CGRectGetMinY(rect), 300);
+}
+
+TEST(SiteIsolation, LookUpTextIndicatorRectInScrolledCrossOriginIframe)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/iframe#target'></iframe></body>"_s } },
+        { "/iframe"_s, { "<!DOCTYPE html><body style='margin: 0; font-size: 32px'><div style='height: 1000px'></div><div id='target'>test</div><div style='height: 1000px'></div></body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedImmediateActionViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // The fragment scrolls the iframe by 1000px, putting the word back at (100, 100) in the main
+    // frame. Ignoring the scroll offset lands the rect near y = 1100.
+    auto rect = lookUpTextBoundingRect(webView.get(), NSMakePoint(110, 115));
+    EXPECT_FALSE(CGRectIsEmpty(rect));
+    EXPECT_GT(CGRectGetMinX(rect), 90);
+    EXPECT_LT(CGRectGetMinX(rect), 160);
+    EXPECT_GT(CGRectGetMinY(rect), 90);
+    EXPECT_LT(CGRectGetMinY(rect), 160);
 }
 
 #endif


### PR DESCRIPTION
#### 465033e25b659b0567c3f9695aff901b2e953f61
<pre>
[Site Isolation] [Catalyst] Look Up at a point does nothing in a cross-origin iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=321336">https://bugs.webkit.org/show_bug.cgi?id=321336</a>
<a href="https://rdar.apple.com/184366886">rdar://184366886</a>

Reviewed by NOBODY (OOPS!).

PerformDictionaryLookupAtLocation was sent only to the main frame&apos;s process, and the handler
hit tested localMainFrame(). AllowChildFrameContent cannot descend into a RemoteFrameView, so
a point over a cross-origin iframe resolved to the &lt;iframe&gt; element, rangeAtHitTestResult()
found no text, and the lookup silently did nothing.

Give the message a frameID and have it reply with a RemoteUserInputEventData when the point
lands over a remote frame, so the UI process retries the lookup in that frame&apos;s process with
the transformed point, one hop per nesting level. This is the same pattern
PerformImmediateActionHitTestAtLocation and MouseEvent already use. The point now arrives in
the target frame&apos;s root view coordinates, so the hit test uses rootViewToContents().

On macOS this path is unreachable: WebViewImpl::quickLookWithEvent() returns to super whenever
m_immediateActionGestureRecognizer is non-null, and that is created unconditionally in the
constructor, so trackpad Look Up goes through WKImmediateActionController and
performImmediateActionHitTestAtLocation instead. The live caller is
-[WKContentView _lookupGestureRecognized:], which is Mac Catalyst only
(HAVE_LOOKUP_GESTURE_RECOGNIZER). No test: the macOS entry point is dead code and Catalyst is
not covered by TestWebKitAPI.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::performDictionaryLookupAtLocation):
(WebKit::WebPageProxy::performDictionaryLookupAtLocationInFrame):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::performDictionaryLookupAtLocation):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
</pre>
----------------------------------------------------------------------
#### 1782742615623f3e4578b3106fe1de388f7bcf80
<pre>
[Site Isolation] Right click Lookup on a word shows the word displaced
<a href="https://bugs.webkit.org/show_bug.cgi?id=321331">https://bugs.webkit.org/show_bug.cgi?id=321331</a>
<a href="https://rdar.apple.com/130518304">rdar://130518304</a>

Reviewed by NOBODY (OOPS!).

Right-clicking a word in a cross-origin iframe and choosing Look Up drew the highlighted word
at the wrong place, offset by the iframe&apos;s position in the page.

Look Up runs in the iframe&apos;s own process, where dictionaryPopupInfoForRange() computes the
popup origin with contentsToWindow() and takes the TextIndicator&apos;s rects, all of which are
relative to the local root: Widget&apos;s walk up the widget tree stops there, since the parent
frame is in another process. DidPerformDictionaryLookup carries no frame identifier, so the UI
process handed them to Reveal unchanged.

Add FrameView::contentsToWindowAcrossIsolatedFrames(), the site-isolation-aware counterpart of
ScrollView::contentsToWindow(), alongside the existing convertToRootViewAcrossIsolatedFrames().
It walks the frame tree instead of the widget tree, so it covers any nesting depth in one pass
and handles CSS transforms on the remote ancestor frames, and it leaves the root-view-to-window
step to the root of this process&apos;s widget tree, which is where the platform widget lives. Use it
for the popup origin.

The TextIndicator&apos;s rects stay in local root coordinates where they are produced, because page
overlays in the same process draw with them (WebFoundTextRangeController). They are mapped the
rest of the way in dictionaryPopupInfoForRange(), on the way out to the UI process, with
FrameView::convertToRootViewAcrossIsolatedFrames(). That runs on the local root frame&apos;s view,
because the rects have already been walked up to the local root; starting from the hit frame&apos;s
view would count an intervening same-origin frame twice.
textRectsInBoundingRectCoordinates are offsets from the bounding rect, so they are converted in
root view coordinates and then re-relativized.

This also covers the force-touch path, so RemoteDictionaryPopupInfoToRootView is removed. It
only ever converted the origin, TextIndicator::data() returns by value, so its edits to the
indicator&apos;s rects were dropped and it hopped just one frame.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::convertToContainingWindowAcrossIsolatedFrames):
(WebCore::FrameView::contentsToWindowAcrossIsolatedFrames):
* Source/WebCore/page/FrameView.h:
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h:
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm:
(-[_WKHitTestResult _dictionaryPopupTextBoundingRectForTesting]):
* Source/WebKit/UIProcess/API/APIHitTestResult.h:
(API::HitTestResult::dictionaryPopupTextBoundingRect const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didPerformImmediateActionHitTest):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::dictionaryPopupInfoForRange):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::remoteDictionaryPopupInfoToRootView): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, LookUpTextIndicatorRectInCrossOriginIframeUsesMainFrameCoordinates)):
(TestWebKitAPI::(SiteIsolation, LookUpTextIndicatorRectInNestedCrossOriginIframesUsesMainFrameCoordinates)):
(TestWebKitAPI::(SiteIsolation, LookUpTextIndicatorRectInSameOriginIframeInsideCrossOriginIframe)):
(TestWebKitAPI::(SiteIsolation, LookUpTextIndicatorRectInMainFrameIsNotOffset)):
(TestWebKitAPI::(SiteIsolation, LookUpTextIndicatorRectInCrossOriginIframeBelowSpacer)):
(TestWebKitAPI::(SiteIsolation, LookUpTextIndicatorRectInScrolledCrossOriginIframe)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/465033e25b659b0567c3f9695aff901b2e953f61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186096 "Failed to checkout and rebase branch from PR 71192") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59992 "Failed to checkout and rebase branch from PR 71192") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53776 "Failed to checkout and rebase branch from PR 71192") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196387 "Failed to checkout and rebase branch from PR 71192") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150682 "Failed to checkout and rebase branch from PR 71192") | ⏳ 🛠 ios-apple 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187958 "Failed to checkout and rebase branch from PR 71192") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61367 "Failed to checkout and rebase branch from PR 71192") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59711 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/196387 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/150682 "Failed to checkout and rebase branch from PR 71192") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189051 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/61367 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/53776 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/196387 "Failed to checkout and rebase branch from PR 71192") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/61367 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/59711 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/196387 "Failed to checkout and rebase branch from PR 71192") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/53776 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/61367 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/53776 "Failed to checkout and rebase branch from PR 71192") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7458 "Failed to checkout and rebase branch from PR 71192") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52520 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/59711 "Failed to checkout and rebase branch from PR 71192") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198365 "Failed to checkout and rebase branch from PR 71192") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59648 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/53776 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/198365 "Failed to checkout and rebase branch from PR 71192") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60360 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/53776 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/198365 "Failed to checkout and rebase branch from PR 71192") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/60360 "Failed to checkout and rebase branch from PR 71192") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132648 "Failed to checkout and rebase branch from PR 71192") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129774 "Failed to checkout and rebase branch from PR 71192") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58799 "Failed to checkout and rebase branch from PR 71192") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/53776 "Failed to checkout and rebase branch from PR 71192") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58192 "Failed to checkout and rebase branch from PR 71192") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58421 "Failed to checkout and rebase branch from PR 71192") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58251 "Failed to checkout and rebase branch from PR 71192") | | | | 
<!--EWS-Status-Bubble-End-->