### PR TITLE
[JSC] Table64 size should be checked when creating / growing, not parsing

### DIFF
--- a/JSTests/wasm/stress/table-oversized-initial-reflection.js
+++ b/JSTests/wasm/stress/table-oversized-initial-reflection.js
@@ -1,0 +1,78 @@
+//@ skip if $addressBits <= 32
+import * as assert from "../assert.js";
+
+// A table may declare a size larger than this implementation can create. That is a compile-time
+// success and an instantiation-time failure, so the type reflected by Module.imports() and
+// Module.exports() has to be the size the module declared, not one clamped to what is creatable.
+
+const SECTION_TYPE = 1;
+const SECTION_IMPORT = 2;
+const SECTION_TABLE = 4;
+const SECTION_EXPORT = 7;
+
+function leb(value) {
+    let bytes = [];
+    do {
+        let byte = Number(value & 0x7fn);
+        value >>= 7n;
+        if (value)
+            byte |= 0x80;
+        bytes.push(byte);
+    } while (value);
+    return bytes;
+}
+
+function section(id, payload) {
+    return [id, ...leb(BigInt(payload.length)), ...payload];
+}
+
+const name = (text) => [text.length, ...Array.from(text, (c) => c.charCodeAt(0))];
+
+// flags: 0x00 min only i32, 0x04 min only i64
+function importedTable(initial, isTable64) {
+    let bytes = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+    bytes.push(...section(SECTION_TYPE, [0x00]));
+    bytes.push(...section(SECTION_IMPORT, [0x01, ...name("m"), ...name("t"), 0x01, 0x70, isTable64 ? 0x04 : 0x00, ...leb(initial)]));
+    return new Uint8Array(bytes);
+}
+
+function exportedTable(initial, isTable64) {
+    let bytes = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+    bytes.push(...section(SECTION_TYPE, [0x00]));
+    bytes.push(...section(SECTION_TABLE, [0x01, 0x70, isTable64 ? 0x04 : 0x00, ...leb(initial)]));
+    bytes.push(...section(SECTION_EXPORT, [0x01, ...name("t"), 0x01, 0x00]));
+    return new Uint8Array(bytes);
+}
+
+function checkMinimum(bytes, expected, description) {
+    const module = new WebAssembly.Module(bytes);
+    const imports = WebAssembly.Module.imports(module);
+    const exports = WebAssembly.Module.exports(module);
+    const descriptor = imports.length ? imports[0] : exports[0];
+    assert.eq(descriptor.kind, "table");
+    assert.eq(descriptor.type.minimum, expected, description);
+}
+
+// Sizes above the creatable limit keep their declared value.
+checkMinimum(importedTable(1099511627776n, true), 1099511627776n, "table64 import, 2^40");
+checkMinimum(importedTable(4294967301n, true), 4294967301n, "table64 import, 2^32 + 5");
+checkMinimum(importedTable(18446744073709551615n, true), 18446744073709551615n, "table64 import, 2^64 - 1");
+checkMinimum(importedTable(20000000n, false), 20000000, "table32 import, 20000000");
+checkMinimum(exportedTable(4294967301n, true), 4294967301n, "table64 definition, 2^32 + 5");
+checkMinimum(exportedTable(20000000n, false), 20000000, "table32 definition, 20000000");
+
+// Sizes at or below it are unaffected.
+checkMinimum(importedTable(10n, true), 10n, "table64 import, 10");
+checkMinimum(importedTable(10n, false), 10, "table32 import, 10");
+checkMinimum(exportedTable(9999999n, false), 9999999, "table32 definition, 9999999");
+
+// Such a table still cannot be created, and no JS table can satisfy the import.
+for (const isTable64 of [false, true]) {
+    const initial = isTable64 ? 4294967301n : 20000000n;
+    assert.throws(() => new WebAssembly.Instance(new WebAssembly.Module(exportedTable(initial, isTable64))),
+        WebAssembly.LinkError, "couldn't create Table");
+
+    const table = new WebAssembly.Table({ element: "anyfunc", initial: isTable64 ? 10n : 10, address: isTable64 ? "i64" : "i32" });
+    assert.throws(() => new WebAssembly.Instance(new WebAssembly.Module(importedTable(initial, isTable64)), { m: { t: table } }),
+        WebAssembly.LinkError, "Table import m:t provided an 'initial' that is too small");
+}

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4824,7 +4824,7 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
             ASSERT(tableIndex < m_info.tableCount());
 
             auto& tableInformation = m_info.table(tableIndex);
-            if (tableInformation.maximum() && tableInformation.maximum().value() == tableInformation.initial()) {
+            if (tableInformation.maximum() && tableInformation.maximum().value() == tableInformation.initial() && Table::isValidLength(tableInformation.initial())) {
                 if (!tableIndex)
                     m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfCachedTable0Buffer()), callableFunctionBuffer);
                 else {

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -794,7 +794,7 @@ public:
         ASSERT(!*this);
     }
 
-    TableInformation(uint32_t initial, std::optional<uint64_t> maximum, bool isImport, TableElementType type, Type wasmType, InitializationType initType, uint64_t initialBitsOrImportNumber, bool isTable64)
+    TableInformation(uint64_t initial, std::optional<uint64_t> maximum, bool isImport, TableElementType type, Type wasmType, InitializationType initType, uint64_t initialBitsOrImportNumber, bool isTable64)
         : m_wasmType(wasmType)
         , m_maximum(maximum)
         , m_initialBitsOrImportNumber(initialBitsOrImportNumber)
@@ -810,7 +810,9 @@ public:
 
     explicit operator bool() const { return m_isValid; }
     bool isImport() const { return m_isImport; }
-    uint32_t initial() const { return m_initial; }
+    // The size the module declared, which may be larger than any table this implementation can
+    // create. It is checked when the table is created, not when the declaration is parsed.
+    uint64_t initial() const { return m_initial; }
     std::optional<uint64_t> maximum() const { return m_maximum; }
     TableElementType type() const { return m_type; }
     Type wasmType() const { return m_wasmType; }
@@ -822,7 +824,7 @@ private:
     Type m_wasmType;
     std::optional<uint64_t> m_maximum;
     uint64_t m_initialBitsOrImportNumber;
-    uint32_t m_initial;
+    uint64_t m_initial;
     TableElementType m_type;
     Wasm::AddressType m_addressType;
     InitializationType m_initType { Default };

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -6341,7 +6341,7 @@ auto OMGIRGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIn
         ASSERT(tableIndex < m_info.tableCount());
         auto& tableInformation = m_info.table(tableIndex);
 
-        if (tableInformation.maximum() && tableInformation.maximum().value() == tableInformation.initial()) {
+        if (tableInformation.maximum() && tableInformation.maximum().value() == tableInformation.initial() && Table::isValidLength(tableInformation.initial())) {
             // The buffer is immutable & non-control-dependent since this table is not resizable / reaching to the maximum size.
             callableFunctionBufferLength = constant(B3::Int32, tableInformation.initial(), origin());
             if (!tableIndex) {

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -345,8 +345,6 @@ auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
     if (!limits) [[unlikely]]
         return makeUnexpected(WTF::move(limits.error()));
 
-    uint32_t clampedInitial = initial > maxTableEntries ? static_cast<uint32_t>(maxTableEntries) : static_cast<uint32_t>(initial);
-
     ASSERT(!maximum || *maximum >= initial);
 
     if (hasInitExpr) {
@@ -370,7 +368,7 @@ auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
     }
 
     TableElementType tableType = isSubtype(type, funcrefType()) ? TableElementType::Funcref : TableElementType::Externref;
-    m_info->tables.append(TableInformation(clampedInitial, maximum, isImport, tableType, type, tableInitType, initialBitsOrImportNumber, isTable64));
+    m_info->tables.append(TableInformation(initial, maximum, isImport, tableType, type, tableInitType, initialBitsOrImportNumber, isTable64));
 
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -95,10 +95,11 @@ Table::Table(uint32_t initial, std::optional<uint64_t> maximum, Type wasmType, W
     ASSERT(!m_maximum || *m_maximum >= m_length);
 }
 
-RefPtr<Table> Table::tryCreate(VM& vm, uint32_t initial, std::optional<uint64_t> maximum, TableElementType type, Type wasmType, Wasm::AddressType addressType)
+RefPtr<Table> Table::tryCreate(VM& vm, uint64_t declaredInitial, std::optional<uint64_t> maximum, TableElementType type, Type wasmType, Wasm::AddressType addressType)
 {
-    if (!isValidLength(initial))
+    if (!isValidLength(declaredInitial))
         return nullptr;
+    uint32_t initial = static_cast<uint32_t>(declaredInitial);
     switch (type) {
     case TableElementType::Externref:
         return adoptRef(new ExternOrAnyRefTable(initial, maximum, wasmType, addressType));

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -55,7 +55,7 @@ class Table : public ThreadSafeRefCounted<Table> {
     WTF_MAKE_NONCOPYABLE(Table);
     WTF_MAKE_TZONE_ALLOCATED(Table);
 public:
-    static RefPtr<Table> tryCreate(VM&, uint32_t initial, std::optional<uint64_t> maximum, TableElementType, Type, Wasm::AddressType);
+    static RefPtr<Table> tryCreate(VM&, uint64_t initial, std::optional<uint64_t> maximum, TableElementType, Type, Wasm::AddressType);
 
     JS_EXPORT_PRIVATE ~Table() = default;
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -439,8 +439,8 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
             if (!table)
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Table import"_s, "is not an instance of WebAssembly.Table"_s)));
 
-            uint32_t expectedInitial = moduleInformation.tables[import.kindIndex].initial();
-            uint32_t actualInitial = table->length();
+            uint64_t expectedInitial = moduleInformation.tables[import.kindIndex].initial();
+            uint64_t actualInitial = table->length();
             if (actualInitial < expectedInitial)
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Table import"_s, "provided an 'initial' that is too small"_s)));
 


### PR DESCRIPTION
#### aa8167a2feb9a49f5380353389324102f2a63462
<pre>
[JSC] Table64 size should be checked when creating / growing, not parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=321338">https://bugs.webkit.org/show_bug.cgi?id=321338</a>
<a href="https://rdar.apple.com/184367247">rdar://184367247</a>

Reviewed by Yijia Huang.

Clamping the table size at parsing time will cause incorrect table size
reporting. The correct behavior is (1) parsing should accept, it is just
declaration and then (2) creating a table actually should reject it.
This patch fixes this issue.

Test: JSTests/wasm/stress/table-oversized-initial-reflection.js

* JSTests/wasm/stress/table-oversized-initial-reflection.js: Added.
(leb):
(section):
(importedTable):
(exportedTable):
(checkMinimum):
(true.assert.throws.new.WebAssembly.Instance.new.WebAssembly.Module.importedTable):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::TableInformation::TableInformation):
(JSC::Wasm::TableInformation::initial const):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseTableHelper):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::Table::tryCreate):
* Source/JavaScriptCore/wasm/WasmTable.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):

Canonical link: <a href="https://commits.webkit.org/318834@main">https://commits.webkit.org/318834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d60201a4c9f070f32c88d9d33e0c0ba85ff9ab88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189333 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d023bc4d-5998-4e8d-91a7-bcc09d8d2b08) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139981 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/97287028-a1e4-45ae-9bba-8d3bc79cff11) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120434 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0f0711f-bf9c-40d5-b178-e79fcdfdc04c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40585 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2403 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9207 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40229 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/787 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40776 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191554 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53110 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149242 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53791 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148986 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27260 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43653 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126063 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120961 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52308 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15217 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51693 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51934 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51754 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->